### PR TITLE
fix(rspeedy/core): bundle ts-blank-space

### DIFF
--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -99,8 +99,8 @@
         "types": "./client.d.ts"
       },
       "./register": {
-        "types": "./register/index.d.ts",
-        "import": "./register/index.js"
+        "types": "./dist/register/index.d.ts",
+        "import": "./dist/register/index.js"
       },
       "./package.json": "./package.json"
     },

--- a/packages/rspeedy/core/rslib.config.ts
+++ b/packages/rspeedy/core/rslib.config.ts
@@ -4,7 +4,22 @@ import { TypiaRspackPlugin } from 'typia-rspack-plugin'
 
 export default defineConfig({
   lib: [
-    { format: 'esm', syntax: 'es2022', dts: { bundle: true } },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      dts: { bundle: true },
+      tools: {
+        rspack: {
+          plugins: [
+            new TypiaRspackPlugin({
+              cache: false,
+              include: './src/config/validate.ts',
+              tsconfig: './tsconfig.build.json',
+            }),
+          ],
+        },
+      },
+    },
     {
       format: 'esm',
       syntax: 'es2022',
@@ -15,6 +30,30 @@ export default defineConfig({
         },
       },
       dts: false,
+    },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      source: {
+        entry: {
+          'register/index': './register/index.js',
+          'register/hooks': './register/hooks.js',
+        },
+      },
+      dts: false,
+      output: {
+        copy: {
+          patterns: [
+            {
+              from: './register/index.d.ts',
+              to: './register/index.d.ts',
+            },
+          ],
+        },
+        externals: [
+          'typescript',
+        ],
+      },
     },
   ],
   output: {
@@ -31,13 +70,6 @@ export default defineConfig({
       optimization: {
         chunkIds: 'named',
       },
-      plugins: [
-        new TypiaRspackPlugin({
-          cache: false,
-          include: './src/config/validate.ts',
-          tsconfig: './tsconfig.build.json',
-        }),
-      ],
     },
   },
 })

--- a/packages/rspeedy/core/turbo.json
+++ b/packages/rspeedy/core/turbo.json
@@ -9,6 +9,7 @@
         "^build"
       ],
       "inputs": [
+        "register",
         "src",
         "rslib.config.ts"
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,9 +282,6 @@ importers:
       '@rsdoctor/rspack-plugin':
         specifier: 1.0.1
         version: 1.0.1(@rsbuild/core@1.3.2)(@rspack/core@1.3.1(@swc/helpers@0.5.15))(webpack@5.98.0)
-      ts-blank-space:
-        specifier: ^0.6.1
-        version: 0.6.1
     devDependencies:
       '@lynx-js/vitest-setup':
         specifier: workspace:*
@@ -328,6 +325,9 @@ importers:
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
+      ts-blank-space:
+        specifier: ^0.6.1
+        version: 0.6.1
       type-fest:
         specifier: ^4.39.0
         version: 4.39.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       '@rsdoctor/rspack-plugin':
         specifier: 1.0.1
         version: 1.0.1(@rsbuild/core@1.3.2)(@rspack/core@1.3.1(@swc/helpers@0.5.15))(webpack@5.98.0)
+      ts-blank-space:
+        specifier: ^0.6.1
+        version: 0.6.1
     devDependencies:
       '@lynx-js/vitest-setup':
         specifier: workspace:*
@@ -325,9 +328,6 @@ importers:
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
-      ts-blank-space:
-        specifier: ^0.6.1
-        version: 0.6.1
       type-fest:
         specifier: ^4.39.0
         version: 4.39.0


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix a regression from #470: "Cannot find package 'ts-blank-space' imported from @lynx-js/rspeedy/register/hooks.js"

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
