### PR TITLE
fix(eslint): allow preact imports in no-extraneous-import rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -132,7 +132,7 @@ export default tseslint.config(
       'n/file-extension-in-import': ['error', 'always'],
       'n/prefer-node-protocol': 'error',
       'n/no-extraneous-import': ['error', {
-        allowModules: ['vitest'],
+        allowModules: ['vitest', 'preact'],
       }],
       'n/no-unpublished-import': 'off',
       'n/no-missing-import': 'off',


### PR DESCRIPTION
## Summary

Add 'preact' to the allowed modules list to resolve import errors when using the Preact library.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
