### PR TITLE
feat(web): supports lynx.getI18nResource() and onI18nResourceReady ev…

### DIFF
--- a/.changeset/heavy-sides-enter.md
+++ b/.changeset/heavy-sides-enter.md
@@ -1,0 +1,13 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+feat: supports `lynx.getI18nResource()` and `onI18nResourceReady` event in bts.
+
+- `lynx.getI18nResource()` can be used to get i18nResource in bts, it has two data sources:
+  - the result of `_I18nResourceTranslation()`
+  - lynx-view `updateI18nResources(data: InitI18nResources, options: I18nResourceTranslationOptions)`, it will be matched to the correct i8nResource as a result of `lynx.getI18nResource()`
+- `onI18nResourceReady` event can be used to listen `_I18nResourceTranslation` and lynx-view `updateI18nResources` execution.

--- a/packages/web-platform/web-constants/src/endpoints.ts
+++ b/packages/web-platform/web-constants/src/endpoints.ts
@@ -218,3 +218,13 @@ export const updateI18nResourcesEndpoint = createRpcEndpoint<
   [Cloneable],
   void
 >('updateI18nResources', false, false);
+
+export const updateI18nResourceEndpoint = createRpcEndpoint<
+  [Cloneable | undefined],
+  void
+>('updateI18nResource', false, false);
+
+export const dispatchI18nResourceEndpoint = createRpcEndpoint<
+  [Cloneable],
+  void
+>('dispatchI18nResource', false, false);

