### PR TITLE
ci: fix the merge queue

### DIFF
--- a/.github/workflows/pre-code-review-check.yml
+++ b/.github/workflows/pre-code-review-check.yml
@@ -3,13 +3,15 @@ name: pre-code-review-check
 on:
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
 env:
   CI: 1
   GITHUB_BASE_REF: ${{ github.base_ref }}
   GITHUB_HEAD_REF: ${{ github.head_ref }}
   GITHUB_REF: ${{ github.ref }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
   code-style-check:

--- a/.github/workflows/pre-code-review-check.yml
+++ b/.github/workflows/pre-code-review-check.yml
@@ -7,7 +7,7 @@ on:
     types: [checks_requested]
 env:
   CI: 1
-  GITHUB_BASE_REF: ${{ github.base_ref }}
+  GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
   GITHUB_HEAD_REF: ${{ github.head_ref }}
   GITHUB_REF: ${{ github.ref }}
 concurrency:

--- a/.github/workflows/pre-code-review-check.yml
+++ b/.github/workflows/pre-code-review-check.yml
@@ -7,7 +7,6 @@ on:
     types: [checks_requested]
 env:
   CI: 1
-  GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
   GITHUB_HEAD_REF: ${{ github.head_ref }}
   GITHUB_REF: ${{ github.ref }}
 concurrency:
@@ -35,7 +34,7 @@ jobs:
       - name: API Check
         run: pnpm turbo api-extractor
       - name: has-changeset
-        run: pnpm changeset status --since=origin/$GITHUB_BASE_REF
+        run: pnpm changeset status --since=origin/main
   no-confusion-check:
     runs-on: lynx-ubuntu-24.04-medium
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
 concurrency:
-  group: ${{github.event_name}}-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{github.event_name}}-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
   build:


### PR DESCRIPTION
In the merge queue, the workflows are triggered by the `merge_group`, which means the `github.event.pull_request.number` will be null

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#event-object-common-properties
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency
