### PR TITLE
refactor: allow elements to be rendered before :defined

### DIFF
--- a/.changeset/fresh-terms-guess.md
+++ b/.changeset/fresh-terms-guess.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+refactor: allow elements to be rendered before :defined
+
+Before this commit, we don't allow developers to render these elements before they're defined.
+
+In this commit, we will remove these restrictions.

--- a/packages/web-platform/web-elements/src/XImage/x-image.css
+++ b/packages/web-platform/web-elements/src/XImage/x-image.css
@@ -13,9 +13,7 @@ x-image, filter-image {
 }
 
 x-image > *,
-filter-image > *,
-x-image:not(:defined),
-filter-image:not(:defined) {
+filter-image > * {
   display: none;
 }
 

--- a/packages/web-platform/web-elements/src/XInput/x-input.css
+++ b/packages/web-platform/web-elements/src/XInput/x-input.css
@@ -4,10 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 */
 x-input {
-  display: none;
-}
-
-x-input:defined {
   display: contents;
 }
 

--- a/packages/web-platform/web-elements/src/XOverlayNg/x-overlay-ng.css
+++ b/packages/web-platform/web-elements/src/XOverlayNg/x-overlay-ng.css
@@ -3,9 +3,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-x-overlay-ng:not(:defined) {
-  display: none;
-}
 x-overlay-ng::part(dialog) {
   padding: 0;
   border: 0;

--- a/packages/web-platform/web-elements/src/XRefreshView/x-refresh-view.css
+++ b/packages/web-platform/web-elements/src/XRefreshView/x-refresh-view.css
@@ -18,9 +18,6 @@ x-refresh-view {
   min-height: 0;
   border-style: solid;
 }
-x-refresh-view:not(:defined) {
-  display: none;
-}
 
 x-refresh-view::part(container),
 x-refresh-view::part(content),

--- a/packages/web-platform/web-elements/src/XText/x-text.css
+++ b/packages/web-platform/web-elements/src/XText/x-text.css
@@ -40,7 +40,6 @@ inline-text, inline-image, inline-truncation {
 /* nested components */
 x-text > x-text,
 x-text > inline-text,
-x-text > x-text,
 inline-text > inline-text,
 inline-truncation > inline-text,
 inline-truncation > x-text,

--- a/packages/web-platform/web-elements/src/XText/x-text.css
+++ b/packages/web-platform/web-elements/src/XText/x-text.css
@@ -15,9 +15,6 @@ x-text:not(x-text > x-text):not(x-text > lynx-wrapper > x-text) {
   --lynx-color: canvastext;
   --lynx-text-bg-color: initial;
 }
-x-text:not(:defined) {
-  display: none;
-}
 
 x-text > * {
   display: none;
@@ -41,36 +38,36 @@ inline-text, inline-image, inline-truncation {
 }
 
 /* nested components */
-x-text > x-text:defined,
-x-text > inline-text:defined,
-x-text > x-text:defined,
-inline-text > inline-text:defined,
-inline-truncation > inline-text:defined,
-inline-truncation > x-text:defined,
-x-text > lynx-wrapper > x-text:defined,
-x-text > lynx-wrapper > inline-text:defined,
-x-text > lynx-wrapper > x-text:defined,
-inline-text > lynx-wrapper > inline-text:defined,
-x-text > lynx-wrapper > x:defined,
-inline-truncation > lynx-wrapper > inline-text:defined,
-inline-truncation > lynx-wrapper > x-text:defined {
+x-text > x-text,
+x-text > inline-text,
+x-text > x-text,
+inline-text > inline-text,
+inline-truncation > inline-text,
+inline-truncation > x-text,
+x-text > lynx-wrapper > x-text,
+x-text > lynx-wrapper > inline-text,
+x-text > lynx-wrapper > x-text,
+inline-text > lynx-wrapper > inline-text,
+x-text > lynx-wrapper > *,
+inline-truncation > lynx-wrapper > inline-text,
+inline-truncation > lynx-wrapper > x-text {
   display: inline;
   background-clip: inherit;
   -webkit-background-clip: inherit;
 }
 
-x-text > inline-image:defined,
-x-text > x-image:defined,
-inline-truncation > inline-image:defined,
-inline-truncation > x-image:defined,
-inline-text > inline-image:defined,
-inline-text > x-image:defined,
-x-text > lynx-wrapper > inline-image:defined,
-x-text > lynx-wrapper > x-image:defined,
-inline-truncation > lynx-wrapper > inline-image:defined,
-inline-truncation > lynx-wrapper > x-image:defined,
-inline-text > lynx-wrapper > inline-image:defined,
-inline-text > lynx-wrapper > x-image:defined {
+x-text > inline-image,
+x-text > x-image,
+inline-truncation > inline-image,
+inline-truncation > x-image,
+inline-text > inline-image,
+inline-text > x-image,
+x-text > lynx-wrapper > inline-image,
+x-text > lynx-wrapper > x-image,
+inline-truncation > lynx-wrapper > inline-image,
+inline-truncation > lynx-wrapper > x-image,
+inline-text > lynx-wrapper > inline-image,
+inline-text > lynx-wrapper > x-image {
   display: contents !important;
 }
 x-text > x-view, x-text > lynx-wrapper > x-view {
@@ -230,7 +227,7 @@ x-text[text-maxline][tail-color-convert="false"]::part(inner-box) {
 }
 
 raw-text {
-  display: none;
+  display: none; /* raw-text only works in x-text */
   white-space-collapse: preserve-breaks;
 }
 x-text > raw-text,
@@ -238,4 +235,9 @@ inline-text > raw-text,
 x-text > lynx-wrapper > raw-text,
 inline-text > lynx-wrapper > raw-text {
   display: contents !important;
+}
+
+raw-text:not(:defined)::before {
+  content: attr(text);
+  display: contents;
 }

--- a/packages/web-platform/web-elements/src/XTextarea/x-textarea.css
+++ b/packages/web-platform/web-elements/src/XTextarea/x-textarea.css
@@ -4,10 +4,6 @@
 // LICENSE file in the root directory of this source tree.
 */
 x-textarea {
-  display: none;
-}
-
-x-textarea:defined {
   display: contents;
 }
 

--- a/packages/web-platform/web-elements/src/XViewpagerNg/x-viewpager-ng.css
+++ b/packages/web-platform/web-elements/src/XViewpagerNg/x-viewpager-ng.css
@@ -7,9 +7,9 @@ x-viewpager-ng, x-viewpager-item-ng {
   display: none;
 }
 
-x-viewpager-ng:defined,
-x-viewpager-ng > x-viewpager-item-ng:defined,
-x-viewpager-ng > lynx-wrapper > x-viewpager-item-ng:defined {
+x-viewpager-ng,
+x-viewpager-ng > x-viewpager-item-ng,
+x-viewpager-ng > lynx-wrapper > x-viewpager-item-ng {
   display: flex;
 }
 


### PR DESCRIPTION
Before this commit, we don't allow developers to render these elements before they're defined.

In this commit, we will remove these restrictions.
