### PR TITLE
fix: inline style will be removed for value number `0`

### DIFF
--- a/.changeset/rude-bears-brake.md
+++ b/.changeset/rude-bears-brake.md
@@ -1,0 +1,10 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-core": patch
+---
+
+fix: inline style will be removed for value number `0`
+
+the inline style value could be incorrectly removed for number value `0`;
+
+For example, `flex-shrink:0` may be ignored.

--- a/packages/web-platform/web-mainthread-apis/src/elementAPI/style/styleFunctions.ts
+++ b/packages/web-platform/web-mainthread-apis/src/elementAPI/style/styleFunctions.ts
@@ -64,19 +64,20 @@ export function createStyleFunctions(
   function __AddInlineStyle(
     element: HTMLElement,
     key: number | string,
-    value: string | undefined,
+    value: string | number | null | undefined,
   ): void {
     const lynxStyleInfo = queryCSSProperty(Number(key));
-    if (!value) {
-      element.style.setProperty(lynxStyleInfo.dashName, null);
-      return;
-    }
-    const { transformedStyle } = transfromParsedStyles([[
-      lynxStyleInfo.dashName,
-      value,
-    ]]);
-    for (const [property, value] of transformedStyle) {
-      element.style.setProperty(property, value);
+    const valueStr = typeof value === 'number' ? value.toString() : value;
+    if (!valueStr) { // null or undefined
+      element.style.removeProperty(lynxStyleInfo.dashName);
+    } else {
+      const { transformedStyle } = transfromParsedStyles([[
+        lynxStyleInfo.dashName,
+        valueStr,
+      ]]);
+      for (const [property, value] of transformedStyle) {
+        element.style.setProperty(property, value);
+      }
     }
   }
 

--- a/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
+++ b/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
@@ -1114,4 +1114,22 @@ test.describe('main thread api tests', () => {
       expect(randomObject).toBe(-1);
     },
   );
+
+  test(
+    '__AddInlineStyle_value_number_0',
+    async ({ page }, { title }) => {
+      await page.evaluate(() => {
+        const root = globalThis.__CreatePage('page', 0);
+        const view = globalThis.__CreateView(0);
+        globalThis.__AddInlineStyle(root, 24, 'flex'); // display: flex
+        globalThis.__AddInlineStyle(view, 51, 0); // flex-shrink:0;
+        globalThis.__SetID(view, 'target');
+        globalThis.__AppendElement(root, view);
+        globalThis.__FlushElementTree();
+        return {};
+      });
+      const inlineStyle = await page.locator('#target').getAttribute('style');
+      expect(inlineStyle).toContain('flex-shrink');
+    },
+  );
 });

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -1923,8 +1923,9 @@ test.describe('reactlynx3 tests', () => {
       test('basic-element-x-input-bindinput', async ({ page }, { title }) => {
         await goto(page, title);
         await page.locator('input').press('Enter');
-        await wait(100);
+        await wait(200);
         await page.locator('input').fill('foobar');
+        await wait(200);
         const result = await page.locator('.result').first().innerText();
         expect(result).toBe('foobar');
       });


### PR DESCRIPTION
the inline style value could be incorrectly removed for number value `0`;

For example, `flex-shrink:0` may be ignored.

fix #171
