### PR TITLE
fix(react/runtime): prevent multiple firstScreen events when reloadin…

### DIFF
--- a/.changeset/nasty-kids-matter.md
+++ b/.changeset/nasty-kids-matter.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+fix: prevent multiple firstScreen events when reloading before `jsReady`

--- a/packages/react/runtime/__test__/lifecycle/reload.test.jsx
+++ b/packages/react/runtime/__test__/lifecycle/reload.test.jsx
@@ -1274,6 +1274,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
     {
       // LifecycleConstant.firstScreen
       globalEnvManager.switchToBackground();
+      expect(globalThis.__OnLifecycleEvent).toHaveBeenCalledTimes(1);
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
       lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
       expect(rLynxFirstScreen).toMatchInlineSnapshot(`
@@ -1679,6 +1680,197 @@ describe('firstScreenSyncTiming - jsReady', () => {
               "pipelineID": "pipelineID",
             },
             "reloadVersion": 5,
+          },
+        }
+      `);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      lynx.getNativeApp().callLepusMethod.mockClear();
+    }
+  });
+
+  it('reload template before js ready', async function() {
+    // main thread render
+    {
+      __root.__jsx = BasicMT;
+      renderPage({
+        text: 'Hello',
+      });
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Hello"
+              />
+            </text>
+            <text>
+              <raw-text
+                text="World"
+              />
+            </text>
+            <view
+              attr={
+                {
+                  "dataX": "WorldX",
+                }
+              }
+            />
+            <wrapper>
+              <view
+                attr={
+                  {
+                    "attr": {
+                      "dataX": "WorldX",
+                    },
+                  }
+                }
+              />
+            </wrapper>
+          </view>
+        </page>
+      `);
+    }
+
+    // main thread update 1
+    {
+      updatePage({
+        text: 'Hello 1',
+      }, { reloadTemplate: true });
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Hello 1"
+              />
+            </text>
+            <text>
+              <raw-text
+                text="World"
+              />
+            </text>
+            <view
+              attr={
+                {
+                  "dataX": "WorldX",
+                }
+              }
+            />
+            <wrapper>
+              <view
+                attr={
+                  {
+                    "attr": {
+                      "dataX": "WorldX",
+                    },
+                  }
+                }
+              />
+            </wrapper>
+          </view>
+        </page>
+      `);
+    }
+
+    // main thread update 2
+    {
+      updatePage({
+        text: 'Hello 2',
+      }, { reloadTemplate: true });
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Hello 2"
+              />
+            </text>
+            <text>
+              <raw-text
+                text="World"
+              />
+            </text>
+            <view
+              attr={
+                {
+                  "dataX": "WorldX",
+                }
+              }
+            />
+            <wrapper>
+              <view
+                attr={
+                  {
+                    "attr": {
+                      "dataX": "WorldX",
+                    },
+                  }
+                }
+              />
+            </wrapper>
+          </view>
+        </page>
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      root.render(ViewBG, __root);
+
+      expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
+      expect(lynx.getNativeApp().callLepusMethod.mock.calls[0]).toMatchInlineSnapshot(`
+        [
+          "rLynxJSReady",
+          {},
+        ]
+      `);
+      globalEnvManager.switchToMainThread();
+      const rLynxJSReady = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxJSReady[0]](rLynxJSReady[1]);
+      lynx.getNativeApp().callLepusMethod.mockClear();
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      globalEnvManager.switchToBackground();
+      expect(globalThis.__OnLifecycleEvent).toHaveBeenCalledTimes(1);
+      const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
+      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      expect(rLynxFirstScreen).toMatchInlineSnapshot(`
+        [
+          [
+            "rLynxFirstScreen",
+            {
+              "jsReadyEventIdSwap": {},
+              "refPatch": "{}",
+              "root": "{"id":-17,"type":"root","children":[{"id":-21,"type":"__Card__:__snapshot_a94a8_test_2","values":[{"dataX":"WorldX"}],"children":[{"id":-18,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-23,"type":null,"values":["Hello 2"]}]},{"id":-19,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-24,"type":null,"values":["World"]}]},{"id":-20,"type":"wrapper","children":[{"id":-22,"type":"__Card__:__snapshot_a94a8_test_1","values":[{"attr":{"dataX":"WorldX"}}]}]}]}]}",
+            },
+          ],
+        ]
+      `);
+      expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
+      expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
+        {
+          "data": "{"patchList":[{"snapshotPatch":[2,-17,-21,0,"__Card__:__snapshot_a94a8_test_5",2,0,"__Card__:__snapshot_a94a8_test_2",3,4,3,[{"dataX":"WorldX"}],0,"__Card__:__snapshot_a94a8_test_3",4,0,null,5,4,5,["Hello 2"],1,4,5,null,1,3,4,null,0,"__Card__:__snapshot_a94a8_test_4",6,0,null,7,4,7,["World"],1,6,7,null,1,3,6,null,0,"wrapper",8,0,"__Card__:__snapshot_a94a8_test_1",9,4,9,[{"attr":{"dataX":"WorldX"}}],1,8,9,null,1,3,8,null,1,2,3,null,1,-17,2,null],"id":27}]}",
+          "patchOptions": {
+            "isHydration": true,
+            "pipelineOptions": {
+              "needTimestamps": true,
+              "pipelineID": "pipelineID",
+            },
+            "reloadVersion": 7,
           },
         }
       `);

--- a/packages/react/runtime/src/lifecycle/event/jsReady.ts
+++ b/packages/react/runtime/src/lifecycle/event/jsReady.ts
@@ -1,0 +1,33 @@
+import { LifecycleConstant } from '../../lifecycleConstant.js';
+import { __root } from '../../root.js';
+import { takeGlobalRefPatchMap } from '../../snapshot/ref.js';
+
+let isJSReady: boolean;
+let jsReadyEventIdSwap: Record<number, number>;
+
+function jsReady(): void {
+  isJSReady = true;
+  __OnLifecycleEvent([
+    LifecycleConstant.firstScreen, /* FIRST_SCREEN */
+    {
+      root: JSON.stringify(__root),
+      refPatch: JSON.stringify(takeGlobalRefPatchMap()),
+      jsReadyEventIdSwap,
+    },
+  ]);
+  jsReadyEventIdSwap = {};
+}
+
+function clearJSReadyEventIdSwap(): void {
+  jsReadyEventIdSwap = {};
+}
+
+function resetJSReady(): void {
+  isJSReady = false;
+  jsReadyEventIdSwap = {};
+}
+
+/**
+ * @internal
+ */
+export { jsReady, isJSReady, jsReadyEventIdSwap, clearJSReadyEventIdSwap, resetJSReady };

--- a/packages/react/runtime/src/lifecycle/reload.ts
+++ b/packages/react/runtime/src/lifecycle/reload.ts
@@ -1,18 +1,19 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { __root, setRoot } from '../root.js';
-import { SnapshotInstance, __page, snapshotInstanceManager } from '../snapshot.js';
-import { isEmptyObject } from '../utils.js';
-import { destroyBackground } from './destroy.js';
-import { increaseReloadVersion } from './pass.js';
-import { renderBackground, renderMainThread } from './render.js';
 import { hydrate } from '../hydrate.js';
 import { LifecycleConstant } from '../lifecycleConstant.js';
 import { __pendingListUpdates } from '../list.js';
+import { __root, setRoot } from '../root.js';
 import { takeGlobalRefPatchMap } from '../snapshot/ref.js';
-import { deinitGlobalSnapshotPatch } from './patch/snapshotPatch.js';
+import { SnapshotInstance, __page, snapshotInstanceManager } from '../snapshot.js';
+import { isEmptyObject } from '../utils.js';
+import { destroyBackground } from './destroy.js';
 import { destroyWorklet } from '../worklet/destroy.js';
+import { clearJSReadyEventIdSwap, isJSReady } from './event/jsReady.js';
+import { increaseReloadVersion } from './pass.js';
+import { deinitGlobalSnapshotPatch } from './patch/snapshotPatch.js';
+import { renderBackground, renderMainThread } from './render.js';
 
 function reloadMainThread(data: any, options: UpdatePageOption): void {
   if (__PROFILE__) {
@@ -28,6 +29,7 @@ function reloadMainThread(data: any, options: UpdatePageOption): void {
   destroyWorklet();
   snapshotInstanceManager.clear();
   __pendingListUpdates.clear();
+  clearJSReadyEventIdSwap();
 
   const oldRoot = __root;
   setRoot(new SnapshotInstance('root'));
@@ -39,15 +41,18 @@ function reloadMainThread(data: any, options: UpdatePageOption): void {
 
   // always call this before `__FlushElementTree`
   __pendingListUpdates.flush();
-  __FlushElementTree(__page, options);
 
-  __OnLifecycleEvent([
-    LifecycleConstant.firstScreen, /* FIRST_SCREEN */
-    {
-      root: JSON.stringify(__root),
-      refPatch: JSON.stringify(takeGlobalRefPatchMap()),
-    },
-  ]);
+  if (isJSReady) {
+    __OnLifecycleEvent([
+      LifecycleConstant.firstScreen, /* FIRST_SCREEN */
+      {
+        root: JSON.stringify(__root),
+        refPatch: JSON.stringify(takeGlobalRefPatchMap()),
+      },
+    ]);
+  }
+
+  __FlushElementTree(__page, options);
 
   if (__PROFILE__) {
     console.profileEnd();
@@ -76,4 +81,4 @@ function reloadBackground(updateData: Record<string, any>): void {
   }
 }
 
-export { reloadMainThread, reloadBackground };
+export { reloadBackground, reloadMainThread };


### PR DESCRIPTION
## Summary

This PR fixes an issue where multiple `firstScreen` events were being sent to the Background Thread (BT) when reloading before the `jsReady` event is triggered. This could cause problems with page rendering and state management.

The changes include:
- Centralizing JS Ready state management in a dedicated module
- Adding proper state checks before triggering `firstScreen` events
- Refactoring lifecycle event handling for better maintainability
- Adding test coverage for the reload-before-jsReady scenario

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
