### PR TITLE
fix(react/runtime): should have `lynx.loadLazyBundle`

### DIFF
--- a/.changeset/afraid-rivers-float.md
+++ b/.changeset/afraid-rivers-float.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix `lynx.loadLazyBundle` is not a function

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -32,15 +32,18 @@ import {
   useRef,
   useState,
 } from './hooks/react.js';
-import { mainThreadLazy } from './lynx/lazy-bundle.js';
+import { loadLazyBundle, mainThreadLazy } from './lynx/lazy-bundle.js';
 
 export { Component, createContext } from 'preact';
 export { PureComponent } from 'preact/compat';
 export * from './hooks/react.js';
 
-const lazy: typeof import('preact/compat').lazy = __LEPUS__
-  ? mainThreadLazy
-  : backgroundLazy;
+const lazy: typeof import('preact/compat').lazy = /*#__PURE__*/ (() => {
+  lynx.loadLazyBundle = loadLazyBundle;
+  return __LEPUS__
+    ? mainThreadLazy
+    : backgroundLazy;
+})();
 
 /**
  * @internal

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/load-lazy-bundle/foo.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/load-lazy-bundle/foo.js
@@ -1,0 +1,3 @@
+export function foo() {
+  return 42;
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/load-lazy-bundle/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/load-lazy-bundle/index.jsx
@@ -1,0 +1,9 @@
+/// <reference types="vitest/globals" />
+
+import { lazy } from '@lynx-js/react';
+
+lazy(() => import('./foo.js'));
+
+it('should have lynx.loadLazyBundle', () => {
+  expect(lynx.loadLazyBundle).not.toBeUndefined();
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/load-lazy-bundle/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/load-lazy-bundle/rspack.config.js
@@ -1,0 +1,17 @@
+import { createConfig } from '../../../create-react-config.js';
+
+const config = createConfig();
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...config,
+  optimization: {
+    ...config.optimization,
+    usedExports: true,
+    innerGraph: true,
+    sideEffects: true,
+    minimize: true,
+  },
+  mode: 'production',
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/load-lazy-bundle/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/load-lazy-bundle/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main:main-thread.js',
+    'main:background.js',
+  ],
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix a regression of #284. Should set `lynx.loadLazyBundle` when using `lazy()`.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
