### PR TITLE
feat(web): x-list supports need-visible-item-info

### DIFF
--- a/.changeset/yummy-trains-sort.md
+++ b/.changeset/yummy-trains-sort.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+feat: x-list supports `need-visible-item-info`, now you can get visible cells info in `scroll`、`scrolltoupper`、`scrolltolower` event.

--- a/packages/web-platform/web-elements/src/XList/XListEvents.ts
+++ b/packages/web-platform/web-elements/src/XList/XListEvents.ts
@@ -51,6 +51,10 @@ export class XListEvents
     '#lower-threshold-observer',
   );
   #getScrollDetail() {
+    const needVisibleItemInfo = this.#dom.getAttribute(
+      'need-visible-item-info',
+    ) !== null;
+
     const { scrollTop, scrollLeft, scrollHeight, scrollWidth } = this
       .#getListContainer();
     const detail = {
@@ -60,6 +64,9 @@ export class XListEvents
       scrollWidth,
       deltaX: scrollLeft - this.#prevX,
       deltaY: scrollTop - this.#prevY,
+      attachedCells: needVisibleItemInfo
+        ? this.#dom.getVisibleCells()
+        : undefined,
     };
     this.#prevX = scrollLeft;
     this.#prevY = scrollTop;
@@ -337,9 +344,7 @@ export class XListEvents
     this.#dom.dispatchEvent(
       new CustomEvent('lynxscroll', {
         ...commonComponentEventSetting,
-        detail: {
-          type: 'scroll',
-        },
+        detail: this.#getScrollDetail(),
       }),
     );
   };

--- a/packages/web-platform/web-tests/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-tests/tests/web-elements.spec.ts
@@ -2299,6 +2299,53 @@ test.describe('web-elements test suite', () => {
         await diffScreenShot(page, title, 'insert');
       },
     );
+
+    test(
+      'need-visible-item-info',
+      async ({ page, browserName }, { titlePath }) => {
+        let scroll = false;
+        let scrolltoupper = false;
+        let scrolltolower = false;
+        await page.on('console', async (msg) => {
+          const event = await msg.args()[0]?.evaluate((e) => ({
+            type: e.type,
+            detail: e.detail,
+          }));
+          if (!event) return;
+          if (
+            event.type === 'lynxscroll'
+            && Array.isArray(event.detail.attachedCells)
+          ) {
+            scroll = true;
+          }
+          if (
+            event.type === 'scrolltoupper'
+            && Array.isArray(event.detail.attachedCells)
+          ) {
+            scrolltoupper = true;
+          }
+          if (
+            event.type === 'scrolltolower'
+            && Array.isArray(event.detail.attachedCells)
+          ) {
+            scrolltolower = true;
+          }
+        });
+
+        const title = getTitle(titlePath);
+        await gotoWebComponentPage(page, title);
+        await page.evaluate(() => {
+          document.querySelector('x-list')?.shadowRoot?.querySelector(
+            '#content',
+          )
+            ?.scrollTo(0, 5000);
+        });
+        await wait(1000);
+        expect(scroll).toBeTruthy();
+        expect(scrolltoupper).toBeTruthy();
+        expect(scrolltolower).toBeTruthy();
+      },
+    );
   });
   test.describe('x-input', () => {
     test('placeholder', async ({ page }, { titlePath }) => {

--- a/packages/web-platform/web-tests/tests/web-elements/x-list/need-visible-item-info.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-list/need-visible-item-info.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation">
+    <link
+      href="/node_modules/@lynx-js/web-elements/index.css"
+      rel="stylesheet"
+    />
+    <link
+      href="/web-elements.css"
+      rel="stylesheet"
+    />
+
+    <style>
+    @import url("../../common.css");
+    x-list {
+      width: 100%;
+      height: 500px;
+    }
+
+    .item {
+      border-width: 5px;
+      border-color: green;
+      height: 100px;
+      background-color: hsl(calc(20 * var(--item-index)), 100%, 50%);
+    }
+    </style>
+  </head>
+
+  <body>
+    <script src="/web-elements.js" defer></script>
+    <script type="module">
+    document.querySelector('x-list').addEventListener('lynxscroll', (e) => {
+      console.log(e);
+    });
+    document.querySelector('x-list').addEventListener('scrolltoupper', (e) => {
+      console.log(e);
+    });
+    document.querySelector('x-list').addEventListener('scrolltolower', (e) => {
+      console.log(e);
+    });
+    </script>
+    <x-view class="page">
+      <x-list need-visible-item-info>
+        <list-item class="item" style="--item-index: 0;" item-key="0"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 1;" item-key="1"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 2;" item-key="2"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 3;" item-key="3"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 4;" item-key="4"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 5;" item-key="5"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 6;" item-key="6"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 7;" item-key="7"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 8;" item-key="8"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 9;" item-key="9"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 10;" item-key="10"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 11;" item-key="11"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 12;" item-key="12"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 13;" item-key="13"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 14;" item-key="14"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 15;" item-key="15"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 16;" item-key="16"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 17;" item-key="17"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 18;" item-key="18"><x-view
+          ></x-view></list-item>
+        <list-item class="item" style="--item-index: 19;" item-key="19"><x-view
+          ></x-view></list-item>
+      </x-list>
+    </x-view>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

feat: x-list supports `need-visible-item-info`, now you can get visible cells info in `scroll`、`scrolltoupper`、`scrolltolower` event.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
