### PR TITLE
fix(webpack/template): delete inlined assets in `processAssets`

### DIFF
--- a/.changeset/five-boats-fix.md
+++ b/.changeset/five-boats-fix.md
@@ -1,0 +1,10 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/web-webpack-plugin": patch
+---
+
+Be compatible with rspack-manifest-plugin.
+
+Now only the `[name].lynx.bundle` and `[name].web.bundle` would exist in `manifest.json`.
+
+See [lynx-family/lynx-stack#763](https://github.com/lynx-family/lynx-stack/issues/763) for details.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix: #763

We move the deleting from `compiler.hooks.emit` to `compilation.hooks.processAssets` to avoid having inlined JS chunks in manifest generated by `rspack-manifest-plugin`.

Here is the new timeline:

- `processAssets`
  - stage `PROCESS_ASSETS_STAGE_OPTIMIZE_HASH`: generate `.lynx.bundle`
  - stage `PROCESS_ASSETS_STAGE_REPORT`: upload source-map or assets map (see: https://github.com/lynx-family/lynx-stack/issues/179)
  - stage `PROCESS_ASSETS_STAGE_REPORT` + 1: delete inlined assets (`main-thread.js`, `background.[hash].js`)
  - stage `Inifity`: generating manifest (see: #763)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
