### PR TITLE
refactor: code clean

### DIFF
--- a/.changeset/cold-regions-attend.md
+++ b/.changeset/cold-regions-attend.md
@@ -1,0 +1,16 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/offscreen-document": patch
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/web-core-server": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+refactor: code clean
+
+rename many internal apis to make logic be clear:
+
+multi-thread: startMainWorker -> prepareMainThreadAPIs -> startMainThread -> createMainThreadContext(new MainThreadRuntime)
+all-on-ui: prepareMainThreadAPIs -> startMainThread -> createMainThreadContext(new MainThreadRuntime)

--- a/packages/web-platform/web-constants/src/endpoints.ts
+++ b/packages/web-platform/web-constants/src/endpoints.ts
@@ -8,7 +8,7 @@ import type {
   LynxCrossThreadEvent,
 } from './types/EventType.js';
 import type { Cloneable, CloneableObject } from './types/Cloneable.js';
-import type { MainThreadStartConfigs } from './types/MainThreadStartConfigs.js';
+import type { StartMainThreadContextConfig } from './types/MainThreadStartConfigs.js';
 import type { IdentifierType, InvokeCallbackRes } from './types/NativeApp.js';
 import type { LynxTemplate } from './types/LynxModule.js';
 import type { NapiModulesMap } from './types/NapiModules.js';
@@ -55,7 +55,7 @@ export const switchExposureServiceEndpoint = createRpcEndpoint<
 );
 
 export const mainThreadStartEndpoint = createRpcEndpoint<
-  [MainThreadStartConfigs],
+  [StartMainThreadContextConfig],
   void
 >('mainThreadStart', false, false);
 

--- a/packages/web-platform/web-constants/src/types/MainThreadStartConfigs.ts
+++ b/packages/web-platform/web-constants/src/types/MainThreadStartConfigs.ts
@@ -8,7 +8,7 @@ import type { NapiModulesMap } from './NapiModules.js';
 import type { NativeModulesMap } from './NativeModules.js';
 import type { BrowserConfig } from './PageConfig.js';
 
