### PR TITLE
fix(webpack/react): `globDynamicComponentEntry` not found

### DIFF
--- a/.changeset/little-candles-brake.md
+++ b/.changeset/little-candles-brake.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Avoid wrapping standalone lazy bundles with `var globDynamicComponentEntry`.

--- a/.changeset/violet-shoes-love.md
+++ b/.changeset/violet-shoes-love.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+The code of lazy bundle should be minimized.

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -221,6 +221,7 @@ export function applyEntry(
           ?.disableCreateSelectorQueryIncompatibleWarning ?? false,
         firstScreenSyncTiming,
         mainThreadChunks,
+        experimental_isLazyBundle,
       }])
   })
 }

--- a/packages/webpack/react-webpack-plugin/etc/react-webpack-plugin.api.md
+++ b/packages/webpack/react-webpack-plugin/etc/react-webpack-plugin.api.md
@@ -40,6 +40,8 @@ export class ReactWebpackPlugin {
 // @public
 export interface ReactWebpackPluginOptions {
     disableCreateSelectorQueryIncompatibleWarning?: boolean | undefined;
+    // @alpha
+    experimental_isLazyBundle?: boolean;
     firstScreenSyncTiming?: 'immediately' | 'jsReady';
     mainThreadChunks?: string[] | undefined;
 }

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -36,6 +36,13 @@ interface ReactWebpackPluginOptions {
    * The chunk names to be considered as main thread chunks.
    */
   mainThreadChunks?: string[] | undefined;
+
+  /**
+   * Whether to enable lazy bundle.
+   *
+   * @alpha
+   */
+  experimental_isLazyBundle?: boolean;
 }
 
 /**
@@ -105,6 +112,7 @@ class ReactWebpackPlugin {
       disableCreateSelectorQueryIncompatibleWarning: false,
       firstScreenSyncTiming: 'immediately',
       mainThreadChunks: [],
+      experimental_isLazyBundle: false,
     });
 
   /**
@@ -119,13 +127,15 @@ class ReactWebpackPlugin {
     );
     const { BannerPlugin, DefinePlugin, EnvironmentPlugin } = compiler.webpack;
 
-    new BannerPlugin({
-      // TODO: handle cases that do not have `'use strict'`
-      banner:
-        `'use strict';var globDynamicComponentEntry=globDynamicComponentEntry||'__Card__';`,
-      raw: true,
-      test: options.mainThreadChunks!,
-    }).apply(compiler);
+    if (!options.experimental_isLazyBundle) {
+      new BannerPlugin({
+        // TODO: handle cases that do not have `'use strict'`
+        banner:
+          `'use strict';var globDynamicComponentEntry=globDynamicComponentEntry||'__Card__';`,
+        raw: true,
+        test: options.mainThreadChunks!,
+      }).apply(compiler);
+    }
 
     new EnvironmentPlugin({
       // Default values of null and undefined behave differently.

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/bar.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/bar.js
@@ -1,0 +1,6 @@
+export function bar() {
+  expect(globDynamicComponentEntry).toBeUndefined();
+  return import('./baz.js').then(({ baz }) => {
+    return `bar ${baz()}`;
+  });
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/baz.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/baz.js
@@ -1,0 +1,4 @@
+export function baz() {
+  expect(globDynamicComponentEntry).toBeUndefined();
+  return 'baz';
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/foo.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/foo.js
@@ -1,0 +1,5 @@
+export async function foo() {
+  expect(globDynamicComponentEntry).toBeUndefined();
+  const { bar } = await import('./bar.js');
+  return 'foo ' + await bar();
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/index.jsx
@@ -1,0 +1,112 @@
+/// <reference types="vitest/globals" />
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { snapshotManager } from '@lynx-js/react/internal';
+
+const importPromise = import('./foo.js');
+
+it('should have globDynamicComponentEntry', async () => {
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/main/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  const mainThreadCode = tasmJSON.lepusCode['root'];
+  const backgroundCode = await readFile(
+    __filename,
+    'utf-8',
+  );
+  // main-thread.js has one more globDynamicComponentEntry than background.js
+  // at the parameter of the IIFE.
+  expect(mainThreadCode.split('globDynamicComponentEntry').length)
+    .toBeGreaterThan(backgroundCode.split('globDynamicComponentEntry').length);
+
+  const jsx = <view id='xxx' />;
+  expect(jsx).toBeDefined();
+
+  expect(snapshotManager.values.get(jsx.type).entryName).toBe(
+    globDynamicComponentEntry,
+  );
+});
+
+it('should have module.exports in foo.js template', async () => {
+  const { foo } = await importPromise;
+  await expect(foo()).resolves.toBe(`foo bar baz`);
+
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/async/foo.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('const module = { exports: {} }'),
+  );
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('function (globDynamicComponentEntry)'),
+  );
+
+  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js'])
+    .toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
+    .toContain('const module = { exports: {} }');
+  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
+    .toContain('function (globDynamicComponentEntry)');
+});
+
+it('should have module.exports in bar.js template', async () => {
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/async/bar.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('const module = { exports: {} }'),
+  );
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('function (globDynamicComponentEntry)'),
+  );
+
+  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js'])
+    .toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
+    .toContain('const module = { exports: {} }');
+  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
+    .toContain('function (globDynamicComponentEntry)');
+});
+
+it('should have module.exports in baz.js template', async () => {
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/async/baz.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('const module = { exports: {} }'),
+  );
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('function (globDynamicComponentEntry)'),
+  );
+
+  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js'])
+    .toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
+    .toContain('const module = { exports: {} }');
+  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
+    .toContain('function (globDynamicComponentEntry)');
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/rspack.config.js
@@ -1,0 +1,30 @@
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { createConfig } from '../../../create-react-config.js';
+
+const config = createConfig();
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...config,
+  output: {
+    ...config.output,
+    chunkFilename: '.rspeedy/async/[name].js',
+  },
+  plugins: [
+    ...config.plugins,
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      experimental_isLazyBundle: true,
+      chunks: ['main:main-thread', 'main:background'],
+      filename: 'main/template.js',
+      intermediate: '.rspeedy/main',
+    }),
+  ],
+  mode: 'production',
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/test.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    // We do not run main-thread.js since the async chunk has been modified.
+    // 'main:main-thread.js',
+    'main:background.js',
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/bar.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/bar.js
@@ -1,0 +1,6 @@
+export function bar() {
+  expect(globDynamicComponentEntry).toBeUndefined();
+  return import('./baz.js').then(({ baz }) => {
+    return `bar ${baz()}`;
+  });
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/baz.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/baz.js
@@ -1,0 +1,4 @@
+export function baz() {
+  expect(globDynamicComponentEntry).toBeUndefined();
+  return 'baz';
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/foo.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/foo.js
@@ -1,0 +1,5 @@
+export async function foo() {
+  expect(globDynamicComponentEntry).toBeUndefined();
+  const { bar } = await import('./bar.js');
+  return 'foo ' + await bar();
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/index.jsx
@@ -1,0 +1,84 @@
+/// <reference types="vitest/globals" />
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const importPromise = import('./foo.js');
+
+it('should have module.exports in foo.js template', async () => {
+  const { foo } = await importPromise;
+  await expect(foo()).resolves.toBe(`foo bar baz`);
+
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/async/foo.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('const module = { exports: {} }'),
+  );
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('function (globDynamicComponentEntry)'),
+  );
+
+  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js'])
+    .toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
+    .toContain('const module = { exports: {} }');
+  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
+    .toContain('function (globDynamicComponentEntry)');
+});
+
+it('should have module.exports in bar.js template', async () => {
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/async/bar.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('const module = { exports: {} }'),
+  );
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('function (globDynamicComponentEntry)'),
+  );
+
+  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js'])
+    .toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
+    .toContain('const module = { exports: {} }');
+  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
+    .toContain('function (globDynamicComponentEntry)');
+});
+
+it('should have module.exports in baz.js template', async () => {
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/async/baz.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('const module = { exports: {} }'),
+  );
+  expect(tasmJSON.lepusCode).toHaveProperty(
+    'root',
+    expect.stringContaining('function (globDynamicComponentEntry)'),
+  );
+
+  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js'])
+    .toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
+    .toContain('const module = { exports: {} }');
+  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
+    .toContain('function (globDynamicComponentEntry)');
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/rspack.config.js
@@ -1,0 +1,29 @@
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { createConfig } from '../../../create-react-config.js';
+
+const config = createConfig();
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...config,
+  output: {
+    ...config.output,
+    chunkFilename: '.rspeedy/async/[name].js',
+  },
+  plugins: [
+    ...config.plugins,
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: ['main:main-thread', 'main:background'],
+      filename: 'main/template.js',
+      intermediate: '.rspeedy/main',
+    }),
+  ],
+  mode: 'production',
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/test.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    // We do not run main-thread.js since the async chunk has been modified.
+    // 'main:main-thread.js',
+    'main:background.js',
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/create-react-config.js
+++ b/packages/webpack/react-webpack-plugin/test/create-react-config.js
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { rspack } from '@rspack/core';
+
 import { LAYERS, ReactWebpackPlugin } from '../src';
 
 /**
@@ -106,6 +108,15 @@ export function createConfig(loaderOptions, pluginOptions, swcLoaderOptions) {
     optimization: {
       chunkIds: 'named',
       moduleIds: 'named',
+      minimizer: [
+        new rspack.SwcJsMinimizerRspackPlugin({
+          minimizerOptions: {
+            mangle: {
+              toplevel: true,
+            },
+          },
+        }),
+      ],
     },
   };
 }

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -565,7 +565,16 @@ class LynxTemplatePluginImpl {
         );
       });
 
-      compilation.hooks.processAssets.tapPromise(this.name, async () => {
+      compilation.hooks.processAssets.tapPromise({
+        name: this.name,
+        stage:
+          /**
+           * Generate the html after minification and dev tooling is done
+           * and source-map is generated
+           */
+          compiler.webpack.Compilation
+            .PROCESS_ASSETS_STAGE_REPORT,
+      }, async () => {
         await this.#generateAsyncTemplate(compilation);
       });
     });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

When building a lazy bundle in a standalone project, we need the IIFE wrapper to inject `globDynamicComponentEntry`. But we also have a `var globDynamicComponentEntry` statement injected, which is not correct after minification.

```js
function (globDynamicComponentEntry) {
  var globDynamicComponentEntry = globDynamicComponentEntry || '__Card__';
  // ...
  const __snapshot_xx = createSnapshot(globDynamicComponentEntry)
}
```

is minified to:

```js
function (globDynamicComponentEntry) {
  var e = e || '__Card__';
  // ...
  var x = c(e)
}
```

which result in getting **WRONG** `entryName` in lazy bundle on the main-thread.

We just remove the `var globDynamicComponentEntry` when building standalone lazy bundle so that the output would become:

```js
function (globDynamicComponentEntry) {
  // ...
  var x = c(globDynamicComponentEntry)
}
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or **not required**).
