### PR TITLE
fix(eslint): update copyright header format and year pattern

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -97,13 +97,18 @@ export default tseslint.config(
           source: 'string',
           style: 'line',
           content: [
-            'Copyright {year} {authors}. All rights reserved.',
+            'Copyright (year) {authors}. All rights reserved.',
             'Licensed under the Apache License Version 2.0 that can be found in the',
             'LICENSE file in the root directory of this source tree.',
           ].join('\n'),
           variables: {
-            year: '2024',
             authors: 'The Lynx Authors',
+          },
+          patterns: {
+            year: {
+              pattern: '\\d{4}',
+              defaultValue: new Date().getFullYear().toString(),
+            },
           },
         },
       ],


### PR DESCRIPTION
## Summary

Update the copyright header template to use parentheses for the year placeholder and add a pattern to dynamically set the current year. This ensures the copyright year stays up-to-date automatically.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
