### PR TITLE
ci: enable Rust test on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,9 @@ jobs:
         with:
           tool: cargo-llvm-cov,cargo-nextest
       - name: Test
+        env:
+          CARGO_LLVM_COV_FLAGS_NO_RUNNER: --no-sparse
         run: |
-          export CARGO_LLVM_COV_FLAGS_NO_RUNNER='--no-sparse'
           cargo llvm-cov nextest --profile ci --config-file .cargo/nextest.toml --lcov --output-path lcov.info  --release
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,16 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    runs-on: lynx-ubuntu-24.04-xlarge
-    timeout-minutes: 10
+    name: Test (${{ matrix.runs-on.name }})
+    runs-on: ${{ matrix.runs-on.label }}
+    strategy:
+      matrix:
+        runs-on:
+          - label: lynx-ubuntu-24.04-xlarge
+            name: Ubuntu
+          - label: lynx-windows-2022-large
+            name: Windows
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -62,6 +70,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1
         with:
           components: rustfmt
-          cache-key: test-${{ runner.os }}
+          cache: false
       - name: Format
         run: cargo fmt --check


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Following up #1030. Enable Rust test on Windows.

1. Use matrix to reuse existing workflow.
2. Set `timeout-minutes: 30` since Rust toolchain downloading and compiling could be slow.
3. Set `cache: false` for `rustfmt` job since we don't need to compile in this job.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

issue: #81

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
