### PR TITLE
fix(rspeedy/core): `output.inlineScripts` should defaults to `true`

### DIFF
--- a/.changeset/solid-birds-vanish.md
+++ b/.changeset/solid-birds-vanish.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+The default value of `output.inlineScripts` should be `true`.

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -44,6 +44,8 @@ export function toRsbuildConfig(
 
       filenameHash: config.output?.filenameHash,
 
+      inlineScripts: config.output?.inlineScripts,
+
       // TODO(OSS): change the default value to `linked`(or `undefined`) when OSS.
       // We expect to use different default legalComments with Rsbuild
       legalComments: config.output?.legalComments ?? 'none',

--- a/packages/rspeedy/core/test/config/output/inline-scripts.test.ts
+++ b/packages/rspeedy/core/test/config/output/inline-scripts.test.ts
@@ -1,0 +1,57 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { RsbuildPluginAPI } from '@rsbuild/core'
+import { describe, expect, test } from 'vitest'
+
+import { createStubRspeedy } from '../../createStubRspeedy.js'
+
+describe('output.inlineScripts', () => {
+  test('defaults', async () => {
+    const rspeedy = await createStubRspeedy({
+      plugins: [
+        {
+          name: 'test',
+          setup(api: RsbuildPluginAPI) {
+            api.modifyRsbuildConfig((config) => {
+              expect(config.output?.inlineScripts).toBe(true)
+            })
+            api.modifyBundlerChain((_, { environment }) => {
+              expect(environment.config.output.inlineScripts).toBe(true)
+            })
+          },
+        },
+      ],
+    })
+
+    await rspeedy.initConfigs()
+
+    expect.assertions(2)
+  })
+
+  test('output.inlineScripts: false', async () => {
+    const rspeedy = await createStubRspeedy({
+      output: {
+        inlineScripts: false,
+      },
+
+      plugins: [
+        {
+          name: 'test',
+          setup(api: RsbuildPluginAPI) {
+            api.modifyRsbuildConfig((config) => {
+              expect(config.output?.inlineScripts).toBe(false)
+            })
+            api.modifyBundlerChain((_, { environment }) => {
+              expect(environment.config.output.inlineScripts).toBe(false)
+            })
+          },
+        },
+      ],
+    })
+
+    await rspeedy.initConfigs()
+
+    expect.assertions(2)
+  })
+})

--- a/packages/rspeedy/core/test/config/rsbuild.test.ts
+++ b/packages/rspeedy/core/test/config/rsbuild.test.ts
@@ -358,6 +358,7 @@ describe('Config - toRsBuildConfig', () => {
           "dataUriLimit": 2048,
           "distPath": undefined,
           "filenameHash": undefined,
+          "inlineScripts": undefined,
           "legalComments": "none",
           "polyfill": "off",
           "sourceMap": undefined,
@@ -404,6 +405,17 @@ describe('Config - toRsBuildConfig', () => {
       })
 
       expect(rsbuildConfig.output?.distPath?.root).toBe('foo')
+    })
+
+    test('transform output.inlineScripts', () => {
+      const rsbuildConfig = toRsbuildConfig({
+        output: {
+          inlineScripts: false,
+        },
+      })
+      expect(rsbuildConfig.output?.inlineScripts).toMatchInlineSnapshot(
+        `false`,
+      )
     })
 
     test('transform output.legalComments', () => {


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix a regression of #874.

We should set `output.inlineScripts` to Rsbuild, so that:

- The default value of `environment.config.output.inlineScripts` could be `true`
- The `output.inlineScripts` could be set in `lynx.config.js`

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
