### PR TITLE
fix(rspeedy/react)!: remove the `jsx` option

### DIFF
--- a/.changeset/long-paws-relax.md
+++ b/.changeset/long-paws-relax.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": minor
+---
+
+**BREAKING CHANGE**: Remove the unused `jsx` option.

--- a/packages/rspeedy/plugin-react/src/loaders.ts
+++ b/packages/rspeedy/plugin-react/src/loaders.ts
@@ -14,7 +14,6 @@ export function applyLoaders(
   const {
     compat,
     enableRemoveCSSScope,
-    jsx,
     shake,
     defineDCE,
 
@@ -63,7 +62,6 @@ export function applyLoaders(
         .options({
           compat,
           enableRemoveCSSScope,
-          jsx,
           isDynamicComponent: experimental_isLazyBundle,
           inlineSourcesContent,
           defineDCE,
@@ -102,7 +100,6 @@ export function applyLoaders(
         .options({
           compat,
           enableRemoveCSSScope,
-          jsx,
           inlineSourcesContent,
           isDynamicComponent: experimental_isLazyBundle,
           shake,

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -16,7 +16,6 @@ import type {
   CompatVisitorConfig,
   DefineDceVisitorConfig,
   ExtractStrConfig,
-  JsxTransformerConfig,
   ShakeVisitorConfig,
 } from '@lynx-js/react-transform'
 import type { ExposedAPI } from '@lynx-js/rspeedy'
@@ -237,13 +236,6 @@ export interface PluginReactLynxOptions {
   enableSSR?: boolean
 
   /**
-   * The `jsx` option controls how JSX is transformed.
-   *
-   * @internal
-   */
-  jsx?: Partial<JsxTransformerConfig> | undefined
-
-  /**
    * Composite configuration representing pipeline scheduling strategies, including {@link PluginReactLynxOptions.enableParallelElement} and list batch-rendering. All newly introduced scheduling strategies will be managed by this uint64 configuration.
    *
    * @remarks
@@ -351,7 +343,6 @@ export function pluginReactLynx(
     enableRemoveCSSScope: true,
     firstScreenSyncTiming: 'immediately',
     enableSSR: false,
-    jsx: undefined,
     pipelineSchedulerConfig: 0x00010000,
     removeDescendantSelectorScope: true,
     shake: undefined,

--- a/packages/rspeedy/plugin-react/src/validate.ts
+++ b/packages/rspeedy/plugin-react/src/validate.ts
@@ -6,51 +6,28 @@ import * as typia from 'typia'
 
 import type { PluginReactLynxOptions } from './pluginReactLynx.js'
 
-const validate: (
-  input: unknown,
-) => typia.IValidation<PluginReactLynxOptions | undefined> = typia
-  .createValidateEquals<PluginReactLynxOptions | undefined>()
-
 export const validateConfig: (
   input: unknown,
-) => PluginReactLynxOptions | undefined = (input: unknown) => {
-  const result = validate(input)
+) => PluginReactLynxOptions | undefined = typia.createAssertEquals<
+  PluginReactLynxOptions | undefined
+>(({ path, expected, value }) => {
+  if (expected === 'undefined') {
+    const errorMessage =
+      `Unknown property: \`${path}\` in the configuration of pluginReactLynx`
 
-  if (result.success) {
-    return result.data
+    // Unknown properties
+    return new Error(errorMessage)
   }
 
-  const messages: string[] = result
-    .errors
-    .flatMap(({ expected, path, value }) => {
-      // Ignore the internal options
-      // See: #846
-      if (
-        path
-        && (path === '$input.jsx' || path.startsWith('$input.jsx.'))
-        && expected === 'undefined'
-      ) {
-        return null
-      }
-
-      if (expected === 'undefined') {
-        return `Unknown property: \`${path}\` in the configuration of pluginReactLynx`
-      }
-      return [
-        `Invalid config on pluginReactLynx: \`${path}\`.`,
-        `  - Expect to be ${expected}`,
-        `  - Got: ${whatIs(value)}`,
-        '',
-      ]
-    })
-    .filter(message => message !== null)
-
-  if (messages.length === 0) {
-    return result.data as PluginReactLynxOptions | undefined
-  }
-
-  throw new Error(messages.join('\n'))
-}
+  return new Error(
+    [
+      `Invalid config on pluginReactLynx: \`${path}\`.`,
+      `  - Expect to be ${expected}`,
+      `  - Got: ${whatIs(value)}`,
+      '',
+    ].join('\n'),
+  )
+})
 
 function whatIs(value: unknown): string {
   return Object.prototype.toString.call(value)

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -276,7 +276,6 @@ describe('Config', () => {
         "enableRemoveCSSScope": true,
         "inlineSourcesContent": true,
         "isDynamicComponent": false,
-        "jsx": undefined,
       }
     `)
   })
@@ -303,7 +302,6 @@ describe('Config', () => {
         "enableRemoveCSSScope": undefined,
         "inlineSourcesContent": true,
         "isDynamicComponent": false,
-        "jsx": undefined,
       }
     `)
 

--- a/packages/rspeedy/plugin-react/test/validate.test.ts
+++ b/packages/rspeedy/plugin-react/test/validate.test.ts
@@ -107,10 +107,6 @@ describe('Validation', () => {
         [Error: Invalid config on pluginReactLynx: \`$input.defineDCE.define.foo\`.
           - Expect to be string
           - Got: number
-
-        Invalid config on pluginReactLynx: \`$input.defineDCE.define.bar\`.
-          - Expect to be string
-          - Got: null
         ]
       `)
   })
@@ -125,7 +121,9 @@ describe('Validation', () => {
     ]
 
     cases.forEach(jsx => {
-      expect(validateConfig({ jsx })).toStrictEqual({ jsx })
+      expect(() => validateConfig({ jsx })).toThrow(
+        `Unknown property: \`$input.jsx\``,
+      )
     })
 
     // cSpell:disable


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The `jsx` was marked as internal in #846, but it serves no purpose and should be removed entirely.

A minor bump has been made since removing an option is a breaking change.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
