### PR TITLE
fix(rspeedy/react): use better name for `main-thread.js`

### DIFF
--- a/.changeset/twenty-lamps-sort.md
+++ b/.changeset/twenty-lamps-sort.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Should generate `.rspeedy/[name]/main-thread.js` instead of `.rspeedy/[name]__main-thread/main-thread.js`

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -89,7 +89,7 @@ export function applyEntry(
           // For non-Lynx environment, the entry is not deleted.
           // So we do not put it in the intermediate.
           : '',
-        `${mainThreadEntry}/main-thread.js`,
+        `${entryName}/main-thread.js`,
       )
 
       const backgroundName = path.posix.join(

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -447,7 +447,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "main__main-thread": {
-            "filename": ".rspeedy/main__main-thread/main-thread.js",
+            "filename": ".rspeedy/main/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -491,7 +491,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "bar__main-thread": {
-            "filename": ".rspeedy/bar__main-thread/main-thread.js",
+            "filename": ".rspeedy/bar/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -505,7 +505,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "foo__main-thread": {
-            "filename": ".rspeedy/foo__main-thread/main-thread.js",
+            "filename": ".rspeedy/foo/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -549,7 +549,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "foo/bar__main-thread": {
-            "filename": ".rspeedy/foo/bar__main-thread/main-thread.js",
+            "filename": ".rspeedy/foo/bar/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -563,7 +563,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "foo/baz__main-thread": {
-            "filename": ".rspeedy/foo/baz__main-thread/main-thread.js",
+            "filename": ".rspeedy/foo/baz/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -613,7 +613,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "bar__main-thread": {
-            "filename": ".rspeedy/bar__main-thread/main-thread.js",
+            "filename": ".rspeedy/bar/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -634,14 +634,14 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "foo/baz__main-thread": {
-            "filename": ".rspeedy/foo/baz__main-thread/main-thread.js",
+            "filename": ".rspeedy/foo/baz/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
             "layer": "react:main-thread",
           },
           "foo__main-thread": {
-            "filename": ".rspeedy/foo__main-thread/main-thread.js",
+            "filename": ".rspeedy/foo/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -689,7 +689,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "main__main-thread": {
-            "filename": ".rspeedy/main__main-thread/main-thread.js",
+            "filename": ".rspeedy/main/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -740,7 +740,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "bar__main-thread": {
-            "filename": ".rspeedy/bar__main-thread/main-thread.js",
+            "filename": ".rspeedy/bar/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -761,14 +761,14 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "foo/baz__main-thread": {
-            "filename": ".rspeedy/foo/baz__main-thread/main-thread.js",
+            "filename": ".rspeedy/foo/baz/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
             "layer": "react:main-thread",
           },
           "foo__main-thread": {
-            "filename": ".rspeedy/foo__main-thread/main-thread.js",
+            "filename": ".rspeedy/foo/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -814,7 +814,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "main__main-thread": {
-            "filename": ".rspeedy/main__main-thread/main-thread.js",
+            "filename": ".rspeedy/main/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -861,7 +861,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "main__main-thread": {
-            "filename": ".rspeedy/main__main-thread/main-thread.js",
+            "filename": ".rspeedy/main/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -907,7 +907,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "main__main-thread": {
-            "filename": ".rspeedy/main__main-thread/main-thread.js",
+            "filename": ".rspeedy/main/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -953,7 +953,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "main__main-thread": {
-            "filename": ".rspeedy/main__main-thread/main-thread.js",
+            "filename": ".rspeedy/main/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
             ],
@@ -999,7 +999,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "main__main-thread": {
-            "filename": ".rspeedy/main__main-thread/main-thread.js",
+            "filename": ".rspeedy/main/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
               "<WORKSPACE>/packages/webpack/css-extract-webpack-plugin/runtime/hotModuleReplacement.lepus.cjs",
@@ -1049,7 +1049,7 @@ describe('Config', () => {
             "layer": "react:background",
           },
           "main__main-thread": {
-            "filename": ".rspeedy/main__main-thread/main-thread.js",
+            "filename": ".rspeedy/main/main-thread.js",
             "import": [
               "./fixtures/basic.tsx",
               "<WORKSPACE>/packages/webpack/css-extract-webpack-plugin/runtime/hotModuleReplacement.lepus.cjs",
@@ -1611,8 +1611,8 @@ describe('MPA Config', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(reactWebpackPlugin.options.mainThreadChunks).toMatchInlineSnapshot(`
       [
-        ".rspeedy/foo__main-thread/main-thread.js",
-        ".rspeedy/bar__main-thread/main-thread.js",
+        ".rspeedy/foo/main-thread.js",
+        ".rspeedy/bar/main-thread.js",
       ]
     `)
   })
@@ -1677,8 +1677,8 @@ describe('MPA Config', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(reactWebpackPlugin.options.mainThreadChunks).toMatchInlineSnapshot(`
       [
-        ".rspeedy/foo__main-thread/main-thread.js",
-        ".rspeedy/bar__main-thread/main-thread.js",
+        ".rspeedy/foo/main-thread.js",
+        ".rspeedy/bar/main-thread.js",
       ]
     `)
   })
@@ -1720,8 +1720,8 @@ describe('MPA Config', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(reactWebpackPlugin.options.mainThreadChunks).toMatchInlineSnapshot(`
       [
-        "foo__main-thread/main-thread.js",
-        "bar__main-thread/main-thread.js",
+        "foo/main-thread.js",
+        "bar/main-thread.js",
       ]
     `)
   })
@@ -1786,8 +1786,8 @@ describe('MPA Config', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(reactWebpackPlugin.options.mainThreadChunks).toMatchInlineSnapshot(`
       [
-        ".rspeedy/foo__main-thread/main-thread.js",
-        ".rspeedy/bar__main-thread/main-thread.js",
+        ".rspeedy/foo/main-thread.js",
+        ".rspeedy/bar/main-thread.js",
       ]
     `)
   })
@@ -1852,8 +1852,8 @@ describe('MPA Config', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(reactWebpackPlugin.options.mainThreadChunks).toMatchInlineSnapshot(`
       [
-        ".rspeedy/foo__main-thread/main-thread.js",
-        ".rspeedy/bar__main-thread/main-thread.js",
+        ".rspeedy/foo/main-thread.js",
+        ".rspeedy/bar/main-thread.js",
       ]
     `)
   })
@@ -1919,8 +1919,8 @@ describe('MPA Config', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(reactWebpackPlugin.options.mainThreadChunks).toMatchInlineSnapshot(`
       [
-        ".rspeedy/foo__main-thread/main-thread.js",
-        ".rspeedy/bar__main-thread/main-thread.js",
+        ".rspeedy/foo/main-thread.js",
+        ".rspeedy/bar/main-thread.js",
       ]
     `)
   })
@@ -1992,9 +1992,9 @@ describe('MPA Config', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(reactWebpackPlugin.options.mainThreadChunks).toMatchInlineSnapshot(`
       [
-        ".rspeedy/foo__main-thread/main-thread.js",
-        ".rspeedy/bar__main-thread/main-thread.js",
-        ".rspeedy/baz__main-thread/main-thread.js",
+        ".rspeedy/foo/main-thread.js",
+        ".rspeedy/bar/main-thread.js",
+        ".rspeedy/baz/main-thread.js",
       ]
     `)
   })


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Use `.rspeedy/[name]/main-thread.js` instead of `.rspeedy/[name]__main-thread/main-thread.js`.

This is a regression of #76.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] **Tests updated** (or not required).
- [x] Documentation updated (or **not required**).
