### PR TITLE
chore(web-tests): use `is-ci` instead of shell

### DIFF
--- a/packages/web-platform/web-tests/package.json
+++ b/packages/web-platform/web-tests/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "bench": "vitest bench",
-    "build": "if [ \"$CI\" = \"1\" ]; then pnpm build:cases; fi",
-    "build:cases": "rm -rf dist && node  ./scripts/generate-build-command.js",
+    "build": "pnpm dlx is-ci && pnpm build:cases || echo 'Skipping build:cases in non-CI environment'",
+    "build:cases": "rm -rf dist && node ./scripts/generate-build-command.js",
     "coverage": "nyc report --cwd=$(realpath ../)",
     "coverage:ci": "nyc report --cwd=$(realpath ../) --reporter=lcov",
     "lh": "pnpm dlx @lhci/cli autorun",


### PR DESCRIPTION
## Summary

Fix [Rspack EcoSystem CI failure](https://github.com/web-infra-dev/rspack/actions/runs/14986731044/job/42102260301) (since `CI` could be something like `true` or `github`).

This would also make web-tests:build work on Windows.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
