### PR TITLE
fix(webpack/react): always use posix filename for snapshot ID

### DIFF
--- a/.changeset/light-wombats-buy.md
+++ b/.changeset/light-wombats-buy.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Keep snapshot id unchanged on Windows.

--- a/packages/webpack/react-webpack-plugin/src/loaders/options.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/options.ts
@@ -80,10 +80,16 @@ export interface ReactLoaderOptions {
   transformPath?: string | undefined;
 }
 
+function normalizeSlashes(file: string) {
+  return file.replaceAll(path.win32.sep, '/');
+}
+
 function getCommonOptions(
   this: LoaderContext<ReactLoaderOptions>,
 ) {
-  const filename = path.relative(this.rootContext, this.resourcePath);
+  const filename = normalizeSlashes(
+    path.relative(this.rootContext, this.resourcePath),
+  );
 
   const {
     compat,


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Currently, we use `__snapshot_${hash(filename)}_${hash(content)}` as snapshot ID. However, the filename is not normalized and it's different between Linux/macOS and Windows.

To make Web SSR snapshot tests work, we need to generate the same snapshot ID on different platform.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

issue: #81

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
