### PR TITLE
feat(web): add a new package @lynx-js/offscreen-document

### DIFF
--- a/packages/web-platform/offscreen-document/Notice.txt
+++ b/packages/web-platform/offscreen-document/Notice.txt
@@ -1,0 +1,1 @@
+Copyright 2023-2024 The Lynx Authors. All rights reserved.

--- a/packages/web-platform/offscreen-document/README.md
+++ b/packages/web-platform/offscreen-document/README.md
@@ -1,0 +1,3 @@
+# @lynx-js/offscreen-document
+
+Offscreen Document allows developers to use partical DOM in WebWorker

--- a/packages/web-platform/offscreen-document/README.md
+++ b/packages/web-platform/offscreen-document/README.md
@@ -1,3 +1,3 @@
 # @lynx-js/offscreen-document
 
-Offscreen Document allows developers to use partical DOM in WebWorker
+Offscreen Document allows developers to use partial DOM in WebWorker

--- a/packages/web-platform/offscreen-document/package.json
+++ b/packages/web-platform/offscreen-document/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@lynx-js/offscreen-document",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Offscreen Document allows developers to use partical DOM in WebWorker",
+  "keywords": [
+    "WebWorker",
+    "DOM",
+    "lynx"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/web-platform/offscreen-document"
+  },
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    "./main": {
+      "types": "./dist/main/index.d.ts",
+      "default": "./dist/main/index.js"
+    },
+    "./webworker": {
+      "types": "./dist/webworker/index.d.ts",
+      "default": "./dist/webworker/index.js"
+    },
+    ".": {
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "!dist/**/*.js.map",
+    "LICENSE.txt",
+    "Notice.txt",
+    "CHANGELOG.md",
+    "README.md"
+  ]
+}

--- a/packages/web-platform/offscreen-document/src/index.ts
+++ b/packages/web-platform/offscreen-document/src/index.ts
@@ -1,0 +1,3 @@
+export type * from './webworker/index.js';
+export type * from './main/index.js';
+export type * from './types/index.js';

--- a/packages/web-platform/offscreen-document/src/main/index.ts
+++ b/packages/web-platform/offscreen-document/src/main/index.ts
@@ -1,0 +1,1 @@
+export * from './initOffscreenDocument.js';

--- a/packages/web-platform/offscreen-document/src/types/ElementOperation.ts
+++ b/packages/web-platform/offscreen-document/src/types/ElementOperation.ts
@@ -1,0 +1,119 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const OperationType = {
+  CreateElement: 1,
+  SetAttribute: 2,
+  RemoveAttribute: 3,
+  Append: 4,
+  Remove: 5,
+  ReplaceWith: 6,
+  InsertBefore: 7,
+  EnableEvent: 8,
+  RemoveChild: 9,
+  StyleDeclarationSetProperty: 10,
+  StyleDeclarationRemoveProperty: 11,
+  SetInnerHTML: 12,
+} as const;
+
+type IOperationType = typeof OperationType;
+interface ElementOperationBase {
+  type: IOperationType[keyof IOperationType];
+  /**
+   * uniqueId
+   */
+  uid: number;
+}
+
+export interface CreateOperation extends ElementOperationBase {
+  type: IOperationType['CreateElement'];
+  tag: string;
+}
+
+export interface SetAttributeOperation extends ElementOperationBase {
+  type: IOperationType['SetAttribute'];
+  key: string;
+  value: string;
+}
+export interface RemoveAttributeOperation extends ElementOperationBase {
+  type: IOperationType['RemoveAttribute'];
+  key: string;
+}
+
+export interface AppendOperation extends ElementOperationBase {
+  type: IOperationType['Append'];
+  /**
+   * child uniqueId
+   */
+  cid: number[];
+}
+
+export interface RemoveOperation extends ElementOperationBase {
+  type: IOperationType['Remove'];
+}
+
+export interface InsertBeforeOperation extends ElementOperationBase {
+  type: IOperationType['InsertBefore'];
+  /**
+   * child uniqueId
+   */
+  cid: number;
+  ref?: number | undefined;
+}
+
+export interface ReplaceOperation extends ElementOperationBase {
+  type: IOperationType['ReplaceWith'];
+  /**
+   * the new element's unique id.
+   */
+  nid: number[];
+}
+
+export interface EnableEventOperation extends ElementOperationBase {
+  type: IOperationType['EnableEvent'];
+  eventType: string;
+}
+
+export interface RemoveChildOperation extends ElementOperationBase {
+  type: IOperationType['RemoveChild'];
+  /**
+   * the child element's unique id to be removed.
+   */
+  cid: number;
+}
+
+export interface StyleDeclarationSetPropertyOperation
+  extends ElementOperationBase
+{
+  type: IOperationType['StyleDeclarationSetProperty'];
+  property: string;
+  value: string;
+  priority: string | undefined | '';
+}
+
+export interface StyleDeclarationRemovePropertyOperation
+  extends ElementOperationBase
+{
+  type: IOperationType['StyleDeclarationRemoveProperty'];
+  property: string;
+}
+
+export interface SetInnerHTMLOperation extends ElementOperationBase {
+  type: IOperationType['SetInnerHTML'];
+  text: string;
+}
+
+export type ElementOperation =
+  | EnableEventOperation
+  | ReplaceOperation
+  | InsertBeforeOperation
+  | CreateOperation
+  | SetAttributeOperation
+  | RemoveAttributeOperation
+  | AppendOperation
+  | RemoveOperation
+  | RemoveChildOperation
+  | StyleDeclarationSetPropertyOperation
+  | StyleDeclarationRemovePropertyOperation
+  | SetInnerHTMLOperation;

