### PR TITLE
fix(react/types): export `JSX.ElementType`

### DIFF
--- a/.changeset/chubby-icons-cross.md
+++ b/.changeset/chubby-icons-cross.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix type error when using `Suspense` with `"jsx": "react-jsx"`.

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "rspeedy build",
-    "dev": "rspeedy dev"
+    "dev": "rspeedy dev",
+    "test:type": "vitest --typecheck.only"
   },
   "dependencies": {
     "@lynx-js/react": "workspace:*"
@@ -13,6 +14,8 @@
   "devDependencies": {
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
-    "@lynx-js/rspeedy": "workspace:*"
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/types": "3.3.0",
+    "@types/react": "^18.3.21"
   }
 }

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "preserve",
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
     "noEmit": true,
 
     "allowJs": true,
     "checkJs": true,
     "isolatedDeclarations": false,
   },
-  "include": ["src", "lynx.config.js"],
+  "include": ["src", "lynx.config.js", "test"],
   "references": [
     { "path": "../../packages/react/tsconfig.json" },
     { "path": "../../packages/rspeedy/core/tsconfig.build.json" },

--- a/examples/react/vitest.config.ts
+++ b/examples/react/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+  test: {
+    name: 'examples/react',
+  },
+});

--- a/packages/react/runtime/jsx-dev-runtime/index.d.ts
+++ b/packages/react/runtime/jsx-dev-runtime/index.d.ts
@@ -1,17 +1,23 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { JSX as _JSX } from 'react';
+import * as React from 'react';
 
-import { IntrinsicElements as _IntrinsicElements } from '@lynx-js/types';
+import * as Lynx from '@lynx-js/types';
 
-export { jsxDEV, Fragment } from 'react/jsx-dev-runtime';
+export { jsxDEV, Fragment, JSXSource } from 'react/jsx-dev-runtime';
 export { jsx, jsxs } from 'react/jsx-runtime';
 
+// Modified from
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/981449c691b9be0fca569c48151fc57606f5ea7a/types/react/jsx-runtime.d.ts#L5
 export namespace JSX {
-  interface IntrinsicElements extends _IntrinsicElements {}
-
+  type ElementType = React.JSX.ElementType;
+  interface Element extends React.JSX.Element {}
+  interface ElementClass extends React.JSX.ElementClass {}
+  interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
+  interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
+  type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
   interface IntrinsicAttributes {}
-
-  type Element = _JSX.Element;
+  interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
+  interface IntrinsicElements extends Lynx.IntrinsicElements {}
 }

--- a/packages/react/runtime/jsx-runtime/index.d.ts
+++ b/packages/react/runtime/jsx-runtime/index.d.ts
@@ -1,16 +1,22 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { JSX as _JSX } from 'react';
+import * as React from 'react';
 
-import { IntrinsicElements as _IntrinsicElements } from '@lynx-js/types';
+import * as Lynx from '@lynx-js/types';
 
 export { jsx, jsxs, Fragment } from 'react/jsx-runtime';
 
+// Modified from
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/981449c691b9be0fca569c48151fc57606f5ea7a/types/react/jsx-runtime.d.ts#L5
 export namespace JSX {
-  interface IntrinsicElements extends _IntrinsicElements {}
-
+  type ElementType = React.JSX.ElementType;
+  interface Element extends React.JSX.Element {}
+  interface ElementClass extends React.JSX.ElementClass {}
+  interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
+  interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
+  type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
   interface IntrinsicAttributes {}
-
-  type Element = _JSX.Element;
+  interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
+  interface IntrinsicElements extends Lynx.IntrinsicElements {}
 }

--- a/packages/react/runtime/package.json
+++ b/packages/react/runtime/package.json
@@ -15,8 +15,7 @@
     "src"
   ],
   "scripts": {
-    "test": "vitest run --coverage",
-    "test:type": "vitest --typecheck.only"
+    "test": "vitest run --coverage"
   },
   "devDependencies": {
     "@lynx-js/react": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,12 @@ importers:
       '@lynx-js/rspeedy':
         specifier: workspace:*
         version: link:../../packages/rspeedy/core
+      '@lynx-js/types':
+        specifier: 3.3.0
+        version: 3.3.0
+      '@types/react':
+        specifier: ^18.3.21
+        version: 18.3.21
 
   packages/background-only: {}
 

--- a/vitest.workspace.json
+++ b/vitest.workspace.json
@@ -1,4 +1,5 @@
 [
+  "examples/*/vitest.config.ts",
   "packages/react/*/vitest.config.ts",
   "packages/rspeedy/*/vitest.config.ts",
   "packages/testing-library/*/vitest.config.mts",


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Export types like `react/jsx-runtime` does. Including:

- `ElementType`: for `<Fragment>`, `<Suspense>`, `memo()`, `forwardRef()`, etc.
- `ElementClass`: for class component
- `ElementAttributesProperty`: for `props`
- `ElementChildrenAttribute`: for `children`
- `IntrinsicClassAttributes`: for `ref` on class component

Note that we did not change the `IntrinsicAttributes` since we don't have correct definition at `@lynx-js/types`.

The type test has been relocated from `packages/react/runtime` to `examples/react` to ensure accurate dependencies and references.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: #848

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
