### PR TITLE
fix(web): x-foldview-ng overflow-y: scroll add important to avoid bei…

### DIFF
--- a/.changeset/fresh-clowns-crash.md
+++ b/.changeset/fresh-clowns-crash.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: x-foldview-ng `overflow-y: scroll` add !important to avoid being covered.

--- a/packages/web-platform/web-elements/src/XFoldViewNg/x-foldview-ng.css
+++ b/packages/web-platform/web-elements/src/XFoldViewNg/x-foldview-ng.css
@@ -5,7 +5,7 @@
 */
 x-foldview-ng {
   display: flex;
-  overflow-y: scroll;
+  overflow-y: scroll !important;
   overflow-x: clip;
   overflow-x: hidden;
   overscroll-behavior: contain;


### PR DESCRIPTION
…ng covered.

## Summary

fix: x-foldview-ng `overflow-y: scroll` add !important to avoid being covered.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
