### PR TITLE
fix(react/runtime): should have `__webpack_require__` in `evaluate`

### DIFF
--- a/.changeset/cute-hounds-sip.md
+++ b/.changeset/cute-hounds-sip.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix the "main-thread.js exception: ReferenceError: `__webpack_require__` is not defined" error in HMR.
+
+This error occurred when setting `output.iife: true`, which is the default value in `@lynx-js/rspeedy` v0.9.8.

--- a/packages/react/runtime/src/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/lifecycle/patch/snapshotPatchApply.ts
@@ -129,10 +129,20 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
   }
 }
 
+declare global {
+  const __webpack_require__: (<T>(id: string) => T) | undefined;
+}
+
 /**
  * Evaluates a string as code with ReactLynx runtime injected.
  * Used for HMR (Hot Module Replacement) to update snapshot definitions.
  */
 function evaluate<T>(code: string): T {
+  // This is a workaround for webpack when `output.iife` is `true`.
+  // We should fully support main-thread HMR and remove this `evaluate` function entirely.
+  // See https://github.com/lynx-family/lynx-stack/issues/983 for more details.
+  if (typeof __webpack_require__ !== 'undefined') {
+    return new Function('__webpack_require__', `return ${code}`)(__webpack_require__);
+  }
   return new Function(`return ${code}`)();
 }


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: https://github.com/lynx-family/lynx-stack/issues/983

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
