### PR TITLE
fix(testing-library): __SetInlineStyles of raw styles should not normalize css

### DIFF
--- a/.changeset/tired-breads-wonder.md
+++ b/.changeset/tired-breads-wonder.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/react": patch
+"create-rspeedy": patch
+---
+
+Fix a bug in ReactLynx Testing Library that rendered snapshot of inline style was normalized incorrectly (eg. `flex:1` was normalized to `flex: 1 1 0%;` incorrectly).

--- a/packages/react/testing-library/src/__tests__/css.test.jsx
+++ b/packages/react/testing-library/src/__tests__/css.test.jsx
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom';
+import { describe, expect, vi } from 'vitest';
+import { render, screen } from '..';
+
+describe('CSS', () => {
+  it('should render a component with CSS styles object', () => {
+    const TestComponent = () => <text style={{ color: 'red', fontSize: '20px', flex: 1 }}>Hello World</text>;
+
+    const { container } = render(<TestComponent />);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <text
+        style="color:red;font-size:20px;flex:1"
+      >
+        Hello World
+      </text>
+    `);
+  });
+  it('should render a component with CSS styles string', () => {
+    const TestComponent = () => <text style='color: red; font-size: 20px; flex: 1;'>Hello World</text>;
+
+    const { container } = render(<TestComponent />);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <text
+        style="color: red; font-size: 20px; flex: 1;"
+      >
+        Hello World
+      </text>
+    `);
+  });
+});

--- a/packages/react/testing-library/src/__tests__/worklet.test.jsx
+++ b/packages/react/testing-library/src/__tests__/worklet.test.jsx
@@ -428,7 +428,7 @@ describe('worklet', () => {
       <page>
         <view
           has-react-ref="true"
-          style="width: 300px; height: 300px;"
+          style="width:300px;height:300px"
         >
           <text>
             Hello main thread ref

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-js/src/__tests__/index.test.jsx
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-js/src/__tests__/index.test.jsx
@@ -73,7 +73,7 @@ test('App', async () => {
             >
               Edit
               <text
-                style="font-style: italic;"
+                style="font-style:italic"
               >
                  src/App.tsx 
               </text>
@@ -81,7 +81,7 @@ test('App', async () => {
             </text>
           </view>
           <view
-            style="flex: 1;"
+            style="flex:1"
           />
         </view>
       </view>

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/src/__tests__/index.test.tsx
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/src/__tests__/index.test.tsx
@@ -73,7 +73,7 @@ test('App', async () => {
             >
               Edit
               <text
-                style="font-style: italic;"
+                style="font-style:italic"
               >
                  src/App.tsx 
               </text>
@@ -81,7 +81,7 @@ test('App', async () => {
             </text>
           </view>
           <view
-            style="flex: 1;"
+            style="flex:1"
           />
         </view>
       </view>

--- a/packages/testing-library/testing-environment/src/lynx/ElementPAPI.ts
+++ b/packages/testing-library/testing-environment/src/lynx/ElementPAPI.ts
@@ -284,15 +284,8 @@ export const initElementTree = () => {
       styles: string | Record<string, string>,
     ) {
       if (typeof styles === 'string') {
-        // Copied from https://github.com/jsdom/jsdom/blob/6197af431c46b95622eb4ce9d3e4df3010c66984/lib/jsdom/living/nodes/ElementCSSInlineStyle-impl.js#L8
-        // @ts-expect-error
-        if (!this._settingCssText) {
-          // @ts-expect-error
-          e._settingCssText = true;
-          e.setAttributeNS(null, 'style', styles);
-          // @ts-expect-error
-          e._settingCssText = false;
-        }
+        // Same as from https://github.com/jsdom/jsdom/blob/6197af431c46b95622eb4ce9d3e4df3010c66984/lib/jsdom/living/nodes/ElementCSSInlineStyle-impl.js#L8
+        e.setAttributeNS(null, 'style', styles);
       } else {
         Object.assign(e.style, styles);
       }

--- a/packages/testing-library/testing-environment/src/lynx/ElementPAPI.ts
+++ b/packages/testing-library/testing-environment/src/lynx/ElementPAPI.ts
@@ -284,7 +284,15 @@ export const initElementTree = () => {
       styles: string | Record<string, string>,
     ) {
       if (typeof styles === 'string') {
-        e.style.cssText = styles;
+        // Copied from https://github.com/jsdom/jsdom/blob/6197af431c46b95622eb4ce9d3e4df3010c66984/lib/jsdom/living/nodes/ElementCSSInlineStyle-impl.js#L8
+        // @ts-expect-error
+        if (!this._settingCssText) {
+          // @ts-expect-error
+          e._settingCssText = true;
+          e.setAttributeNS(null, 'style', styles);
+          // @ts-expect-error
+          e._settingCssText = false;
+        }
       } else {
         Object.assign(e.style, styles);
       }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In JSDOM, `element.style.cssText = 'flex:1'` will normalize the style to `flex: 1 1 0%;`, this is not the  actual behavior of `__SetInlineStyles` in Lynx. We changed to use `element.setAttributeNS(null, 'style', 'flex:1');` to avoid issues.

Related change in `cssstyle`: https://github.com/jsdom/cssstyle/commit/79c88c407ee5da7f4fd9849725c9e9cc04b1a2c8#diff-72d4401db3e024bcef1fc57d7d43457be6f5b3f8f89a80b1580063362e280782

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
