### PR TITLE
ci: disable Rust test on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,8 +27,8 @@ jobs:
         runs-on:
           - label: lynx-ubuntu-24.04-xlarge
             name: Ubuntu
-          - label: lynx-windows-2022-large
-            name: Windows
+          # - label: lynx-windows-2022-large
+          #   name: Windows
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Partially reverting #1031 due to frequent timeout issues with Windows Rust tests.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
