### PR TITLE
feat(react/runtime): support 'main-thread' as an alias for 'main thread'

### DIFF
--- a/.changeset/fresh-guests-wish.md
+++ b/.changeset/fresh-guests-wish.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Support the 'main-thread' directive as an alias for 'main thread'.

--- a/packages/react/transform/src/swc_plugin_worklet/mod.rs
+++ b/packages/react/transform/src/swc_plugin_worklet/mod.rs
@@ -525,6 +525,35 @@ function worklet(event: Event) {
         TransformMode::Test,
         WorkletVisitorConfig {
           filename: "index.js".into(),
+          target: TransformTarget::LEPUS,
+          custom_global_ident_names: None,
+          runtime_pkg: "@lynx-js/react".into(),
+        }
+      )),
+      hygiene()
+    ),
+    should_transform_lepus_alias,
+    r#"
+function worklet(event: Event) {
+    "main-thread";
+    console.log(y1);
+    console.log(this.y1);
+    let a: object = y1;
+}
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Typescript(TsSyntax {
+      ..Default::default()
+    }),
+    |_| (
+      resolver(Mark::new(), Mark::new(), true),
+      visit_mut_pass(WorkletVisitor::new(
+        TransformMode::Test,
+        WorkletVisitorConfig {
+          filename: "index.js".into(),
           target: TransformTarget::MIXED,
           custom_global_ident_names: None,
           runtime_pkg: "@lynx-js/react".into(),

--- a/packages/react/transform/src/swc_plugin_worklet/worklet_type.rs
+++ b/packages/react/transform/src/swc_plugin_worklet/worklet_type.rs
@@ -6,7 +6,7 @@ pub enum WorkletType {
 
 impl WorkletType {
   pub fn from_directive(directive: String) -> Option<WorkletType> {
-    if directive == "main thread" {
+    if directive == "main thread" || directive == "main-thread" {
       Some(WorkletType::Element)
     } else if directive == "use worklet" {
       Some(WorkletType::UI)

--- a/packages/react/transform/tests/__swc_snapshots__/src/swc_plugin_worklet/mod.rs/should_transform_lepus_alias.js
+++ b/packages/react/transform/tests/__swc_snapshots__/src/swc_plugin_worklet/mod.rs/should_transform_lepus_alias.js
@@ -1,0 +1,16 @@
+import { loadWorkletRuntime as __loadWorkletRuntime } from "@lynx-js/react";
+var loadWorkletRuntime = __loadWorkletRuntime;
+let worklet = {
+    _c: {
+        y1
+    },
+    _wkltId: "a77b:test:1"
+};
+loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry) && registerWorkletInternal("main-thread", "a77b:test:1", function(event: Event) {
+    const worklet = lynxWorkletImpl._workletMap["a77b:test:1"].bind(this);
+    let { y1 } = this["_c"];
+    "main-thread";
+    console.log(y1);
+    console.log(this.y1);
+    let a: object = y1;
+});


### PR DESCRIPTION
## Summary

Support the 'main-thread' directive as an alias for 'main thread'.

This change would provide a better experience when using AI tools to generate code automatically.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
