### PR TITLE
test(rspeedy): fix tests on Windows

### DIFF
--- a/packages/rspeedy/core/test/cli/register.test.ts
+++ b/packages/rspeedy/core/test/cli/register.test.ts
@@ -3,11 +3,14 @@
 // LICENSE file in the root directory of this source tree.
 import { exec } from 'node:child_process'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { describe, expect, test } from 'vitest'
 
 describe('register - hooks', () => {
-  const registerPath = path.resolve(__dirname, './fixtures/register.js')
+  const registerPath = pathToFileURL(
+    path.resolve(__dirname, './fixtures/register.js'),
+  ).toString()
 
   async function runWithRegister(script: string) {
     return await new Promise<[string, string]>((resolve, reject) => {

--- a/packages/rspeedy/core/test/config/loadConfig.test.ts
+++ b/packages/rspeedy/core/test/config/loadConfig.test.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -253,7 +253,8 @@ describe('Config - loadConfig', () => {
     test('load non-exists default config', async () => {
       await expect(() => loadConfig({ cwd: 'non-exist-path' })).rejects
         .toThrowError(
-          `Cannot find the default config file: non-exist-path/lynx.config.ts. Use custom config with \`--config <config>\` options.`,
+          `Cannot find the default config file: non-exist-path/lynx.config.ts. Use custom config with \`--config <config>\` options.`
+            .replaceAll('/', sep),
         )
     })
 

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -58,7 +58,9 @@ describe('Plugins - Dev', () => {
     assert(config.resolve?.alias)
 
     expect(config.resolve.alias['webpack/hot/emitter.js']).toStrictEqual(
-      expect.stringContaining('@rspack/core/hot/emitter.js'),
+      expect.stringContaining(
+        ('@rspack/core/hot/emitter.js').replaceAll('/', path.sep),
+      ),
     )
   })
 
@@ -87,11 +89,13 @@ describe('Plugins - Dev', () => {
 
     expect(config.resolve?.alias).toHaveProperty(
       '@rspack/core/hot/dev-server',
-      expect.stringContaining('hot/dev-server.js'),
+      expect.stringContaining('hot/dev-server.js'.replaceAll('/', path.sep)),
     )
     expect(config.resolve?.alias).toHaveProperty(
       '@lynx-js/webpack-dev-transport/client',
-      expect.stringContaining('packages/webpack/webpack-dev-transport'),
+      expect.stringContaining(
+        'packages/webpack/webpack-dev-transport'.replaceAll('/', path.sep),
+      ),
     )
   })
 

--- a/packages/rspeedy/plugin-react-alias/test/index.test.ts
+++ b/packages/rspeedy/plugin-react-alias/test/index.test.ts
@@ -1,6 +1,8 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import path from 'node:path'
+
 import { createRsbuild } from '@rsbuild/core'
 import type { RsbuildPlugin } from '@rsbuild/core'
 import { describe, expect, test, vi } from 'vitest'
@@ -38,79 +40,109 @@ describe('React - alias', () => {
 
     expect(config.resolve.alias).toHaveProperty(
       'react$',
-      expect.stringContaining('/packages/react/runtime/lib/index.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/index.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react$',
-      expect.stringContaining('/packages/react/runtime/lib/index.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/index.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react/internal$',
-      expect.stringContaining('/packages/react/runtime/lib/internal.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/internal.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react/experimental/lazy/import$',
-      expect.stringContaining('/packages/react/runtime/lazy/import.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lazy/import.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       'preact$',
-      expect.stringContaining('/preact/dist/preact.mjs'),
+      expect.stringContaining(
+        '/preact/dist/preact.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat$',
-      expect.stringContaining('/preact/compat/dist/compat.mjs'),
+      expect.stringContaining(
+        '/preact/compat/dist/compat.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/debug$',
-      expect.stringContaining('/preact/debug/dist/debug.mjs'),
+      expect.stringContaining(
+        '/preact/debug/dist/debug.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/devtools$',
-      expect.stringContaining('/preact/devtools/dist/devtools.mjs'),
+      expect.stringContaining(
+        '/preact/devtools/dist/devtools.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/hooks$',
-      expect.stringContaining('/preact/hooks/dist/hooks.mjs'),
+      expect.stringContaining(
+        '/preact/hooks/dist/hooks.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/test-utils$',
-      expect.stringContaining('/preact/test-utils/dist/testUtils.mjs'),
+      expect.stringContaining(
+        '/preact/test-utils/dist/testUtils.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/jsx-runtime$',
-      expect.stringContaining('/preact/jsx-runtime/dist/jsxRuntime.mjs'),
+      expect.stringContaining(
+        '/preact/jsx-runtime/dist/jsxRuntime.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/jsx-dev-runtime$',
       expect.stringContaining(
-        '/preact/jsx-runtime/dist/jsxRuntime.mjs',
+        '/preact/jsx-runtime/dist/jsxRuntime.mjs'.replaceAll('/', path.sep),
       ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/client$',
-      expect.stringContaining('/preact/compat/client.mjs'),
+      expect.stringContaining(
+        '/preact/compat/client.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/server$',
-      expect.stringContaining('/preact/compat/server.mjs'),
+      expect.stringContaining(
+        '/preact/compat/server.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/jsx-runtime$',
-      expect.stringContaining('/preact/compat/jsx-runtime.mjs'),
+      expect.stringContaining(
+        '/preact/compat/jsx-runtime.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/jsx-dev-runtime$',
       expect.stringContaining(
-        '/preact/compat/jsx-dev-runtime.mjs',
+        '/preact/compat/jsx-dev-runtime.mjs'.replaceAll('/', path.sep),
       ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/scheduler$',
-      expect.stringContaining('/preact/compat/scheduler.mjs'),
+      expect.stringContaining(
+        '/preact/compat/scheduler.mjs'.replaceAll('/', path.sep),
+      ),
     )
   })
 
@@ -144,17 +176,23 @@ describe('React - alias', () => {
 
     expect(config.resolve.alias).toHaveProperty(
       'react$',
-      expect.stringContaining('/packages/react/runtime/lib/index.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/index.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react$',
-      expect.stringContaining('/packages/react/runtime/lib/index.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/index.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react/internal$',
-      expect.stringContaining('/packages/react/runtime/lib/internal.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/internal.js'.replaceAll('/', path.sep),
+      ),
     )
   })
 

--- a/packages/rspeedy/plugin-react/test/background-only.test.ts
+++ b/packages/rspeedy/plugin-react/test/background-only.test.ts
@@ -39,7 +39,9 @@ describe('Config', () => {
         if (
           Object.prototype.hasOwnProperty.call(alias, 'background-only$')
           && typeof alias['background-only$'] === 'string'
-          && alias['background-only$'].includes('background-only/empty.js')
+          && alias['background-only$'].includes(
+            'background-only/empty.js'.replaceAll('/', path.sep),
+          )
         ) {
           return true
         }
@@ -56,7 +58,9 @@ describe('Config', () => {
         if (
           Object.prototype.hasOwnProperty.call(alias, 'background-only$')
           && typeof alias['background-only$'] === 'string'
-          && alias['background-only$'].includes('background-only/error.js')
+          && alias['background-only$'].includes(
+            'background-only/error.js'.replaceAll('/', path.sep),
+          )
         ) {
           return true
         }
@@ -180,7 +184,6 @@ describe('Build background-only', () => {
     const rsbuild = await createRspeedy({
       rspeedyConfig: {
         source: {
-          tsconfigPath: new URL('./tsconfig.json', import.meta.url).pathname,
           entry: {
             main:
               new URL('./fixtures/background-only/success.tsx', import.meta.url)

--- a/packages/rspeedy/plugin-react/test/basic.test.ts
+++ b/packages/rspeedy/plugin-react/test/basic.test.ts
@@ -18,7 +18,7 @@ vi
   .stubEnv('NODE_ENV', 'development')
 
 describe('ReactLynx rsbuild', () => {
-  test('basic usage', async () => {
+  test('basic usage', { timeout: 10000 }, async () => {
     // TODO(react-refresh): support refresh
     vi.stubEnv('NODE_ENV', 'production')
     const { pluginReactLynx } = await import('../src/index.js')
@@ -26,7 +26,6 @@ describe('ReactLynx rsbuild', () => {
     const rsbuild = await createRspeedy({
       rspeedyConfig: {
         source: {
-          tsconfigPath: new URL('./tsconfig.json', import.meta.url).pathname,
           entry: {
             main: new URL('./fixtures/basic.tsx', import.meta.url).pathname,
           },
@@ -63,7 +62,6 @@ describe('ReactLynx rsbuild', () => {
     const rspeedy = await createRspeedy({
       rspeedyConfig: {
         source: {
-          tsconfigPath: new URL('./tsconfig.json', import.meta.url).pathname,
           entry: {
             main: new URL(
               './fixtures/special-var-name/index.jsx',

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -1,6 +1,8 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import path from 'node:path'
+
 import { createRsbuild } from '@rsbuild/core'
 import type { RsbuildInstance } from '@rsbuild/core'
 import { describe, expect, test, vi } from 'vitest'
@@ -41,12 +43,16 @@ describe('Config', () => {
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react$',
-      expect.stringContaining('/packages/react/runtime/lib/index.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/index.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react/internal$',
-      expect.stringContaining('/packages/react/runtime/lib/internal.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/internal.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).not.toHaveProperty(
@@ -63,80 +69,112 @@ describe('Config', () => {
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react/refresh$',
-      expect.stringContaining('/packages/react/refresh/dist/index.js'),
+      expect.stringContaining(
+        '/packages/react/refresh/dist/index.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       'preact$',
-      expect.stringContaining('/preact/dist/preact.mjs'),
+      expect.stringContaining(
+        '/preact/dist/preact.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat$',
-      expect.stringContaining('/preact/compat/dist/compat.mjs'),
+      expect.stringContaining(
+        '/preact/compat/dist/compat.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/debug$',
-      expect.stringContaining('/preact/debug/dist/debug.mjs'),
+      expect.stringContaining(
+        '/preact/debug/dist/debug.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/devtools$',
-      expect.stringContaining('/preact/devtools/dist/devtools.mjs'),
+      expect.stringContaining(
+        '/preact/devtools/dist/devtools.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/hooks$',
-      expect.stringContaining('/preact/hooks/dist/hooks.mjs'),
+      expect.stringContaining(
+        '/preact/hooks/dist/hooks.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/test-utils$',
-      expect.stringContaining('/preact/test-utils/dist/testUtils.mjs'),
+      expect.stringContaining(
+        '/preact/test-utils/dist/testUtils.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/jsx-runtime$',
-      expect.stringContaining('/preact/jsx-runtime/dist/jsxRuntime.mjs'),
+      expect.stringContaining(
+        '/preact/jsx-runtime/dist/jsxRuntime.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/jsx-dev-runtime$',
       expect.stringContaining(
-        '/preact/jsx-runtime/dist/jsxRuntime.mjs',
+        '/preact/jsx-runtime/dist/jsxRuntime.mjs'.replaceAll('/', path.sep),
       ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/client$',
-      expect.stringContaining('/preact/compat/client.mjs'),
+      expect.stringContaining(
+        '/preact/compat/client.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/server$',
-      expect.stringContaining('/preact/compat/server.mjs'),
+      expect.stringContaining(
+        '/preact/compat/server.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/jsx-runtime$',
-      expect.stringContaining('/preact/compat/jsx-runtime.mjs'),
+      expect.stringContaining(
+        '/preact/compat/jsx-runtime.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/jsx-dev-runtime$',
       expect.stringContaining(
-        '/preact/compat/jsx-dev-runtime.mjs',
+        '/preact/compat/jsx-dev-runtime.mjs'.replaceAll('/', path.sep),
       ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'preact/compat/scheduler$',
-      expect.stringContaining('/preact/compat/scheduler.mjs'),
+      expect.stringContaining(
+        '/preact/compat/scheduler.mjs'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store$',
-      expect.stringContaining('/use-sync-external-store/index.js'),
+      expect.stringContaining(
+        '/use-sync-external-store/index.js'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store/with-selector$',
-      expect.stringContaining('/use-sync-external-store/with-selector.js'),
+      expect.stringContaining(
+        '/use-sync-external-store/with-selector.js'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store/shim$',
-      expect.stringContaining('/use-sync-external-store/index.js'),
+      expect.stringContaining(
+        '/use-sync-external-store/index.js'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store/shim/with-selector$',
-      expect.stringContaining('/use-sync-external-store/with-selector.js'),
+      expect.stringContaining(
+        '/use-sync-external-store/with-selector.js'.replaceAll('/', path.sep),
+      ),
     )
   })
 
@@ -169,12 +207,16 @@ describe('Config', () => {
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react$',
-      expect.stringContaining('/packages/react/runtime/lib/index.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/index.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react/internal$',
-      expect.stringContaining('/packages/react/runtime/lib/internal.js'),
+      expect.stringContaining(
+        '/packages/react/runtime/lib/internal.js'.replaceAll('/', path.sep),
+      ),
     )
 
     expect(config.resolve.alias).not.toHaveProperty(
@@ -195,19 +237,27 @@ describe('Config', () => {
 
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store$',
-      expect.stringContaining('/use-sync-external-store/index.js'),
+      expect.stringContaining(
+        '/use-sync-external-store/index.js'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store/with-selector$',
-      expect.stringContaining('/use-sync-external-store/with-selector.js'),
+      expect.stringContaining(
+        '/use-sync-external-store/with-selector.js'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store/shim$',
-      expect.stringContaining('/use-sync-external-store/index.js'),
+      expect.stringContaining(
+        '/use-sync-external-store/index.js'.replaceAll('/', path.sep),
+      ),
     )
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store/shim/with-selector$',
-      expect.stringContaining('/use-sync-external-store/with-selector.js'),
+      expect.stringContaining(
+        '/use-sync-external-store/with-selector.js'.replaceAll('/', path.sep),
+      ),
     )
   })
 
@@ -1518,7 +1568,6 @@ describe('Config', () => {
       const rsbuild = await createRspeedy({
         rspeedyConfig: {
           source: {
-            tsconfigPath: new URL('./tsconfig.json', import.meta.url).pathname,
             entry: {
               main: new URL('./fixtures/defineDCE/basic.js', import.meta.url)
                 .pathname,

--- a/packages/rspeedy/plugin-react/test/css.test.ts
+++ b/packages/rspeedy/plugin-react/test/css.test.ts
@@ -252,7 +252,7 @@ describe('Plugins - CSS', () => {
 
       expect(mainThreadRule).not.toBeUndefined()
       expect({ module: { rules: [mainThreadRule] } }).toHaveLoader(
-        /\/css-loader\//,
+        /[\\/]css-loader[\\/]/,
       )
       expect({ module: { rules: [mainThreadRule] } }).not.toHaveLoader(
         CssExtractRspackPlugin.loader,
@@ -260,7 +260,7 @@ describe('Plugins - CSS', () => {
 
       const cssLoaderOptions = getLoaderOptions<CSSLoaderOptions>({
         module: { rules: [mainThreadRule] },
-      }, /\/css-loader\//)
+      }, /[\\/]css-loader[\\/]/)
 
       expect(cssLoaderOptions).not.toBeUndefined()
       expect(cssLoaderOptions?.modules).toHaveProperty(
@@ -293,7 +293,7 @@ describe('Plugins - CSS', () => {
 
       expect(mainThreadRule).not.toBeUndefined()
       expect({ module: { rules: [mainThreadRule] } }).toHaveLoader(
-        /\/css-loader\//,
+        /[\\/]css-loader[\\/]/,
       )
       expect({ module: { rules: [mainThreadRule] } }).not.toHaveLoader(
         CssExtractRspackPlugin.loader,
@@ -301,7 +301,7 @@ describe('Plugins - CSS', () => {
 
       const cssLoaderOptions = getLoaderOptions<CSSLoaderOptions>({
         module: { rules: [mainThreadRule] },
-      }, /\/css-loader\//)
+      }, /[\\/]css-loader[\\/]/)
 
       expect(cssLoaderOptions).not.toBeUndefined()
       expect(cssLoaderOptions?.modules).toStrictEqual({
@@ -333,7 +333,7 @@ describe('Plugins - CSS', () => {
 
       expect(mainThreadRule).not.toBeUndefined()
       expect({ module: { rules: [mainThreadRule] } }).toHaveLoader(
-        /\/css-loader\//,
+        /[\\/]css-loader[\\/]/,
       )
       expect({ module: { rules: [mainThreadRule] } }).not.toHaveLoader(
         CssExtractRspackPlugin.loader,
@@ -341,7 +341,7 @@ describe('Plugins - CSS', () => {
 
       const cssLoaderOptions = getLoaderOptions<CSSLoaderOptions>({
         module: { rules: [mainThreadRule] },
-      }, /\/css-loader\//)
+      }, /[\\/]css-loader[\\/]/)
 
       expect(cssLoaderOptions).not.toBeUndefined()
       expect(cssLoaderOptions?.modules).toHaveProperty(

--- a/packages/rspeedy/plugin-react/test/lazy.test.ts
+++ b/packages/rspeedy/plugin-react/test/lazy.test.ts
@@ -1,6 +1,8 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import path from 'node:path'
+
 import { createRsbuild } from '@rsbuild/core'
 import type { Rspack } from '@rsbuild/core'
 import { describe, expect, test, vi } from 'vitest'
@@ -31,14 +33,14 @@ describe('Lazy', () => {
     )
     expect(config?.resolve?.alias).toHaveProperty(
       '@lynx-js/react$',
-      expect.stringContaining('lazy/react'),
+      expect.stringContaining('lazy/react'.replaceAll('/', path.sep)),
     )
     expect(config?.resolve?.alias).not.toHaveProperty(
       'react',
     )
     expect(config?.resolve?.alias).toHaveProperty(
       'react$',
-      expect.stringContaining('lazy/react'),
+      expect.stringContaining('lazy/react'.replaceAll('/', path.sep)),
     )
 
     expect(config?.resolve?.alias).not.toHaveProperty(
@@ -46,7 +48,7 @@ describe('Lazy', () => {
     )
     expect(config?.resolve?.alias).toHaveProperty(
       '@lynx-js/react/internal$',
-      expect.stringContaining('lazy/internal'),
+      expect.stringContaining('lazy/internal'.replaceAll('/', path.sep)),
     )
   })
 

--- a/packages/rspeedy/plugin-react/test/swc-config.test.ts
+++ b/packages/rspeedy/plugin-react/test/swc-config.test.ts
@@ -246,7 +246,7 @@ describe('SWC configuration', () => {
     )
     expect(backgroundRules).not.toBeUndefined()
     expect({ module: { rules: [backgroundRules] } }).toHaveLoader(
-      /@rsbuild\/plugin-webpack-swc/,
+      /@rsbuild[\\/]plugin-webpack-swc/,
     )
     expect({ module: { rules: [backgroundRules] } }).toHaveLoader(
       ReactWebpackPlugin.loaders.BACKGROUND,
@@ -260,7 +260,7 @@ describe('SWC configuration', () => {
     )
     expect(mainThreadRules).not.toBeUndefined()
     expect({ module: { rules: [mainThreadRules] } }).toHaveLoader(
-      /@rsbuild\/plugin-webpack-swc/,
+      /@rsbuild[\\/]plugin-webpack-swc/,
     )
     expect({ module: { rules: [mainThreadRules] } }).toHaveLoader(
       ReactWebpackPlugin.loaders.MAIN_THREAD,


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Make most part of the Rspeedy unit tests working on Windows. Including:

1. Use `.replaceAll('/', sep)` for all alias like `'@rspack/core/hot/emitter.js'`.
2. Use `[\\/]` instead of `\/` in RegExp.
3. Remove `source.tsConfig` since it uses `new URL` which not working on Windows.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

issue: #81

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
