### PR TITLE
ci: disable bundle-analysis in merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,6 @@ jobs:
     uses: ./.github/workflows/workflow-website.yml
   done:
     needs:
-      - bundle-analysis
       - code-style-check
       - playwright-linux
       - playwright-linux-all-on-ui

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -21,6 +21,7 @@ jobs:
           - path: ./packages/rspeedy/core
             name: rspeedy
     name: Build ${{ matrix.project.name }}
+    if: github.event_name != 'merge_group'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Since we are not requiring RelativeCI, we can remove it from merge queue to same some job runs.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
