### PR TITLE
feat(webpack/runtime-wrapper): support `requestAnimationFrame`

### DIFF
--- a/.changeset/sweet-tires-flash.md
+++ b/.changeset/sweet-tires-flash.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/runtime-wrapper-webpack-plugin": minor
+---
+
+Add parameter forwarding for Browser Object Model (BOM) APIs.
+
+This allows direct access to APIs like `fetch`, `requestAnimationFrame`.

--- a/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
@@ -60,6 +60,32 @@ const defaultInjectVars = [
   'LynxJSBI',
   'lynx',
   'window',
+
+  // BOM API
+  'document',
+  'frames',
+  'self',
+  'location',
+  'navigator',
+  'localStorage',
+  'history',
+  'Caches',
+  'screen',
+  'alert',
+  'confirm',
+  'prompt',
+  'fetch',
+  'XMLHttpRequest',
+  '__WebSocket__', // We would provide `WebSocket` using `ProvidePlugin`
+  'webkit',
+  'Reporter',
+  'print',
+  '__Function__', // We should allow using `Function`
+  'global',
+
+  // Lynx API
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
 ];
 
 /**
@@ -242,7 +268,9 @@ lynx.targetSdkVersion=lynx.targetSdkVersion||${
       JSON.stringify(targetSdkVersion)
     };
 ${overrideRuntimePromise ? `var Promise = lynx.Promise;` : ''}
-var fetch = lynx.fetch;
+fetch = fetch || lynx.fetch;
+requestAnimationFrame = requestAnimationFrame || lynx.requestAnimationFrame;
+cancelAnimationFrame = cancelAnimationFrame || lynx.cancelAnimationFrame;
 `
   );
 };

--- a/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
@@ -59,9 +59,9 @@ const defaultInjectVars = [
   'Behavior',
   'LynxJSBI',
   'lynx',
-  'window',
 
   // BOM API
+  'window',
   'document',
   'frames',
   'self',

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases.test.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases.test.js
@@ -48,6 +48,37 @@ describeCases({
             null,
             null,
             console,
+            undefined, // Component
+            undefined, // ReactLynx
+            undefined, // nativeAppId
+            undefined, // Behavior
+            undefined, // LynxJSBI
+            undefined, // lynx
+            undefined, // window
+            // BOM API
+            undefined, // document
+            undefined, // frames
+            undefined, // self
+            undefined, // location
+            undefined, // navigator
+            undefined, // localStorage
+            undefined, // history
+            undefined, // Caches
+            undefined, // screen
+            undefined, // alert
+            undefined, // confirm
+            undefined, // prompt
+            undefined, // fetch
+            undefined, // XMLHttpRequest
+            undefined, // WebSocket
+            undefined, // webkit
+            undefined, // Reporter
+            undefined, // print
+            undefined, // Function
+            undefined, // global
+            // Lynx API
+            vi.fn(), // requestAnimationFrame
+            vi.fn(), // cancelAnimationFrame
           );
         },
       },

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/request-animation-frame/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/request-animation-frame/index.js
@@ -1,0 +1,11 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+expect(requestAnimationFrame).toStrictEqual(expect.any(Function));
+expect(cancelAnimationFrame).toStrictEqual(expect.any(Function));
+expect(requestAnimationFrame).not.toBe(lynx.requestAnimationFrame);
+expect(cancelAnimationFrame).not.toBe(lynx.cancelAnimationFrame);
+expect(requestAnimationFrame).not.toBe(globalThis.requestAnimationFrame);
+expect(cancelAnimationFrame).not.toBe(globalThis.cancelAnimationFrame);

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/request-animation-frame/rspack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/request-animation-frame/rspack.config.js
@@ -1,0 +1,8 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import config from './webpack.config.js';
+
+export default config;

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/request-animation-frame/webpack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/request-animation-frame/webpack.config.js
@@ -1,0 +1,13 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { RuntimeWrapperWebpackPlugin } from '../../../../src';
+
+/** @type {import('webpack').Configuration} */
+export default {
+  plugins: [
+    new RuntimeWrapperWebpackPlugin(),
+  ],
+};

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/websocket/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/websocket/index.js
@@ -1,0 +1,7 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+expect(WebSocket).toBe(globalThis.WebSocket);

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/websocket/rspack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/websocket/rspack.config.js
@@ -1,0 +1,8 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import config from './webpack.config.js';
+
+export default config;

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/websocket/webpack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/websocket/webpack.config.js
@@ -1,0 +1,13 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { RuntimeWrapperWebpackPlugin } from '../../../../src';
+
+/** @type {import('webpack').Configuration} */
+export default {
+  plugins: [
+    new RuntimeWrapperWebpackPlugin(),
+  ],
+};


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Allow direct access to `requestAnimationFrame` and `cancelAnimationFrame` in background thread script.

close: #181 since `fetch` is now a parameter of the runtime wrapper.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
