### PR TITLE
fix(rspeedy/core): should run typia transform on CLI

### DIFF
--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -41,7 +41,6 @@
     "bin/rspeedy.js",
     "client",
     "dist",
-    "register",
     "client.d.ts",
     "CHANGELOG.md",
     "README.md"

--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "api-extractor": "api-extractor run --verbose",
     "build": "rslib build",
+    "prepublishOnly": "rslib build",
     "test": "pnpm -w run test --project rspeedy",
     "test:type": "vitest --typecheck.only"
   },

--- a/packages/rspeedy/core/rslib.config.ts
+++ b/packages/rspeedy/core/rslib.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@rslib/core'
+import { defineConfig, type rsbuild } from '@rslib/core'
 import { pluginPublint } from 'rsbuild-plugin-publint'
 import { TypiaRspackPlugin } from 'typia-rspack-plugin'
 
@@ -8,17 +8,7 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2022',
       dts: { bundle: true },
-      tools: {
-        rspack: {
-          plugins: [
-            new TypiaRspackPlugin({
-              cache: false,
-              include: './src/config/validate.ts',
-              tsconfig: './tsconfig.build.json',
-            }),
-          ],
-        },
-      },
+      plugins: [pluginTypia()],
     },
     {
       format: 'esm',
@@ -30,6 +20,7 @@ export default defineConfig({
         },
       },
       dts: false,
+      plugins: [pluginTypia()],
     },
     {
       format: 'esm',
@@ -73,3 +64,25 @@ export default defineConfig({
     },
   },
 })
+
+function pluginTypia(): rsbuild.RsbuildPlugin {
+  return {
+    name: 'rspeedy-plugin-typia',
+    setup(api) {
+      api.modifyBundlerChain(chain => {
+        const { source } = api.getRsbuildConfig()
+
+        chain
+          .plugin('typia')
+          .use(TypiaRspackPlugin, [
+            {
+              cache: false,
+              include: './src/config/validate.ts',
+              tsconfig: source?.tsconfigPath,
+              log: false,
+            },
+          ])
+      })
+    },
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix a regression of #475: "Error on typia.createValidateEquals(): no transform has been configured."

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
