### PR TITLE
chore(webpack/chunk-loading): minor bump for updating peerDependencies @rspack/core

### DIFF
--- a/.changeset/icy-paths-battle.md
+++ b/.changeset/icy-paths-battle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/chunk-loading-webpack-plugin": minor
+---
+
+**BREAKING CHANGE**: Requires `@rspack/core` v1.3.10.

--- a/packages/webpack/chunk-loading-webpack-plugin/package.json
+++ b/packages/webpack/chunk-loading-webpack-plugin/package.json
@@ -49,7 +49,7 @@
     "webpack": "^5.99.9"
   },
   "peerDependencies": {
-    "@rspack/core": "^1.3.0"
+    "@rspack/core": "^1.3.10"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
This is a cherry-pick of #921 to release/rspeedy-0-9-7.

Fix a regression of #798

PeerDependencies @rspack/core should be v1.3.10.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
