### PR TITLE
fix(react/runtime): delay applying mt:ref until hydration has finished

### DIFF
--- a/.changeset/red-meals-battle.md
+++ b/.changeset/red-meals-battle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix a problem causing `MainThreadRef`s to not be updated correctly during hydration when they are set to `main-thread:ref`s.

--- a/packages/react/runtime/__test__/snapshot/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/workletRef.test.jsx
@@ -30,6 +30,11 @@ beforeAll(() => {
     _runOnBackgroundDelayImpl: {
       runDelayedBackgroundFunctions: vi.fn(),
     },
+    _eventDelayImpl: {
+      runDelayedWorklet: vi.fn(),
+      clearDelayedWorklets: vi.fn(),
+    },
+    _hydrateCtx: vi.fn(),
   };
   globalThis.runWorklet = vi.fn();
 });

--- a/packages/react/runtime/__test__/snapshot/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/workletRef.test.jsx
@@ -339,6 +339,15 @@ describe('WorkletRef', () => {
           ],
           [
             {
+              "_unmount": undefined,
+              "_wkltId": 233,
+            },
+            [
+              null,
+            ],
+          ],
+          [
+            {
               "_execId": 2,
               "_unmount": undefined,
               "_wkltId": 233,
@@ -349,15 +358,6 @@ describe('WorkletRef', () => {
                   has-react-ref={true}
                 />,
               },
-            ],
-          ],
-          [
-            {
-              "_unmount": undefined,
-              "_wkltId": 233,
-            },
-            [
-              null,
             ],
           ],
           [
@@ -376,7 +376,7 @@ describe('WorkletRef', () => {
           ],
         ]
       `);
-      globalThis.runWorklet.mock.calls[1][0]._unmount = cleanup;
+      globalThis.runWorklet.mock.calls[2][0]._unmount = cleanup;
     }
 
     // update

--- a/packages/react/runtime/__test__/worklet/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/worklet/workletRef.test.jsx
@@ -28,6 +28,9 @@ beforeAll(() => {
     _runOnBackgroundDelayImpl: {
       runDelayedBackgroundFunctions: vi.fn(),
     },
+    _eventDelayImpl: {
+      clearDelayedWorklets: vi.fn(),
+    },
   };
 });
 

--- a/packages/react/runtime/src/lifecycle/patch/updateMainThread.ts
+++ b/packages/react/runtime/src/lifecycle/patch/updateMainThread.ts
@@ -6,12 +6,13 @@ import { updateWorkletRefInitValueChanges } from '@lynx-js/react/worklet-runtime
 
 import { LifecycleConstant } from '../../lifecycleConstant.js';
 import { __pendingListUpdates } from '../../list.js';
-import { markTiming, PerformanceTimingKeys, setPipeline } from '../../lynx/performance.js';
+import { PerformanceTimingKeys, markTiming, setPipeline } from '../../lynx/performance.js';
 import { __page } from '../../snapshot.js';
 import { getReloadVersion } from '../pass.js';
 import type { PatchList, PatchOptions } from './commit.js';
 import { setMainThreadHydrationFinished } from './isMainThreadHydrationFinished.js';
 import { snapshotPatchApply } from './snapshotPatchApply.js';
+import { applyRefQueue } from '../../snapshot/workletRef.js';
 
 function updateMainThread(
   { data, patchOptions }: {
@@ -46,6 +47,7 @@ function updateMainThread(
   if (patchOptions.isHydration) {
     setMainThreadHydrationFinished(true);
   }
+  applyRefQueue();
   if (patchOptions.pipelineOptions) {
     flushOptions.pipelineOptions = patchOptions.pipelineOptions;
   }

--- a/packages/react/runtime/src/lifecycle/reload.ts
+++ b/packages/react/runtime/src/lifecycle/reload.ts
@@ -13,16 +13,17 @@ import { hydrate } from '../hydrate.js';
 import { LifecycleConstant } from '../lifecycleConstant.js';
 import { __pendingListUpdates } from '../list.js';
 import { __root, setRoot } from '../root.js';
+import { destroyBackground } from './destroy.js';
+import { applyRefQueue } from '../snapshot/workletRef.js';
 import { SnapshotInstance, __page, snapshotInstanceManager } from '../snapshot.js';
 import { isEmptyObject } from '../utils.js';
-import { destroyBackground } from './destroy.js';
 import { destroyWorklet } from '../worklet/destroy.js';
 import { clearJSReadyEventIdSwap, isJSReady } from './event/jsReady.js';
 import { increaseReloadVersion } from './pass.js';
+import { setMainThreadHydrationFinished } from './patch/isMainThreadHydrationFinished.js';
 import { deinitGlobalSnapshotPatch } from './patch/snapshotPatch.js';
 import { shouldDelayUiOps } from './ref/delay.js';
 import { renderMainThread } from './render.js';
-import { setMainThreadHydrationFinished } from './patch/isMainThreadHydrationFinished.js';
 
 function reloadMainThread(data: any, options: UpdatePageOption): void {
   if (__PROFILE__) {
@@ -51,6 +52,7 @@ function reloadMainThread(data: any, options: UpdatePageOption): void {
 
   // always call this before `__FlushElementTree`
   __pendingListUpdates.flush();
+  applyRefQueue();
 
   if (isJSReady) {
     __OnLifecycleEvent([

--- a/packages/react/runtime/src/list.ts
+++ b/packages/react/runtime/src/list.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { hydrate } from './hydrate.js';
+import { applyRefQueue } from './snapshot/workletRef.js';
 import type { SnapshotInstance } from './snapshot.js';
 
 export interface ListUpdateInfo {
@@ -338,6 +339,7 @@ export function componentAtIndexFactory(
         __FlushElementTree(root, flushOptions);
       }
       signMap.set(sign, childCtx);
+      applyRefQueue();
       return sign;
     }
 
@@ -358,6 +360,7 @@ export function componentAtIndexFactory(
       });
     }
     signMap.set(sign, childCtx);
+    applyRefQueue();
     return sign;
   };
 

--- a/packages/react/runtime/src/list.ts
+++ b/packages/react/runtime/src/list.ts
@@ -312,6 +312,7 @@ export function componentAtIndexFactory(
       hydrate(oldCtx, childCtx);
       oldCtx.unRenderElements();
       const root = childCtx.__element_root!;
+      applyRefQueue();
       if (!enableBatchRender) {
         const flushOptions: FlushOptions = {
           triggerLayout: true,
@@ -339,7 +340,6 @@ export function componentAtIndexFactory(
         __FlushElementTree(root, flushOptions);
       }
       signMap.set(sign, childCtx);
-      applyRefQueue();
       return sign;
     }
 
@@ -347,6 +347,7 @@ export function componentAtIndexFactory(
     const root = childCtx.__element_root!;
     __AppendElement(list, root);
     const sign = __GetElementUniqueID(root);
+    applyRefQueue();
     if (!enableBatchRender) {
       __FlushElementTree(root, {
         triggerLayout: true,
@@ -360,7 +361,6 @@ export function componentAtIndexFactory(
       });
     }
     signMap.set(sign, childCtx);
-    applyRefQueue();
     return sign;
   };
 

--- a/packages/react/runtime/src/lynx/calledByNative.ts
+++ b/packages/react/runtime/src/lynx/calledByNative.ts
@@ -12,6 +12,7 @@ import { __root, setRoot } from '../root.js';
 import { SnapshotInstance, __page, setupPage } from '../snapshot.js';
 import { isEmptyObject } from '../utils.js';
 import { PerformanceTimingKeys, markTiming, setPipeline } from './performance.js';
+import { applyRefQueue } from '../snapshot/workletRef.js';
 
 function ssrEncode() {
   const { __opcodes } = __root;
@@ -87,6 +88,7 @@ function renderPage(data: any): void {
   // always call this before `__FlushElementTree`
   // (There is an implicit `__FlushElementTree` in `renderPage`)
   __pendingListUpdates.flush();
+  applyRefQueue();
 
   if (__FIRST_SCREEN_SYNC_TIMING__ === 'immediately') {
     jsReady();
@@ -128,6 +130,7 @@ function updatePage(data: any, options?: UpdatePageOption): void {
 
       // always call this before `__FlushElementTree`
       __pendingListUpdates.flush();
+      applyRefQueue();
     }
     markTiming(PerformanceTimingKeys.updateDiffVdomEnd);
   }

--- a/packages/react/worklet-runtime/__test__/workletRef.test.js
+++ b/packages/react/worklet-runtime/__test__/workletRef.test.js
@@ -134,11 +134,11 @@ describe('WorkletRef', () => {
       [4, 'background-thread-init-4'],
       [5, 'background-thread-init-5'],
     ]);
+    globalThis.lynxWorkletImpl._hydrateCtx(worklet, firstScreenWorklet);
     globalThis.lynxWorkletImpl._refImpl.updateWorkletRef({
       _wvid: 5,
       _initValue: 'background-thread-init-5',
     }, 'background-thread-element-5');
-    globalThis.lynxWorkletImpl._hydrateCtx(worklet, firstScreenWorklet);
     expect(getFromWorkletRefMap({ _wvid: 1 }).current).toBe('main-thread-set-1');
     expect(getFromWorkletRefMap({ _wvid: 2 }).current).toBe('main-thread-init-2');
     expect(getFromWorkletRefMap({ _wvid: 3 }).current).toBe('main-thread-init-3');

--- a/packages/react/worklet-runtime/src/bindings/observers.ts
+++ b/packages/react/worklet-runtime/src/bindings/observers.ts
@@ -11,9 +11,8 @@ import type { Worklet } from './types.js';
  * @param oldWorklet - The old worklet context
  * @param isFirstScreen - Whether it is before the hydration is finished
  * @param element - The element
- * @internal
  */
-function onWorkletCtxUpdate(
+export function onWorkletCtxUpdate(
   worklet: Worklet,
   oldWorklet: Worklet | null | undefined,
   isFirstScreen: boolean,
@@ -24,17 +23,17 @@ function onWorkletCtxUpdate(
     globalThis.lynxWorkletImpl?._hydrateCtx(worklet, oldWorklet);
   }
   // For old version dynamic component compatibility.
-  globalThis.lynxWorkletImpl?._eventDelayImpl.runDelayedWorklet(worklet, element);
+  if (isFirstScreen) {
+    globalThis.lynxWorkletImpl?._eventDelayImpl.runDelayedWorklet(worklet, element);
+  }
 }
 
 /**
  * This must be called when the hydration is finished.
- *
- * @internal
  */
-function onHydrationFinished(): void {
+export function onHydrationFinished(): void {
   globalThis.lynxWorkletImpl?._runOnBackgroundDelayImpl.runDelayedBackgroundFunctions();
   globalThis.lynxWorkletImpl?._refImpl.clearFirstScreenWorkletRefMap();
+  // For old version dynamic component compatibility.
+  globalThis.lynxWorkletImpl?._eventDelayImpl.clearDelayedWorklets();
 }
-
-export { onWorkletCtxUpdate, onHydrationFinished };

--- a/packages/react/worklet-runtime/src/hydrate.ts
+++ b/packages/react/worklet-runtime/src/hydrate.ts
@@ -2,7 +2,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { Element } from './api/element.js';
 import type { ClosureValueType, JsFnHandle, Worklet, WorkletRefId, WorkletRefImpl } from './bindings/index.js';
 import { profile } from './utils/profile.js';
 
@@ -64,10 +63,6 @@ function hydrateMainThreadRef(refId: WorkletRefId, value: WorkletRefImpl<unknown
     return;
   }
   const ref = lynxWorkletImpl!._refImpl._workletRefMap[refId]!;
-  if (ref.current instanceof Element) {
-    // Modified by `main-thread:ref`
-    return;
-  }
   ref.current = value.current;
 }
 


### PR DESCRIPTION
## Summary

Fix a problem causing `MainThreadRef`s to not be updated correctly during hydration when they are set to `main-thread:ref`s.

This is caused by a mixed order of MTS hydration and `main-thread:ref` triggering. Therefore, we ensure that hydration completes first before triggering references.

Fix #1046

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
