### PR TITLE
fix(web): the scroll-x field of scroll-view needs to be handled corre…

### DIFF
--- a/.changeset/soft-baths-scream.md
+++ b/.changeset/soft-baths-scream.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: the scroll-x field of scroll-view needs to be handled correctly.
+
+Before this, scroll-x of '' would result in no scrolling along x-axis.

--- a/packages/web-platform/web-elements/src/ScrollView/ScrollAttributes.ts
+++ b/packages/web-platform/web-elements/src/ScrollView/ScrollAttributes.ts
@@ -68,7 +68,7 @@ export class ScrollAttributes
       const scrollValue = parseFloat(newVal);
       const childrenElement = this.#dom.children.item(scrollValue);
       if (childrenElement && childrenElement instanceof HTMLElement) {
-        const scrollX = !!this.#dom.getAttribute('scroll-x');
+        const scrollX = this.#dom.getAttribute('scroll-x') !== null;
         requestAnimationFrame(() => {
           if (scrollX) {
             this.#dom.scrollLeft = childrenElement.offsetLeft;


### PR DESCRIPTION
## Summary

fix: the scroll-x field of scroll-view needs to be handled correctly.

Before this, scroll-x of '' would result in no scrolling along x-axis.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
