### PR TITLE
fix: worker not released when backgroundWorkerContextCount != 1

### DIFF
--- a/.changeset/good-falcons-sort.md
+++ b/.changeset/good-falcons-sort.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: worker not released when backgroundWorkerContextCount != 1

--- a/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
+++ b/packages/web-platform/web-core/src/uiThread/bootWorkers.ts
@@ -52,6 +52,11 @@ export function bootWorkers(
         curBackgroundWorker.backgroundThreadWorker.terminate();
         backgroundWorkerContextCount[lynxGroupId] = 0;
         contextIdToBackgroundWorker[lynxGroupId] = undefined;
+      } else if (
+        typeof backgroundWorkerContextCount[lynxGroupId] === 'number'
+        && backgroundWorkerContextCount[lynxGroupId] > 1
+      ) {
+        backgroundWorkerContextCount[lynxGroupId]--;
       }
     },
   };

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -691,6 +691,22 @@ test.describe('reactlynx3 tests', () => {
       expect(page.workers().length).toBeLessThanOrEqual(4);
     });
 
+    test('api-shared-context-worker-count-release', async ({ page }) => {
+      await goto(page, 'api-setSharedData', 'api-getSharedData');
+      await wait(100);
+      expect(page.workers().length).toBeLessThanOrEqual(4);
+      await page.evaluate(() =>
+        document.body.querySelector('lynx-view')?.remove()
+      );
+      await wait(100);
+      expect(page.workers().length).toBeLessThanOrEqual(3);
+      await page.evaluate(() =>
+        document.body.querySelector('lynx-view')?.remove()
+      );
+      await wait(100);
+      expect(page.workers().length).toBeLessThanOrEqual(1);
+    });
+
     test.describe('api-exposure', () => {
       const module = 'exposure';
       test(


### PR DESCRIPTION
## Summary

fix: worker not released when backgroundWorkerContextCount != 1

#821 

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