--- a/packages/web-platform/offscreen-document/src/types/index.ts
+++ b/packages/web-platform/offscreen-document/src/types/index.ts
@@ -1,0 +1,1 @@
+export type * from './ElementOperation.js';

--- a/packages/web-platform/offscreen-document/src/webworker/OffscreenCSSStyleDeclaration.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/OffscreenCSSStyleDeclaration.ts
@@ -1,0 +1,41 @@
+import {
+  ancestorDocument,
+  uniqueId,
+  type OffscreenElement,
+} from './OffscreenElement.js';
+import { operations } from './OffscreenDocument.js';
+import { OperationType } from '../types/ElementOperation.js';
+
+const _parent = Symbol('_parent');
+export class OffscreenCSSStyleDeclaration {
+  /**
+   * @private
+   */
+  readonly [_parent]: OffscreenElement;
+
+  constructor(parent: OffscreenElement) {
+    this[_parent] = parent;
+  }
+
+  setProperty(
+    property: string,
+    value: string,
+    priority?: 'important' | undefined | '',
+  ): void {
+    this[_parent][ancestorDocument][operations].push({
+      type: OperationType['StyleDeclarationSetProperty'],
+      uid: this[_parent][uniqueId],
+      property,
+      value: value,
+      priority: priority,
+    });
+  }
+
+  removeProperty(property: string): void {
+    this[_parent][ancestorDocument][operations].push({
+      type: OperationType['StyleDeclarationRemoveProperty'],
+      uid: this[_parent][uniqueId],
+      property,
+    });
+  }
+}

