### PR TITLE
fix(rspeedy/react): should allow overriding SWC config

### DIFF
--- a/.changeset/young-parents-fry.md
+++ b/.changeset/young-parents-fry.md
@@ -1,0 +1,23 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Support overriding SWC configuration.
+
+Now you can override configuration like `useDefineForClassFields` using `tools.swc`.
+
+```js
+import { defineConfig } from '@lynx-js/rspeedy';
+
+export default defineConfig({
+  tools: {
+    swc: {
+      jsc: {
+        transform: {
+          useDefineForClassFields: true,
+        },
+      },
+    },
+  },
+});
+```

--- a/packages/rspeedy/plugin-react/src/swc.ts
+++ b/packages/rspeedy/plugin-react/src/swc.ts
@@ -5,26 +5,25 @@ import type { RsbuildPluginAPI } from '@rsbuild/core'
 
 export function applySWC(api: RsbuildPluginAPI): void {
   api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-    return mergeRsbuildConfig(config, {
+    return mergeRsbuildConfig({
       tools: {
-        swc(config) {
-          config.jsc ??= {}
-          config.jsc.transform ??= {}
-          config.jsc.transform.useDefineForClassFields = false
-          config.jsc.transform.optimizer ??= {}
-          config.jsc.transform.optimizer.simplify = true
-
-          config.jsc.parser ??= {
-            syntax: 'typescript',
-          }
-          if (config.jsc.parser.syntax === 'typescript') {
-            config.jsc.parser.tsx = false
-            config.jsc.parser.decorators = true
-          }
-
-          return config
+        swc: {
+          jsc: {
+            transform: {
+              // TODO: remove this in the next minor version
+              useDefineForClassFields: false,
+              optimizer: {
+                simplify: true,
+              },
+            },
+            parser: {
+              syntax: 'typescript',
+              tsx: false,
+              decorators: true,
+            },
+          },
         },
       },
-    })
+    }, config)
   })
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

This patch resolves the issue that `tools.swc` cannot be used with `pluginReactLynx`.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
