### PR TITLE
chore: add `repository.url` for npm provenance

### DIFF
--- a/.changeset/cuddly-papayas-start.md
+++ b/.changeset/cuddly-papayas-start.md
@@ -1,0 +1,32 @@
+---
+"@lynx-js/runtime-wrapper-webpack-plugin": patch
+"@lynx-js/chunk-loading-webpack-plugin": patch
+"@lynx-js/react-refresh-webpack-plugin": patch
+"@lynx-js/web-elements-reactive": patch
+"@lynx-js/web-style-transformer": patch
+"@lynx-js/css-extract-webpack-plugin": patch
+"@lynx-js/web-elements-compat": patch
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/webpack-runtime-globals": patch
+"@lynx-js/webpack-dev-transport": patch
+"@lynx-js/react-webpack-plugin": patch
+"@lynx-js/tailwind-preset": patch
+"@lynx-js/web-worker-rpc": patch
+"@lynx-js/react-alias-rsbuild-plugin": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-webpack-plugin": patch
+"@lynx-js/web-elements": patch
+"@lynx-js/web-explorer": patch
+"create-rspeedy": patch
+"@lynx-js/qrcode-rsbuild-plugin": patch
+"@lynx-js/web-core": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/css-serializer": patch
+"@lynx-js/websocket": patch
+"@lynx-js/rspeedy": patch
+"@lynx-js/react": patch
+---
+
+Support NPM provenance.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,6 +2,11 @@
   "name": "@lynx-js/react",
   "version": "0.105.0",
   "description": "ReactLynx is a framework for developing Lynx applications with familiar React.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/react"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -8,6 +8,11 @@
     "Lynx",
     "ReactLynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/rspeedy/core"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/rspeedy/create-rspeedy/package.json
+++ b/packages/rspeedy/create-rspeedy/package.json
@@ -9,6 +9,11 @@
     "Lynx",
     "ReactLynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/rspeedy/create-rspeedy"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -7,6 +7,11 @@
     "Lynx",
     "ReactLynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/rspeedy/plugin-qrcode"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/rspeedy/plugin-react-alias/package.json
+++ b/packages/rspeedy/plugin-react-alias/package.json
@@ -7,6 +7,11 @@
     "Lynx",
     "ReactLynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/rspeedy/plugin-react-alias"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/rspeedy/plugin-react/package.json
+++ b/packages/rspeedy/plugin-react/package.json
@@ -7,6 +7,11 @@
     "Lynx",
     "ReactLynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/rspeedy/plugin-react"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/rspeedy/websocket/package.json
+++ b/packages/rspeedy/websocket/package.json
@@ -7,6 +7,11 @@
     "Lynx",
     "WebSocket"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/rspeedy/websocket"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/third-party/tailwind-preset/package.json
+++ b/packages/third-party/tailwind-preset/package.json
@@ -7,6 +7,11 @@
     "ReactLynx",
     "tailwindcss"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/third-party/tailwind-preset"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/tools/css-serializer/package.json
+++ b/packages/tools/css-serializer/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@lynx-js/css-serializer",
   "version": "0.1.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/tools/css-serializer"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web-platform/web-constants/package.json
+++ b/packages/web-platform/web-constants/package.json
@@ -4,6 +4,11 @@
   "private": false,
   "description": "",
   "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-constants"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web-platform/web-core/package.json
+++ b/packages/web-platform/web-core/package.json
@@ -4,6 +4,11 @@
   "private": false,
   "description": "",
   "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-core"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web-platform/web-elements-compat/package.json
+++ b/packages/web-platform/web-elements-compat/package.json
@@ -2,6 +2,11 @@
   "name": "@lynx-js/web-elements-compat",
   "version": "0.2.2",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-elements-compat"
+  },
   "license": "Apache-2.0",
   "sideEffects": true,
   "type": "module",

--- a/packages/web-platform/web-elements-reactive/package.json
+++ b/packages/web-platform/web-elements-reactive/package.json
@@ -2,6 +2,11 @@
   "name": "@lynx-js/web-elements-reactive",
   "version": "0.1.0",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-elements-reactive"
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "type": "module",

