### PR TITLE
ci: cannot use `github.ref` as artifact name

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Save Turbo Result
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.ref }}-${{ github.sha }}
+          name: deploy-${{ github.sha }}
           path: .turbo
           if-no-files-found: error
           retention-days: 1
@@ -127,7 +127,7 @@ jobs:
         uses: actions/download-artifact@v4
         timeout-minutes: 5
         with:
-          name: ${{ github.ref }}-${{ github.sha }}
+          name: deploy-${{ github.sha }}
           path: .turbo
       - name: build
         run: |
@@ -173,7 +173,7 @@ jobs:
         uses: actions/download-artifact@v4
         timeout-minutes: 5
         with:
-          name: ${{ github.ref }}-${{ github.sha }}
+          name: deploy-${{ github.sha }}
           path: .turbo
       - name: build
         run: |


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
> Error: The artifact name is not valid: refs/heads/release/react-0-107-x-e2326f34961375f0ea32b842b7ad62fa9479a050. Contains the following character:  Forward slash /
>
> https://github.com/lynx-family/lynx-stack/actions/runs/14751119946/job/41408647299
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
