### PR TITLE
refactor(test-environment): fix publint error

### DIFF
--- a/.changeset/young-seals-train.md
+++ b/.changeset/young-seals-train.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/test-environment": minor
+---
+
+Switch to ESM package format by setting `"type": "module"`.

--- a/packages/testing-library/test-environment/package.json
+++ b/packages/testing-library/test-environment/package.json
@@ -17,23 +17,31 @@
     "name": "Yiming Li",
     "email": "yimingli.cs@gmail.com"
   },
+  "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.mjs",
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
     },
     "./env/vitest": {
-      "default": "./dist/env/vitest/index.mjs",
       "types": "./dist/env/vitest/index.d.ts",
-      "import": "./dist/env/vitest/index.mjs",
-      "require": "./dist/env/vitest/index.js"
+      "import": "./dist/env/vitest/index.js",
+      "require": "./dist/env/vitest/index.cjs",
+      "default": "./dist/env/vitest/index.js"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "env/vitest": [
+        "./dist/env/vitest/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],
@@ -44,6 +52,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
-    "@types/jsdom": "^21.1.7"
+    "@types/jsdom": "^21.1.7",
+    "rsbuild-plugin-publint": "0.3.1"
   }
 }

--- a/packages/testing-library/test-environment/rslib.config.ts
+++ b/packages/testing-library/test-environment/rslib.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rslib/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
 
 export default defineConfig({
   source: {
@@ -21,5 +22,8 @@ export default defineConfig({
       format: 'cjs',
       syntax: 'es2021',
     },
+  ],
+  plugins: [
+    pluginPublint(),
   ],
 });

--- a/packages/testing-library/test-environment/src/index.ts
+++ b/packages/testing-library/test-environment/src/index.ts
@@ -7,11 +7,11 @@
 
 import EventEmitter from 'events';
 import { JSDOM } from 'jsdom';
-import { createGlobalThis, LynxGlobalThis } from './lynx/GlobalThis';
-import { initElementTree } from './lynx/ElementPAPI';
-export { initElementTree } from './lynx/ElementPAPI';
-export type { LynxElement } from './lynx/ElementPAPI';
-export type { LynxGlobalThis } from './lynx/GlobalThis';
+import { createGlobalThis, LynxGlobalThis } from './lynx/GlobalThis.js';
+import { initElementTree } from './lynx/ElementPAPI.js';
+export { initElementTree } from './lynx/ElementPAPI.js';
+export type { LynxElement } from './lynx/ElementPAPI.js';
+export type { LynxGlobalThis } from './lynx/GlobalThis.js';
 /**
  * @public
  * The lynx element tree

--- a/packages/testing-library/test-environment/src/lynx/GlobalThis.ts
+++ b/packages/testing-library/test-environment/src/lynx/GlobalThis.ts
@@ -1,4 +1,4 @@
-import { define } from '../util';
+import { define } from '../util.js';
 
 function installOwnProperties(globalThis: any) {
   define(globalThis, {

--- a/packages/testing-library/test-environment/turbo.json
+++ b/packages/testing-library/test-environment/turbo.json
@@ -9,6 +9,12 @@
       "cache": false
     },
     "build": {
+      "dependsOn": [],
+      "inputs": [
+        "src/**",
+        "!src/**/__tests__/**",
+        "rslib.config.ts"
+      ],
       "outputs": ["dist/**"]
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,6 +588,9 @@ importers:
       '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7
+      rsbuild-plugin-publint:
+        specifier: 0.3.1
+        version: 0.3.1(@rsbuild/core@1.3.15)
 
   packages/third-party/tailwind-preset:
     devDependencies:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

There are some publint and TypeScript error when using `@lynx-js/test-environment`:

### Publint

> https://publint.dev/@lynx-js/test-environment@0.0.1

```
Running publint v0.3.12 for @lynx-js/test-environment...
Packing files with `pnpm pack`...
Linting...
Errors:
1. pkg.exports["."].types should be the first in the object as conditions are order-sensitive so it can be resolved by TypeScript.
2. pkg.exports["."].default should be the last in the object so it doesn't take precedence over the keys following it.
3. pkg.exports["./env/vitest"].types should be the first in the object as conditions are order-sensitive so it can be resolved by TypeScript.
4. pkg.exports["./env/vitest"].default should be the last in the object so it doesn't take precedence over the keys following it.
Warnings:
1. pkg.exports["."].default types is not exported. Consider adding pkg.exports["."].default.types to be compatible with TypeScript's "moduleResolution": "bundler" compiler option. Note that you cannot use "./dist/index.d.ts" because it has a mismatching format. Instead, you can duplicate the file and use the .mts extension, e.g. pkg.exports["."].default.types: "./dist/index.d.mts"
Suggestions:
1. The package does not specify the "type" field. Node.js may attempt to detect the package type causing a small performance hit. Consider adding "type": "commonjs".
2. pkg.repository.url is https://github.com/lynx-family/lynx-stack.git but could be a full git URL like "git+https://github.com/lynx-family/lynx-stack.git".
```

### Are The Types Wrong?

> https://arethetypeswrong.github.io/?p=@lynx-js/test-environment@0.0.1

  | "@lynx-js/test-environment" | "@lynx-js/test-environment/env/vitest"
-- | -- | --
node10 | ✅ | 💀 Resolution failed
node16 (from CJS) | ⚠️ ESM (dynamic import only)🐛 Used fallback condition🎭 Masquerading as CJS | ⚠️ ESM (dynamic import only)🐛 Used fallback condition🎭 Masquerading as CJS
node16 (from ESM) | 🎭 Masquerading as CJS🐛 Used fallback condition | 🎭 Masquerading as CJS🐛 Used fallback condition
bundler | 🐛 Used fallback condition | 🐛 Used fallback condition

This patch fixes most of the publint errors and the TypeScript resolution errors.

</div>
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
