### PR TITLE
test: replace `file://` URL

### DIFF
--- a/packages/webpack/css-extract-webpack-plugin/test/diagnostic/error/sass/expected/rspack.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/diagnostic/error/sass/expected/rspack.txt
@@ -9,7 +9,7 @@ ERROR in × Module build failed:
 ERROR in ./error/sass/index.scss
 × Module build failed:
 ╰─▶   × TypeError: Cannot read properties of undefined (reading '__esModule')
-at isCJSExports (file://<ROOT>/packages/webpack/css-extract-webpack-plugin/src/loader.ts:<LINE:COLUMN>)
-at isNamedExports (file://<ROOT>/packages/webpack/css-extract-webpack-plugin/src/loader.ts:<LINE:COLUMN>)
-at Object.load (file://<ROOT>/packages/webpack/css-extract-webpack-plugin/src/loader.ts:<LINE:COLUMN>)
-at Object.pitch (file://<ROOT>/packages/webpack/css-extract-webpack-plugin/src/rspack-loader.ts:<LINE:COLUMN>)
+at isCJSExports (<ROOT>/packages/webpack/css-extract-webpack-plugin/src/loader.ts:<LINE:COLUMN>)
+at isNamedExports (<ROOT>/packages/webpack/css-extract-webpack-plugin/src/loader.ts:<LINE:COLUMN>)
+at Object.load (<ROOT>/packages/webpack/css-extract-webpack-plugin/src/loader.ts:<LINE:COLUMN>)
+at Object.pitch (<ROOT>/packages/webpack/css-extract-webpack-plugin/src/rspack-loader.ts:<LINE:COLUMN>)

--- a/packages/webpack/react-webpack-plugin/test/diagnostic/compat/utf-8/expected/rspack.txt
+++ b/packages/webpack/react-webpack-plugin/test/diagnostic/compat/utf-8/expected/rspack.txt
@@ -10,7 +10,7 @@ WARNING in ./compat/utf-8/index.jsx
 
 WARNING in ./compat/utf-8/index.jsx
 ⚠ ModuleWarning: DEPRECATED: old JSXElementName "Text" is changed to "text" (from: <ROOT>/packages/webpack/react-webpack-plugin/lib/loaders/background.js??ruleSet[1].rules[0].use[1])
-at Object.backgroundLoader (file://<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
+at Object.backgroundLoader (<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
 at <ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/index.js:<LINE:COLUMN>
 at node:internal/util:<LINE:COLUMN>
 at new Promise (<anonymous>)

--- a/packages/webpack/react-webpack-plugin/test/diagnostic/jsx/component/expected/rspack.txt
+++ b/packages/webpack/react-webpack-plugin/test/diagnostic/jsx/component/expected/rspack.txt
@@ -1,7 +1,7 @@
 ERROR in ./jsx/component/index.jsx
 × Module build failed:
 ╰─▶   × Error: react-transform failed
-at Object.backgroundLoader (file://<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
+at Object.backgroundLoader (<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
 at <ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/index.js:<LINE:COLUMN>
 at node:internal/util:<LINE:COLUMN>
 at new Promise (<anonymous>)

--- a/packages/webpack/react-webpack-plugin/test/diagnostic/jsx/component/expected/webpack.txt
+++ b/packages/webpack/react-webpack-plugin/test/diagnostic/jsx/component/expected/webpack.txt
@@ -5,4 +5,4 @@ Module Error (from ../../lib/loaders/background.js):
 ERROR in ./jsx/component/index.jsx
 Module build failed (from ../../lib/loaders/background.js):
 Error: react-transform failed
-    at Object.backgroundLoader (file://<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
+    at Object.backgroundLoader (<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)

--- a/packages/webpack/react-webpack-plugin/test/diagnostic/jsx/namespace-name/expected/rspack.txt
+++ b/packages/webpack/react-webpack-plugin/test/diagnostic/jsx/namespace-name/expected/rspack.txt
@@ -1,7 +1,7 @@
 ERROR in ./jsx/namespace-name/index.jsx
 × Module build failed:
 ╰─▶   × Error: react-transform failed
-at Object.backgroundLoader (file://<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
+at Object.backgroundLoader (<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
 at <ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/index.js:<LINE:COLUMN>
 at node:internal/util:<LINE:COLUMN>
 at new Promise (<anonymous>)

--- a/packages/webpack/react-webpack-plugin/test/diagnostic/jsx/namespace-name/expected/webpack.txt
+++ b/packages/webpack/react-webpack-plugin/test/diagnostic/jsx/namespace-name/expected/webpack.txt
@@ -5,4 +5,4 @@ JSX Namespace is disabled
 ERROR in ./jsx/namespace-name/index.jsx
 Module build failed (from ../../lib/loaders/background.js):
 Error: react-transform failed
-    at Object.backgroundLoader (file://<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
+    at Object.backgroundLoader (<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)

--- a/packages/webpack/react-webpack-plugin/test/diagnostic/module-build-failed/errors/expected/rspack.txt
+++ b/packages/webpack/react-webpack-plugin/test/diagnostic/module-build-failed/errors/expected/rspack.txt
@@ -1,7 +1,7 @@
 ERROR in ./module-build-failed/errors/invalid.js
 × Module build failed:
 ╰─▶   × Error: react-transform failed
-at Object.backgroundLoader (file://<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
+at Object.backgroundLoader (<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
 at <ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/index.js:<LINE:COLUMN>
 at node:internal/util:<LINE:COLUMN>
 at new Promise (<anonymous>)

--- a/packages/webpack/react-webpack-plugin/test/diagnostic/module-build-failed/errors/expected/webpack.txt
+++ b/packages/webpack/react-webpack-plugin/test/diagnostic/module-build-failed/errors/expected/webpack.txt
@@ -5,4 +5,4 @@ Expected ';', '}' or <eof>
 ERROR in ./module-build-failed/errors/invalid.js
 Module build failed (from ../../lib/loaders/background.js):
 Error: react-transform failed
-    at Object.backgroundLoader (file://<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)
+    at Object.backgroundLoader (<ROOT>/packages/webpack/react-webpack-plugin/src/loaders/background.ts:<LINE:COLUMN>)


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Since the error stack of Node.js is file URL (`file://`) instead of path (`C:\foo\bar.js` on Windows, `/foo/bar.js` on Posix), we should use `fileURLToPath` to make sure the snapshots are the same in different platform.

> [!NOTE]
> We are not implementing this in `path-serializer` because the `fileURLToPath` method from `node:url` exhibits varying behavior across platforms. I believe it’s not appropriate to include it there.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

issue: #81

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
