### PR TITLE
fix(rspeedy/react): avoid error when using special var names

### DIFF
--- a/.changeset/fifty-moose-boil.md
+++ b/.changeset/fifty-moose-boil.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Fix runtime error: "SyntaxError: Identifier 'i' has already been declared".

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -191,9 +191,15 @@ export function applyEntry(
         .plugin(PLUGIN_NAME_RUNTIME_WRAPPER)
         .use(RuntimeWrapperWebpackPlugin, [{
           injectVars(vars) {
+            const UNUSED_VARS = new Set([
+              'Card',
+              'Component',
+              'ReactLynx',
+              'Behavior',
+            ])
             return vars.map(name => {
-              if (name === 'Component') {
-                return '__Component'
+              if (UNUSED_VARS.has(name)) {
+                return `__${name}`
               }
               return name
             })

--- a/packages/rspeedy/plugin-react/test/basic.test.ts
+++ b/packages/rspeedy/plugin-react/test/basic.test.ts
@@ -1,11 +1,16 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { dirname } from 'node:path'
+import { existsSync } from 'node:fs'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { createRsbuild } from '@rsbuild/core'
 import { describe, expect, test, vi } from 'vitest'
+
+import { createRspeedy } from '@lynx-js/rspeedy'
 
 import { pluginStubRspeedyAPI } from './stub-rspeedy-api.plugin.js'
 
@@ -58,5 +63,53 @@ describe('ReactLynx rsbuild', () => {
     await rsbuild.build()
 
     expect(1).toBe(1)
+  })
+
+  test('special var name', async () => {
+    const { pluginReactLynx } = await import('../src/index.js')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const tmp = await mkdtemp(tmpdir())
+
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        source: {
+          tsconfigPath: new URL('./tsconfig.json', import.meta.url).pathname,
+          entry: {
+            main: new URL(
+              './fixtures/special-var-name/index.jsx',
+              import.meta.url,
+            ).pathname,
+          },
+        },
+        output: {
+          distPath: {
+            root: tmp,
+          },
+          filenameHash: false,
+        },
+        plugins: [
+          pluginReactLynx(),
+        ],
+      },
+    })
+
+    const result = await rspeedy.build()
+
+    await result.close()
+
+    const backgroundJSPath = path.resolve(tmp, '.rspeedy/main/background.js')
+    expect(existsSync(backgroundJSPath)).toBe(true)
+
+    const define = vi.fn()
+
+    Object.assign(globalThis, {
+      tt: {
+        define,
+        require: vi.fn(),
+      },
+    })
+    await expect(import(backgroundJSPath)).resolves.not.toThrow()
+    expect(define).toHaveBeenCalledWith('background.js', expect.any(Function))
   })
 })

--- a/packages/rspeedy/plugin-react/test/basic.test.ts
+++ b/packages/rspeedy/plugin-react/test/basic.test.ts
@@ -69,7 +69,7 @@ describe('ReactLynx rsbuild', () => {
     const { pluginReactLynx } = await import('../src/index.js')
     vi.stubEnv('NODE_ENV', 'production')
 
-    const tmp = await mkdtemp(tmpdir())
+    const tmp = await mkdtemp(path.join(tmpdir(), 'rspeedy-react-test'))
 
     const rspeedy = await createRspeedy({
       rspeedyConfig: {

--- a/packages/rspeedy/plugin-react/test/fixtures/special-var-name/Behavior.jsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/special-var-name/Behavior.jsx
@@ -1,0 +1,7 @@
+export default function Behavior() {
+  return (
+    <view>
+      <text>Behavior</text>
+    </view>
+  )
+}

--- a/packages/rspeedy/plugin-react/test/fixtures/special-var-name/Card/Card.js
+++ b/packages/rspeedy/plugin-react/test/fixtures/special-var-name/Card/Card.js
@@ -1,0 +1,1 @@
+export default 42

--- a/packages/rspeedy/plugin-react/test/fixtures/special-var-name/Component.js
+++ b/packages/rspeedy/plugin-react/test/fixtures/special-var-name/Component.js
@@ -1,0 +1,5 @@
+const Component = () => {
+  return 42
+}
+
+export default Component

--- a/packages/rspeedy/plugin-react/test/fixtures/special-var-name/ReactLynx/index.js
+++ b/packages/rspeedy/plugin-react/test/fixtures/special-var-name/ReactLynx/index.js
@@ -1,0 +1,3 @@
+export default function ReactLynx() {
+  return 42
+}

--- a/packages/rspeedy/plugin-react/test/fixtures/special-var-name/index.jsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/special-var-name/index.jsx
@@ -1,0 +1,15 @@
+import { root } from '@lynx-js/react'
+
+import Behavior from './Behavior'
+import Card from './Card/Card'
+import Component from './Component'
+import ReactLynx from './ReactLynx'
+
+root.render(
+  <page>
+    <Behavior />
+    <Card />
+    <Component />
+    <ReactLynx />
+  </page>,
+)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Modules or variables with specific names like `Behavior`, `Card`, `Component`, or `ReactLynx` may conflict with parameters injected by the runtime wrapper.

```js
function (ReactLynx) {
  let ReactLynx = 42 // <-- SyntaxError: Identifier 'ReactLynx' has already been declared
}
```

We are renaming these unused variables to prevent any conflicts with existing variables.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
