### PR TITLE
refactor: isolate SystemInfo

### DIFF
--- a/.changeset/cruel-hornets-burn.md
+++ b/.changeset/cruel-hornets-burn.md
@@ -1,0 +1,10 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+refactor: isolate SystemInfo
+
+Never assign `SystemInfo` on worker's self object.

--- a/packages/web-platform/web-constants/src/constants.ts
+++ b/packages/web-platform/web-constants/src/constants.ts
@@ -24,3 +24,8 @@ export const globalMuteableVars = [
   'lynxWorkletImpl',
   'runWorklet',
 ] as const;
+
+export const systemInfo = {
+  platform: 'web',
+  lynxSdkVersion: '3.0',
+} as Record<string, string | number>;

--- a/packages/web-platform/web-constants/src/endpoints.ts
+++ b/packages/web-platform/web-constants/src/endpoints.ts
@@ -14,6 +14,7 @@ import type { LynxTemplate } from './types/LynxModule.js';
 import type { NapiModulesMap } from './types/NapiModules.js';
 import type { NativeModulesMap } from './types/NativeModules.js';
 import type { ElementOperation } from '@lynx-js/offscreen-document';
+import type { BrowserConfig } from './types/PageConfig.js';
 
 export const postExposureEndpoint = createRpcEndpoint<
   [{ exposures: ExposureWorkerEvent[]; disExposures: ExposureWorkerEvent[] }],
@@ -82,6 +83,7 @@ export const BackgroundThreadStartEndpoint = createRpcEndpoint<[
     customSections: Record<string, Cloneable>;
     nativeModulesMap: NativeModulesMap;
     napiModulesMap: NapiModulesMap;
+    browserConfig: BrowserConfig;
   },
 ], void>('start', false, true);
 

--- a/packages/web-platform/web-constants/src/types/PageConfig.ts
+++ b/packages/web-platform/web-constants/src/types/PageConfig.ts
@@ -9,4 +9,5 @@ export interface PageConfig {
 }
 
 export interface BrowserConfig {
+  pixelRatio: number;
 }

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -54,7 +54,9 @@ export function createLynxView(configs: LynxViewConfigs): LynxView {
       globalProps,
       nativeModulesMap,
       napiModulesMap,
-      browserConfig: {},
+      browserConfig: {
+        pixelRatio: window.devicePixelRatio,
+      },
     },
     shadowRoot,
     lynxGroupId,

--- a/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
+++ b/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
@@ -57,7 +57,6 @@ function createMainWorker() {
     mode: 'main',
     toUIThread: channelToMainThread.port2,
     toPeerThread: channelMainThreadWithBackground.port1,
-    pixelRatio: window.devicePixelRatio,
   };
 
   mainThreadWorker.postMessage(mainThreadMessage, [
@@ -89,7 +88,6 @@ function createBackgroundWorker(
     mode: 'background',
     toUIThread: channelToBackground.port2,
     toPeerThread: channelMainThreadWithBackground.port2,
-    pixelRatio: window.devicePixelRatio,
   };
   backgroundThreadWorker.postMessage(backgroundThreadMessage, [
     channelToBackground.port2,

--- a/packages/web-platform/web-core/src/utils/loadTemplate.ts
+++ b/packages/web-platform/web-core/src/utils/loadTemplate.ts
@@ -99,6 +99,7 @@ const mainThreadInjectVars = [
   '__OnLifecycleEvent',
   '__FlushElementTree',
   '__LoadLepusChunk',
+  'SystemInfo',
 ];
 
 const backgroundInjectVars = [
@@ -106,6 +107,7 @@ const backgroundInjectVars = [
   'globalThis',
   'lynx',
   'lynxCoreInject',
+  'SystemInfo',
 ];
 
 const backgroundInjectWithBind = [

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
@@ -145,9 +145,10 @@ export class MainThreadRuntime {
     );
     this._ReportError = this.config.callbacks._ReportError;
     this.__OnLifecycleEvent = this.config.callbacks.__OnLifecycleEvent;
-    this.SystemInfo = Object.assign(systemInfo, {
+    this.SystemInfo = {
+      ...systemInfo,
       pixelRatio: config.browserConfig.pixelRatio,
-    });
+    };
     /**
      * Start the exposure service
      */

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
@@ -19,6 +19,7 @@ import {
   type postExposureEndpoint,
   type LynxContextEventTarget,
   type LynxJSModule,
+  systemInfo,
 } from '@lynx-js/web-constants';
 import { globalMuteableVars } from '@lynx-js/web-constants';
 import { createMainThreadLynx, type MainThreadLynx } from './MainThreadLynx.js';
@@ -144,6 +145,9 @@ export class MainThreadRuntime {
     );
     this._ReportError = this.config.callbacks._ReportError;
     this.__OnLifecycleEvent = this.config.callbacks.__OnLifecycleEvent;
+    this.SystemInfo = Object.assign(systemInfo, {
+      pixelRatio: config.browserConfig.pixelRatio,
+    });
     /**
      * Start the exposure service
      */
@@ -203,6 +207,8 @@ export class MainThreadRuntime {
   get globalThis() {
     return this;
   }
+
+  SystemInfo: typeof systemInfo;
 
   lynx: MainThreadLynx;
 

--- a/packages/web-platform/web-mainthread-apis/src/loadMainThread.ts
+++ b/packages/web-platform/web-mainthread-apis/src/loadMainThread.ts
@@ -111,6 +111,7 @@ export function loadMainThread(
             ),
             nativeModulesMap,
             napiModulesMap,
+            browserConfig,
           });
 
           runtime.renderPage!(initData);

--- a/packages/web-platform/web-worker-runtime/src/index.ts
+++ b/packages/web-platform/web-worker-runtime/src/index.ts
@@ -9,13 +9,11 @@ export interface WorkerStartMessage {
   mode: 'main' | 'background';
   toPeerThread: MessagePort;
   toUIThread: MessagePort;
-  pixelRatio: number;
 }
 
 self.onmessage = (ev) => {
-  const { mode, toPeerThread, toUIThread, pixelRatio } = ev
+  const { mode, toPeerThread, toUIThread } = ev
     .data as WorkerStartMessage;
-  (globalThis as any).SystemInfo.pixelRatio = pixelRatio;
   if (mode === 'main') {
     startMainThread(toUIThread, toPeerThread);
   } else {
@@ -23,6 +21,5 @@ self.onmessage = (ev) => {
   }
 };
 Object.assign(globalThis, {
-  SystemInfo: { platform: 'web', lynxSdkVersion: '3.0' },
   module: { exports: null },
 });


### PR DESCRIPTION
Never assign `SystemInfo` on worker's self object.

This is a step to `all-on-ui`
