### PR TITLE
feat(web): x-input and x-textarea bindinput event structure change

### DIFF
--- a/.changeset/chilly-snakes-hunt.md
+++ b/.changeset/chilly-snakes-hunt.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+feat: x-input and x-textarea bindinput event return structures add `selectionStart`, `selectionEnd`, and `textLength`, `textLength` are marked as @deprecated

--- a/packages/web-platform/web-elements/src/XInput/XInputEvents.ts
+++ b/packages/web-platform/web-elements/src/XInput/XInputEvents.ts
@@ -82,9 +82,13 @@ export class XInputEvents
         ...commonComponentEventSetting,
         detail: {
           value,
+          /** @deprecated */
           textLength: value.length,
+          /** @deprecated */
           cursor: input.selectionStart,
           isComposing,
+          selectionStart: input.selectionStart,
+          selectionEnd: input.selectionEnd,
         },
       }),
     );
@@ -100,8 +104,13 @@ export class XInputEvents
           ...commonComponentEventSetting,
           detail: {
             value,
+            /** @deprecated */
             textLength: value.length,
+            /** @deprecated */
             cursor: input.selectionStart,
+            isComposing: false,
+            selectionStart: input.selectionStart,
+            selectionEnd: input.selectionEnd,
           },
         }),
       );

--- a/packages/web-platform/web-elements/src/XTextarea/XTextareaEvents.ts
+++ b/packages/web-platform/web-elements/src/XTextarea/XTextareaEvents.ts
@@ -82,9 +82,13 @@ export class XTextareaEvents
         ...commonComponentEventSetting,
         detail: {
           value,
+          /** @deprecated */
           textLength: value.length,
+          /** @deprecated */
           cursor: input.selectionStart,
           isComposing,
+          selectionStart: input.selectionStart,
+          selectionEnd: input.selectionEnd,
         },
       }),
     );
@@ -100,8 +104,13 @@ export class XTextareaEvents
           ...commonComponentEventSetting,
           detail: {
             value,
+            /** @deprecated */
             textLength: value.length,
+            /** @deprecated */
             cursor: input.selectionStart,
+            isComposing: false,
+            selectionStart: input.selectionStart,
+            selectionEnd: input.selectionEnd,
           },
         }),
       );

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -2195,7 +2195,7 @@ test.describe('reactlynx3 tests', () => {
         await page.locator('input').fill('foobar');
         await wait(200);
         const result = await page.locator('.result').first().innerText();
-        expect(result).toBe('foobar');
+        expect(result).toBe('foobar-6-6');
       });
       // input/bindinput test-case end
       test(
@@ -3477,6 +3477,8 @@ test.describe('reactlynx3 tests', () => {
               event.type === 'input'
               && dataset.testid === 'textarea'
               && event.detail.value === 'value'
+              && event.detail.selectionStart === 5
+              && event.detail.selectionEnd === 5
             ) {
               bindinput = true;
             }

--- a/packages/web-platform/web-tests/tests/react/basic-element-x-input-bindinput/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-element-x-input-bindinput/index.jsx
@@ -8,7 +8,7 @@ function App() {
   const [result, setResult] = useState();
 
   const onInput = ({ detail }) => {
-    const { value, cursor, textLength } = detail;
+    const { value, cursor, textLength, selectionStart, selectionEnd } = detail;
 
     if (value.length !== textLength) {
       throw new Error(
@@ -16,7 +16,7 @@ function App() {
       );
     }
 
-    setResult(value);
+    setResult(`${value}-${selectionStart}-${selectionStart}`);
   };
 
   return (


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

feat: x-input and x-textarea bindinput event return structures add `selectionStart`, `selectionEnd`, and `textLength`, `textLength` are marked as @deprecated

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
