### PR TITLE
feat: support `shared-context`

### DIFF
--- a/.changeset/blue-lies-flash.md
+++ b/.changeset/blue-lies-flash.md
@@ -1,0 +1,15 @@
+---
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+feat: allow multi lynx-view to share bts worker
+
+Now we allow users to enable so-called "shared-context" feature on the Web Platform.
+
+Similar to the same feature for Lynx iOS/Android, this feature let multi lynx cards to share one js context.
+
+The `lynx.getSharedData` and `lynx.setSharedData` are also supported in this commit.
+
+To enable this feature, set property `backgroundContextId` or attribute `background-context-id` before a lynx-view starts rendering. Those card with same context id will share one web worker for the bts scripts.

--- a/.changeset/blue-lies-flash.md
+++ b/.changeset/blue-lies-flash.md
@@ -12,4 +12,4 @@ Similar to the same feature for Lynx iOS/Android, this feature let multi lynx ca
 
 The `lynx.getSharedData` and `lynx.setSharedData` are also supported in this commit.
 
-To enable this feature, set property `backgroundContextId` or attribute `background-context-id` before a lynx-view starts rendering. Those card with same context id will share one web worker for the bts scripts.
+To enable this feature, set property `lynxGroupId` or attribute `lynx-group-id` before a lynx-view starts rendering. Those card with same context id will share one web worker for the bts scripts.

