### PR TITLE
chore: add semi-controlled-styles testing

### DIFF
--- a/packages/react/testing-library/src/__tests__/semi-controlled-styles.test.jsx
+++ b/packages/react/testing-library/src/__tests__/semi-controlled-styles.test.jsx
@@ -1,0 +1,223 @@
+import { describe, expect, vi } from 'vitest';
+import { fireEvent, render, waitSchedule, screen } from '..';
+import { runOnBackground, useMainThreadRef, runOnMainThread, useState } from '@lynx-js/react';
+
+describe('Semi Controlled Styles', () => {
+  it('Setting different styles using declarative and imperative way should both take effect', async () => {
+    const Comp = () => {
+      const viewMTRef = useMainThreadRef(null);
+      const [height, setHeight] = useState(100);
+
+      function updateViewWidth() {
+        'main thread';
+        viewMTRef.current?.setStyleProperties({
+          width: '100px',
+        });
+      }
+
+      return (
+        <view
+          style={{
+            height: `${height}px`,
+          }}
+          main-thread:ref={viewMTRef}
+          main-thread:bindtap={(e) => {
+            'main thread';
+            updateViewWidth();
+          }}
+        >
+          <text>Hello Main Thread Script</text>
+        </view>
+      );
+    };
+    const { container } = render(<Comp />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view
+        has-react-ref="true"
+        style="height: 100px;"
+      >
+        <text>
+          Hello Main Thread Script
+        </text>
+      </view>
+    `);
+
+    fireEvent.tap(container.firstChild, {
+      key: 'value',
+    });
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view
+        has-react-ref="true"
+        style="height: 100px; width: 100px;"
+      >
+        <text>
+          Hello Main Thread Script
+        </text>
+      </view>
+    `);
+  });
+
+  it('Imperatively setting style should override the declarative style', async () => {
+    const Comp = () => {
+      const viewMTRef = useMainThreadRef(null);
+      const [height, setHeight] = useState(100);
+
+      function updateViewWidth() {
+        'main thread';
+        viewMTRef.current?.setStyleProperties({
+          height: '500px',
+        });
+      }
+
+      return (
+        <view
+          style={{
+            height: `${height}px`,
+          }}
+          main-thread:ref={viewMTRef}
+          main-thread:bindtap={(e) => {
+            'main thread';
+            updateViewWidth();
+          }}
+        >
+          <text>Hello Main Thread Script</text>
+        </view>
+      );
+    };
+    const { container } = render(<Comp />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view
+        has-react-ref="true"
+        style="height: 100px;"
+      >
+        <text>
+          Hello Main Thread Script
+        </text>
+      </view>
+    `);
+
+    fireEvent.tap(container.firstChild, {
+      key: 'value',
+    });
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view
+        has-react-ref="true"
+        style="height: 500px;"
+      >
+        <text>
+          Hello Main Thread Script
+        </text>
+      </view>
+    `);
+  });
+
+  it('Rerender will override the imperatively set style', async () => {
+    const Comp = () => {
+      const viewMTRef = useMainThreadRef(null);
+      const [height, setHeight] = useState(100);
+
+      function updateViewWidth() {
+        'main thread';
+        viewMTRef.current?.setStyleProperties({
+          height: '500px',
+        });
+      }
+
+      return (
+        <view
+          style={{
+            height: `${height}px`,
+          }}
+          main-thread:ref={viewMTRef}
+        >
+          <text data-testid='StateButton' bindtap={() => setHeight(200)}>Update in State</text>
+          <text
+            data-testid='MTSButton'
+            main-thread:bindtap={(e) => {
+              'main thread';
+              updateViewWidth();
+            }}
+          >
+            Update in MTS
+          </text>
+        </view>
+      );
+    };
+    const { container, rerender } = render(<Comp />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view
+        has-react-ref="true"
+        style="height: 100px;"
+      >
+        <text
+          data-testid="StateButton"
+        >
+          Update in State
+        </text>
+        <text
+          data-testid="MTSButton"
+        >
+          Update in MTS
+        </text>
+      </view>
+    `);
+
+    fireEvent.tap(screen.getByTestId('MTSButton'), {
+      key: 'value',
+    });
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view
+        has-react-ref="true"
+        style="height: 500px;"
+      >
+        <text
+          data-testid="StateButton"
+        >
+          Update in State
+        </text>
+        <text
+          data-testid="MTSButton"
+        >
+          Update in MTS
+        </text>
+      </view>
+    `);
+
+    fireEvent.tap(screen.getByTestId('StateButton'), {
+      key: 'value',
+    });
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view
+        has-react-ref="true"
+        style="height: 200px;"
+      >
+        <text
+          data-testid="StateButton"
+        >
+          Update in State
+        </text>
+        <text
+          data-testid="MTSButton"
+        >
+          Update in MTS
+        </text>
+      </view>
+    `);
+  });
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary
Add more test cases demostrating how Main Thread Script's imperative way of updating style used combiled with declartive way of setting styles via style props.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify how declarative and imperative style updates interact in React components, including scenarios where styles are combined, overridden, or reset by rerenders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->