### PR TITLE
fix(react): fix error `createRef is not a function`

### DIFF
--- a/.changeset/hip-stars-cross.md
+++ b/.changeset/hip-stars-cross.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix error `createRef is not a function`

--- a/packages/react/runtime/src/legacy-react-runtime/index.ts
+++ b/packages/react/runtime/src/legacy-react-runtime/index.ts
@@ -1,14 +1,14 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { createContext } from 'preact';
+import { createContext, createRef } from 'preact';
 import { lazy } from 'preact/compat';
 
 import {
   ComponentFromReactRuntime as Component,
   ComponentFromReactRuntime as PureComponent,
 } from '../compat/lynxComponent.js';
-import { useCallback, useEffect, useMemo, useReducer, useState } from '../hooks/react.js';
+import { useCallback, useEffect, useMemo, useReducer, useState, useRef } from '../hooks/react.js';
 
 /* v8 ignore next 3 */
 function __runInJS<T>(value: T): T | undefined | null {
@@ -30,9 +30,11 @@ export default {
   Component,
   PureComponent,
   createContext,
+  createRef,
   lazy,
   useState,
   useReducer,
+  useRef,
   useEffect,
   useMemo,
   useCallback,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

We may split the compat logic (the runtime part and the transformer part) and release it separately in the future, when `@lynx-js/react-transform` can be refactored to a standard swc plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
