### PR TITLE
fix: web-explorer crash

### DIFF
--- a/.changeset/sour-streets-remain.md
+++ b/.changeset/sour-streets-remain.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-explorer": patch
+---
+
+fix: blank screen issue for 0.0.4

--- a/packages/web-platform/web-explorer/index.html
+++ b/packages/web-platform/web-explorer/index.html
@@ -8,11 +8,10 @@
     <link rel="icon" type="image/png" href="icons/icon-128x128.png">
     <link rel="stylesheet" href="dist/static/css/index.css">
     <title>Lynx Explorer on Web Platform</title>
-    <script type="module" src="./dist/static/js/index.js"></script>
     <script
-      src="https://fastly.jsdelivr.net/npm/@vant/touch-emulator"
-      defer
+      src="https://www.unpkg.com/@vant/touch-emulator@1.4.0/dist/index.js"
     ></script>
+    <script type="module" src="./dist/static/js/index.js"></script>
     <style>
     #install-button {
       position: fixed;


### PR DESCRIPTION
rsbuild uses the last script element's url to generate the publich(aka `__webpack_require.p`)
