### PR TITLE
feat(react/runtime): support return value for `runOnBackground()` and…

### DIFF
--- a/.changeset/nine-rats-agree.md
+++ b/.changeset/nine-rats-agree.md
@@ -1,0 +1,20 @@
+---
+"@lynx-js/react": patch
+---
+
+Support return value for `runOnBackground()` and `runOnMainThread()`.
+
+Now you can get the return value from `runOnBackground()` and `runOnMainThread()`, which enables more flexible data flow between the main thread and the background thread.
+
+```js
+import { runOnBackground } from '@lynx-js/react';
+
+const onTap = async () => {
+  'main thread';
+  const text = await runOnBackground(() => {
+    'background only';
+    return 'Hello, world!';
+  })();
+  console.log(text);
+};
+```

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -102,10 +102,10 @@ export interface Root {
 export const root: Root;
 
 // @public
-export function runOnBackground<Fn extends (...args: any[]) => any>(f: Fn): (...args: Parameters<Fn>) => void;
+export function runOnBackground<R, Fn extends (...args: any[]) => R>(f: Fn): (...args: Parameters<Fn>) => Promise<R>;
 
 // @public
-export function runOnMainThread<Fn extends (...args: any[]) => any>(fn: Fn): (...args: Parameters<Fn>) => void;
+export function runOnMainThread<R, Fn extends (...args: any[]) => R>(fn: Fn): (...args: Parameters<Fn>) => Promise<R>;
 
 export { Suspense }
 

--- a/packages/react/runtime/__test__/utils/globals.js
+++ b/packages/react/runtime/__test__/utils/globals.js
@@ -31,36 +31,6 @@ const performance = {
   }),
 };
 
-class EventListener {
-  _listeners = {};
-  _addEventListener = (type, listener) => {
-    if (this._listeners[type]) {
-      this._listeners[type].push(listener);
-    } else {
-      this._listeners[type] = [listener];
-    }
-  };
-  _removeEventListener = (type, listener) => {
-    if (this._listeners[type]) {
-      this._listeners[type] = this._listeners[type].filter((l) => l !== listener);
-    }
-  };
-  _dispatchEvent = (event) => {
-    if (this._listeners[event.type]) {
-      this._listeners[event.type].forEach((listener) => listener(event));
-    }
-  };
-
-  addEventListener = vi.fn(this._addEventListener);
-
-  removeEventListener = vi.fn(this._removeEventListener);
-
-  dispatchEvent = vi.fn(this._dispatchEvent);
-}
-
-const coreContext = new EventListener();
-const jsContext = new EventListener();
-
 function injectGlobals() {
   globalThis.__DEV__ = true;
   globalThis.__PROFILE__ = true;
@@ -85,8 +55,6 @@ function injectGlobals() {
         },
       };
     }),
-    getCoreContext: vi.fn(() => coreContext),
-    getJSContext: vi.fn(() => jsContext),
   };
   globalThis.requestAnimationFrame = setTimeout;
   globalThis.cancelAnimationFrame = clearTimeout;

