### PR TITLE
feat(web): fully support MTS

### DIFF
--- a/.changeset/bright-forks-try.md
+++ b/.changeset/bright-forks-try.md
@@ -1,0 +1,17 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/react-webpack-plugin": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-elements": patch
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+feat: fully support MTS
+
+Now use support the following usage
+
+- mainthread event
+- mainthread ref
+- runOnMainThread/runOnBackground
+- ref.current.xx

--- a/packages/web-platform/web-constants/src/constants.ts
+++ b/packages/web-platform/web-constants/src/constants.ts
@@ -22,4 +22,5 @@ export const globalMuteableVars = [
   'registerDataProcessor',
   'registerWorkletInternal',
   'lynxWorkletImpl',
+  'runWorklet',
 ] as const;

--- a/packages/web-platform/web-constants/src/endpoints.ts
+++ b/packages/web-platform/web-constants/src/endpoints.ts
@@ -194,10 +194,18 @@ export const dispatchNapiModuleEndpoint = createRpcEndpoint<
   [data: Cloneable],
   void
 >('dispatchNapiModule', false, false);
-export const dispatchCoreContextEventEndpoint = createRpcEndpoint<
-  [
-    eventType: string,
-    data: Cloneable | undefined | null,
-  ],
+export const dispatchCoreContextOnBackgroundEndpoint = createRpcEndpoint<
+  [{
+    type: string;
+    data: Cloneable;
+  }],
   void
->('dispatchCoreContextEventEndpoint', false, false);
+>('dispatchCoreContextOnBackground', false, false);
+
+export const dispatchJSContextOnMainThreadEndpoint = createRpcEndpoint<
+  [{
+    type: string;
+    data: Cloneable;
+  }],
+  void
+>('dispatchJSContextOnMainThread', false, false);

