### PR TITLE
fix(rspeedy/react): enable CSS minification

### DIFF
--- a/.changeset/seven-foxes-read.md
+++ b/.changeset/seven-foxes-read.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Enable CSS minification for scoped CSS.

--- a/packages/rspeedy/plugin-react/src/css.ts
+++ b/packages/rspeedy/plugin-react/src/css.ts
@@ -151,11 +151,6 @@ export function applyCSS(
         .end()
         .end()
 
-      if (enableRemoveCSSScope !== true) {
-        // TODO: enable CSS minimizer when `LightningCssMinimizerRspackPlugin` supports custom parser options.
-        chain.optimization.minimizers.delete(CHAIN_ID.MINIMIZER.CSS)
-      }
-
       // We add `sideEffects: false` to all Scoped CSS Modules.
       // Since there is no need to emit scoped CSS when the CSS Modules is not used.
       chain


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

When using scoped CSS, the CSS minification is not enabled now.

## Checklist

<!--- Check and mark with an "x" -->

- [x] **Tests updated** (or not required).
- [x] Documentation updated (or **not required**).
