### PR TITLE
perf: improve raw-text performance

### DIFF
--- a/.changeset/shaky-games-cough.md
+++ b/.changeset/shaky-games-cough.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+perf: improve raw-text performance

--- a/packages/web-platform/web-elements/src/XText/RawText.ts
+++ b/packages/web-platform/web-elements/src/XText/RawText.ts
@@ -11,16 +11,17 @@ import {
 export class RawTextAttributes {
   static observedAttributes = ['text'];
   readonly #dom: HTMLElement;
+  #text?: Text;
 
   constructor(currentElement: HTMLElement) {
     this.#dom = currentElement;
   }
   @registerAttributeHandler('text', true)
   #handleText(newVal: string | null) {
+    this.#text?.remove();
     if (newVal) {
-      this.#dom.innerHTML = newVal;
-    } else {
-      this.#dom.innerHTML = '';
+      this.#text = new Text(newVal);
+      this.#dom.append(this.#text);
     }
   }
 }

--- a/packages/web-platform/web-tests/tests/lighthouse.cases.js
+++ b/packages/web-platform/web-tests/tests/lighthouse.cases.js
@@ -28,7 +28,7 @@ export default [
       'categories:performance': [
         'error',
         {
-          'minScore': 0.81,
+          'minScore': 0.87,
         },
       ],
       'first-contentful-paint': [
@@ -40,7 +40,7 @@ export default [
       'total-blocking-time': [
         'error',
         {
-          'maxNumericValue': 750,
+          'maxNumericValue': 500,
         },
       ],
     },


### PR DESCRIPTION
use `new Text()` to replace innerHTML
