### PR TITLE
fix(webpack/react): add missing semicolon

### DIFF
--- a/.changeset/deep-views-join.md
+++ b/.changeset/deep-views-join.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Fix lazy bundle build failed on Rspeedy v0.9.8 (with `output.iife: true`).

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -297,7 +297,7 @@ class ReactWebpackPlugin {
               `\
 (function (globDynamicComponentEntry) {
   const module = { exports: {} }
-  const exports = module.exports
+  const exports = module.exports;
 `,
               old,
               `


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

We have a project injecting some code using `BannerPlugin`. Currently we would get code like this:

```js
(function (globDynamicComponentEntry) {
  const module = { exports: {} }
  const exports = module.exports
  (function () {
    /* code from BannerPlugin */
  })(),
  (() => {
    /* code from main-thread.js */
  })()
})
```

which result in "SyntaxError: Unexpected token '('".

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
