### PR TITLE
feat: remove attributes `x-enable-xx-event` for web

### DIFF
--- a/.changeset/common-rice-pick.md
+++ b/.changeset/common-rice-pick.md
@@ -1,0 +1,24 @@
+---
+"@lynx-js/web-elements-reactive": minor
+---
+
+feat: add new decorator `registerEventEnableStatusChangeHandler`
+
+example
+
+```typescript
+@registerEventEnableStatusChangeHandler('load')
+ #enableLoadEvent(status:boolean) {
+   if (status) {
+     this.#getImg().addEventListener('load', this.#teleportLoadEvent, {
+       passive: true,
+     });
+   } else {
+     this.#getImg().removeEventListener('load', this.#teleportLoadEvent);
+   }
+ }
+```
+
+After this commit, we override the `HTMLElement.addEventListener` and the `HTMLElement.removeEventListner` to know if there is any listener attached on current element.
+
+If event should be enabled/disabled, the callback will be invoked.

--- a/.changeset/lucky-llamas-check.md
+++ b/.changeset/lucky-llamas-check.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+feat: never require the x-enable-xx-event attributes
+
+After this commit, we do not need user to add `x-enable-xx-event` to enable corresponding events

--- a/.changeset/tired-spoons-tickle.md
+++ b/.changeset/tired-spoons-tickle.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-core": minor
+---
+
+feat: never add the x-enable-xx-event attributes
+
+After this commit, we update the reqirement of the version of `@lynx-js/web-elements` to `>=0.3.1`

--- a/packages/web-platform/web-core/package.json
+++ b/packages/web-platform/web-core/package.json
@@ -34,6 +34,6 @@
   },
   "peerDependencies": {
     "@lynx-js/lynx-core": "0.1.0",
-    "@lynx-js/web-elements": ">=0.1.0"
+    "@lynx-js/web-elements": ">=0.3.1"
   }
 }

