### PR TITLE
ci: update fetch command in workflow to use upstream references

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -40,11 +40,11 @@ jobs:
           UPSTREAM_REMOTE: ${{ github.server_url }}/${{ github.repository }}
         run: |
           git remote add upstream $UPSTREAM_REMOTE
-          git fetch --progress --depth=1 upstream "+refs/heads/$CLEAN_BASE_REF:refs/heads/$CLEAN_BASE_REF"
+          git fetch --progress --depth=1 upstream "+refs/heads/$CLEAN_BASE_REF:refs/remotes/upstream/$CLEAN_BASE_REF"
           MAX_ATTEMPTS=10
           ATTEMPT=0
-          while [ -z "$( git merge-base "refs/heads/$CLEAN_BASE_REF" "$CLEAN_HEAD_REF" )" ] && [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
-            git fetch -q --deepen=10 upstream "refs/heads/$CLEAN_BASE_REF"
+          while [ -z "$( git merge-base "refs/remotes/upstream/$CLEAN_BASE_REF" "$CLEAN_HEAD_REF" )" ] && [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
+            git fetch -q --deepen=10 upstream "refs/heads/$CLEAN_BASE_REF:refs/remotes/upstream/$CLEAN_BASE_REF"
             git fetch -q --deepen=10 origin "$CLEAN_HEAD_REF"
             ATTEMPT=$((ATTEMPT + 1))
           done


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

Modified the GitHub Actions workflow to fetch branches from the upstream remote instead of the origin. This change ensures that the correct base branch is used during CI processes, addressing potential issues with branch merging and CI failures.

Fix the failure [here](https://github.com/lynx-family/lynx-stack/actions/runs/14514801704/job/40721341799?pr=545).

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
