### PR TITLE
docs(react): README; add some comments; deprecate some old macros

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -28,6 +28,7 @@
 
 ## Content
 
+- [Content](#content)
 - [Getting Started](#getting-started)
 - [Documentation](#documentation)
 - [Community and Support](#community-and-support)
@@ -67,6 +68,7 @@ ReactLynx is [Apache License 2.0](https://github.com/lynx-family/lynx-stack/blob
 
 Thanks to:
 
-- [Preact](https://preactjs.com/) for creating a lightweight and efficient UI library that served as a foundation for the ReactLynx project.
-- [React](https://react.dev/) for creating a comprehensive and intuitive library for building user interfaces and providing the inspiration for ReactLynx's development model.
+- [Preact](https://preactjs.com/) for creating a lightweight and efficient implementation of React's APIs that served as the foundation for ReactLynx runtime.
+- [React](https://react.dev/) for creating a gaming-changing UI library and programming model that has inspired a generation of declarative UI technologies.
+- [Reanimated](https://docs.swmansion.com/react-native-reanimated/), [React Server Component](https://react.dev/reference/rsc/server-components) and [Web Worklet](https://developer.mozilla.org/en-US/docs/Web/API/Worklet) for inspiring ReactLynx's dual-threaded programming models such as [Main Thread Scripting](https://lynxjs.org/react/main-thread-script.html).
 - [SWC](https://github.com/swc-project/swc) project created by [@kdy1](https://github.com/kdy1), which turbocharges ReactLynx's code transformation with Rust-powered efficiency, achieving sub-second build times and frictionless developer experience.

--- a/packages/react/runtime/package.json
+++ b/packages/react/runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@lynx-js/react-runtime",
   "version": "0.100.1",
   "private": true,
-  "description": "All-in-one package for React on Lynx (3.0)",
+  "description": "All-in-one package for React on Lynx",
   "type": "module",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/react/runtime/src/backgroundSnapshot.ts
+++ b/packages/react/runtime/src/backgroundSnapshot.ts
@@ -1,31 +1,38 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+
+/**
+ * Background snapshot implementation that runs in the background thread.
+ *
+ * This is the mirror of main thread's {@link SnapshotInstance}:
+ */
+
 import type { Worklet } from '@lynx-js/react/worklet-runtime/bindings';
 
+import { processGestureBackground } from './gesture/processGestureBagkround.js';
+import type { GestureKind } from './gesture/types.js';
 import { diffArrayAction, diffArrayLepus } from './hydrate.js';
 import { globalBackgroundSnapshotInstancesToRemove } from './lifecycle/patch/commit.js';
-import { markRefToRemove } from './snapshot/ref.js';
-import { transformSpread } from './snapshot/spread.js';
-import {
-  DynamicPartType,
-  backgroundSnapshotInstanceManager,
-  snapshotManager,
-  traverseSnapshotInstance,
-} from './snapshot.js';
-import type { SerializedSnapshotInstance } from './snapshot.js';
+import type { SnapshotPatch } from './lifecycle/patch/snapshotPatch.js';
 import {
   SnapshotOperation,
   __globalSnapshotPatch,
   initGlobalSnapshotPatch,
   takeGlobalSnapshotPatch,
 } from './lifecycle/patch/snapshotPatch.js';
-import type { SnapshotPatch } from './lifecycle/patch/snapshotPatch.js';
+import { globalPipelineOptions } from './lynx/performance.js';
+import type { SerializedSnapshotInstance } from './snapshot.js';
+import {
+  DynamicPartType,
+  backgroundSnapshotInstanceManager,
+  snapshotManager,
+  traverseSnapshotInstance,
+} from './snapshot.js';
+import { markRefToRemove } from './snapshot/ref.js';
+import { transformSpread } from './snapshot/spread.js';
 import { isDirectOrDeepEqual } from './utils.js';
 import { onPostWorkletCtx } from './worklet/ctx.js';
-import { processGestureBackground } from './gesture/processGestureBagkround.js';
-import type { GestureKind } from './gesture/types.js';
-import { globalPipelineOptions } from './lynx/performance.js';
 
 export class BackgroundSnapshotInstance {
   constructor(public type: string) {

--- a/packages/react/runtime/src/lifecycle/delayUnmount.ts
+++ b/packages/react/runtime/src/lifecycle/delayUnmount.ts
@@ -1,8 +1,8 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { options } from 'preact';
 import type { VNode } from 'preact';
+import { options } from 'preact';
 
 import { CATCH_ERROR, COMPONENT, DIFF, VNODE } from '../renderToOpcodes/constants.js';
 
@@ -74,4 +74,4 @@ function initDelayUnmount(): void {
   };
 }
 
-export { initDelayUnmount, takeDelayedUnmounts, runDelayedUnmounts };
+export { initDelayUnmount, runDelayedUnmounts, takeDelayedUnmounts };

--- a/packages/react/runtime/src/lifecycle/patch/commit.ts
+++ b/packages/react/runtime/src/lifecycle/patch/commit.ts
@@ -1,12 +1,28 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+
+/**
+ * Implements the commit phase of the rendering lifecycle.
+ * This module patches Preact's commit phase to integrate with the snapshot system,
+ * handling the collection and transmission of patches between threads.
+ *
+ * The commit phase is responsible for:
+ * - Collecting patches from the snapshot system
+ * - Managing commit tasks and their execution
+ * - Coordinating with the native layer for updates
+ * - Handling performance timing and pipeline options
+ */
+
+/**
+ * This module patches Preact's commit phase by hacking into the internal of
+ * its [options](https://preactjs.com/guide/v10/options/) API
+ */
+
 import type { VNode } from 'preact';
 import { options } from 'preact';
 import type { Component } from 'preact/compat';
 
-import type { SnapshotPatch } from './snapshotPatch.js';
-import { takeGlobalSnapshotPatch } from './snapshotPatch.js';
 import { LifecycleConstant } from '../../lifecycleConstant.js';
 import {
   PerformanceTimingKeys,
@@ -16,12 +32,14 @@ import {
   setPipeline,
 } from '../../lynx/performance.js';
 import { CATCH_ERROR, COMMIT, RENDER_CALLBACKS, VNODE } from '../../renderToOpcodes/constants.js';
-import { updateBackgroundRefs } from '../../snapshot/ref.js';
 import { backgroundSnapshotInstanceManager } from '../../snapshot.js';
+import { updateBackgroundRefs } from '../../snapshot/ref.js';
 import { isEmptyObject } from '../../utils.js';
 import { takeWorkletRefInitValuePatch } from '../../worklet/workletRefPool.js';
 import { runDelayedUnmounts, takeDelayedUnmounts } from '../delayUnmount.js';
 import { getReloadVersion } from '../pass.js';
+import type { SnapshotPatch } from './snapshotPatch.js';
+import { takeGlobalSnapshotPatch } from './snapshotPatch.js';
 
 let globalFlushOptions: FlushOptions = {};
 
@@ -30,34 +48,50 @@ let nextCommitTaskId = 1;
 
 let globalBackgroundSnapshotInstancesToRemove: number[] = [];
 
+/**
+ * A single patch operation.
+ */
 interface Patch {
   id: number;
   snapshotPatch?: SnapshotPatch;
   workletRefInitValuePatch?: [id: number, value: unknown][];
 }
 
+/**
+ * List of patches to be applied in a single update cycle with flush options.
+ */
 interface PatchList {
   patchList: Patch[];
   flushOptions?: FlushOptions;
 }
 
+/**
+ * Configuration options for patch operations
+ */
 interface PatchOptions {
   pipelineOptions?: PipelineOptions;
   reloadVersion: number;
   isHydration?: boolean;
 }
 
+/**
+ * Replaces Preact's default commit hook with our custom implementation
+ */
 function replaceCommitHook(): void {
-  const oldCommit = options[COMMIT];
+  const originalPreactCommit = options[COMMIT];
   const commit = async (vnode: VNode, commitQueue: any[]) => {
-    if (__LEPUS__) {
+    // Skip commit phase for MT runtime
+    if (__MAIN_THREAD__) {
       // for testing only
       commitQueue.length = 0;
       return;
     }
 
+    // Mark the end of virtual DOM diffing phase for performance tracking
     markTimingLegacy(PerformanceTimingKeys.updateDiffVdomEnd);
     markTiming(PerformanceTimingKeys.diffVdomEnd);
+
+    // The callback functions to be called after components are rendered.
     const renderCallbacks = commitQueue.map((component: Component<any>) => {
       const ret = {
         component,
@@ -68,16 +102,19 @@ function replaceCommitHook(): void {
       return ret;
     });
     commitQueue.length = 0;
+
     const delayedUnmounts = takeDelayedUnmounts();
 
     const backgroundSnapshotInstancesToRemove = globalBackgroundSnapshotInstancesToRemove;
     globalBackgroundSnapshotInstancesToRemove = [];
 
     const commitTaskId = genCommitTaskId();
+
+    // Register the commit task
     globalCommitTaskMap.set(commitTaskId, () => {
       updateBackgroundRefs(commitTaskId);
       runDelayedUnmounts(delayedUnmounts);
-      oldCommit?.(vnode, renderCallbacks);
+      originalPreactCommit?.(vnode, renderCallbacks);
       renderCallbacks.some(wrapper => {
         try {
           wrapper[RENDER_CALLBACKS].some((cb: (this: Component) => void) => {
@@ -96,6 +133,7 @@ function replaceCommitHook(): void {
       }
     });
 
+    // Collect patches for this update
     const snapshotPatch = takeGlobalSnapshotPatch();
     const flushOptions = globalFlushOptions;
     const workletRefInitValuePatch = takeWorkletRefInitValuePatch();
@@ -123,6 +161,7 @@ function replaceCommitHook(): void {
     }
     const obj = commitPatchUpdate(patchList, {});
 
+    // Send the update to the native layer
     lynx.getNativeApp().callLepusMethod(LifecycleConstant.patchUpdate, obj, () => {
       const commitTask = globalCommitTaskMap.get(commitTaskId);
       if (commitTask) {
@@ -134,6 +173,9 @@ function replaceCommitHook(): void {
   options[COMMIT] = commit as ((...args: Parameters<typeof commit>) => void);
 }
 
+/**
+ * Prepares the patch update for transmission to the native layer
+ */
 function commitPatchUpdate(patchList: PatchList, patchOptions: Omit<PatchOptions, 'reloadVersion'>): {
   data: string;
   patchOptions: PatchOptions;
@@ -169,9 +211,16 @@ function commitPatchUpdate(patchList: PatchList, patchOptions: Omit<PatchOptions
   return obj;
 }
 
+/**
+ * Generates a unique ID for commit tasks
+ */
 function genCommitTaskId(): number {
   return nextCommitTaskId++;
 }
+
+/**
+ * Resets the commit task ID counter
+ */
 function clearCommitTaskId(): void {
   nextCommitTaskId = 1;
 }
@@ -188,15 +237,15 @@ function replaceRequestAnimationFrame(): void {
  * @internal
  */
 export {
+  clearCommitTaskId,
   commitPatchUpdate,
   genCommitTaskId,
-  clearCommitTaskId,
   globalBackgroundSnapshotInstancesToRemove,
   globalCommitTaskMap,
   globalFlushOptions,
   nextCommitTaskId,
   replaceCommitHook,
   replaceRequestAnimationFrame,
-  type PatchOptions,
   type PatchList,
+  type PatchOptions,
 };

--- a/packages/react/runtime/src/lifecycle/patch/snapshotPatch.ts
+++ b/packages/react/runtime/src/lifecycle/patch/snapshotPatch.ts
@@ -1,6 +1,13 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+
+/**
+ * Defines the core patch operations for the snapshot system.
+ * The patch operations are designed to be serializable and minimal, allowing
+ * efficient transmission between threads and application to element tree.
+ */
+
 export const enum SnapshotOperation {
   CreateElement,
   InsertBefore,
@@ -12,6 +19,8 @@ export const enum SnapshotOperation {
   DEV_ONLY_RegisterWorklet = 101,
 }
 
+// Operation format definitions:
+//
 // [opcode: SnapshotOperation.CreateElement, type: string, id: number]
 // [opcode: SnapshotOperation.InsertBefore, parentId: number, id: number, beforeId: number | undefined]
 // [opcode: SnapshotOperation.RemoveChild, parentId: number, childId: number]

--- a/packages/react/runtime/src/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/lifecycle/patch/snapshotPatchApply.ts
@@ -1,14 +1,31 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+
+/**
+ * Implements the patch application logic for the snapshot system.
+ * This module is responsible for interpreting and executing patch operations
+ * that were generated in the background thread, applying them to the DOM
+ * in the main thread.
+ *
+ * The module handles various operations like element creation, insertion,
+ * removal, and attribute updates, ensuring they are applied in the correct
+ * order and with proper error handling.
+ */
+
+import { SnapshotInstance, createSnapshot, snapshotInstanceManager, snapshotManager } from '../../snapshot.js';
 import type { SnapshotPatch } from './snapshotPatch.js';
 import { SnapshotOperation } from './snapshotPatch.js';
-import { SnapshotInstance, createSnapshot, snapshotInstanceManager, snapshotManager } from '../../snapshot.js';
 
 function reportCtxNotFound(): void {
   lynx.reportError(new Error(`snapshotPatchApply failed: ctx not found`));
 }
 
+/**
+ * Applies a patch of snapshot operations to the main thread.
+ * This is the counterpart to the patch generation in the background thread.
+ * Each operation in the patch is processed sequentially to update the DOM.
+ */
 export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
   const length = snapshotPatch.length;
   for (let i = 0; i < length; ++i) {
@@ -107,10 +124,8 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
 }
 
 /**
- * Given an expression string, return the evaluated result with ReactLynx runtime injected.
- *
- * @param code - The code to be evaluated
- * @returns the evaluated expression
+ * Evaluates a string as code with ReactLynx runtime injected.
+ * Used for HMR (Hot Module Replacement) to update snapshot definitions.
  */
 function evaluate<T>(code: string): T {
   return new Function(`return ${code}`)();

--- a/packages/react/runtime/src/lifecycle/reload.ts
+++ b/packages/react/runtime/src/lifecycle/reload.ts
@@ -1,17 +1,23 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+
+/**
+ * Implements the reload (thinking of "refresh" in browser) for both main thread
+ * and background thread.
+ */
+
 import { render } from 'preact';
 
 import { hydrate } from '../hydrate.js';
 import { LifecycleConstant } from '../lifecycleConstant.js';
 import { __pendingListUpdates } from '../list.js';
 import { __root, setRoot } from '../root.js';
-import { takeGlobalRefPatchMap } from '../snapshot/ref.js';
 import { SnapshotInstance, __page, snapshotInstanceManager } from '../snapshot.js';
+import { takeGlobalRefPatchMap } from '../snapshot/ref.js';
 import { isEmptyObject } from '../utils.js';
-import { destroyBackground } from './destroy.js';
 import { destroyWorklet } from '../worklet/destroy.js';
+import { destroyBackground } from './destroy.js';
 import { clearJSReadyEventIdSwap, isJSReady } from './event/jsReady.js';
 import { increaseReloadVersion } from './pass.js';
 import { deinitGlobalSnapshotPatch } from './patch/snapshotPatch.js';

--- a/packages/react/runtime/src/lifecycle/render.ts
+++ b/packages/react/runtime/src/lifecycle/render.ts
@@ -1,6 +1,11 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+
+/**
+ * Implements the IFR (Instant First-Frame Rendering) on main thread.
+ */
+
 import { render } from 'preact';
 
 import { renderOpcodesInto } from '../opcodes.js';

--- a/packages/react/runtime/src/lynx-api.ts
+++ b/packages/react/runtime/src/lynx-api.ts
@@ -43,13 +43,13 @@ export interface Root {
    *   return <view>...</view>
    * }
    *
-   * if (__LEPUS__) {
+   * if (__MAIN_THREAD__) {
    *   root.render(
    *     <DataProvider data={DEFAULT_DATA}>
    *        <App/>
    *     </DataProvider>
    *   );
-   * } else if (__JS__) {
+   * } else if (__BACKGROUND__) {
    *   fetchData().then((data) => {
    *     root.render(
    *       <DataProvider data={data}>
@@ -82,7 +82,7 @@ export interface Root {
  */
 export const root: Root = {
   render: (jsx: ReactNode): void => {
-    if (__LEPUS__) {
+    if (__MAIN_THREAD__) {
       __root.__jsx = jsx;
     } else {
       __root.__jsx = jsx;
@@ -370,7 +370,7 @@ export interface Lynx {
   registerDataProcessors: (dataProcessorDefinition?: DataProcessorDefinition) => void;
 }
 
-export { runOnMainThread } from './worklet/runOnMainThread.js';
-export { runOnBackground } from './worklet/runOnBackground.js';
-export { MainThreadRef, useMainThreadRef } from './worklet/workletRef.js';
 export { useLynxGlobalEventListener } from './hooks/useLynxGlobalEventListener.js';
+export { runOnBackground } from './worklet/runOnBackground.js';
+export { runOnMainThread } from './worklet/runOnMainThread.js';
+export { MainThreadRef, useMainThreadRef } from './worklet/workletRef.js';

--- a/packages/react/runtime/src/lynx.ts
+++ b/packages/react/runtime/src/lynx.ts
@@ -18,14 +18,14 @@ import { injectTt } from './lynx/tt.js';
 export { runWithForce } from './lynx/runWithForce.js';
 
 // @ts-expect-error Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature
-if (__LEPUS__ && typeof globalThis.processEvalResult === 'undefined') {
+if (__MAIN_THREAD__ && typeof globalThis.processEvalResult === 'undefined') {
   // @ts-expect-error Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature
   globalThis.processEvalResult = <T>(result: ((schema: string) => T) | undefined, schema: string) => {
     return result?.(schema);
   };
 }
 
-if (__LEPUS__) {
+if (__MAIN_THREAD__) {
   injectCalledByNative();
   injectUpdateMainThread();
   if (__DEV__) {
@@ -39,8 +39,9 @@ if (__PROFILE__) {
   initProfileHook();
 }
 
-if (__JS__) {
-  options.document = document;
+if (__BACKGROUND__) {
+  // Trick Preact and TypeScript to accept our custom document adapter.
+  options.document = document as any;
   setupBackgroundDocument();
   injectTt();
 

--- a/packages/react/runtime/src/renderToOpcodes/index.ts
+++ b/packages/react/runtime/src/renderToOpcodes/index.ts
@@ -2,7 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-// modified from preact-render-to-string@6.0.3
+/**
+ * Implements rendering to opcodes.
+ * This module is modified from preact-render-to-string@6.0.3 to generate
+ * opcodes instead of HTML strings for Lynx.
+ */
+
 // @ts-nocheck
 
 import { Fragment, h, options } from 'preact';

--- a/packages/react/runtime/src/root.ts
+++ b/packages/react/runtime/src/root.ts
@@ -4,15 +4,19 @@
 import { BackgroundSnapshotInstance } from './backgroundSnapshot.js';
 import { SnapshotInstance } from './snapshot.js';
 
+/**
+ * The internal ReactLynx's root.
+ * {@link @lynx-js/react!Root | root}.
+ */
 let __root: (SnapshotInstance | BackgroundSnapshotInstance) & { __jsx?: React.ReactNode; __opcodes?: any[] };
 
 function setRoot(root: typeof __root): void {
   __root = root;
 }
 
-if (__LEPUS__) {
+if (__MAIN_THREAD__) {
   setRoot(new SnapshotInstance('root'));
-} else if (__JS__) {
+} else if (__BACKGROUND__) {
   setRoot(new BackgroundSnapshotInstance('root'));
 }
 

--- a/packages/react/runtime/src/snapshot/ref.ts
+++ b/packages/react/runtime/src/snapshot/ref.ts
@@ -137,12 +137,12 @@ function markRefToRemove(sign: string, ref: unknown): void {
 }
 
 export {
-  updateRef,
-  takeGlobalRefPatchMap,
-  updateBackgroundRefs,
-  unref,
-  transformRef,
   globalRefsToRemove,
   globalRefsToSet,
   markRefToRemove,
+  takeGlobalRefPatchMap,
+  transformRef,
+  unref,
+  updateBackgroundRefs,
+  updateRef,
 };

--- a/packages/react/runtime/src/snapshot/spread.ts
+++ b/packages/react/runtime/src/snapshot/spread.ts
@@ -1,16 +1,24 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { SnapshotInstance } from '../snapshot.js';
-import { updateEvent } from './event.js';
+
+/**
+ * Handles JSX spread operator in the snapshot system.
+ *
+ * Spread operators in JSX (e.g., <div {...props}>) are transformed into
+ * optimized attribute updates at compile time, avoiding runtime object spreads.
+ */
+
 import { BackgroundSnapshotInstance } from '../backgroundSnapshot.js';
+import { __pendingListUpdates, ListUpdateInfoRecording } from '../list.js';
+import { SnapshotInstance } from '../snapshot.js';
+import { isDirectOrDeepEqual, isEmptyObject, pick } from '../utils.js';
+import { updateEvent } from './event.js';
+import { updateGesture } from './gesture.js';
+import { platformInfoAttributes, updateListItemPlatformInfo } from './platformInfo.js';
 import { transformRef, updateRef } from './ref.js';
 import { updateWorkletEvent } from './workletEvent.js';
 import { updateWorkletRef } from './workletRef.js';
-import { updateGesture } from './gesture.js';
-import { platformInfoAttributes, updateListItemPlatformInfo } from './platformInfo.js';
-import { isDirectOrDeepEqual, isEmptyObject, pick } from '../utils.js';
-import { __pendingListUpdates, ListUpdateInfoRecording } from '../list.js';
 
 const eventRegExp = /^(([A-Za-z-]*):)?(bind|catch|capture-bind|capture-catch|global-bind)([A-Za-z]+)$/;
 const eventTypeMap: Record<string, string> = {
@@ -284,4 +292,4 @@ function transformSpread(
   return result;
 }
 
-export { updateSpread, transformSpread };
+export { transformSpread, updateSpread };

--- a/packages/react/runtime/types/types.d.ts
+++ b/packages/react/runtime/types/types.d.ts
@@ -182,6 +182,7 @@ declare global {
     dsl: string;
     stage: string;
   }
+
   declare let lynxCoreInject: any;
 
   interface ISystemInfo {


### PR DESCRIPTION
This diff does 3 things:
- add Reanimated, RSC and others into README
- try to help with https://github.com/lynx-family/lynx-stack/issues/726 whenever I see it
- add doc comments for files to clarify understandings for all