### PR TITLE
feat(react/transform): auto import lazy runtime when using `<component>`

### DIFF
--- a/.changeset/lemon-bars-walk.md
+++ b/.changeset/lemon-bars-walk.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Auto import `@lynx-js/react/experimental/lazy/import` when using `<component is={url} />`

--- a/packages/react/runtime/lazy/import.js
+++ b/packages/react/runtime/lazy/import.js
@@ -16,7 +16,7 @@ import {
   sExportsReactInternal,
   sExportsReactLepus,
   target,
-} from './target';
+} from './target.js';
 
 Object.defineProperty(target, sExportsReact, {
   value: ReactAPIs,

--- a/packages/react/runtime/lepus/index.js
+++ b/packages/react/runtime/lepus/index.js
@@ -1,7 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { jsx as createVNode } from './jsx-runtime';
+import { jsx as createVNode } from './jsx-runtime/index.js';
 
 const slice = /* @__PURE__ */ [].slice;
 

--- a/packages/react/runtime/lepus/jsx-dev-runtime/index.js
+++ b/packages/react/runtime/lepus/jsx-dev-runtime/index.js
@@ -1,4 +1,4 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-export * from '../jsx-runtime';
+export * from '../jsx-runtime/index.js';

--- a/packages/react/transform/tests/__swc_snapshots__/src/swc_plugin_compat/mod.rs/should_add_component_is_import.js
+++ b/packages/react/transform/tests/__swc_snapshots__/src/swc_plugin_compat/mod.rs/should_add_component_is_import.js
@@ -1,0 +1,3 @@
+import "@lynx-js/react/experimental/lazy/import";
+import * as ReactLynx from "@lynx-js/react/internal";
+let c = <ReactLynx.__ComponentIsPolyfill is="xxxx"/>;

--- a/packages/webpack/react-webpack-plugin/test/cases/basic/lazy-imports/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/basic/lazy-imports/index.jsx
@@ -1,0 +1,38 @@
+/// <reference types="vitest/globals" />
+
+const sExportsReact = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react)');
+const sExportsReactLepus = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/lepus)',
+);
+const sExportsReactInternal = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/internal)',
+);
+const sExportsJSXRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/jsx-runtime)',
+);
+const sExportsJSXDevRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/jsx-dev-runtime)',
+);
+const sExportsLegacyReactRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/legacy-react-runtime)',
+);
+
+export {};
+
+it('should not have experimental/lazy/import imported', () => {
+  if (__BACKGROUND__) {
+    expect(lynx[sExportsReact]).toBeUndefined();
+    expect(lynx[sExportsReactLepus]).toBeUndefined();
+    expect(lynx[sExportsReactInternal]).toBeUndefined();
+    expect(lynx[sExportsJSXRuntime]).toBeUndefined();
+    expect(lynx[sExportsJSXDevRuntime]).toBeUndefined();
+    expect(lynx[sExportsLegacyReactRuntime]).toBeUndefined();
+  } else {
+    expect(globalThis[sExportsReact]).toBeUndefined();
+    expect(globalThis[sExportsReactLepus]).toBeUndefined();
+    expect(globalThis[sExportsReactInternal]).toBeUndefined();
+    expect(globalThis[sExportsJSXRuntime]).toBeUndefined();
+    expect(globalThis[sExportsJSXDevRuntime]).toBeUndefined();
+    expect(globalThis[sExportsLegacyReactRuntime]).toBeUndefined();
+  }
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/basic/lazy-imports/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/basic/lazy-imports/rspack.config.js
@@ -1,0 +1,7 @@
+import { createConfig } from '../../../create-react-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...createConfig(),
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/basic/lazy-imports/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/basic/lazy-imports/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main:main-thread.js',
+    'main:background.js',
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/compat/component-is/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/compat/component-is/index.jsx
@@ -1,0 +1,40 @@
+/// <reference types="vitest/globals" />
+
+const sExportsReact = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react)');
+const sExportsReactLepus = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/lepus)',
+);
+const sExportsReactInternal = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/internal)',
+);
+const sExportsJSXRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/jsx-runtime)',
+);
+const sExportsJSXDevRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/jsx-dev-runtime)',
+);
+const sExportsLegacyReactRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/legacy-react-runtime)',
+);
+
+export {};
+
+it('should have experimental/lazy/import imported', () => {
+  const jsx = <component is='foo' />;
+  expect(jsx).toBeDefined();
+  if (__BACKGROUND__) {
+    expect(lynx[sExportsReact]).not.toBeUndefined();
+    expect(lynx[sExportsReactLepus]).not.toBeUndefined();
+    expect(lynx[sExportsReactInternal]).not.toBeUndefined();
+    expect(lynx[sExportsJSXRuntime]).not.toBeUndefined();
+    expect(lynx[sExportsJSXDevRuntime]).not.toBeUndefined();
+    expect(lynx[sExportsLegacyReactRuntime]).not.toBeUndefined();
+  } else {
+    expect(globalThis[sExportsReact]).not.toBeUndefined();
+    expect(globalThis[sExportsReactLepus]).not.toBeUndefined();
+    expect(globalThis[sExportsReactInternal]).not.toBeUndefined();
+    expect(globalThis[sExportsJSXRuntime]).not.toBeUndefined();
+    expect(globalThis[sExportsJSXDevRuntime]).not.toBeUndefined();
+    expect(globalThis[sExportsLegacyReactRuntime]).not.toBeUndefined();
+  }
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/compat/component-is/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/compat/component-is/rspack.config.js
@@ -1,0 +1,11 @@
+import { createConfig } from '../../../create-react-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...createConfig({
+    compat: {
+      disableDeprecatedWarning: true,
+    },
+  }),
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/compat/component-is/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/compat/component-is/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main:main-thread.js',
+    'main:background.js',
+  ],
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

We would like to avoid the manually imported `@lynx-js/react/experimental/lazy/import` (which is easy to forget).

This patch auto imports the lazy runtimes when `<component is={url} />` is used.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
