### PR TITLE
feat: volta pin node@22.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   "packageManager": "pnpm@10.10.0",
   "engines": {
     "node": ">=22"
+  },
+  "volta": {
+    "node": "22.14.0"
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

- With [Volta](https://volta.sh/), we can pin Node.js versions per project with atomic version management, eliminating the need for manual version switching.
- Volta can coexist with nvm (side by side). Pinning Node.js versions in `package.json` is just one way to use Volta.
  See: https://github.com/volta-cli/volta/issues/1176
- If you want to use Volta, after installation, ensure you're using the system Node.js version by running: `nvm alias default system`

Example usage in a repository with Volta-pinned Node.js version:
```shell
curl https://get.volta.sh | bash

volta pin node@22.14

node -v
# Output: v22.14.0
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