--- a/packages/web-platform/web-core/src/uiThread/decodeElementOperation.ts
+++ b/packages/web-platform/web-core/src/uiThread/decodeElementOperation.ts
@@ -203,10 +203,8 @@ export function decodeElementOperation<
           const isCaptureEvent = op.eventType === 'capture-bind'
             || op.eventType === 'capture-catch';
           if (op.hname === undefined) {
-            target.removeAttribute(`x-enable-${lynxEventName}-event`);
             target[lynxRuntimeValue].eventHandler[lynxEventName] = undefined;
           } else {
-            target.setAttribute(`x-enable-${lynxEventName}-event`, '');
             target.addEventListener(htmlEventName, handleHtmlEvent, {
               passive: true,
               capture: isCaptureEvent,

--- a/packages/web-platform/web-elements-reactive/src/bindSwitchToEventListener.ts
+++ b/packages/web-platform/web-elements-reactive/src/bindSwitchToEventListener.ts
@@ -13,8 +13,7 @@ export function bindSwitchToEventListener<T>(
   options?: AddEventListenerOptions,
 ) {
   let listening = false;
-  return function(this: T, newVal: string | null) {
-    const enable = newVal !== null;
+  return function(this: T, enable: boolean) {
     if (enable !== listening) {
       const target = elementGetter.call(this);
       if (enable) {

--- a/packages/web-platform/web-elements-reactive/src/generateRegister.ts
+++ b/packages/web-platform/web-elements-reactive/src/generateRegister.ts
@@ -1,0 +1,48 @@
+/**
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+export function generateRegister<
+  DecoratorArgs extends any[],
+  RegistryItem,
+  HandlerType,
+  RegisterStorageMapName extends string,
+>(
+  registerName: RegisterStorageMapName,
+  convertHandlerToRegistryItem: (
+    handler: HandlerType,
+    decoratorArgs: DecoratorArgs,
+  ) => RegistryItem,
+) {
+  return function registerHandler(key: string, ...args: DecoratorArgs) {
+    return function<T>(
+      this: T,
+      target: HandlerType | undefined,
+      context: ClassMemberDecoratorContext | ClassFieldDecoratorContext<T>,
+    ) {
+      if (context.kind === 'method') {
+        (
+          context as ClassMethodDecoratorContext<
+            Record<RegisterStorageMapName, Record<string, RegistryItem>>
+          >
+        ).addInitializer(function() {
+          this[registerName] ??= {};
+          (this[registerName] as Record<string, RegistryItem>)[key] =
+            convertHandlerToRegistryItem(target!, args);
+        });
+      } else if (context.kind === 'field') {
+        return function(this: any, value: HandlerType) {
+          this[registerName] ??= {};
+          this[registerName][key] = convertHandlerToRegistryItem(value, args);
+          return value;
+        } as any;
+      } else {
+        throw new Error(
+          `[lynx-web-components] decorator type ${context.kind} is not supported`,
+        );
+      }
+    };
+  };
+}

--- a/packages/web-platform/web-elements-reactive/src/index.ts
+++ b/packages/web-platform/web-elements-reactive/src/index.ts
@@ -21,3 +21,5 @@ export { registerAttributeHandler } from './registerAttributeHandler.js';
 export type { AttributeChangeHandler } from './registerAttributeHandler.js';
 export { registerStyleChangeHandler } from './registerStyleChangeHandler.js';
 export type { StyleChangeHandler } from './registerStyleChangeHandler.js';
+export { registerEventEnableStatusChangeHandler } from './registerEventStatusChangedHandler.js';
+export type { EventStatusChangeHandler } from './registerEventStatusChangedHandler.js';

--- a/packages/web-platform/web-elements-reactive/src/registerAttributeHandler.ts
+++ b/packages/web-platform/web-elements-reactive/src/registerAttributeHandler.ts
@@ -1,3 +1,5 @@
+import { generateRegister } from './generateRegister.js';
+
 /**
 // Copyright 2023 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
@@ -9,56 +11,20 @@ export type AttributeChangeHandler = (
   attributeName: string,
 ) => void;
 
-type HasAttributeChangedHandler = {
-  attributeChangedHandler?: Record<
-    string,
-    { handler: AttributeChangeHandler; noDomMeasure: boolean }
-  >;
-};
 /**
  * @param attributeName
  * @param noDomMeasure  If there are any measurement operation, the handler will be invoked after connected
  * @returns
  */
-export function registerAttributeHandler(
-  attributeName: string,
-  noDomMeasure: boolean,
-) {
-  return function<T>(
-    this: T,
-    target: AttributeChangeHandler | undefined,
-    context: ClassMemberDecoratorContext | ClassFieldDecoratorContext<T>,
-  ) {
-    if (context.kind === 'method') {
-      (
-        context as ClassMethodDecoratorContext<HasAttributeChangedHandler>
-      ).addInitializer(function() {
-        const handlerObj = {
-          handler: target!,
-          noDomMeasure,
-        };
-        this.attributeChangedHandler
-          ? (this.attributeChangedHandler[attributeName] = handlerObj)
-          : (this.attributeChangedHandler = { [attributeName]: handlerObj });
-      });
-    } else if (context.kind === 'field') {
-      return function(
-        this: HasAttributeChangedHandler,
-        value: AttributeChangeHandler,
-      ) {
-        const handlerObj = {
-          handler: value!,
-          noDomMeasure,
-        };
-        this.attributeChangedHandler
-          ? (this.attributeChangedHandler[attributeName] = handlerObj)
-          : (this.attributeChangedHandler = { [attributeName]: handlerObj });
-        return value;
-      } as any;
-    } else {
-      throw new Error(
-        `[lynx-web-components] decorator type ${context.kind} is not supported`,
-      );
-    }
-  };
-}
+export const registerAttributeHandler = generateRegister<
+  [boolean],
+  { handler: AttributeChangeHandler; noDomMeasure: boolean },
+  AttributeChangeHandler,
+  'attributeChangedHandler'
+>(
+  'attributeChangedHandler',
+  (handler, [noDomMeasure]) => ({
+    handler,
+    noDomMeasure,
+  }),
+);

--- a/packages/web-platform/web-elements-reactive/src/registerEventStatusChangedHandler.ts
+++ b/packages/web-platform/web-elements-reactive/src/registerEventStatusChangedHandler.ts
@@ -1,0 +1,24 @@
+import { generateRegister } from './generateRegister.js';
+
+/**
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+export type EventStatusChangeHandler = (
+  enable: boolean,
+  eventName: string,
+) => void;
+/**
+ * @param eventName
+ * @returns
+ */
+export const registerEventEnableStatusChangeHandler = generateRegister<
+  [],
+  EventStatusChangeHandler,
+  EventStatusChangeHandler,
+  'eventStatusChangedHandler'
+>(
+  'eventStatusChangedHandler' as const,
+  (handler) => handler,
+);

--- a/packages/web-platform/web-elements-reactive/src/registerStyleChangeHandler.ts
+++ b/packages/web-platform/web-elements-reactive/src/registerStyleChangeHandler.ts
@@ -3,38 +3,18 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
+import { generateRegister } from './generateRegister.js';
 export type StyleChangeHandler = (
   newValue: string | null,
   styleHypenName: string,
 ) => void;
 
-export function registerStyleChangeHandler(styleHyphenName: string) {
-  return function<T>(
-    this: T,
-    target: StyleChangeHandler | undefined,
-    context: ClassMemberDecoratorContext | ClassFieldDecoratorContext<T>,
-  ) {
-    if (context.kind === 'method') {
-      (
-        context as ClassMethodDecoratorContext<{
-          cssPropertyChangedHandler?: Record<string, StyleChangeHandler>;
-        }>
-      ).addInitializer(function() {
-        this.cssPropertyChangedHandler
-          ? (this.cssPropertyChangedHandler[styleHyphenName] = target!)
-          : (this.cssPropertyChangedHandler = { [styleHyphenName]: target! });
-      });
-    } else if (context.kind === 'field') {
-      return function(this: any, value: StyleChangeHandler) {
-        this.cssPropertyChangedHandler
-          ? (this.cssPropertyChangedHandler[styleHyphenName] = value!)
-          : (this.cssPropertyChangedHandler = { [styleHyphenName]: value! });
-        return value;
-      } as any;
-    } else {
-      throw new Error(
-        `[lynx-web-components] decorator type ${context.kind} is not supported`,
-      );
-    }
-  };
-}
+export const registerStyleChangeHandler = generateRegister<
+  [],
+  StyleChangeHandler,
+  StyleChangeHandler,
+  'cssPropertyChangedHandler'
+>(
+  'cssPropertyChangedHandler',
+  (handler) => handler,
+);

--- a/packages/web-platform/web-elements/src/XImage/ImageEvents.ts
+++ b/packages/web-platform/web-elements/src/XImage/ImageEvents.ts
@@ -6,37 +6,37 @@
 import {
   type AttributeReactiveClass,
   genDomGetter,
-  registerAttributeHandler,
 } from '@lynx-js/web-elements-reactive';
 import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
+import { registerEventEnableStatusChangeHandler } from '@lynx-js/web-elements-reactive';
 
 export class ImageEvents
   implements InstanceType<AttributeReactiveClass<typeof HTMLElement>>
 {
-  static observedAttributes = ['x-enable-load-event', 'x-enable-error-event'];
+  static observedAttributes = [];
   #dom: HTMLElement;
 
   #getImg = genDomGetter<HTMLImageElement>(() => this.#dom.shadowRoot!, '#img');
 
-  @registerAttributeHandler('x-enable-load-event', true)
-  #enableLoadEvent(value: string | null) {
-    if (value === null) {
-      this.#getImg().removeEventListener('load', this.#teleportLoadEvent);
-    } else {
+  @registerEventEnableStatusChangeHandler('load')
+  #enableLoadEvent(status: boolean) {
+    if (status) {
       this.#getImg().addEventListener('load', this.#teleportLoadEvent, {
         passive: true,
       });
+    } else {
+      this.#getImg().removeEventListener('load', this.#teleportLoadEvent);
     }
   }
 
-  @registerAttributeHandler('x-enable-error-event', true)
-  #enableErrorEvent(value: string | null) {
-    if (value === null) {
-      this.#getImg().removeEventListener('error', this.#teleportErrorEvent);
-    } else {
+  @registerEventEnableStatusChangeHandler('error')
+  #enableErrorEvent(status: boolean) {
+    if (status) {
       this.#getImg().addEventListener('error', this.#teleportErrorEvent, {
         passive: true,
       });
+    } else {
+      this.#getImg().removeEventListener('error', this.#teleportErrorEvent);
     }
   }
 

--- a/packages/web-platform/web-elements/src/XInput/XInputEvents.ts
+++ b/packages/web-platform/web-elements/src/XInput/XInputEvents.ts
@@ -10,11 +10,12 @@ import {
 } from '@lynx-js/web-elements-reactive';
 import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
 import { renameEvent } from '../common/renameEvent.js';
+import { registerEventEnableStatusChangeHandler } from '@lynx-js/web-elements-reactive';
 
 export class XInputEvents
   implements InstanceType<AttributeReactiveClass<typeof HTMLElement>>
 {
-  static observedAttributes = ['x-enable-input-event', 'send-composing-input'];
+  static observedAttributes = ['send-composing-input'];
   #dom: HTMLElement;
 
   #sendComposingInput = false;
@@ -28,10 +29,10 @@ export class XInputEvents
     '#form',
   );
 
-  @registerAttributeHandler('x-enable-input-event', true)
-  #handleEnableConfirmEvent(newValue: string | null) {
+  @registerEventEnableStatusChangeHandler('input')
+  #handleEnableConfirmEvent(status: boolean) {
     const input = this.#getInputElement();
-    if (newValue !== null) {
+    if (status) {
       input.addEventListener(
         'input',
         this.#teleportInput as (ev: Event) => void,

--- a/packages/web-platform/web-elements/src/XList/XListEvents.ts
+++ b/packages/web-platform/web-elements/src/XList/XListEvents.ts
@@ -13,21 +13,14 @@ import type { XList } from './XList.js';
 import { throttle } from '../common/throttle.js';
 import { bindToIntersectionObserver } from '../common/bindToIntersectionObserver.js';
 import { useScrollEnd } from '../common/constants.js';
+import { registerEventEnableStatusChangeHandler } from '@lynx-js/web-elements-reactive';
 
 export class XListEvents
   implements InstanceType<AttributeReactiveClass<typeof HTMLElement>>
 {
   static observedAttributes = [
-    'x-enable-scroll-event',
-    'x-enable-scrollend-event',
     'upper-threshold-item-count',
     'lower-threshold-item-count',
-    'x-enable-scrolltoupper-event',
-    'x-enable-scrolltolower-event',
-    'x-enable-scrolltoupperedge-event',
-    'x-enable-scrolltoloweredge-event',
-    'x-enable-snap-event',
-    'scroll-event-throttle',
   ];
 
   #dom: XList;
@@ -74,13 +67,10 @@ export class XListEvents
   }
 
   #handleUpperObserver = (entries: IntersectionObserverEntry[]) => {
-    const { isIntersecting, target } = entries[0]!;
-    const scrolltoupper = this.#dom.getAttribute(
-      'x-enable-scrolltoupper-event',
-    );
+    const { isIntersecting } = entries[0]!;
 
     if (isIntersecting) {
-      scrolltoupper !== null && this.#dom.dispatchEvent(
+      this.#dom.dispatchEvent(
         new CustomEvent('scrolltoupper', {
           ...commonComponentEventSetting,
           detail: this.#getScrollDetail(),
@@ -89,18 +79,14 @@ export class XListEvents
     }
   };
 
-  @registerAttributeHandler('upper-threshold-item-count', true)
-  @registerAttributeHandler('x-enable-scrolltoupper-event', true)
-  #updateUpperIntersectionObserver(
-    newValue: string | null,
-    oldValue: string | null,
-    name: string,
-  ) {
-    const enableScrollToUpper = this.#dom.getAttribute(
-      'x-enable-scrolltoupper-event',
-    );
+  @registerEventEnableStatusChangeHandler('scrolltoupper')
+  #updateEventSwitches = (enableScrollToUpper: boolean) => {
+    enableScrollToUpper
+      ? this.#dom.setAttribute('x-enable-scrolltoupper-event', '')
+      : this.#dom.removeAttribute('x-enable-scrolltoupper-event'); // css needs this;
+    this.#eventSwitches.scrolltoupper = enableScrollToUpper;
 
-    if (enableScrollToUpper === null) {
+    if (!enableScrollToUpper) {
       // if x-enable-scrolltoupper-event null, no need to handle upper-threshold-item-count
       if (this.#upperObserver) {
         this.#upperObserver.disconnect();
@@ -110,24 +96,20 @@ export class XListEvents
         this.#childrenObserver.disconnect();
         this.#childrenObserver = undefined;
       }
-      return;
-    }
-
-    if (!this.#upperObserver) {
-      this.#upperObserver = new IntersectionObserver(
-        this.#handleUpperObserver,
-        {
-          root: this.#getListContainer(),
-        },
-      );
-    }
-    if (!this.#childrenObserver) {
-      this.#childrenObserver = new MutationObserver(
-        this.#handleChildrenObserver,
-      );
-    }
-
-    if (name === 'x-enable-scrolltoupper-event') {
+    } else {
+      if (!this.#upperObserver) {
+        this.#upperObserver = new IntersectionObserver(
+          this.#handleUpperObserver,
+          {
+            root: this.#getListContainer(),
+          },
+        );
+      }
+      if (!this.#childrenObserver) {
+        this.#childrenObserver = new MutationObserver(
+          this.#handleChildrenObserver,
+        );
+      }
       const upperThresholdItemCount = this.#dom.getAttribute(
         'upper-threshold-item-count',
       );
@@ -145,38 +127,38 @@ export class XListEvents
         childList: true,
       });
     }
+  };
 
