### PR TITLE
fix: some valus should be updateable by global scope

### DIFF
--- a/.changeset/modern-forks-unite.md
+++ b/.changeset/modern-forks-unite.md
@@ -1,0 +1,16 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+fix: some valus should be updateable by global scope
+
+Now we add an allowlist to allow some identifiers could be updated by globalThis.
+
+For those values in the allowlist:
+
+```
+globalThis.foo = 'xx';
+console.log(foo); //'xx'
+```

--- a/packages/web-platform/web-constants/src/constants.ts
+++ b/packages/web-platform/web-constants/src/constants.ts
@@ -25,3 +25,7 @@ export const lynxViewRootDomId = 'lynx-view-root' as const;
 export const __lynx_timing_flag = '__lynx_timing_flag' as const;
 
 export const lynxViewEntryIdPrefix = 'lynx-view-id' as const;
+
+export const globalMuteableVars = [
+  'registerDataProcessor',
+] as const;

--- a/packages/web-platform/web-core/src/utils/loadTemplate.ts
+++ b/packages/web-platform/web-core/src/utils/loadTemplate.ts
@@ -33,9 +33,9 @@ function generateJavascriptUrl<T extends Record<string, string>>(
             ...muteableVars.map((nm) =>
               `${nm} = lynx_runtime.__lynxGlobalBindingValues.${nm};`
             ),
-            '};',
+            '};\n',
             content,
-            'return module.exports;}',
+            '\n return module.exports;}',
           ].join(''),
         ),
       ];

--- a/packages/web-platform/web-core/src/utils/loadTemplate.ts
+++ b/packages/web-platform/web-core/src/utils/loadTemplate.ts
@@ -1,4 +1,4 @@
-import type { LynxTemplate } from '@lynx-js/web-constants';
+import { globalMuteableVars, type LynxTemplate } from '@lynx-js/web-constants';
 
 const TemplateCache: Record<string, LynxTemplate> = {};
 
@@ -10,24 +10,33 @@ function generateJavascriptUrl<T extends Record<string, string>>(
   obj: T,
   injectVars: string[],
   injectWithBind: string[],
+  muteableVars: readonly string[],
 ) {
+  injectVars = injectVars.concat(muteableVars);
   return Object.fromEntries(
     Object.entries(obj).map(([name, content]) => {
       return [
         name,
         createJsModuleUrl(
-          `globalThis.module.exports = function(lynx_runtime) {
-const module= {exports:{}};let exports = module.exports;
-var {${injectVars.join(',')}} = lynx_runtime; 
-${
-            injectWithBind.map((nm) =>
-              `const ${nm} = lynx_runtime.${nm}?.bind(lynx_runtime)`
-            ).join(';')
-          }
-var globDynamicComponentEntry = '__Card__';
-var {__globalProps} = lynx;
-${content}
-return module.exports;}`,
+          [
+            'globalThis.module.exports = function(lynx_runtime) {',
+            'const module= {exports:{}};let exports = module.exports;',
+            'var {',
+            injectVars.join(','),
+            '} = lynx_runtime;',
+            ...injectWithBind.map((nm) =>
+              `const ${nm} = lynx_runtime.${nm}?.bind(lynx_runtime);`
+            ),
+            ';var globDynamicComponentEntry = \'__Card__\';',
+            'var {__globalProps} = lynx;',
+            'lynx_runtime._updateVars=()=>{',
+            ...muteableVars.map((nm) =>
+              `${nm} = lynx_runtime.__lynxGlobalBindingValues.${nm};`
+            ),
+            '};',
+            content,
+            'return module.exports;}',
+          ].join(''),
         ),
       ];
     }),
@@ -114,11 +123,13 @@ export async function loadTemplate(url: string): Promise<LynxTemplate> {
       template.lepusCode,
       mainThreadInjectVars,
       [],
+      globalMuteableVars,
     ),
     manifest: generateJavascriptUrl(
       template.manifest,
       backgroundInjectVars,
       backgroundInjectWithBind,
+      [],
     ),
   };
   TemplateCache[url] = decodedTemplate;

--- a/packages/web-platform/web-tests/resources/web-core.main-thread.json
+++ b/packages/web-platform/web-tests/resources/web-core.main-thread.json
@@ -1,7 +1,7 @@
 {
   "styleInfo": {},
   "lepusCode": {
-    "root": "self.runtime = lynx_runtime;self.__lynx_worker_type = 'main'",
+    "root": "self.runtime = lynx_runtime;self.__lynx_worker_type = 'main'; globalThis.registerDataProcessor='pass'; self.registerDataProcessor = registerDataProcessor;",
     "/manifest-chunk.js": "module.exports = 'hello';",
     "/manifest-chunk2.js": "module.exports = 'world';"
   },

--- a/packages/web-platform/web-tests/tests/web-core.test.ts
+++ b/packages/web-platform/web-tests/tests/web-core.test.ts
@@ -209,6 +209,14 @@ test.describe('web core tests', () => {
     expect(success).toBe(true);
     expect(fail).toBe(false);
   });
+  test('registerDataProcessor-as-global-var-update', async ({ page, browserName }) => {
+    await goto(page);
+    const mainWorker = await getMainThreadWorker(page);
+    const registerDataProcessor = await mainWorker.evaluate(() => {
+      return globalThis.registerDataProcessor;
+    });
+    expect(registerDataProcessor).toBe('pass');
+  });
 
   test('createJSObjectDestructionObserver', async ({ page, browserName }) => {
     // firefox dose not support this.


### PR DESCRIPTION
https://github.com/lynx-family/lynx-stack/pull/90

This PR causes an issue:

the `registerDataProcessor` depending on the globalThis behavior.

Now we pass an updater callback to the runtime instance. This allows us to update the registerDataProcessor just like it's really assigned on globalthis.

```
var {ident} = runtimeInstance
runtimeInstance.updater = () => {
 ident = runtimeInstance.storage.ident;
}
```

We just add a getter&setter for the "ident" value and call the updater on any new value set. This allows the DSL&User code to do this.

```
globalThis.ident = () => {};
ident();
```

Overall, the running code will work like this.

```
function entry(runtimeInstance) {
  var {ident} = runtimeInstance;
  runtimeInstance.updater = () => {
   ident = runtimeInstance.storage.ident;
  }
  globalThis.ident = () => {}; // this will be traped into a setter and the updater will be called.
  ident();
}
```
