### PR TITLE
fix(rspeedy/core): avoid pre-publish build

### DIFF
--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -48,7 +48,6 @@
   "scripts": {
     "api-extractor": "api-extractor run --verbose",
     "build": "rslib build",
-    "prepublishOnly": "rslib build",
     "test": "pnpm -w run test --project rspeedy",
     "test:type": "vitest --typecheck.only"
   },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix an regression of #478: "error TS2307: Cannot find module '@lynx-js/rspeedy/register' or its corresponding type declarations."

> https://github.com/lynx-family/lynx-stack/actions/runs/14280496355/job/40029566753

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
