### PR TITLE
chore(rspeedy/qrcode): bundle qrcode-terminal

### DIFF
--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -47,16 +47,14 @@
     "build": "rslib build",
     "test": "pnpm -w run test --project rspeedy/qrcode"
   },
-  "dependencies": {
-    "picocolors": "^1.1.1",
-    "qrcode-terminal": "^0.12.0"
-  },
   "devDependencies": {
     "@clack/prompts": "^0.10.0",
     "@lynx-js/rspeedy": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rsbuild/core": "catalog:rsbuild",
-    "@types/qrcode-terminal": "^0.12.2"
+    "@types/qrcode-terminal": "^0.12.2",
+    "picocolors": "^1.1.1",
+    "qrcode-terminal": "^0.12.0"
   },
   "engines": {
     "node": ">=18"

--- a/patches/qrcode-terminal.patch
+++ b/patches/qrcode-terminal.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/main.js b/lib/main.js
+index 488cc1aea9802b3d6ae13aee27556403bec55d1c..263d68a1520dd9402ef4231d30bc74c3aba5c821 100644
+--- a/lib/main.js
++++ b/lib/main.js
+@@ -1,7 +1,7 @@
+ var QRCode = require('./../vendor/QRCode'),
+     QRErrorCorrectLevel = require('./../vendor/QRCode/QRErrorCorrectLevel'),
+-    black = "\033[40m  \033[0m",
+-    white = "\033[47m  \033[0m",
++    black = "\x1b[40m  \x1b[0m",
++    white = "\x1b[47m  \x1b[0m",
+     toCell = function (isBlack) {
+         return isBlack ? black : white;
+     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ patchedDependencies:
   '@rollup/plugin-typescript':
     hash: 926ba262ec682d27369f1a8648a0dfb657fb5f1b28539ca3628d292276c91c3d
     path: patches/@rollup__plugin-typescript.patch
+  qrcode-terminal:
+    hash: 68024eba5b12e002fd49ff4978670cfa0f4fea3db213c0f3d6ccd3cadf8d6d4e
+    path: patches/qrcode-terminal.patch
 
 importers:
 
@@ -361,13 +364,6 @@ importers:
         version: link:../core
 
   packages/rspeedy/plugin-qrcode:
-    dependencies:
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
-      qrcode-terminal:
-        specifier: ^0.12.0
-        version: 0.12.0
     devDependencies:
       '@clack/prompts':
         specifier: ^0.10.0
@@ -384,6 +380,12 @@ importers:
       '@types/qrcode-terminal':
         specifier: ^0.12.2
         version: 0.12.2
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0(patch_hash=68024eba5b12e002fd49ff4978670cfa0f4fea3db213c0f3d6ccd3cadf8d6d4e)
 
   packages/rspeedy/plugin-react:
     dependencies:
@@ -15085,7 +15087,7 @@ snapshots:
     dependencies:
       '@types/offscreencanvas': 2019.7.3
 
-  qrcode-terminal@0.12.0: {}
+  qrcode-terminal@0.12.0(patch_hash=68024eba5b12e002fd49ff4978670cfa0f4fea3db213c0f3d6ccd3cadf8d6d4e): {}
 
   qs@6.13.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,7 @@ overrides:
 patchedDependencies:
   "@napi-rs/cli@2.18.4": "patches/@napi-rs__cli@2.18.4.patch"
   "@rollup/plugin-typescript": "patches/@rollup__plugin-typescript.patch"
+  "qrcode-terminal": "patches/qrcode-terminal.patch"
 
 onlyBuiltDependencies:
   - dprint


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Shift `qrcode-terminal` from `dependencies` to `devDependencies` to enhance startup speed and reduce bundle size.

We patch `qrcode-terminal` to fix the error "Legacy octal escape is not permitted in strict mode".

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
