### PR TITLE
feat(web):  nativeModulesUrl  of lynx-view is changed to nativeModulesMap

### DIFF
--- a/.changeset/afraid-shirts-try.md
+++ b/.changeset/afraid-shirts-try.md
@@ -1,0 +1,42 @@
+---
+"@lynx-js/web-worker-runtime": minor
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": minor
+---
+
+feat: `nativeModulesUrl` of lynx-view is changed to `nativeModulesMap`, and the usage is completely aligned with `napiModulesMap`.
+
+"warning: This is a breaking change."
+
+`nativeModulesMap` will be a map: key is module-name, value should be a esm url which export default a
+function with two parameters(you never need to use `this`):
+
+- `NativeModules`: oriented `NativeModules`, which you can use to call
+  other Native-Modules.
+
+- `NativeModulesCall`: trigger `onNativeModulesCall`, same as the deprecated `this.nativeModulesCall`.
+
+example:
+
+```js
+const nativeModulesMap = {
+  CustomModule: URL.createObjectURL(
+    new Blob(
+      [
+        `export default function(NativeModules, NativeModulesCall) {
+    return {
+      async getColor(data, callback) {
+        const color = await NativeModulesCall('getColor', data);
+        callback(color);
+      },
+    }
+  };`,
+      ],
+      { type: 'text/javascript' },
+    ),
+  ),
+};
+lynxView.nativeModulesMap = nativeModulesMap;
+```
+
+In addition, we will use Promise.all to load `nativeModules`, which will optimize performance in the case of multiple modules.

--- a/packages/web-platform/web-constants/src/endpoints.ts
+++ b/packages/web-platform/web-constants/src/endpoints.ts
@@ -18,6 +18,7 @@ import type { PageConfig } from './types/PageConfig.js';
 import type { IdentifierType, InvokeCallbackRes } from './types/NativeApp.js';
 import type { LynxTemplate } from './types/LynxModule.js';
 import type { NapiModulesMap } from './types/NapiModules.js';
+import type { NativeModulesMap } from './types/NativeModules.js';
 
 export const postExposureEndpoint = createRpcEndpoint<
   [{ exposures: ExposureWorkerEvent[]; disExposures: ExposureWorkerEvent[] }],
@@ -104,7 +105,7 @@ export const BackgroundThreadStartEndpoint = createRpcEndpoint<[
     template: LynxTemplate;
     cardType: string;
     customSections: Record<string, Cloneable>;
-    nativeModulesUrl?: string;
+    nativeModulesMap: NativeModulesMap;
     napiModulesMap: NapiModulesMap;
   },
 ], void>('start', false, true);

--- a/packages/web-platform/web-constants/src/types/MainThreadStartConfigs.ts
+++ b/packages/web-platform/web-constants/src/types/MainThreadStartConfigs.ts
@@ -5,6 +5,7 @@
 import type { Cloneable } from './Cloneable.js';
 import type { LynxTemplate } from './LynxModule.js';
 import type { NapiModulesMap } from './NapiModules.js';
