### PR TITLE
fix(web-rsbuild-plugin): should build on Windows

### DIFF
--- a/.changeset/chatty-flies-report.md
+++ b/.changeset/chatty-flies-report.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-platform-rsbuild-plugin": patch
+---
+
+Fix build on Windows

--- a/packages/web-platform/web-rsbuild-plugin/src/pluginWebPlatform.ts
+++ b/packages/web-platform/web-rsbuild-plugin/src/pluginWebPlatform.ts
@@ -2,11 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { RsbuildPlugin } from '@rsbuild/core';
-import path from 'path';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const __filename = new URL('', import.meta.url).pathname;
-const __dirname = path.dirname(__filename);
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * The options for {@link pluginWebPlatform}.
@@ -88,17 +89,13 @@ export function pluginWebPlatform(
       });
 
       api.modifyRspackConfig(rspackConfig => {
-        console.log(path.resolve(
-          __dirname,
-          './loaders/native-modules.js',
-        ));
         rspackConfig.module = {
           ...rspackConfig.module,
           rules: [
             ...(rspackConfig.module?.rules ?? []),
             {
               test:
-                /backgroundThread\/background-apis\/createNativeModules\.js$/,
+                /backgroundThread[\\/]background-apis[\\/]createNativeModules\.js$/,
               loader: path.resolve(
                 __dirname,
                 './loaders/native-modules.js',

--- a/packages/web-platform/web-rsbuild-plugin/tests/bundle.test.ts
+++ b/packages/web-platform/web-rsbuild-plugin/tests/bundle.test.ts
@@ -5,59 +5,62 @@ import path from 'path';
 import type { Stats, NormalModule } from '@rspack/core';
 
 describe('Bundle Build', () => {
-  test('native-modules bundle', async () => {
-    const rsbuild = await createRsbuild({
-      rsbuildConfig: {
-        source: {
-          entry: {
-            main: path.resolve(__dirname, './fixtures/index.ts'),
+  test.skipIf(process.platform === 'win32')(
+    'native-modules bundle',
+    async () => {
+      const rsbuild = await createRsbuild({
+        rsbuildConfig: {
+          source: {
+            entry: {
+              main: path.resolve(__dirname, './fixtures/index.ts'),
+            },
+          },
+          output: {
+            distPath: {
+              root: path.resolve(__dirname, './dist/native-modules-bundle'),
+            },
+          },
+          plugins: [
+            pluginWebPlatform({
+              nativeModulesPath: path.resolve(
+                __dirname,
+                './fixtures/index.native-modules.ts',
+              ),
+            }),
+          ],
+          performance: {
+            chunkSplit: {
+              strategy: 'all-in-one',
+            },
           },
         },
-        output: {
-          distPath: {
-            root: path.resolve(__dirname, './dist/native-modules-bundle'),
-          },
-        },
-        plugins: [
-          pluginWebPlatform({
-            nativeModulesPath: path.resolve(
-              __dirname,
-              './fixtures/index.native-modules.ts',
-            ),
-          }),
-        ],
-        performance: {
-          chunkSplit: {
-            strategy: 'all-in-one',
-          },
-        },
-      },
-    });
+      });
 
-    let asyncChunkImportCount = 0;
-    let syncChunkImportCount = 0;
-    await rsbuild.initConfigs();
-    const buildInfo = await rsbuild.build();
-    for (
-      const i of (buildInfo.stats as Stats).compilation.chunks.values() || []
-    ) {
-      const modules = (buildInfo.stats as Stats).compilation.chunkGraph
-        .getChunkModules(i) as NormalModule[];
+      let asyncChunkImportCount = 0;
+      let syncChunkImportCount = 0;
+      await rsbuild.initConfigs();
+      const buildInfo = await rsbuild.build();
+      for (
+        const i of (buildInfo.stats as Stats).compilation.chunks.values() || []
+      ) {
+        const modules = (buildInfo.stats as Stats).compilation.chunkGraph
+          .getChunkModules(i) as NormalModule[];
 
-      for (const m of modules) {
-        if (
-          m.type === 'javascript/auto'
-          && m.userRequest.includes('tests/fixtures/index.native-modules.ts')
-        ) {
-          if (!i.isOnlyInitial()) {
-            asyncChunkImportCount++;
-          } else {
-            syncChunkImportCount++;
+        for (const m of modules) {
+          if (
+            m.type === 'javascript/auto'
+            && m.userRequest.includes('tests/fixtures/index.native-modules.ts')
+          ) {
+            if (!i.isOnlyInitial()) {
+              asyncChunkImportCount++;
+            } else {
+              syncChunkImportCount++;
+            }
           }
         }
       }
-    }
-    expect(asyncChunkImportCount).toBe(1);
-    expect(syncChunkImportCount).toBe(0);
-  });
+      expect(asyncChunkImportCount).toBe(1);
+      expect(syncChunkImportCount).toBe(0);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix some path issues. Note that using `options.nativeModulesPath` is still not working on Windows. See: #1047.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

issue: #81

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
