### PR TITLE
feat: use shadowroot to isolate one lynx-view

### DIFF
--- a/.changeset/soft-dragons-show.md
+++ b/.changeset/soft-dragons-show.md
@@ -1,0 +1,15 @@
+---
+"@lynx-js/web-mainthread-apis": minor
+"@lynx-js/web-core": minor
+---
+
+feat: use shadowroot to isolate one lynx-view
+
+Before this commit, we have been detecting if current browser supports the `@scope` rule.
+This allows us to scope one lynx-view's styles.
+
+After this commit we always create a shadowroot to scope then.
+
+Also for the new shadowroot pattern, we add a new **attribute** `inject-head-links`.
+By default, we will iterate all `<link rel="stylesheet">` in the `<head>`, and use `@import url()` to import them inside the shadowroot.
+Developers could add a `inject-head-links="false"` to disable this behavior.

--- a/.changeset/warm-lamps-spend.md
+++ b/.changeset/warm-lamps-spend.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+feat: add support for `<lynx-view/>` with shadowroot
+
+add a minor logic in `<x-overlay-ng>` to be compatiable with the <lynx-view> with a shadowroot

--- a/packages/web-platform/web-constants/src/types/PageConfig.ts
+++ b/packages/web-platform/web-constants/src/types/PageConfig.ts
@@ -8,5 +8,4 @@ export interface PageConfig {
 }
 
 export interface BrowserConfig {
-  supportAtScope: boolean;
 }

--- a/packages/web-platform/web-core/index.css
+++ b/packages/web-platform/web-core/index.css
@@ -3,17 +3,13 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-[lynx-default-display-linear="false"] * {
-  --lynx-display: flex;
-  --lynx-display-toggle: var(--lynx-display-flex);
-}
 
 lynx-view {
   contain: strict;
   display: flex;
 }
 
