### PR TITLE
ci: use different keys for different projects

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -17,8 +17,10 @@ jobs:
         project:
           - path: ./examples/react
             name: example-react
+            key: RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY
           - path: ./packages/web-platform/web-explorer
             name: web-explorer
+            key: RELATIVE_CI_PROJECT_WEB_EXPLORER_KEY
     runs-on: lynx-ubuntu-24.04-medium
     name: Upload ${{ matrix.project.name }}
     steps:
@@ -26,5 +28,5 @@ jobs:
         uses: relative-ci/agent-action@38328454d6a23942175eba485fca4fbb807b1f03 #v2
         with:
           artifactName: ${{ matrix.project.name }}-relative-ci-artifacts
-          key: ${{ secrets.RELATIVE_CI_KEY }}
+          key: ${{ secrets[matrix.project.key] }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -4,7 +4,7 @@ on:
   # zizmor: ignore[dangerous-triggers] This is a dangerous trigger, but it's ok because we're not using it to trigger other workflows
   # See: https://relative-ci.com/documentation/setup/agent/github-action/#workflow_run-event
   workflow_run:
-    workflows: ["Bundle Analysis", "Deploy", "Test"]
+    workflows: ["Bundle Analysis"]
     types:
       - completed
 
@@ -23,10 +23,13 @@ jobs:
             key: RELATIVE_CI_PROJECT_WEB_EXPLORER_KEY
     runs-on: lynx-ubuntu-24.04-medium
     name: Upload ${{ matrix.project.name }}
+    env:
+      RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY: ${{ secrets.RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY }}
+      RELATIVE_CI_PROJECT_WEB_EXPLORER_KEY: ${{ secrets.RELATIVE_CI_PROJECT_WEB_EXPLORER_KEY }}
     steps:
       - name: Send bundle stats and build information to RelativeCI - ${{ matrix.project.name }}
         uses: relative-ci/agent-action@38328454d6a23942175eba485fca4fbb807b1f03 #v2
         with:
           artifactName: ${{ matrix.project.name }}-relative-ci-artifacts
-          key: ${{ secrets[matrix.project.key] }}
+          key: ${{ env[matrix.project.key] }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

We should use different key for different projects in a monorepo.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
