### PR TITLE
test(webpack): use different paths for output

### DIFF
--- a/packages/webpack/test-tools/src/case.ts
+++ b/packages/webpack/test-tools/src/case.ts
@@ -96,7 +96,7 @@ function createCase(
 }
 
 export function describeCases(suite: ITestSuite): void {
-  const distPath = path.resolve(suite.casePath, '../dist');
+  const distPath = path.resolve(suite.casePath, '../dist/config');
   rimrafSync(distPath);
   describeByWalk(suite.name, (name, src, dist) => {
     createCase(name, src, dist, suite.casePath, {

--- a/packages/webpack/test-tools/src/diagnostic.ts
+++ b/packages/webpack/test-tools/src/diagnostic.ts
@@ -15,6 +15,7 @@ import type {
   TCompilerOptions,
 } from '@rspack/test-tools';
 import fs from 'fs-extra';
+import { rimrafSync } from 'rimraf';
 import { describe, expect, it } from 'vitest';
 
 import { createVitestEnv, getOptions } from './suite.js';
@@ -126,8 +127,8 @@ function createCase(name: string, src: string, dist: string, cwd: string) {
 }
 
 export function diagnosticCases(suite: ITestSuite): void {
-  const distPath = path.resolve(suite.casePath, '../dist');
-  fs.rmSync(distPath, { recursive: true, force: true });
+  const distPath = path.resolve(suite.casePath, '../dist/diagnostic');
+  rimrafSync(distPath);
   describeByWalk(suite.name, (name, src, dist) => {
     createCase(name, src, dist, suite.casePath);
   }, {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

This should fix the flaky test [here](https://github.com/lynx-family/lynx-stack/actions/runs/14055011715/job/39352668039).

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
