### PR TITLE
chore(deps): pin `@lynx-js/types` to v3.3.0

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -15,7 +15,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
-    "@lynx-js/types": "^3.3.0",
+    "@lynx-js/types": "3.3.0",
     "@types/react": "^18.3.22"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -164,7 +164,7 @@
     "preact": "npm:@hongzhiyuan/preact@10.24.0-319c684e"
   },
   "devDependencies": {
-    "@lynx-js/types": "^3.3.0",
+    "@lynx-js/types": "3.3.0",
     "@microsoft/api-extractor": "catalog:",
     "@types/react": "^18.3.22"
   },

--- a/packages/react/worklet-runtime/package.json
+++ b/packages/react/worklet-runtime/package.json
@@ -35,7 +35,7 @@
     "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "@lynx-js/types": "^3.3.0",
+    "@lynx-js/types": "3.3.0",
     "esbuild": "^0.25.4"
   }
 }

--- a/packages/rspeedy/create-rspeedy/template-react-ts/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/package.json
@@ -14,7 +14,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
-    "@lynx-js/types": "^3.3.0",
+    "@lynx-js/types": "3.3.0",
     "@types/react": "^18.3.22",
     "typescript": "~5.8.3"
   },

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/package.json
@@ -15,7 +15,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
-    "@lynx-js/types": "^3.3.0",
+    "@lynx-js/types": "3.3.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/react": "^18.3.22",
     "jsdom": "^26.1.0",

--- a/packages/rspeedy/upgrade-rspeedy/package.json
+++ b/packages/rspeedy/upgrade-rspeedy/package.json
@@ -38,7 +38,7 @@
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
-    "@lynx-js/types": "^3.3.0",
+    "@lynx-js/types": "3.3.0",
     "@lynx-js/web-core": "workspace:*",
     "@lynx-js/web-elements": "workspace:*",
     "@rsbuild/plugin-less": "catalog:rsbuild",

--- a/packages/third-party/tailwind-preset/package.json
+++ b/packages/third-party/tailwind-preset/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@lynx-js/types": "^3.3.0",
+    "@lynx-js/types": "3.3.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspeedy/core
       '@lynx-js/types':
-        specifier: ^3.3.0
+        specifier: 3.3.0
         version: 3.3.0
       '@types/react':
         specifier: ^18.3.22
@@ -180,7 +180,7 @@ importers:
         version: '@hongzhiyuan/preact@10.24.0-319c684e'
     devDependencies:
       '@lynx-js/types':
-        specifier: ^3.3.0
+        specifier: 3.3.0
         version: 3.3.0
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -270,7 +270,7 @@ importers:
   packages/react/worklet-runtime:
     devDependencies:
       '@lynx-js/types':
-        specifier: ^3.3.0
+        specifier: 3.3.0
         version: 3.3.0
       esbuild:
         specifier: ^0.25.4
@@ -511,7 +511,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@lynx-js/types':
-        specifier: ^3.3.0
+        specifier: 3.3.0
         version: 3.3.0
       '@lynx-js/web-core':
         specifier: workspace:*
@@ -594,7 +594,7 @@ importers:
   packages/third-party/tailwind-preset:
     devDependencies:
       '@lynx-js/types':
-        specifier: ^3.3.0
+        specifier: 3.3.0
         version: 3.3.0
       postcss:
         specifier: ^8.5.3


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Avoid TS error introduced in `@lynx-js/types` v3.3.1.

```
Error: src/App.tsx(41,24): error TS2322: Type 'number' is not assignable to type 'string'.
Error: Process completed with exit code 2.
```
> https://github.com/lynx-family/lynx-stack/actions/runs/15269327250/job/42941699971?pr=899

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