--- a/packages/react/runtime/__test__/utils/runtimeProxy.ts
+++ b/packages/react/runtime/__test__/utils/runtimeProxy.ts
@@ -1,0 +1,69 @@
+import { vi } from 'vitest';
+import { globalEnvManager } from './envManager.ts';
+
+const eventEmitters = {};
+
+function getType(context: string, type: string) {
+  return `${context}+${type}`;
+}
+
+function getCurrentContextName() {
+  return __JS__ ? 'jsContext' : 'coreContext';
+}
+
+function switchConext() {
+  if (__JS__) {
+    globalEnvManager.switchToMainThread();
+  } else {
+    globalEnvManager.switchToBackground();
+  }
+}
+
+class EventEmitter {
+  name = '';
+  listeners = {};
+  _addEventListener = (type, listener) => {
+    const realType = getType(getCurrentContextName(), type);
+    if (this.listeners[realType]) {
+      this.listeners[realType].push(listener);
+    } else {
+      this.listeners[realType] = [listener];
+    }
+  };
+  _removeEventListener = (type, listener) => {
+    const realType = getType(getCurrentContextName(), type);
+    if (this.listeners[realType]) {
+      this.listeners[realType] = this.listeners[realType].filter((l) => l !== listener);
+    }
+  };
+  _dispatchEvent = (event) => {
+    const currentContextName = getCurrentContextName();
+    if (this.name == currentContextName) {
+      throw new Error('EventEmitter: cannot emit event on the same context');
+    }
+    const context = eventEmitters[currentContextName];
+    const realType = getType(this.name, event.type);
+    switchConext();
+    if (context.listeners[realType]) {
+      context.listeners[realType].forEach((listener) => listener(event));
+    }
+    switchConext();
+  };
+
+  constructor(name: string) {
+    eventEmitters[name] = this;
+    this.name = name;
+  }
+
+  addEventListener = vi.fn(this._addEventListener);
+
+  removeEventListener = vi.fn(this._removeEventListener);
+
+  dispatchEvent = vi.fn(this._dispatchEvent);
+}
+
+const coreContext = new EventEmitter('coreContext');
+const jsContext = new EventEmitter('jsContext');
+
+globalThis.lynx.getCoreContext = vi.fn(() => coreContext);
+globalThis.lynx.getJSContext = vi.fn(() => jsContext);

--- a/packages/react/runtime/__test__/worklet/runOnMainThread.test.js
+++ b/packages/react/runtime/__test__/worklet/runOnMainThread.test.js
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { WorkletEvents } from '@lynx-js/react/worklet-runtime/bindings';
+
 import { destroyWorklet } from '../../src/worklet/destroy';
 import { clearConfigCacheForTesting } from '../../src/worklet/functionality';
 import { runOnMainThread } from '../../src/worklet/runOnMainThread';
