### PR TITLE
chore: unbind `@lynx-js/web-worker-rpc` version with lynx's web platform

### DIFF
--- a/.changeset/bumpy-spiders-itch.md
+++ b/.changeset/bumpy-spiders-itch.md
@@ -1,0 +1,13 @@
+---
+"@lynx-js/web-worker-rpc": minor
+---
+
+chore: unbind `@lynx-js/web-worker-rpc` version with lynx's web platform
+
+This package supports cross-threads(web worker) rpc for lynx's web platform.
+
+It's based on browser `MessagePort`.
+
+Compare with vscode-jsonrpc, it have less package size, which is very important for Web Application.
+
+Documents will be added later.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,6 @@
       "@lynx-js/web-core",
       "@lynx-js/web-constants",
       "@lynx-js/web-mainthread-apis",
-      "@lynx-js/web-worker-rpc",
       "@lynx-js/web-worker-runtime"
     ],
     [

--- a/packages/web-platform/web-worker-rpc/README.md
+++ b/packages/web-platform/web-worker-rpc/README.md
@@ -1,1 +1,3 @@
 # @lynx-js/web-worker-rpc
+
+A simple Remote calling infrastructure for calling remote function from WebWorker.

--- a/packages/web-platform/web-worker-rpc/api-extractor.json
+++ b/packages/web-platform/web-worker-rpc/api-extractor.json
@@ -1,0 +1,10 @@
+/**
+ * Config file for API Extractor.  For more info, please visit: https://api-extractor.com
+ */
+{
+  "extends": "../../../api-extractor.json",
+  "mainEntryPointFilePath": "./dist/index.d.ts",
+  "compiler": {
+    "tsconfigFilePath": "./tsconfig.json",
+  },
+}

--- a/packages/web-platform/web-worker-rpc/package.json
+++ b/packages/web-platform/web-worker-rpc/package.json
@@ -20,5 +20,8 @@
     "Notice.txt",
     "CHANGELOG.md",
     "README.md"
-  ]
+  ],
+  "scripts": {
+    "api-extractor": "api-extractor run --verbose"
+  }
 }


### PR DESCRIPTION
This package supports cross-threads(web worker) rpc for lynx's web platform.

It's based on browser `MessagePort`.

Compare with vscode-jsonrpc, it have less package size, which is very important for Web Application.

Documents will be added later.