### PR TITLE
ci: add Rspeedy to RelativeCI

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -21,6 +21,9 @@ jobs:
           - path: ./packages/web-platform/web-explorer
             name: web-explorer
             key: RELATIVE_CI_PROJECT_WEB_EXPLORER_KEY
+          - path: ./packages/rspeedy/core
+            name: rspeedy
+            key: RELATIVE_CI_PROJECT_RSPEEDY_CORE_KEY
     runs-on: lynx-ubuntu-24.04-medium
     name: Upload ${{ matrix.project.name }}
     env:

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -18,6 +18,8 @@ jobs:
             name: example-react
           - path: ./packages/web-platform/web-explorer
             name: web-explorer
+          - path: ./packages/rspeedy/core
+            name: rspeedy
     name: Build ${{ matrix.project.name }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -42,6 +44,8 @@ jobs:
         run: |
           pnpm turbo build --summarize
       - name: Build ${{ matrix.project.name }}
+        env:
+          RSPEEDY_BUNDLE_ANALYSIS: 1
         run: |
           pnpm --filter ${{ matrix.project.path }} run build
       - uses: relative-ci/agent-upload-artifact-action@a2b5741b4f7e6a989c84ec1a3059696b23c152e5 #v2

--- a/packages/rspeedy/core/rslib.config.ts
+++ b/packages/rspeedy/core/rslib.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
       syntax: 'es2022',
       dts: { bundle: true },
       plugins: [pluginTypia()],
+      performance: {
+        profile: !!process.env.RSPEEDY_BUNDLE_ANALYSIS,
+      },
     },
     {
       format: 'esm',

--- a/packages/rspeedy/core/turbo.json
+++ b/packages/rspeedy/core/turbo.json
@@ -8,6 +8,9 @@
       "dependsOn": [
         "^build"
       ],
+      "env": [
+        "RSPEEDY_BUNDLE_ANALYSIS"
+      ],
       "inputs": [
         "register",
         "src",


### PR DESCRIPTION
## Summary

Add the Rspeedy to RelativeCI to monitor the bundle size change.

See https://app.relative-ci.com/projects/IlmtJm9v1Hh532Ir067b

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
