### PR TITLE
feat(rspeedy/core): enable native Rsdoctor plugin by default

### DIFF
--- a/.changeset/three-baboons-hunt.md
+++ b/.changeset/three-baboons-hunt.md
@@ -1,0 +1,23 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Enable native Rsdoctor plugin by default.
+
+Set `tools.rsdoctor.experiments.enableNativePlugin` to `false` to use the old JS plugin.
+
+```js
+import { defineConfig } from '@lynx-js/rspeedy';
+
+export default defineConfig({
+  tools: {
+    rsdoctor: {
+      experiments: {
+        enableNativePlugin: false,
+      },
+    },
+  },
+});
+```
+
+See [Rsdoctor - 1.0](https://rsdoctor.dev/blog/release/release-note-1_0#-faster-analysis) for more details.

--- a/packages/rspeedy/core/src/config/defaults.ts
+++ b/packages/rspeedy/core/src/config/defaults.ts
@@ -8,14 +8,22 @@ import type { Filename } from './output/filename.js'
 import type { Config } from './index.js'
 
 export function applyDefaultRspeedyConfig(config: Config): Config {
-  const ret = mergeRsbuildConfig(config, {
+  const ret = mergeRsbuildConfig({
     output: {
       // We are applying the default filename to the config
       // since some plugin(e.g.: `@lynx-js/qrcode-rsbuild-plugin`) will read
       // from the `output.filename.bundle` field.
       filename: getFilename(config.output?.filename),
     },
-  })
+
+    tools: {
+      rsdoctor: {
+        experiments: {
+          enableNativePlugin: true,
+        },
+      },
+    },
+  }, config)
 
   return ret
 }

--- a/packages/rspeedy/core/test/config/tools/tools.test-d.ts
+++ b/packages/rspeedy/core/test/config/tools/tools.test-d.ts
@@ -160,6 +160,28 @@ describe('Config - Tools', () => {
     })
   })
 
+  test('tools.rsdoctor', () => {
+    assertType<Tools>({
+      rsdoctor: {},
+    })
+
+    assertType<Tools>({
+      rsdoctor: {
+        experiments: {
+          enableNativePlugin: true,
+        },
+      },
+    })
+
+    assertType<Tools>({
+      rsdoctor: {
+        experiments: {
+          enableNativePlugin: false,
+        },
+      },
+    })
+  })
+
   test('tools.rspack', () => {
     // Object
     assertType<Tools>({

--- a/packages/rspeedy/core/test/plugins/output.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/output.plugin.test.ts
@@ -698,12 +698,7 @@ describe('Plugins - Output', () => {
       await rsbuild.unwrapConfig()
 
       expect(rsbuild.getRspeedyConfig().output?.filename).toMatchInlineSnapshot(
-        `
-        {
-          "bundle": "static/bundle/[name].bundle",
-          "template": "static/bundle/[name].bundle",
-        }
-      `,
+        `"static/bundle/[name].bundle"`,
       )
     })
 
@@ -758,7 +753,7 @@ describe('Plugins - Output', () => {
         .toMatchInlineSnapshot(`
           {
             "bundle": "[name].bundle",
-            "template": "[name].bundle",
+            "template": "[name].template",
           }
         `)
     })

--- a/packages/rspeedy/core/test/plugins/rsdoctor.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/rsdoctor.plugin.test.ts
@@ -29,6 +29,33 @@ describe('Plugins - Rsdoctor', () => {
     })
 
     expect(options.supports.banner).toBe(true)
+
+    expect(options.experiments?.enableNativePlugin).toBe(true)
+  })
+
+  test('experiments.enableNativePlugin: false', async () => {
+    vi.stubEnv('RSDOCTOR', 'true')
+
+    const { createStubRspeedy } = await import('../createStubRspeedy.js')
+
+    const rsbuild = await createStubRspeedy({
+      tools: {
+        rsdoctor: {
+          experiments: {
+            enableNativePlugin: false,
+          },
+        },
+      },
+    })
+
+    const compiler = await rsbuild.createCompiler<Rspack.Compiler>()
+
+    const { options } = compiler.options.plugins.find(
+      (plugin) => (typeof plugin === 'object'
+        && plugin?.['isRsdoctorPlugin'] === true),
+    ) as RsdoctorRspackPlugin<[]>
+
+    expect(options.experiments?.enableNativePlugin).toBe(false)
   })
 
   test('linter.rules.ecma-version-check', async () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

We want to enable more Rstack experimental features.

Starting from the native Rsdoctor plugin.

Ref: https://rsdoctor.dev/blog/release/release-note-1_0#-faster-analysis

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