--- a/packages/web-platform/web-constants/src/types/I18n.ts
+++ b/packages/web-platform/web-constants/src/types/I18n.ts
@@ -27,12 +27,24 @@ export type InitI18nResources = Array<{
 
 export const i18nResourceMissedEventName = 'i18nResourceMissed' as const;
 
+// The purpose of using class is to keep the reference when reassigning
 export class I18nResources {
   data?: InitI18nResources;
   constructor(data?: InitI18nResources) {
     this.data = data;
   }
   setData(data: InitI18nResources) {
+    this.data = data;
+  }
+}
+
+// The purpose of using class is to keep the reference when reassigning
+export class I18nResource {
+  data?: Cloneable;
+  constructor(data?: Cloneable) {
+    this.data = data;
+  }
+  setData(data: Cloneable) {
     this.data = data;
   }
 }

--- a/packages/web-platform/web-constants/src/types/NativeApp.ts
+++ b/packages/web-platform/web-constants/src/types/NativeApp.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 
 import type { CloneableObject } from './Cloneable.js';
+import type { I18nResource } from './I18n.js';
 import type { LynxContextEventTarget } from './LynxContextEventTarget.js';
 import type { PerformancePipelineOptions } from './Performance.js';
 
@@ -189,4 +190,6 @@ export interface NativeApp {
 
   setSharedData<T>(dataKey: string, dataVal: T): void;
   getSharedData<T = unknown>(dataKey: string): T | undefined;
+
+  i18nResource: I18nResource;
 }

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -9,6 +9,7 @@ import {
 import {
   inShadowRootStyles,
   type Cloneable,
+  type I18nResourceTranslationOptions,
   type InitI18nResources,
   type LynxTemplate,
   type NapiModulesCall,
@@ -160,8 +161,11 @@ export class LynxView extends HTMLElement {
    * @method
    * update the `__initData` and trigger essential flow
    */
-  updateI18nResources(data: InitI18nResources) {
-    this.#instance?.updateI18nResources(data as Cloneable);
+  updateI18nResources(
+    data: InitI18nResources,
+    options: I18nResourceTranslationOptions,
+  ) {
+    this.#instance?.updateI18nResources(data, options);
   }
 
   #overrideLynxTagToHTMLTagMap: Record<string, string> = { 'page': 'div' };

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -4,6 +4,7 @@
 
 import type {
   Cloneable,
+  I18nResourceTranslationOptions,
   InitI18nResources,
   NapiModulesMap,
   NativeModulesMap,
@@ -42,7 +43,10 @@ export interface LynxView {
   dispose(): Promise<void>;
   sendGlobalEvent: RpcCallType<typeof sendGlobalEventEndpoint>;
   updateGlobalProps: (data: Cloneable) => void;
-  updateI18nResources: (data: Cloneable) => void;
+  updateI18nResources: (
+    data: InitI18nResources,
+    options: I18nResourceTranslationOptions,
+  ) => void;
 }
 
 export function createLynxView(configs: LynxViewConfigs): LynxView {

--- a/packages/web-platform/web-core/src/uiThread/startBackground.ts
+++ b/packages/web-platform/web-core/src/uiThread/startBackground.ts
@@ -1,7 +1,12 @@
 import {
+  getCacheI18nResourcesKey,
   markTimingEndpoint,
   sendGlobalEventEndpoint,
   updateDataEndpoint,
+  updateI18nResourceEndpoint,
+  type Cloneable,
+  type I18nResourceTranslationOptions,
+  type InitI18nResources,
   type NapiModulesCall,
   type NativeModulesCall,
 } from '@lynx-js/web-constants';
@@ -53,9 +58,22 @@ export function startBackground(
   const sendGlobalEvent = backgroundRpc.createCall(sendGlobalEventEndpoint);
   const markTiming = backgroundRpc.createCall(markTimingEndpoint);
   const updateDataBackground = backgroundRpc.createCall(updateDataEndpoint);
+  const updateI18nResourceBackground = (
+    data: InitI18nResources,
+    options: I18nResourceTranslationOptions,
+  ) => {
+    const matchedResources = data.find(i =>
+      getCacheI18nResourcesKey(i.options)
+        === getCacheI18nResourcesKey(options)
+    );
+    backgroundRpc.invoke(updateI18nResourceEndpoint, [
+      matchedResources?.resource as Cloneable,
+    ]);
+  };
   return {
     sendGlobalEvent,
     markTiming,
     updateDataBackground,
+    updateI18nResourceBackground,
   };
 }

--- a/packages/web-platform/web-core/src/uiThread/startUIThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/startUIThread.ts
@@ -41,7 +41,12 @@ export function startUIThread(
     backgroundRpc,
     terminateWorkers,
   } = bootWorkers(lynxGroupId, allOnUI);
-  const { markTiming, sendGlobalEvent, updateDataBackground } = startBackground(
+  const {
+    markTiming,
+    sendGlobalEvent,
+    updateDataBackground,
+    updateI18nResourceBackground,
+  } = startBackground(
     backgroundRpc,
     shadowRoot,
     callbacks,
@@ -83,7 +88,9 @@ export function startUIThread(
     ),
     sendGlobalEvent,
     updateGlobalProps: backgroundRpc.createCall(updateGlobalPropsEndpoint),
-    updateI18nResources: (data: Cloneable) =>
-      updateI18nResourcesMainThread(data),
+    updateI18nResources: (...args) => {
+      updateI18nResourcesMainThread(args[0] as Cloneable);
+      updateI18nResourceBackground(...args);
+    },
   };
 }

--- a/packages/web-platform/web-mainthread-apis/src/prepareMainThreadAPIs.ts
+++ b/packages/web-platform/web-mainthread-apis/src/prepareMainThreadAPIs.ts
@@ -22,6 +22,8 @@ import {
   getCacheI18nResourcesKey,
   type InitI18nResources,
   type I18nResources,
+  dispatchI18nResourceEndpoint,
+  type Cloneable,
 } from '@lynx-js/web-constants';
 import { registerCallLepusMethodHandler } from './crossThreadHandlers/registerCallLepusMethodHandler.js';
 import { registerGetCustomSectionHandler } from './crossThreadHandlers/registerGetCustomSectionHandler.js';
@@ -54,6 +56,9 @@ export function prepareMainThreadAPIs(
     publicComponentEventEndpoint,
   );
   const postExposure = backgroundThreadRpc.createCall(postExposureEndpoint);
+  const dispatchI18nResource = backgroundThreadRpc.createCall(
+    dispatchI18nResourceEndpoint,
+  );
   markTimingInternal('lepus_execute_start');
   async function startMainThread(
     config: StartMainThreadContextConfig,
@@ -189,6 +194,7 @@ export function prepareMainThreadAPIs(
             getCacheI18nResourcesKey(i.options)
               === getCacheI18nResourcesKey(options)
           );
+          dispatchI18nResource(matchedInitI18nResources?.resource as Cloneable);
           if (matchedInitI18nResources) {
             return matchedInitI18nResources.resource;
           }

--- a/packages/web-platform/web-tests/tests/web-core.test.ts
+++ b/packages/web-platform/web-tests/tests/web-core.test.ts
@@ -436,7 +436,11 @@ test.describe('web core tests', () => {
             lynx: 'lynx web platform2',
           },
         },
-      ]);
+      ], {
+        locale: 'en',
+        channel: '2',
+        fallback_url: '',
+      });
     });
     await wait(500);
     const second = await mainWorker.evaluate(() => {
@@ -454,5 +458,178 @@ test.describe('web core tests', () => {
     await wait(500);
     expect(first).toBeTruthy();
     expect(second).toBeTruthy();
+  });
+  test('api-get-i18n-resource-by-mts', async ({ page, browserName }) => {
+    // firefox dose not support this.
+    test.skip(browserName === 'firefox');
+    await goto(page);
+    const mainWorker = await getMainThreadWorker(page);
+    await mainWorker.evaluate(() => {
+      globalThis.runtime.renderPage = () => {};
+    });
+    await wait(500);
+    const backWorker = await getBackgroundThreadWorker(page);
+    const first = await backWorker?.evaluate(() =>
+      globalThis.runtime.lynx.getNativeLynx().getI18nResource() === undefined
+    );
+    await wait(500);
+    await mainWorker?.evaluate(() => {
+      globalThis.runtime._I18nResourceTranslation({
+        locale: 'en',
+        channel: '1',
+        fallback_url: '',
+      });
+    });
+    const second = await backWorker?.evaluate(() =>
+      JSON.stringify(globalThis.runtime.lynx.getNativeLynx().getI18nResource())
+        === '{"hello":"hello","lynx":"lynx web platform1"}'
+    );
+    expect(first).toBeTruthy();
+    expect(second).toBeTruthy();
+  });
+  test('api-get-i18n-resource-by-lynx-update', async ({ page, browserName }) => {
+    // firefox dose not support this.
+    test.skip(browserName === 'firefox');
+    await goto(page);
+    const mainWorker = await getMainThreadWorker(page);
+    await mainWorker.evaluate(() => {
+      globalThis.runtime.renderPage = () => {};
+    });
+    await wait(500);
+    const backWorker = await getBackgroundThreadWorker(page);
+    const first = await backWorker?.evaluate(() =>
+      globalThis.runtime.lynx.getNativeLynx().getI18nResource() === undefined
+    );
+    await wait(500);
+    await page.evaluate(() => {
+      document.querySelector('lynx-view').updateI18nResources([
+        {
+          options: {
+            locale: 'en',
+            channel: '1',
+            fallback_url: '',
+          },
+          resource: {
+            hello: 'hello',
+            lynx: 'lynx web platform1',
+          },
+        },
+        {
+          options: {
+            locale: 'en',
+            channel: '2',
+            fallback_url: '',
+          },
+          resource: {
+            hello: 'hello',
+            lynx: 'lynx web platform2',
+          },
+        },
+      ], {
+        locale: 'en',
+        channel: '2',
+        fallback_url: '',
+      });
+    });
+    await wait(500);
+    const second = await backWorker?.evaluate(() =>
+      JSON.stringify(globalThis.runtime.lynx.getNativeLynx().getI18nResource())
+        === '{"hello":"hello","lynx":"lynx web platform2"}'
+    );
+    expect(first).toBeTruthy();
+    expect(second).toBeTruthy();
+  });
+  test('api-onI18nResourceReady-by-mts', async ({ page, browserName }) => {
+    // firefox dose not support this.
+    test.skip(browserName === 'firefox');
+    await goto(page);
+    const mainWorker = await getMainThreadWorker(page);
+    await mainWorker.evaluate(() => {
+      globalThis.runtime.renderPage = () => {};
+    });
+    await wait(500);
+    let success = false;
+    await page.on('console', async (message) => {
+      if (message.text() === 'onI18nResourceReady') {
+        success = true;
+      }
+    });
+    const backWorker = await getBackgroundThreadWorker(page);
+    await backWorker?.evaluate(() => {
+      globalThis.runtime.GlobalEventEmitter.addListener(
+        'onI18nResourceReady',
+        () => {
+          console.log('onI18nResourceReady');
+        },
+      );
+    });
+    await wait(500);
+    await mainWorker?.evaluate(() => {
+      globalThis.runtime._I18nResourceTranslation({
+        locale: 'en',
+        channel: '1',
+        fallback_url: '',
+      });
+    });
+    await wait(500);
+    expect(success).toBeTruthy();
+  });
+  test('api-onI18nResourceReady-by-lynx-update', async ({ page, browserName }) => {
+    // firefox dose not support this.
+    test.skip(browserName === 'firefox');
+    await goto(page);
+    const mainWorker = await getMainThreadWorker(page);
+    await mainWorker.evaluate(() => {
+      globalThis.runtime.renderPage = () => {};
+    });
+    await wait(500);
+    let success = false;
+    await page.on('console', async (message) => {
+      if (message.text() === 'onI18nResourceReady') {
+        success = true;
+      }
+    });
+    const backWorker = await getBackgroundThreadWorker(page);
+    await backWorker?.evaluate(() => {
+      globalThis.runtime.GlobalEventEmitter.addListener(
+        'onI18nResourceReady',
+        () => {
+          console.log('onI18nResourceReady');
+        },
+      );
+    });
+    await wait(500);
+    await page.evaluate(() => {
+      document.querySelector('lynx-view').updateI18nResources([
+        {
+          options: {
+            locale: 'en',
+            channel: '1',
+            fallback_url: '',
+          },
+          resource: {
+            hello: 'hello',
+            lynx: 'lynx web platform1',
+          },
+        },
+        {
+          options: {
+            locale: 'en',
+            channel: '2',
+            fallback_url: '',
+          },
+          resource: {
+            hello: 'hello',
+            lynx: 'lynx web platform2',
+          },
+        },
+      ], {
+        locale: 'en',
+        channel: '2',
+        fallback_url: '',
+      });
+    });
+    await wait(500);
+    expect(success).toBeTruthy();
   });
 });

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createBackgroundLynx.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createBackgroundLynx.ts
@@ -47,5 +47,6 @@ export function createBackgroundLynx(
     createElement(_: string, id: string) {
       return createElement(id, uiThreadRpc);
     },
+    getI18nResource: () => nativeApp.i18nResource.data,
   };
 }

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -13,6 +13,7 @@ import {
   type LynxCrossThreadContext,
   systemInfo,
   type BackMainThreadContextConfig,
+  I18nResource,
 } from '@lynx-js/web-constants';
 import { createInvokeUIMethod } from './crossThreadHandlers/createInvokeUIMethod.js';
 import { registerPublicComponentEventHandler } from './crossThreadHandlers/registerPublicComponentEventHandler.js';
@@ -25,6 +26,7 @@ import { registerSendGlobalEventHandler } from './crossThreadHandlers/registerSe
 import { createJSObjectDestructionObserver } from './crossThreadHandlers/createJSObjectDestructionObserver.js';
 import type { TimingSystem } from './createTimingSystem.js';
 import { registerUpdateGlobalPropsHandler } from './crossThreadHandlers/registerUpdateGlobalPropsHandler.js';
+import { registerUpdateI18nResource } from './crossThreadHandlers/registerUpdateI18nResource.js';
 
 let nativeAppCount = 0;
 const sharedData: Record<string, unknown> = {};
@@ -88,6 +90,7 @@ export async function createNativeApp(
       },
     };
   };
