### PR TITLE
fix(timing): The pipeline timing is not marked correctly

### DIFF
--- a/packages/react/runtime/__test__/lynx/timing.test.jsx
+++ b/packages/react/runtime/__test__/lynx/timing.test.jsx
@@ -211,6 +211,7 @@ describe('attribute timing api', () => {
         [
           "_onPipelineStart",
           "pipelineID",
+          "updateTriggeredByBts",
         ],
         [
           "_markTiming",
@@ -235,6 +236,11 @@ describe('attribute timing api', () => {
         [
           "_markTiming",
           "pipelineID",
+          "mtsRenderStart",
+        ],
+        [
+          "_markTiming",
+          "pipelineID",
           "parse_changes_start",
         ],
         [
@@ -251,6 +257,11 @@ describe('attribute timing api', () => {
           "_markTiming",
           "pipelineID",
           "patch_changes_end",
+        ],
+        [
+          "_markTiming",
+          "pipelineID",
+          "mtsRenderEnd",
         ],
       ]
     `);
@@ -311,6 +322,7 @@ describe('attribute timing api', () => {
         [
           "_onPipelineStart",
           "pipelineID",
+          "updateTriggeredByBts",
         ],
         [
           "_markTiming",
@@ -398,6 +410,7 @@ describe('attribute timing api', () => {
         [
           "_onPipelineStart",
           "pipelineID",
+          "reactLynxHydrate",
         ],
         [
           "_bindPipelineIdWithTimingFlag",
@@ -514,6 +527,7 @@ describe('attribute timing api', () => {
           [
             "_onPipelineStart",
             "pipelineID",
+            "updateTriggeredByBts",
           ],
           [
             "_markTiming",
@@ -689,6 +703,7 @@ describe('attribute timing api', () => {
         [
           "_onPipelineStart",
           "pipelineID",
+          "updateTriggeredByBts",
         ],
         [
           "_markTiming",
@@ -713,6 +728,11 @@ describe('attribute timing api', () => {
         [
           "_markTiming",
           "pipelineID",
+          "mtsRenderStart",  
+        ],
+        [
+          "_markTiming",
+          "pipelineID",
           "parse_changes_start",
         ],
         [
@@ -729,6 +749,11 @@ describe('attribute timing api', () => {
           "_markTiming",
           "pipelineID",
           "patch_changes_end",
+        ],
+        [
+          "_markTiming",
+          "pipelineID",
+          "mtsRenderEnd",
         ],
       ]
     `);
@@ -782,6 +807,7 @@ describe('attribute timing api', () => {
           [
             "_onPipelineStart",
             "pipelineID",
+            "updateTriggeredByBts",
           ],
           [
             "_markTiming",

--- a/packages/react/runtime/src/lifecycle/patch/updateMainThread.ts
+++ b/packages/react/runtime/src/lifecycle/patch/updateMainThread.ts
@@ -25,6 +25,7 @@ function updateMainThread(
   }
 
   setPipeline(patchOptions.pipelineOptions);
+  markTiming(PerformanceTimingKeys.mtsRenderStart);
   markTiming(PerformanceTimingKeys.parse_changes_start);
   const { patchList, flushOptions = {} } = JSON.parse(data) as PatchList;
 
@@ -44,6 +45,7 @@ function updateMainThread(
     commitMainThreadPatchUpdate(id);
   }
   markTiming(PerformanceTimingKeys.patch_changes_end);
+  markTiming(PerformanceTimingKeys.mtsRenderEnd);
   if (patchOptions.isHydration) {
     clearDelayedWorklets();
   }

--- a/packages/react/runtime/src/lynx/tt.ts
+++ b/packages/react/runtime/src/lynx/tt.ts
@@ -5,7 +5,13 @@ import { options } from 'preact';
 import type { VNode } from 'preact';
 
 import { LifecycleConstant, NativeUpdateDataType } from '../lifecycleConstant.js';
-import { PerformanceTimingKeys, beginPipeline, markTiming } from './performance.js';
+import {
+  PerformanceTimingKeys,
+  PerformanceTimingFlags,
+  PipelineOrigins,
+  beginPipeline,
+  markTiming,
+} from './performance.js';
 import { BackgroundSnapshotInstance, hydrate } from '../backgroundSnapshot.js';
 import { destroyBackground } from '../lifecycle/destroy.js';
 import { commitPatchUpdate, genCommitTaskId, globalCommitTaskMap } from '../lifecycle/patch/commit.js';
@@ -104,7 +110,7 @@ async function OnLifecycleEvent([type, data]: [string, any]) {
       if (__PROFILE__) {
         console.profile('hydrate');
       }
-      beginPipeline(true, 'react_lynx_hydrate');
+      beginPipeline(true, PipelineOrigins.reactLynxHydrate, PerformanceTimingFlags.reactLynxHydrate);
       markTiming(PerformanceTimingKeys.hydrate_parse_snapshot_start);
       const before = JSON.parse(lepusSide);
       markTiming(PerformanceTimingKeys.hydrate_parse_snapshot_end);

--- a/packages/react/runtime/types/types.d.ts
+++ b/packages/react/runtime/types/types.d.ts
@@ -163,6 +163,7 @@ declare global {
 
   declare interface PipelineOptions {
     pipelineID: string; // Returned by native when calling `onPipelineStart()`
+    pipelineOrigin: string; // The origin of the pipeline
     needTimestamps: boolean; // Whether timing points should be reported
   }
   declare let lynxCoreInject: any;
@@ -243,7 +244,7 @@ declare module '@lynx-js/types/background' {
 
   interface Performance {
     _generatePipelineOptions?(): PipelineOptions;
-    _onPipelineStart?(pipelineID: string): void;
+    _onPipelineStart?(pipelineID: string, pipelineOrigin?: string): void;
     _bindPipelineIdWithTimingFlag?(pipelineID: string, timingFlag: string): void;
     _markTiming?(pipelineID: string, key: string): void;
   }


### PR DESCRIPTION
## Summary

lynx.performance.OnPipelineStart add param pipeline_origin to annotate the pipeline origin.

When the pipeline is started by the framework, actively mark the start and end time of MtsRender.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
