### PR TITLE
ci: add default permission

### DIFF
--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -6,6 +6,8 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   nodejs-benchmark:
+    permissions:
+      contents: read
     timeout-minutes: 10
     # CodSpeed does not support merge_group event.
     #

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -8,6 +8,8 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   get-merge-base:
+    permissions:
+      contents: read
     runs-on: lynx-ubuntu-24.04-medium
     timeout-minutes: 5
     env:
@@ -62,6 +64,8 @@ jobs:
         run: |
           echo "merge-base=$(git merge-base "$CLEAN_BASE_REF" "$CLEAN_HEAD_REF" || git rev-parse "$CLEAN_BASE_REF")" >> $GITHUB_OUTPUT
   build-all:
+    permissions:
+      contents: read
     runs-on: lynx-ubuntu-24.04-xlarge
     timeout-minutes: 30
     needs: get-merge-base

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -8,6 +8,8 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: lynx-ubuntu-24.04-medium
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Add a default permission to all jobs.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fixes:

- https://github.com/lynx-family/lynx-stack/security/code-scanning/138
- https://github.com/lynx-family/lynx-stack/security/code-scanning/137
- https://github.com/lynx-family/lynx-stack/security/code-scanning/136
- https://github.com/lynx-family/lynx-stack/security/code-scanning/134


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
