### PR TITLE
fix(webpack/runtime-wrapper): remove non-existed `Function`

### DIFF
--- a/.changeset/breezy-parts-look.md
+++ b/.changeset/breezy-parts-look.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/runtime-wrapper-webpack-plugin": patch
+---
+
+Fix `requestAnimationFrame` is not working.

--- a/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
@@ -80,7 +80,6 @@ const defaultInjectVars = [
   'webkit',
   'Reporter',
   'print',
-  '__Function__', // We should allow using `Function`
   'global',
 
   // Lynx API

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases.test.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases.test.js
@@ -74,7 +74,6 @@ describeCases({
             undefined, // webkit
             undefined, // Reporter
             undefined, // print
-            undefined, // Function
             undefined, // global
             // Lynx API
             vi.fn(), // requestAnimationFrame


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The Lynx Engine does not pass `Function`.

```js
          undefined, // WebSocket
          undefined, // webkit
          undefined, // Reporter
          undefined, // print
          undefined, // global
          that.requestAnimationFrame,
          that.cancelAnimationFrame
```

> https://github.com/lynx-family/lynx/blob/43b4c399c74148853679d355dcf9713b13584b4a/js_libraries/lynx-core/src/app/app.ts#L649-L655

This patch remove the extra parameter that make `requestAnimationFrame` not working.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
