### PR TITLE
feat(rspeedy/core)!: requires typescript 5.1.6 - 5.8.x

### DIFF
--- a/.changeset/tired-lamps-attend.md
+++ b/.changeset/tired-lamps-attend.md
@@ -1,0 +1,11 @@
+---
+"@lynx-js/rspeedy": minor
+---
+
+**BREAKING CHANGE**: Added explicit TypeScript peer dependency requirement of 5.1.6 - 5.8.x.
+
+This formalizes the existing TypeScript version requirement in `peerDependencies` (marked as optional since it is only needed for TypeScript configurations). The actual required TypeScript version has not changed.
+
+Note: This may cause installation to fail if you have strict peer dependency checks enabled.
+
+Node.js v22.7+ users can bypass TypeScript installation using `--experimental-transform-types` or `--experimental-strip-types` flags. Node.js v23.6+ users don't need any flags. See [Node.js - TypeScript](https://nodejs.org/api/typescript.html) for details.

--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -81,6 +81,14 @@
     "vitest": "^3.1.1",
     "webpack": "^5.98.0"
   },
+  "peerDependencies": {
+    "typescript": "5.1.6 - 5.8.x"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       '@rsdoctor/rspack-plugin':
         specifier: 1.0.1
         version: 1.0.1(@rsbuild/core@1.3.2)(@rspack/core@1.3.1(@swc/helpers@0.5.15))(webpack@5.98.0)
+      typescript:
+        specifier: 5.1.6 - 5.8.x
+        version: 5.8.2
     devDependencies:
       '@lynx-js/vitest-setup':
         specifier: workspace:*


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Since we are now bundling `ts-blank-space` and externalizing `typescript` (#475), we need to manually specify the `peerDependencies`.

The version requirement is copied from [`ts-blank-space/package.json`](https://github.com/bloomberg/ts-blank-space/blob/4102b1f26b1c53d38a1de74c10f262af5fd34fe8/package.json#L26).

> [!NOTE]
> The `typescript` is not required when:
>
> 1. Using JavaScript (`.js`) configuration
> 1. Using Node.js v23.6+
> 1. Using Node.js v22.6+ with `--experimental-strip-types` or `--experimental-transform-types`

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
