### PR TITLE
feat: add new property `inject-style-rules` for LynxView

### DIFF
--- a/.changeset/gold-chefs-obey.md
+++ b/.changeset/gold-chefs-obey.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/web-core": patch
+---
+
+feat: add new property `inject-style-rules` for LynxView
+
+This property allows developer to inject some style rules into the shadowroot.
+
+It's a wrapper of https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/insertRule

--- a/packages/web-platform/web-constants/src/constants.ts
+++ b/packages/web-platform/web-constants/src/constants.ts
@@ -29,3 +29,13 @@ export const systemInfo = {
   platform: 'web',
   lynxSdkVersion: '3.0',
 } as Record<string, string | number>;
+
+export const inShadowRootStyles: string[] = [
+  ` [lynx-default-display-linear="false"] * {
+    --lynx-display: flex;
+    --lynx-display-toggle: var(--lynx-display-flex);
+  }`,
+  `[lynx-default-overflow-visible="true"] x-view{
+    overflow: visible;
+  }`,
+];

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -308,6 +308,8 @@ export class LynxView extends HTMLElement {
   set injectHeadLinks(val: boolean) {
     if (val) {
       this.setAttribute('inject-head-links', 'true');
+    } else {
+      this.removeAttribute('inject-head-links');
     }
   }
 

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -7,6 +7,7 @@ import {
   createLynxView,
 } from './createLynxView.js';
 import {
+  inShadowRootStyles,
   type Cloneable,
   type LynxTemplate,
   type NapiModulesCall,
@@ -15,7 +16,6 @@ import {
   type NativeModulesMap,
   type UpdateDataType,
 } from '@lynx-js/web-constants';
-import { inShadowRootStyles } from './inShadowRootStyles.js';
 
 export type INapiModulesCall = (
   name: string,
@@ -43,7 +43,8 @@ export type INapiModulesCall = (
  * @property {"auto" | null} width [optional] (attribute: "width") set it to "auto" for width auto-sizing
  * @property {NapiModulesMap} napiModulesMap [optional] the napiModule which is called in lynx-core. key is module-name, value is esm url.
  * @property {INapiModulesCall} onNapiModulesCall [optional] the NapiModule value handler.
- * @property {"false" | "true" | null} injectHeadLinks [optional] @default true set it to "false" to disable injecting the <link href="" ref="stylesheet"> styles into shadowroot
+ * @property {"false" | "true" | null} injectHeadLinks [optional] (attribute: "inject-head-links") @default true set it to "false" to disable injecting the <link href="" ref="stylesheet"> styles into shadowroot
+ * @property {string[]} injectStyleRules [optional] the css rules which will be injected into shadowroot. Each items will be inserted by `insertRule` method. @see https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/insertRule
  * @property {number} lynxGroupId [optional] (attribute: "lynx-group-id") the background shared context id, which is used to share webworker between different lynx cards
  * @property {"all-on-ui" | "multi-thread"} threadStrategy [optional] @default "multi-thread" (attribute: "thread-strategy") controls the thread strategy for current lynx view
  * @property {(string)=>Promise<LynxTemplate>} customTemplateLoader [optional] the custom template loader, which is used to load the template
@@ -301,6 +302,17 @@ export class LynxView extends HTMLElement {
     }
   }
 
+  get injectHeadLinks(): boolean {
+    return this.getAttribute('inject-head-links') !== 'false';
+  }
+  set injectHeadLinks(val: boolean) {
+    if (val) {
+      this.setAttribute('inject-head-links', 'true');
+    }
+  }
+
+  public injectStyleRules: string[] = [];
+
   /**
    * @private
    */
@@ -390,6 +402,9 @@ export class LynxView extends HTMLElement {
           this.shadowRoot!.append(styleElement);
           const styleSheet = styleElement.sheet!;
           for (const rule of inShadowRootStyles) {
+            styleSheet.insertRule(rule);
+          }
+          for (const rule of this.injectStyleRules) {
             styleSheet.insertRule(rule);
           }
           const injectHeadLinks =

--- a/packages/web-platform/web-core/src/apis/inShadowRootStyles.ts
+++ b/packages/web-platform/web-core/src/apis/inShadowRootStyles.ts
@@ -1,9 +1,0 @@
-export const inShadowRootStyles: string[] = [
-  ` [lynx-default-display-linear="false"] * {
-    --lynx-display: flex;
-    --lynx-display-toggle: var(--lynx-display-flex);
-  }`,
-  `[lynx-default-overflow-visible="true"] x-view{
-    overflow: visible;
-  }`,
-];

--- a/packages/web-platform/web-tests/shell-project/index.ts
+++ b/packages/web-platform/web-tests/shell-project/index.ts
@@ -40,6 +40,7 @@ if (casename) {
     if (casename2) {
       lynxView.setAttribute('lynx-group-id', '2');
     }
+    lynxView.injectStyleRules = [`.injected-style-rules{background:green}`];
     lynxView.onNativeModulesCall = (name, data, moduleName) => {
       if (name === 'getColor' && moduleName === 'CustomModule') {
         return data.color;

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -551,6 +551,15 @@ test.describe('reactlynx3 tests', () => {
       ); // green;
     });
 
+    test('api-inject-style-rules', async ({ page }, { title }) => {
+      await goto(page, title);
+      const target = page.locator('#target');
+      await expect(target).toHaveCSS(
+        'background-color',
+        'rgb(0, 128, 0)',
+      ); // green;
+    });
+
     test('api-updateData-callback', async ({ page }, { title }) => {
       let successCallback = false;
       await page.on('console', async (message) => {

--- a/packages/web-platform/web-tests/tests/react/api-inject-style-rules/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-inject-style-rules/index.jsx
@@ -4,18 +4,13 @@
 import { root, useEffect } from '@lynx-js/react';
 
 function App() {
-  useEffect(() => {
-    return () => {
-      console.log('fin');
-    };
-  }, []);
   return (
     <view
       id='target'
+      class='injected-style-rules'
       style={{
         height: '100px',
         width: '100px',
-        background: 'pink',
       }}
     />
   );


### PR DESCRIPTION
This property allows developer to inject some style rules into the shadowroot.

It's a wrapper of https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/insertRule