--- a/packages/web-platform/offscreen-document/src/webworker/OffscreenDocument.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/OffscreenDocument.ts
@@ -1,0 +1,126 @@
+import {
+  OperationType,
+  type ElementOperation,
+} from '../types/ElementOperation.js';
+import { OffscreenElement, uniqueId } from './OffscreenElement.js';
+import {
+  eventPhase,
+  OffscreenEvent,
+  propagationStopped,
+} from './OffscreenEvent.js';
+
+export const operations = Symbol('opeartions');
+export const enableEvent = Symbol('enableEvent');
+export const getElementByUniqueId = Symbol('getElementByUniqueId');
+const _onEvent = Symbol('_onEvent');
+const _uniqueIdInc = Symbol('uniqueIdInc');
+const _uniqueIdToElement = Symbol('_uniqueIdToElement');
+export class OffscreenDocument extends EventTarget {
+  /**
+   * @private
+   */
+  [_uniqueIdInc] = 1;
+
+  /**
+   * @private
+   */
+  [_uniqueIdToElement]: WeakRef<OffscreenElement>[] = [];
+
+  /**
+   * @private
+   */
+  [operations]: ElementOperation[] = [];
+
+  /**
+   * @private
+   * @param uniqueId
+   * @returns
+   */
+  [getElementByUniqueId](uniqueId: number): OffscreenElement | undefined {
+    return this[_uniqueIdToElement][uniqueId]?.deref();
+  }
+
+  constructor(
+    private _callbacks: {
+      onCommit: (operations: ElementOperation[]) => void;
+    },
+  ) {
+    super();
+  }
+
+  commit(): void {
+    const currentOperations = this[operations];
+    this[operations] = [];
+    this._callbacks.onCommit(currentOperations);
+  }
+
+  append(element: OffscreenElement) {
+    this[operations].push({
+      type: OperationType.Append,
+      uid: 0,
+      cid: [element[uniqueId]],
+    });
+  }
+
+  createElement(tagName: string): OffscreenElement {
+    const uniqueId = this[_uniqueIdInc]++;
+    const element = new OffscreenElement(tagName, this, uniqueId);
+    this[_uniqueIdToElement][uniqueId] = new WeakRef(element);
+    this[operations].push({
+      type: OperationType.CreateElement,
+      uid: uniqueId,
+      tag: tagName,
+    });
+    return element;
+  }
+
+  #enabledEvents = new Set<string>();
+  [enableEvent](eventType: string): void {
+    if (!this.#enabledEvents.has(eventType)) {
+      this[operations].push({
+        type: OperationType.EnableEvent,
+        eventType,
+        uid: 0,
+      });
+    }
+  }
+
+  [_onEvent] = (
+    eventType: string,
+    targetUniqueId: number,
+    bubbles: boolean,
+  ) => {
+    const target = this[getElementByUniqueId](targetUniqueId);
+    if (target) {
+      const bubblePath: OffscreenElement[] = [];
+      let tempTarget = target;
+      while (tempTarget.parentElement) {
+        bubblePath.push(tempTarget.parentElement);
+        tempTarget = tempTarget.parentElement;
+      }
+      const event = new OffscreenEvent(eventType, target);
+      // capture phase
+      event[eventPhase] = Event.CAPTURING_PHASE;
+      for (let ii = bubblePath.length - 1; ii >= 0; ii--) {
+        const currentPhaseTarget = bubblePath[ii]!;
+        currentPhaseTarget.dispatchEvent(event);
+        if (event[propagationStopped]) {
+          return;
+        }
+      }
+      // target phase
+      event[eventPhase] = Event.AT_TARGET;
+      target.dispatchEvent(event);
+      // bubble phase
+      if (bubbles) {
+        event[eventPhase] = Event.BUBBLING_PHASE;
+        for (const currentPhaseTarget of bubblePath) {
+          currentPhaseTarget.dispatchEvent(event);
+          if (event[propagationStopped]) {
+            return;
+          }
+        }
+      }
+    }
+  };
+}

--- a/packages/web-platform/offscreen-document/src/webworker/OffscreenDocument.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/OffscreenDocument.ts
@@ -9,7 +9,7 @@ import {
   propagationStopped,
 } from './OffscreenEvent.js';
 
-export const operations = Symbol('opeartions');
+export const operations = Symbol('operations');
 export const enableEvent = Symbol('enableEvent');
 export const getElementByUniqueId = Symbol('getElementByUniqueId');
 const _onEvent = Symbol('_onEvent');

