### PR TITLE
test: patch `path-serializer` for Windows paths

### DIFF
--- a/patches/path-serializer.patch
+++ b/patches/path-serializer.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/cjs/index.js b/dist/cjs/index.js
+index 69e629f439307cb11bde2acb0c1e598adc9da474..64e70d1fa329fe57944c8b47d5524b4c993a9ead 100644
+--- a/dist/cjs/index.js
++++ b/dist/cjs/index.js
+@@ -869,8 +869,8 @@ function __webpack_require__(moduleId) {
+     const normalizePathToPosix = (p)=>upath_default().normalizeSafe(external_node_path_default().normalize(p || '')).replace(/^([a-zA-Z]+):/, (_, m)=>`/${m.toLowerCase()}`);
+     // find the path in code and replace it with normalizePathToPosix
+     const normalizeCodeToPosix = (code)=>code.replace(// ignore http, https, file
+-        /(?<![a-zA-Z])([a-zA-Z]:[\\/])([-\u4e00-\u9fa5\w\s.()~!@#$%^&()\[\]{}+=]+[\\/])*/g, (match, _diskName)=>normalizePathToPosix(match));
+-    const normalizeCLR = (str)=>str.replace(/\u001b\[1m\u001b\[([0-9;]*)m/g, '<CLR=$1,BOLD>').replace(/\u001b\[1m/g, '<CLR=BOLD>').replace(/\u001b\[39m\u001b\[22m/g, '</CLR>').replace(/\u001b\[([0-9;]*)m/g, '<CLR=$1>') // CHANGE: The time unit display in Rspack is second
++      /(?<![a-zA-Z])([a-zA-Z]:[\\/]+)([-\u4e00-\u9fa5\w\s.()~!@#$%^&()\[\]{}+=]+[\\/]+)*/g, (match, _diskName)=>normalizePathToPosix(match.replace(/[\\]{2,}/g, '\\')));
++  const normalizeCLR = (str)=>str.replace(/\u001b\[1m\u001b\[([0-9;]*)m/g, '<CLR=$1,BOLD>').replace(/\u001b\[1m/g, '<CLR=BOLD>').replace(/\u001b\[39m\u001b\[22m/g, '</CLR>').replace(/\u001b\[([0-9;]*)m/g, '<CLR=$1>') // CHANGE: The time unit display in Rspack is second
+         // CHANGE2: avoid a bad case "./react/assets.svg" -> "./react/assetsXsvg"
+         // modified based on https://github.com/webpack/webpack/blob/001cab14692eb9a833c6b56709edbab547e291a1/test/StatsTestCases.basictest.js#L199
+         .replace(/[0-9]+(\.[0-9]+)*(<\/CLR>)?(\s?s)/g, 'X$2$3');
+diff --git a/dist/esm/index.mjs b/dist/esm/index.mjs
+index 5690ea06648e1cbd7e8c30f7066fd4920cef8218..fffb02bbaa6fdd9536c5defad398bf8d5060e0a4 100644
+--- a/dist/esm/index.mjs
++++ b/dist/esm/index.mjs
+@@ -844,7 +844,7 @@ var upath_default = /*#__PURE__*/ __webpack_require__.n(upath);
+ const normalizePathToPosix = (p)=>upath_default().normalizeSafe(__WEBPACK_EXTERNAL_MODULE_node_path__["default"].normalize(p || '')).replace(/^([a-zA-Z]+):/, (_, m)=>`/${m.toLowerCase()}`);
+ // find the path in code and replace it with normalizePathToPosix
+ const normalizeCodeToPosix = (code)=>code.replace(// ignore http, https, file
+-    /(?<![a-zA-Z])([a-zA-Z]:[\\/])([-\u4e00-\u9fa5\w\s.()~!@#$%^&()\[\]{}+=]+[\\/])*/g, (match, _diskName)=>normalizePathToPosix(match));
++  /(?<![a-zA-Z])([a-zA-Z]:[\\/]+)([-\u4e00-\u9fa5\w\s.()~!@#$%^&()\[\]{}+=]+[\\/]+)*/g, (match, _diskName)=>normalizePathToPosix(match.replace(/[\\]{2,}/g, '\\')));
+ const normalizeCLR = (str)=>str.replace(/\u001b\[1m\u001b\[([0-9;]*)m/g, '<CLR=$1,BOLD>').replace(/\u001b\[1m/g, '<CLR=BOLD>').replace(/\u001b\[39m\u001b\[22m/g, '</CLR>').replace(/\u001b\[([0-9;]*)m/g, '<CLR=$1>') // CHANGE: The time unit display in Rspack is second
+     // CHANGE2: avoid a bad case "./react/assets.svg" -> "./react/assetsXsvg"
+     // modified based on https://github.com/webpack/webpack/blob/001cab14692eb9a833c6b56709edbab547e291a1/test/StatsTestCases.basictest.js#L199

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ patchedDependencies:
   '@rollup/plugin-typescript':
     hash: 926ba262ec682d27369f1a8648a0dfb657fb5f1b28539ca3628d292276c91c3d
     path: patches/@rollup__plugin-typescript.patch
+  path-serializer:
+    hash: 46aafd3e7dc478c63e376e54c0350b1126a463a87cdfd7ee67f2900c8813c071
+    path: patches/path-serializer.patch
 
 importers:
 
@@ -614,7 +617,7 @@ importers:
     devDependencies:
       path-serializer:
         specifier: ^0.4.0
-        version: 0.4.0
+        version: 0.4.0(patch_hash=46aafd3e7dc478c63e376e54c0350b1126a463a87cdfd7ee67f2900c8813c071)
       vitest:
         specifier: ^3.2.1
         version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/ui@3.2.1)(jsdom@26.1.0)(sass-embedded@1.89.0)(terser@5.31.6)
@@ -9775,7 +9778,7 @@ snapshots:
       jest-snapshot: 29.7.0
       jsdom: 26.1.0
       memfs: 4.17.1
-      path-serializer: 0.4.0
+      path-serializer: 0.4.0(patch_hash=46aafd3e7dc478c63e376e54c0350b1126a463a87cdfd7ee67f2900c8813c071)
       pretty-format: 29.7.0
       rimraf: 5.0.10
       source-map: 0.7.4
@@ -14386,7 +14389,7 @@ snapshots:
       lru-cache: 11.0.2
       minipass: 7.1.2
 
-  path-serializer@0.4.0: {}
+  path-serializer@0.4.0(patch_hash=46aafd3e7dc478c63e376e54c0350b1126a463a87cdfd7ee67f2900c8813c071): {}
 
   path-to-regexp@0.1.12: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,7 @@ overrides:
 patchedDependencies:
   "@napi-rs/cli@2.18.4": "patches/@napi-rs__cli@2.18.4.patch"
   "@rollup/plugin-typescript": "patches/@rollup__plugin-typescript.patch"
+  "path-serializer": patches/path-serializer.patch
 
 onlyBuiltDependencies:
   - dprint


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The hot snapshot tests in react-refresh-webpack-plugin have been failing on Windows due to incorrect path serialization. This patch resolves the issue.

We are not waiting for the new version of the [`path-serializer`](https://github.com/rspack-contrib/path-serializer) as it will be updated through `@rspack/test-tools`, which would take considerable time.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

issue: #81 

The fix has been made at https://github.com/rspack-contrib/path-serializer/pull/16

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
