### PR TITLE
fix: the default value of `output.inlineScript` should be true in rsbuild

### DIFF
--- a/.changeset/small-donkeys-reflect.md
+++ b/.changeset/small-donkeys-reflect.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Set the default value of `output.inlineScript` to `true` in `toRsbuildConfig`

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -52,6 +52,8 @@ export function toRsbuildConfig(
 
       // TODO: update the Rsbuild type to allow `sourceMap.js` to be `*-debugids`
       sourceMap: config.output?.sourceMap as SourceMap,
+
+      inlineScripts: config.output?.inlineScripts,
     },
     source: {
       alias: config.source?.alias,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The default value of `output.inlineScript` should be true in Rsbuild, or `environment.config.output.inlineScripts` will be initialized with `false` by Rsbuild even if output.inlineScript is set to `true` in Rspeedy.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
