### PR TITLE
ci: upload test results in merge queue to main context

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -50,7 +50,7 @@ jobs:
   # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
   build-all:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-build-${{ github.ref }}
       cancel-in-progress: true
     uses: ./.github/workflows/workflow-build.yml
     if: github.repository == 'lynx-family/lynx-stack'
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'lynx-family/lynx-stack'
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-publish-${{ github.ref }}
       cancel-in-progress: false
     environment: main branch
     permissions:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ inputs.codecov-flags }}
-          override_branch: ${{ github.event_name == 'merge_queue' && 'main' || '' }}
+          override_branch: ${{ github.event_name == 'merge_group' && 'main' || '' }}
       - name: Upload Test Result
         if: ${{ inputs.is-web && failure() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix a regression of #646. The event name should be `merge_group` instead of `merge_queue`. See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group.

Also fix an issue that `publish` and `build-all` share the same `concurrency.group`.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
