### PR TITLE
ci: add missing `RELATIVE_CI_PROJECT_RSPEEDY_CORE_KEY`

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY: ${{ secrets.RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY }}
       RELATIVE_CI_PROJECT_WEB_EXPLORER_KEY: ${{ secrets.RELATIVE_CI_PROJECT_WEB_EXPLORER_KEY }}
+      RELATIVE_CI_PROJECT_RSPEEDY_CORE_KEY: ${{ secrets.RELATIVE_CI_PROJECT_RSPEEDY_CORE_KEY }}
     steps:
       - name: Send bundle stats and build information to RelativeCI - ${{ matrix.project.name }}
         uses: relative-ci/agent-action@38328454d6a23942175eba485fca4fbb807b1f03 #v2


### PR DESCRIPTION
## Summary

A mistake in #760.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
