### PR TITLE
Revert "feat(rspeedy/qrcode): support autocomplete"

### DIFF
--- a/.changeset/cool-nights-admire.md
+++ b/.changeset/cool-nights-admire.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/qrcode-rsbuild-plugin": minor
----
-
-Support "Type to search" when switching entries and schema.

--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -48,7 +48,7 @@
     "test": "pnpm -w run test --project rspeedy/qrcode"
   },
   "devDependencies": {
-    "@clack/prompts": "1.0.0-alpha.0",
+    "@clack/prompts": "^0.10.1",
     "@lynx-js/rspeedy": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rsbuild/core": "catalog:rsbuild",

--- a/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
+++ b/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
@@ -61,14 +61,12 @@ async function loop(
   devUrls: Record<string, string>,
 ) {
   const [
-    { autocomplete, select, selectKey, isCancel, cancel },
+    { select, selectKey, isCancel, cancel },
     { default: showQRCode },
   ] = await Promise.all([
     import('@clack/prompts'),
     import('./showQRCode.js'),
   ])
-
-  const selectFn = (length: number) => length > 5 ? autocomplete : select
 
   let currentEntry = options.entries[0]!
   let currentSchema = Object.keys(devUrls)[0]!
@@ -95,7 +93,7 @@ async function loop(
       break
     }
     if (name === 'r') {
-      const selection = await selectFn(options.entries.length)({
+      const selection = await select({
         message: 'Select entry',
         options: options.entries.map(entry => ({
           value: entry,
@@ -107,11 +105,7 @@ async function loop(
             options.port,
           )[currentSchema]!,
         })),
-        // autoComplete requires `maxItems`, otherwise it will render all items
-        maxItems: 8,
-        // autoComplete will not work if `initialValue` is set
-        // See: https://github.com/bombshell-dev/clack/issues/326
-        // initialValue: currentEntry,
+        initialValue: currentEntry,
       })
       if (isCancel(selection)) {
         break
@@ -125,18 +119,14 @@ async function loop(
         options.schema,
         options.port,
       )
-      const selection = await selectFn(Object.keys(devUrls).length)({
+      const selection = await select({
         message: 'Select schema',
         options: Object.entries(devUrls).map(([name, url]) => ({
           value: name,
           label: name,
           hint: url,
         })),
-        // autoComplete requires `maxItems`, otherwise it will render all items
-        maxItems: 8,
-        // autoComplete will not work if `initialValue` is set
-        // See: https://github.com/bombshell-dev/clack/issues/326
-        // initialValue: currentSchema,
+        initialValue: currentSchema,
       })
       if (isCancel(selection)) {
         break

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,8 +380,8 @@ importers:
   packages/rspeedy/plugin-qrcode:
     devDependencies:
       '@clack/prompts':
-        specifier: 1.0.0-alpha.0
-        version: 1.0.0-alpha.0
+        specifier: ^0.10.1
+        version: 0.10.1
       '@lynx-js/rspeedy':
         specifier: workspace:*
         version: link:../core
@@ -1553,11 +1553,11 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clack/core@1.0.0-alpha.0':
-    resolution: {integrity: sha512-Cp/bPW/pMUCkJ7Lr8VFixvFrlnJ4tQPDHqfTNQ51z50qwX1fSIAstQLfel2NquVHqbfjyrUkBsal8OJRBPJVjw==}
+  '@clack/core@0.4.2':
+    resolution: {integrity: sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==}
 
-  '@clack/prompts@1.0.0-alpha.0':
-    resolution: {integrity: sha512-Aem7r4U2A4jdOh0PIv51Ugi+4vDgzJjGVMnuPUNVVHDGhFHEO//u6F/JY6NsZQFtXrd7ZmfePSiipikr/e5wWg==}
+  '@clack/prompts@0.10.1':
+    resolution: {integrity: sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==}
 
   '@codspeed/core@4.0.1':
     resolution: {integrity: sha512-fJ53arfgtzCDZa8DuGJhpTZ3Ll9A1uW5nQ2jSJnfO4Hl5MRD2cP8P4vPvIUAGbdbjwCxR1jat6cW8OloMJkJXw==}
@@ -8674,14 +8674,14 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@clack/core@1.0.0-alpha.0':
+  '@clack/core@0.4.2':
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.0.0-alpha.0':
+  '@clack/prompts@0.10.1':
     dependencies:
-      '@clack/core': 1.0.0-alpha.0
+      '@clack/core': 0.4.2
       picocolors: 1.1.1
       sisteransi: 1.0.5
 


### PR DESCRIPTION
Reverts lynx-family/lynx-stack#902

We'll wait until https://github.com/bombshell-dev/clack/issues/331 and https://github.com/bombshell-dev/clack/issues/326 being released.