### PR TITLE
feat(web): support for using lynx.queueMicrotask.

### DIFF
--- a/.changeset/cuddly-beans-enter.md
+++ b/.changeset/cuddly-beans-enter.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-worker-runtime": patch
+---
+
+feat: support for using `lynx.queueMicrotask`.

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -135,6 +135,7 @@
     // lighthouse CI
     "lhci",
     "lh",
+    "queueMicrotask",
   ],
   // Glob
   "ignorePaths": [

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -956,6 +956,15 @@ test.describe('reactlynx3 tests', () => {
       await wait(100);
       await expect(result).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
     });
+    test(
+      'api-queueMicrotask',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(200);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
   });
 
   test.describe('configs', () => {

--- a/packages/web-platform/web-tests/tests/react/api-queueMicrotask/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-queueMicrotask/index.jsx
@@ -1,0 +1,26 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useEffect, useState } from '@lynx-js/react';
+
+function App() {
+  const [color, setColor] = useState('pink');
+  useEffect(() => {
+    lynx.queueMicrotask(() => {
+      setColor('green');
+    });
+  }, []);
+
+  return (
+    <view
+      id='target'
+      style={{
+        height: '100px',
+        width: '100px',
+        background: color,
+      }}
+    />
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createBackgroundLynx.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createBackgroundLynx.ts
@@ -43,5 +43,8 @@ export function createBackgroundLynx(
       mainThreadRpc,
       config.customSections,
     ),
+    queueMicrotask: (callback: () => void) => {
+      queueMicrotask(callback);
+    },
   };
 }


### PR DESCRIPTION
## Summary

feat: support for using `lynx.queueMicrotask`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
