### PR TITLE
ci: use minimal permission

### DIFF
--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -6,8 +6,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   nodejs-benchmark:
-    permissions:
-      contents: read
+    permissions: {}
     timeout-minutes: 10
     # CodSpeed does not support merge_group event.
     #

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -8,8 +8,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   get-merge-base:
-    permissions:
-      contents: read
+    permissions: {}
     runs-on: lynx-ubuntu-24.04-medium
     timeout-minutes: 5
     env:
@@ -64,8 +63,7 @@ jobs:
         run: |
           echo "merge-base=$(git merge-base "$CLEAN_BASE_REF" "$CLEAN_HEAD_REF" || git rev-parse "$CLEAN_BASE_REF")" >> $GITHUB_OUTPUT
   build-all:
-    permissions:
-      contents: read
+    permissions: {}
     runs-on: lynx-ubuntu-24.04-xlarge
     timeout-minutes: 30
     needs: get-merge-base

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -8,8 +8,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   build:
-    permissions:
-      contents: read
+    permissions: {}
     runs-on: lynx-ubuntu-24.04-medium
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix the deploy pipeline not running:

```
Invalid workflow file: .github/workflows/deploy-main.yml#L59
The workflow is not valid. .github/workflows/deploy-main.yml (Line: 59, Col: 3): Error calling workflow 'lynx-family/lynx-stack/.github/workflows/workflow-build.yml@81361f3c72001ffdf07f2f9f53f8e43d2ff7c961'. The nested job 'get-merge-base' is requesting 'contents: read', but is only allowed 'contents: none'. .github/workflows/deploy-main.yml (Line: 59, Col: 3): Error calling workflow 'lynx-family/lynx-stack/.github/workflows/workflow-build.yml@81361f3c72001ffdf07f2f9f53f8e43d2ff7c961'. The nested job 'build-all' is requesting 'contents: read', but is only allowed 'contents: none'.
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
