### PR TITLE
WIP: add prefetchWorker of web-platform-rsbuild-plugin

### DIFF
--- a/packages/web-platform/web-explorer/index.html
+++ b/packages/web-platform/web-explorer/index.html
@@ -6,11 +6,9 @@
     <meta name="theme-color" content="#000000">
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/png" href="icons/icon-128x128.png">
-    <link rel="stylesheet" href="dist/static/css/index.css">
     <title>Lynx Explorer on Web Platform</title>
     <script type="module" src="https://unpkg.com/qr-scanner@1.4.2"></script>
-    <script type="module" src="preinstalled/vant-touch.js"></script>
-    <script type="module" src="./dist/static/js/index.js"></script>
+    <script type="module" src="../preinstalled/vant-touch.js"></script>
     <style>
     #install-button {
       position: fixed;

--- a/packages/web-platform/web-explorer/index.ts
+++ b/packages/web-platform/web-explorer/index.ts
@@ -9,7 +9,7 @@ let lynxView = document.getElementById('lynx-view') as LynxView;
 const backButton = document.getElementById('back-button') as HTMLDivElement;
 const nav = document.getElementById('nav') as HTMLDivElement;
 
-const homepage = 'preinstalled/homepage.json';
+const homepage = '../preinstalled/homepage.json';
 
 backButton.addEventListener('click', () => {
   setLynxViewUrl(homepage);

--- a/packages/web-platform/web-explorer/rsbuild.config.ts
+++ b/packages/web-platform/web-explorer/rsbuild.config.ts
@@ -23,9 +23,10 @@ export default defineConfig({
     hmr: false,
     liveReload: false,
   },
-  html: {},
+  html: {
+    template: path.resolve(__dirname, './index.html'),
+  },
   tools: {
-    htmlPlugin: false,
     rspack: {
       output: {
         publicPath: 'auto',
@@ -50,6 +51,7 @@ export default defineConfig({
     pluginWebPlatform({
       polyfill: false,
       nativeModulesPath: path.resolve(__dirname, './index.native-modules.ts'),
+      prefetchWorker: true,
     }),
   ],
 });

--- a/packages/web-platform/web-rsbuild-plugin/package.json
+++ b/packages/web-platform/web-rsbuild-plugin/package.json
@@ -33,9 +33,9 @@
     "@lynx-js/web-elements": "workspace:*",
     "@rsbuild/core": "catalog:rsbuild",
     "@types/loader-utils": "^2.0.6",
-    "@types/webpack": "^5.28.5",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.3",
+    "webpack-merge": "^6.0.1"
   },
   "peerDependencies": {
     "@lynx-js/web-core": ">0.13.0",

--- a/packages/web-platform/web-rsbuild-plugin/src/plugins/prefetch-worker.ts
+++ b/packages/web-platform/web-rsbuild-plugin/src/plugins/prefetch-worker.ts
@@ -1,0 +1,129 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { HtmlRspackPlugin } from '@rsbuild/core';
+import path from 'path';
+import type { Compiler, Compilation } from '@rspack/core';
+
+export class PrefetchWorkerPlugin {
+  resourceHints: HtmlRspackPlugin.HtmlTagObject[] = [];
+  chunkIds: Set<string> = new Set();
+
+  HtmlPlugin: HtmlRspackPlugin;
+
+  constructor(
+    options: { HtmlPlugin: HtmlRspackPlugin },
+  ) {
+    this.HtmlPlugin = options.HtmlPlugin;
+  }
+
+  apply(compiler: Compiler) {
+    if (
+      compiler.options.mode !== 'production'
+      || typeof compiler.options.output?.publicPath === 'function'
+    ) {
+      console.warn(
+        'PrefetchWorkerPlugin only works in production mode and when publicPath is a string',
+      );
+      return;
+    }
+
+    compiler.hooks.compilation.tap(
+      'PrefetchWorkerPlugin',
+      (compilation: Compilation) => {
+        if (!this.HtmlPlugin) {
+          console.warn('HtmlWebpackPlugin not found');
+          return;
+        }
+
+        const htmlPluginHooks = (this.HtmlPlugin as any).getCompilationHooks(
+          compilation,
+        );
+        htmlPluginHooks.alterAssetTags.tap(
+          'PrefetchWorkerPlugin',
+          (data: any) => {
+            this.chunkIds.values().forEach(id => {
+              // [name] is replaced with [id] in chunkFilename(detail: https://rspack.dev/config/output#outputchunkfilename)
+              const outputRelativePath = compilation.getPath(
+                (compilation.options.output.chunkFilename as string)!.replace(
+                  /\[name\]/g,
+                  '[id]',
+                ),
+                {
+                  chunk: Array.from(compilation.chunks).find(i => i.id === id),
+                },
+              );
+              const finalPath = path.join(
+                (compilation.options.output.publicPath as string) === 'auto'
+                  ? ''
+                  : (compilation.options.output.publicPath as string),
+                outputRelativePath,
+              );
+              data.assetTags.scripts = [
+                {
+                  tagName: 'link',
+                  voidTag: true,
+                  attributes: {
+                    rel: 'prefetch',
+                    href: finalPath,
+                  },
+                },
+                ...data.assetTags.scripts,
+              ];
+            });
+            return data;
+          },
+        );
+
+        compilation.hooks.processAssets.tapAsync(
+          'PrefetchWorkerPlugin',
+          (_, callback) => {
+            // Since webpack will not add chunks by new URL() to chunkGraph, the target worker-chunk needs to be filtered out
+            // 1. Not referenced by other chunks
+            const chunkIds = new Set<string>(
+              Array.from(compilation.chunks).filter(Boolean).map(i =>
+                String(i.id)
+              ),
+            );
+            for (const chunk of compilation.chunks) {
+              if (
+                chunk.isOnlyInitial()
+                || chunk.canBeInitial()
+              ) {
+                chunkIds.delete(String(chunk.id));
+              }
+
+              const chunkMaps = chunk.getChunkMaps(true);
+              const importedChunk = Object.keys(chunkMaps.hash);
+              importedChunk.forEach(i => {
+                chunkIds.delete(i);
+              });
+            }
+
+            // 2. Containing the worker-runtime key module
+            for (const chunk of compilation.chunks) {
+              if (chunkIds.has(String(chunk.id))) {
+                const matchedWorkerResource = compilation.chunkGraph
+                  .getChunkModules(chunk).some(
+                    module =>
+                      /mainThread[/\\]startMainThread\.js$/.test(
+                        (module as unknown as { userRequest: string })
+                          .userRequest,
+                      ),
+                  );
+
+                if (!matchedWorkerResource) {
+                  chunkIds.delete(String(chunk.id));
+                }
+              }
+            }
+
+            Array.from(chunkIds).forEach(i => this.chunkIds.add(i));
+            callback();
+          },
+        );
+      },
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,6 +763,9 @@ importers:
       vitest:
         specifier: ^3.1.3
         version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(@vitest/ui@3.1.3)(jsdom@26.1.0)(sass-embedded@1.86.0)(terser@5.31.6)
+      webpack-merge:
+        specifier: ^6.0.1
+        version: 6.0.1
 
   packages/web-platform/web-style-transformer: {}
 


### PR DESCRIPTION
## Summary

add `prefetchWorker` configuration of web-platform-rsbuild-plugin.

When enable it, a prefetch link of the worker-async-chunk will be inserted into the generated HTML.

Before:

- Performance: ![image](https://github.com/user-attachments/assets/1c9df30d-dfa2-4d91-9210-977bea4f8e41)

- NetWork: ![image](https://github.com/user-attachments/assets/23cb5556-57aa-444a-a011-126a3a21b93f)


After:

- Performance: ![image](https://github.com/user-attachments/assets/980e1ede-6807-4346-91e0-232c99794353)

- NetWork: ![image](https://github.com/user-attachments/assets/7570dd6e-7a53-41f4-817f-74e9b03c87fb)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