--- a/packages/web-platform/web-constants/src/types/NativeApp.ts
+++ b/packages/web-platform/web-constants/src/types/NativeApp.ts
@@ -185,4 +185,7 @@ export interface NativeApp {
   createJSObjectDestructionObserver(
     callback: (...args: unknown[]) => unknown,
   ): {};
+
+  setSharedData<T>(dataKey: string, dataVal: T): void;
+  getSharedData<T = unknown>(dataKey: string): T | undefined;
 }

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -43,7 +43,7 @@ export type INapiModulesCall = (
  * @property {NapiModulesMap} napiModulesMap [optional] the napiModule which is called in lynx-core. key is module-name, value is esm url.
  * @property {INapiModulesCall} onNapiModulesCall [optional] the NapiModule value handler.
  * @property {"false" | "true" | null} injectHeadLinks [optional] @default true set it to "false" to disable injecting the <link href="" ref="stylesheet"> styles into shadowroot
- * @property {number} backgroundContextId [optional] (attribute: "background-context-id") the background shared context id, which is used to share webworker between different lynx cards
+ * @property {number} lynxGroupId [optional] (attribute: "lynx-group-id") the background shared context id, which is used to share webworker between different lynx cards
  *
  * @event error lynx card fired an error
  *
@@ -205,16 +205,16 @@ export class LynxView extends HTMLElement {
    * @param
    * @property
    */
-  get backgroundContextId(): number | undefined {
-    return this.getAttribute('background-context-id')
-      ? Number(this.getAttribute('background-context-id')!)
+  get lynxGroupId(): number | undefined {
+    return this.getAttribute('lynx-group-id')
+      ? Number(this.getAttribute('lynx-group-id')!)
       : undefined;
   }
-  set backgroundContextId(val: number | undefined) {
+  set lynxGroupId(val: number | undefined) {
     if (val) {
-      this.setAttribute('background-context-id', val.toString());
+      this.setAttribute('lynx-group-id', val.toString());
     } else {
-      this.removeAttribute('background-context-id');
+      this.removeAttribute('lynx-group-id');
     }
   }
 
@@ -322,7 +322,7 @@ export class LynxView extends HTMLElement {
           if (!this.shadowRoot) {
             this.attachShadow({ mode: 'open' });
           }
-          const backgroundContextId = this.backgroundContextId;
+          const lynxGroupId = this.lynxGroupId;
           const lynxView = createLynxView({
             tagMap,
             shadowRoot: this.shadowRoot!,
@@ -331,7 +331,7 @@ export class LynxView extends HTMLElement {
             initData: this.#initData,
             nativeModulesMap: this.#nativeModulesMap,
             napiModulesMap: this.#napiModulesMap,
-            backgroundContextId,
+            lynxGroupId,
             callbacks: {
               nativeModulesCall: (
                 ...args: [name: string, data: any, moduleName: string]

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -43,6 +43,7 @@ export type INapiModulesCall = (
  * @property {NapiModulesMap} napiModulesMap [optional] the napiModule which is called in lynx-core. key is module-name, value is esm url.
  * @property {INapiModulesCall} onNapiModulesCall [optional] the NapiModule value handler.
  * @property {"false" | "true" | null} injectHeadLinks [optional] @default true set it to "false" to disable injecting the <link href="" ref="stylesheet"> styles into shadowroot
+ * @property {number} backgroundContextId [optional] (attribute: "background-context-id") the background shared context id, which is used to share webworker between different lynx cards
  *
  * @event error lynx card fired an error
  *
@@ -201,6 +202,23 @@ export class LynxView extends HTMLElement {
   }
 
   /**
+   * @param
+   * @property
+   */
+  get backgroundContextId(): number | undefined {
+    return this.getAttribute('background-context-id')
+      ? Number(this.getAttribute('background-context-id')!)
+      : undefined;
+  }
+  set backgroundContextId(val: number | undefined) {
+    if (val) {
+      this.setAttribute('background-context-id', val.toString());
+    } else {
+      this.removeAttribute('background-context-id');
+    }
+  }
+
+  /**
    * @public
    * @method
    * update the `__initData` and trigger essential flow
@@ -304,6 +322,7 @@ export class LynxView extends HTMLElement {
           if (!this.shadowRoot) {
             this.attachShadow({ mode: 'open' });
           }
+          const backgroundContextId = this.backgroundContextId;
           const lynxView = createLynxView({
             tagMap,
             shadowRoot: this.shadowRoot!,
@@ -312,6 +331,7 @@ export class LynxView extends HTMLElement {
             initData: this.#initData,
             nativeModulesMap: this.#nativeModulesMap,
             napiModulesMap: this.#napiModulesMap,
+            backgroundContextId,
             callbacks: {
               nativeModulesCall: (
                 ...args: [name: string, data: any, moduleName: string]

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -21,7 +21,7 @@ export interface LynxViewConfigs {
   nativeModulesMap: NativeModulesMap;
   napiModulesMap: NapiModulesMap;
   tagMap: Record<string, string>;
-  backgroundContextId: number | undefined;
+  lynxGroupId: number | undefined;
 }
 
 export interface LynxView {
@@ -44,7 +44,7 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
     nativeModulesMap,
     napiModulesMap,
     tagMap,
-    backgroundContextId,
+    lynxGroupId,
   } = configs;
   return startUIThread(
     templateUrl,
@@ -57,7 +57,7 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
       browserConfig: {},
     },
     shadowRoot,
-    backgroundContextId,
+    lynxGroupId,
     callbacks,
   );
 }

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -17,10 +17,11 @@ export interface LynxViewConfigs {
   initData: Cloneable;
   globalProps: Cloneable;
   shadowRoot: ShadowRoot;
-  callbacks: Parameters<typeof startUIThread>[3];
+  callbacks: Parameters<typeof startUIThread>[4];
   nativeModulesMap: NativeModulesMap;
   napiModulesMap: NapiModulesMap;
   tagMap: Record<string, string>;
+  backgroundContextId: number | undefined;
 }
 
 export interface LynxView {
@@ -43,6 +44,7 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
     nativeModulesMap,
     napiModulesMap,
     tagMap,
+    backgroundContextId,
   } = configs;
   return startUIThread(
     templateUrl,
@@ -55,6 +57,7 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
       browserConfig: {},
     },
     shadowRoot,
+    backgroundContextId,
     callbacks,
   );
 }

--- a/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
+++ b/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
@@ -11,21 +11,40 @@ interface LynxViewRpc {
   terminateWorkers: () => void;
 }
 
+const backgroundWorkerContextCount: number[] = [];
+const contextIdToBackgroundWorker: (Worker | undefined)[] = [];
+
 let preHeatedMainWorker = createMainWorker();
 
-export function bootWorkers(): LynxViewRpc {
+export function bootWorkers(
+  backgroundContextId: number | undefined,
+): LynxViewRpc {
   const curMainWorker = preHeatedMainWorker;
+  preHeatedMainWorker = createMainWorker();
   const curBackgroundWorker = createBackgroundWorker(
+    backgroundContextId,
     curMainWorker.channelMainThreadWithBackground,
   );
+  if (backgroundContextId) {
+    if (backgroundWorkerContextCount[backgroundContextId]) {
+      backgroundWorkerContextCount[backgroundContextId]++;
+    } else {
+      backgroundWorkerContextCount[backgroundContextId] = 1;
+    }
+  }
 
-  preHeatedMainWorker = createMainWorker();
   return {
     mainThreadRpc: curMainWorker.mainThreadRpc,
     backgroundRpc: curBackgroundWorker.backgroundRpc,
     terminateWorkers: () => {
       curMainWorker.mainThreadWorker.terminate();
-      curBackgroundWorker.backgroundThreadWorker.terminate();
+      if (!backgroundContextId) {
+        curBackgroundWorker.backgroundThreadWorker.terminate();
+      } else if (backgroundWorkerContextCount[backgroundContextId] === 1) {
+        curBackgroundWorker.backgroundThreadWorker.terminate();
+        backgroundWorkerContextCount[backgroundContextId] = 0;
+        contextIdToBackgroundWorker[backgroundContextId] = undefined;
+      }
     },
   };
 }
@@ -33,7 +52,7 @@ export function bootWorkers(): LynxViewRpc {
 function createMainWorker() {
   const channelToMainThread = new MessageChannel();
   const channelMainThreadWithBackground = new MessageChannel();
-  const mainThreadWorker = createWebWorker();
+  const mainThreadWorker = createWebWorker('lynx-main');
   const mainThreadMessage: WorkerStartMessage = {
     mode: 'main',
     toUIThread: channelToMainThread.port2,
@@ -54,10 +73,18 @@ function createMainWorker() {
 }
 
 function createBackgroundWorker(
+  backgroundContextId: number | undefined,
   channelMainThreadWithBackground: MessageChannel,
 ) {
   const channelToBackground = new MessageChannel();
-  const backgroundThreadWorker = createWebWorker();
+  let backgroundThreadWorker: Worker;
+  if (backgroundContextId) {
+    backgroundThreadWorker = contextIdToBackgroundWorker[backgroundContextId]
+      ?? createWebWorker('lynx-bg');
+    contextIdToBackgroundWorker[backgroundContextId] = backgroundThreadWorker;
+  } else {
+    backgroundThreadWorker = createWebWorker('lynx-bg');
+  }
   const backgroundThreadMessage: WorkerStartMessage = {
     mode: 'background',
     toUIThread: channelToBackground.port2,
@@ -72,12 +99,12 @@ function createBackgroundWorker(
   return { backgroundRpc, backgroundThreadWorker };
 }
 
-function createWebWorker(): Worker {
+function createWebWorker(name: string): Worker {
   return new Worker(
     new URL('@lynx-js/web-worker-runtime', import.meta.url),
     {
       type: 'module',
-      name: `lynx-web`,
+      name,
     },
   );
 }

--- a/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
+++ b/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
@@ -38,7 +38,7 @@ export function bootWorkers(
     backgroundRpc: curBackgroundWorker.backgroundRpc,
     terminateWorkers: () => {
       curMainWorker.mainThreadWorker.terminate();
-      if (!backgroundContextId) {
+      if (backgroundContextId === undefined) {
         curBackgroundWorker.backgroundThreadWorker.terminate();
       } else if (backgroundWorkerContextCount[backgroundContextId] === 1) {
         curBackgroundWorker.backgroundThreadWorker.terminate();

--- a/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
+++ b/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
@@ -17,19 +17,19 @@ const contextIdToBackgroundWorker: (Worker | undefined)[] = [];
 let preHeatedMainWorker = createMainWorker();
 
 export function bootWorkers(
-  backgroundContextId: number | undefined,
+  lynxGroupId: number | undefined,
 ): LynxViewRpc {
   const curMainWorker = preHeatedMainWorker;
   preHeatedMainWorker = createMainWorker();
   const curBackgroundWorker = createBackgroundWorker(
-    backgroundContextId,
+    lynxGroupId,
     curMainWorker.channelMainThreadWithBackground,
   );
-  if (backgroundContextId !== undefined) {
-    if (backgroundWorkerContextCount[backgroundContextId]) {
-      backgroundWorkerContextCount[backgroundContextId]++;
+  if (lynxGroupId !== undefined) {
+    if (backgroundWorkerContextCount[lynxGroupId]) {
+      backgroundWorkerContextCount[lynxGroupId]++;
     } else {
-      backgroundWorkerContextCount[backgroundContextId] = 1;
+      backgroundWorkerContextCount[lynxGroupId] = 1;
     }
   }
 
@@ -38,12 +38,12 @@ export function bootWorkers(
     backgroundRpc: curBackgroundWorker.backgroundRpc,
     terminateWorkers: () => {
       curMainWorker.mainThreadWorker.terminate();
-      if (backgroundContextId === undefined) {
+      if (lynxGroupId === undefined) {
         curBackgroundWorker.backgroundThreadWorker.terminate();
-      } else if (backgroundWorkerContextCount[backgroundContextId] === 1) {
+      } else if (backgroundWorkerContextCount[lynxGroupId] === 1) {
         curBackgroundWorker.backgroundThreadWorker.terminate();
-        backgroundWorkerContextCount[backgroundContextId] = 0;
-        contextIdToBackgroundWorker[backgroundContextId] = undefined;
+        backgroundWorkerContextCount[lynxGroupId] = 0;
+        contextIdToBackgroundWorker[lynxGroupId] = undefined;
       }
     },
   };
@@ -73,15 +73,15 @@ function createMainWorker() {
 }
 
 function createBackgroundWorker(
-  backgroundContextId: number | undefined,
+  lynxGroupId: number | undefined,
   channelMainThreadWithBackground: MessageChannel,
 ) {
   const channelToBackground = new MessageChannel();
   let backgroundThreadWorker: Worker;
-  if (backgroundContextId) {
-    backgroundThreadWorker = contextIdToBackgroundWorker[backgroundContextId]
+  if (lynxGroupId) {
+    backgroundThreadWorker = contextIdToBackgroundWorker[lynxGroupId]
       ?? createWebWorker('lynx-bg');
-    contextIdToBackgroundWorker[backgroundContextId] = backgroundThreadWorker;
+    contextIdToBackgroundWorker[lynxGroupId] = backgroundThreadWorker;
   } else {
     backgroundThreadWorker = createWebWorker('lynx-bg');
   }

--- a/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
+++ b/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
@@ -25,7 +25,7 @@ export function bootWorkers(
     backgroundContextId,
     curMainWorker.channelMainThreadWithBackground,
   );
-  if (backgroundContextId) {
+  if (backgroundContextId !== undefined) {
     if (backgroundWorkerContextCount[backgroundContextId]) {
       backgroundWorkerContextCount[backgroundContextId]++;
     } else {

--- a/packages/web-platform/web-core/src/uiThread/startUIThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/startUIThread.ts
@@ -29,6 +29,7 @@ export function startUIThread(
   templateUrl: string,
   configs: Omit<MainThreadStartConfigs, 'template'>,
   shadowRoot: ShadowRoot,
+  backgroundContextId: number | undefined,
   callbacks: {
     nativeModulesCall: NativeModulesCall;
     napiModulesCall: NapiModulesCall;
@@ -41,7 +42,7 @@ export function startUIThread(
     mainThreadRpc,
     backgroundRpc,
     terminateWorkers,
-  } = bootWorkers();
+  } = bootWorkers(backgroundContextId);
   const sendGlobalEvent = backgroundRpc.createCall(sendGlobalEventEndpoint);
   const mainThreadStart = mainThreadRpc.createCall(mainThreadStartEndpoint);
   const markTiming = backgroundRpc.createCall(markTimingEndpoint);

--- a/packages/web-platform/web-core/src/uiThread/startUIThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/startUIThread.ts
@@ -29,7 +29,7 @@ export function startUIThread(
   templateUrl: string,
   configs: Omit<MainThreadStartConfigs, 'template'>,
   shadowRoot: ShadowRoot,
-  backgroundContextId: number | undefined,
+  lynxGroupId: number | undefined,
   callbacks: {
     nativeModulesCall: NativeModulesCall;
     napiModulesCall: NapiModulesCall;
@@ -42,7 +42,7 @@ export function startUIThread(
     mainThreadRpc,
     backgroundRpc,
     terminateWorkers,
-  } = bootWorkers(backgroundContextId);
+  } = bootWorkers(lynxGroupId);
   const sendGlobalEvent = backgroundRpc.createCall(sendGlobalEventEndpoint);
   const mainThreadStart = mainThreadRpc.createCall(mainThreadStartEndpoint);
   const markTiming = backgroundRpc.createCall(markTimingEndpoint);

--- a/packages/web-platform/web-tests/shell-project/index.ts
+++ b/packages/web-platform/web-tests/shell-project/index.ts
@@ -35,7 +35,7 @@ if (casename) {
     lynxView.nativeModulesMap = nativeModulesMap;
     lynxView.id = 'lynxview1';
     if (casename2) {
-      lynxView.setAttribute('background-context-id', '2');
+      lynxView.setAttribute('lynx-group-id', '2');
     }
     lynxView.onNativeModulesCall = (name, data, moduleName) => {
       if (name === 'getColor' && moduleName === 'CustomModule') {
@@ -51,7 +51,7 @@ if (casename) {
       lynxView2.id = 'lynxview2';
       lynxView2.setAttribute('url', `${dir2}/index.web.json`);
       lynxView2.nativeModulesMap = nativeModulesMap;
-      lynxView2.setAttribute('background-context-id', '2');
+      lynxView2.setAttribute('lynx-group-id', '2');
     });
   }
 } else {

--- a/packages/web-platform/web-tests/shell-project/index.ts
+++ b/packages/web-platform/web-tests/shell-project/index.ts
@@ -24,14 +24,19 @@ const nativeModulesMap = {
 
 const searchParams = new URLSearchParams(document.location.search);
 const casename = searchParams.get('casename');
+const casename2 = searchParams.get('casename2');
 const hasdir = searchParams.get('hasdir') === 'true';
 
 if (casename) {
   const dir = `/dist/${casename}${hasdir ? `/${casename}` : ''}`;
-  const lepusjs = `${dir}/index.web.json`;
+  const dir2 = `/dist/${casename2}${hasdir ? `/${casename2}` : ''}`;
   lynxViewTests(lynxView => {
-    lynxView.setAttribute('url', lepusjs);
+    lynxView.setAttribute('url', `${dir}/index.web.json`);
     lynxView.nativeModulesMap = nativeModulesMap;
+    lynxView.id = 'lynxview1';
+    if (casename2) {
+      lynxView.setAttribute('background-context-id', '2');
+    }
     lynxView.onNativeModulesCall = (name, data, moduleName) => {
       if (name === 'getColor' && moduleName === 'CustomModule') {
         return data.color;
@@ -41,6 +46,14 @@ if (casename) {
       }
     };
   });
+  if (casename2) {
+    lynxViewTests(lynxView2 => {
+      lynxView2.id = 'lynxview2';
+      lynxView2.setAttribute('url', `${dir2}/index.web.json`);
+      lynxView2.nativeModulesMap = nativeModulesMap;
+      lynxView2.setAttribute('background-context-id', '2');
+    });
+  }
 } else {
   console.warn('cannot find casename');
 }

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -42,8 +42,20 @@ const expectNoText = async (page: Page, text: string) => {
   await expect(hasText).toBe(false);
 };
 
-const goto = async (page: Page, testname: string, hasDir?: boolean) => {
-  await page.goto(`/?casename=${testname}${hasDir ? '&hasdir=true' : ''}`, {
+const goto = async (
+  page: Page,
+  testname: string,
+  testname2?: string,
+  hasDir?: boolean,
+) => {
+  let url = `/?casename=${testname}`;
+  if (hasDir) {
+    url += '&hasdir=true';
+  }
+  if (testname2) {
+    url += `&casename2=${testname2}`;
+  }
+  await page.goto(url, {
     waitUntil: 'load',
   });
   await page.evaluate(() => document.fonts.ready);
@@ -539,9 +551,9 @@ test.describe('reactlynx3 tests', () => {
           await goto(page, title);
           await diffScreenShot(page, module, title, 'initial');
           await page.evaluate(() => {
-            // @ts-expect-error
             document.querySelector('lynx-view')!.shadowRoot!.querySelector(
               '#x',
+              // @ts-expect-error
             )!.scrollTo({ offset: 200 });
           });
           await wait(200);
@@ -553,9 +565,9 @@ test.describe('reactlynx3 tests', () => {
           );
           await wait(200);
           await page.evaluate(() => {
-            // @ts-expect-error
             document.querySelector('lynx-view')!.shadowRoot!.querySelector(
               '#x',
+              // @ts-expect-error
             )!.scrollTo({ offset: 400 });
           });
           await diffScreenShot(page, module, title, 'scroll-200-green');
@@ -574,8 +586,8 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          // @ts-expect-error
           document.querySelector('lynx-view')!.shadowRoot!.querySelector('#x')!
+            // @ts-expect-error
             .scrollTo({ offset: 600 });
         });
         await wait(100);
@@ -584,8 +596,8 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          // @ts-expect-error
           document.querySelector('lynx-view')!.shadowRoot!.querySelector('#x')!
+            // @ts-expect-error
             .scrollTo({ offset: 0 });
         });
         await wait(100);
@@ -594,8 +606,8 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          // @ts-expect-error
           document.querySelector('lynx-view')!.shadowRoot!.querySelector('#y')!
+            // @ts-expect-error
             .scrollTo({ offset: 50 });
         });
         await wait(100);
@@ -604,8 +616,8 @@ test.describe('reactlynx3 tests', () => {
         });
         await wait(100);
         await page.evaluate(() => {
-          // @ts-expect-error
           document.querySelector('lynx-view')!.shadowRoot!.querySelector('#y')!
+            // @ts-expect-error
             .scrollTo({ offset: 0 });
         });
         await wait(100);
@@ -648,6 +660,24 @@ test.describe('reactlynx3 tests', () => {
         await diffScreenShot(page, module, title, 'all-green', {
           fullPage: true,
         });
+      });
+
+      test('api-setSharedData', async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        await expect(page.locator('#target')).toHaveCSS(
+          'background-color',
+          'rgb(0, 128, 0)',
+        ); // green
+      });
+
+      test('api-shared-context', async ({ page }, { title }) => {
+        await goto(page, 'api-setSharedData', 'api-getSharedData');
+        await wait(1000);
+        await expect(page.locator('#lynxview2').locator('#target')).toHaveCSS(
+          'background-color',
+          'rgb(0, 128, 0)',
+        ); // green
       });
 
       test(
@@ -964,7 +994,7 @@ test.describe('reactlynx3 tests', () => {
     test(
       'config-splitchunk-single-vendor',
       async ({ page }, { title }) => {
-        await goto(page, title, true);
+        await goto(page, title, undefined, true);
         await wait(1500);
         const target = page.locator('#target');
         await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
@@ -973,7 +1003,7 @@ test.describe('reactlynx3 tests', () => {
     test(
       'config-splitchunk-split-by-experience',
       async ({ page }, { title }) => {
-        await goto(page, title, true);
+        await goto(page, title, undefined, true);
         await wait(1500);
         const target = page.locator('#target');
         await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
@@ -982,7 +1012,7 @@ test.describe('reactlynx3 tests', () => {
     test(
       'config-splitchunk-split-by-module',
       async ({ page }, { title }) => {
-        await goto(page, title, true);
+        await goto(page, title, undefined, true);
         await wait(1500);
         const target = page.locator('#target');
         await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
@@ -990,7 +1020,7 @@ test.describe('reactlynx3 tests', () => {
     );
 
     test('config-mode-dev-with-all-in-one', async ({ page }, { title }) => {
-      await goto(page, title, true);
+      await goto(page, title, undefined, true);
       await wait(100);
       const target = page.locator('#target');
       await target.click();

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -543,6 +543,31 @@ test.describe('reactlynx3 tests', () => {
       expect(page.workers().length).toBe(5);
     });
 
+    test('api-setSharedData', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      await expect(page.locator('#target')).toHaveCSS(
+        'background-color',
+        'rgb(0, 128, 0)',
+      ); // green
+    });
+
+    test('api-shared-context', async ({ page }) => {
+      await goto(page, 'api-setSharedData', 'api-getSharedData');
+      await wait(100);
+      await page.locator('#lynxview2').locator('#target').click();
+      await expect(page.locator('#lynxview2').locator('#target')).toHaveCSS(
+        'background-color',
+        'rgb(0, 128, 0)',
+      ); // green
+    });
+
+    test('api-shared-context-worker-count', async ({ page }) => {
+      await goto(page, 'api-setSharedData', 'api-getSharedData');
+      await wait(100);
+      expect(page.workers().length).toBeLessThanOrEqual(4);
+    });
+
     test.describe('api-exposure', () => {
       const module = 'exposure';
       test(
@@ -660,24 +685,6 @@ test.describe('reactlynx3 tests', () => {
         await diffScreenShot(page, module, title, 'all-green', {
           fullPage: true,
         });
-      });
-
-      test('api-setSharedData', async ({ page }, { title }) => {
-        await goto(page, title);
-        await wait(100);
-        await expect(page.locator('#target')).toHaveCSS(
-          'background-color',
-          'rgb(0, 128, 0)',
-        ); // green
-      });
-
-      test('api-shared-context', async ({ page }, { title }) => {
-        await goto(page, 'api-setSharedData', 'api-getSharedData');
-        await wait(1000);
-        await expect(page.locator('#lynxview2').locator('#target')).toHaveCSS(
-          'background-color',
-          'rgb(0, 128, 0)',
-        ); // green
       });
 
       test(

--- a/packages/web-platform/web-tests/tests/react/api-getSharedData/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-getSharedData/index.jsx
@@ -1,0 +1,22 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useState, root, useEffect } from '@lynx-js/react';
+function App() {
+  const [color, setColor] = useState('orange');
+
+  return (
+    <view
+      id='target'
+      bindtap={() => {
+        setColor(lynx.getSharedData('color'));
+      }}
+      style={{
+        height: '100px',
+        width: '100px',
+        background: color,
+      }}
+    />
+  );
+}
+root.render(<App />);

--- a/packages/web-platform/web-tests/tests/react/api-setSharedData/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-setSharedData/index.jsx
@@ -1,0 +1,22 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useState, root, useEffect } from '@lynx-js/react';
+function App() {
+  const [color, setColor] = useState('orange');
+  useEffect(() => {
+    lynx.setSharedData('color', 'green');
+    setColor(lynx.getSharedData('color'));
+  }, []);
+  return (
+    <view
+      id='target'
+      style={{
+        height: '100px',
+        width: '100px',
+        background: color,
+      }}
+    />
+  );
+}
+root.render(<App />);

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -26,6 +26,7 @@ import type { TimingSystem } from './createTimingSystem.js';
 import type { LynxCrossThreadContext } from './createBackgroundLynx.js';
 
 let nativeAppCount = 0;
+const sharedData: Record<string, unknown> = {};
 
 export async function createNativeApp(config: {
   template: LynxTemplate;
@@ -138,6 +139,12 @@ export async function createNativeApp(config: {
     triggerComponentEvent,
     selectComponent,
     createJSObjectDestructionObserver: createJSObjectDestructionObserver(),
+    setSharedData<T>(dataKey: string, dataVal: T) {
+      sharedData[dataKey] = dataVal;
+    },
+    getSharedData<T>(dataKey: string): T | undefined {
+      return sharedData[dataKey] as T | undefined;
+    },
   };
   return nativeApp;
 }


### PR DESCRIPTION
* support `nativeApp.getSharedData` and `nativeApp.setSharedData`
* add the context id for labeling workers. Now for those workers with context id, we will count the number of running cards. We kill those workers only if all lynx card has been killed.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