-export interface MainThreadStartConfigs {
+export interface StartMainThreadContextConfig {
   template: LynxTemplate;
   initData: Cloneable;
   globalProps: Cloneable;

--- a/packages/web-platform/web-core-server/src/createLynxView.ts
+++ b/packages/web-platform/web-core-server/src/createLynxView.ts
@@ -1,9 +1,9 @@
 import {
   inShadowRootStyles,
-  type MainThreadStartConfigs,
+  type StartMainThreadContextConfig,
 } from '@lynx-js/web-constants';
 import { Rpc } from '@lynx-js/web-worker-rpc';
-import { loadMainThread } from '@lynx-js/web-mainthread-apis';
+import { prepareMainThreadAPIs } from '@lynx-js/web-mainthread-apis';
 import { loadTemplate } from './utils/loadTemplate.js';
 import {
   dumpHTMLString,
@@ -27,7 +27,7 @@ import {
 
 interface LynxViewConfig extends
   Pick<
-    MainThreadStartConfigs,
+    StartMainThreadContextConfig,
     'browserConfig' | 'tagMap' | 'initData' | 'globalProps' | 'template'
   >
 {
@@ -93,9 +93,10 @@ export async function createLynxView(
     onCommit: () => {
     },
   });
-  const { startMainThread } = loadMainThread(
+  const { startMainThread } = prepareMainThreadAPIs(
     backgroundThreadRpc,
     offscreenDocument,
+    offscreenDocument.createElement.bind(offscreenDocument),
     () => {
       firstPaintReady();
     },

--- a/packages/web-platform/web-core/src/uiThread/createRenderAllOnUI.ts
+++ b/packages/web-platform/web-core/src/uiThread/createRenderAllOnUI.ts
@@ -1,5 +1,5 @@
 import type {
-  MainThreadStartConfigs,
+  StartMainThreadContextConfig,
   RpcCallType,
   updateDataEndpoint,
 } from '@lynx-js/web-constants';
@@ -7,7 +7,7 @@ import type { MainThreadRuntime } from '@lynx-js/web-mainthread-apis';
 import { Rpc } from '@lynx-js/web-worker-rpc';
 
 const {
-  loadMainThread,
+  prepareMainThreadAPIs,
 } = await import('@lynx-js/web-mainthread-apis');
 
 export function createRenderAllOnUI(
@@ -25,12 +25,10 @@ export function createRenderAllOnUI(
   if (!globalThis.module) {
     Object.assign(globalThis, { module: {} });
   }
-  const docu = Object.assign(shadowRoot, {
-    createElement: document.createElement.bind(document),
-  });
-  const { startMainThread } = loadMainThread(
+  const { startMainThread } = prepareMainThreadAPIs(
     mainToBackgroundRpc,
-    docu,
+    shadowRoot,
+    document.createElement.bind(document),
     () => {},
     markTimingInternal,
     () => {
@@ -38,7 +36,7 @@ export function createRenderAllOnUI(
     },
   );
   let runtime!: MainThreadRuntime;
-  const start = async (configs: MainThreadStartConfigs) => {
+  const start = async (configs: StartMainThreadContextConfig) => {
     const mainThreadRuntime = startMainThread(configs);
     runtime = await mainThreadRuntime;
   };

--- a/packages/web-platform/web-core/src/uiThread/startUIThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/startUIThread.ts
@@ -7,7 +7,7 @@ import { bootWorkers } from './bootWorkers.js';
 import { createDispose } from './crossThreadHandlers/createDispose.js';
 import {
   type LynxTemplate,
-  type MainThreadStartConfigs,
+  type StartMainThreadContextConfig,
   type NapiModulesCall,
   type NativeModulesCall,
 } from '@lynx-js/web-constants';
@@ -26,7 +26,7 @@ export type StartUIThreadCallbacks = {
 
 export function startUIThread(
   templateUrl: string,
-  configs: Omit<MainThreadStartConfigs, 'template'>,
+  configs: Omit<StartMainThreadContextConfig, 'template'>,
   shadowRoot: ShadowRoot,
   lynxGroupId: number | undefined,
   threadStrategy: 'all-on-ui' | 'multi-thread',

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadLynx.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadLynx.ts
@@ -1,10 +1,10 @@
 // Copyright 2023 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { type MainThreadConfig } from './MainThreadRuntime.js';
+import { type MainThreadRuntimeConfig } from './MainThreadRuntime.js';
 
 export function createMainThreadLynx(
-  config: MainThreadConfig,
+  config: MainThreadRuntimeConfig,
 ) {
   return {
     getJSContext() {

--- a/packages/web-platform/web-mainthread-apis/src/elementAPI/elementCreating/elementCreatingFunctions.ts
+++ b/packages/web-platform/web-mainthread-apis/src/elementAPI/elementCreating/elementCreatingFunctions.ts
@@ -37,7 +37,7 @@ export function initializeElementCreatingFunction(
       typeof createStyleFunctions
     >['__SetCSSId'];
     const htmlTag = runtime.config.tagMap[tag] ?? tag;
-    const element = runtime.config.docu.createElement(
+    const element = runtime._createElement(
       htmlTag,
     ) as HTMLElement;
     element.setAttribute(lynxTagAttribute, tag);
@@ -177,7 +177,7 @@ export function initializeElementCreatingFunction(
     childA: HTMLElement,
     childB: HTMLElement,
   ): void {
-    const temp = runtime.config.docu.createElement('div');
+    const temp = runtime._createElement('div');
     childA.replaceWith(temp);
     childB.replaceWith(childA);
     temp.replaceWith(childB);

--- a/packages/web-platform/web-mainthread-apis/src/index.ts
+++ b/packages/web-platform/web-mainthread-apis/src/index.ts
@@ -2,5 +2,5 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-export { loadMainThread } from './loadMainThread.js';
+export { prepareMainThreadAPIs } from './prepareMainThreadAPIs.js';
 export * from './MainThreadRuntime.js';

--- a/packages/web-platform/web-tests/shell-project/mainthread-test.ts
+++ b/packages/web-platform/web-tests/shell-project/mainthread-test.ts
@@ -102,13 +102,19 @@ function initializeMainThreadTest() {
     },
     lepusCode: { root: '' },
     customSections: {},
-    browserConfig: {},
+    browserConfig: {
+      pixelRatio: 0,
+      pixelWidth: 0,
+      pixelHeight: 0,
+    },
     pageConfig: {
       enableCSSSelector: true,
       enableRemoveCSSScope: true,
       defaultDisplayLinear: true,
+      defaultOverflowVisible: false,
     },
-    docu,
+    rootDom: docu,
+    createElement: docu.createElement.bind(docu),
     styleInfo: {},
     globalProps: {},
     callbacks: {

--- a/packages/web-platform/web-worker-runtime/src/index.ts
+++ b/packages/web-platform/web-worker-runtime/src/index.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { startBackgroundThread } from './backgroundThread/index.js';
-import { startMainThread } from './mainThread/startMainThread.js';
+import { startMainThreadWorker } from './mainThread/startMainThread.js';
 
 export interface WorkerStartMessage {
   mode: 'main' | 'background';
@@ -15,7 +15,7 @@ globalThis.onmessage = (ev) => {
   const { mode, toPeerThread, toUIThread } = ev
     .data as WorkerStartMessage;
   if (mode === 'main') {
-    startMainThread(toUIThread, toPeerThread);
+    startMainThreadWorker(toUIThread, toPeerThread);
   } else {
     startBackgroundThread(toUIThread, toPeerThread);
   }
@@ -23,5 +23,3 @@ globalThis.onmessage = (ev) => {
 Object.assign(globalThis, {
   module: { exports: null },
 });
-
-export { startMainThread };

--- a/packages/web-platform/web-worker-runtime/src/mainThread/index.ts
+++ b/packages/web-platform/web-worker-runtime/src/mainThread/index.ts
@@ -2,4 +2,4 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-export { startMainThread } from './startMainThread.js';
+export { startMainThreadWorker } from './startMainThread.js';

--- a/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
+++ b/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
@@ -13,14 +13,12 @@ import { createMarkTimingInternal } from './crossThreadHandlers/createMainthread
 import { OffscreenDocument } from '@lynx-js/offscreen-document/webworker';
 import { _onEvent } from '@lynx-js/offscreen-document/webworker';
 import { registerUpdateDataHandler } from './crossThreadHandlers/registerUpdateDataHandler.js';
-const { loadMainThread } = await import('@lynx-js/web-mainthread-apis');
+const { prepareMainThreadAPIs } = await import('@lynx-js/web-mainthread-apis');
 
-export function startMainThread(
+export function startMainThreadWorker(
   uiThreadPort: MessagePort,
   backgroundThreadPort: MessagePort,
-): {
-  docu: OffscreenDocument;
-} {
+) {
   const uiThreadRpc = new Rpc(uiThreadPort, 'main-to-ui');
   const backgroundThreadRpc = new Rpc(backgroundThreadPort, 'main-to-bg');
   const markTimingInternal = createMarkTimingInternal(backgroundThreadRpc);
@@ -30,9 +28,10 @@ export function startMainThread(
     onCommit: uiFlush,
   });
   uiThreadRpc.registerHandler(postOffscreenEventEndpoint, docu[_onEvent]);
-  const { startMainThread } = loadMainThread(
+  const { startMainThread } = prepareMainThreadAPIs(
     backgroundThreadRpc,
     docu,
+    docu.createElement.bind(docu),
     docu.commit.bind(docu),
     markTimingInternal,
     reportError,
@@ -45,7 +44,4 @@ export function startMainThread(
       });
     },
   );
-  return {
-    docu,
-  };
 }


### PR DESCRIPTION
rename many internal apis to make logic be clear:

multi-thread: startMainWorker -> prepareMainThreadAPIs -> startMainThread -> createMainThreadContext(new MainThreadRuntime)
all-on-ui: prepareMainThreadAPIs -> startMainThread -> createMainThreadContext(new MainThreadRuntime)
