### PR TITLE
feat: allow lynx code to get JS engine provided properties on globalThis

### DIFF
--- a/.changeset/busy-hounds-take.md
+++ b/.changeset/busy-hounds-take.md
@@ -1,0 +1,13 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/web-core": patch
+---
+
+feat: allow lynx code to get JS engine provided properties on globalThis
+
+```
+globalThis.Reflect; // this will be the Reflect Object
+```
+
+Note that `assigning to the globalThis` is still not allowed.

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
@@ -215,6 +215,9 @@ export class MainThreadRuntime {
       target[prop] = value;
       return true;
     },
+    ownKeys(target) {
+      return Reflect.ownKeys(target).filter((key) => key !== 'globalThis');
+    },
   });
 
   SystemInfo: typeof systemInfo;

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
@@ -205,9 +205,17 @@ export class MainThreadRuntime {
    */
   __lynxGlobalBindingValues: Record<string, any> = {};
 
-  get globalThis() {
-    return this;
-  }
+  globalThis = new Proxy(this, {
+    get: (target, prop) => {
+      // @ts-expect-error
+      return target[prop] ?? globalThis[prop];
+    },
+    set: (target, prop, value) => {
+      // @ts-expect-error
+      target[prop] = value;
+      return true;
+    },
+  });
 
   SystemInfo: typeof systemInfo;
 

--- a/packages/web-platform/web-mainthread-apis/src/loadMainThread.ts
+++ b/packages/web-platform/web-mainthread-apis/src/loadMainThread.ts
@@ -169,7 +169,7 @@ export function loadMainThread(
         publicComponentEvent,
         postExposure,
       },
-    }).globalThis;
+    });
     markTimingInternal('decode_end');
     entry!(runtime);
     jsContext.__start(); // start the jsContext after the runtime is created

--- a/packages/web-platform/web-tests/shell-project/mainthread-test.ts
+++ b/packages/web-platform/web-tests/shell-project/mainthread-test.ts
@@ -135,7 +135,7 @@ function initializeMainThreadTest() {
       },
       postExposure: () => {},
     },
-  });
+  }).globalThis;
   Object.assign(globalThis, runtime);
   Object.assign(globalThis, {
     genFiberElementTree,

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -387,6 +387,16 @@ test.describe('reactlynx3 tests', () => {
       await wait(100);
       await expect(page.locator('#target')).toHaveCSS('color', 'rgb(0, 0, 0)');
     });
+    test('basic-globalThis-property-bts', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      await expect(page.locator('#target')).toHaveCSS('color', 'rgb(0, 0, 0)');
+    });
+    test('basic-globalThis-property-mts', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      await expect(page.locator('#target')).toHaveCSS('color', 'rgb(0, 0, 0)');
+    });
   });
   test.describe('apis', () => {
     test('api-custom-template-loader', async ({ page }, { title }) => {

--- a/packages/web-platform/web-tests/tests/react/basic-globalThis-property-bts/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-globalThis-property-bts/index.jsx
@@ -1,0 +1,19 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+function App() {
+  return (
+    <view
+      id='target'
+      style={{
+        height: '100px',
+        width: '100px',
+        background: globalThis.Object ? 'green' : 'pink',
+      }}
+    />
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-globalThis-property-mts/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-globalThis-property-mts/index.jsx
@@ -1,0 +1,23 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useState, root, useEffect } from '@lynx-js/react';
+function App() {
+  const [color, setColor] = useState('pink');
+  useEffect(() => {
+    if (globalThis.Object) {
+      setColor('green');
+    }
+  }, []);
+  return (
+    <view
+      id='target'
+      style={{
+        height: '100px',
+        width: '100px',
+        background: color,
+      }}
+    />
+  );
+}
+root.render(<App />);

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -66,7 +66,17 @@ export async function createNativeApp(config: {
     return {
       init: (lynxCoreInject) => {
         lynxCoreInject.tt.lynxCoreInject = lynxCoreInject;
-        lynxCoreInject.tt.globalThis ??= lynxCoreInject;
+        lynxCoreInject.tt.globalThis ??= new Proxy(lynxCoreInject, {
+          get(target, prop) {
+            // @ts-expect-error
+            return target[prop] ?? globalThis[prop];
+          },
+          set(target, prop, value) {
+            // @ts-expect-error
+            target[prop] = value;
+            return true;
+          },
+        });
         Object.assign(lynxCoreInject.tt, {
           SystemInfo: { ...systemInfo, ...browserConfig },
         });

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -76,6 +76,11 @@ export async function createNativeApp(config: {
             target[prop] = value;
             return true;
           },
+          ownKeys(target) {
+            return Reflect.ownKeys(target).filter((key) =>
+              key !== 'globalThis'
+            );
+          },
         });
         Object.assign(lynxCoreInject.tt, {
           SystemInfo: { ...systemInfo, ...browserConfig },


### PR DESCRIPTION
```
globalThis.Reflect; // this will be the Reflect Object
```

Note that `assigning to the globalThis` is still not allowed.

fix #716 