### PR TITLE
chore: turn-off codecov github annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,9 @@ parsers:
   javascript:
     enable_partials: yes
 
+github_checks:
+  annotations: false
+
 comment:
   layout: "header, diff, flags, components" # show component info in the PR comment
   behavior: default


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

> **Deprecation of GitHub Annotations Due to API Limitations**
>
> GitHub Annotations will be deprecated due to the following API constraints:
> 
> The GitHub API does not provide a way to clear annotations once they are sent. Even if subsequent reports processed by Codecov include updated coverage data, previous annotations remain.
>
> Annotations do not work if "Flags" or "Components" are configured, due to conflicts with these features.
>
> https://docs.codecov.com/docs/github-checks

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
