### PR TITLE
ci: not restore cache from same PR

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -77,15 +77,10 @@ jobs:
         with:
           path: .turbo
           key: turbo-v3-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
-          # We can restore caches from
-          #   1. Runs in the same PR
-          #   2. Previous commit from base branch
-          #     2.1 Use the merge base
-          #     2.2 Use the base SHA
-          #   3. Any cache
+          # We can restore caches from:
+          #   1. Previous commit from base branch (merge base or base SHA)
+          #   2. Any cache
           restore-keys: |
-            turbo-pull-request-${{ github.event.pull_request.number || 'non-exists' }}-${{ github.run_number }}
-            turbo-pull-request-${{ github.event.pull_request.number || 'non-exists' }}-
             turbo-v3-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ needs.get-merge-base.outputs.merge-base }}
             turbo-v3-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
             turbo-v3-${{ hashFiles('**/packages/**/src/**/*.rs') }}-
@@ -122,9 +117,3 @@ jobs:
           pnpm turbo build --summarize
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Save turbo cache
-        if: github.event_name == 'pull_request'
-        uses: lynx-infra/cache/save@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
-        with:
-          path: .turbo
-          key: turbo-pull-request-${{ github.event.pull_request.number }}-${{ github.run_number }}-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Previously, we restored the cache from the previous task of the current PR. However, GitHub runs actions not directly on the PR ref but on a ref merged with the `main` branch. As a result, using the cache from the current PR often leads to cache misses when there are changes in the `main` branch.

We would also save some time on saving the PR cache.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
