### PR TITLE
ci: set default minimum permissions

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -79,6 +79,8 @@ jobs:
     if: github.repository == 'lynx-family/lynx-stack'
     permissions:
       checks: write
+      contents: read
+      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -10,7 +10,6 @@ on:
 # Set default minimum permissions to prevent unnecessary access
 permissions: {}
 
-
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
@@ -78,7 +77,8 @@ jobs:
     needs: build-all
     uses: ./.github/workflows/workflow-test.yml
     if: github.repository == 'lynx-family/lynx-stack'
-    permissions: {}
+    permissions:
+      checks: write
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -7,6 +7,10 @@ on:
       "release/*",
     ]
 
+# Set default minimum permissions to prevent unnecessary access
+permissions: {}
+
+
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
@@ -18,6 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.repository == 'lynx-family/lynx-stack'
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -55,11 +62,13 @@ jobs:
       cancel-in-progress: true
     uses: ./.github/workflows/workflow-build.yml
     if: github.repository == 'lynx-family/lynx-stack'
+    permissions: {}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   benchmark:
     needs: build-all
     uses: ./.github/workflows/workflow-bench.yml
+    permissions: {}
   bundle-analysis:
     permissions: {}
     needs: build-all
@@ -69,6 +78,7 @@ jobs:
     needs: build-all
     uses: ./.github/workflows/workflow-test.yml
     if: github.repository == 'lynx-family/lynx-stack'
+    permissions: {}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -125,7 +135,7 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date -u +'%Y-%m-%d %H:%M:%S')"
       - name: attempt to release
-        uses: changesets/action@v1
+        uses: changesets/action@e0538e686673de0265c8a3e2904b8c76beaa43fd # v1.5.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -184,6 +194,7 @@ jobs:
     needs: build-all
     if: github.repository == 'lynx-family/lynx-stack'
     uses: ./.github/workflows/workflow-website.yml
+    permissions: {}
   website-deploy:
     needs: website-build
     if: github.repository == 'lynx-family/lynx-stack'
@@ -192,6 +203,7 @@ jobs:
     permissions:
       pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
+      contents: read
 
     # Deploy to the github-pages environment
     environment:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -77,10 +77,6 @@ jobs:
     needs: build-all
     uses: ./.github/workflows/workflow-test.yml
     if: github.repository == 'lynx-family/lynx-stack'
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/nodejs-dependencies.yml
+++ b/.github/workflows/nodejs-dependencies.yml
@@ -7,6 +7,10 @@ name: NodeJS Dependencies
       - package.json
       - pnpm-lock.yaml
       - "**/package.json"
+
+# Set minimum permissions to prevent unnecessary access
+permissions: {}
+
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
@@ -16,6 +20,8 @@ concurrency:
 jobs:
   sherif:
     runs-on: lynx-ubuntu-24.04-medium
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,10 @@ on:
       CODECOV_TOKEN:
         required: true
 
+# Set minimum permissions to prevent unnecessary access
+permissions: {}
+
+
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
@@ -18,6 +22,8 @@ concurrency:
 jobs:
   test:
     runs-on: lynx-ubuntu-24.04-xlarge
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -46,6 +52,8 @@ jobs:
 
   rustfmt:
     runs-on: lynx-ubuntu-24.04-medium
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,6 @@ on:
 # Set minimum permissions to prevent unnecessary access
 permissions: {}
 
-
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,9 +3,15 @@ on:
   schedule:
     - cron: "30 17 * * *"
 
+# Set minimum permissions to prevent unnecessary access
+permissions: {}
+
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # Need write permission to mark and close stale issues
+      pull-requests: write # Need write permission to mark and close stale PRs
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         if: github.repository == 'lynx-family/lynx-stack'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ permissions:
   repository-projects: read
   contents: read
   statuses: read
+
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
@@ -58,6 +59,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
     permissions:
+      checks: write
       contents: read
       pull-requests: read
       statuses: write
@@ -73,6 +75,8 @@ jobs:
   playwright-linux:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
+    permissions:
+      checks: write
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -87,6 +91,8 @@ jobs:
   playwright-linux-all-on-ui:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
