### PR TITLE
fix(webpack-dev-transport): apply the new `LynxDevToolSetModule`

### DIFF
--- a/.changeset/common-games-hope.md
+++ b/.changeset/common-games-hope.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/webpack-dev-transport": patch
+---
+
+Fix live-reload not working on Lynx 3.3

--- a/packages/webpack/webpack-dev-transport/test/client/reloadApp.test.ts
+++ b/packages/webpack/webpack-dev-transport/test/client/reloadApp.test.ts
@@ -115,6 +115,22 @@ describe('reloadApp', () => {
       expect(LynxDevToolSetModule.invokeCdp).not.toBeCalled();
     });
 
+    it('should not throw when no modules are present', () => {
+      vi.useFakeTimers();
+
+      vi.stubGlobal('NativeModules', {});
+
+      reloadApp({ liveReload: true, hot: false, progress: false }, status);
+
+      expect(LynxDevToolSetModule.invokeCdp).not.toBeCalled();
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+
+      vi.runAllTimers();
+
+      expect(LynxDevToolSetModule.invokeCdp).not.toBeCalled();
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+    });
+
     it('should call new method when both modules are present', () => {
       vi.useFakeTimers();
 

--- a/packages/webpack/webpack-dev-transport/test/client/reloadApp.test.ts
+++ b/packages/webpack/webpack-dev-transport/test/client/reloadApp.test.ts
@@ -1,0 +1,146 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import reloadApp from '../../client/reloadApp.js';
+
+describe('reloadApp', () => {
+  describe('liveReload', () => {
+    // New NativeModule that introduced in 3.2
+    const LynxDevToolSetModule = {
+      invokeCdp: vi.fn(),
+    };
+
+    const EmptyModule = {};
+
+    // Old NativeModule
+    const LynxDevtoolSetModule = {
+      invokeCdp: vi.fn(),
+    };
+
+    const status = {
+      currentHash: '123',
+      previousHash: '456',
+      isReconnecting: false,
+    };
+
+    beforeEach(() => {
+      vi.unstubAllGlobals();
+      LynxDevToolSetModule.invokeCdp.mockClear();
+      LynxDevtoolSetModule.invokeCdp.mockClear();
+    });
+
+    it('should live reload on legacy Lynx', () => {
+      vi.useFakeTimers();
+
+      vi.stubGlobal('NativeModules', {
+        LynxDevtoolSetModule,
+      });
+
+      reloadApp({ liveReload: true, hot: false, progress: false }, status);
+
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+
+      vi.runAllTimers();
+
+      expect(LynxDevtoolSetModule.invokeCdp).toHaveBeenCalledWith(
+        'Page.reload',
+        JSON.stringify({
+          method: 'Page.reload',
+          params: {
+            ignoreCache: true,
+          },
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('should live reload on Lynx >= 3.3', () => {
+      vi.useFakeTimers();
+
+      vi.stubGlobal('NativeModules', {
+        LynxDevToolSetModule,
+      });
+
+      reloadApp({ liveReload: true, hot: false, progress: false }, status);
+
+      expect(LynxDevToolSetModule.invokeCdp).not.toBeCalled();
+
+      vi.runAllTimers();
+
+      expect(LynxDevToolSetModule.invokeCdp).toHaveBeenCalledWith(
+        JSON.stringify({
+          method: 'Page.reload',
+          params: {
+            ignoreCache: true,
+          },
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('should not throw on Lynx 3.2', () => {
+      vi.useFakeTimers();
+
+      vi.stubGlobal('NativeModules', {
+        LynxDevToolSetModule: EmptyModule,
+      });
+
+      reloadApp({ liveReload: true, hot: false, progress: false }, status);
+
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+
+      vi.runAllTimers();
+
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+    });
+
+    it('should not throw on both modules are empty', () => {
+      vi.useFakeTimers();
+
+      vi.stubGlobal('NativeModules', {
+        LynxDevToolSetModule: EmptyModule,
+        LynxDevtoolSetModule: EmptyModule,
+      });
+
+      reloadApp({ liveReload: true, hot: false, progress: false }, status);
+
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+      expect(LynxDevToolSetModule.invokeCdp).not.toBeCalled();
+
+      vi.runAllTimers();
+
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+      expect(LynxDevToolSetModule.invokeCdp).not.toBeCalled();
+    });
+
+    it('should call new method when both modules are present', () => {
+      vi.useFakeTimers();
+
+      vi.stubGlobal('NativeModules', {
+        LynxDevToolSetModule,
+        LynxDevtoolSetModule,
+      });
+
+      reloadApp({ liveReload: true, hot: false, progress: false }, status);
+
+      expect(LynxDevToolSetModule.invokeCdp).not.toBeCalled();
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+
+      vi.runAllTimers();
+
+      expect(LynxDevToolSetModule.invokeCdp).toHaveBeenCalledWith(
+        JSON.stringify({
+          method: 'Page.reload',
+          params: {
+            ignoreCache: true,
+          },
+        }),
+        expect.any(Function),
+      );
+
+      expect(LynxDevtoolSetModule.invokeCdp).not.toBeCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Adopt the new `LynxDevToolSetModule.invokeCdp` method introduced in Lynx 3.3.

See: https://github.com/lynx-family/lynx/commit/d278c8fa1bc5d24dfe25e6a23c2cdf8a31669ef0

This would make `dev.liveReload` work.

fix: #657 
fix: https://github.com/lynx-family/lynx/issues/698

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
