### PR TITLE
refactor: remove entryId concept

### DIFF
--- a/.changeset/rotten-humans-sniff.md
+++ b/.changeset/rotten-humans-sniff.md
@@ -1,0 +1,12 @@
+---
+"@lynx-js/web-mainthread-apis": minor
+"@lynx-js/web-worker-runtime": minor
+"@lynx-js/web-constants": minor
+"@lynx-js/web-core": minor
+---
+
+refractor: remove entryId concept
+
+After the PR #198
+All contents are isolated by a shadowroot.
+Therefore we don't need to add the entryId selector to avoid the lynx-view's style taking effect on the whole page.

--- a/.changeset/sharp-cougars-go.md
+++ b/.changeset/sharp-cougars-go.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-webpack-plugin": patch
+---
+
+chore: remove unused file

--- a/packages/web-platform/web-constants/src/constants.ts
+++ b/packages/web-platform/web-constants/src/constants.ts
@@ -11,8 +11,6 @@ export const componentIdAttribute = 'lynx-component-id' as const;
 export const parentComponentUniqueIdAttribute =
   'lynx-parent-component-uid' as const;
 
-export const cardIdAttribute = 'lynx-card-id' as const;
-
 export const lynxTagAttribute = 'lynx-tag' as const;
 
 export const lynxRuntimeValue = Symbol('lynx-runtime-value');
@@ -23,8 +21,6 @@ export const lynxDefaultDisplayLinearAttribute =
 export const lynxViewRootDomId = 'lynx-view-root' as const;
 
 export const __lynx_timing_flag = '__lynx_timing_flag' as const;
