### PR TITLE
chore(web): add export lynx-view tests for other projects

### DIFF
--- a/packages/web-platform/web-tests/package.json
+++ b/packages/web-platform/web-tests/package.json
@@ -4,6 +4,11 @@
   "private": true,
   "license": "Apache-2.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "default": "./shell-project/lynx-view.ts"
+    }
+  },
   "scripts": {
     "build": "if [ \"$CI\" = \"1\" ]; then pnpm build:cases; fi",
     "build:cases": "rm -rf dist && node  ./scripts/generate-build-command.js",

--- a/packages/web-platform/web-tests/shell-project/index.ts
+++ b/packages/web-platform/web-tests/shell-project/index.ts
@@ -1,13 +1,8 @@
 // Copyright 2023 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { LynxView } from '@lynx-js/web-core';
-import '@lynx-js/web-core';
-import '@lynx-js/web-elements/all';
-import '@lynx-js/web-elements/index.css';
-import '@lynx-js/web-elements-compat/LinearContainer';
-import '@lynx-js/web-core/index.css';
-import './index.css';
+
+import { lynxViewTests } from './lynx-view.ts';
 
 const nativeModulesMap = {
   CustomModule: URL.createObjectURL(
@@ -27,26 +22,15 @@ const nativeModulesMap = {
   ),
 };
 
-async function run() {
-  const searchParams = new URLSearchParams(document.location.search);
-  const casename = searchParams.get('casename');
-  const hasdir = searchParams.get('hasdir') === 'true';
-  if (casename) {
-    const dir = `/dist/${casename}${hasdir ? `/${casename}` : ''}`;
-    const lepusjs = `${dir}/index.web.json`;
-    const lynxView = document.createElement('lynx-view') as LynxView;
+const searchParams = new URLSearchParams(document.location.search);
+const casename = searchParams.get('casename');
+const hasdir = searchParams.get('hasdir') === 'true';
+
+if (casename) {
+  const dir = `/dist/${casename}${hasdir ? `/${casename}` : ''}`;
+  const lepusjs = `${dir}/index.web.json`;
+  lynxViewTests(lynxView => {
     lynxView.setAttribute('url', lepusjs);
-    lynxView.initData = { mockData: 'mockData' };
-    lynxView.setAttribute('height', 'auto');
-    lynxView.globalProps = { pink: 'pink' };
-    lynxView.addEventListener('error', () => {
-      lynxView.setAttribute('style', 'display:none');
-      lynxView.innerHTML = '';
-    });
-    lynxView.addEventListener('timing', (ev) => {
-      // @ts-expect-error
-      globalThis.timing = Object.assign(globalThis.timing ?? {}, ev.detail);
-    });
     lynxView.nativeModulesMap = nativeModulesMap;
     lynxView.onNativeModulesCall = (name, data, moduleName) => {
       if (name === 'getColor' && moduleName === 'CustomModule') {
@@ -56,11 +40,7 @@ async function run() {
         return data.color;
       }
     };
-    document.body.append(lynxView);
-
-    Object.assign(globalThis, { lynxView });
-  } else {
-    console.warn('cannot find casename');
-  }
+  });
+} else {
+  console.warn('cannot find casename');
 }
-run();

--- a/packages/web-platform/web-tests/shell-project/lynx-view.ts
+++ b/packages/web-platform/web-tests/shell-project/lynx-view.ts
@@ -1,0 +1,29 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { LynxView } from '@lynx-js/web-core';
+import '@lynx-js/web-core';
+import '@lynx-js/web-elements/all';
+import '@lynx-js/web-elements/index.css';
+import '@lynx-js/web-elements-compat/LinearContainer';
+import '@lynx-js/web-core/index.css';
+import './index.css';
+
+export const lynxViewTests = (callback: (lynxView: LynxView) => void) => {
+  const lynxView = document.createElement('lynx-view') as LynxView;
+  lynxView.initData = { mockData: 'mockData' };
+  lynxView.setAttribute('height', 'auto');
+  lynxView.globalProps = { pink: 'pink' };
+  lynxView.addEventListener('error', () => {
+    lynxView.setAttribute('style', 'display:none');
+    lynxView.innerHTML = '';
+  });
+  lynxView.addEventListener('timing', (ev) => {
+    // @ts-expect-error
+    globalThis.timing = Object.assign(globalThis.timing ?? {}, ev.detail);
+  });
+  callback(lynxView);
+  document.body.append(lynxView);
+
+  Object.assign(globalThis, { lynxView });
+};


### PR DESCRIPTION
## Summary

web-tests adds public configuration export of lynxView, which is to synchronize the break change of lynxView

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