-    if (name === 'upper-threshold-item-count') {
-      const oldItemCount = oldValue !== null
-        ? parseFloat(oldValue)
-        : 0;
-      const oldObserverDom = oldItemCount === 0
-        ? this.#getUpperThresholdObserverDom()
-        : this.#dom.children[
-          oldItemCount - 1
-        ];
-      oldObserverDom && this.#upperObserver.unobserve(oldObserverDom);
+  @registerAttributeHandler('upper-threshold-item-count', true)
+  #handleUpperThresholdItemCountChange(
+    newValue: string | null,
+    oldValue: string | null,
+  ) {
+    const oldItemCount = oldValue !== null
+      ? parseFloat(oldValue)
+      : 0;
+    const oldObserverDom = oldItemCount === 0
+      ? this.#getUpperThresholdObserverDom()
+      : this.#dom.children[
+        oldItemCount - 1
+      ];
+    oldObserverDom && this.#upperObserver?.unobserve(oldObserverDom);
 
-      const itemCount = newValue !== null
-        ? parseFloat(newValue)
-        : 0;
-      const observerDom = itemCount === 0
-        ? this.#getUpperThresholdObserverDom()
-        : this.#dom.children[
-          itemCount - 1
-        ];
-      observerDom && this.#upperObserver.observe(observerDom);
-    }
+    const itemCount = newValue !== null
+      ? parseFloat(newValue)
+      : 0;
+    const observerDom = itemCount === 0
+      ? this.#getUpperThresholdObserverDom()
+      : this.#dom.children[
+        itemCount - 1
+      ];
+    observerDom && this.#upperObserver?.observe(observerDom);
   }
 
   #handleLowerObserver = (entries: IntersectionObserverEntry[]) => {
     const { isIntersecting } = entries[0]!;
-    const scrolltolower = this.#dom.getAttribute(
-      'x-enable-scrolltolower-event',
-    );
-
     if (isIntersecting) {
-      scrolltolower !== null && this.#dom.dispatchEvent(
+      this.#dom.dispatchEvent(
         new CustomEvent('scrolltolower', {
           ...commonComponentEventSetting,
           detail: this.#getScrollDetail(),
@@ -185,18 +167,22 @@ export class XListEvents
     }
   };
 
-  @registerAttributeHandler('lower-threshold-item-count', true)
-  @registerAttributeHandler('x-enable-scrolltolower-event', true)
-  #updateLowerIntersectionObserver(
-    newValue: string | null,
-    oldValue: string | null,
-    name: string,
-  ) {
-    const enableScrollToLower = this.#dom.getAttribute(
-      'x-enable-scrolltolower-event',
-    );
+  #eventSwitches = {
+    scroll: false,
+    scrollend: false,
+    snap: false,
+    scrolltolower: false,
+    scrolltoupper: false,
+  };
 
-    if (enableScrollToLower === null) {
+  @registerEventEnableStatusChangeHandler('scrolltolower')
+  #updateScrollToLowerEventSwitches = (enableScrollToLower: boolean) => {
+    this.#eventSwitches.scrolltolower = enableScrollToLower;
+    enableScrollToLower
+      ? this.#dom.setAttribute('x-enable-scrolltolower-event', '')
+      : this.#dom.removeAttribute('x-enable-scrolltolower-event'); // css needs this;
+
+    if (!enableScrollToLower) {
       if (this.#lowerObserver) {
         this.#lowerObserver.disconnect();
         this.#lowerObserver = undefined;
@@ -205,24 +191,20 @@ export class XListEvents
         this.#childrenObserver.disconnect();
         this.#childrenObserver = undefined;
       }
-      return;
-    }
-
-    if (!this.#lowerObserver) {
-      this.#lowerObserver = new IntersectionObserver(
-        this.#handleLowerObserver,
-        {
-          root: this.#getListContainer(),
-        },
-      );
-    }
-    if (!this.#childrenObserver) {
-      this.#childrenObserver = new MutationObserver(
-        this.#handleChildrenObserver,
-      );
-    }
-
-    if (name === 'x-enable-scrolltolower-event') {
+    } else {
+      if (!this.#lowerObserver) {
+        this.#lowerObserver = new IntersectionObserver(
+          this.#handleLowerObserver,
+          {
+            root: this.#getListContainer(),
+          },
+        );
+      }
+      if (!this.#childrenObserver) {
+        this.#childrenObserver = new MutationObserver(
+          this.#handleChildrenObserver,
+        );
+      }
       const lowerThresholdItemCount = this.#dom.getAttribute(
         'lower-threshold-item-count',
       );
@@ -241,27 +223,31 @@ export class XListEvents
         childList: true,
       });
     }
+  };
 
-    if (name === 'lower-threshold-item-count') {
-      const oldItemCount = oldValue !== null
-        ? parseFloat(oldValue)
-        : 0;
-      const oldObserverDom = oldItemCount === 0
-        ? this.#getLowerThresholdObserverDom()
-        : this.#dom.children[this.#dom.children.length - oldItemCount];
-      oldObserverDom && this.#lowerObserver.unobserve(oldObserverDom);
+  @registerAttributeHandler('lower-threshold-item-count', true)
+  #handleLowerThresholdItemCountChange(
+    newValue: string | null,
+    oldValue: string | null,
+  ) {
+    const oldItemCount = oldValue !== null
+      ? parseFloat(oldValue)
+      : 0;
+    const oldObserverDom = oldItemCount === 0
+      ? this.#getLowerThresholdObserverDom()
+      : this.#dom.children[this.#dom.children.length - oldItemCount];
+    oldObserverDom && this.#lowerObserver?.unobserve(oldObserverDom);
 
-      const itemCount = newValue !== null
-        ? parseFloat(newValue)
-        : 0;
-      const observerDom = itemCount === 0
-        ? this.#getLowerThresholdObserverDom()
-        : this.#dom.children[
-          this.#dom.children.length
-          - itemCount
-        ];
-      observerDom && this.#lowerObserver.observe(observerDom);
-    }
+    const itemCount = newValue !== null
+      ? parseFloat(newValue)
+      : 0;
+    const observerDom = itemCount === 0
+      ? this.#getLowerThresholdObserverDom()
+      : this.#dom.children[
+        this.#dom.children.length
+        - itemCount
+      ];
+    observerDom && this.#lowerObserver?.observe(observerDom);
   }
 
   #handleChildrenObserver = (mutationList: MutationRecord[]) => {
@@ -270,9 +256,7 @@ export class XListEvents
     // reset upper and lower observers
     if (mutation?.type === 'childList') {
       if (
-        this.#dom.getAttribute(
-          'x-enable-scrolltolower-event',
-        ) !== null
+        this.#eventSwitches.scrolltolower
       ) {
         // The reason why unobserve cannot be used is that the structure of list-item has changed,
         // and the list-item before the change cannot be obtained.
@@ -360,15 +344,13 @@ export class XListEvents
     );
   };
 
-  @registerAttributeHandler('x-enable-scroll-event', true)
-  @registerAttributeHandler('scroll-event-throttle', true)
-  @registerAttributeHandler('x-enable-scrollend-event', true)
-  @registerAttributeHandler('x-enable-snap-event', true)
-  #handleScrollEvents() {
-    const scroll = this.#dom.getAttribute('x-enable-scroll-event') !== null;
+  @registerEventEnableStatusChangeHandler('lynxscroll')
+  @registerEventEnableStatusChangeHandler('lynxscrollend')
+  @registerEventEnableStatusChangeHandler('snap')
+  #handleScrollEventsSwitches = (enabled: boolean, name: string) => {
+    this.#eventSwitches[name as 'scroll' | 'scrollend' | 'snap'] = enabled;
+    const { scroll, scrollend, snap } = this.#eventSwitches;
     const scrollEventThrottle = this.#dom.getAttribute('scroll-event-throttle');
-    const scrollend = this.#dom.getAttribute('x-enable-scrollend-event');
-    const snap = this.#dom.getAttribute('x-enable-snap-event');
     this.#enableScrollEnd = scrollend !== null || snap !== null;
     const listContainer = this.#getListContainer();
 
@@ -398,7 +380,7 @@ export class XListEvents
     } else {
       listContainer.removeEventListener('scrollend', this.#handleScrollEnd);
     }
-  }
+  };
 
   #handleObserver = (entries: IntersectionObserverEntry[]) => {
     const { isIntersecting, target } = entries[0]!;
@@ -422,14 +404,28 @@ export class XListEvents
     }
   };
 
