### PR TITLE
fix(react): add typing for `useErrorBoundary`

### DIFF
--- a/.changeset/five-cooks-greet.md
+++ b/.changeset/five-cooks-greet.md
@@ -1,0 +1,11 @@
+---
+"@lynx-js/react": patch
+---
+
+Add missing typing for `useErrorBoundary`.
+
+You can now use `useErrorBoundary` it in TypeScript like this:
+
+```tsx
+import { useErrorBoundary } from '@lynx-js/react';
+```

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -25,6 +25,7 @@ import { Suspense } from 'react';
 import { useCallback } from 'react';
 import { useContext } from 'react';
 import { useDebugValue } from 'react';
+import { useErrorBoundary } from 'preact/hooks';
 import { useImperativeHandle } from 'react';
 import { useMemo } from 'react';
 import { useReducer } from 'react';
@@ -117,6 +118,8 @@ export { useDebugValue }
 
 // @public
 export function useEffect(effect: EffectCallback, deps?: DependencyList): void;
+
+export { useErrorBoundary }
 
 export { useImperativeHandle }
 

--- a/packages/react/types/react.docs.d.ts
+++ b/packages/react/types/react.docs.d.ts
@@ -48,7 +48,7 @@ export {
   useSyncExternalStore,
 } from 'react';
 
-export { useEffect, useLayoutEffect } from '../runtime/lib/hooks/react.js';
+export { useEffect, useLayoutEffect, useErrorBoundary } from '../runtime/lib/hooks/react.js';
 
 /**
  * Built-in React APIs


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
