### PR TITLE
feat(testing-library): support lazy bundle testing

### DIFF
--- a/.changeset/cold-corners-agree.md
+++ b/.changeset/cold-corners-agree.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Support lazy bundle in ReactLynx testing library.

--- a/.changeset/fair-pears-smile.md
+++ b/.changeset/fair-pears-smile.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix a bug in HMR that snapshots are always updated because the same unique ID check is not performed correctly.

--- a/packages/react/runtime/src/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/lifecycle/patch/snapshotPatchApply.ts
@@ -13,7 +13,13 @@
  * order and with proper error handling.
  */
 
-import { SnapshotInstance, createSnapshot, snapshotInstanceManager, snapshotManager } from '../../snapshot.js';
+import {
+  SnapshotInstance,
+  createSnapshot,
+  entryUniqID,
+  snapshotInstanceManager,
+  snapshotManager,
+} from '../../snapshot.js';
 import type { SnapshotPatch } from './snapshotPatch.js';
 import { SnapshotOperation } from './snapshotPatch.js';
 
@@ -94,7 +100,7 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
           const cssId: number = snapshotPatch[++i] ?? 0;
           const entryName: string | undefined = snapshotPatch[++i];
 
-          if (!snapshotManager.values.has(uniqID)) {
+          if (!snapshotManager.values.has(entryUniqID(uniqID, entryName))) {
             // HMR-related
             // Update the evaluated snapshots from JS.
             createSnapshot(

--- a/packages/react/runtime/src/snapshot.ts
+++ b/packages/react/runtime/src/snapshot.ts
@@ -181,6 +181,10 @@ export const backgroundSnapshotInstanceManager: {
   },
 };
 
+export function entryUniqID(uniqID: string, entryName?: string): string {
+  return entryName ? `${entryName}:${uniqID}` : uniqID;
+}
+
 export function createSnapshot(
   uniqID: string,
   create: Snapshot['create'] | null,
@@ -194,7 +198,7 @@ export function createSnapshot(
     // `__globalSnapshotPatch` does not exist before hydration,
     // so the snapshot of the first screen will not be sent to the main thread.
     && __globalSnapshotPatch
-    && !snapshotManager.values.has(uniqID)
+    && !snapshotManager.values.has(entryUniqID(uniqID, entryName))
     // `create` may be `null` when loading a lazy bundle after hydration.
     && create !== null
   ) {
@@ -215,9 +219,7 @@ export function createSnapshot(
     );
   }
 
-  if (entryName) {
-    uniqID = `${entryName}:${uniqID}`;
-  }
+  uniqID = entryUniqID(uniqID, entryName);
 
   const s: Snapshot = { create, update, slot, cssId, entryName };
   snapshotManager.values.set(uniqID, s);

--- a/packages/react/testing-library/src/__tests__/lazy-bundle/LazyComponent.jsx
+++ b/packages/react/testing-library/src/__tests__/lazy-bundle/LazyComponent.jsx
@@ -1,0 +1,4 @@
+export default function LazyComponent() {
+  const content = `Hello from LazyComponent`;
+  return <text>{content}</text>;
+}

--- a/packages/react/testing-library/src/__tests__/lazy-bundle/index.test.jsx
+++ b/packages/react/testing-library/src/__tests__/lazy-bundle/index.test.jsx
@@ -1,0 +1,57 @@
+import '@testing-library/jest-dom';
+import { expect, it } from 'vitest';
+import { render, screen, waitForElementToBeRemoved } from '@lynx-js/react/testing-library';
+import { Suspense, lazy } from '@lynx-js/react';
+import { createRequire } from 'node:module';
+import { describe } from 'node:test';
+
+const require = createRequire(import.meta.url);
+
+function LazyComponentLoader({ url }) {
+  const ExternalComponent = lazy(() => import(url));
+  const InternalComponent = lazy(() => import('./LazyComponent'));
+
+  return (
+    <Suspense fallback={<text>loading...</text>}>
+      <InternalComponent />
+      <ExternalComponent />
+    </Suspense>
+  );
+}
+
+export function App({ url }) {
+  return (
+    <view>
+      <LazyComponentLoader url={url}></LazyComponentLoader>
+    </view>
+  );
+}
+
+describe('lazy bundle', () => {
+  it('should render lazy component', async () => {
+    const { container } = render(
+      <App url={require.resolve('./LazyComponent.jsx')} />,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+    <view>
+      <text>
+        loading...
+      </text>
+    </view>
+  `);
+
+    await waitForElementToBeRemoved(() => screen.getByText('loading...'));
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          Hello from LazyComponent
+        </text>
+        <text>
+          Hello from LazyComponent
+        </text>
+      </view>
+    `);
+  });
+});

--- a/packages/react/testing-library/src/vitest-global-setup.js
+++ b/packages/react/testing-library/src/vitest-global-setup.js
@@ -129,6 +129,14 @@ globalThis.onInjectBackgroundThreadGlobals = (target) => {
   injectTt();
   globalThis.lynxCoreInject = oldLynxCoreInject;
 
+  target.lynx.requireModuleAsync = async (url, callback) => {
+    try {
+      callback(null, await __vite_ssr_dynamic_import__(url));
+    } catch (err) {
+      callback(err, null);
+    }
+  };
+
   // re-init global snapshot patch to undefined
   deinitGlobalSnapshotPatch();
   clearCommitTaskId();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fixes #852

In the testing library, we do not need HMR for snapshots because `snapshotManager` is always created when the test is started. This is fixed by correcting the `SnapshotOperation.DEV_ONLY_AddSnapshot`'s checking logic.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
