### PR TITLE
refactor(react/runtime): rename _id to _wvid in MainThreadRef

### DIFF
--- a/packages/react/runtime/__test__/snapshot/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/workletRef.test.jsx
@@ -223,7 +223,7 @@ describe('WorkletRef', () => {
           [
             "rLynxChange",
             {
-              "data": "{"patchList":[{"id":5,"workletRefInitValuePatch":[[5,null],[6,null],[7,null],[8,null],[9,null],[10,null]]}]}",
+              "data": "{"patchList":[{"id":5,"workletRefInitValuePatch":[[1,null],[2,null],[3,null],[4,null],[5,null],[6,null]]}]}",
               "patchOptions": {
                 "reloadVersion": 0,
               },
@@ -233,7 +233,7 @@ describe('WorkletRef', () => {
           [
             "rLynxChange",
             {
-              "data": "{"patchList":[{"snapshotPatch":[3,-2,0,{"_wvid":5},3,-3,0,{"_wkltId":233,"_execId":2},3,-4,0,{"_wkltId":233,"_execId":3}],"id":6}]}",
+              "data": "{"patchList":[{"snapshotPatch":[3,-2,0,{"_wvid":1},3,-3,0,{"_wkltId":233,"_execId":2},3,-4,0,{"_wkltId":233,"_execId":3}],"id":6}]}",
               "patchOptions": {
                 "isHydration": true,
                 "pipelineOptions": {
@@ -264,7 +264,7 @@ describe('WorkletRef', () => {
         [
           [
             {
-              "_wvid": 5,
+              "_wvid": 1,
             },
             <view
               has-react-ref={true}
@@ -317,7 +317,7 @@ describe('WorkletRef', () => {
           [
             "rLynxChange",
             {
-              "data": "{"patchList":[{"id":7,"snapshotPatch":[3,-2,0,{"_wvid":6},3,-3,0,{"_wvid":7},3,-4,0,{"_wkltId":233,"_execId":4}]}]}",
+              "data": "{"patchList":[{"id":7,"snapshotPatch":[3,-2,0,{"_wvid":2},3,-3,0,{"_wvid":3},3,-4,0,{"_wkltId":233,"_execId":4}]}]}",
               "patchOptions": {
                 "reloadVersion": 0,
               },
@@ -336,13 +336,13 @@ describe('WorkletRef', () => {
         [
           [
             {
-              "_wvid": 5,
+              "_wvid": 1,
             },
             null,
           ],
           [
             {
-              "_wvid": 6,
+              "_wvid": 2,
             },
             <view
               has-react-ref={true}
@@ -350,7 +350,7 @@ describe('WorkletRef', () => {
           ],
           [
             {
-              "_wvid": 7,
+              "_wvid": 3,
             },
             <view
               has-react-ref={true}
@@ -448,7 +448,7 @@ describe('WorkletRef', () => {
         [
           [
             {
-              "_wvid": 11,
+              "_wvid": 1,
             },
             <view
               has-react-ref={true}
@@ -496,7 +496,7 @@ describe('WorkletRef', () => {
         [
           [
             {
-              "_wvid": 11,
+              "_wvid": 1,
             },
             null,
           ],
@@ -719,7 +719,7 @@ describe('WorkletRef in spread', () => {
         [
           [
             {
-              "_wvid": 15,
+              "_wvid": 1,
             },
             <view
               has-react-ref={true}
@@ -744,7 +744,7 @@ describe('WorkletRef in spread', () => {
         [
           [
             {
-              "_wvid": 15,
+              "_wvid": 1,
             },
             null,
           ],

--- a/packages/react/runtime/__test__/utils/envManager.ts
+++ b/packages/react/runtime/__test__/utils/envManager.ts
@@ -10,6 +10,7 @@ import { backgroundSnapshotInstanceManager, SnapshotInstance, snapshotInstanceMa
 import { deinitGlobalSnapshotPatch } from '../../src/lifecycle/patch/snapshotPatch.js';
 import { globalPipelineOptions, setPipeline } from '../../src/lynx/performance.js';
 import { clearListGlobal } from '../../src/list.js';
+import { clearWorkletRefLastIdForTesting } from '../../src/worklet/workletRef.js';
 
 export class EnvManager {
   root: typeof __root | undefined;
@@ -72,6 +73,7 @@ export class EnvManager {
     snapshotInstanceManager.nextId = 0;
     clearListGlobal();
     deinitGlobalSnapshotPatch();
+    clearWorkletRefLastIdForTesting();
     this.switchToBackground();
     this.switchToMainThread();
   }

--- a/packages/react/runtime/__test__/worklet/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/worklet/workletRef.test.jsx
@@ -54,7 +54,7 @@ describe('WorkletRef in js', () => {
   it('to json', () => {
     globalEnvManager.switchToBackground();
     const ref = new MainThreadRef(1);
-    expect(JSON.stringify(ref)).toMatchInlineSnapshot(`"{"_wvid":2}"`);
+    expect(JSON.stringify(ref)).toMatchInlineSnapshot(`"{"_wvid":1}"`);
   });
 
   it('should send init value to the main thread', () => {
@@ -88,7 +88,7 @@ describe('WorkletRef in js', () => {
           [
             "rLynxChange",
             {
-              "data": "{"patchList":[{"id":1,"workletRefInitValuePatch":[[3,233]]}]}",
+              "data": "{"patchList":[{"id":1,"workletRefInitValuePatch":[[1,233]]}]}",
               "patchOptions": {
                 "reloadVersion": 0,
               },

--- a/packages/react/runtime/src/worklet/workletRef.ts
+++ b/packages/react/runtime/src/worklet/workletRef.ts
@@ -11,6 +11,10 @@ import { useMemo } from '../hooks/react.js';
 
 let lastId = 0;
 
+export function clearWorkletRefLastIdForTesting(): void {
+  lastId = 0;
+}
+
 abstract class WorkletRef<T> {
   /**
    * @internal


### PR DESCRIPTION
## Summary

To support using MainThreadRef directly on the first screen, it is necessary to add sufficient fields for those created in the main thread.

1. Ensure the fields have the same names as in the toJSON() function.
2. Add an _initValue field.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