+    permissions:
+      checks: write
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -102,6 +108,8 @@ jobs:
   test-api:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
+    permissions:
+      checks: write
     with:
       runs-on: lynx-ubuntu-24.04-medium
       run: |
@@ -127,6 +135,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
     permissions:
+      checks: write
       contents: read
       pull-requests: read
       statuses: read
@@ -156,6 +165,8 @@ jobs:
   test-react:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
+    permissions:
+      checks: write
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -184,6 +195,8 @@ jobs:
   test-type:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
+    permissions:
+      checks: write
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -192,6 +205,8 @@ jobs:
   test-vitest:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
+    permissions:
+      checks: write
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,6 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
     permissions:
-      checks: write
-      contents: read
-      pull-requests: read
       statuses: write
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -75,10 +72,7 @@ jobs:
   playwright-linux:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: read
+
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -93,10 +87,7 @@ jobs:
   playwright-linux-all-on-ui:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: read
+
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -112,10 +103,7 @@ jobs:
   test-api:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: read
+
     with:
       runs-on: lynx-ubuntu-24.04-medium
       run: |
@@ -140,11 +128,6 @@ jobs:
   test-publish:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: read
-      statuses: read
     with:
       runs-on: lynx-ubuntu-24.04-medium
       run: |
@@ -171,10 +154,6 @@ jobs:
   test-react:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -203,10 +182,6 @@ jobs:
   test-type:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -215,10 +190,6 @@ jobs:
   test-vitest:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,8 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions:
       checks: write
+      contents: read
+      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -93,6 +95,8 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions:
       checks: write
+      contents: read
+      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -110,6 +114,8 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions:
       checks: write
+      contents: read
+      pull-requests: read
     with:
       runs-on: lynx-ubuntu-24.04-medium
       run: |
@@ -167,6 +173,8 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions:
       checks: write
+      contents: read
+      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -197,6 +205,8 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions:
       checks: write
+      contents: read
+      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -207,6 +217,8 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions:
       checks: write
+      contents: read
+      pull-requests: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -12,6 +12,7 @@ on:
       run:
         required: true
         type: string
+        description: "Command run parameters, limited to predefined test commands"
       is-web:
         required: false
         type: boolean
@@ -21,12 +22,19 @@ on:
         type: string
         default: "unittest"
 
+# Set minimum permissions to prevent unnecessary access
+permissions: {}
+
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   check:
     runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+      checks: write  # For test result reports
+      pull-requests: read  # For PR related information
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -63,7 +71,15 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-        run: ${{ inputs.run }}
+        # Run commands in a secure way to avoid code injection
+        run: |
+          # Validate if the input command matches the expected format
+          if [[ "${{ inputs.run }}" =~ ^pnpm\ run\ test.*$ ]]; then
+            ${{ inputs.run }}
+          else
+            echo "Error: Disallowed command format. Only commands starting with 'pnpm run test' are allowed."
+            exit 1
+          fi
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
         with:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -71,15 +71,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-        # Run commands in a secure way to avoid code injection
-        run: |
-          # Validate if the input command matches the expected format
-          if [[ "${{ inputs.run }}" =~ ^pnpm\ run\ test.*$ ]]; then
-            ${{ inputs.run }}
-          else
-            echo "Error: Disallowed command format. Only commands starting with 'pnpm run test' are allowed."
-            exit 1
-          fi
+        run: ${{ inputs.run }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
         with:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: read
-      checks: write  # For test result reports
-      pull-requests: read  # For PR related information
+      checks: write # For test result reports
+      pull-requests: read # For PR related information
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -31,10 +31,7 @@ env:
 jobs:
   check:
     runs-on: ${{ inputs.runs-on }}
-    permissions:
-      contents: read
-      checks: write # For test result reports
-      pull-requests: read # For PR related information
+    permissions: {}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Set `permissions: {}` for all workflows. And set required permissions for each job.

Fix: https://github.com/lynx-family/lynx-stack/security/code-scanning/124

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

See https://docs.zizmor.sh/audits/#excessive-permissions for more details.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
