### PR TITLE
feat(rspeedy/qrcode): support autocomplete

### DIFF
--- a/.changeset/cool-nights-admire.md
+++ b/.changeset/cool-nights-admire.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/qrcode-rsbuild-plugin": minor
+---
+
+Support "Type to search" when switching entries and schema.

--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -48,7 +48,7 @@
     "test": "pnpm -w run test --project rspeedy/qrcode"
   },
   "devDependencies": {
-    "@clack/prompts": "^0.10.1",
+    "@clack/prompts": "1.0.0-alpha.0",
     "@lynx-js/rspeedy": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rsbuild/core": "catalog:rsbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,8 +380,8 @@ importers:
   packages/rspeedy/plugin-qrcode:
     devDependencies:
       '@clack/prompts':
-        specifier: ^0.10.1
-        version: 0.10.1
+        specifier: 1.0.0-alpha.0
+        version: 1.0.0-alpha.0
       '@lynx-js/rspeedy':
         specifier: workspace:*
         version: link:../core
@@ -1575,11 +1575,11 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clack/core@0.4.2':
-    resolution: {integrity: sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==}
+  '@clack/core@1.0.0-alpha.0':
+    resolution: {integrity: sha512-Cp/bPW/pMUCkJ7Lr8VFixvFrlnJ4tQPDHqfTNQ51z50qwX1fSIAstQLfel2NquVHqbfjyrUkBsal8OJRBPJVjw==}
 
-  '@clack/prompts@0.10.1':
-    resolution: {integrity: sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==}
+  '@clack/prompts@1.0.0-alpha.0':
+    resolution: {integrity: sha512-Aem7r4U2A4jdOh0PIv51Ugi+4vDgzJjGVMnuPUNVVHDGhFHEO//u6F/JY6NsZQFtXrd7ZmfePSiipikr/e5wWg==}
 
   '@codspeed/core@4.0.1':
     resolution: {integrity: sha512-fJ53arfgtzCDZa8DuGJhpTZ3Ll9A1uW5nQ2jSJnfO4Hl5MRD2cP8P4vPvIUAGbdbjwCxR1jat6cW8OloMJkJXw==}
@@ -8986,14 +8986,14 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@clack/core@0.4.2':
+  '@clack/core@1.0.0-alpha.0':
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.10.1':
+  '@clack/prompts@1.0.0-alpha.0':
     dependencies:
-      '@clack/core': 0.4.2
+      '@clack/core': 1.0.0-alpha.0
       picocolors: 1.1.1
       sisteransi: 1.0.5
 


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

This patch bump `@clack/prompts` [v1.0.0-alpha.0](https://github.com/bombshell-dev/clack/releases/tag/%40clack%2Fprompts%401.0.0-alpha.0) and use the `autocomplete` prompts.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: #895 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