--- a/packages/web-platform/web-constants/src/types/LynxContextEventTarget.ts
+++ b/packages/web-platform/web-constants/src/types/LynxContextEventTarget.ts
@@ -1,3 +1,5 @@
+import type { Cloneable } from './Cloneable.js';
+
 export const DispatchEventResult = {
   // Event was not canceled by event handler or default event handler.
   NotCanceled: 0,
@@ -16,16 +18,21 @@ export const DispatchEventResult = {
   // to execute.
   CanceledBeforeDispatch: 3,
 } as const;
+
+export type ContextCrossThreadEvent = {
+  type: string;
+  data: Cloneable;
+};
 export interface LynxContextEventTarget {
-  onTriggerEvent?: (event: MessageEvent) => void;
+  onTriggerEvent?: (event: ContextCrossThreadEvent) => void;
 
   postMessage(message: any): void;
   dispatchEvent(
-    event: MessageEvent,
+    event: ContextCrossThreadEvent,
   ): typeof DispatchEventResult[keyof typeof DispatchEventResult];
-  addEventListener(type: string, listener: (event: MessageEvent) => void): void;
+  addEventListener(type: string, listener: (event: Event) => void): void;
   removeEventListener(
     type: string,
-    listener: (event: MessageEvent) => void,
+    listener: (event: Event) => void,
   ): void;
 }

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadLynx.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadLynx.ts
@@ -13,8 +13,7 @@ export function createMainThreadLynx(
 ) {
   return {
     getJSContext() {
-      // TODO: implement this
-      return new EventTarget();
+      return config.jsContext;
     },
     requestAnimationFrame(cb: FrameRequestCallback) {
       return requestAnimationFrame(cb);

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
@@ -17,6 +17,7 @@ import {
   type reportErrorEndpoint,
   type RpcCallType,
   type postExposureEndpoint,
+  type LynxContextEventTarget,
 } from '@lynx-js/web-constants';
 import { globalMuteableVars } from '@lynx-js/web-constants';
 import { createMainThreadLynx, type MainThreadLynx } from './MainThreadLynx.js';
@@ -58,6 +59,7 @@ export interface MainThreadConfig {
   browserConfig: BrowserConfig;
   tagMap: Record<string, string>;
   docu: Pick<Document, 'append' | 'createElement' | 'addEventListener'>;
+  jsContext: LynxContextEventTarget;
 }
 
 export const elementToRuntimeInfoMap = Symbol('elementToRuntimeInfoMap');

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -291,6 +291,36 @@ test.describe('reactlynx3 tests', () => {
         await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
       },
     );
+    test(
+      'basic-mts-mainthread-ref',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
+    test(
+      'basic-mts-run-on-background',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
+    test(
+      'basic-mts-run-on-main-thread',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
   });
   test.describe('basic-css', () => {
     test('basic-css-asset-in-css', async ({ page }, { title }) => {

--- a/packages/web-platform/web-tests/tests/react/basic-mts-mainthread-ref/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-mts-mainthread-ref/index.jsx
@@ -1,0 +1,31 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useMainThreadRef } from '@lynx-js/react';
+
+export function App() {
+  const ref = useMainThreadRef(null);
+
+  const handleTap = () => {
+    'main thread';
+    ref.current.setStyleProperties({
+      'background-color': 'green',
+      'height': '200px',
+      'width': '200px',
+    });
+  };
+
+  return (
+    <view
+      id='target'
+      main-thread:ref={ref}
+      main-thread:bindtap={handleTap}
+      style={{
+        height: '100px',
+        width: '100px',
+        background: 'pink',
+      }}
+    />
+  );
+}
+root.render(<App />);

--- a/packages/web-platform/web-tests/tests/react/basic-mts-run-on-background/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-mts-run-on-background/index.jsx
@@ -1,0 +1,22 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useState, root, runOnBackground } from '@lynx-js/react';
+function App() {
+  const [color, setColor] = useState('pink');
+  return (
+    <view
+      id='target'
+      main-thread:bindTap={() => {
+        'main thread';
+        runOnBackground(setColor)('green');
+      }}
+      style={{
+        height: '100px',
+        width: '100px',
+        background: color,
+      }}
+    />
+  );
+}
+root.render(<App />);

--- a/packages/web-platform/web-tests/tests/react/basic-mts-run-on-main-thread/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-mts-run-on-main-thread/index.jsx
@@ -1,0 +1,39 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  root,
+  useMainThreadRef,
+  runOnMainThread,
+  useEffect,
+} from '@lynx-js/react';
+
+export function App() {
+  const ref = useMainThreadRef(null);
+
+  const handleColor = (color) => {
+    'main thread';
+    ref.current.setStyleProperties({
+      'background-color': color,
+      'height': '200px',
+      'width': '200px',
+    });
+  };
+
+  useEffect(() => {
+    runOnMainThread(handleColor)('green');
+  }, []);
+
+  return (
+    <view
+      id='target'
+      main-thread:ref={ref}
+      style={{
+        height: '100px',
+        width: '100px',
+        background: 'pink',
+      }}
+    />
+  );
+}
+root.render(<App />);

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -23,7 +23,7 @@ import { createPerformanceApis } from './createPerformanceApis.js';
 import { registerSendGlobalEventHandler } from './crossThreadHandlers/registerSendGlobalEvent.js';
 import { createJSObjectDestructionObserver } from './crossThreadHandlers/createJSObjectDestructionObserver.js';
 import type { TimingSystem } from './createTimingSystem.js';
-import type { LynxCrossThreadContext } from './createBackgroundLynx.js';
+import type { LynxCrossThreadContext } from '../../common/LynxCrossThreadContext.js';
 
 let nativeAppCount = 0;
 const sharedData: Record<string, unknown> = {};

--- a/packages/web-platform/web-worker-runtime/src/common/LynxCrossThreadContext.ts
+++ b/packages/web-platform/web-worker-runtime/src/common/LynxCrossThreadContext.ts
@@ -1,0 +1,35 @@
+import {
+  DispatchEventResult,
+  type dispatchCoreContextOnBackgroundEndpoint,
+  type LynxContextEventTarget,
+  type Rpc,
+} from '@lynx-js/web-constants';
+
+export class LynxCrossThreadContext extends EventTarget
+  implements LynxContextEventTarget
+{
+  constructor(
+    private _config: {
+      rpc: Rpc;
+      receiveEventEndpoint: typeof dispatchCoreContextOnBackgroundEndpoint;
+      sendEventEndpoint: typeof dispatchCoreContextOnBackgroundEndpoint;
+    },
+  ) {
+    super();
+  }
+  postMessage(...args: any[]) {
+    console.error('[lynx-web] postMessage not implemented, args:', ...args);
+  }
+  // @ts-expect-error
+  override dispatchEvent(event: ContextCrossThreadEvent) {
+    const { rpc, sendEventEndpoint } = this._config;
+    rpc.invoke(sendEventEndpoint, [event]);
+    return DispatchEventResult.CanceledBeforeDispatch;
+  }
+  __start() {
+    const { rpc, receiveEventEndpoint } = this._config;
+    rpc.registerHandler(receiveEventEndpoint, ({ type, data }) => {
+      super.dispatchEvent(new MessageEvent(type, { data: data ?? {} }));
+    });
+  }
+}


### PR DESCRIPTION
* mainthread event
* mainthread ref
* runOnMainThread/runOnBackground
* ref.current.xx

After this commit:

* `runWorklet` will be a mutable variable
* implment lynx.getJSContext() on main thread context
* support sending event main <------> bg

close Support MTS #54
