### PR TITLE
feat: support mts event with target methods

### DIFF
--- a/.changeset/tidy-lemons-bow.md
+++ b/.changeset/tidy-lemons-bow.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-core": patch
+---
+
+feat: support mts event with target methods
+
+After this commit, developers are allowed to invoke `event.target.setStyleProperty` in mts handler

--- a/packages/web-platform/web-constants/src/types/EventType.ts
+++ b/packages/web-platform/web-constants/src/types/EventType.ts
@@ -31,6 +31,17 @@ export interface LynxCrossThreadEvent<
   [key: string]: string | number | undefined | null | {};
 }
 
+export interface MainThreadScriptEvent<
+  T = {
+    [key: string]: string | number | undefined | null;
+  },
+> extends LynxCrossThreadEvent<T> {
+  target: LynxCrossThreadEventTarget & { elementRefptr: unknown };
+  currentTarget:
+    | (LynxCrossThreadEventTarget & { elementRefptr: unknown })
+    | null;
+}
+
 export type ExposureEventDetail = {
   'exposure-id': string;
   'exposure-scene': string;

--- a/packages/web-platform/web-mainthread-apis/src/elementAPI/style/styleFunctions.ts
+++ b/packages/web-platform/web-mainthread-apis/src/elementAPI/style/styleFunctions.ts
@@ -66,13 +66,18 @@ export function createStyleFunctions(
     key: number | string,
     value: string | number | null | undefined,
   ): void {
-    const lynxStyleInfo = queryCSSProperty(Number(key));
+    let dashName: string | undefined;
+    if (typeof key === 'number') {
+      dashName = queryCSSProperty(key).dashName;
+    } else {
+      dashName = key;
+    }
     const valueStr = typeof value === 'number' ? value.toString() : value;
     if (!valueStr) { // null or undefined
-      element.style.removeProperty(lynxStyleInfo.dashName);
+      element.style.removeProperty(dashName);
     } else {
       const { transformedStyle } = transfromParsedStyles([[
-        lynxStyleInfo.dashName,
+        dashName,
         valueStr,
       ]]);
       for (const [property, value] of transformedStyle) {

--- a/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
+++ b/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
@@ -518,6 +518,16 @@ test.describe('main thread api tests', () => {
     await expect(pageElement).toHaveCSS('height', '80px');
   });
 
+  test('__AddInlineStyle_key_is_name', async ({ page }, { title }) => {
+    await page.evaluate(() => {
+      let root = globalThis.__CreatePage('page', 0);
+      globalThis.__AddInlineStyle(root, 'height', '80px');
+      globalThis.__FlushElementTree();
+    });
+    const pageElement = page.locator(`[lynx-tag='page']`);
+    await expect(pageElement).toHaveCSS('height', '80px');
+  });
+
   test('__AddInlineStyle_raw_string', async ({ page }, { title }) => {
     await page.evaluate(() => {
       let root = globalThis.__CreatePage('page', 0);

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -281,6 +281,16 @@ test.describe('reactlynx3 tests', () => {
       await wait(100);
       expect(eventHandlerTriggered).toBe(true);
     });
+    test(
+      'basic-mts-bindtap-change-element-background',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
   });
   test.describe('basic-css', () => {
     test('basic-css-asset-in-css', async ({ page }, { title }) => {

--- a/packages/web-platform/web-tests/tests/react/basic-mts-bindtap-change-element-background/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-mts-bindtap-change-element-background/index.jsx
@@ -1,0 +1,21 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+function App() {
+  return (
+    <view
+      id='target'
+      main-thread:bindTap={(event) => {
+        'main thread';
+        event.currentTarget.setStyleProperty('background-color', 'green');
+      }}
+      style={{
+        height: '100px',
+        width: '100px',
+        background: 'pink',
+      }}
+    />
+  );
+}
+root.render(<App />);


### PR DESCRIPTION
After this commit, developers are allowed to invoke `event.target.setStyleProperty` in mts handler

`__AddInlineStyle`  now supports a raw name as proeprty name, pervious we only accept a number as property id.

#54 