### PR TITLE
fix(react): memory leak because of cycle reference

### DIFF
--- a/.changeset/empty-roses-greet.md
+++ b/.changeset/empty-roses-greet.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/react": patch
+---
+
+Fixed two memory leaks:
+
+1. When JSX is rendered on the main thread and removed, FiberElement can still be referenced by `__root.__jsx` through `props.children`;
+
+2. When the SnapshotInstance tree is removed from the root node, its child nodes form a cycle reference because the `__previousSibling` and `__nextSibling` properties point to each other, thus causing a FiberElement leak.

--- a/packages/react/runtime/__test__/renderToOpcodes.test.jsx
+++ b/packages/react/runtime/__test__/renderToOpcodes.test.jsx
@@ -635,6 +635,97 @@ describe('renderOpcodesInto', () => {
       />
     `);
   });
+
+  it('opcodes will not ref FiberElement', () => {
+    scratch.ensureElements();
+
+    function Fragment({ children }) {
+      return children;
+    }
+
+    const opcodes = renderToString(
+      <view>
+        <text>Hello World</text>
+        {[
+          <view>A</view>,
+          <view>B</view>,
+          <view>C</view>,
+          <view>
+            C
+            <Fragment>
+              <text>C1</text>
+              <text>C2</text>
+              <text>C3</text>
+              <text>C4</text>
+            </Fragment>
+          </view>,
+          <view>D{[<text>D1</text>, <text>D2</text>, <text>D3</text>, <text>D4</text>]}</view>,
+        ]}
+      </view>,
+    );
+
+    renderOpcodesInto(opcodes, scratch);
+
+    scratch.__firstChild.removeChild(scratch.__firstChild.__firstChild);
+    scratch.__firstChild.removeChild(scratch.__firstChild.__lastChild);
+    scratch.__firstChild.removeChild(scratch.__firstChild.__lastChild);
+
+    expect(scratch.__element_root).toMatchInlineSnapshot(`
+      <page
+        cssId="default-entry-from-native:0"
+      >
+        <view>
+          <text>
+            <raw-text
+              text="Hello World"
+            />
+          </text>
+          <wrapper>
+            <view>
+              <raw-text
+                text="B"
+              />
+            </view>
+            <view>
+              <raw-text
+                text="C"
+              />
+            </view>
+          </wrapper>
+        </view>
+      </page>
+    `);
+
+    const [vnodeA, vnodeB, vnodeC, vnodeC2, vnodeD] = scratch.__firstChild.props.children;
+
+    expect(vnodeA).not.toHaveProperty('__elements');
+    expect(vnodeA).not.toHaveProperty('__element_root');
+    expect(vnodeB).toHaveProperty('__elements');
+    expect(vnodeB).toHaveProperty('__element_root');
+    expect(vnodeC).toHaveProperty('__elements');
+    expect(vnodeC).toHaveProperty('__element_root');
+    expect(vnodeD).not.toHaveProperty('__elements');
+    expect(vnodeD).not.toHaveProperty('__element_root');
+
+    {
+      const componentVNodeC = vnodeC2.props.children;
+      expect(componentVNodeC.type).toBe(Fragment);
+      expect(componentVNodeC.props.children).toHaveLength(4);
+      expect(componentVNodeC.__c.constructor).toBe(Fragment);
+      // FIXME(hzy): there is still a cycle reference
+      expect(componentVNodeC.__c.__v).toBe(componentVNodeC);
+      componentVNodeC.props.children.forEach((vnode) => {
+        expect(vnode).not.toHaveProperty('__elements');
+        expect(vnode).not.toHaveProperty('__element_root');
+      });
+    }
+
+    expect(vnodeD.props.children).toHaveLength(4);
+    vnodeD.props.children.forEach((vnode) => {
+      expect(vnode).not.toHaveProperty('__elements');
+      expect(vnode).not.toHaveProperty('__element_root');
+    });
+  });
 });
 
 it('should compile @jsxImportSource', () => {
@@ -656,8 +747,8 @@ describe('createElement', () => {
         0,
         {
           "children": undefined,
-          "id": -44,
-          "type": "__Card__:__snapshot_a94a8_test_30",
+          "id": -59,
+          "type": "__Card__:__snapshot_a94a8_test_44",
           "values": undefined,
         },
         1,
@@ -669,8 +760,8 @@ describe('createElement', () => {
         0,
         {
           "children": undefined,
-          "id": -45,
-          "type": "__Card__:__snapshot_a94a8_test_30",
+          "id": -60,
+          "type": "__Card__:__snapshot_a94a8_test_44",
           "values": undefined,
         },
         1,
@@ -690,8 +781,8 @@ describe('createElement', () => {
         0,
         {
           "children": undefined,
-          "id": -46,
-          "type": "__Card__:__snapshot_a94a8_test_31",
+          "id": -61,
+          "type": "__Card__:__snapshot_a94a8_test_45",
           "values": undefined,
         },
         1,
@@ -703,8 +794,8 @@ describe('createElement', () => {
         0,
         {
           "children": undefined,
-          "id": -47,
-          "type": "__Card__:__snapshot_a94a8_test_31",
+          "id": -62,
+          "type": "__Card__:__snapshot_a94a8_test_45",
           "values": undefined,
         },
         1,

--- a/packages/react/runtime/src/backgroundSnapshot.ts
+++ b/packages/react/runtime/src/backgroundSnapshot.ts
@@ -164,6 +164,8 @@ export class BackgroundSnapshotInstance {
 
     traverseSnapshotInstance(node, v => {
       v.__parent = null;
+      v.__previousSibling = null;
+      v.__nextSibling = null;
       if (v.__values) {
         v.__snapshot_def.refAndSpreadIndexes?.forEach((i) => {
           const value = v.__values![i] as unknown;

--- a/packages/react/runtime/src/list.ts
+++ b/packages/react/runtime/src/list.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { hydrate } from './hydrate.js';
 import { applyRefQueue } from './snapshot/workletRef.js';
-import type { SnapshotInstance } from './snapshot.js';
+import { type SnapshotInstance } from './snapshot.js';
 
 export interface ListUpdateInfo {
   flush(): void;
@@ -311,6 +311,9 @@ export function componentAtIndexFactory(
       recycleSignMap.delete(sign);
       hydrate(oldCtx, childCtx);
       oldCtx.unRenderElements();
+      if (!oldCtx.__id) {
+        oldCtx.tearDown();
+      }
       const root = childCtx.__element_root!;
       applyRefQueue();
       if (!enableBatchRender) {

--- a/packages/react/runtime/src/snapshot.ts
+++ b/packages/react/runtime/src/snapshot.ts
@@ -393,6 +393,14 @@ export class SnapshotInstance {
     return a;
   }
 
+  tearDown(): void {
+    traverseSnapshotInstance(this, v => {
+      v.__parent = null;
+      v.__previousSibling = null;
+      v.__nextSibling = null;
+    });
+  }
+
   // onCreate?: () => void;
   // onAttach?: () => void;
   // onDetach?: () => void;
@@ -544,25 +552,22 @@ export class SnapshotInstance {
   }
 
   removeChild(child: SnapshotInstance): void {
-    const r = () => {
-      this.__removeChild(child);
-      traverseSnapshotInstance(child, v => {
-        v.__parent = null;
-        snapshotInstanceManager.values.delete(v.__id);
-      });
-    };
-
     const __snapshot_def = this.__snapshot_def;
     if (__snapshot_def.isListHolder) {
       (__pendingListUpdates.values[this.__id] ??= new ListUpdateInfoRecording(
         this,
       )).onRemoveChild(child);
-      r();
+
+      this.__removeChild(child);
+      traverseSnapshotInstance(child, v => {
+        snapshotInstanceManager.values.delete(v.__id);
+      });
+      // mark this child as deleted
+      child.__id = 0;
       return;
     }
 
     unref(child, true);
-    r();
     if (this.__elements) {
       const [, elementIndex] = __snapshot_def.slot[0]!;
       __RemoveElement(this.__elements[elementIndex]!, child.__element_root!);
@@ -571,6 +576,16 @@ export class SnapshotInstance {
     if (child.__snapshot_def.isListHolder) {
       snapshotDestroyList(child);
     }
+
+    this.__removeChild(child);
+    traverseSnapshotInstance(child, v => {
+      v.__parent = null;
+      v.__previousSibling = null;
+      v.__nextSibling = null;
+      delete v.__elements;
+      delete v.__element_root;
+      snapshotInstanceManager.values.delete(v.__id);
+    });
   }
 
   setAttribute(key: string | number, value: any): void {

--- a/packages/react/testing-library/src/__tests__/list.test.jsx
+++ b/packages/react/testing-library/src/__tests__/list.test.jsx
@@ -231,6 +231,9 @@ describe('list', () => {
     let setListVal;
     let initListVal = Array(6).fill(0).map((v, i) => i);
 
+    const A = () => {
+      return <text>hello</text>;
+    };
     const Comp = () => {
       const [listVal, _setListVal] = useState(initListVal);
       setListVal = _setListVal;
@@ -261,6 +264,10 @@ describe('list', () => {
                         ? <text>{v}</text>
                         : null}
                     </view>
+                    {/* This will generate `__DynamicPartSlot` part for testing the hydration behavior of slot is as expceted */}
+                    <view>
+                      <A />
+                    </view>
                   </list-item>
                 );
               })}
@@ -278,7 +285,7 @@ describe('list', () => {
         >
           <list
             style="width:100%;height:100%"
-            update-list-info="[{"insertAction":[{"position":0,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"0","full-span":true},{"position":1,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"1","full-span":true},{"position":2,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"2","full-span":true},{"position":3,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"3","full-span":true},{"position":4,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"4","full-span":true},{"position":5,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]}]"
+            update-list-info="[{"insertAction":[{"position":0,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"0","full-span":true},{"position":1,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"1","full-span":true},{"position":2,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"2","full-span":true},{"position":3,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"3","full-span":true},{"position":4,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"4","full-span":true},{"position":5,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]}]"
           />
         </view>
       </page>
@@ -304,6 +311,11 @@ describe('list', () => {
             3
           </text>
         </view>
+        <view>
+          <text>
+            hello
+          </text>
+        </view>
       </list-item>
     `);
 
@@ -326,12 +338,12 @@ describe('list', () => {
 
     // Remove action is generated
     expect(
-      JSON.parse(list.getAttribute('update-list-info'))[1].removeAction
+      JSON.parse(list.getAttribute('update-list-info'))[1].removeAction,
     ).toMatchInlineSnapshot(`
       [
         3,
       ]
-    `)
+    `);
     // Reuse the element 3
     elementTree.leaveListItem(list, uid3);
     elementTree.enterListItemAtIndex(list, 1);
@@ -355,6 +367,11 @@ describe('list', () => {
             1
           </text>
         </view>
+        <view>
+          <text>
+            hello
+          </text>
+        </view>
       </list-item>
     `);
 
@@ -373,6 +390,11 @@ describe('list', () => {
                 1
               </text>
             </view>
+            <view>
+              <text>
+                hello
+              </text>
+            </view>
           </list-item>,
           "item-key",
           "1",
@@ -388,6 +410,11 @@ describe('list', () => {
               </text>
               <text>
                 1
+              </text>
+            </view>
+            <view>
+              <text>
+                hello
               </text>
             </view>
           </list-item>,
@@ -422,9 +449,14 @@ describe('list', () => {
                 1
               </text>
             </view>
+            <view>
+              <text>
+                hello
+              </text>
+            </view>
           </list-item>,
           {
-            "elementID": 21,
+            "elementID": 36,
             "listID": 2,
             "operationID": undefined,
             "triggerLayout": true,
@@ -436,7 +468,7 @@ describe('list', () => {
     expect(list).toMatchInlineSnapshot(`
       <list
         style="width:100%;height:100%"
-        update-list-info="[{"insertAction":[{"position":0,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"0","full-span":true},{"position":1,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"1","full-span":true},{"position":2,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"2","full-span":true},{"position":3,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"3","full-span":true},{"position":4,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"4","full-span":true},{"position":5,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]},{"insertAction":[],"removeAction":[3],"updateAction":[]}]"
+        update-list-info="[{"insertAction":[{"position":0,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"0","full-span":true},{"position":1,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"1","full-span":true},{"position":2,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"2","full-span":true},{"position":3,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"3","full-span":true},{"position":4,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"4","full-span":true},{"position":5,"type":"__Card__:__snapshot_a9e46_test_6","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]},{"insertAction":[],"removeAction":[3],"updateAction":[]}]"
       >
         <list-item
           full-span="true"
@@ -448,6 +480,11 @@ describe('list', () => {
             </text>
             <text>
               4
+            </text>
+          </view>
+          <view>
+            <text>
+              hello
             </text>
           </view>
         </list-item>
@@ -463,6 +500,11 @@ describe('list', () => {
               5
             </text>
           </view>
+          <view>
+            <text>
+              hello
+            </text>
+          </view>
         </list-item>
         <list-item
           full-span="true"
@@ -476,6 +518,11 @@ describe('list', () => {
               2
             </text>
           </view>
+          <view>
+            <text>
+              hello
+            </text>
+          </view>
         </list-item>
         <list-item
           full-span="true"
@@ -487,6 +534,11 @@ describe('list', () => {
             </text>
             <text>
               1
+            </text>
+          </view>
+          <view>
+            <text>
+              hello
             </text>
           </view>
         </list-item>

--- a/packages/react/testing-library/src/__tests__/list.test.jsx
+++ b/packages/react/testing-library/src/__tests__/list.test.jsx
@@ -2,6 +2,7 @@ import { describe, expect } from 'vitest';
 import { render } from '..';
 import { useState } from '@lynx-js/react';
 import { __pendingListUpdates } from '../../../runtime/lib/list.js';
+import { act } from 'preact/test-utils';
 
 describe('list', () => {
   it('basic', async () => {
@@ -225,5 +226,271 @@ describe('list', () => {
     `);
     expect(uid2).toMatchInlineSnapshot(`2`);
     expect(uid0).toBe(uid2);
+  });
+  it('should reuse removed list item', async () => {
+    let setListVal;
+    let initListVal = Array(6).fill(0).map((v, i) => i);
+
+    const Comp = () => {
+      const [listVal, _setListVal] = useState(initListVal);
+      setListVal = _setListVal;
+      const showMask = true;
+
+      return (
+        <view
+          style={{
+            width: '100vw',
+            height: '100vh',
+          }}
+        >
+          {
+            <list
+              style={{
+                width: '100%',
+                height: '100%',
+              }}
+            >
+              {listVal.map((v) => {
+                return (
+                  <list-item item-key={`${v}`} key={v} full-span>
+                    <view>
+                      {showMask
+                        ? <text>{v}</text>
+                        : null}
+                      {showMask
+                        ? <text>{v}</text>
+                        : null}
+                    </view>
+                  </list-item>
+                );
+              })}
+            </list>
+          }
+        </view>
+      );
+    };
+
+    const { container } = render(<Comp />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          style="width:100vw;height:100vh"
+        >
+          <list
+            style="width:100%;height:100%"
+            update-list-info="[{"insertAction":[{"position":0,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"0","full-span":true},{"position":1,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"1","full-span":true},{"position":2,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"2","full-span":true},{"position":3,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"3","full-span":true},{"position":4,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"4","full-span":true},{"position":5,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]}]"
+          />
+        </view>
+      </page>
+    `);
+    const list = container.firstChild.firstChild;
+
+    const uid0 = elementTree.enterListItemAtIndex(list, 0);
+    const uid1 = elementTree.enterListItemAtIndex(list, 1);
+    const uid2 = elementTree.enterListItemAtIndex(list, 2);
+    const uid3 = elementTree.enterListItemAtIndex(list, 3);
+
+    const listItem3 = list.children[3];
+    expect(listItem3).toMatchInlineSnapshot(`
+      <list-item
+        full-span="true"
+        item-key="3"
+      >
+        <view>
+          <text>
+            3
+          </text>
+          <text>
+            3
+          </text>
+        </view>
+      </list-item>
+    `);
+
+    elementTree.leaveListItem(list, uid0);
+    const uid4 = elementTree.enterListItemAtIndex(list, 4);
+    expect(uid4).toBe(uid0);
+
+    elementTree.leaveListItem(list, uid1);
+    const uid5 = elementTree.enterListItemAtIndex(list, 5);
+    expect(uid5).toBe(uid1);
+
+    // Remove the element 3
+    act(() => {
+      setListVal(initListVal.filter(x => x !== 3));
+    });
+
+    const __CreateElement = vi.spyOn(globalThis, '__CreateElement');
+    const __SetAttribute = vi.spyOn(globalThis, '__SetAttribute');
+    const __FlushElementTree = vi.spyOn(globalThis, '__FlushElementTree');
+
+    // Remove action is generated
+    expect(
+      JSON.parse(list.getAttribute('update-list-info'))[1].removeAction
+    ).toMatchInlineSnapshot(`
+      [
+        3,
+      ]
+    `)
+    // Reuse the element 3
+    elementTree.leaveListItem(list, uid3);
+    elementTree.enterListItemAtIndex(list, 1);
+
+    expect(__CreateElement).toHaveBeenCalledTimes(0);
+    expect(__SetAttribute).toHaveBeenCalledTimes(4);
+    // The orginal FiberElement of element 3 is resued for
+    // element 1 now
+    expect(__SetAttribute.mock.calls[0][0]).toBe(listItem3);
+    expect(__SetAttribute.mock.calls[0][0].$$uiSign).toBe(uid3);
+    expect(listItem3).toMatchInlineSnapshot(`
+      <list-item
+        full-span="true"
+        item-key="1"
+      >
+        <view>
+          <text>
+            1
+          </text>
+          <text>
+            1
+          </text>
+        </view>
+      </list-item>
+    `);
+
+    expect(__SetAttribute.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          <list-item
+            full-span="true"
+            item-key="1"
+          >
+            <view>
+              <text>
+                1
+              </text>
+              <text>
+                1
+              </text>
+            </view>
+          </list-item>,
+          "item-key",
+          "1",
+        ],
+        [
+          <list-item
+            full-span="true"
+            item-key="1"
+          >
+            <view>
+              <text>
+                1
+              </text>
+              <text>
+                1
+              </text>
+            </view>
+          </list-item>,
+          "full-span",
+          true,
+        ],
+        [
+          1,
+          "text",
+          1,
+        ],
+        [
+          1,
+          "text",
+          1,
+        ],
+      ]
+    `);
+    expect(__FlushElementTree).toHaveBeenCalledTimes(1);
+    expect(__FlushElementTree.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          <list-item
+            full-span="true"
+            item-key="1"
+          >
+            <view>
+              <text>
+                1
+              </text>
+              <text>
+                1
+              </text>
+            </view>
+          </list-item>,
+          {
+            "elementID": 21,
+            "listID": 2,
+            "operationID": undefined,
+            "triggerLayout": true,
+          },
+        ],
+      ]
+    `);
+
+    expect(list).toMatchInlineSnapshot(`
+      <list
+        style="width:100%;height:100%"
+        update-list-info="[{"insertAction":[{"position":0,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"0","full-span":true},{"position":1,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"1","full-span":true},{"position":2,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"2","full-span":true},{"position":3,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"3","full-span":true},{"position":4,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"4","full-span":true},{"position":5,"type":"__Card__:__snapshot_a9e46_test_5","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]},{"insertAction":[],"removeAction":[3],"updateAction":[]}]"
+      >
+        <list-item
+          full-span="true"
+          item-key="4"
+        >
+          <view>
+            <text>
+              4
+            </text>
+            <text>
+              4
+            </text>
+          </view>
+        </list-item>
+        <list-item
+          full-span="true"
+          item-key="5"
+        >
+          <view>
+            <text>
+              5
+            </text>
+            <text>
+              5
+            </text>
+          </view>
+        </list-item>
+        <list-item
+          full-span="true"
+          item-key="2"
+        >
+          <view>
+            <text>
+              2
+            </text>
+            <text>
+              2
+            </text>
+          </view>
+        </list-item>
+        <list-item
+          full-span="true"
+          item-key="1"
+        >
+          <view>
+            <text>
+              1
+            </text>
+            <text>
+              1
+            </text>
+          </view>
+        </list-item>
+      </list>
+    `);
   });
 });

--- a/packages/react/testing-library/src/__tests__/list.test.jsx
+++ b/packages/react/testing-library/src/__tests__/list.test.jsx
@@ -264,7 +264,7 @@ describe('list', () => {
                         ? <text>{v}</text>
                         : null}
                     </view>
-                    {/* This will generate `__DynamicPartSlot` part for testing the hydration behavior of slot is as expceted */}
+                    {/* This will generate `__DynamicPartSlot` part for testing the hydration behavior of slot is as expected */}
                     <view>
                       <A />
                     </view>
@@ -350,7 +350,7 @@ describe('list', () => {
 
     expect(__CreateElement).toHaveBeenCalledTimes(0);
     expect(__SetAttribute).toHaveBeenCalledTimes(4);
-    // The orginal FiberElement of element 3 is resued for
+    // The original FiberElement of element 3 is reused for
     // element 1 now
     expect(__SetAttribute.mock.calls[0][0]).toBe(listItem3);
     expect(__SetAttribute.mock.calls[0][0].$$uiSign).toBe(uid3);


### PR DESCRIPTION
Different from #1054, this fix avoids disconnecting the `SnapshotInstance` that is about to be reused, and avoids incompleteness when it is reused in the `<list/>`.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