-
-export const lynxViewEntryIdPrefix = 'lynx-view-id' as const;
 
 export const globalMuteableVars = [
   'registerDataProcessor',

--- a/packages/web-platform/web-constants/src/types/MainThreadStartConfigs.ts
+++ b/packages/web-platform/web-constants/src/types/MainThreadStartConfigs.ts
@@ -11,7 +11,6 @@ export interface MainThreadStartConfigs {
   template: LynxTemplate;
   initData: Cloneable;
   globalProps: Cloneable;
-  entryId: string;
   browserConfig: BrowserConfig;
   nativeModulesUrl?: string;
   napiModulesMap: NapiModulesMap;

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -7,9 +7,7 @@ import {
   createLynxView,
 } from './createLynxView.js';
 import {
-  cardIdAttribute,
   type Cloneable,
-  lynxViewEntryIdPrefix,
   lynxViewRootDomId,
   type NapiModulesCall,
   type NapiModulesMap,
@@ -34,8 +32,6 @@ import { inShadowRootStyles } from './inShadowRootStyles.js';
  * @param {NapiModulesMap} napiModulesMap [optional] the napiModule which is called in lynx-core. key is module-name, value is esm url.
  * @param {NapiModulesCall} onNapiModulesCall [optional] the NapiModule value handler.
  * @param {"false" | "true" | null} injectHeadLinks [optional] @default true set it to "false" to disable injecting the <link href="" ref="stylesheet"> styles into shadowroot
- *
- * @property entryId the currently Lynx view entryId.
  *
  * @event error lynx card fired an error
  *
@@ -127,17 +123,6 @@ export class LynxView extends HTMLElement {
     } else {
       this.#initData = val;
     }
-  }
-
-  #entryId?: string;
-  /**
-   * @public
-   * @readonly
-   * @property
-   * The random generated entryId of current lynxview
-   */
-  get entryId() {
-    return this.#entryId;
   }
 
   #overrideLynxTagToHTMLTagMap: Record<string, string> = { 'page': 'div' };
@@ -369,16 +354,8 @@ export class LynxView extends HTMLElement {
         if (this.#url) {
           const rootDom = document.createElement('div');
           rootDom.id = lynxViewRootDomId;
-          const entryId = `${lynxViewEntryIdPrefix}-${LynxView
-            .lynxViewCount++}`;
-          this.#entryId = entryId;
-          rootDom.setAttribute(cardIdAttribute, entryId);
           rootDom.setAttribute('part', lynxViewRootDomId);
-          const commonEventDetail = {
-            entryId,
-          };
           const lynxView = createLynxView({
-            entryId,
             rootDom,
             templateUrl: this.#url,
             globalProps: this.#globalProps,
@@ -403,9 +380,7 @@ export class LynxView extends HTMLElement {
               },
               onError: () => {
                 this.dispatchEvent(
-                  new CustomEvent('error', {
-                    detail: commonEventDetail,
-                  }),
+                  new CustomEvent('error', {}),
                 );
               },
             },

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -13,7 +13,6 @@ export interface LynxViewConfigs {
   templateUrl: string;
   initData: Cloneable;
   globalProps: Cloneable;
-  entryId: string;
   rootDom: HTMLElement;
   callbacks: Parameters<typeof startUIThread>[3];
   overrideLynxTagToHTMLTagMap?: Record<string, string>;
@@ -37,7 +36,6 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
     callbacks,
     templateUrl,
     globalProps,
-    entryId,
     initData,
     overrideLynxTagToHTMLTagMap,
     nativeModulesUrl,
@@ -48,7 +46,6 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
     {
       initData,
       globalProps,
-      entryId,
       napiModulesMap,
       browserConfig: {},
     },

--- a/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/registerFlushElementTreeHandler.ts
+++ b/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/registerFlushElementTreeHandler.ts
@@ -2,7 +2,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import {
-  cardIdAttribute,
   componentIdAttribute,
   lynxDefaultDisplayLinearAttribute,
   lynxRuntimeValue,
@@ -24,9 +23,7 @@ import { createCrossThreadEvent } from '../../utils/createCrossThreadEvent.js';
 function applyPageAttributes(
   page: HTMLElement,
   pageConfig: PageConfig,
-  entryId: string,
 ) {
-  page.setAttribute(cardIdAttribute, entryId);
   if (pageConfig.defaultDisplayLinear === false) {
     page.setAttribute(lynxDefaultDisplayLinearAttribute, 'false');
   }
@@ -40,7 +37,6 @@ export function registerFlushElementTreeHandler(
     overrideTagMap: Record<string, string>;
     backgroundRpc: Rpc;
     rootDom: HTMLElement;
-    entryId: string;
   },
   onCommit: (info: {
     pipelineId: string | undefined;
@@ -58,7 +54,6 @@ export function registerFlushElementTreeHandler(
     overrideTagMap,
     backgroundRpc,
     rootDom,
-    entryId,
   } = options;
   const uniqueIdToElement: WeakRef<
     HTMLElement & RuntimePropertyOnElement
@@ -150,7 +145,7 @@ export function registerFlushElementTreeHandler(
         styleElement.innerHTML = cardCss!;
         rootDom.append(styleElement);
         rootDom.append(page);
-        applyPageAttributes(page, pageConfig, entryId);
+        applyPageAttributes(page, pageConfig);
       }
       markTimingInternal('layout_end', pipelineId);
       markTimingInternal('dispatch_end', pipelineId);

--- a/packages/web-platform/web-core/src/uiThread/startUIThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/startUIThread.ts
@@ -41,7 +41,7 @@ export function startUIThread(
   nativeModulesUrl: string | undefined,
 ): LynxView {
   const createLynxStartTiming = performance.now() + performance.timeOrigin;
-  const { entryId, napiModulesMap } = configs;
+  const { napiModulesMap } = configs;
   const {
     mainThreadRpc,
     backgroundRpc,
@@ -82,7 +82,6 @@ export function startUIThread(
           overrideTagMap,
           backgroundRpc,
           rootDom,
-          entryId,
         },
         (info) => {
           const { pipelineId, timingFlags, isFP } = info;

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
@@ -47,7 +47,6 @@ export interface MainThreadConfig {
   styleInfo: StyleInfo;
   customSections: LynxTemplate['customSections'];
   lepusCode: LynxTemplate['lepusCode'];
-  entryId: string;
   browserConfig: BrowserConfig;
 }
 

--- a/packages/web-platform/web-tests/shell-project/mainthread-test.ts
+++ b/packages/web-platform/web-tests/shell-project/mainthread-test.ts
@@ -68,7 +68,6 @@ function initializeMainThreadTest() {
   const runtime = new MainThreadRuntime({
     lepusCode: { root: '' },
     customSections: {},
-    entryId: 't',
     browserConfig: {},
     pageConfig: {
       enableCSSSelector: true,

--- a/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
+++ b/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
@@ -42,7 +42,6 @@ export function startMainThread(
       const {
         globalProps,
         template,
-        entryId,
         browserConfig,
         nativeModulesUrl,
         napiModulesMap,
@@ -55,7 +54,6 @@ export function startMainThread(
       );
       const entry = (globalThis.module as LynxJSModule).exports!;
       const runtime = new MainThreadRuntime({
-        entryId,
         browserConfig,
         customSections,
         globalProps,

--- a/packages/webpack/web-webpack-plugin/src/constants.ts
+++ b/packages/webpack/web-webpack-plugin/src/constants.ts
@@ -1,4 +1,0 @@
-// Copyright 2024 The Lynx Authors. All rights reserved.
-// Licensed under the Apache License Version 2.0 that can be found in the
-// LICENSE file in the root directory of this source tree.
-export const cardIdAttribute = 'lynx-card-id';


### PR DESCRIPTION
After the PR #198
All contents are isolated by a shadowroot.
Therefore we don't need to add the entryId selector to avoid the lynx-view's style taking effect on the whole page.