-  @registerAttributeHandler('x-enable-scrolltoupperedge-event', true)
+  @registerEventEnableStatusChangeHandler('scrolltoupperedge')
+  #handleScrollToUpperEdgeEventEnable = (enabled: boolean) => {
+    enabled
+      ? this.#dom.setAttribute('x-enable-scrolltoupperedge-event', '')
+      : this.#dom.removeAttribute('x-enable-scrolltoupperedge-event'); // css needs this;
+    this.#updateUpperEdgeIntersectionObserver(enabled);
+  };
+
   #updateUpperEdgeIntersectionObserver = bindToIntersectionObserver(
     this.#getListContainer,
     this.#getUpperThresholdObserverDom,
     this.#handleObserver,
   );
 
-  @registerAttributeHandler('x-enable-scrolltoloweredge-event', true)
+  @registerEventEnableStatusChangeHandler('scrolltoloweredge')
+  #handleScrollToLowerEdgeEventEnable = (enabled: boolean) => {
+    enabled
+      ? this.#dom.setAttribute('x-enable-scrolltoloweredge-event', '')
+      : this.#dom.removeAttribute('x-enable-scrolltoloweredge-event'); // css needs this;
+    this.#updateLowerEdgeIntersectionObserver(enabled);
+  };
+
   #updateLowerEdgeIntersectionObserver = bindToIntersectionObserver(
     this.#getListContainer,
     this.#getLowerThresholdObserverDom,
@@ -437,19 +433,15 @@ export class XListEvents
   );
 
   #handleScrollEnd = () => {
-    const scrollend = this.#dom.getAttribute('x-enable-scrollend-event');
     const itemSnap = this.#dom.getAttribute('item-snap');
-    const snap = this.#dom.getAttribute('x-enable-snap-event');
 
-    if (scrollend !== null) {
-      this.#dom.dispatchEvent(
-        new CustomEvent('lynxscrollend', {
-          ...commonComponentEventSetting,
-        }),
-      );
-    }
+    this.#dom.dispatchEvent(
+      new CustomEvent('lynxscrollend', {
+        ...commonComponentEventSetting,
+      }),
+    );
 
-    if (itemSnap !== null && snap !== null) {
+    if (itemSnap !== null) {
       const children = Array.from(this.#dom.children).filter(node => {
         return node.tagName === 'LIST-ITEM';
       });

--- a/packages/web-platform/web-elements/src/XList/XListEvents.ts
+++ b/packages/web-platform/web-elements/src/XList/XListEvents.ts
@@ -168,8 +168,8 @@ export class XListEvents
   };
 
   #eventSwitches = {
-    scroll: false,
-    scrollend: false,
+    lynxscroll: false,
+    lynxscrollend: false,
     snap: false,
     scrolltolower: false,
     scrolltoupper: false,
@@ -348,10 +348,11 @@ export class XListEvents
   @registerEventEnableStatusChangeHandler('lynxscrollend')
   @registerEventEnableStatusChangeHandler('snap')
   #handleScrollEventsSwitches = (enabled: boolean, name: string) => {
-    this.#eventSwitches[name as 'scroll' | 'scrollend' | 'snap'] = enabled;
-    const { scroll, scrollend, snap } = this.#eventSwitches;
+    this.#eventSwitches[name as 'lynxscroll' | 'lynxscrollend' | 'snap'] =
+      enabled;
+    const { lynxscroll, lynxscrollend, snap } = this.#eventSwitches;
     const scrollEventThrottle = this.#dom.getAttribute('scroll-event-throttle');
-    this.#enableScrollEnd = scrollend !== null || snap !== null;
+    this.#enableScrollEnd = lynxscrollend !== null || snap !== null;
     const listContainer = this.#getListContainer();
 
     // cancel the previous listener first

--- a/packages/web-platform/web-elements/src/XSvg/XSvg.ts
+++ b/packages/web-platform/web-elements/src/XSvg/XSvg.ts
@@ -44,7 +44,6 @@ export class XSvgFeatures
   );
 
   #fireLoadEvent = () => {
-    if (this.#dom.getAttribute('x-enable-load-event') === null) return;
     const { width, height } = this.#loadEventInvoker;
     this.#dom.dispatchEvent(
       new CustomEvent('load', {

--- a/packages/web-platform/web-elements/src/XSwiper/XSwiperCircular.ts
+++ b/packages/web-platform/web-elements/src/XSwiper/XSwiperCircular.ts
@@ -159,9 +159,8 @@ export class XSwiperCircular
 
   @registerAttributeHandler('circular', false)
   #handleCircular(newVal: string | null) {
-    this.#listeners.forEach((l) => l(newVal));
+    this.#listeners.forEach((l) => l(newVal != null));
     if (newVal !== null) {
-      this.#dom.setAttribute('x-enable-change-event-for-indicator', '');
       this.#changeEventHandler({
         detail: {
           current: this.#dom.current,

--- a/packages/web-platform/web-elements/src/XSwiper/XSwiperEvents.ts
+++ b/packages/web-platform/web-elements/src/XSwiper/XSwiperEvents.ts
@@ -7,22 +7,16 @@ import {
   type AttributeReactiveClass,
   bindSwitchToEventListener,
   genDomGetter,
-  registerAttributeHandler,
 } from '@lynx-js/web-elements-reactive';
 import type { XSwiper } from './XSwiper.js';
 import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
 import { useScrollEnd } from '../common/constants.js';
+import { registerEventEnableStatusChangeHandler } from '@lynx-js/web-elements-reactive';
 
 export class XSwipeEvents
   implements InstanceType<AttributeReactiveClass<typeof XSwiper>>
 {
-  static observedAttributes = [
-    'x-enable-scrollstart-event',
-    'x-enable-scrollend-event',
-    'x-enable-change-event',
-    'x-enable-change-event-for-indicator',
-    'x-enable-transition-event',
-  ];
+  static observedAttributes = [];
   readonly #dom: XSwiper;
   #current: number = 0;
   #pervScrollPosition: number = 0;
@@ -37,7 +31,7 @@ export class XSwipeEvents
     '#content',
   ).bind(this);
 
-  @registerAttributeHandler('x-enable-transition-event', true)
+  @registerEventEnableStatusChangeHandler('transition')
   #handleEnableTransitionEvent = bindSwitchToEventListener(
     this.#getContentContainer,
     'scroll',
@@ -165,24 +159,30 @@ export class XSwipeEvents
     ),
   ];
 
-  @registerAttributeHandler('x-enable-scrollstart-event', false)
-  @registerAttributeHandler('x-enable-scrollend-event', false)
-  @registerAttributeHandler('x-enable-change-event', false)
-  @registerAttributeHandler('x-enable-change-event-for-indicator', false)
-  #enableScrollEventProcessor() {
-    const enableScrollstartEvent =
-      this.#dom.getAttribute('x-enable-scrollstart-event') !== null;
-    const enableScrollendEvent =
-      this.#dom.getAttribute('x-enable-scrollend-event') !== null;
-    const enableChangeEvent =
-      this.#dom.getAttribute('x-enable-change-event') !== null;
-    const enableChangeforindicatorEvent =
-      this.#dom.getAttribute('x-enable-change-event-for-indicator') !== null;
-    const enableEvent = enableChangeEvent
-      || enableScrollendEvent
-      || enableScrollstartEvent
-      || enableChangeforindicatorEvent;
-    this.#listeners.forEach((l) => l(enableEvent ? '' : null));
+  #eventSwitches = {
+    scrollstart: false,
+    scrollend: false,
+    change: false,
+    'change-event-for-indicator': false,
+  };
+
+  @registerEventEnableStatusChangeHandler('scrollstart')
+  @registerEventEnableStatusChangeHandler('scrollend')
+  @registerEventEnableStatusChangeHandler('change')
+  @registerEventEnableStatusChangeHandler('change-event-for-indicator')
+  #enableScrollEventProcessor(value: boolean, eventName: string) {
+    this
+      .#eventSwitches[
+        eventName as
+          | 'scrollstart'
+          | 'scrollend'
+          | 'change'
+          | 'change-event-for-indicator'
+      ] = value;
+    const { scrollend, scrollstart, change } = this.#eventSwitches;
+    const changeEventEnabled = change || scrollend || scrollstart
+      || this.#eventSwitches['change-event-for-indicator'];
+    this.#listeners.forEach((l) => l(changeEventEnabled));
   }
 
   connectedCallback(): void {

--- a/packages/web-platform/web-elements/src/XSwiper/XSwiperEvents.ts
+++ b/packages/web-platform/web-elements/src/XSwiper/XSwiperEvents.ts
@@ -161,13 +161,13 @@ export class XSwipeEvents
 
   #eventSwitches = {
     scrollstart: false,
-    scrollend: false,
+    lynxscrollend: false,
     change: false,
     'change-event-for-indicator': false,
   };
 
   @registerEventEnableStatusChangeHandler('scrollstart')
