### PR TITLE
refactor: adopt background-only npm package

### DIFF
--- a/.changeset/rotten-walls-hear.md
+++ b/.changeset/rotten-walls-hear.md
@@ -1,0 +1,13 @@
+---
+"@lynx-js/react-alias-rsbuild-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Refactor: Replace built-in `background-only` implementation with npm package
+
+Previously we maintained custom files:
+
+- `empty.ts` for background thread
+- `error.ts` for main thread validation
+
+Now adopting the standard `background-only` npm package

--- a/packages/rspeedy/plugin-react-alias/etc/react-alias-rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-react-alias/etc/react-alias-rsbuild-plugin.api.md
@@ -6,6 +6,11 @@
 
 import type { RsbuildPlugin } from '@rsbuild/core';
 
+// Warning: (ae-missing-release-tag) "createLazyResolver" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function createLazyResolver(context: string, conditionNames: string[]): (request: string) => Promise<string>;
+
 // Warning: (ae-missing-release-tag) "Options" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -164,13 +164,13 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
   }
 }
 
-function createLazyResolver(context: string, conditionNames: string[]) {
+export function createLazyResolver(context: string, conditionNames: string[]) {
   let lazyExports: Record<string, string | false>
   let resolverLazy: ResolveFunction
 
   return async (
     request: string,
-  ) => {
+  ): Promise<string> => {
     const { default: resolver } = await import('enhanced-resolve')
 
     return (
@@ -179,6 +179,6 @@ function createLazyResolver(context: string, conditionNames: string[]) {
           context,
           request,
         )
-    )
+    ) as string
   }
 }

--- a/packages/rspeedy/plugin-react/package.json
+++ b/packages/rspeedy/plugin-react/package.json
@@ -43,7 +43,8 @@
     "@lynx-js/react-webpack-plugin": "workspace:*",
     "@lynx-js/runtime-wrapper-webpack-plugin": "workspace:*",
     "@lynx-js/template-webpack-plugin": "workspace:*",
-    "@lynx-js/web-webpack-plugin": "workspace:*"
+    "@lynx-js/web-webpack-plugin": "workspace:*",
+    "background-only": "^0.0.1"
   },
   "devDependencies": {
     "@lynx-js/react": "workspace:*",

--- a/packages/rspeedy/plugin-react/src/background-only/empty.ts
+++ b/packages/rspeedy/plugin-react/src/background-only/empty.ts
@@ -1,3 +1,0 @@
-// Copyright 2024 The Lynx Authors. All rights reserved.
-// Licensed under the Apache License Version 2.0 that can be found in the
-// LICENSE file in the root directory of this source tree.

--- a/packages/rspeedy/plugin-react/src/background-only/error.ts
+++ b/packages/rspeedy/plugin-react/src/background-only/error.ts
@@ -1,7 +1,0 @@
-// Copyright 2024 The Lynx Authors. All rights reserved.
-// Licensed under the Apache License Version 2.0 that can be found in the
-// LICENSE file in the root directory of this source tree.
-throw new Error(
-  'This module cannot be imported from a Main Thread module. '
-    + 'It should only be used from a Background Thread.',
-)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       '@lynx-js/web-webpack-plugin':
         specifier: workspace:*
         version: link:../../webpack/web-webpack-plugin
+      background-only:
+        specifier: ^0.0.1
+        version: 0.0.1
     devDependencies:
       '@lynx-js/react':
         specifier: workspace:*
@@ -3645,6 +3648,9 @@ packages:
     resolution: {integrity: sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  background-only@0.0.1:
+    resolution: {integrity: sha512-YXR2zshAf3qs3jnpApQaDUG0x4L6YWpSZfLDhdeiCFxfp/n8YwfoAQ1hAigEF3VpXOMOJeZYFWtBbiFv/v2Qfg==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -11359,6 +11365,8 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.10)
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.10)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.10)
+
+  background-only@0.0.1: {}
 
   bail@2.0.2: {}
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

close #600 

Refactor: Replace built-in `background-only` implementation with npm package

Previously we maintained custom files:

- `empty.ts` for background thread
- `error.ts` for main thread validation

Now adopting the standard `background-only` npm package


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
