### PR TITLE
fix: gesture config not being processed correctly

### DIFF
--- a/.changeset/tangy-pugs-peel.md
+++ b/.changeset/tangy-pugs-peel.md
@@ -1,0 +1,11 @@
+---
+'@lynx-js/react': patch
+---
+
+fix: gesture config not processed correctly
+
+```typescript
+const pan = Gesture.Pan().minDistance(100);
+```
+
+After this commit, gesture config like `minDistance` should work as expected.

--- a/packages/react/runtime/__test__/snapshot/gesture.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/gesture.test.jsx
@@ -256,7 +256,8 @@ describe('Gesture', () => {
     }
   });
   it('update gesture', async function() {
-    let _gesture, id = 1;
+    let _gesture,
+      id = 1;
     function Comp() {
       _gesture = {
         id: id++,
@@ -517,6 +518,113 @@ describe('Gesture', () => {
       `);
     }
   });
+  it('gesture with config', async function() {
+    function Comp() {
+      const gesture = {
+        id: 1,
+        type: 0,
+        callbacks: {
+          onUpdate: {
+            _wkltId: 'bdd4:dd564:2',
+          },
+        },
+        config: {
+          minDistance: 100,
+        },
+        __isGesture: true,
+        toJSON: () => ({
+          ...gesture,
+          __isSerialized: true,
+        }),
+      };
+
+      return (
+        <view>
+          <text main-thread:gesture={gesture}>1</text>
+        </view>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="1"
+              />
+            </text>
+          </view>
+        </page>
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+    }
+
+    {
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text
+              flatten={false}
+              gesture={
+                {
+                  "config": {
+                    "callbacks": [
+                      {
+                        "callback": {
+                          "_execId": 7,
+                          "_wkltId": "bdd4:dd564:2",
+                        },
+                        "name": "onUpdate",
+                      },
+                    ],
+                    "config": {
+                      "minDistance": 100,
+                    },
+                  },
+                  "id": 1,
+                  "relationMap": {
+                    "continueWith": [],
+                    "simultaneous": [],
+                    "waitFor": [],
+                  },
+                  "type": 0,
+                }
+              }
+              has-react-gesture={true}
+            >
+              <raw-text
+                text="1"
+              />
+            </text>
+          </view>
+        </page>
+      `);
+    }
+  });
 });
 
 describe('Gesture in spread', () => {
@@ -599,7 +707,7 @@ describe('Gesture in spread', () => {
                     "callbacks": [
                       {
                         "callback": {
-                          "_execId": 7,
+                          "_execId": 8,
                           "_wkltId": "bdd4:dd564:2",
                         },
                         "name": "onUpdate",
@@ -719,7 +827,7 @@ describe('Gesture in spread', () => {
                     "callbacks": [
                       {
                         "callback": {
-                          "_execId": 9,
+                          "_execId": 10,
                           "_wkltId": "bdd4:dd564:2",
                         },
                         "name": "onUpdate",
@@ -843,7 +951,7 @@ describe('Gesture in spread', () => {
                     "callbacks": [
                       {
                         "callback": {
-                          "_execId": 10,
+                          "_execId": 11,
                           "_wkltId": "bdd4:dd564:2",
                         },
                         "name": "onUpdate",

--- a/packages/react/runtime/src/gesture/processGesture.ts
+++ b/packages/react/runtime/src/gesture/processGesture.ts
@@ -17,6 +17,10 @@ function getGestureInfo(gesture: BaseGesture, dom: FiberElement) {
   } as GestureConfig;
   const baseGesture = gesture;
 
+  if (baseGesture.config) {
+    config.config = baseGesture.config;
+  }
+
   for (
     const key of Object.keys(baseGesture.callbacks) as Array<
       keyof BaseGesture['callbacks']

--- a/packages/react/runtime/src/gesture/types.ts
+++ b/packages/react/runtime/src/gesture/types.ts
@@ -29,6 +29,7 @@ export interface BaseGesture extends GestureKind {
   waitFor: BaseGesture[];
   simultaneousWith: BaseGesture[];
   continueWith: BaseGesture[];
+  config?: Record<string, unknown>;
 }
 
 export interface GestureConfig {
@@ -36,4 +37,5 @@ export interface GestureConfig {
     name: string;
     callback: Worklet;
   }[];
+  config?: Record<string, unknown>;
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

Gesture may have configs like `minDistance` fro `PanGesture`, but it is not correctly processed. Now we add it when processing gesture object.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
