### PR TITLE
feat(react/transform): auto import lazy runtime when using `import()`

### DIFF
--- a/.changeset/hip-toes-admire.md
+++ b/.changeset/hip-toes-admire.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Auto import `@lynx-js/react/experimental/lazy/import` when using `import(url)`

--- a/packages/react/runtime/lazy/import.js
+++ b/packages/react/runtime/lazy/import.js
@@ -22,34 +22,40 @@ Object.defineProperty(target, sExportsReact, {
   value: ReactAPIs,
   enumerable: false,
   writable: false,
+  configurable: true,
 });
 
 Object.defineProperty(target, sExportsReactLepus, {
   value: ReactLepusAPIs,
   enumerable: false,
   writable: false,
+  configurable: true,
 });
 
 Object.defineProperty(target, sExportsReactInternal, {
   value: ReactInternal,
   enumerable: false,
   writable: false,
+  configurable: true,
 });
 
 Object.defineProperty(target, sExportsJSXRuntime, {
   value: ReactJSXRuntime,
   enumerable: false,
   writable: false,
+  configurable: true,
 });
 
 Object.defineProperty(target, sExportsJSXDevRuntime, {
   value: ReactJSXDevRuntime,
   enumerable: false,
   writable: false,
+  configurable: true,
 });
 
 Object.defineProperty(target, sExportsLegacyReactRuntime, {
   value: ReactLegacyReactRuntime,
   enumerable: false,
   writable: false,
+  configurable: true,
 });

--- a/packages/react/transform/__test__/fixture.spec.js
+++ b/packages/react/transform/__test__/fixture.spec.js
@@ -870,7 +870,8 @@ describe('dynamic import', () => {
     );
 
     expect(result.code).toMatchInlineSnapshot(`
-      "import { __dynamicImport } from "@lynx-js/react/internal";
+      "import "@lynx-js/react/experimental/lazy/import";
+      import { __dynamicImport } from "@lynx-js/react/internal";
       (async function() {
           await import();
           await import(0);

--- a/packages/react/transform/tests/__swc_snapshots__/src/swc_plugin_dynamic_import/mod.rs/should_not_import_lazy.js
+++ b/packages/react/transform/tests/__swc_snapshots__/src/swc_plugin_dynamic_import/mod.rs/should_not_import_lazy.js
@@ -1,0 +1,15 @@
+(async function() {
+    await import("./index.js");
+    await import(`./locales/${name}`);
+    await import("ftp://www/a.js");
+    await import("./index.js", {
+        with: {
+            type: "component"
+        }
+    });
+    await import("ftp://www/a.js", {
+        with: {
+            type: "component"
+        }
+    });
+})();

--- a/packages/react/transform/tests/__swc_snapshots__/src/swc_plugin_dynamic_import/mod.rs/should_transform_import_call.js
+++ b/packages/react/transform/tests/__swc_snapshots__/src/swc_plugin_dynamic_import/mod.rs/should_transform_import_call.js
@@ -1,3 +1,4 @@
+import "@lynx-js/react/experimental/lazy/import";
 import { __dynamicImport } from "@lynx-js/react/internal";
 (async function() {
     await import("./index.js");

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/lazy-imports/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/lazy-imports/index.jsx
@@ -1,0 +1,43 @@
+/// <reference types="vitest/globals" />
+
+const sExportsReact = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react)');
+const sExportsReactLepus = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/lepus)',
+);
+const sExportsReactInternal = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/internal)',
+);
+const sExportsJSXRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/jsx-runtime)',
+);
+const sExportsJSXDevRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/jsx-dev-runtime)',
+);
+const sExportsLegacyReactRuntime = Symbol.for(
+  '__REACT_LYNX_EXPORTS__(@lynx-js/react/legacy-react-runtime)',
+);
+
+export {};
+
+it('should have experimental/lazy/import imported', async () => {
+  try {
+    await import('https://www/a.js');
+  } catch {
+    // ignore error
+  }
+  if (__BACKGROUND__) {
+    expect(lynx[sExportsReact]).not.toBeUndefined();
+    expect(lynx[sExportsReactLepus]).not.toBeUndefined();
+    expect(lynx[sExportsReactInternal]).not.toBeUndefined();
+    expect(lynx[sExportsJSXRuntime]).not.toBeUndefined();
+    expect(lynx[sExportsJSXDevRuntime]).not.toBeUndefined();
+    expect(lynx[sExportsLegacyReactRuntime]).not.toBeUndefined();
+  } else {
+    expect(globalThis[sExportsReact]).not.toBeUndefined();
+    expect(globalThis[sExportsReactLepus]).not.toBeUndefined();
+    expect(globalThis[sExportsReactInternal]).not.toBeUndefined();
+    expect(globalThis[sExportsJSXRuntime]).not.toBeUndefined();
+    expect(globalThis[sExportsJSXDevRuntime]).not.toBeUndefined();
+    expect(globalThis[sExportsLegacyReactRuntime]).not.toBeUndefined();
+  }
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/lazy-imports/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/lazy-imports/rspack.config.js
@@ -1,0 +1,7 @@
+import { createConfig } from '../../../create-react-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...createConfig(),
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/lazy-imports/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/lazy-imports/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main:main-thread.js',
+    'main:background.js',
+  ],
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Similar with #666.

We would like to avoid the manually imported `@lynx-js/react/experimental/lazy/import` (which is easy to forget).

This patch auto imports the lazy runtimes when `import(url)` is used.

> [!NOTE]
> The lazy runtime is only needed when using an external `import()` (e.g.: `https://` or a variable).

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
