### PR TITLE
ci: add `timeout-minutes` for all jobs

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   codeql:
+    timeout-minutes: 10
     name: CodeQL Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
@@ -86,6 +87,7 @@ jobs:
           category: "/language:${{matrix.language}}"
 
   zizmor:
+    timeout-minutes: 10
     runs-on: lynx-ubuntu-24.04-medium
     permissions:
       security-events: write

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.repository == 'lynx-family/lynx-stack'
     permissions:
       contents: read
@@ -92,6 +93,7 @@ jobs:
         --logHeapUsage
         --silent
   publish:
+    timeout-minutes: 30
     needs: build
     runs-on: ubuntu-latest
     if: github.repository == 'lynx-family/lynx-stack'
@@ -142,6 +144,7 @@ jobs:
           title: "chore: Release ${{ steps.date.outputs.date }}"
 
   canary-publish:
+    timeout-minutes: 30
     needs: build
     runs-on: ubuntu-latest
     if: github.repository == 'lynx-family/lynx-stack'
@@ -194,6 +197,7 @@ jobs:
     uses: ./.github/workflows/workflow-website.yml
     permissions: {}
   website-deploy:
+    timeout-minutes: 10
     needs: website-build
     if: github.repository == 'lynx-family/lynx-stack'
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs-dependencies.yml
+++ b/.github/workflows/nodejs-dependencies.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   sherif:
     runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pull-request-content-check.yml
+++ b/.github/workflows/pull-request-content-check.yml
@@ -15,6 +15,7 @@ jobs:
   validate-pr-title:
     name: Validate PR title
     runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 10
     steps:
       # https://github.com/amannn/action-semantic-pull-request
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -12,6 +12,7 @@ permissions: {}
 
 jobs:
   upload:
+    timeout-minutes: 10
     strategy:
       matrix:
         project:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   test:
     runs-on: lynx-ubuntu-24.04-xlarge
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -51,6 +52,7 @@ jobs:
 
   rustfmt:
     runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
     uses: ./.github/workflows/workflow-bundle-analysis.yml
   code-style-check:
     runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -6,6 +6,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   nodejs-benchmark:
+    timeout-minutes: 10
     # CodSpeed does not support merge_group event.
     #
     # Error: Event merge_group is not supported by CodSpeed

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -9,6 +9,7 @@ env:
 jobs:
   get-merge-base:
     runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 5
     env:
       # We have 2 cases:
       #   1. Pull request
@@ -62,6 +63,7 @@ jobs:
           echo "merge-base=$(git merge-base "$CLEAN_BASE_REF" "$CLEAN_HEAD_REF" || git rev-parse "$CLEAN_BASE_REF")" >> $GITHUB_OUTPUT
   build-all:
     runs-on: lynx-ubuntu-24.04-xlarge
+    timeout-minutes: 30
     needs: get-merge-base
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   build:
     runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 10
     strategy:
       matrix:
         project:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -30,6 +30,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   check:
+    timeout-minutes: 30
     runs-on: ${{ inputs.runs-on }}
     permissions: {}
     steps:

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -9,6 +9,7 @@ env:
 jobs:
   build:
     runs-on: lynx-ubuntu-24.04-medium
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Set a `timeout-minutes` value for all jobs. The default of 360 minutes is too long for our needs. Adjusting this will prevent CI from hanging during network issues.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
