### PR TITLE
feat: expose `main.lynx.bundle` file to compiler

### DIFF
--- a/.changeset/deep-words-hope.md
+++ b/.changeset/deep-words-hope.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+expose main.lynx.bundle to compiler

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -522,7 +522,7 @@ class LynxTemplatePluginImpl {
                  * and source-map is generated
                  */
                 compiler.webpack.Compilation
-                  .PROCESS_ASSETS_STAGE_REPORT,
+                  .PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
             },
             () => {
               return this.#generateTemplate(
@@ -573,7 +573,7 @@ class LynxTemplatePluginImpl {
            * and source-map is generated
            */
           compiler.webpack.Compilation
-            .PROCESS_ASSETS_STAGE_REPORT,
+            .PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
       }, async () => {
         await this.#generateAsyncTemplate(compilation);
       });


### PR DESCRIPTION
## Summary

Closes #179 

Change the process stage where the `main.lynx.bundle` file is located in order to be able to attach mid-process.

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
