### PR TITLE
fix(web): loading errors caused by script import order

### DIFF
--- a/.changeset/fine-ants-rush.md
+++ b/.changeset/fine-ants-rush.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-explorer": patch
+---
+
+fix: loading errors caused by script import order

--- a/packages/web-platform/web-explorer/index.html
+++ b/packages/web-platform/web-explorer/index.html
@@ -8,8 +8,8 @@
     <link rel="icon" type="image/png" href="icons/icon-128x128.png">
     <link rel="stylesheet" href="dist/static/css/index.css">
     <title>Lynx Explorer on Web Platform</title>
-    <script type="module" src="./dist/static/js/index.js"></script>
     <script type="module" src="preinstalled/vant-touch.js"></script>
+    <script type="module" src="./dist/static/js/index.js"></script>
     <style>
     #install-button {
       position: fixed;


### PR DESCRIPTION
## Summary

fix: loading errors caused by script import order

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
