### PR TITLE
feat(rspeedy/core): use `process.features.typescript`

### DIFF
--- a/.changeset/slick-pianos-beg.md
+++ b/.changeset/slick-pianos-beg.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Support Node.js v23.6+ native TypeScript.
+
+See [Node.js - TypeScript](https://nodejs.org/api/typescript.html) for more details.

--- a/packages/rspeedy/core/src/config/loadConfig.ts
+++ b/packages/rspeedy/core/src/config/loadConfig.ts
@@ -150,6 +150,20 @@ function shouldUseNativeImport(configPath: string): boolean {
 }
 
 function hasNativeTSSupport(): boolean {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  if (process.features.typescript) {
+    // This is added in Node.js v22.10.
+    // 1. Node.js v22.10+ with --experimental-transform-types or --experimental-strip-types
+    // 2. Node.js v23.6+
+    return true
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  } else if (process.features.typescript === false) {
+    // 1. Node.js v22.10+ without --experimental-transform-types or --experimental-strip-types
+    // 2. Node.js v23.6+ with --no-experimental-strip-types
+    return false
+  }
+
+  // Node.js < v22.10
   const { NODE_OPTIONS } = process.env
 
   if (!NODE_OPTIONS) {

--- a/packages/rspeedy/core/src/config/loadConfig.ts
+++ b/packages/rspeedy/core/src/config/loadConfig.ts
@@ -178,3 +178,7 @@ function isJavaScriptPath(configPath: string): boolean {
   const ext = extname(configPath)
   return ['.js', '.mjs', '.cjs'].includes(ext)
 }
+
+export function TEST_ONLY_hasNativeTSSupport(): boolean {
+  return hasNativeTSSupport()
+}

--- a/website/docs/en/guide/cli.md
+++ b/website/docs/en/guide/cli.md
@@ -18,13 +18,21 @@ Just like [Rush](https://rushstack.io/), Rspeedy implements a "version selector"
 
 ## Using Node.js TypeScript support
 
-If the version of Node.js you are using supports the [--experimental-transform-types](https://nodejs.org/api/cli.html#--experimental-transform-types)(v22.7.0) or [--experimental-strip-types](https://nodejs.org/api/cli.html#--experimental-strip-types)(v22.6.0) flag, you can use the built-in TS transformation of Node.js.
+If the version of Node.js you are using supports TypeScript:
+
+1. Node.js >= v23.6
+1. Node.js >= v22.6 with [--experimental-strip-types](https://nodejs.org/api/cli.html#--experimental-strip-types)
+1. Node.js >= v22.7 with [--experimental-transform-types](https://nodejs.org/api/cli.html#--experimental-transform-types)
+
+you can use the built-in TS transformation of Node.js.
 
 ```json title="package.json"
 {
   "build": "NODE_OPTIONS=--experimental-transform-types rspeedy build"
 }
 ```
+
+See [Node.js - TypeScript](https://nodejs.org/api/typescript.html) for more details.
 
 ## rspeedy -h
 

--- a/website/docs/zh/guide/cli.md
+++ b/website/docs/zh/guide/cli.md
@@ -18,7 +18,13 @@ npm install --global @lynx-js/rspeedy
 
 ## 使用 Node.js 的 TypeScript 支持
 
-如果你使用的 Node.js 版本支持 [--experimental-transform-types](https://nodejs.org/api/cli.html#--experimental-transform-types)（v22.7.0）或 [--experimental-strip-types](https://nodejs.org/api/cli.html#--experimental-strip-types)（v22.6.0）标志，可以使用 Node.js 内置的 TS 转换功能。
+如果你使用的 Node.js 版本支持 TypeScript：
+
+1. Node.js >= v23.6
+1. Node.js >= v22.6 使用 [--experimental-strip-types](https://nodejs.org/api/cli.html#--experimental-strip-types)
+1. Node.js >= v22.7 使用 [--experimental-transform-types](https://nodejs.org/api/cli.html#--experimental-transform-types)
+
+可以使用 Node.js 内置的 TypeScript 转换功能。
 
 ```json title="package.json"
 {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Node.js v23.6 has unflagged the `--experimental-strip-types` feature (https://github.com/nodejs/node/pull/56350). Instead of relying solely on this flag, it’s recommended to also check the standard `process.feature.typescript` to confirm native TypeScript support.

> [!NOTE]
> It will be backport to v22 soon. See: https://github.com/nodejs/node/pull/57298 

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
