### PR TITLE
chore: remove useless build script

### DIFF
--- a/packages/third-party/tailwind-preset/package.json
+++ b/packages/third-party/tailwind-preset/package.json
@@ -26,9 +26,6 @@
     "CHANGELOG.md",
     "README.md"
   ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json"
-  },
   "devDependencies": {
     "tailwindcss": "^3.4.17"
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Since we are using TypeScript project reference, there is no need to run `tsc --build` in `packages/third-party/tailwind-preset/package.json#scripts.build`.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
