### PR TITLE
fix: delay 500ms to send the `webExplorerReady`

### DIFF
--- a/.changeset/angry-buckets-chew.md
+++ b/.changeset/angry-buckets-chew.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-explorer": patch
+---
+
+fix: delay 500ms to send the `webExplorerReady`

--- a/packages/web-platform/web-explorer/index.ts
+++ b/packages/web-platform/web-explorer/index.ts
@@ -66,7 +66,9 @@ window.addEventListener('message', (ev) => {
     setLynxViewUrl(ev.data.url);
   }
 });
-window.parent?.postMessage('webExplorerReady');
+setTimeout(() => {
+  window.parent?.postMessage('webExplorerReady');
+}, 500);
 
 function setLynxViewUrl(url: string) {
   if (url === homepage) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