-  @registerEventEnableStatusChangeHandler('scrollend')
+  @registerEventEnableStatusChangeHandler('lynxscrollend')
   @registerEventEnableStatusChangeHandler('change')
   @registerEventEnableStatusChangeHandler('change-event-for-indicator')
   #enableScrollEventProcessor(value: boolean, eventName: string) {
@@ -175,12 +175,12 @@ export class XSwipeEvents
       .#eventSwitches[
         eventName as
           | 'scrollstart'
-          | 'scrollend'
+          | 'lynxscrollend'
           | 'change'
           | 'change-event-for-indicator'
       ] = value;
-    const { scrollend, scrollstart, change } = this.#eventSwitches;
-    const changeEventEnabled = change || scrollend || scrollstart
+    const { lynxscrollend, scrollstart, change } = this.#eventSwitches;
+    const changeEventEnabled = change || lynxscrollend || scrollstart
       || this.#eventSwitches['change-event-for-indicator'];
     this.#listeners.forEach((l) => l(changeEventEnabled));
   }

--- a/packages/web-platform/web-elements/src/XSwiper/XSwiperIndicator.ts
+++ b/packages/web-platform/web-elements/src/XSwiper/XSwiperIndicator.ts
@@ -114,7 +114,6 @@ export class XSwiperIndicator
       subtree: false,
     });
     if (!CSS.supports('timeline-scope', '--a, --b')) {
-      this.#dom.setAttribute('x-enable-change-event-for-indicator', '');
       this.#dom.addEventListener(
         'change',
         (({ detail }: CustomEvent<{ current: number }>) => {

--- a/packages/web-platform/web-elements/src/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/XText/XTextTruncation.ts
@@ -11,6 +11,7 @@ import {
 } from '@lynx-js/web-elements-reactive';
 import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
 import type { XText } from './XText.js';
+import { registerEventEnableStatusChangeHandler } from '@lynx-js/web-elements-reactive';
 type NodeInfo = {
   node: Text | Element;
   start: number;
@@ -29,7 +30,6 @@ export class XTextTruncation
     'text-maxlength',
     'text-maxline',
     'tail-color-convert',
-    'x-enable-layout-event',
   ];
   #scheduledTextLayout = false;
   #componentConnected: boolean = false;
@@ -317,9 +317,9 @@ export class XTextTruncation
     this.#layoutText();
   }
 
-  @registerAttributeHandler('x-enable-layout-event', true)
-  #handleEnableLayoutEvent(newVal: string | null) {
-    this.#enableLayoutEvent = newVal !== null;
+  @registerEventEnableStatusChangeHandler('layout')
+  #handleEnableLayoutEvent(status: boolean) {
+    this.#enableLayoutEvent = status;
   }
 
   #sendLayoutEvent(truncateAt?: number) {
@@ -387,7 +387,7 @@ export class XTextTruncation
   connectedCallback(): void {
     this.#componentConnected = true;
     this.#handleEnableLayoutEvent(
-      this.#dom.getAttribute('x-enable-layout-event'),
+      this.#enableLayoutEvent,
     );
     document.fonts.ready.then(() => {
       this.#handleAttributeChange();

--- a/packages/web-platform/web-elements/src/XTextarea/XTextareaEvents.ts
+++ b/packages/web-platform/web-elements/src/XTextarea/XTextareaEvents.ts
@@ -10,11 +10,12 @@ import {
 } from '@lynx-js/web-elements-reactive';
 import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
 import { renameEvent } from '../common/renameEvent.js';
+import { registerEventEnableStatusChangeHandler } from '@lynx-js/web-elements-reactive';
 
 export class XTextareaEvents
   implements InstanceType<AttributeReactiveClass<typeof HTMLElement>>
 {
-  static observedAttributes = ['x-enable-input-event', 'send-composing-input'];
+  static observedAttributes = ['send-composing-input'];
   #dom: HTMLElement;
 
   #sendComposingInput = false;
@@ -28,10 +29,10 @@ export class XTextareaEvents
     '#form',
   );
 
-  @registerAttributeHandler('x-enable-input-event', true)
-  #handleEnableConfirmEvent(newValue: string | null) {
+  @registerEventEnableStatusChangeHandler('input')
+  #handleEnableConfirmEvent(status: boolean) {
     const textareaElement = this.#getTextareaElement();
-    if (newValue !== null) {
+    if (status) {
       textareaElement.addEventListener(
         'input',
         this.#teleportInput as (ev: Event) => void,

--- a/packages/web-platform/web-elements/src/XViewpagerNg/XViewpagerNgEvents.ts
+++ b/packages/web-platform/web-elements/src/XViewpagerNg/XViewpagerNgEvents.ts
@@ -6,24 +6,20 @@
 import {
   type AttributeReactiveClass,
   genDomGetter,
-  registerAttributeHandler,
 } from '@lynx-js/web-elements-reactive';
 import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
 import type { XViewpagerNg } from './XViewpagerNg.js';
 import { useScrollEnd } from '../common/constants.js';
+import { registerEventEnableStatusChangeHandler } from '@lynx-js/web-elements-reactive';
 
 export class XViewpagerNgEvents
   implements InstanceType<AttributeReactiveClass<typeof XViewpagerNg>>
 {
-  static observedAttributes = [
-    'x-enable-change-event',
-    'x-enable-offsetchange-event',
-  ];
+  static observedAttributes = [];
   readonly #dom: XViewpagerNg;
   #isDragging: boolean = false;
   #connected = false;
   #currentIndex = 0;
-  #enableChange = false;
   #debounceScrollForMockingScrollEnd?: ReturnType<typeof setTimeout>;
 
   constructor(dom: XViewpagerNg) {
@@ -81,16 +77,22 @@ export class XViewpagerNgEvents
     this.#isDragging = false;
   };
 
-  @registerAttributeHandler('x-enable-change-event', true)
-  @registerAttributeHandler('x-enable-offsetchange-event', true)
-  #enableScrollEventListener() {
-    this.#enableChange =
-      this.#dom.getAttribute('x-enable-change-event') !== null;
-    const enableOffsetChange =
-      this.#dom.getAttribute('x-enable-offsetchange-event') !== null;
+  #enableChange = false;
+  @registerEventEnableStatusChangeHandler('change')
+  #enableChangeEvent(status: boolean) {
+    this.#enableChange = status;
+    this.#enableScrollEventListener();
+  }
 
+  #enableOffsetChange: boolean = false;
+  @registerEventEnableStatusChangeHandler('offsetchange')
+  #enableOffsetChangeEvent(status: boolean) {
+    this.#enableChange = status;
+    this.#enableScrollEventListener();
+  }
+  #enableScrollEventListener() {
     const scrollContainer = this.#getScrollContainer();
-    if (enableOffsetChange !== null || this.#enableChange) {
+    if (this.#enableOffsetChange || this.#enableChange) {
       scrollContainer.addEventListener(
         'scroll',
         this.#scrollHandler,

--- a/packages/web-platform/web-elements/src/common/Exposure.ts
+++ b/packages/web-platform/web-elements/src/common/Exposure.ts
@@ -29,8 +29,6 @@ export interface ExposureEvent {
 
 export class LynxExposure {
   static readonly observedAttributes = [
-    'x-enable-uiappear-event',
-    'x-enable-uidisappear-event',
     'exposure-id',
     'exposure-area',
     'exposure-screen-margin-top',
@@ -42,6 +40,9 @@ export class LynxExposure {
     'exposure-ui-margin-bottom',
     'exposure-ui-margin-left',
   ];
+
+  #uiAppearEnabled = false;
+  #uiDisappearEnabled = false;
 
   readonly #currentElement: HTMLElement;
 
@@ -62,9 +63,8 @@ export class LynxExposure {
 
   get #exposureEnabled() {
     return (
-      this.#currentElement.getAttribute('x-enable-uiappear-event') !== null
-      || this.#currentElement.getAttribute('x-enable-uidisappear-event')
-        !== null
+      this.#uiAppearEnabled
+      || this.#uiDisappearEnabled
       || this.#currentElement.getAttribute('exposure-id') !== null
     );
   }
@@ -105,6 +105,17 @@ export class LynxExposure {
       return;
     },
   });
+
+  eventStatusChangedHandler = {
+    'uiappear': (status: boolean) => {
+      this.#uiAppearEnabled = status;
+      this.onExposureParamsChanged();
+    },
+    'uidisappear': (status: boolean) => {
+      this.#uiDisappearEnabled = status;
+      this.onExposureParamsChanged();
+    },
+  };
 
   #updateExposure() {
     const newParams: ExposureParameters = {

--- a/packages/web-platform/web-elements/src/common/bindToIntersectionObserver.ts
+++ b/packages/web-platform/web-elements/src/common/bindToIntersectionObserver.ts
@@ -8,7 +8,7 @@ export function bindToIntersectionObserver(
   callback: IntersectionObserverCallback,
 ) {
   let observer: IntersectionObserver | undefined;
-  return (newVal: string | null) => {
+  return (newVal: string | boolean | null) => {
     if (newVal !== null) {
       if (!observer) {
         observer = new IntersectionObserver(callback, {

--- a/packages/web-platform/web-elements/tsconfig.json
+++ b/packages/web-platform/web-elements/tsconfig.json
@@ -9,4 +9,9 @@
     "noUnusedLocals": false,
   },
   "include": ["src"],
+  "references": [
+    {
+      "path": "../web-elements-reactive",
+    },
+  ],
 }

--- a/packages/web-platform/web-tests/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-tests/tests/web-elements.spec.ts
@@ -532,7 +532,7 @@ test.describe('web-elements test suite', () => {
       await page.evaluate(() => {
         document.querySelector('scroll-view')!.scrollTop = 200;
       });
-      await wait(200);
+      await wait(300);
       const scrollEvents = await events.jsonValue();
       expect(scrollEvents.length, 'should only have one scroll end event').toBe(
         1,

--- a/packages/web-platform/web-tests/tests/web-elements/filter-image/event-error.html
+++ b/packages/web-platform/web-tests/tests/web-elements/filter-image/event-error.html
@@ -24,12 +24,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    document.querySelector('#target').addEventListener('error', (ev) => {
-      ev.target.style.setProperty('background-color', 'green');
-    });
-    document.querySelector('#target').setAttribute('src', '/unknown/path');
-    </script>
     <style>
     @import url("../../common.css");
     </style>
@@ -37,11 +31,16 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('#target').addEventListener('error', (ev) => {
+      ev.target.style.setProperty('background-color', 'green');
+    });
+    document.querySelector('#target').setAttribute('src', '/unknown/path');
+    </script>
     <x-view class="page">
       <filter-image
         src="../../resources/firefox-logo.png"
         id="target"
-        x-enable-error-event
         style="width:100px; height:400px; background-color: aquamarine;"
       >
       </filter-image>

--- a/packages/web-platform/web-tests/tests/web-elements/filter-image/event-load.html
+++ b/packages/web-platform/web-tests/tests/web-elements/filter-image/event-load.html
@@ -24,6 +24,13 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
+    <style>
+    @import url("../../common.css");
+    </style>
+  </head>
+
+  <body>
+    <script src="/web-elements.js" defer></script>
     <script type="module">
     document.querySelector('#target').addEventListener('load', (ev) => {
       if (ev.detail.height === 984 && ev.detail.width === 953) {
@@ -35,17 +42,9 @@
       '../../resources/firefox-logo.png',
     );
     </script>
-    <style>
-    @import url("../../common.css");
-    </style>
-  </head>
-
-  <body>
-    <script src="/web-elements.js" defer></script>
     <x-view class="page">
       <filter-image
         id="target"
-        x-enable-load-event
         style="width:100px; height:400px; background-color: aquamarine;"
       >
       </filter-image>

--- a/packages/web-platform/web-tests/tests/web-elements/scroll-view/event-scroll.html
+++ b/packages/web-platform/web-tests/tests/web-elements/scroll-view/event-scroll.html
@@ -40,7 +40,6 @@ LICENSE file in the root directory of this source tree. -->
       <scroll-view
         style="width:300px; height:400px; background-color: wheat;"
         scroll-y
-        x-enable-scroll-event
       >
         <x-view style="background-color:aqua;"> </x-view>
         <x-view style="background-color:orange;"> </x-view>

--- a/packages/web-platform/web-tests/tests/web-elements/scroll-view/event-scrollend.html
+++ b/packages/web-platform/web-tests/tests/web-elements/scroll-view/event-scrollend.html
@@ -40,7 +40,6 @@ LICENSE file in the root directory of this source tree. -->
       <scroll-view
         style="width:300px; height:400px; background-color: wheat;"
         scroll-y
-        x-enable-scrollend-event
       >
         <x-view style="background-color:aqua;"> </x-view>
         <x-view style="background-color:orange;"> </x-view>

--- a/packages/web-platform/web-tests/tests/web-elements/scroll-view/event-scrolltolower.html
+++ b/packages/web-platform/web-tests/tests/web-elements/scroll-view/event-scrolltolower.html
@@ -23,11 +23,6 @@ LICENSE file in the root directory of this source tree. -->
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    document.querySelector('scroll-view').addEventListener('scrolltolower', () => {
-      document.querySelector('div').style.setProperty('background-color', 'green');
-    });
-    </script>
     <style>
     x-view {
       width: 100%;
@@ -38,13 +33,17 @@ LICENSE file in the root directory of this source tree. -->
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('scroll-view').addEventListener('scrolltolower', () => {
+      document.querySelector('div').style.setProperty('background-color', 'green');
+    });
+    </script>
     <x-view
       style="height:100vh;width: 100vw; display:flex; --lynx-display:flex;--lynx-display-toggle:var(--lynx-display-flex); flex-direction: column;"
     >
       <scroll-view
         style="width:300px; height:400px; background-color: wheat;"
         scroll-y
-        x-enable-scrolltolower-event
         lower-threshold="100"
       >
         <x-view style="background-color:aqua;"> </x-view>

--- a/packages/web-platform/web-tests/tests/web-elements/scroll-view/scrollable-even-inline-overflow-visible.html
+++ b/packages/web-platform/web-tests/tests/web-elements/scroll-view/scrollable-even-inline-overflow-visible.html
@@ -42,7 +42,6 @@ LICENSE file in the root directory of this source tree. -->
         style="width:300px; height:300px;"
         scroll-y
         bounces
-        x-enable-scroll-event
       >
         <x-view style="background-color:aqua;"> </x-view>
         <x-view style="background-color:slateblue;"> </x-view>

--- a/packages/web-platform/web-tests/tests/web-elements/x-foldview-ng/event-offset-granularity.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-foldview-ng/event-offset-granularity.html
@@ -39,7 +39,6 @@ LICENSE file in the root directory of this source tree. -->
     >
       <x-foldview-ng
         style="width:80%; height:400px; background-color: wheat;display:flex; --lynx-display:flex;--lynx-display-toggle:var(--lynx-display-flex); flex-direction: column;"
-        x-enable-scroll-event
         granularity="100"
       >
         <x-foldview-header-ng

--- a/packages/web-platform/web-tests/tests/web-elements/x-image/event-error.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-image/event-error.html
@@ -24,12 +24,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    document.querySelector('#target').addEventListener('error', (ev) => {
-      ev.target.style.setProperty('background-color', 'green');
-    });
-    document.querySelector('#target').setAttribute('src', '/unknown/path');
-    </script>
     <style>
     @import url("../../common.css");
     </style>
@@ -37,11 +31,16 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('#target').addEventListener('error', (ev) => {
+      ev.target.style.setProperty('background-color', 'green');
+    });
+    document.querySelector('#target').setAttribute('src', '/unknown/path');
+    </script>
     <x-view class="page">
       <x-image
         src="../../resources/firefox-logo.png"
         id="target"
-        x-enable-error-event
         style="width:100px; height:400px; background-color: aquamarine;"
       >
       </x-image>

--- a/packages/web-platform/web-tests/tests/web-elements/x-image/event-load.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-image/event-load.html
@@ -24,6 +24,13 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
+    <style>
+    @import url("../../common.css");
+    </style>
+  </head>
+
+  <body>
+    <script src="/web-elements.js" defer></script>
     <script type="module">
     document.querySelector('#target').addEventListener('load', (ev) => {
       if (ev.detail.height === 984 && ev.detail.width === 953) {
@@ -35,17 +42,9 @@
       '../../resources/firefox-logo.png',
     );
     </script>
-    <style>
-    @import url("../../common.css");
-    </style>
-  </head>
-
-  <body>
-    <script src="/web-elements.js" defer></script>
     <x-view class="page">
       <x-image
         id="target"
-        x-enable-load-event
         style="width:100px; height:400px; background-color: aquamarine;"
       >
       </x-image>

--- a/packages/web-platform/web-tests/tests/web-elements/x-input/event-input.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-input/event-input.html
@@ -37,7 +37,6 @@
         id="target"
         value="hello"
         style="height:50px; width:200px;border: 1px;"
-        x-enable-input-event
       ></x-input>
     </x-view>
   </body>

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/auto-scroll.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/auto-scroll.html
@@ -24,14 +24,6 @@
       rel="stylesheet"
     />
 
-    <script type="module">
-    document.querySelector('#autoScroll').addEventListener('click', () => {
-      document.querySelector('x-list').autoScroll({ rate: 100, start: true });
-    });
-    document.querySelector('x-list').addEventListener('lynxscroll', (e) => {
-      console.log(e);
-    });
-    </script>
     <style>
     @import url("../../common.css");
     x-list {
@@ -51,10 +43,17 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('#autoScroll').addEventListener('click', () => {
+      document.querySelector('x-list').autoScroll({ rate: 100, start: true });
+    });
+    document.querySelector('x-list').addEventListener('lynxscroll', (e) => {
+      console.log(e);
+    });
+    </script>
     <x-view class="page">
       <x-list
         list-type="single"
-        x-enable-scroll-event
         scroll-event-throttle="1000"
       >
         <list-item item-key="1" id="1"><x-view class="item"

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/event-layoutcomplete.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/event-layoutcomplete.html
@@ -24,11 +24,6 @@
       rel="stylesheet"
     />
 
-    <script type="module">
-    document.querySelector('x-list').addEventListener('layoutcomplete', (e) => {
-      console.log(e);
-    });
-    </script>
     <style>
     @import url("../../common.css");
     x-list {
@@ -48,6 +43,11 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('x-list').addEventListener('layoutcomplete', (e) => {
+      console.log(e);
+    });
+    </script>
     <x-view class="page">
       <x-list list-type="single">
         <list-item item-key="1" id="1"><x-view class="item"

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/event-lower-load-more.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/event-lower-load-more.html
@@ -24,21 +24,6 @@
       rel="stylesheet"
     />
 
-    <script type="module">
-    document.querySelector('#target').addEventListener('click', () => {
-      const newItem = document.createElement('list-item');
-      newItem.setAttribute('item-key', 21);
-      newItem.setAttribute('id', 21);
-      const textElement = document.createElement('x-text');
-      textElement.textContent = 21;
-      newItem.appendChild(textElement);
-
-      document.querySelector('x-list').appendChild(newItem);
-    });
-    document.querySelector('x-list').addEventListener('scrolltolower', (e) => {
-      console.log(e);
-    });
-    </script>
     <style>
     @import url("../../common.css");
     x-list {
@@ -58,12 +43,25 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('#target').addEventListener('click', () => {
+      const newItem = document.createElement('list-item');
+      newItem.setAttribute('item-key', 21);
+      newItem.setAttribute('id', 21);
+      const textElement = document.createElement('x-text');
+      textElement.textContent = 21;
+      newItem.appendChild(textElement);
+
+      document.querySelector('x-list').appendChild(newItem);
+    });
+    document.querySelector('x-list').addEventListener('scrolltolower', (e) => {
+      console.log(e);
+    });
+    </script>
     <x-view class="page">
       <x-text id="target">添加 list-item</x-text>
       <x-list
         list-type="single"
-        x-enable-scrolltoupper-event
-        x-enable-scrolltolower-event
         lower-threshold-item-count="2"
       >
         <list-item item-key="1" id="1"><x-view class="item"

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/event-lower-threshold-item-count.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/event-lower-threshold-item-count.html
@@ -23,14 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    document.querySelector('x-list').addEventListener('scrolltoupper', (e) => {
-      console.log(e);
-    });
-    document.querySelector('x-list').addEventListener('scrolltolower', (e) => {
-      console.log(e);
-    });
-    </script>
     <style>
     @import url("../../common.css");
     x-list {
@@ -50,11 +42,17 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('x-list').addEventListener('scrolltoupper', (e) => {
+      console.log(e);
+    });
+    document.querySelector('x-list').addEventListener('scrolltolower', (e) => {
+      console.log(e);
+    });
+    </script>
     <x-view class="page">
       <x-list
         list-type="single"
-        x-enable-scrolltoupper-event
-        x-enable-scrolltolower-event
         lower-threshold-item-count="10"
       >
         <list-item item-key="1" id="1"><x-view class="item"

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/event-scroll.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/event-scroll.html
@@ -23,14 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    document.querySelector('x-list').addEventListener('lynxscroll', (e) => {
-      console.log(e);
-    });
-    document.querySelector('x-list').addEventListener('lynxscrollend', (e) => {
-      console.log(e);
-    });
-    </script>
     <style>
     @import url("../../common.css");
     x-list {
@@ -50,8 +42,16 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('x-list').addEventListener('lynxscroll', (e) => {
+      console.log(e);
+    });
+    document.querySelector('x-list').addEventListener('lynxscrollend', (e) => {
+      console.log(e);
+    });
+    </script>
     <x-view class="page">
-      <x-list list-type="single" x-enable-scroll-event x-enable-scrollend-event>
+      <x-list list-type="single">
         <list-item item-key="1" id="1"><x-view class="item"
           >1</x-view></list-item>
         <list-item item-key="2" id="2"><x-view class="item"

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/event-scrolltolower.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/event-scrolltolower.html
@@ -23,11 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    document.querySelector('x-list').addEventListener('scrolltolower', (e) => {
-      console.log(e);
-    });
-    </script>
     <style>
     @import url("../../common.css");
     x-list {
@@ -47,8 +42,13 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('x-list').addEventListener('scrolltolower', (e) => {
+      console.log(e);
+    });
+    </script>
     <x-view class="page">
-      <x-list list-type="single" x-enable-scrolltolower-event>
+      <x-list list-type="single">
         <list-item item-key="1" id="1"><x-view class="item"
           >1</x-view></list-item>
         <list-item item-key="2" id="2"><x-view class="item"

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/event-scrolltoupper.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/event-scrolltoupper.html
@@ -23,11 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    document.querySelector('x-list').addEventListener('scrolltoupper', (e) => {
-      console.log(e);
-    });
-    </script>
     <style>
     @import url("../../common.css");
     x-list {
@@ -47,8 +42,13 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('x-list').addEventListener('scrolltoupper', (e) => {
+      console.log(e);
+    });
+    </script>
     <x-view class="page">
-      <x-list list-type="single" x-enable-scrolltoupper-event>
+      <x-list list-type="single">
         <list-item item-key="1" id="1"><x-view class="item"
           >1</x-view></list-item>
         <list-item item-key="2" id="2"><x-view class="item"

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/event-snap.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/event-snap.html
@@ -24,11 +24,6 @@
       rel="stylesheet"
     />
 
-    <script type="module">
-    document.querySelector('x-list').addEventListener('snap', (e) => {
-      console.log(e);
-    });
-    </script>
     <style>
     @import url("../../common.css");
     x-list {
@@ -48,8 +43,13 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('x-list').addEventListener('snap', (e) => {
+      console.log(e);
+    });
+    </script>
     <x-view class="page">
-      <x-list list-type="single" x-enable-snap-event item-snap>
+      <x-list list-type="single" item-snap>
         <list-item item-key="1" id="1"><x-view class="item"
           >1</x-view></list-item>
         <list-item item-key="2" id="2"><x-view class="item"

--- a/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/enable-auto-loadmore-false.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/enable-auto-loadmore-false.html
@@ -23,14 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    const content = document.getElementById('content');
-    const refreshView = document.querySelector('x-refresh-view');
-    const refreshFooter = document.querySelector('x-refresh-footer');
-    refreshView.addEventListener('startloadmore', () => {
-      content.style.backgroundColor = 'chartreuse';
-    });
-    </script>
     <style>
     .refresh-view {
       width: 100%;
@@ -78,10 +70,17 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    const content = document.getElementById('content');
+    const refreshView = document.querySelector('x-refresh-view');
+    const refreshFooter = document.querySelector('x-refresh-footer');
+    refreshView.addEventListener('startloadmore', () => {
+      content.style.backgroundColor = 'chartreuse';
+    });
+    </script>
     <x-refresh-view
       class="refresh-view"
       id="refresh-view"
-      x-enable-startloadmore-event
       enable-auto-loadmore="false"
     >
       <x-refresh-header class="refresh-header"> </x-refresh-header>

--- a/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/enable-auto-loadmore-true.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/enable-auto-loadmore-true.html
@@ -23,14 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    const content = document.getElementById('content');
-    const refreshView = document.querySelector('x-refresh-view');
-    const refreshFooter = document.querySelector('x-refresh-footer');
-    refreshView.addEventListener('startloadmore', () => {
-      content.style.backgroundColor = 'chartreuse';
-    });
-    </script>
     <style>
     .refresh-view {
       width: 100%;
@@ -78,10 +70,17 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    const content = document.getElementById('content');
+    const refreshView = document.querySelector('x-refresh-view');
+    const refreshFooter = document.querySelector('x-refresh-footer');
+    refreshView.addEventListener('startloadmore', () => {
+      content.style.backgroundColor = 'chartreuse';
+    });
+    </script>
     <x-refresh-view
       class="refresh-view"
       id="refresh-view"
-      x-enable-startloadmore-event
       enable-auto-loadmore="true"
     >
       <x-refresh-header class="refresh-header"> </x-refresh-header>

--- a/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/enable-loadmore-false.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/enable-loadmore-false.html
@@ -23,20 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    const content = document.getElementById('content');
-    const refreshView = document.querySelector('x-refresh-view');
-    const refreshFooter = document.querySelector('x-refresh-footer');
-    const observer = new IntersectionObserver((e) => {
-      if (e[0].isIntersecting) {
-        content.style.backgroundColor = 'chartreuse';
-      }
-    }, {
-      root: refreshView,
-      threshold: 1,
-    });
-    observer.observe(refreshFooter);
-    </script>
     <style>
     .refresh-view {
       width: 100%;
@@ -84,6 +70,20 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    const content = document.getElementById('content');
+    const refreshView = document.querySelector('x-refresh-view');
+    const refreshFooter = document.querySelector('x-refresh-footer');
+    const observer = new IntersectionObserver((e) => {
+      if (e[0].isIntersecting) {
+        content.style.backgroundColor = 'chartreuse';
+      }
+    }, {
+      root: refreshView,
+      threshold: 1,
+    });
+    observer.observe(refreshFooter);
+    </script>
     <x-refresh-view
       class="refresh-view"
       id="refresh-view"

--- a/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/enable-refresh-false.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/enable-refresh-false.html
@@ -23,20 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    const content = document.getElementById('content');
-    const refreshView = document.querySelector('x-refresh-view');
-    const refreshFooter = document.querySelector('x-refresh-footer');
-    const observer = new IntersectionObserver((e) => {
-      if (e[0].isIntersecting) {
-        content.style.backgroundColor = 'chartreuse';
-      }
-    }, {
-      root: refreshView,
-      threshold: 1,
-    });
-    observer.observe(refreshFooter);
-    </script>
     <style>
     .refresh-view {
       width: 100%;
@@ -84,6 +70,20 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    const content = document.getElementById('content');
+    const refreshView = document.querySelector('x-refresh-view');
+    const refreshFooter = document.querySelector('x-refresh-footer');
+    const observer = new IntersectionObserver((e) => {
+      if (e[0].isIntersecting) {
+        content.style.backgroundColor = 'chartreuse';
+      }
+    }, {
+      root: refreshView,
+      threshold: 1,
+    });
+    observer.observe(refreshFooter);
+    </script>
     <x-refresh-view
       class="refresh-view"
       id="refresh-view"

--- a/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/event-footerreleased.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/event-footerreleased.html
@@ -23,14 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    const content = document.getElementById('content');
-    const refreshView = document.querySelector('x-refresh-view');
-    const refreshFooter = document.querySelector('x-refresh-footer');
-    refreshView.addEventListener('footerreleased', () => {
-      content.style.backgroundColor = 'chartreuse';
-    });
-    </script>
     <style>
     .refresh-view {
       width: 100%;
@@ -78,10 +70,17 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    const content = document.getElementById('content');
+    const refreshView = document.querySelector('x-refresh-view');
+    const refreshFooter = document.querySelector('x-refresh-footer');
+    refreshView.addEventListener('footerreleased', () => {
+      content.style.backgroundColor = 'chartreuse';
+    });
+    </script>
     <x-refresh-view
       class="refresh-view"
       id="refresh-view"
-      x-enable-footerreleased-event
     >
       <x-refresh-header class="refresh-header"> </x-refresh-header>
 

--- a/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/event-headeroffset.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/event-headeroffset.html
@@ -23,14 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    const content = document.getElementById('content');
-    const refreshView = document.querySelector('x-refresh-view');
-    const refreshFooter = document.querySelector('x-refresh-footer');
-    refreshView.addEventListener('headeroffset', () => {
-      content.style.backgroundColor = 'chartreuse';
-    });
-    </script>
     <style>
     .refresh-view {
       width: 100%;
@@ -78,10 +70,17 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    const content = document.getElementById('content');
+    const refreshView = document.querySelector('x-refresh-view');
+    const refreshFooter = document.querySelector('x-refresh-footer');
+    refreshView.addEventListener('headeroffset', () => {
+      content.style.backgroundColor = 'chartreuse';
+    });
+    </script>
     <x-refresh-view
       class="refresh-view"
       id="refresh-view"
-      x-enable-headeroffset-event
     >
       <x-refresh-header class="refresh-header"> </x-refresh-header>
 

--- a/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/event-headerreleased.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/event-headerreleased.html
@@ -23,14 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    const content = document.getElementById('content');
-    const refreshView = document.querySelector('x-refresh-view');
-    const refreshFooter = document.querySelector('x-refresh-footer');
-    refreshView.addEventListener('headerreleased', () => {
-      content.style.backgroundColor = 'chartreuse';
-    });
-    </script>
     <style>
     .refresh-view {
       width: 100%;
@@ -78,10 +70,17 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    const content = document.getElementById('content');
+    const refreshView = document.querySelector('x-refresh-view');
+    const refreshFooter = document.querySelector('x-refresh-footer');
+    refreshView.addEventListener('headerreleased', () => {
+      content.style.backgroundColor = 'chartreuse';
+    });
+    </script>
     <x-refresh-view
       class="refresh-view"
       id="refresh-view"
-      x-enable-headerreleased-event
     >
       <x-refresh-header class="refresh-header"> </x-refresh-header>
 

--- a/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/event-headershow.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-refresh-view/event-headershow.html
@@ -23,14 +23,6 @@
       href="/web-elements.css"
       rel="stylesheet"
     />
-    <script type="module">
-    const content = document.getElementById('content');
-    const refreshView = document.querySelector('x-refresh-view');
-    const refreshFooter = document.querySelector('x-refresh-footer');
-    refreshView.addEventListener('headershow', () => {
-      content.style.backgroundColor = 'chartreuse';
-    });
-    </script>
     <style>
     .refresh-view {
       width: 100%;
@@ -78,10 +70,17 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    const content = document.getElementById('content');
+    const refreshView = document.querySelector('x-refresh-view');
+    const refreshFooter = document.querySelector('x-refresh-footer');
+    refreshView.addEventListener('headershow', () => {
+      content.style.backgroundColor = 'chartreuse';
+    });
+    </script>
     <x-refresh-view
       class="refresh-view"
       id="refresh-view"
-      x-enable-headershow-event
     >
       <x-refresh-header class="refresh-header"> </x-refresh-header>
 

--- a/packages/web-platform/web-tests/tests/web-elements/x-swiper/x-swiper-set-curren-smooth-scroll.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-swiper/x-swiper-set-curren-smooth-scroll.html
@@ -46,7 +46,6 @@
         id="target"
         style="display:flex; --lynx-display:linear;"
         indicator-dots="false"
-        x-enable-change-event
       >
         <x-swiper-item style="background-color:red;"> </x-swiper-item>
         <x-swiper-item style="background-color:green;"> </x-swiper-item>

--- a/packages/web-platform/web-tests/tests/web-elements/x-textarea/event-input.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-textarea/event-input.html
@@ -25,11 +25,6 @@
       rel="stylesheet"
     />
 
-    <script type="module">
-    document.querySelector('x-textarea').addEventListener('input', (e) => {
-      document.querySelector('.result').innerHTML = e.detail.value;
-    });
-    </script>
     <style>
     @import url("../../common.css");
     </style>
@@ -37,11 +32,15 @@
 
   <body>
     <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('x-textarea').addEventListener('input', (e) => {
+      document.querySelector('.result').innerHTML = e.detail.value;
+    });
+    </script>
     <x-view class="page">
       <x-textarea
         id="target"
         style="height:50px; width:200px;border: 1px;"
-        x-enable-input-event
       ></x-textarea>
       <text class="result"></text>
     </x-view>

--- a/packages/web-platform/web-tests/tests/web-elements/x-viewpager-ng/event-offsetchange-offset-value.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-viewpager-ng/event-offsetchange-offset-value.html
@@ -35,7 +35,6 @@
       <x-viewpager-ng
         style="width:200px;height:200px;"
         id="target"
-        x-enable-offsetchange-event
       >
         <x-viewpager-item-ng style="background:wheat;">
           <x-view style="height:100px; width:100px; background: pink;"></x-view>

--- a/packages/web-platform/web-tests/tests/web-elements/x-viewpager-ng/selecttab-method-default-smooth.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-viewpager-ng/selecttab-method-default-smooth.html
@@ -35,7 +35,6 @@
       <x-viewpager-ng
         style="width:200px;height:200px;"
         id="target"
-        x-enable-offsetchange-event
       >
         <x-viewpager-item-ng style="background:wheat;">
           <x-view style="height:100px; width:100px; background: pink;"></x-view>

--- a/packages/web-platform/web-tests/tests/web-elements/x-viewpager-ng/selecttab-method-not-smooth.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-viewpager-ng/selecttab-method-not-smooth.html
@@ -35,7 +35,6 @@
       <x-viewpager-ng
         style="width:200px;height:200px;"
         id="target"
-        x-enable-offsetchange-event
       >
         <x-viewpager-item-ng style="background:wheat;">
           <x-view style="height:100px; width:100px; background: pink;"></x-view>


### PR DESCRIPTION
After this commit, we override the `HTMLElement.addEventListener` and the `HTMLElement.removeEventListner` to know if there is any listener attached on current element.

If event should be enabled/disabled, the callback will be invoked.

Therefore we don't need to append the extra attribute to initialize some events.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