-lynx-view > #lynx-view-root {
+lynx-view::part(lynx-view-root) {
   display: contents;
   width: 100%;
   height: 100%;
@@ -24,7 +20,7 @@ lynx-view[height="auto"] {
   height: var(--lynx-view-height);
   block-size: var(--lynx-view-height);
 }
-lynx-view[height="auto"] > #lynx-view-root {
+lynx-view[height="auto"]::part(lynx-view-root) {
   height: unset;
 }
 
@@ -33,15 +29,15 @@ lynx-view[width="auto"] {
   width: var(--lynx-view-width);
   inline-size: var(--lynx-view-width);
 }
-lynx-view[width="auto"] > #lynx-view-root {
+lynx-view[width="auto"]::part(lynx-view-root) {
   width: unset;
 }
 
 lynx-view[height="auto"], lynx-view[width="auto"] {
   contain-intrinsic-size: var(--lynx-view-width) var(--lynx-view-height);
 }
-lynx-view[height="auto"] > #lynx-view-root,
-lynx-view[width="auto"] > #lynx-view-root {
+lynx-view[height="auto"]::part(lynx-view-root),
+lynx-view[width="auto"]::part(lynx-view-root) {
   display: unset;
   position: fixed;
   top: 0;
@@ -60,7 +56,7 @@ lynx-view[width="auto"] > #lynx-view-root {
   initial-value: 100%;
 }
 
-lynx-view:not([width="auto"]):not([height="auto"]) [lynx-tag="page"] {
+lynx-view:not([width="auto"]):not([height="auto"])::part(page) {
   height: 100%;
   width: 100%;
 }

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -8,7 +8,6 @@ import type {
   UpdateDataType,
 } from '@lynx-js/web-constants';
 import { startUIThread } from '../uiThread/startUIThread.js';
-import { supportAtScope } from '../utils/browser.js';
 
 export interface LynxViewConfigs {
   templateUrl: string;
@@ -50,10 +49,8 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
       initData,
       globalProps,
       entryId,
-      browserConfig: {
-        supportAtScope,
-      },
       napiModulesMap,
+      browserConfig: {},
     },
     rootDom,
     callbacks,

--- a/packages/web-platform/web-core/src/apis/inShadowRootStyles.ts
+++ b/packages/web-platform/web-core/src/apis/inShadowRootStyles.ts
@@ -1,0 +1,6 @@
+export const inShadowRootStyles = `
+[lynx-default-display-linear="false"] * {
+  --lynx-display: flex;
+  --lynx-display-toggle: var(--lynx-display-flex);
+}
+`;

--- a/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/bootTimingSystem.ts
+++ b/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/bootTimingSystem.ts
@@ -53,6 +53,7 @@ export function bootTimingSystem(
         detail: isFp ? setupTiming : timingInfo,
         bubbles: true,
         cancelable: true,
+        composed: true,
       }),
     );
     if (pipelineId) {

--- a/packages/web-platform/web-core/src/utils/browser.ts
+++ b/packages/web-platform/web-core/src/utils/browser.ts
@@ -5,5 +5,3 @@ export const isWebkit = /\b(iPad|iPhone|iPod|OS X)\b/.test(UA)
   && /WebKit/.test(UA)
   // @ts-expect-error
   && !window.MSStream;
-
-export const supportAtScope = !!globalThis.CSSScopeRule;

--- a/packages/web-platform/web-elements/src/XOverlayNg/XOverlayAttributes.ts
+++ b/packages/web-platform/web-elements/src/XOverlayNg/XOverlayAttributes.ts
@@ -72,8 +72,13 @@ export class XOverlayAttributes
     if (e.target === this.#dom || e.target === diaglogDom) {
       diaglogDom.close();
       const { clientX, clientY } = e;
-      const targetElemnt = document.elementFromPoint(clientX, clientY);
-      targetElemnt?.dispatchEvent(new MouseEvent('click', e));
+      let targetElement = document.elementFromPoint(clientX, clientY);
+      if (targetElement?.tagName === 'LYNX-VIEW' && targetElement.shadowRoot) {
+        targetElement =
+          targetElement.shadowRoot.elementFromPoint(clientX, clientY)
+            ?? targetElement;
+      }
+      targetElement?.dispatchEvent(new MouseEvent('click', e));
       requestAnimationFrame(() => {
         if (this.#visible && diaglogDom.isConnected) {
           diaglogDom.showModal();

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
@@ -152,9 +152,7 @@ export class MainThreadRuntime {
       this.isFp
         ? genCssContent(
           this.config.styleInfo,
-          this.config.entryId,
           this.config.pageConfig,
-          this.config.browserConfig,
         )
         : undefined,
     );

--- a/packages/web-platform/web-mainthread-apis/src/utils/processStyleInfo.ts
+++ b/packages/web-platform/web-mainthread-apis/src/utils/processStyleInfo.ts
@@ -7,10 +7,8 @@ import {
   type StyleInfo,
   type CssInJsInfo,
   type PageConfig,
-  type BrowserConfig,
   cssIdAttribute,
   lynxTagAttribute,
-  cardIdAttribute,
 } from '@lynx-js/web-constants';
 import { transformLynxStyles } from '@lynx-js/web-style-transformer';
 
@@ -69,9 +67,7 @@ export function transformToWebCss(styleInfo: StyleInfo) {
  */
 export function genCssContent(
   styleInfo: StyleInfo,
-  entryId: string,
   pageConfig: PageConfig,
-  browserConfig: BrowserConfig,
 ): string {
   function getExtraSelectors(
     cssId?: string,
@@ -84,10 +80,8 @@ export function genCssContent(
         // To make sure the Specificity correct
         suffix += `[${lynxTagAttribute}]`;
       }
-    }
-    if (!browserConfig.supportAtScope) {
-      prepend = `[${cardIdAttribute}="${entryId}"] `
-        + prepend;
+    } else {
+      suffix += `[${lynxTagAttribute}]`;
     }
     return { prepend, suffix };
   }

--- a/packages/web-platform/web-tests/shell-project/mainthread-test.ts
+++ b/packages/web-platform/web-tests/shell-project/mainthread-test.ts
@@ -69,7 +69,7 @@ function initializeMainThreadTest() {
     lepusCode: { root: '' },
     customSections: {},
     entryId: 't',
-    browserConfig: { supportAtScope: true },
+    browserConfig: {},
     pageConfig: {
       enableCSSSelector: true,
       enableRemoveCSSScope: true,

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -422,6 +422,7 @@ test.describe('reactlynx3 tests', () => {
       const target = page.locator('#target');
       await expect(target).toHaveCSS('background-color', 'rgb(255, 192, 203)'); // pink
       await page.evaluate(() => {
+        // @ts-expect-error
         globalThis.lynxView.updateData({ mockData: 'updatedData' }, 1, () => {
           console.log('update Data success');
         });
@@ -443,6 +444,7 @@ test.describe('reactlynx3 tests', () => {
       await goto(page, title);
       await wait(1000);
       await page.evaluate(() => {
+        // @ts-expect-error
         globalThis.lynxView.updateData({ mockData: 'updatedData' }, 0, () => {
           console.log('update Data success');
         });
@@ -540,8 +542,10 @@ test.describe('reactlynx3 tests', () => {
           await goto(page, title);
           await diffScreenShot(page, module, title, 'initial');
           await page.evaluate(() => {
-            // @ts-ignore
-            document.getElementById('x').scrollTo({ offset: 200 });
+            // @ts-expect-error
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              '#x',
+            )!.scrollTo({ offset: 200 });
           });
           await wait(200);
           await diffScreenShot(
@@ -552,8 +556,10 @@ test.describe('reactlynx3 tests', () => {
           );
           await wait(200);
           await page.evaluate(() => {
-            // @ts-ignore
-            document.getElementById('x').scrollTo({ offset: 400 });
+            // @ts-expect-error
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              '#x',
+            )!.scrollTo({ offset: 400 });
           });
           await diffScreenShot(page, module, title, 'scroll-200-green');
         },
@@ -571,8 +577,9 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          // @ts-ignore
-          document.getElementById('x').scrollTo({ offset: 600 });
+          // @ts-expect-error
+          document.querySelector('lynx-view')!.shadowRoot!.querySelector('#x')!
+            .scrollTo({ offset: 600 });
         });
         await wait(100);
         await diffScreenShot(page, module, title, '1-right-yellow', {
@@ -580,8 +587,9 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          // @ts-ignore
-          document.getElementById('x').scrollTo({ offset: 0 });
+          // @ts-expect-error
+          document.querySelector('lynx-view')!.shadowRoot!.querySelector('#x')!
+            .scrollTo({ offset: 0 });
         });
         await wait(100);
         await diffScreenShot(page, module, title, '2-white-back', {
@@ -589,8 +597,9 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          // @ts-ignore
-          document.getElementById('y').scrollTo({ offset: 50 });
+          // @ts-expect-error
+          document.querySelector('lynx-view')!.shadowRoot!.querySelector('#y')!
+            .scrollTo({ offset: 50 });
         });
         await wait(100);
         await diffScreenShot(page, module, title, '3-red-down', {
@@ -598,8 +607,9 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          // @ts-ignore
-          document.getElementById('y').scrollTo({ offset: 0 });
+          // @ts-expect-error
+          document.querySelector('lynx-view')!.shadowRoot!.querySelector('#y')!
+            .scrollTo({ offset: 0 });
         });
         await wait(100);
         await diffScreenShot(page, module, title, '4-white-down-back', {
@@ -653,7 +663,9 @@ test.describe('reactlynx3 tests', () => {
           });
           await wait(100);
           await page.evaluate(() => {
-            document.querySelector('#y').scrollTop = 200;
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              '#y',
+            )!.scrollTop = 200;
           });
           await wait(100);
           await diffScreenShot(
@@ -665,7 +677,9 @@ test.describe('reactlynx3 tests', () => {
           );
           await wait(100);
           await page.evaluate(() => {
-            document.querySelector('#y').scrollTop = 800;
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              '#y',
+            )!.scrollTop = 800;
           });
           await wait(100);
           await diffScreenShot(
@@ -677,7 +691,9 @@ test.describe('reactlynx3 tests', () => {
           );
           await wait(100);
           await page.evaluate(() => {
-            document.querySelector('#y').scrollTop = 1000;
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              '#y',
+            )!.scrollTop = 1000;
           });
           await wait(100);
           await diffScreenShot(page, module, title, '3-green-half-do-trigger', {
@@ -693,7 +709,8 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          document.querySelector('#y').scrollTop = 200;
+          document.querySelector('lynx-view')!.shadowRoot!.querySelector('#y')!
+            .scrollTop = 200;
         });
         await wait(100);
         await diffScreenShot(page, module, title, '1-orange-half-do-trigger', {
@@ -701,7 +718,8 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          document.querySelector('#y').scrollTop = 800;
+          document.querySelector('lynx-view')!.shadowRoot!.querySelector('#y')!
+            .scrollTop = 800;
         });
         await wait(100);
         await diffScreenShot(page, module, title, '2-green-half-not-trigger', {
@@ -709,7 +727,8 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          document.querySelector('#y').scrollTop = 1000;
+          document.querySelector('lynx-view')!.shadowRoot!.querySelector('#y')!
+            .scrollTop = 1000;
         });
         await wait(100);
         await diffScreenShot(page, module, title, '3-green-half-do-trigger', {
@@ -1046,12 +1065,19 @@ test.describe('reactlynx3 tests', () => {
       test.describe('basic-element-text-text-selection', () => {
         const title = 'basic-element-text-text-selection';
 
-        test('selection-true-boolean-flatten-false', async ({ page }) => {
+        test('selection-true-boolean-flatten-false', async ({ page, browserName }) => {
           await goto(page, title);
-          await page
-            .getByText('text-selection-true-boolean-flatten-false')
-            .first()
-            .selectText();
+          if (browserName === 'webkit') {
+            await page
+              .getByText('text-selection-true-boolean-flatten-false')
+              .first()
+              .click({ 'clickCount': 3 });
+          } else {
+            await page
+              .getByText('text-selection-true-boolean-flatten-false')
+              .first()
+              .selectText();
+          }
           await wait(1000);
           await diffScreenShot(
             page,
@@ -1462,7 +1488,9 @@ test.describe('reactlynx3 tests', () => {
           await wait(100);
           const eventDetails = await page.evaluate(() => {
             const event = JSON.parse(
-              document.querySelector('#result>raw-text')!.innerHTML,
+              document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+                '#result>raw-text',
+              )!.innerHTML,
             );
             const { scrollTop, scrollLeft, scrollHeight, scrollWidth } =
               event.detail;
@@ -1492,12 +1520,16 @@ test.describe('reactlynx3 tests', () => {
           await goto(page, title);
           await wait(300);
           await page.evaluate(() => {
-            document.querySelector('scroll-view')!.scrollTop = 200;
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              'scroll-view',
+            )!.scrollTop = 200;
           });
           await wait(200);
           const eventDetails = await page.evaluate(() => {
             const event = JSON.parse(
-              document.querySelector('#result>raw-text')!.innerHTML,
+              document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+                '#result>raw-text',
+              )!.innerHTML,
             );
             const { scrollTop, scrollLeft, scrollHeight, scrollWidth } =
               event.detail;
@@ -1543,7 +1575,9 @@ test.describe('reactlynx3 tests', () => {
         await wait(600);
         const eventDetails = await page.evaluate(() => {
           const event = JSON.parse(
-            document.querySelector('#result>raw-text')!.innerHTML,
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              '#result>raw-text',
+            )!.innerHTML,
           );
           const { scrollTop, scrollLeft, scrollHeight, scrollWidth } =
             event.detail;
@@ -1588,7 +1622,9 @@ test.describe('reactlynx3 tests', () => {
         await wait(100);
         const eventDetails = await page.evaluate(() => {
           const event = JSON.parse(
-            document.querySelector('#result>raw-text')!.innerHTML,
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              '#result>raw-text',
+            )!.innerHTML,
           );
           const { scrollTop, scrollLeft, scrollHeight, scrollWidth } =
             event.detail;
@@ -1658,7 +1694,7 @@ test.describe('reactlynx3 tests', () => {
           const cdpSession = await context.newCDPSession(page);
           const eventDetails: any[] = [];
           page.on('console', async (msg) => {
-            eventDetails.push(await msg.args()[0].jsonValue());
+            eventDetails.push(await msg.args()[0]!.jsonValue());
           });
           await swipe(cdpSession, {
             x: 300,
@@ -1684,7 +1720,6 @@ test.describe('reactlynx3 tests', () => {
         const cdpSession = await context.newCDPSession(page);
         const offsets: any[] = [];
         page.on('console', async (msg) => {
-          const event = await msg.args()[0].jsonValue();
           offsets.push(offsets);
         });
         await swipe(cdpSession, {
@@ -1755,7 +1790,9 @@ test.describe('reactlynx3 tests', () => {
             'select-index',
           );
           await page.evaluateHandle(() => {
-            document.querySelector('x-viewpager-ng')?.setAttribute(
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              'x-viewpager-ng',
+            )?.setAttribute(
               'select-index',
               '3',
             );
@@ -1853,7 +1890,7 @@ test.describe('reactlynx3 tests', () => {
         async ({ page, browserName }, { title }) => {
           test.skip(browserName === 'firefox', 'flaky');
           await goto(page, title);
-          await page.locator('.focus').click();
+          await page.locator('.focus').click({ force: true });
           await wait(100);
           const result = await page.locator('.result').first().innerText();
           expect(result).toBe('bindfocus');
@@ -1864,7 +1901,7 @@ test.describe('reactlynx3 tests', () => {
       // input/bindfocus test-case start
       test('basic-element-x-input-bindfocus', async ({ page }, { title }) => {
         await goto(page, title);
-        await page.locator('input').click();
+        await page.locator('input').click({ force: true });
         await wait(100);
         const result = await page.locator('.result').first().innerText();
         expect(result).toBe('bindfocus');
@@ -2043,7 +2080,7 @@ test.describe('reactlynx3 tests', () => {
         await goto(page, 'basic-element-x-overlay-ng-playground-test');
         await page.mouse.click(0, 0); // webkit needs this
         await wait(200);
-        await page.mouse.click(100, 370);
+        await page.locator('#toggleModal4').click({ force: true });
         await wait(50);
         await diffScreenShot(
           page,
@@ -3126,7 +3163,7 @@ test.describe('reactlynx3 tests', () => {
             // NOTE: dataset is not included in the previous json value, so we should
             // manually find it from the JSHandle.
             const dataset = await (
-              await (await msg.args()[0].getProperty('target')).getProperty(
+              await (await msg.args()[0]!.getProperty('target')).getProperty(
                 'dataset',
               )
             ).jsonValue();
@@ -3155,7 +3192,7 @@ test.describe('reactlynx3 tests', () => {
             }
           });
           await wait(100);
-          await page.locator('textarea')?.click();
+          await page.locator('textarea')?.click({ force: true });
           await wait(50);
           await page.locator('textarea')?.blur();
           await wait(50);
@@ -3197,7 +3234,9 @@ test.describe('reactlynx3 tests', () => {
           await goto(page, title);
           await diffScreenShot(page, elementName, title);
           await page.evaluate(() => {
-            document.querySelector('x-list')?.shadowRoot?.querySelector(
+            document.querySelector('lynx-view')!.shadowRoot!.querySelector(
+              'x-list',
+            )?.shadowRoot?.querySelector(
               '#content',
             )
               ?.scrollTo(0, 500);


### PR DESCRIPTION
Before this commit, we have been detecting if current browser supports the `@scope` rule.
This allows us to scope one lynx-view's styles.

After this commit we always create a shadowroot to scope then.

Also for the new shadowroot pattern, we add a new **attribute** `inject-head-links`.
By default, we will iterate all `<link rel="stylesheet">` in the `<head>`, and use `@import url()` to import them inside the shadowroot.
Developers could add a `inject-head-links="false"` to disable this behavior.
#51 