### PR TITLE
fix(rspeedy): duplicate chunks in chunkSplit with multiple entries

### DIFF
--- a/.changeset/light-donuts-sin.md
+++ b/.changeset/light-donuts-sin.md
@@ -1,5 +1,5 @@
 ---
-"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/template-webpack-plugin": minor
 ---
 
 Fixed an issue in rspeedy where chunks weren't being properly shared between multiple entries during chunk splitting. This resulted in duplicate chunks being generated, increasing bundle size and reducing performance.

--- a/.changeset/light-donuts-sin.md
+++ b/.changeset/light-donuts-sin.md
@@ -4,4 +4,4 @@
 
 Fixed an issue in rspeedy where chunks weren't being properly shared between multiple entries during chunk splitting. This resulted in duplicate chunks being generated, increasing bundle size and reducing performance.
 
-**BREAKING CHANGE**: Exclude non-background files from the `encodeData.manifest`.
+**BREAKING CHANGE**: `encodeData.manifest` now only contains the `/app-service.js` entry.

--- a/.changeset/light-donuts-sin.md
+++ b/.changeset/light-donuts-sin.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Fixed an issue in rspeedy where chunks weren't being properly shared between multiple entries during chunk splitting. This resulted in duplicate chunks being generated, increasing bundle size and reducing performance.
+
+**BREAKING CHANGE**: Exclude non-background files from the `encodeData.manifest`.

