### PR TITLE
fix(rspeedy/react): should return ESM in ignore-css-loader

### DIFF
--- a/.changeset/flat-planes-laugh.md
+++ b/.changeset/flat-planes-laugh.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Avoid entry IIFE in `main-thread.js`

--- a/packages/rspeedy/plugin-react/src/loaders/ignore-css-loader.ts
+++ b/packages/rspeedy/plugin-react/src/loaders/ignore-css-loader.ts
@@ -13,7 +13,9 @@ export default function ignoreCssLoader(
   // It is not a CSS Modules file because exportOnlyLocals is enabled,
   // so we don't need to preserve it.
   if (source.includes('___CSS_LOADER_EXPORT___')) {
-    return ''
+    // Return an ESM to make sure the module strict.
+    // See: https://github.com/webpack/webpack/discussions/18367#discussion-6580398
+    return 'export {}'
   }
 
   // Preserve css modules export for background layer.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

We need to return a ESM module to make sure that all the modules are strict. So that the IIFE of the entry could be removed.

See https://github.com/webpack/webpack/discussions/18367#discussion-6580398 for details.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
