### PR TITLE
fix(rspeedy/plugin-react): use path.posix.join for backgroundName to ensure consistent path separators across platforms

### DIFF
--- a/.changeset/metal-jobs-hide.md
+++ b/.changeset/metal-jobs-hide.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+fix(rspeedy/plugin-react): use path.posix.join for backgroundName to ensure consistent path separators across platforms.

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -82,7 +82,7 @@ export function applyEntry(
       // We would like to avoid adding `__background` to the output CSS filename.
       const mainThreadEntry = `${entryName}__main-thread`
 
-      const mainThreadName = path.join(
+      const mainThreadName = path.posix.join(
         isLynx
           // TODO: config intermediate
           ? DEFAULT_DIST_PATH_INTERMEDIATE
@@ -92,7 +92,7 @@ export function applyEntry(
         `${mainThreadEntry}/main-thread.js`,
       )
 
-      const backgroundName = path.join(
+      const backgroundName = path.posix.join(
         isLynx
           // TODO: config intermediate
           ? DEFAULT_DIST_PATH_INTERMEDIATE
@@ -155,7 +155,7 @@ export function applyEntry(
             '[platform]',
             environment.name,
           ),
-          intermediate: path.join(
+          intermediate: path.posix.join(
             // TODO: config intermediate
             DEFAULT_DIST_PATH_INTERMEDIATE,
             entryName,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary
fix #121

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
