### PR TITLE
fix(rspeedy/react): use React from `rootPath`

### DIFF
--- a/.changeset/tasty-months-rush.md
+++ b/.changeset/tasty-months-rush.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/react-alias-rsbuild-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Fix the issue where the canary version of React was not included in the `rule.include` configuration.

--- a/packages/rspeedy/plugin-react-alias/package.json
+++ b/packages/rspeedy/plugin-react-alias/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-webpack-plugin": "workspace:*",
+    "@lynx-js/vitest-setup": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rsbuild/core": "catalog:rsbuild"
   },

--- a/packages/rspeedy/plugin-react-alias/package.json
+++ b/packages/rspeedy/plugin-react-alias/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "api-extractor": "api-extractor run --verbose",
     "build": "rslib build",
-    "test": "vitest"
+    "test": "pnpm -w run test --project rspeedy/react-alias"
   },
   "dependencies": {
     "enhanced-resolve": "^5.18.1"

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -44,6 +44,15 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
         reactLynxDir,
         lazy ? ['lazy', 'import'] : ['import'],
       )
+
+      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+        return mergeRsbuildConfig(config, {
+          source: {
+            include: [reactLynxDir],
+          },
+        })
+      })
+
       api.modifyBundlerChain(async chain => {
         // FIXME(colinaaa): use `Promise.all`
         const jsxRuntime = {

--- a/packages/rspeedy/plugin-react-alias/test/include.test.ts
+++ b/packages/rspeedy/plugin-react-alias/test/include.test.ts
@@ -1,0 +1,53 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createRsbuild } from '@rsbuild/core'
+import type { Rspack } from '@rsbuild/core'
+import { describe, expect, it } from 'vitest'
+
+import { LAYERS } from '@lynx-js/react-webpack-plugin'
+
+import { pluginReactAlias } from '../src/index.js'
+
+// The Default JS RegExp of Rsbuild
+const SCRIPT_REGEXP = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/
+
+describe('React - Include', () => {
+  it('should include react', async () => {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          pluginReactAlias({ LAYERS }),
+        ],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+
+    expect(config).not.toBeNull()
+
+    const swcRule = config?.module?.rules?.find(
+      (rule): rule is Rspack.RuleSetRule => {
+        return !!(rule && rule !== '...'
+          && (rule.test as RegExp | undefined)?.toString()
+            === SCRIPT_REGEXP.toString())
+      },
+    )
+
+    expect(swcRule?.include).toMatchInlineSnapshot(`
+      [
+        {
+          "and": [
+            "<WORKSPACE>/packages/rspeedy/plugin-react-alias",
+            {
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+            },
+          ],
+        },
+        /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+        "<WORKSPACE>/packages/react",
+      ]
+    `)
+  })
+})

--- a/packages/rspeedy/plugin-react-alias/test/include.test.ts
+++ b/packages/rspeedy/plugin-react-alias/test/include.test.ts
@@ -39,7 +39,7 @@ describe('React - Include', () => {
       [
         {
           "and": [
-            "<WORKSPACE>/packages/rspeedy/plugin-react-alias",
+            "<WORKSPACE>",
             {
               "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },

--- a/packages/rspeedy/plugin-react-alias/vitest.config.ts
+++ b/packages/rspeedy/plugin-react-alias/vitest.config.ts
@@ -7,6 +7,7 @@ import type { UserWorkspaceConfig } from 'vitest/config'
 const config: UserWorkspaceConfig = defineProject({
   test: {
     name: 'rspeedy/react-alias',
+    setupFiles: ['@lynx-js/vitest-setup/setup.ts'],
   },
 })
 

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -9,7 +9,6 @@
  */
 
 import { createRequire } from 'node:module'
-import path from 'node:path'
 
 import type { RsbuildPlugin } from '@rsbuild/core'
 
@@ -362,14 +361,6 @@ export function pluginReactLynx(
       applySWC(api)
 
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-        config = mergeRsbuildConfig(config, {
-          source: {
-            include: [
-              path.dirname(require.resolve('@lynx-js/react/package.json')),
-            ],
-          },
-        })
-
         const userConfig = api.getRsbuildConfig('original')
         if (typeof userConfig.source?.include === 'undefined') {
           return mergeRsbuildConfig(config, {

--- a/packages/rspeedy/plugin-react/test/swc-config.test.ts
+++ b/packages/rspeedy/plugin-react/test/swc-config.test.ts
@@ -108,7 +108,6 @@ describe('SWC configuration', () => {
         },
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
-        "<WORKSPACE>/packages/react",
         /\\\\\\.\\(\\?:js\\|mjs\\|cjs\\)\\$/,
       ]
     `)
@@ -192,7 +191,6 @@ describe('SWC configuration', () => {
         },
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
-        "<WORKSPACE>/packages/react",
         /\\\\\\.\\(\\?:js\\|mjs\\|cjs\\)\\$/,
       ]
     `)
@@ -385,7 +383,6 @@ describe('SWC configuration', () => {
         },
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
-        "<WORKSPACE>/packages/react",
       ]
     `)
   })

--- a/packages/rspeedy/plugin-react/test/swc-config.test.ts
+++ b/packages/rspeedy/plugin-react/test/swc-config.test.ts
@@ -108,6 +108,7 @@ describe('SWC configuration', () => {
         },
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
+        "<WORKSPACE>/packages/react",
         /\\\\\\.\\(\\?:js\\|mjs\\|cjs\\)\\$/,
       ]
     `)
@@ -191,6 +192,7 @@ describe('SWC configuration', () => {
         },
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
+        "<WORKSPACE>/packages/react",
         /\\\\\\.\\(\\?:js\\|mjs\\|cjs\\)\\$/,
       ]
     `)
@@ -383,6 +385,7 @@ describe('SWC configuration', () => {
         },
         /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
+        "<WORKSPACE>/packages/react",
       ]
     `)
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       '@lynx-js/react-webpack-plugin':
         specifier: workspace:*
         version: link:../../webpack/react-webpack-plugin
+      '@lynx-js/vitest-setup':
+        specifier: workspace:*
+        version: link:../../tools/vitest-setup
       '@microsoft/api-extractor':
         specifier: 'catalog:'
         version: 7.51.1(@types/node@22.13.5)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The react set in the `source.include` is not correct when using canary version.

https://github.com/lynx-family/lynx-stack/blob/33a64cffba578bba9240eb491d5886e1e41467b9/packages/rspeedy/plugin-react/src/pluginReactLynx.ts#L365-L371

We should use `require.resolve` from `rootPath` just like aliases does.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] **Tests updated** (or not required).
- [x] Documentation updated (or **not required**).
