### PR TITLE
fix(react/types): add `key` to `JSX.IntrinsicAttributes`

### DIFF
--- a/.changeset/few-stars-write.md
+++ b/.changeset/few-stars-write.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix missing types of `key` on components when using `"jsx": "react-jsx"`.

--- a/examples/react/test/jsx-runtime.test-d.tsx
+++ b/examples/react/test/jsx-runtime.test-d.tsx
@@ -1,7 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { assertType, describe, test } from 'vitest';
+import { assertType, describe, expectTypeOf, test } from 'vitest';
 
 import {
   Component,
@@ -12,7 +12,7 @@ import {
   useMainThreadRef,
   useRef,
 } from '@lynx-js/react';
-import type { JSX, ReactNode } from '@lynx-js/react';
+import type { FC, JSX, ReactNode } from '@lynx-js/react';
 import type { MainThread, NodesRef, Target, TouchEvent } from '@lynx-js/types';
 
 describe('JSX Runtime Types', () => {
@@ -180,5 +180,31 @@ describe('JSX Runtime Types', () => {
         }}
       />,
     );
+  });
+
+  test('should support key on JSX elements', () => {
+    assertType<JSX.Element>(<text key='foo'>Hello, World!</text>);
+    assertType<JSX.Element>(<text key={null}>Hello, World!</text>);
+  });
+
+  test('should support key on Components', () => {
+    class Foo extends Component {
+      override render(): ReactNode {
+        expectTypeOf(this.props).not.toHaveProperty('key');
+        return <text>Hello, World!</text>;
+      }
+    }
+    const Bar: FC = function Bar(props) {
+      expectTypeOf(props).not.toHaveProperty('key');
+      return <text>Hello, World!</text>;
+    };
+    const ForwardRefComponent = forwardRef<NodesRef>((props, ref) => {
+      expectTypeOf(props).not.toHaveProperty('key');
+      return <text ref={ref}>Hello, World!</text>;
+    });
+    assertType<JSX.Element>(<Foo key={null} />);
+    assertType<JSX.Element>(<Foo key='foo' />);
+    assertType<JSX.Element>(<Bar key='bar' />);
+    assertType<JSX.Element>(<ForwardRefComponent key='forward' />);
   });
 });

--- a/packages/react/runtime/jsx-runtime/index.d.ts
+++ b/packages/react/runtime/jsx-runtime/index.d.ts
@@ -16,7 +16,11 @@ export namespace JSX {
   interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
   interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}
   type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<C, P>;
-  interface IntrinsicAttributes {}
+  // We are not extending the `React.JSX.IntrinsicAttributes` because it will be populated
+  // by `Lynx.IntrinsicAttributes`.
+  interface IntrinsicAttributes {
+    key?: React.Key | null | undefined;
+  }
   interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
   interface IntrinsicElements extends Lynx.IntrinsicElements {}
 }

--- a/packages/react/types/react.d.ts
+++ b/packages/react/types/react.d.ts
@@ -95,7 +95,7 @@ declare module '@lynx-js/types' {
   interface StandardProps {
     children?: ReactNode;
     ref?: Ref<NodesRef>;
-    key?: Key;
+    key?: Key | null | undefined;
     'main-thread:ref'?: Ref<MainThread.Element>;
   }
 


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Add `key` to `JSX.IntrinsicAttributes`.

```jsx
<Foo key='foo' />
     ^^^ Type '{ key: string; }' is not assignable to type 'IntrinsicAttributes'.
           Property 'key' does not exist on type 'IntrinsicAttributes'.ts(2322)
```

> [!NOTE]
> We did not extends `React.JSX.IntrinsicAttributes` like [`@types/react`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/981449c691b9be0fca569c48151fc57606f5ea7a/types/react/jsx-runtime.d.ts#L11) does.
> This is because the `React.JSX.IntrinsicAttributes` would be populated by `@lynx-js/types`, which contains incorrect properties.
 

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: #871 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
