### PR TITLE
fix(webpack/template): delay deleting debugging assets

### DIFF
--- a/.changeset/famous-dryers-play.md
+++ b/.changeset/famous-dryers-play.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Fix source-maps (`.js.map` files) were not accessible in the `compiler.hooks.afterEmit` hook.

--- a/.changeset/seven-cougars-look.md
+++ b/.changeset/seven-cougars-look.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Fix incorrect hash of `background.[contenthash].js` in `.lynx.bundle` files.

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -130,14 +130,13 @@ export class LynxEncodePluginImpl {
         const { manifest } = encodeData;
 
         if (!isDebug() && !isDev && !isRsdoctor()) {
-          templateHooks.beforeEmit.tap(this.name, (args) => {
+          compiler.hooks.afterEmit.tap(this.name, () => {
             this.deleteDebuggingAssets(compilation, [
               encodeData.lepusCode.root,
               ...encodeData.lepusCode.chunks,
               ...Object.keys(manifest).map(name => ({ name })),
               ...encodeData.css.chunks,
             ]);
-            return args;
           });
         }
 

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -522,7 +522,7 @@ class LynxTemplatePluginImpl {
                  * and source-map is generated
                  */
                 compiler.webpack.Compilation
-                  .PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
+                  .PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
             },
             () => {
               return this.#generateTemplate(
@@ -571,9 +571,10 @@ class LynxTemplatePluginImpl {
           /**
            * Generate the html after minification and dev tooling is done
            * and source-map is generated
+           * and real content hash is generated
            */
           compiler.webpack.Compilation
-            .PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
+            .PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
       }, async () => {
         await this.#generateAsyncTemplate(compilation);
       });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

This patch resolves a regression from issue #231 that prevented obtaining the correct content hash for `background.js`. The fix involves delaying the `processAssets` stage of Encode to `PROCESS_ASSETS_STAGE_OPTIMIZE_HASH`.

The removal of debugging assets is postponed to `compiler.hooks.afterEmit` to ensure accurate retrieval of assets and their corresponding source maps.

close: #251

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
