### PR TITLE
fix(rspeedy/plugin-react): be compatible with @lynx-js/rspeedy <= 0.9.6

### DIFF
--- a/.changeset/cold-jars-doubt.md
+++ b/.changeset/cold-jars-doubt.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+The default value of `output.inlineScripts` should be `true` on `@lynx-js/rspeedy` <= v0.9.6.

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -378,11 +378,22 @@ export function pluginReactLynx(
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
         const userConfig = api.getRsbuildConfig('original')
         if (typeof userConfig.source?.include === 'undefined') {
-          return mergeRsbuildConfig(config, {
+          config = mergeRsbuildConfig(config, {
             source: {
               include: [
                 /\.(?:js|mjs|cjs)$/,
               ],
+            },
+          })
+        }
+
+        // This is used for compat with `@lynx-js/rspeedy` <= 0.9.6
+        // where the default value of `output.inlineScripts` is `false`.
+        // TODO: remove this when required Rspeedy version bumped to ^0.9.7
+        if (typeof userConfig.output?.inlineScripts === 'undefined') {
+          config = mergeRsbuildConfig(config, {
+            output: {
+              inlineScripts: true,
             },
           })
         }

--- a/packages/rspeedy/plugin-react/test/basic.test.ts
+++ b/packages/rspeedy/plugin-react/test/basic.test.ts
@@ -7,7 +7,6 @@ import { tmpdir } from 'node:os'
 import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { createRsbuild } from '@rsbuild/core'
 import { describe, expect, test, vi } from 'vitest'
 
 import { createRspeedy } from '@lynx-js/rspeedy'
@@ -24,8 +23,8 @@ describe('ReactLynx rsbuild', () => {
     vi.stubEnv('NODE_ENV', 'production')
     const { pluginReactLynx } = await import('../src/index.js')
 
-    const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
         source: {
           tsconfigPath: new URL('./tsconfig.json', import.meta.url).pathname,
           entry: {
@@ -33,14 +32,7 @@ describe('ReactLynx rsbuild', () => {
           },
         },
         tools: {
-          swc(config) {
-            delete config.env
-            return config
-          },
           rspack: {
-            output: {
-              chunkFormat: 'commonjs',
-            },
             context: dirname(fileURLToPath(import.meta.url)),
             resolve: {
               extensionAlias: {
@@ -49,9 +41,6 @@ describe('ReactLynx rsbuild', () => {
               },
             },
           },
-        },
-        environments: {
-          lynx: {},
         },
         plugins: [
           pluginReactLynx(),

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -411,6 +411,101 @@ describe('Config', () => {
     ).toHaveLength(1)
   })
 
+  describe('Output inlineScripts', () => {
+    test('defaults', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rsbuild = await createRspeedy({
+        rspeedyConfig: {
+          plugins: [
+            pluginReactLynx(),
+            pluginStubRspeedyAPI(),
+          ],
+        },
+      })
+
+      const [config] = await rsbuild.initConfigs()
+
+      const encodePlugin = config?.plugins?.find(p =>
+        p && p.constructor.name === 'LynxEncodePlugin'
+      )
+
+      expect(encodePlugin).toHaveProperty('options', { inlineScripts: true })
+    })
+
+    test('output.inlineScripts: false', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rsbuild = await createRspeedy({
+        rspeedyConfig: {
+          output: {
+            inlineScripts: false,
+          },
+          plugins: [
+            pluginReactLynx(),
+            pluginStubRspeedyAPI(),
+          ],
+        },
+      })
+
+      const [config] = await rsbuild.initConfigs()
+
+      const encodePlugin = config?.plugins?.find(p =>
+        p && p.constructor.name === 'LynxEncodePlugin'
+      )
+
+      expect(encodePlugin).toHaveProperty('options', { inlineScripts: false })
+    })
+
+    test('environments.lynx.output.inlineScripts: false', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rsbuild = await createRspeedy({
+        rspeedyConfig: {
+          environments: {
+            lynx: {
+              output: {
+                inlineScripts: false,
+              },
+            },
+          },
+          plugins: [
+            pluginReactLynx(),
+            pluginStubRspeedyAPI(),
+          ],
+        },
+      })
+
+      const [config] = await rsbuild.initConfigs()
+
+      const encodePlugin = config?.plugins?.find(p =>
+        p && p.constructor.name === 'LynxEncodePlugin'
+      )
+
+      expect(encodePlugin).toHaveProperty('options', { inlineScripts: false })
+    })
+
+    test('legacy Rspeedy version (with `output.inlineScripts` defaults to `false`)', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rsbuild = await createRsbuild({
+        rsbuildConfig: {
+          plugins: [
+            pluginReactLynx(),
+            pluginStubRspeedyAPI(),
+          ],
+          environments: {
+            lynx: {},
+          },
+        },
+      })
+
+      const [config] = await rsbuild.initConfigs()
+
+      const encodePlugin = config?.plugins?.find(p =>
+        p && p.constructor.name === 'LynxEncodePlugin'
+      )
+
+      expect(encodePlugin).toHaveProperty('options', { inlineScripts: true })
+    })
+  })
+
   describe('Output Filename', () => {
     test('Defaults in production', async () => {
       vi.stubEnv('NODE_ENV', 'production')


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This is a cherry-pick of https://github.com/lynx-family/lynx-stack/pull/914 to release/rspeedy-0-9-7.

Fix a regression of https://github.com/lynx-family/lynx-stack/pull/874.

The @lynx-js/react-rsbuild-plugin should be compatible with @lynx-js/rspeedy <= 0.9.6, where the default value of output.inlineScripts is undefined.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