@@ -28,12 +30,28 @@ describe('runOnMainThread', () => {
       [
         [
           {
-            "data": "{"worklet":{"_wkltId":"835d:450ef:2"},"params":[1,["args"]]}",
+            "data": "{"worklet":{"_wkltId":"835d:450ef:2"},"params":[1,["args"]],"resolveId":1}",
             "type": "Lynx.Worklet.runWorkletCtx",
           },
         ],
       ]
     `);
+  });
+
+  it('should get return value', async () => {
+    globalEnvManager.switchToBackground();
+    const promise = runOnMainThread('someWorklet')('hello');
+
+    globalEnvManager.switchToMainThread();
+    lynx.getJSContext().dispatchEvent({
+      type: WorkletEvents.FunctionCallRet,
+      data: JSON.stringify({
+        resolveId: 1,
+        returnValue: 'world',
+      }),
+    });
+
+    await expect(promise).resolves.toBe('world');
   });
 
   it('should throw when on the main thread', () => {

--- a/packages/react/runtime/src/lifecycle/reload.ts
+++ b/packages/react/runtime/src/lifecycle/reload.ts
@@ -14,6 +14,7 @@ import { LifecycleConstant } from '../lifecycleConstant.js';
 import { __pendingListUpdates } from '../list.js';
 import { takeGlobalRefPatchMap } from '../snapshot/ref.js';
 import { deinitGlobalSnapshotPatch } from '../snapshotPatch.js';
+import { destroyWorklet } from '../worklet/destroy.js';
 
 function reloadMainThread(data: any, options: UpdatePageOption): void {
   if (__PROFILE__) {
@@ -26,6 +27,7 @@ function reloadMainThread(data: any, options: UpdatePageOption): void {
     Object.assign(lynx.__initData, data);
   }
 
+  destroyWorklet();
   snapshotInstanceManager.clear();
   __pendingListUpdates.clear();
 

--- a/packages/react/runtime/src/worklet/functionCall.ts
+++ b/packages/react/runtime/src/worklet/functionCall.ts
@@ -1,0 +1,42 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { WorkletEvents } from '@lynx-js/react/worklet-runtime/bindings';
+import type { RunWorkletCtxRetData } from '@lynx-js/react/worklet-runtime/bindings';
+
+import { destroyTasks } from './destroy.js';
+import { IndexMap } from './indexMap.js';
+
+let resolveMap: IndexMap<(value: any) => void> | undefined;
+
+function initReturnValueListener(): void {
+  const context: RuntimeProxy = __JS__ ? lynx.getCoreContext() : lynx.getJSContext();
+
+  resolveMap = new IndexMap();
+  context.addEventListener(WorkletEvents.FunctionCallRet, onFunctionCallRet);
+
+  destroyTasks.push(() => {
+    context.removeEventListener(WorkletEvents.FunctionCallRet, onFunctionCallRet);
+    resolveMap = undefined;
+  });
+}
+
+/**
+ * @internal
+ */
+function onFunctionCall(resolve: (value: any) => void): number {
+  if (!resolveMap) {
+    initReturnValueListener();
+  }
+  return resolveMap!.add(resolve);
+}
+
+function onFunctionCallRet(event: RuntimeProxy.Event): void {
+  const data = JSON.parse(event.data as string) as RunWorkletCtxRetData;
+  const resolve = resolveMap!.get(data.resolveId)!;
+  resolveMap!.remove(data.resolveId);
+  resolve(data.returnValue);
+}
+
+export { onFunctionCall };

--- a/packages/react/runtime/src/worklet/runOnMainThread.ts
+++ b/packages/react/runtime/src/worklet/runOnMainThread.ts
@@ -6,28 +6,45 @@ import { WorkletEvents } from '@lynx-js/react/worklet-runtime/bindings';
 
 import { onPostWorkletCtx } from './ctx.js';
 import { isMtsEnabled } from './functionality.js';
+import { onFunctionCall } from './functionCall.js';
 
 /**
  * `runOnMainThread` allows triggering main thread functions on the main thread asynchronously.
  * @param fn - The main thread functions to be called.
- * @returns A function. Calling which with the arguments to be passed to the main thread function to trigger it on the main thread.
+ * @returns A function. Calling which with the arguments to be passed to the main thread function to trigger it on the main thread. This function returns a promise that resolves to the return value of the main thread function.
+ * @example
+ * ```ts
+ * import { runOnMainThread } from '@lynx-js/react';
+ *
+ * async function someFunction() {
+ *   const fn = runOnMainThread(() => {
+ *     'main thread';
+ *     return 'hello';
+ *   });
+ *   const result = await fn();
+ * }
+ * ```
  * @public
  */
-export function runOnMainThread<Fn extends (...args: any[]) => any>(fn: Fn): (...args: Parameters<Fn>) => void {
+export function runOnMainThread<R, Fn extends (...args: any[]) => R>(fn: Fn): (...args: Parameters<Fn>) => Promise<R> {
   if (__LEPUS__) {
     throw new Error('runOnMainThread can only be used on the background thread.');
   }
   if (!isMtsEnabled()) {
     throw new Error('runOnMainThread requires Lynx sdk version 2.14.');
   }
-  return (...params: any[]): void => {
-    onPostWorkletCtx(fn as any as Worklet);
-    lynx.getCoreContext!().dispatchEvent({
-      type: WorkletEvents.runWorkletCtx,
-      data: JSON.stringify({
-        worklet: fn as any as Worklet,
-        params,
-      } as RunWorkletCtxData),
+  return async (...params: any[]): Promise<R> => {
+    return new Promise((resolve) => {
+      onPostWorkletCtx(fn as any as Worklet);
+      const resolveId = onFunctionCall(resolve);
+      lynx.getCoreContext!().dispatchEvent({
+        type: WorkletEvents.runWorkletCtx,
+        data: JSON.stringify({
+          worklet: fn as any as Worklet,
+          params,
+          resolveId,
+        } as RunWorkletCtxData),
+      });
     });
   };
 }

--- a/packages/react/runtime/vitest.config.ts
+++ b/packages/react/runtime/vitest.config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
     setupFiles: [
       path.join(__dirname, './__test__/utils/globals.js'),
       path.join(__dirname, './__test__/utils/setup.js'),
+      path.join(__dirname, './__test__/utils/runtimeProxy.ts'),
     ],
   },
 });

--- a/packages/react/worklet-runtime/src/bindings/events.ts
+++ b/packages/react/worklet-runtime/src/bindings/events.ts
@@ -3,13 +3,20 @@ import type { Worklet } from './types.js';
 const enum WorkletEvents {
   runWorkletCtx = 'Lynx.Worklet.runWorkletCtx',
   runOnBackground = 'Lynx.Worklet.runOnBackground',
+  FunctionCallRet = 'Lynx.Worklet.FunctionCallRet',
   releaseBackgroundWorkletCtx = 'Lynx.Worklet.releaseBackgroundWorkletCtx',
   releaseWorkletRef = 'Lynx.Worklet.releaseWorkletRef',
 }
 
 interface RunWorkletCtxData {
+  resolveId: number;
   worklet: Worklet;
   params: unknown[];
 }
 
-export { WorkletEvents, type RunWorkletCtxData };
+interface RunWorkletCtxRetData {
+  resolveId: number;
+  returnValue: unknown;
+}
+
+export { WorkletEvents, type RunWorkletCtxData, type RunWorkletCtxRetData };

--- a/packages/react/worklet-runtime/src/bindings/index.ts
+++ b/packages/react/worklet-runtime/src/bindings/index.ts
@@ -13,4 +13,4 @@ export {
 
 export type * from './types.js';
 
-export { WorkletEvents, type RunWorkletCtxData } from './events.js';
+export { WorkletEvents, type RunWorkletCtxData, type RunWorkletCtxRetData } from './events.js';

--- a/packages/react/worklet-runtime/src/global.ts
+++ b/packages/react/worklet-runtime/src/global.ts
@@ -14,7 +14,7 @@ declare global {
     _refImpl: RefImpl;
   };
 
-  function runWorklet(ctx: Worklet, params: ClosureValueType[]): void;
+  function runWorklet(ctx: Worklet, params: ClosureValueType[]): unknown;
 
   function registerWorklet(type: string, id: string, worklet: Function): void;
   function registerWorkletInternal(type: string, id: string, worklet: Function): void;

--- a/packages/react/worklet-runtime/src/listeners.ts
+++ b/packages/react/worklet-runtime/src/listeners.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { WorkletEvents } from './bindings/events.js';
-import type { RunWorkletCtxData } from './bindings/events.js';
+import type { RunWorkletCtxData, RunWorkletCtxRetData } from './bindings/events.js';
 import type { ClosureValueType } from './bindings/types.js';
 import { removeValueFromWorkletRefMap } from './workletRef.js';
 
@@ -12,7 +12,14 @@ function initEventListeners(): void {
     WorkletEvents.runWorkletCtx,
     (event: RuntimeProxy.Event) => {
       const data = JSON.parse(event.data as string) as RunWorkletCtxData;
-      runWorklet(data.worklet, data.params as ClosureValueType[]);
+      const returnValue = runWorklet(data.worklet, data.params as ClosureValueType[]);
+      jsContext.dispatchEvent({
+        type: WorkletEvents.FunctionCallRet,
+        data: JSON.stringify({
+          resolveId: data.resolveId,
+          returnValue,
+        } as RunWorkletCtxRetData),
+      });
     },
   );
   jsContext.addEventListener(


### PR DESCRIPTION
… `runOnMainThread()`

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support return value for `runOnBackground()` and `runOnMainThread()`.

Now you can get the return value from `runOnBackground()` and `runOnMainThread()`, which enables more flexible data flow between the main thread and the background thread.

```js
import { runOnBackground } from '@lynx-dev/react';

const onTap = async () => {
  'main thread';
  const text = await runOnBackground(() => {
    'background only';
    return 'Hello, world!';
  })();
  console.log(text);
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
