### PR TITLE
fix: flushDelayedLifecycleEvents stack overflow  error

### DIFF
--- a/.changeset/hot-tools-relax.md
+++ b/.changeset/hot-tools-relax.md
@@ -2,4 +2,4 @@
 "@lynx-js/react": patch
 ---
 
-fix: flushDelayedLifecycleEvents stackOverflow error
+fix: flushDelayedLifecycleEvents stack overflow error

--- a/.changeset/hot-tools-relax.md
+++ b/.changeset/hot-tools-relax.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+fix: flushDelayedLifecycleEvents stackOverflow error

--- a/packages/react/runtime/__test__/delayed-lifecycle-events.test.jsx
+++ b/packages/react/runtime/__test__/delayed-lifecycle-events.test.jsx
@@ -1,0 +1,61 @@
+import { describe, it, beforeEach, afterEach, vi } from 'vitest';
+import { delayedLifecycleEvents } from '../src/lifecycle/event/delayLifecycleEvents';
+import { flushDelayedLifecycleEvents } from '../src/lynx/tt';
+import { __root } from '../src/root';
+import { globalEnvManager } from './utils/envManager';
+import { expect } from 'vitest';
+import { render } from 'preact';
+import { globalCommitTaskMap, replaceCommitHook, replaceRequestAnimationFrame } from '../src/lifecycle/patch/commit';
+
+beforeEach(() => {
+  replaceCommitHook();
+  globalEnvManager.resetEnv();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('delayedLifecycleEvents', () => {
+  it('should flush', async () => {
+    function Comp() {
+      return <view />;
+    }
+    __root.__jsx = <Comp />;
+    renderPage();
+    globalEnvManager.switchToBackground();
+    expect(__FIRST_SCREEN_SYNC_TIMING__).toMatchInlineSnapshot(`"immediately"`);
+    expect(globalThis.__OnLifecycleEvent.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          [
+            "rLynxFirstScreen",
+            {
+              "jsReadyEventIdSwap": {},
+              "refPatch": "{}",
+              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_1"}]}",
+            },
+          ],
+        ],
+      ]
+    `);
+    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    expect(delayedLifecycleEvents).toMatchInlineSnapshot(`
+      [
+        [
+          "rLynxFirstScreen",
+          {
+            "jsReadyEventIdSwap": {},
+            "refPatch": "{}",
+            "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_1"}]}",
+          },
+        ],
+      ]
+    `);
+    render(
+      <Comp />,
+      __root,
+    );
+    flushDelayedLifecycleEvents();
+    expect(delayedLifecycleEvents).toMatchInlineSnapshot(`[]`);
+  });
+});

--- a/packages/react/runtime/src/lynx/tt.ts
+++ b/packages/react/runtime/src/lynx/tt.ts
@@ -195,13 +195,18 @@ async function onLifecycleEventImpl(type: string, data: any): Promise<void> {
   }
 }
 
+let flushingDelayedLifecycleEvents = false;
 function flushDelayedLifecycleEvents(): void {
+  // avoid stackoverflow
+  if (flushingDelayedLifecycleEvents) return;
+  flushingDelayedLifecycleEvents = true;
   if (delayedLifecycleEvents) {
     delayedLifecycleEvents.forEach((e) => {
       onLifecycleEvent(e);
     });
     delayedLifecycleEvents.length = 0;
   }
+  flushingDelayedLifecycleEvents = false;
 }
 
 function publishEvent(handlerName: string, data: unknown) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This fix an edge case when `__FIRST_SCREEN_SYNC_TIMING__ === 'immediately'`, user will run `flushDelayedLifecycleEvents` immediately after preact render,

```js
      __root.__jsx = jsx;
      renderBackground(jsx, __root as any);
      if (__FIRST_SCREEN_SYNC_TIMING__ === 'immediately') {
        // This is for cases where `root.render()` is called asynchronously,
        // `firstScreen` message might have been reached.
        flushDelayedLifecycleEvents();
```

`delayedLifecycleEvents` is:

```json
[
  [
    "rLynxFirstScreen",
    {
      "root": "{\\"id\\":-1,\\"type\\":\\"root\\"}",
      "refPatch": "{}",
      "jsReadyEventIdSwap": {}
    }
  ]
]
```

After run into `onLifecycleEventImpl`, we will run `flushDelayedLifecycleEvents` again, get stack overflow

```js
      // TODO: It seems `delayedEvents` and `delayedLifecycleEvents` should be merged into one array to ensure the proper order of events.
      flushDelayedLifecycleEvents();
```


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
