### PR TITLE
feat(rspeedy/core): support cli flag --no-env

### DIFF
--- a/.changeset/open-oranges-shake.md
+++ b/.changeset/open-oranges-shake.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Support cli option `--no-env` to disable loading of .env files

--- a/packages/rspeedy/core/src/cli/build.ts
+++ b/packages/rspeedy/core/src/cli/build.ts
@@ -36,7 +36,9 @@ export async function build(
       rspeedyConfig,
     }
 
-    if (buildOptions.envMode) {
+    if (buildOptions.noEnv) {
+      options.loadEnv = false
+    } else if (buildOptions.envMode) {
       options.loadEnv = { mode: buildOptions.envMode }
     }
 

--- a/packages/rspeedy/core/src/cli/commands.ts
+++ b/packages/rspeedy/core/src/cli/commands.ts
@@ -13,6 +13,7 @@ import { version } from '../version.js'
 export interface CommonOptions {
   config?: string
   envMode?: string
+  noEnv?: boolean
 }
 
 function applyCommonOptions(command: Command) {
@@ -23,7 +24,11 @@ function applyCommonOptions(command: Command) {
     )
     .option(
       '--env-mode <mode>',
-      'specify the env mode to load the .env.[mode] file"',
+      'specify the env mode to load the .env.[mode] file',
+    )
+    .option(
+      '--no-env',
+      'disable loading `.env` files"',
     )
 }
 

--- a/packages/rspeedy/core/src/cli/dev.ts
+++ b/packages/rspeedy/core/src/cli/dev.ts
@@ -70,7 +70,9 @@ export async function dev(
       rspeedyConfig,
     }
 
-    if (devOptions.envMode) {
+    if (devOptions.noEnv) {
+      options.loadEnv = false
+    } else if (devOptions.envMode) {
       options.loadEnv = { mode: devOptions.envMode }
     }
 

--- a/packages/rspeedy/core/src/cli/inspect.ts
+++ b/packages/rspeedy/core/src/cli/inspect.ts
@@ -10,6 +10,7 @@ import type { CommonOptions } from './commands.js'
 import { exit } from './exit.js'
 import { loadConfig } from '../config/loadConfig.js'
 import { createRspeedy } from '../create-rspeedy.js'
+import type { CreateRspeedyOptions } from '../create-rspeedy.js'
 
 export interface InspectOptions extends CommonOptions {
   mode?: 'production' | 'development' | undefined
@@ -28,13 +29,18 @@ export async function inspect(
       configPath: inspectOptions.config,
     })
 
-    const rspeedy = await createRspeedy({
+    const options: CreateRspeedyOptions = {
       cwd,
       rspeedyConfig,
-      ...(inspectOptions.envMode
-        ? { loadEnv: { mode: inspectOptions.envMode } }
-        : {}),
-    })
+    }
+
+    if (inspectOptions.noEnv) {
+      options.loadEnv = false
+    } else if (inspectOptions.envMode) {
+      options.loadEnv = { mode: inspectOptions.envMode }
+    }
+
+    const rspeedy = await createRspeedy(options)
 
     await rspeedy.inspectConfig({
       mode: inspectOptions.mode

--- a/packages/rspeedy/core/src/cli/preview.ts
+++ b/packages/rspeedy/core/src/cli/preview.ts
@@ -11,6 +11,7 @@ import type { CommonOptions } from './commands.js'
 import { exit } from './exit.js'
 import { loadConfig, resolveConfigPath } from '../config/loadConfig.js'
 import { createRspeedy } from '../create-rspeedy.js'
+import type { CreateRspeedyOptions } from '../create-rspeedy.js'
 
 export interface PreviewOptions extends CommonOptions {
   base?: string | undefined
@@ -34,13 +35,18 @@ export async function preview(
       rspeedyConfig.server.base = previewOptions.base
     }
 
-    const rspeedy = await createRspeedy({
+    const options: CreateRspeedyOptions = {
       cwd,
       rspeedyConfig,
-      ...(previewOptions.envMode
-        ? { loadEnv: { mode: previewOptions.envMode } }
-        : {}),
-    })
+    }
+
+    if (previewOptions.noEnv) {
+      options.loadEnv = false
+    } else if (previewOptions.envMode) {
+      options.loadEnv = { mode: previewOptions.envMode }
+    }
+
+    const rspeedy = await createRspeedy(options)
 
     await rspeedy.initConfigs()
 

--- a/packages/rspeedy/core/test/cli/config.test.ts
+++ b/packages/rspeedy/core/test/cli/config.test.ts
@@ -68,6 +68,36 @@ describe('rspeedy config test', () => {
       }),
     )
   })
+
+  test('createRspeedy with no-env ', async () => {
+    const root = join(fixturesRoot, 'project-with-env')
+    const rsbuild = await createRspeedy({
+      cwd: root,
+      loadEnv: false,
+    })
+    const configs = await rsbuild.initConfigs()
+    const maybeDefinePluginInstance = configs[0]?.plugins?.filter((plugin) => {
+      if (plugin) {
+        return plugin.name === 'DefinePlugin'
+      } else {
+        return false
+      }
+    })
+
+    expect(maybeDefinePluginInstance).toHaveLength(1)
+    const defineInstance = maybeDefinePluginInstance![0]
+
+    expect(defineInstance!).toMatchObject(
+      expect.objectContaining({
+        _args: [
+          expect.not.objectContaining({
+            'process.env.PUBLIC_FOO': '"BAR"',
+            'process.env.PUBLIC_TEST': '"TEST"',
+          }),
+        ],
+      }),
+    )
+  })
 })
 
 describe('rspeedy environment test', () => {

--- a/website/docs/en/guide/cli.md
+++ b/website/docs/en/guide/cli.md
@@ -76,6 +76,7 @@ Options:
   -c --config <config>      specify the configuration file, can be a relative or absolute path
   --env-mode <mode>         specify the env mode to load the .env.[mode] file
   --environment <name...>   specify the name of environment to build
+  --no-env                  disable loading `.env` files"
   -h, --help                display help for command
 ```
 
@@ -94,6 +95,7 @@ Options:
   -c --config <config>      specify the configuration file, can be a relative or absolute path
   --env-mode <mode>         specify the env mode to load the .env.[mode] file
   --environment <name...>   specify the name of environment to build
+  --no-env                  disable loading `.env` files"
   -h, --help                display help for command
 ```
 
@@ -110,6 +112,7 @@ Options:
   -b --base <base>      specify the base path of the server
   -c --config <config>  specify the configuration file, can be a relative or absolute path
   --env-mode <mode>     specify the env mode to load the .env.[mode] file
+  --no-env              disable loading `.env` files"
   -h, --help            display help for command
 ```
 
@@ -134,6 +137,7 @@ Options:
   --verbose             show full function definitions in output
   -c --config <config>  specify the configuration file, can be a relative or absolute path
   --env-mode <mode>     specify the env mode to load the .env.[mode] file
+  --no-env              disable loading `.env` files"
   -h, --help            display help for command
 ```
 

--- a/website/docs/zh/guide/cli.md
+++ b/website/docs/zh/guide/cli.md
@@ -74,6 +74,7 @@ Options:
   -c --config <config>      specify the configuration file, can be a relative or absolute path
   --env-mode <mode>         specify the env mode to load the .env.[mode] file
   --environment <name...>   specify the name of environment to build
+  --no-env                  disable loading `.env` files"
   -h, --help                display help for command
 ```
 
@@ -92,6 +93,7 @@ Options:
   -c --config <config>      specify the configuration file, can be a relative or absolute path
   --env-mode <mode>         specify the env mode to load the .env.[mode] file
   --environment <name...>   specify the name of environment to build
+  --no-env                  disable loading `.env` files"
   -h, --help                display help for command
 ```
 
@@ -108,6 +110,7 @@ Options:
   -b --base <base>      specify the base path of the server
   -c --config <config>  specify the configuration file, can be a relative or absolute path
   --env-mode <mode>     specify the env mode to load the .env.[mode] file
+  --no-env              disable loading `.env` files"
   -h, --help            display help for command
 ```
 
@@ -132,6 +135,7 @@ Options:
   --verbose             show full function definitions in output
   -c --config <config>  specify the configuration file, can be a relative or absolute path
   --env-mode <mode>     specify the env mode to load the .env.[mode] file
+  --no-env              disable loading `.env` files"
   -h, --help            display help for command
 ```
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

As one of several PRs addressing issue #304

Support cli option --no-env to disable loading of .env files

Reference links:
- https://github.com/lynx-family/lynx-stack/pull/233#discussion_r2027156364
- https://github.com/web-infra-dev/rsbuild/pull/4947

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
