### PR TITLE
refactor(web-core): improve LynxView resize observer cleanup

### DIFF
--- a/.changeset/fast-forks-build.md
+++ b/.changeset/fast-forks-build.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Improve LynxView resize observer cleanup

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -315,8 +315,8 @@ export class LynxView extends HTMLElement {
    * @private
    */
   disconnectedCallback() {
+    this.cleanupResizeObserver();
     if (this.#instance) {
-      this.#instance.resizeObserver?.disconnect();
       this.#instance.lynxView.dispose();
       this.#instance.rootDom.remove();
     }
@@ -360,7 +360,7 @@ export class LynxView extends HTMLElement {
             nativeModulesUrl: this.#nativeModulesUrl,
             callbacks: {
               loadNewTag: loadElement,
-              nativeModulesCall: (...args) => {
+              nativeModulesCall: (...args: unknown[]) => {
                 if (this.#onNativeModulesCall) {
                   return this.#onNativeModulesCall(...args);
                 } else if (this.#cachedNativeModulesCall) {
@@ -393,6 +393,13 @@ export class LynxView extends HTMLElement {
    */
   connectedCallback() {
     this.#render();
+  }
+
+  private cleanupResizeObserver() {
+    if (this.#instance?.resizeObserver) {
+      this.#instance.resizeObserver.disconnect();
+      this.#instance.resizeObserver = undefined;
+    }
   }
 }
 

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -360,7 +360,9 @@ export class LynxView extends HTMLElement {
             nativeModulesUrl: this.#nativeModulesUrl,
             callbacks: {
               loadNewTag: loadElement,
-              nativeModulesCall: (...args: unknown[]) => {
+              nativeModulesCall: (
+                ...args: [name: string, data: any, moduleName: string]
+              ) => {
                 if (this.#onNativeModulesCall) {
                   return this.#onNativeModulesCall(...args);
                 } else if (this.#cachedNativeModulesCall) {


### PR DESCRIPTION
- Extract resize observer cleanup into a separate method
- Ensure proper disconnection and clearing of resize observer
- Add type safety to nativeModulesCall callback