--- a/examples/react/lynx.config.js
+++ b/examples/react/lynx.config.js
@@ -5,6 +5,15 @@ import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
 const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
 
 export default defineConfig({
+  // performance: {
+  //   chunkSplit: {
+  //     strategy: 'split-by-experience',
+  //     override: {
+  //       // See: https://github.com/web-infra-dev/rspack/issues/9812
+  //       filename: '[name].[contenthash:8].js',
+  //     },
+  //   },
+  // },
   plugins: [
     pluginReactLynx(),
     pluginQRCode({

--- a/packages/webpack/css-extract-webpack-plugin/package.json
+++ b/packages/webpack/css-extract-webpack-plugin/package.json
@@ -59,7 +59,7 @@
     "webpack": "^5.99.8"
   },
   "peerDependencies": {
-    "@lynx-js/template-webpack-plugin": "^0.5.0 || ^0.6.0"
+    "@lynx-js/template-webpack-plugin": "^0.5.0 || ^0.6.0 || ^0.7.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/webpack/react-webpack-plugin/package.json
+++ b/packages/webpack/react-webpack-plugin/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@lynx-js/react": "^0.103.0 || ^0.104.0 || ^0.105.0 || ^0.106.0 || ^0.107.0 || ^0.108.0",
-    "@lynx-js/template-webpack-plugin": "^0.4.0 || ^0.5.0 || ^0.6.0"
+    "@lynx-js/template-webpack-plugin": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0"
   },
   "peerDependenciesMeta": {
     "@lynx-js/react": {

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/index.jsx
@@ -53,12 +53,20 @@ it('should have module.exports in foo.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js'])
+  expect(tasmJSON.manifest['/app-service.js']).toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
-    .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
-    .toContain('function (globDynamicComponentEntry)');
+  expect(tasmJSON.manifest['/app-service.js']).contain(
+    `lynx.requireModule('/.rspeedy/async/./foo.js-react:background.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
+
+  const outputFoo = await readFile(
+    resolve(__dirname, '.rspeedy/async/./foo.js-react:background.js'),
+    'utf-8',
+  );
+
+  expect(outputFoo).not.toContain('const module = { exports: {} }');
+  expect(outputFoo).not.toContain('function (globDynamicComponentEntry)');
 });
 
 it('should have module.exports in bar.js template', async () => {
@@ -78,12 +86,20 @@ it('should have module.exports in bar.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js'])
+  expect(tasmJSON.manifest['/app-service.js']).toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
-    .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
-    .toContain('function (globDynamicComponentEntry)');
+  expect(tasmJSON.manifest['/app-service.js']).contain(
+    `lynx.requireModule('/.rspeedy/async/./bar.js-react:background.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
+
+  const outputBar = await readFile(
+    resolve(__dirname, '.rspeedy/async/./bar.js-react:background.js'),
+    'utf-8',
+  );
+
+  expect(outputBar).not.toContain('const module = { exports: {} }');
+  expect(outputBar).not.toContain('function (globDynamicComponentEntry)');
 });
 
 it('should have module.exports in baz.js template', async () => {
@@ -103,10 +119,18 @@ it('should have module.exports in baz.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js'])
+  expect(tasmJSON.manifest['/app-service.js']).toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
-    .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
-    .toContain('function (globDynamicComponentEntry)');
+  expect(tasmJSON.manifest['/app-service.js']).contain(
+    `lynx.requireModule('/.rspeedy/async/./baz.js-react:background.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
+
+  const outputBaz = await readFile(
+    resolve(__dirname, '.rspeedy/async/./baz.js-react:background.js'),
+    'utf-8',
+  );
+
+  expect(outputBaz).not.toContain('const module = { exports: {} }');
+  expect(outputBaz).not.toContain('function (globDynamicComponentEntry)');
 });

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/index.jsx
@@ -25,12 +25,20 @@ it('should have module.exports in foo.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js'])
+  expect(tasmJSON.manifest['/app-service.js']).toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
-    .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/./foo.js-react:background.js']).not
-    .toContain('function (globDynamicComponentEntry)');
+  expect(tasmJSON.manifest['/app-service.js']).contain(
+    `lynx.requireModule('/.rspeedy/async/./foo.js-react:background.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
+
+  const outputFoo = await readFile(
+    resolve(__dirname, '.rspeedy/async/./foo.js-react:background.js'),
+    'utf-8',
+  );
+
+  expect(outputFoo).not.toContain('const module = { exports: {} }');
+  expect(outputFoo).not.toContain('function (globDynamicComponentEntry)');
 });
 
 it('should have module.exports in bar.js template', async () => {
@@ -50,12 +58,20 @@ it('should have module.exports in bar.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js'])
+  expect(tasmJSON.manifest['/app-service.js']).toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
-    .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/./bar.js-react:background.js']).not
-    .toContain('function (globDynamicComponentEntry)');
+  expect(tasmJSON.manifest['/app-service.js']).contain(
+    `lynx.requireModule('/.rspeedy/async/./bar.js-react:background.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
+
+  const outputBar = await readFile(
+    resolve(__dirname, '.rspeedy/async/./bar.js-react:background.js'),
+    'utf-8',
+  );
+
+  expect(outputBar).not.toContain('const module = { exports: {} }');
+  expect(outputBar).not.toContain('function (globDynamicComponentEntry)');
 });
 
 it('should have module.exports in baz.js template', async () => {
@@ -75,10 +91,18 @@ it('should have module.exports in baz.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js'])
+  expect(tasmJSON.manifest['/app-service.js']).toBeDefined();
+  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
-    .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/./baz.js-react:background.js']).not
-    .toContain('function (globDynamicComponentEntry)');
+  expect(tasmJSON.manifest['/app-service.js']).contain(
+    `lynx.requireModule('/.rspeedy/async/./baz.js-react:background.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
+
+  const outputBaz = await readFile(
+    resolve(__dirname, '.rspeedy/async/./baz.js-react:background.js'),
+    'utf-8',
+  );
+
+  expect(outputBaz).not.toContain('const module = { exports: {} }');
+  expect(outputBaz).not.toContain('function (globDynamicComponentEntry)');
 });

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -241,7 +241,7 @@ export class LynxEncodePluginImpl {
     if (this.#isBackground(name)) {
       return `/${name}`;
     }
-    return new URL(name, publicPath).toString();
+    return publicPath + name;
   }
 
   #isBackground(name: string): boolean {

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -146,10 +146,16 @@ export class LynxEncodePluginImpl {
         const { encodeData } = args;
         const { manifest } = encodeData;
 
-        const publicPath =
-          typeof compilation?.outputOptions.publicPath === 'function'
-            ? compilation.outputOptions.publicPath({})
-            : compilation?.outputOptions.publicPath ?? '';
+        let publicPath = '';
+        if (typeof compilation?.outputOptions.publicPath === 'function') {
+          compilation.errors.push(
+            new compiler.webpack.WebpackError(
+              '`publicPath` as a function is not supported yet.',
+            ),
+          );
+        } else {
+          publicPath = compilation?.outputOptions.publicPath ?? '';
+        }
 
         if (!isDebug() && !isDev && !isRsdoctor()) {
           [
@@ -174,8 +180,6 @@ export class LynxEncodePluginImpl {
           //     lynx.requireModule('initial-chunk1')
           //     lynx.requireModule('initial-chunk2')
           //   `,
-          //   'initial-chunk1': `<content-of-initial-chunk>`,
-          //   'initial-chunk2': `<content-of-initial-chunk>`,
           // },
           // ```
           '/app-service.js': [
@@ -189,14 +193,6 @@ export class LynxEncodePluginImpl {
               .join(','),
             this.#appServiceFooter(),
           ].join(''),
-          ...(Object.fromEntries(
-            Object.entries(manifest)
-              .filter(([name]) => this.#isBackground(name))
-              .map(([name, source]) => [
-                this.#formatJSName(name, publicPath),
-                source,
-              ]),
-          )),
         };
 
         return args;
@@ -238,14 +234,7 @@ export class LynxEncodePluginImpl {
   }
 
   #formatJSName(name: string, publicPath: string): string {
-    if (this.#isBackground(name)) {
-      return `/${name}`;
-    }
     return publicPath + name;
-  }
-
-  #isBackground(name: string): boolean {
-    return /\/background(?:\.[a-f0-9]+)?\.js$/.test(name);
   }
 
   protected options: Required<LynxEncodePluginOptions>;

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -186,9 +186,7 @@ export class LynxEncodePluginImpl {
           ].join(''),
           ...(Object.fromEntries(
             Object.entries(manifest)
-              .filter(([name]) =>
-                /.rspeedy\/[^/]+\/background(?:\.[a-f0-9]+)?\.js$/.test(name)
-              )
+              // .filter(([name]) => this.#isBackground(name))
               .map(([name, source]) => [
                 this.#formatJSName(name),
                 source,
@@ -235,7 +233,14 @@ export class LynxEncodePluginImpl {
   }
 
   #formatJSName(name: string): string {
-    return `/${name}`;
+    if (this.#isBackground(name)) {
+      return `/${name}`;
+    }
+    return `<SERVER>/${name}`;
+  }
+
+  #isBackground(name: string): boolean {
+    return /\.rspeedy\/[^/]+\/background(?:\.[a-f0-9]+)?\.js$/.test(name);
   }
 
   protected options: Required<LynxEncodePluginOptions>;

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -185,10 +185,14 @@ export class LynxEncodePluginImpl {
             this.#appServiceFooter(),
           ].join(''),
           ...(Object.fromEntries(
-            Object.entries(manifest).map(([name, source]) => [
-              this.#formatJSName(name),
-              source,
-            ]),
+            Object.entries(manifest)
+              .filter(([name]) =>
+                /.rspeedy\/[^/]+\/background(?:\.[a-f0-9]+)?\.js$/.test(name)
+              )
+              .map(([name, source]) => [
+                this.#formatJSName(name),
+                source,
+              ]),
           )),
         };
 

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -191,7 +191,7 @@ export class LynxEncodePluginImpl {
           ].join(''),
           ...(Object.fromEntries(
             Object.entries(manifest)
-              // .filter(([name]) => this.#isBackground(name))
+              .filter(([name]) => this.#isBackground(name))
               .map(([name, source]) => [
                 this.#formatJSName(name, publicPath),
                 source,

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -146,6 +146,11 @@ export class LynxEncodePluginImpl {
         const { encodeData } = args;
         const { manifest } = encodeData;
 
+        const publicPath =
+          typeof compilation?.outputOptions.publicPath === 'function'
+            ? compilation.outputOptions.publicPath({})
+            : compilation?.outputOptions.publicPath ?? '';
+
         if (!isDebug() && !isDev && !isRsdoctor()) {
           [
             encodeData.lepusCode.root,
@@ -178,7 +183,7 @@ export class LynxEncodePluginImpl {
             Object.keys(manifest)
               .map((name) =>
                 `module.exports=lynx.requireModule('${
-                  this.#formatJSName(name)
+                  this.#formatJSName(name, publicPath)
                 }',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`
               )
               .join(','),
@@ -188,7 +193,7 @@ export class LynxEncodePluginImpl {
             Object.entries(manifest)
               // .filter(([name]) => this.#isBackground(name))
               .map(([name, source]) => [
-                this.#formatJSName(name),
+                this.#formatJSName(name, publicPath),
                 source,
               ]),
           )),
@@ -232,11 +237,11 @@ export class LynxEncodePluginImpl {
     return amdFooter + loadScriptFooter;
   }
 
-  #formatJSName(name: string): string {
+  #formatJSName(name: string, publicPath: string): string {
     if (this.#isBackground(name)) {
       return `/${name}`;
     }
-    return `<SERVER>/${name}`;
+    return new URL(name, publicPath).toString();
   }
 
   #isBackground(name: string): boolean {

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -245,7 +245,7 @@ export class LynxEncodePluginImpl {
   }
 
   #isBackground(name: string): boolean {
-    return /\.rspeedy\/[^/]+\/background(?:\.[a-f0-9]+)?\.js$/.test(name);
+    return /\/background(?:\.[a-f0-9]+)?\.js$/.test(name);
   }
 
   protected options: Required<LynxEncodePluginOptions>;

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -146,7 +146,7 @@ export class LynxEncodePluginImpl {
         const { encodeData } = args;
         const { manifest } = encodeData;
 
-        let publicPath = '';
+        let publicPath = '/';
         if (typeof compilation?.outputOptions.publicPath === 'function') {
           compilation.errors.push(
             new compiler.webpack.WebpackError(
@@ -154,7 +154,7 @@ export class LynxEncodePluginImpl {
             ),
           );
         } else {
-          publicPath = compilation?.outputOptions.publicPath ?? '';
+          publicPath = compilation?.outputOptions.publicPath ?? '/';
         }
 
         if (!isDebug() && !isDev && !isRsdoctor()) {

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/async-chunk/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/async-chunk/index.js
@@ -29,9 +29,16 @@ it('should generate correct foo template', async () => {
 
   const content = await readFile(tasmJSONPath, 'utf-8');
   const { sourceContent, manifest } = JSON.parse(content);
+
+  const output = resolve(__dirname, 'foo:background.rspack.bundle.js');
+  expect(existsSync(output));
+
+  const outputContent = await readFile(output, 'utf-8');
+  expect(outputContent).toContain(['function', 'foo()'].join(' '));
+
   expect(sourceContent).toHaveProperty('appType', 'DynamicComponent');
-  expect(manifest).toHaveProperty(
-    '/foo:background.rspack.bundle.js',
-    expect.stringContaining('function foo()'),
+
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule('/foo:background.rspack.bundle.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
   );
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/a.js
@@ -23,11 +23,17 @@ it('should have correct tasm.json', async () => {
   );
   expect(fs.existsSync(target));
 
-  const content = await fs.promises.readFile(target, 'utf-8');
+  const output = path.resolve(__dirname, 'a.js');
+  expect(fs.existsSync(output));
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+  expect(outputContent).toContain(['**', 'aaa', '**'].join(''));
 
+  const content = await fs.promises.readFile(target, 'utf-8');
   const { manifest } = JSON.parse(content);
 
-  expect(manifest['/a/a.js']).toContain(['**', 'aaa', '**'].join(''));
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule('/a/a.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 });
 
 it('should generate correct bundle', async () => {
@@ -47,11 +53,22 @@ it('should generate correct bundle', async () => {
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
 
   const fooContent = await fs.promises.readFile(foo, 'utf-8');
-  expect(fooContent).toContain('function foo()');
+  expect(fooContent).toContain(
+    `lynx.requireModule('/foo/foo.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const barContent = await fs.promises.readFile(bar, 'utf-8');
-  expect(barContent).toContain('function bar()');
+  expect(barContent).toContain(
+    `lynx.requireModule('/bar/bar.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const bazContent = await fs.promises.readFile(baz, 'utf-8');
-  expect(bazContent).toContain('function baz()');
+  expect(bazContent).toContain(
+    `lynx.requireModule('/baz/baz.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
+
+  const asyncTemplates = await fs.promises.readdir(
+    path.resolve(__dirname, '../async'),
+  );
+  expect(asyncTemplates).toHaveLength(3); // foo, bar, baz
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/b.js
@@ -23,11 +23,17 @@ it('should have correct tasm.json', async () => {
   );
   expect(fs.existsSync(target));
 
-  const content = await fs.promises.readFile(target, 'utf-8');
+  const output = path.resolve(__dirname, 'b.js');
+  expect(fs.existsSync(output));
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+  expect(outputContent).toContain(['**', 'bbb', '**'].join(''));
 
+  const content = await fs.promises.readFile(target, 'utf-8');
   const { manifest } = JSON.parse(content);
 
-  expect(manifest['/b/b.js']).toContain(['**', 'bbb', '**'].join(''));
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule('/b/b.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 });
 
 it('should generate correct bundle', async () => {
@@ -47,13 +53,19 @@ it('should generate correct bundle', async () => {
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
 
   const fooContent = await fs.promises.readFile(foo, 'utf-8');
-  expect(fooContent).toContain('function foo()');
+  expect(fooContent).toContain(
+    `lynx.requireModule('/foo/foo.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const barContent = await fs.promises.readFile(bar, 'utf-8');
-  expect(barContent).toContain('function bar()');
+  expect(barContent).toContain(
+    `lynx.requireModule('/bar/bar.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const bazContent = await fs.promises.readFile(baz, 'utf-8');
-  expect(bazContent).toContain('function baz()');
+  expect(bazContent).toContain(
+    `lynx.requireModule('/baz/baz.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const asyncTemplates = await fs.promises.readdir(
     path.resolve(__dirname, '../async'),

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/c.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/c.js
@@ -23,11 +23,17 @@ it('should have correct tasm.json', async () => {
   );
   expect(fs.existsSync(target));
 
-  const content = await fs.promises.readFile(target, 'utf-8');
+  const output = path.resolve(__dirname, 'c.js');
+  expect(fs.existsSync(output));
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+  expect(outputContent).toContain(['**', 'ccc', '**'].join(''));
 
+  const content = await fs.promises.readFile(target, 'utf-8');
   const { manifest } = JSON.parse(content);
 
-  expect(manifest['/c/c.js']).toContain(['**', 'ccc', '**'].join(''));
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule('/c/c.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 });
 
 it('should generate correct bundle', async () => {
@@ -47,13 +53,19 @@ it('should generate correct bundle', async () => {
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
 
   const fooContent = await fs.promises.readFile(foo, 'utf-8');
-  expect(fooContent).toContain('function foo()');
+  expect(fooContent).toContain(
+    `lynx.requireModule('/foo/foo.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const barContent = await fs.promises.readFile(bar, 'utf-8');
-  expect(barContent).toContain('function bar()');
+  expect(barContent).toContain(
+    `lynx.requireModule('/bar/bar.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const bazContent = await fs.promises.readFile(baz, 'utf-8');
-  expect(bazContent).toContain('function baz()');
+  expect(bazContent).toContain(
+    `lynx.requireModule('/baz/baz.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const asyncTemplates = await fs.promises.readdir(
     path.resolve(__dirname, '../async'),

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/d.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/d.js
@@ -23,11 +23,17 @@ it('should have correct tasm.json', async () => {
   );
   expect(fs.existsSync(target));
 
-  const content = await fs.promises.readFile(target, 'utf-8');
+  const output = path.resolve(__dirname, 'd.js');
+  expect(fs.existsSync(output));
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+  expect(outputContent).toContain(['**', 'ddd', '**'].join(''));
 
+  const content = await fs.promises.readFile(target, 'utf-8');
   const { manifest } = JSON.parse(content);
 
-  expect(manifest['/d/d.js']).toContain(['**', 'ddd', '**'].join(''));
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule('/d/d.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 });
 
 it('should generate correct bundle', async () => {
@@ -47,13 +53,19 @@ it('should generate correct bundle', async () => {
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
 
   const fooContent = await fs.promises.readFile(foo, 'utf-8');
-  expect(fooContent).toContain('function foo()');
+  expect(fooContent).toContain(
+    `lynx.requireModule('/foo/foo.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const barContent = await fs.promises.readFile(bar, 'utf-8');
-  expect(barContent).toContain('function bar()');
+  expect(barContent).toContain(
+    `lynx.requireModule('/bar/bar.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const bazContent = await fs.promises.readFile(baz, 'utf-8');
-  expect(bazContent).toContain('function baz()');
+  expect(bazContent).toContain(
+    `lynx.requireModule('/baz/baz.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const asyncTemplates = await fs.promises.readdir(
     path.resolve(__dirname, '../async'),

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/e.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/e.js
@@ -23,11 +23,17 @@ it('should have correct tasm.json', async () => {
   );
   expect(fs.existsSync(target));
 
-  const content = await fs.promises.readFile(target, 'utf-8');
+  const output = path.resolve(__dirname, 'e.js');
+  expect(fs.existsSync(output));
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+  expect(outputContent).toContain(['**', 'eee', '**'].join(''));
 
+  const content = await fs.promises.readFile(target, 'utf-8');
   const { manifest } = JSON.parse(content);
 
-  expect(manifest['/e/e.js']).toContain(['**', 'eee', '**'].join(''));
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule('/e/e.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 });
 
 it('should generate correct bundle', async () => {
@@ -47,13 +53,19 @@ it('should generate correct bundle', async () => {
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
 
   const fooContent = await fs.promises.readFile(foo, 'utf-8');
-  expect(fooContent).toContain('function foo()');
+  expect(fooContent).toContain(
+    `lynx.requireModule('/foo/foo.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const barContent = await fs.promises.readFile(bar, 'utf-8');
-  expect(barContent).toContain('function bar()');
+  expect(barContent).toContain(
+    `lynx.requireModule('/bar/bar.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const bazContent = await fs.promises.readFile(baz, 'utf-8');
-  expect(bazContent).toContain('function baz()');
+  expect(bazContent).toContain(
+    `lynx.requireModule('/baz/baz.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
 
   const asyncTemplates = await fs.promises.readdir(
     path.resolve(__dirname, '../async'),

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/webpack-chunk-name/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/webpack-chunk-name/index.js
@@ -18,12 +18,14 @@ it('should have both foo and bar', async () => {
   const content = await readFile(tasmJSONPath, 'utf-8');
 
   const { manifest } = JSON.parse(content);
-  expect(manifest).toHaveProperty(
-    `/async/test.js`,
-    expect.stringContaining(['function', 'foo()'].join(' ')),
-  );
-  expect(manifest).toHaveProperty(
-    `/async/test.js`,
-    expect.stringContaining(['function', 'bar()'].join(' ')),
+
+  const output = join(__dirname, 'async', 'test.js');
+  expect(existsSync(output));
+  const outputContent = await readFile(output, 'utf-8');
+  expect(outputContent).toContain(['function', 'foo()'].join(' '));
+  expect(outputContent).toContain(['function', 'bar()'].join(' '));
+
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule('/async/test.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
   );
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/a.js
@@ -29,10 +29,15 @@ it('should have correct tasm.json', async () => {
 
   const content = await fs.promises.readFile(target, 'utf-8');
 
+  const output = path.resolve(__dirname, 'a.js');
+  expect(fs.existsSync(output));
+
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+
   const { lepusCode, manifest } = JSON.parse(content);
 
-  expect(lepusCode).toHaveProperty('root', manifest['/a/a.js']);
-  expect(manifest['/a/a.js']).toContain(['**', 'aaa', '**'].join(''));
+  expect(lepusCode).toHaveProperty('root', outputContent);
+  expect(outputContent).toContain(['**', 'aaa', '**'].join(''));
   expect(manifest['/app-service.js']).toContain(
     `lynx.requireModule('/a/a.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
   );

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/b.js
@@ -29,10 +29,15 @@ it('should have correct tasm.json', async () => {
 
   const content = await fs.promises.readFile(target, 'utf-8');
 
+  const output = path.resolve(__dirname, 'b.js');
+  expect(fs.existsSync(output));
+
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+
   const { lepusCode, manifest } = JSON.parse(content);
 
-  expect(lepusCode).toHaveProperty('root', manifest['/b/b.js']);
-  expect(manifest['/b/b.js']).toContain(['**', 'bbb', '**'].join(''));
+  expect(lepusCode).toHaveProperty('root', outputContent);
+  expect(outputContent).toContain(['**', 'bbb', '**'].join(''));
   expect(manifest['/app-service.js']).toContain(
     `lynx.requireModule('/b/b.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
   );

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/c.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/c.js
@@ -29,10 +29,15 @@ it('should have correct tasm.json', async () => {
 
   const content = await fs.promises.readFile(target, 'utf-8');
 
+  const output = path.resolve(__dirname, 'c.js');
+  expect(fs.existsSync(output));
+
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+
   const { lepusCode, manifest } = JSON.parse(content);
 
-  expect(lepusCode).toHaveProperty('root', manifest['/c/c.js']);
-  expect(manifest['/c/c.js']).toContain(['**', 'ccc', '**'].join(''));
+  expect(lepusCode).toHaveProperty('root', outputContent);
+  expect(outputContent).toContain(['**', 'ccc', '**'].join(''));
   expect(manifest['/app-service.js']).toContain(
     `lynx.requireModule('/c/c.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
   );

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/d.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/d.js
@@ -29,10 +29,15 @@ it('should have correct tasm.json', async () => {
 
   const content = await fs.promises.readFile(target, 'utf-8');
 
+  const output = path.resolve(__dirname, 'd.js');
+  expect(fs.existsSync(output));
+
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+
   const { lepusCode, manifest } = JSON.parse(content);
 
-  expect(lepusCode).toHaveProperty('root', manifest['/d/d.js']);
-  expect(manifest['/d/d.js']).toContain(['**', 'ddd', '**'].join(''));
+  expect(lepusCode).toHaveProperty('root', outputContent);
+  expect(outputContent).toContain(['**', 'ddd', '**'].join(''));
   expect(manifest['/app-service.js']).toContain(
     `lynx.requireModule('/d/d.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
   );

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/e.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/e.js
@@ -29,10 +29,15 @@ it('should have correct tasm.json', async () => {
 
   const content = await fs.promises.readFile(target, 'utf-8');
 
+  const output = path.resolve(__dirname, 'e.js');
+  expect(fs.existsSync(output));
+
+  const outputContent = await fs.promises.readFile(output, 'utf-8');
+
   const { lepusCode, manifest } = JSON.parse(content);
 
-  expect(lepusCode).toHaveProperty('root', manifest['/e/e.js']);
-  expect(manifest['/e/e.js']).toContain(['**', 'eee', '**'].join(''));
+  expect(lepusCode).toHaveProperty('root', outputContent);
+  expect(outputContent).toContain(['**', 'eee', '**'].join(''));
   expect(manifest['/app-service.js']).toContain(
     `lynx.requireModule('/e/e.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
   );

--- a/packages/webpack/web-webpack-plugin/package.json
+++ b/packages/webpack/web-webpack-plugin/package.json
@@ -34,6 +34,6 @@
     "webpack": "^5.99.8"
   },
   "peerDependencies": {
-    "@lynx-js/template-webpack-plugin": "^0.6.0"
+    "@lynx-js/template-webpack-plugin": "^0.6.0 || ^0.7.0"
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fixed an issue in rspeedy where chunks weren't being properly shared between multiple entries during chunk splitting. This resulted in duplicate chunks being generated, increasing bundle size and reducing performance.

> [!CAUTION]
> **BREAKING CHANGE**:  `encodeData.manifest` now only contains the `/app-service.js` entry.

### TODO
Add support for synchronous chunk loading.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