--- a/packages/web-platform/offscreen-document/src/webworker/OffscreenElement.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/OffscreenElement.ts
@@ -1,0 +1,239 @@
+import {
+  enableEvent,
+  operations,
+  type OffscreenDocument,
+} from './OffscreenDocument.js';
+import { OffscreenCSSStyleDeclaration } from './OffscreenCSSStyleDeclaration.js';
+import { OperationType } from '../types/ElementOperation.js';
+
+export const prevSibling = Symbol('prevSibling');
+export const nextSibling = Symbol('nextSibling');
+export const uniqueId = Symbol('uniqueId');
+export const ancestorDocument = Symbol('ancestorDocument');
+const _parent = Symbol('_parent');
+const _firstChild = Symbol('_firstChild');
+const _lastchild = Symbol('_lastchild');
+const _style = Symbol('_style');
+const _attributes = Symbol('_attributes');
+export class OffscreenElement extends EventTarget {
+  private [_style]?: OffscreenCSSStyleDeclaration;
+  private [_parent]: OffscreenElement | null = null;
+  private [_firstChild]: OffscreenElement | null = null;
+  private [_lastchild]: OffscreenElement | null = null;
+  [prevSibling]: OffscreenElement | null = null;
+  [nextSibling]: OffscreenElement | null = null;
+
+  private readonly [_attributes]: Record<string, string> = {};
+
+  /**
+   * @private
+   */
+  readonly [uniqueId]: number;
+
+  /**
+   * @private
+   */
+  readonly [ancestorDocument]: OffscreenDocument;
+
+  public readonly tagName: string;
+
+  constructor(
+    tagName: string,
+    parentDocument: OffscreenDocument,
+    elementUniqueId: number,
+  ) {
+    super();
+    this.tagName = tagName.toUpperCase();
+    this[ancestorDocument] = parentDocument;
+    this[uniqueId] = elementUniqueId;
+  }
+
+  get style(): OffscreenCSSStyleDeclaration {
+    if (!this[_style]) {
+      this[_style] = new OffscreenCSSStyleDeclaration(
+        this,
+      );
+    }
+    return this[_style];
+  }
+
+  get children(): OffscreenElement[] {
+    return this.children.slice();
+  }
+
+  get parentElement(): OffscreenElement | null {
+    return this[_parent];
+  }
+
+  get firstElementChild(): OffscreenElement | null {
+    return this[_firstChild];
+  }
+
+  get lastElementChild(): OffscreenElement | null {
+    return this[_lastchild];
+  }
+
+  get nextElementSibling(): OffscreenElement | null {
+    return this[nextSibling];
+  }
+
+  get id(): string {
+    return this[_attributes]['id'] ?? '';
+  }
+
+  set id(value: string) {
+    this[_attributes]['id'] = value;
+    this.setAttribute('id', value);
+  }
+
+  get className(): string {
+    return this[_attributes]['class'] ?? '';
+  }
+
+  setAttribute(qualifiedName: string, value: string): void {
+    this[_attributes][qualifiedName] = value;
+    this[ancestorDocument][operations].push({
+      type: OperationType.SetAttribute,
+      uid: this[uniqueId],
+      key: qualifiedName,
+      value,
+    });
+  }
+
+  getAttribute(qualifiedName: string): string | null {
+    return this[_attributes][qualifiedName] ?? null;
+  }
+
+  removeAttribute(qualifiedName: string): void {
+    delete this[_attributes][qualifiedName];
+    this[ancestorDocument][operations].push({
+      type: OperationType.RemoveAttribute,
+      uid: this[uniqueId],
+      key: qualifiedName,
+    });
+  }
+
+  append(...nodes: (OffscreenElement)[]): void {
+    this[ancestorDocument][operations].push({
+      type: OperationType.Append,
+      uid: this[uniqueId],
+      cid: nodes.map(node => node[uniqueId]),
+    });
+    for (const node of nodes) {
+      node.remove();
+      node[prevSibling] = this[_lastchild];
+      if (this[_lastchild]) {
+        this[_lastchild][nextSibling] = node;
+      }
+      node[_parent] = this;
+      if (!this[_firstChild]) {
+        this[_firstChild] = node;
+      }
+      if (!this[_lastchild]) {
+        this[_lastchild] = node;
+      }
+    }
+  }
+
+  replaceWith(...nodes: (OffscreenElement)[]): void {
+    this[ancestorDocument][operations].push({
+      type: OperationType.ReplaceWith,
+      uid: this[uniqueId],
+      nid: nodes.map(node => node[uniqueId]),
+    });
+  }
+
+  getAttributeNames(): string[] {
+    return Object.keys(this[_attributes]);
+  }
+
+  remove(): void {
+    if (this[_parent]) {
+      this[ancestorDocument][operations].push({
+        type: OperationType.Remove,
+        uid: this[uniqueId],
+      });
+      if (this[_parent][_firstChild] === this) {
+        this[_parent][_firstChild] = this[nextSibling];
+      }
+      if (this[_parent][_lastchild] === this) {
+        this[_parent][_lastchild] = null;
+      }
+      if (this[prevSibling]) {
+        this[prevSibling][nextSibling] = this[nextSibling];
+      }
+      if (this[nextSibling]) {
+        this[nextSibling][prevSibling] = this[prevSibling];
+      }
+      this[prevSibling] = null;
+      this[nextSibling] = null;
+      this[_parent] = null;
+    }
+  }
+
+  insertBefore(
+    newNode: OffscreenElement,
+    refNode: OffscreenElement | null,
+  ): OffscreenElement {
+    this[ancestorDocument][operations].push({
+      type: OperationType.InsertBefore,
+      uid: this[uniqueId],
+      cid: newNode[uniqueId],
+      ref: refNode?.[uniqueId],
+    });
+    newNode.remove();
+    if (refNode) {
+      newNode[prevSibling] = refNode[prevSibling];
+      if (refNode[prevSibling]) {
+        refNode[prevSibling][nextSibling] = newNode;
+      }
+      newNode[nextSibling] = refNode;
+      refNode[prevSibling] = newNode;
+    } else {
+      this.append(newNode);
+    }
+    return newNode;
+  }
+
+  removeChild(child: OffscreenElement | null): OffscreenElement {
+    if (!child) {
+      throw new DOMException(
+        'The node to be removed is not a child of this node.',
+        'NotFoundError',
+      );
+    }
+    this[ancestorDocument][operations].push({
+      type: OperationType.RemoveChild,
+      uid: this[uniqueId],
+      cid: child[uniqueId],
+    });
+    if (child[_parent] !== this) {
+      throw new DOMException(
+        'The node to be removed is not a child of this node.',
+        'NotFoundError',
+      );
+    }
+    child.remove();
+    return child;
+  }
+
+  set innerHTML(text: string) {
+    this[ancestorDocument][operations].push({
+      type: OperationType.SetInnerHTML,
+      text,
+      uid: this[uniqueId],
+    });
+  }
+
+  // #captureListeners:Record<string, Set<EventListener> | undefined> = {};
+  // #normalListeners:Record<string, Set<EventListener> | undefined> = {};
+
+  override addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    this[ancestorDocument][enableEvent](type);
+    super.addEventListener(type, callback, options);
+  }
+}

