### PR TITLE
chore: add window var to define callback argument in `background.js`

### DIFF
--- a/.changeset/loud-signs-see.md
+++ b/.changeset/loud-signs-see.md
@@ -1,0 +1,11 @@
+---
+"@lynx-js/runtime-wrapper-webpack-plugin": patch
+---
+
+Add `window` variable to callback argument in `background.js` and the `window` is `undefined` in Lynx. Sometimes it's useful to distinguish between Lynx and the Web.
+
+```js
+define('background.js', (..., window) => {
+  console.log(window); // `undefined` in Lynx
+})
+```

--- a/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
@@ -54,6 +54,7 @@ const defaultInjectVars = [
   'Behavior',
   'LynxJSBI',
   'lynx',
+  'window',
 ];
 
 /**


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

The `window` is `undefined` in Lynx. It's useful to distinguish between Lynx and the Web.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
