### PR TITLE
fix(web): When list-type is not specified, it is treated as single

### DIFF
--- a/.changeset/great-masks-mate.md
+++ b/.changeset/great-masks-mate.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": minor
+---
+
+fix: When list-type is not specified, it is treated as single formatting.

--- a/packages/web-platform/web-elements/src/XList/x-list.css
+++ b/packages/web-platform/web-elements/src/XList/x-list.css
@@ -146,7 +146,7 @@ x-list[vertical-orientation="false"]::part(lower-threshold-observer) {
 }
 
 /* list-type single */
-x-list[list-type="single"] {
+x-list {
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -154,7 +154,7 @@ x-list[list-type="single"] {
   column-gap: var(--list-cross-axis-gap);
 }
 
-x-list[list-type="single"][scroll-orientation="horizontal"] {
+x-list[scroll-orientation="horizontal"] {
   flex-direction: row;
   row-gap: var(--list-cross-axis-gap);
   column-gap: var(--list-main-axis-gap);

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/basic.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/basic.html
@@ -44,7 +44,7 @@
   <body>
     <script src="/web-elements.js" defer></script>
     <x-view class="page">
-      <x-list list-type="single">
+      <x-list>
         <list-item item-key="1" id="1"><x-view class="item"
           >1</x-view></list-item>
         <list-item item-key="2" id="2"><x-view class="item"


### PR DESCRIPTION
## Summary

fix: When list-type is not specified, it is treated as single formatting.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
