### PR TITLE
chore(react/transform): remove `build:debug` from `turbo build`

### DIFF
--- a/packages/react/transform/src/swc_plugin_compat/is_component_class.rs
+++ b/packages/react/transform/src/swc_plugin_compat/is_component_class.rs
@@ -13,7 +13,7 @@ impl TransformVisitor {
     TransformVisitor {
       has_render_method: false,
       has_super_class: false,
-      has_jsx: false,
+      has_jsx: true,
     }
   }
 }

--- a/packages/react/transform/src/swc_plugin_compat/is_component_class.rs
+++ b/packages/react/transform/src/swc_plugin_compat/is_component_class.rs
@@ -13,7 +13,7 @@ impl TransformVisitor {
     TransformVisitor {
       has_render_method: false,
       has_super_class: false,
-      has_jsx: true,
+      has_jsx: false,
     }
   }
 }

--- a/packages/react/transform/turbo.json
+++ b/packages/react/transform/turbo.json
@@ -12,7 +12,6 @@
     },
     "build": {
       "dependsOn": [
-        "build:debug",
         "build:wasm"
       ]
     }


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Currently, we do not need `build:debug` on CI. And there are cases that Build (Windows) failed to exit when building failed. https://github.com/lynx-family/lynx-stack/actions/runs/15530223050/job/43718863465?pr=770.

So we are removing it from `react/transform/turbo.json`.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
