### PR TITLE
fix(web): scroll-view's initial-scroll-index is changed to initial-sc…

### DIFF
--- a/.changeset/afraid-donuts-cut.md
+++ b/.changeset/afraid-donuts-cut.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/web-elements": minor
+---
+
+fix:
+
+- typo of `initial-scroll-offset` in scroll-view.
+- scroll-view's `initial-scroll-index` is changed to `initial-scroll-to-index`.

--- a/packages/web-platform/web-elements/src/ScrollView/ScrollAttributes.ts
+++ b/packages/web-platform/web-elements/src/ScrollView/ScrollAttributes.ts
@@ -18,7 +18,7 @@ export class ScrollAttributes
     'scroll-left',
     'initial-scroll-offset',
     'scroll-to-index',
-    'initial-scroll-index',
+    'initial-scroll-to-index',
   ];
 
   constructor(dom: ScrollView) {
@@ -27,7 +27,7 @@ export class ScrollAttributes
 
   @registerAttributeHandler('scroll-top', false)
   @registerAttributeHandler('scroll-left', false)
-  @registerAttributeHandler('nitial-scroll-offset', false)
+  @registerAttributeHandler('initial-scroll-offset', false)
   #handleInitialScrollOffset(
     newVal: string | null,
     _: string | null,
@@ -62,7 +62,7 @@ export class ScrollAttributes
   }
 
   @registerAttributeHandler('scroll-to-index', false)
-  @registerAttributeHandler('initial-scroll-index', false)
+  @registerAttributeHandler('initial-scroll-to-index', false)
   #handleInitialScrollIndex(newVal: string | null) {
     if (newVal) {
       const scrollValue = parseFloat(newVal);

--- a/packages/web-platform/web-tests/tests/react/basic-element-scroll-view-scroll-to-index/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-element-scroll-view-scroll-to-index/index.jsx
@@ -18,7 +18,7 @@ export default class ScrollBounce extends Component {
         id='bounce-view'
         style={`width:300px; height:600px; background-color:yellow;`}
         scroll-y={true}
-        initial-scroll-index={1}
+        initial-scroll-to-index={1}
       >
         <view style='width:100%;height:300px;background:red;'></view>
         <view style='width:100%;height:300px;background:green;'></view>


### PR DESCRIPTION
…roll-to-index.

## Summary

fix:
- typo of `initial-scroll-offset` in scroll-view.
- scroll-view's `initial-scroll-index` is changed to `initial-scroll-to-index`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
