### PR TITLE
fix(react/runtime): use lazy bundle without MTS

### DIFF
--- a/.changeset/odd-clowns-hide.md
+++ b/.changeset/odd-clowns-hide.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix `not a function` error when using lazy bundle without MTS.

--- a/packages/react/runtime/__test__/lynx/processEvalResult.test.js
+++ b/packages/react/runtime/__test__/lynx/processEvalResult.test.js
@@ -14,4 +14,10 @@ describe('processEvalResult', () => {
     expect(processEvalResult(fn, 'https://example.com/')).toBe('bar');
     expect(fn).toBeCalledWith('https://example.com/');
   });
+
+  test('call with undefined', () => {
+    globalEnvManager.switchToMainThread();
+
+    expect(processEvalResult(undefined, 'https://example.com/')).toBeUndefined();
+  });
 });

--- a/packages/react/runtime/src/lynx.ts
+++ b/packages/react/runtime/src/lynx.ts
@@ -20,8 +20,8 @@ import { COMPONENT, DIFF, DIFFED, FORCE } from './renderToOpcodes/constants.js';
 // @ts-expect-error Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature
 if (__LEPUS__ && typeof globalThis.processEvalResult === 'undefined') {
   // @ts-expect-error Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature
-  globalThis.processEvalResult = <T>(result: (schema: string) => T, schema: string) => {
-    return result(schema);
+  globalThis.processEvalResult = <T>(result: ((schema: string) => T) | undefined, schema: string) => {
+    return result?.(schema);
   };
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix an error when using lazy bundle without main-thread-script(MTS).

This may happen when:

1. Using lazy compilation. See #7 
2. Using `import()` in [background-only code](https://lynxjs.org/react/thinking-in-reactlynx.html)

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or **not required**).
