### PR TITLE
feat(rspeedy/core): set `optimization.emitOnErrors: true` when DEBUG

### DIFF
--- a/.changeset/clear-apples-arrive.md
+++ b/.changeset/clear-apples-arrive.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Set `optimization.emitOnErrors` when `DEBUG` is enabled.
+
+This is useful for debugging PrimJS Syntax error.

--- a/packages/rspeedy/core/src/plugins/emitOnErrors.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/emitOnErrors.plugin.ts
@@ -1,0 +1,16 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { RsbuildPlugin } from '@rsbuild/core'
+
+export function pluginEmitOnErrors(): RsbuildPlugin {
+  return {
+    name: 'lynx:rsbuild:emit-on-errors',
+    setup(api) {
+      api.modifyBundlerChain((chain) => {
+        chain.optimization.emitOnErrors(true)
+      })
+    },
+  }
+}

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -12,6 +12,9 @@ async function applyDebugPlugins(
   config: Config,
 ): Promise<void> {
   const debugPlugins = Object.freeze<Promise<RsbuildPlugin>[]>([
+    import('./emitOnErrors.plugin.js').then(({ pluginEmitOnErrors }) =>
+      pluginEmitOnErrors()
+    ),
     import('./inspect.plugin.js').then(({ pluginInspect }) =>
       pluginInspect(config)
     ),

--- a/packages/rspeedy/core/test/plugins/emitOnErrors.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/emitOnErrors.plugin.test.ts
@@ -1,0 +1,53 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test, vi } from 'vitest'
+
+import { createStubRspeedy } from '../createStubRspeedy.js'
+
+describe('Plugins - emitOnErrors', () => {
+  test('no DEBUG', async () => {
+    vi.stubEnv('DEBUG', '')
+    const rspeedy = await createStubRspeedy({})
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.optimization?.emitOnErrors).toBe(undefined)
+  })
+
+  test('DEBUG=rspeedy', async () => {
+    vi.stubEnv('DEBUG', 'rspeedy')
+    const rspeedy = await createStubRspeedy({})
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.optimization?.emitOnErrors).toBe(true)
+  })
+
+  test('DEBUG=rspeedy,rsbuild', async () => {
+    vi.stubEnv('DEBUG', 'rspeedy,rsbuild')
+    const rspeedy = await createStubRspeedy({})
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.optimization?.emitOnErrors).toBe(true)
+  })
+
+  test('DEBUG=*', async () => {
+    vi.stubEnv('DEBUG', '*')
+    const rspeedy = await createStubRspeedy({})
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.optimization?.emitOnErrors).toBe(true)
+  })
+
+  test('DEBUG=foo,bar', async () => {
+    vi.stubEnv('DEBUG', 'foo,bar')
+    const rspeedy = await createStubRspeedy({})
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.optimization?.emitOnErrors).toBe(undefined)
+  })
+})


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Set `optimization.emitOnErrors: true` when `DEBUG` is enabled.

This is useful for debugging PrimJS Syntax error (a.k.a. encode error).

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
