### PR TITLE
feat(web): pageConfig add new source

### DIFF
--- a/.changeset/puny-monkeys-rule.md
+++ b/.changeset/puny-monkeys-rule.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+feat: Merge the absent configurations for `.web.bundle`.
+
+Before this change, the configuration of pageConfig in `.web.bundle` was `compilerOptions`. After this commit, pageConfig will be a combination of `compilerOptions` and `sourceContent.config`.

--- a/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
@@ -73,7 +73,10 @@ export class WebEncodePlugin {
             },
             customSections: encodeData.customSections,
             cardType: encodeData.sourceContent.dsl.substring(0, 5),
-            pageConfig: encodeData.compilerOptions,
+            pageConfig: {
+              ...encodeData.compilerOptions,
+              ...encodeData.sourceContent.config,
+            },
           });
           return encodeOptions;
         });
@@ -87,7 +90,7 @@ export class WebEncodePlugin {
               styleInfo: encodeOptions['styleInfo'],
               manifest: encodeOptions.manifest,
               cardType: encodeOptions['cardType'],
-              pageConfig: encodeOptions.compilerOptions,
+              pageConfig: encodeOptions['pageConfig'],
               lepusCode: {
                 // flatten the lepusCode to a single object
                 ...encodeOptions.lepusCode.lepusChunk,

--- a/packages/webpack/template-webpack-plugin/test/cases/web/page-config/a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/page-config/a.js
@@ -1,0 +1,1 @@
+console.info('**aaa**');

--- a/packages/webpack/template-webpack-plugin/test/cases/web/page-config/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/page-config/b.js
@@ -1,0 +1,13 @@
+/// <reference types="vitest/globals" />
+
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+
+it('should have enableTest in pageConfig', async () => {
+  const fileContent = (await fs.readFile(
+    path.join(__dirname, '..', '.rspeedy', 'a', 'tasm.json'),
+  ))
+    .toString();
+  const { pageConfig } = JSON.parse(fileContent);
+  expect(pageConfig.enableTest).toBeTruthy();
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/web/page-config/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/page-config/rspack.config.js
@@ -1,0 +1,62 @@
+import { LynxTemplatePlugin, WebEncodePlugin } from '../../../../src';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  entry: {
+    a: './a.js',
+    b: './b.js',
+    'a:main-thread': { import: './a.js', filename: 'a/a.lepus.js' },
+    'b:main-thread': { import: './b.js', filename: 'b/b.lepus.js' },
+  },
+  context: __dirname,
+  output: {
+    filename: '[name]/[name].js',
+  },
+  plugins: [
+    new WebEncodePlugin({
+      include: [/a.js/g],
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: ['a', 'a:main-thread'],
+      filename: 'a/template.js',
+      intermediate: '.rspeedy/a',
+    }),
+
+    compiler => {
+      compiler.hooks.thisCompilation.tap('test', (compilation) => {
+        compilation.hooks.processAssets.tap('test', () => {
+          ['a'].forEach(name => {
+            const asset = compilation.getAsset(`${name}/${name}.js`);
+            compilation.updateAsset(asset.name, asset.source, {
+              ...asset.info,
+              'lynx:main-thread': true,
+            });
+          });
+        });
+        compilation.hooks.processAssets.tap(
+          {
+            name: 'page-config-test',
+            stage:
+              compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_PRE_PROCESS,
+          },
+          () => {
+            const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+              // @ts-expect-error compilation is compatible with webpack
+              compilation,
+            );
+            hooks.beforeEncode.tap('page-config-test', (args) => {
+              args.encodeData.sourceContent.config = {
+                ...(args.encodeData.sourceContent.config),
+                ...{
+                  enableTest: true,
+                },
+              };
+              return args;
+            });
+          },
+        );
+      });
+    },
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/web/page-config/test.config.cjs
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/page-config/test.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import("@lynx-js/test-runner").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'b/b.js',
+  ],
+};


### PR DESCRIPTION
## Summary

feat: output pageConfig add a new source: `encodeOptions.sourceContent.config`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