+import type { NativeModulesMap } from './NativeModules.js';
 import type { BrowserConfig } from './PageConfig.js';
 
 export interface MainThreadStartConfigs {
@@ -13,6 +14,6 @@ export interface MainThreadStartConfigs {
   globalProps: Cloneable;
   entryId: string;
   browserConfig: BrowserConfig;
-  nativeModulesUrl?: string;
+  nativeModulesMap: NativeModulesMap;
   napiModulesMap: NapiModulesMap;
 }

--- a/packages/web-platform/web-constants/src/types/NativeModules.ts
+++ b/packages/web-platform/web-constants/src/types/NativeModules.ts
@@ -2,25 +2,10 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { Cloneable } from './Cloneable.js';
+export type NativeModulesMap = Record<string, string>;
 
 export type NativeModulesCall = (
   name: string,
   data: any,
   moduleName: string,
 ) => Promise<any> | any;
-
-export type OneNativeModule = {
-  [k: string]: (
-    this: NativeModuleHandlerContext,
-    ...args: Cloneable[]
-  ) => Promise<Cloneable>;
-};
-
-export type NativeModuleHandlerContext = {
-  nativeModulesCall: (name: string, data: Cloneable) => Promise<Cloneable>;
-};
-
-export type customNativeModules = {
-  [k: string]: OneNativeModule;
-};

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -14,6 +14,7 @@ import {
   type NapiModulesCall,
   type NapiModulesMap,
   type NativeModulesCall,
+  type NativeModulesMap,
   type UpdateDataType,
 } from '@lynx-js/web-constants';
 import { inShadowRootStyles } from './inShadowRootStyles.js';
@@ -27,8 +28,8 @@ import { inShadowRootStyles } from './inShadowRootStyles.js';
  * @param {Cloneable} globalProps [optional] The globalProps value of this Lynx card
  * @param {Cloneable} initData [oprional] The initial data of this Lynx card
  * @param {Record<string,string>} overrideLynxTagToHTMLTagMap [optional] use this property/attribute to override the lynx tag -> html tag map
- * @param {string} nativeModulesUrl [optional] It is a esm url, use to customize NativeModules.
- * @param {INativeModulesCall} onNativeModulesCall [optional] the NativeModules value handler. Arguments will be cached before this property is assigned.
+ * @param {NativeModulesMap} nativeModulesMap [optional] use to customize NativeModules. key is module-name, value is esm url.
+ * @param {NativeModulesCall} onNativeModulesCall [optional] the NativeModules value handler. Arguments will be cached before this property is assigned.
  * @param {"auto" | null} height [optional] set it to "auto" for height auto-sizing
  * @param {"auto" | null} width [optional] set it to "auto" for width auto-sizing
  * @param {NapiModulesMap} napiModulesMap [optional] the napiModule which is called in lynx-core. key is module-name, value is esm url.
@@ -63,7 +64,7 @@ export class LynxView extends HTMLElement {
     'globalProps',
     'initData',
     'overrideLynxTagToHTMLTagMap',
-    'nativeModulesUrl',
+    'nativeModulesMap',
   ];
   private static attributeCamelCaseMap = Object.fromEntries(
     this.observedAttributeAsProperties.map((
@@ -175,22 +176,24 @@ export class LynxView extends HTMLElement {
     }
   }
 
-  #nativeModulesUrl?: string;
+  #nativeModulesMap: NativeModulesMap = {};
   /**
    * @public
-   * @property nativeModules
+   * @property nativeModulesMap
+   * @default {}
    */
-  get nativeModulesUrl(): string | undefined {
-    return this.#nativeModulesUrl;
+  get nativeModulesMap(): NativeModulesMap | undefined {
+    return this.#nativeModulesMap;
   }
-  set nativeModulesUrl(val: string) {
-    this.#nativeModulesUrl = val;
+  set nativeModulesMap(map: NativeModulesMap) {
+    this.#nativeModulesMap = map;
   }
 
   #napiModulesMap: NapiModulesMap = {};
   /**
    * @param
-   * @property
+   * @property napiModulesMap
+   * @default {}
    */
   get napiModulesMap(): NapiModulesMap | undefined {
     return this.#napiModulesMap;
@@ -384,7 +387,7 @@ export class LynxView extends HTMLElement {
             globalProps: this.#globalProps,
             initData: this.#initData,
             overrideLynxTagToHTMLTagMap: this.#overrideLynxTagToHTMLTagMap,
-            nativeModulesUrl: this.#nativeModulesUrl,
+            nativeModulesMap: this.#nativeModulesMap,
             napiModulesMap: this.#napiModulesMap,
             callbacks: {
               nativeModulesCall: (

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -47,6 +47,7 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
     {
       initData,
       globalProps,
+      nativeModulesMap,
       napiModulesMap,
       browserConfig: {},
     },

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -5,6 +5,7 @@
 import type {
   Cloneable,
   NapiModulesMap,
+  NativeModulesMap,
   UpdateDataType,
 } from '@lynx-js/web-constants';
 import { startUIThread } from '../uiThread/startUIThread.js';
@@ -17,7 +18,7 @@ export interface LynxViewConfigs {
   rootDom: HTMLElement;
   callbacks: Parameters<typeof startUIThread>[3];
   overrideLynxTagToHTMLTagMap?: Record<string, string>;
-  nativeModulesUrl: string | undefined;
+  nativeModulesMap: NativeModulesMap;
   napiModulesMap: NapiModulesMap;
 }
 
@@ -40,7 +41,7 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
     entryId,
     initData,
     overrideLynxTagToHTMLTagMap,
-    nativeModulesUrl,
+    nativeModulesMap,
     napiModulesMap,
   } = configs;
   return startUIThread(
@@ -49,12 +50,12 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
       initData,
       globalProps,
       entryId,
+      nativeModulesMap,
       napiModulesMap,
       browserConfig: {},
     },
     rootDom,
     callbacks,
     overrideLynxTagToHTMLTagMap,
-    nativeModulesUrl,
   );
 }

--- a/packages/web-platform/web-core/src/uiThread/startUIThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/startUIThread.ts
@@ -38,10 +38,9 @@ export function startUIThread(
     onError?: () => void;
   },
   overrideTagMap: Record<string, string> = {},
-  nativeModulesUrl: string | undefined,
 ): LynxView {
   const createLynxStartTiming = performance.now() + performance.timeOrigin;
-  const { entryId, napiModulesMap } = configs;
+  const { entryId, nativeModulesMap, napiModulesMap } = configs;
   const {
     mainThreadRpc,
     backgroundRpc,
@@ -62,7 +61,7 @@ export function startUIThread(
     mainThreadStart({
       ...configs,
       template,
-      nativeModulesUrl,
+      nativeModulesMap,
       napiModulesMap,
     });
   });

--- a/packages/web-platform/web-explorer/index.ts
+++ b/packages/web-platform/web-explorer/index.ts
@@ -32,24 +32,25 @@ const qrScanner = new QrScanner(video, (result) => {
   highlightCodeOutline: true,
 });
 
-const nativeModulesUrl = URL.createObjectURL(
-  new Blob(
-    [`
-export default {
-  ExplorerModule:{
-    openSchema(value) {
-      this.nativeModulesCall('openSchema', value)
-    },
-    openScan() {
-      this.nativeModulesCall('openScan')
-    }
-  }
-}
-      `],
-    { type: 'text/javascript' },
+const nativeModulesMap = {
+  ExplorerModule: URL.createObjectURL(
+    new Blob(
+      [`export default function(NativeModules, NativeModulesCall) {
+    return {
+      openSchema(value) {
+        NativeModulesCall('openSchema', value);
+      },
+      openScan() {
+        NativeModulesCall('openScan');
+      },
+    };
+  }`],
+      { type: 'text/javascript' },
+    ),
   ),
-);
+};
 
+lynxView.nativeModulesMap = nativeModulesMap;
 lynxView.onNativeModulesCall = (nm, data) => {
   if (nm === 'openScan') {
     lynxView.style.visibility = 'hidden';
@@ -58,7 +59,6 @@ lynxView.onNativeModulesCall = (nm, data) => {
     setLynxViewUrl(data);
   }
 };
-lynxView.nativeModulesUrl = nativeModulesUrl;
 lynxView.globalProps = { theme };
 setLynxViewUrl(homepage);
 window.addEventListener('message', (ev) => {

--- a/packages/web-platform/web-tests/shell-project/index.ts
+++ b/packages/web-platform/web-tests/shell-project/index.ts
@@ -9,21 +9,23 @@ import '@lynx-js/web-elements-compat/LinearContainer';
 import '@lynx-js/web-core/index.css';
 import './index.css';
 
-const userNativeModule = URL.createObjectURL(
-  new Blob(
-    [
-      `export default {
-  CustomModule: {
-    async getColor(data, callback) {
-      const color = await this.nativeModulesCall('getColor', data);
-      callback(color);
-    },
-  }
-};`,
-    ],
-    { type: 'text/javascript' },
+const nativeModulesMap = {
+  CustomModule: URL.createObjectURL(
+    new Blob(
+      [
+        `export default function(NativeModules, NativeModulesCall) {
+    return {
+      async getColor(data, callback) {
+        const color = await NativeModulesCall('getColor', data);
+        callback(color);
+      },
+    }
+  };`,
+      ],
+      { type: 'text/javascript' },
+    ),
   ),
-);
+};
 
 async function run() {
   const searchParams = new URLSearchParams(document.location.search);
@@ -45,7 +47,7 @@ async function run() {
       // @ts-expect-error
       globalThis.timing = Object.assign(globalThis.timing ?? {}, ev.detail);
     });
-    lynxView.nativeModulesUrl = userNativeModule;
+    lynxView.nativeModulesMap = nativeModulesMap;
     lynxView.onNativeModulesCall = (name, data, moduleName) => {
       if (name === 'getColor' && moduleName === 'CustomModule') {
         return data.color;

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNapiLoader.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNapiLoader.ts
@@ -14,7 +14,7 @@ export const createNapiLoader = async (
   napiModulesMap: NapiModulesMap,
 ) => {
   const napiModulesCall = rpc.createCall(napiModulesCallEndpoint);
-  let napiModules: Record<string, Record<string, any>> = {};
+  const napiModules: Record<string, Record<string, any>> = {};
   await Promise.all(
     Object.entries(napiModulesMap).map((
       [moduleName, moduleStr],

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -11,6 +11,7 @@ import {
   type LynxJSModule,
   type LynxTemplate,
   type NativeApp,
+  type NativeModulesMap,
 } from '@lynx-js/web-constants';
 import { createInvokeUIMethod } from './crossThreadHandlers/createInvokeUIMethod.js';
 import { registerOnLifecycleEventHandler } from './crossThreadHandlers/registerOnLifecycleEventHandler.js';
@@ -27,19 +28,19 @@ import { createJSObjectDestructionObserver } from './crossThreadHandlers/createJ
 
 let nativeAppCount = 0;
 
-export function createNativeApp(config: {
+export async function createNativeApp(config: {
   template: LynxTemplate;
   uiThreadRpc: Rpc;
   mainThreadRpc: Rpc;
   markTimingInternal: (timingKey: string, pipelineId?: string) => void;
-  customNativeModules: Record<string, Record<string, any>>;
-}): NativeApp {
+  nativeModulesMap: NativeModulesMap;
+}): Promise<NativeApp> {
   const {
     mainThreadRpc,
     uiThreadRpc,
     markTimingInternal,
     template,
-    customNativeModules,
+    nativeModulesMap,
   } = config;
   const { performanceApis, pipelineIdToTimingFlags } = createPerformanceApis(
     markTimingInternal,
@@ -63,9 +64,9 @@ export function createNativeApp(config: {
     setInterval: setInterval,
     clearTimeout: clearTimeout,
     clearInterval: clearInterval,
-    nativeModuleProxy: createNativeModules(
+    nativeModuleProxy: await createNativeModules(
       uiThreadRpc,
-      customNativeModules,
+      nativeModulesMap,
     ),
     loadScriptAsync: function(
       sourceURL: string,

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/startBackgroundThread.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/startBackgroundThread.ts
@@ -26,18 +26,11 @@ export function startBackgroundThread(
     BackgroundThreadStartEndpoint,
     async (config) => {
       markTimingInternal('load_core_end');
-      const customNativeModules: Record<string, Record<string, any>> =
-        config.nativeModulesUrl
-          ? (await import(
-            /* webpackIgnore: true */ config.nativeModulesUrl
-          ))?.default ?? {}
-          : {};
-      const nativeApp = createNativeApp({
+      const nativeApp = await createNativeApp({
         ...config,
         uiThreadRpc,
         mainThreadRpc,
         markTimingInternal,
-        customNativeModules,
       });
       (globalThis as any)['napiLoaderOnRT' + nativeApp.id] =
         await createNapiLoader(

--- a/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
+++ b/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
@@ -44,7 +44,7 @@ export function startMainThread(
         template,
         entryId,
         browserConfig,
-        nativeModulesUrl,
+        nativeModulesMap,
         napiModulesMap,
       } = config;
       const { styleInfo, pageConfig, customSections, cardType, lepusCode } =
@@ -92,7 +92,7 @@ export function startMainThread(
                   value.type !== 'lazy'
                 ).map(([k, v]) => [k, v.content]),
               ),
-              nativeModulesUrl,
+              nativeModulesMap,
               napiModulesMap,
             });
 


### PR DESCRIPTION
## Summary

feat: `nativeModulesUrl` of lynx-view is changed to `nativeModulesMap`, and the usage is completely aligned with `napiModulesMap`.

"warning: This is a breaking change."

`nativeModulesMap` will be a map: key is module-name, value should be a esm url which export default a
function with two parameters(you never need to use `this`):

- `NativeModules`: oriented `NativeModules`, which you can use to call
  other Native-Modules.

- `NativeModulesCall`: trigger `onNativeModulesCall`, same as the deprecated `this.nativeModulesCall`.

example:

```js
const nativeModulesMap = {
  CustomModule: URL.createObjectURL(
    new Blob(
      [
        `export default function(NativeModules, NativeModulesCall) {
    return {
      async getColor(data, callback) {
        const color = await NativeModulesCall('getColor', data);
        callback(color);
      },
    }
  };`,
      ],
      { type: 'text/javascript' },
    ),
  ),
};
lynxView.nativeModulesMap = nativeModulesMap;
```

In addition, we will use Promise.all to load `nativeModules`, which will optimize performance in the case of multiple modules.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