--- a/packages/web-platform/offscreen-document/src/webworker/OffscreenElement.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/OffscreenElement.ts
@@ -58,7 +58,13 @@ export class OffscreenElement extends EventTarget {
   }
 
   get children(): OffscreenElement[] {
-    return this.children.slice();
+    const kids: OffscreenElement[] = [];
+    let child = this[_firstChild];
+    while (child) {
+      kids.push(child);
+      child = child[nextSibling];
+    }
+    return kids;
   }
 
   get parentElement(): OffscreenElement | null {

--- a/packages/web-platform/offscreen-document/src/webworker/OffscreenEvent.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/OffscreenEvent.ts
@@ -1,0 +1,31 @@
+import type { OffscreenElement } from './OffscreenElement.js';
+
+export const propagationStopped = Symbol('propagationStopped');
+export const eventPhase = Symbol('eventPhase');
+
+export class OffscreenEvent extends Event {
+  [eventPhase]: Event['eventPhase'] = Event.CAPTURING_PHASE;
+  constructor(type: string, private _target: OffscreenElement) {
+    super(type);
+  }
+
+  override get target(): OffscreenElement {
+    return this._target;
+  }
+
+  [propagationStopped] = false;
+
+  override stopImmediatePropagation(): void {
+    this[propagationStopped] = true;
+    super.stopImmediatePropagation();
+  }
+
+  override stopPropagation(): void {
+    this[propagationStopped] = true;
+    super.stopPropagation();
+  }
+
+  override get eventPhase() {
+    return this[eventPhase];
+  }
+}

--- a/packages/web-platform/offscreen-document/src/webworker/index.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/index.ts
@@ -1,0 +1,4 @@
+export { OffscreenDocument } from './OffscreenDocument.js';
+export type * from './OffscreenEvent.js';
+export type * from './OffscreenElement.js';
+export type * from './OffscreenCSSStyleDeclaration.js';

--- a/packages/web-platform/offscreen-document/tsconfig.json
+++ b/packages/web-platform/offscreen-document/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["ESNext", "WebWorker", "DOM"],
+    "exactOptionalPropertyTypes": true,
+  },
+  "include": ["src"],
+  "references": [],
+}

--- a/packages/web-platform/tsconfig.json
+++ b/packages/web-platform/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "references": [
     /** packages-start */
+    { "path": "./offscreen-document/tsconfig.json" },
     { "path": "./web-elements-reactive/tsconfig.json" },
     { "path": "./web-elements/tsconfig.json" },
     { "path": "./web-style-transformer/tsconfig.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,8 @@ importers:
         specifier: ^5.98.0
         version: 5.98.0
 
+  packages/web-platform/offscreen-document: {}
+
   packages/web-platform/web-constants:
     dependencies:
       '@lynx-js/web-worker-rpc':


### PR DESCRIPTION
We're splitting cross-threads dom implementation with the Element PAPI implmenetation.

The Element PAPI will be migrate to this package.

Split current mainthread dom apis into a new package and submit a new WICG proposal for OffscreenDocument #51