--- a/packages/web-platform/web-elements/package.json
+++ b/packages/web-platform/web-elements/package.json
@@ -2,6 +2,11 @@
   "name": "@lynx-js/web-elements",
   "version": "0.2.4",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-elements"
+  },
   "license": "Apache-2.0",
   "sideEffects": true,
   "type": "module",

--- a/packages/web-platform/web-explorer/package.json
+++ b/packages/web-platform/web-explorer/package.json
@@ -2,6 +2,11 @@
   "name": "@lynx-js/web-explorer",
   "version": "0.0.1",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-explorer"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "main": "index.html",

--- a/packages/web-platform/web-mainthread-apis/package.json
+++ b/packages/web-platform/web-mainthread-apis/package.json
@@ -4,6 +4,11 @@
   "private": false,
   "description": "",
   "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-mainthread-apis"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -2,6 +2,11 @@
   "name": "@lynx-js/web-style-transformer",
   "version": "0.2.1",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-style-transformer"
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "type": "module",

--- a/packages/web-platform/web-worker-rpc/package.json
+++ b/packages/web-platform/web-worker-rpc/package.json
@@ -4,6 +4,11 @@
   "private": false,
   "description": "",
   "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-worker-rpc"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/web-platform/web-worker-runtime/package.json
+++ b/packages/web-platform/web-worker-runtime/package.json
@@ -4,6 +4,11 @@
   "private": false,
   "description": "",
   "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/web-worker-runtime"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/webpack/chunk-loading-webpack-plugin/package.json
+++ b/packages/webpack/chunk-loading-webpack-plugin/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/lynx-wg/lynx-stack.git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
     "directory": "packages/webpack/chunk-loading-webpack-plugin"
   },
   "license": "Apache-2.0",

--- a/packages/webpack/css-extract-webpack-plugin/package.json
+++ b/packages/webpack/css-extract-webpack-plugin/package.json
@@ -6,6 +6,11 @@
     "webpack",
     "Lynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/webpack/css-extract-webpack-plugin"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/webpack/react-refresh-webpack-plugin/package.json
+++ b/packages/webpack/react-refresh-webpack-plugin/package.json
@@ -6,6 +6,11 @@
     "webpack",
     "Lynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/webpack/react-refresh-webpack-plugin"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/webpack/react-webpack-plugin/package.json
+++ b/packages/webpack/react-webpack-plugin/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/lynx-wg/lynx-stack.git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
     "directory": "packages/webpack/react-webpack-plugin"
   },
   "license": "Apache-2.0",

--- a/packages/webpack/runtime-wrapper-webpack-plugin/package.json
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/package.json
@@ -6,6 +6,11 @@
     "webpack",
     "Lynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/webpack/runtime-wrapper-webpack-plugin"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/webpack/template-webpack-plugin/package.json
+++ b/packages/webpack/template-webpack-plugin/package.json
@@ -6,6 +6,11 @@
     "webpack",
     "Lynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/webpack/template-webpack-plugin"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/webpack/web-webpack-plugin/package.json
+++ b/packages/webpack/web-webpack-plugin/package.json
@@ -4,6 +4,11 @@
   "private": false,
   "description": "TBD",
   "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/webpack/web-webpack-plugin"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/webpack/webpack-dev-transport/package.json
+++ b/packages/webpack/webpack-dev-transport/package.json
@@ -6,6 +6,11 @@
     "webpack",
     "Lynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/webpack/webpack-dev-transport"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",

--- a/packages/webpack/webpack-runtime-globals/package.json
+++ b/packages/webpack/webpack-runtime-globals/package.json
@@ -6,6 +6,11 @@
     "webpack",
     "Lynx"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/webpack/webpack-runtime-globals"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qingyu Wang",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

Add `repository.url` for NPM provenance. See [CI failure](https://github.com/lynx-family/lynx-stack/actions/runs/13653835526/job/38168584888) for details.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or **not required**).
- [x] Documentation updated (or **not required**).
