### PR TITLE
feat: support output.inlineScripts

### DIFF
--- a/.changeset/afraid-meals-attend.md
+++ b/.changeset/afraid-meals-attend.md
@@ -1,0 +1,19 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Support `output.inlineScripts`, which controls whether to inline scripts files when LynxEncodePlugin generates the manifest file.
+
+example:
+
+```js
+import { defineConfig } from '@lynx-js/rspeedy';
+
+export default defineConfig({
+  output: {
+    inlineScripts: false,
+  },
+});
+```

--- a/.changeset/afraid-meals-attend.md
+++ b/.changeset/afraid-meals-attend.md
@@ -4,7 +4,9 @@
 "@lynx-js/rspeedy": patch
 ---
 
-Support `output.inlineScripts`, which controls whether to inline scripts files when LynxEncodePlugin generates the manifest file.
+Support `output.inlineScripts`, which controls whether to inline scripts into Lynx bundle (`.lynx.bundle`).
+
+Only background thread scripts can remain non-inlined, whereas the main thread script is always inlined.
 
 example:
 

--- a/packages/rspeedy/core/etc/rspeedy.api.md
+++ b/packages/rspeedy/core/etc/rspeedy.api.md
@@ -232,6 +232,7 @@ export interface Output {
     distPath?: DistPath | undefined;
     filename?: string | Filename | undefined;
     filenameHash?: boolean | string | undefined;
+    inlineScripts?: boolean | undefined;
     legalComments?: 'none' | 'inline' | 'linked' | undefined;
     minify?: Minify | boolean | undefined;
     sourceMap?: boolean | SourceMap | undefined;

--- a/packages/rspeedy/core/src/config/defaults.ts
+++ b/packages/rspeedy/core/src/config/defaults.ts
@@ -14,6 +14,9 @@ export function applyDefaultRspeedyConfig(config: Config): Config {
       // since some plugin(e.g.: `@lynx-js/qrcode-rsbuild-plugin`) will read
       // from the `output.filename.bundle` field.
       filename: getFilename(config.output?.filename),
+
+      // inlineScripts should be enabled by default
+      inlineScripts: true,
     },
 
     tools: {

--- a/packages/rspeedy/core/src/config/output/index.ts
+++ b/packages/rspeedy/core/src/config/output/index.ts
@@ -312,7 +312,7 @@ export interface Output {
    *
    * @example
    *
-   * Disable inlining scripts.
+   * Disable inlining background thread scripts.
    * ```js
    * import { defineConfig } from '@lynx-js/rspeedy'
    *

--- a/packages/rspeedy/core/src/config/output/index.ts
+++ b/packages/rspeedy/core/src/config/output/index.ts
@@ -300,7 +300,7 @@ export interface Output {
   filenameHash?: boolean | string | undefined
 
   /**
-   * The {@link Output.inlineScripts} option controls whether to inline scripts files when LynxEncodePlugin generates the manifest file.
+   * The {@link Output.inlineScripts} option controls whether to inline scripts into Lynx bundle (`.lynx.bundle`).
    *
    * @remarks
    *

--- a/packages/rspeedy/core/src/config/output/index.ts
+++ b/packages/rspeedy/core/src/config/output/index.ts
@@ -300,6 +300,30 @@ export interface Output {
   filenameHash?: boolean | string | undefined
 
   /**
+   * The {@link Output.inlineScripts} option controls whether to inline scripts files when LynxEncodePlugin generates the manifest file.
+   *
+   * @remarks
+   *
+   * If no value is provided, the default value would be `true`.
+   *
+   * This is different with {@link https://rsbuild.dev/config/output/inline-scripts | output.inlineScripts } since we normally want to inline scripts in Lynx manifest file.
+   *
+   * @example
+   *
+   * Disable inlining scripts.
+   * ```js
+   * import { defineConfig } from '@lynx-js/rspeedy'
+   *
+   * export default defineConfig({
+   *   output: {
+   *     inlineScripts: false,
+   *   },
+   * })
+   * ```
+   */
+  inlineScripts?: boolean | undefined
+
+  /**
    * The {@link Output.legalComments} controls how to handle the legal comment.
    *
    * @remarks

--- a/packages/rspeedy/core/src/config/output/index.ts
+++ b/packages/rspeedy/core/src/config/output/index.ts
@@ -306,7 +306,9 @@ export interface Output {
    *
    * If no value is provided, the default value would be `true`.
    *
-   * This is different with {@link https://rsbuild.dev/config/output/inline-scripts | output.inlineScripts } since we normally want to inline scripts in Lynx manifest file.
+   * This is different with {@link https://rsbuild.dev/config/output/inline-scripts | output.inlineScripts } since we normally want to inline scripts in Lynx bundle (`.lynx.bundle`).
+   *
+   * Only background thread scripts can remain non-inlined, whereas the main thread script is always inlined.
    *
    * @example
    *

--- a/packages/rspeedy/core/test/config/output.test-d.ts
+++ b/packages/rspeedy/core/test/config/output.test-d.ts
@@ -175,6 +175,15 @@ describe('Config - Output', () => {
     })
   })
 
+  test('output.inlineScripts', () => {
+    assertType<Output>({
+      inlineScripts: true,
+    })
+    assertType<Output>({
+      inlineScripts: false,
+    })
+  })
+
   test('output.legalComments', () => {
     assertType<Output>({
       legalComments: 'inline',

--- a/packages/rspeedy/core/test/config/validate.test.ts
+++ b/packages/rspeedy/core/test/config/validate.test.ts
@@ -833,6 +833,8 @@ describe('Config Validation', () => {
         { distPath: { image: 'image' } },
         { distPath: { font: 'font' } },
         { distPath: { svg: 'svg' } },
+        { inlineScripts: true },
+        { inlineScripts: false },
         { legalComments: 'inline' },
         { legalComments: 'none' },
         { legalComments: 'linked' },
@@ -1094,6 +1096,16 @@ describe('Config Validation', () => {
           [Error: Invalid configuration.
 
           Unknown property: \`$input.output.distPath.nonExistent\` in configuration
+          ]
+        `)
+
+      expect(() => validate({ output: { inlineScripts: null } }))
+        .toThrowErrorMatchingInlineSnapshot(`
+          [Error: Invalid configuration.
+
+          Invalid config on \`$input.output.inlineScripts\`.
+            - Expect to be (boolean | undefined)
+            - Got: null
           ]
         `)
 

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -198,6 +198,10 @@ export function applyEntry(
     })
 
     if (isLynx) {
+      const inlineScripts = typeof config.output?.inlineScripts === 'boolean'
+        ? config.output.inlineScripts
+        : true
+
       chain
         .plugin(PLUGIN_NAME_RUNTIME_WRAPPER)
         .use(RuntimeWrapperWebpackPlugin, [{
@@ -222,7 +226,7 @@ export function applyEntry(
         }])
         .end()
         .plugin(`${LynxEncodePlugin.name}`)
-        .use(LynxEncodePlugin, [{}])
+        .use(LynxEncodePlugin, [{ inlineScripts }])
         .end()
     }
 

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -198,9 +198,10 @@ export function applyEntry(
     })
 
     if (isLynx) {
-      const inlineScripts = typeof config.output?.inlineScripts === 'boolean'
-        ? config.output.inlineScripts
-        : true
+      const inlineScripts =
+        typeof environment.config.output?.inlineScripts === 'boolean'
+          ? environment.config.output.inlineScripts
+          : true
 
       chain
         .plugin(PLUGIN_NAME_RUNTIME_WRAPPER)

--- a/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
+++ b/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
@@ -78,6 +78,10 @@ export class LynxEncodePlugin {
 
 // @public
 export interface LynxEncodePluginOptions {
+    // (undocumented)
+    encodeBinary?: string;
+    // (undocumented)
+    inlineScripts?: boolean;
 }
 
 // @public

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/foo.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/foo.js
@@ -1,0 +1,3 @@
+export function foo() {
+  return 42;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
@@ -1,0 +1,46 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="vitest/globals" />
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+it('should have correct chunk content', async () => {
+  const { foo } = await import(
+    /* webpackChunkName: 'foo:main-thread' */
+    './foo.js'
+  );
+  expect(foo()).toBe(42);
+
+  const fooBackground = await import(
+    /* webpackChunkName: 'foo:background' */
+    './foo.js'
+  );
+  expect(fooBackground.foo()).toBe(42);
+});
+
+it('manifest only contains /app-service.js', async () => {
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  expect(existsSync(tasmJSONPath)).toBeTruthy();
+
+  const content = await readFile(tasmJSONPath, 'utf-8');
+  const { sourceContent, manifest } = JSON.parse(content);
+  const output = resolve(__dirname, 'foo:background.rspack.bundle.js');
+  expect(existsSync(output));
+
+  const outputContent = await readFile(output, 'utf-8');
+  expect(outputContent).toContain(['function', 'foo()'].join(' '));
+
+  expect(sourceContent).toHaveProperty('appType', 'DynamicComponent');
+
+  expect(manifest).not.toHaveProperty('/foo:background.rspack.bundle.js');
+  expect(manifest).toHaveProperty('/app-service.js');
+
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule('/foo:background.rspack.bundle.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`,
+  );
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/rspack.config.js
@@ -1,0 +1,33 @@
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../src';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  devtool: false,
+  mode: 'development',
+  plugins: [
+    new LynxEncodePlugin({
+      inlineScripts: false,
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      intermediate: '.rspeedy/main',
+    }),
+    /**
+     * @param {import('@rspack/core').Compiler} compiler - Rspack Compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap('test', (compilation) => {
+        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+          compilation,
+        );
+        hooks.asyncChunkName.tap(
+          'test',
+          chunkName =>
+            chunkName
+              .replace(':main-thread', '')
+              .replace(':background', ''),
+        );
+      });
+    },
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/foo.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/foo.js
@@ -1,0 +1,3 @@
+export function foo() {
+  return 42;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/index.js
@@ -1,0 +1,37 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="vitest/globals" />
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+it('should have correct chunk content', async () => {
+  const { foo } = await import(
+    /* webpackChunkName: 'foo:main-thread' */
+    './foo.js'
+  );
+  expect(foo()).toBe(42);
+
+  const fooBackground = await import(
+    /* webpackChunkName: 'foo:background' */
+    './foo.js'
+  );
+  expect(fooBackground.foo()).toBe(42);
+});
+
+it('should generate correct foo template', async () => {
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  expect(existsSync(tasmJSONPath)).toBeTruthy();
+
+  const content = await readFile(tasmJSONPath, 'utf-8');
+  const { sourceContent, manifest } = JSON.parse(content);
+  expect(sourceContent).toHaveProperty('appType', 'DynamicComponent');
+  expect(manifest).toHaveProperty(
+    '/foo:background.rspack.bundle.js',
+    expect.stringContaining('function foo()'),
+  );
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/rspack.config.js
@@ -1,0 +1,33 @@
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../src';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  devtool: false,
+  mode: 'development',
+  plugins: [
+    new LynxEncodePlugin({
+      inlineScripts: true,
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      intermediate: '.rspeedy/main',
+    }),
+    /**
+     * @param {import('@rspack/core').Compiler} compiler - Rspack Compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap('test', (compilation) => {
+        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+          compilation,
+        );
+        hooks.asyncChunkName.tap(
+          'test',
+          chunkName =>
+            chunkName
+              .replace(':main-thread', '')
+              .replace(':background', ''),
+        );
+      });
+    },
+  ],
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

#870  

follow up #502

Support `output.inlineScripts`, which controls whether to inline scripts files when LynxEncodePlugin generates the manifest file.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
