### PR TITLE
ci: add test-publish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,12 @@ jobs:
   test-publish:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: read
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:
       runs-on: lynx-ubuntu-24.04-medium
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,22 @@ jobs:
         --no-cache
         --logHeapUsage
         --silent
+  test-publish:
+    needs: build
+    uses: ./.github/workflows/workflow-test.yml
+    with:
+      runs-on: lynx-ubuntu-24.04-medium
+      run: |
+        pnpm dlx @pnpm/registry-mock prepare
+        pnpm dlx @pnpm/registry-mock &
+        pnpm changeset version --snapshot regression
+        node packages/tools/canary-release/snapshot.js
+        pnpm --recursive publish --no-git-checks --access public --registry=http://localhost:4873
+        cd `mktemp -d`
+        npx --registry http://localhost:4873 create-rspeedy-canary@latest --template react --dir create-rspeedy-regression
+        cd create-rspeedy-regression
+        pnpm install --registry=http://localhost:4873
+        pnpm run build
   test-tools:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
@@ -176,6 +192,7 @@ jobs:
         pnpm --filter @lynx-js/web-tests run test --reporter='github,dot,junit,html'
         pnpm --filter @lynx-js/web-tests run coverage:ci
   test-rust:
+    needs: build
     uses: ./.github/workflows/rust.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,6 +144,7 @@ jobs:
       run: |
         pnpm dlx @pnpm/registry-mock prepare
         pnpm dlx @pnpm/registry-mock &
+        printf '\nhttp://localhost:4873/:_authToken="this-is-a-fake-token"' >> ~/.npmrc
         pnpm changeset version --snapshot regression
         node packages/tools/canary-release/snapshot.js
         pnpm --recursive publish --no-git-checks --access public --registry=http://localhost:4873

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,8 +139,6 @@ jobs:
       contents: read
       pull-requests: read
       statuses: read
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     with:
       runs-on: lynx-ubuntu-24.04-medium
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,6 +209,7 @@ jobs:
       - code-style-check
       - playwright-linux
       - test-plugins
+      - test-publish
       - test-react
       - test-rust
       - test-rspeedy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
       run: |
         pnpm dlx @pnpm/registry-mock prepare
         pnpm dlx @pnpm/registry-mock &
-        printf '\nhttp://localhost:4873/:_authToken="this-is-a-fake-token"' >> ~/.npmrc
+        printf '\n//localhost:4873/:_authToken="this-is-a-fake-token"\n' >> ~/.npmrc
         pnpm changeset version --snapshot regression
         node packages/tools/canary-release/snapshot.js
         pnpm --recursive publish --no-git-checks --access public --registry=http://localhost:4873

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -3,6 +3,8 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
+      GITHUB_TOKEN:
+        required: false
     inputs:
       runs-on:
         required: true
@@ -68,6 +70,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
           GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ${{ inputs.run }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -3,8 +3,6 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
-      GITHUB_TOKEN:
-        required: false
     inputs:
       runs-on:
         required: true

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -76,6 +76,7 @@
     "manypkg", // https://github.com/Thinkmill/manypkg
     "messageformat", // https://formatjs.github.io/docs/intl-messageformat
     "memfs",
+    "mktemp",
     "napi",
     "nocheck", // @ts-nocheck :)
     "pathinfo", // webpack config output.pathinfo


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

A new test `test-publish` has been added.

This test setup a mocked NPM registry using `@pnpm/registry-mock` ([verdaccio](https://verdaccio.org/) underhood) and publish all packages to that registry. Then a Rspeedy App will be created and tested using the newly published packages.

This is used to avoid future regression like: #475, #478 and #479.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
