### PR TITLE
fix(web): style loss when enableCSSSelector and enableRemoveCSSScope are turned off

### DIFF
--- a/.changeset/busy-vans-heal.md
+++ b/.changeset/busy-vans-heal.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: style loss issue caused by incorrect handling of styleInfo-imports when enableCSSSelector and enableRemoveCSSScope are turned off.

--- a/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
+++ b/packages/web-platform/web-mainthread-apis/src/MainThreadRuntime.ts
@@ -122,7 +122,10 @@ export class MainThreadRuntime {
      * 4. create the style element
      * 5. append the style element to the root dom
      */
-    flattenStyleInfo(this.config.styleInfo);
+    flattenStyleInfo(
+      this.config.styleInfo,
+      this.config.pageConfig.enableCSSSelector,
+    );
     transformToWebCss(this.config.styleInfo);
     const cssInJsInfo: CssInJsInfo = this.config.pageConfig.enableCSSSelector
       ? {}

--- a/packages/web-platform/web-mainthread-apis/src/utils/processStyleInfo.ts
+++ b/packages/web-platform/web-mainthread-apis/src/utils/processStyleInfo.ts
@@ -15,6 +15,7 @@ import { transformLynxStyles } from '@lynx-js/web-style-transformer';
 
 export function flattenStyleInfo(
   styleInfo: StyleInfo,
+  enableCSSSelector: boolean,
 ): void {
   function flattenOneStyleInfo(cssId: string): OneInfo | undefined {
     const oneInfo = styleInfo[cssId];
@@ -24,7 +25,14 @@ export function flattenStyleInfo(
         const flatInfo = flattenOneStyleInfo(im);
         if (flatInfo) {
           oneInfo.content.push(...flatInfo.content);
-          oneInfo.rules.push(...flatInfo.rules);
+          // oneInfo.rules.push(...flatInfo.rules);
+          oneInfo.rules.push(
+            ...(enableCSSSelector
+              ? flatInfo.rules
+              // when enableCSSSelector is false, need to make a shallow copy of rules.sel
+              // otherwise updating `oneCssInfo.sel` in `genCssInJsInfo()` will affect other imported cssInfo
+              : flatInfo.rules.map(i => ({ ...i }))),
+          );
         }
       }
       oneInfo.imports = undefined;

--- a/packages/web-platform/web-tests/shell-project/web-core.ts
+++ b/packages/web-platform/web-tests/shell-project/web-core.ts
@@ -66,7 +66,7 @@ async function run() {
   if (ALL_ON_UI) lynxView.setAttribute('thread-strategy', `all-on-ui`);
   lynxView.initData = { mockData: 'mockData' };
   lynxView.globalProps = { backgroundColor: 'pink' };
-  lynxView.height = 'auto';
+  lynxView.setAttribute('height', 'auto');
   lynxView.napiModulesMap = {
     'color_environment': color_environment,
     'color_methods': color_methods,

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -1225,6 +1225,16 @@ test.describe('reactlynx3 tests', () => {
         );
       },
     );
+
+    test(
+      'config-mixed-01',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
   });
 
   test.describe('elements', () => {

--- a/packages/web-platform/web-tests/tests/react/config-mixed-01.config.ts
+++ b/packages/web-platform/web-tests/tests/react/config-mixed-01.config.ts
@@ -1,0 +1,30 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { glob } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { commonConfig } from './commonConfig.js';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const reactBasicCases = await Array.fromAsync(glob(
+  path.join(
+    __dirname,
+    'config-mixed-01',
+    '*.jsx',
+  ),
+));
+
+export default defineConfig({
+  ...commonConfig({
+    enableCSSSelector: false,
+    enableRemoveCSSScope: false,
+  }),
+  source: {
+    entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
+      return [path.basename(path.dirname(reactBasicEntry)), reactBasicEntry];
+    })),
+  },
+});

--- a/packages/web-platform/web-tests/tests/react/config-mixed-01/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-mixed-01/index.css
@@ -1,0 +1,13 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.background-green {
+  background-color: green;
+}
+
+.background-yellow {
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-mixed-01/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-mixed-01/index.jsx
@@ -1,0 +1,44 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, Component } from '@lynx-js/react';
+import './index.css';
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      stateId: 0,
+    };
+  }
+  handletap() {
+    this.setState({ stateId: this.state.stateId + 1 });
+  }
+  getInline() {
+    switch (this.state.stateId) {
+      default:
+        return { height: '100px', width: '100px' }; // green
+    }
+  }
+  getClass() {
+    switch (this.state.stateId) {
+      case 0:
+        return 'background-yellow background-green';
+      case 1:
+        return 'background-green background-yellow ';
+    }
+  }
+  render() {
+    return (
+      <view
+        id='target'
+        class={this.getClass()}
+        bindtap={() => {
+          this.handletap();
+        }}
+        style={this.getInline()}
+      />
+    );
+  }
+}
+
+root.render(<App></App>);


### PR DESCRIPTION
## Summary

fix: style loss issue caused by incorrect handling of styleInfo-imports when enableCSSSelector and enableRemoveCSSScope are turned off.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
