### PR TITLE
fix(web): remove requireModule, requireModuleAsync of mts

### DIFF
--- a/.changeset/twenty-singers-talk.md
+++ b/.changeset/twenty-singers-talk.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": minor
+---
+
+fix: mts lynx will no longer provide requireModule, requireModuleAsync methods, which is aligned with Native.

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadLynx.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadLynx.ts
@@ -1,15 +1,10 @@
 // Copyright 2023 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { LynxJSModule } from '@lynx-js/web-constants';
-import {
-  type MainThreadConfig,
-  MainThreadRuntime,
-} from './MainThreadRuntime.js';
+import { type MainThreadConfig } from './MainThreadRuntime.js';
 
 export function createMainThreadLynx(
   config: MainThreadConfig,
-  lepusRuntime: MainThreadRuntime,
 ) {
   return {
     getJSContext() {
@@ -22,37 +17,6 @@ export function createMainThreadLynx(
       return cancelAnimationFrame(handler);
     },
     __globalProps: config.globalProps,
-
-    requireModule(path: string) {
-      // @ts-expect-error
-      if (self.WorkerGlobalScope) {
-        const lepusChunkUrl = config.lepusCode[`${path}`];
-        if (lepusChunkUrl) path = lepusChunkUrl;
-        // @ts-expect-error
-        importScripts(path);
-        const entry = (globalThis.module as LynxJSModule).exports;
-        return entry?.(lepusRuntime);
-      } else {
-        throw new Error(
-          'importing scripts synchronously is only available for the multi-thread running mode',
-        );
-      }
-    },
-    requireModuleAsync(
-      path: string,
-      callback: (error: Error | null, exports?: unknown) => void,
-    ) {
-      const lepusChunkUrl = config.lepusCode[`${path}`];
-      if (lepusChunkUrl) path = lepusChunkUrl;
-      import(
-        /* webpackIgnore: true */
-        path
-      ).catch(callback).then(() => {
-        const entry = (globalThis.module as LynxJSModule).exports;
-        const ret = entry?.(lepusRuntime);
-        callback(null, ret);
-      });
-    },
     getCustomSectionSync(key: string) {
       return config.customSections[key]?.content;
     },

--- a/packages/web-platform/web-tests/tests/web-core.test.ts
+++ b/packages/web-platform/web-tests/tests/web-core.test.ts
@@ -167,31 +167,6 @@ test.describe('web core tests', () => {
     expect(hello).toBe('hello');
     expect(world).toBe('world');
   });
-  test('lynx.requireModule+sync-main.thread', async ({ page, browserName }) => {
-    // firefox dose not support this.
-    test.skip(browserName === 'firefox');
-    await goto(page);
-    const mainWorker = await getMainThreadWorker(page);
-    await mainWorker.evaluate(() => {
-      globalThis.runtime.renderPage = () => {};
-    });
-    const [hello, world] = await mainWorker!.evaluate(async () => {
-      const chunk1 = Promise.withResolvers<string>();
-      const chunk2 = Promise.withResolvers<string>();
-      globalThis.runtime.lynx.requireModuleAsync(
-        'manifest-chunk.js',
-        (_, exports) => {
-          chunk1.resolve(exports);
-        },
-      );
-      chunk2.resolve(
-        globalThis.runtime.lynx.requireModule('manifest-chunk2.js'),
-      );
-      return Promise.all([chunk1.promise, chunk2.promise]);
-    });
-    expect(hello).toBe('hello');
-    expect(world).toBe('world');
-  });
 
   test('loadLepusChunk', async ({ page, browserName }) => {
     // firefox dose not support this.


### PR DESCRIPTION
## Summary

fix: mts lynx will no longer provide requireModule, requireModuleAsync methods, which is aligned with Native.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