+  const i18nResource = new I18nResource();
   const nativeApp: NativeApp = {
     id: (nativeAppCount++).toString(),
     ...performanceApis,
@@ -150,6 +153,7 @@ export async function createNativeApp(
         tt,
       );
       registerUpdateGlobalPropsHandler(uiThreadRpc, tt);
+      registerUpdateI18nResource(uiThreadRpc, mainThreadRpc, i18nResource, tt);
       timingSystem.registerGlobalEmitter(tt.GlobalEventEmitter);
       (tt.lynx.getCoreContext() as LynxCrossThreadContext).__start();
     },
@@ -162,6 +166,7 @@ export async function createNativeApp(
     getSharedData<T>(dataKey: string): T | undefined {
       return sharedData[dataKey] as T | undefined;
     },
+    i18nResource,
   };
   return nativeApp;
 }

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/crossThreadHandlers/registerUpdateI18nResource.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/crossThreadHandlers/registerUpdateI18nResource.ts
@@ -1,0 +1,28 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  dispatchI18nResourceEndpoint,
+  updateI18nResourceEndpoint,
+  type NativeTTObject,
+} from '@lynx-js/web-constants';
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+import { I18nResource } from '@lynx-js/web-constants';
+
+export function registerUpdateI18nResource(
+  uiThreadRpc: Rpc,
+  mainThreadRpc: Rpc,
+  i18nResource: I18nResource,
+  tt: NativeTTObject,
+): void {
+  // updateI18nResourceEndpoint from ui thread
+  uiThreadRpc.registerHandler(updateI18nResourceEndpoint, (data) => {
+    i18nResource.setData(data);
+    tt.GlobalEventEmitter.emit('onI18nResourceReady', []);
+  });
+  // dispatchI18nResource from mts
+  mainThreadRpc.registerHandler(dispatchI18nResourceEndpoint, (data) => {
+    i18nResource.setData(data);
+    tt.GlobalEventEmitter.emit('onI18nResourceReady', []);
+  });
+}


### PR DESCRIPTION
…ent in bts.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

feat: supports `lynx.getI18nResource()` and `onI18nResourceReady` event in bts.

- `lynx.getI18nResource()` can be used to get i18nResource in bts, it has two data sources:
  - the result of `_I18nResourceTranslation()`
  - lynx-view `updateI18nResources(data: InitI18nResources, options: I18nResourceTranslationOptions)`, it will be matched to the correct i8nResource as a result of `lynx.getI18nResource()`
- `onI18nResourceReady` event can be used to listen `_I18nResourceTranslation` and lynx-view `updateI18nResources` execution.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
