### PR TITLE
fix(web): decodeCssInJs no longer throw an error

### DIFF
--- a/.changeset/fair-mugs-jump.md
+++ b/.changeset/fair-mugs-jump.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: `decodeCssInJs` function will no longer throw an error, this is to avoid affecting the execution of `cssId -1` when `enableCssSelector: false`

--- a/packages/web-platform/web-mainthread-apis/src/utils/decodeCssInJs.ts
+++ b/packages/web-platform/web-mainthread-apis/src/utils/decodeCssInJs.ts
@@ -23,7 +23,7 @@ export function decodeCssInJs(
       if (oneRule) declarations.push(...oneRule);
     }
   } else {
-    throw new Error(`[lynx-web] cannot find styleinfo for cssid ${cssId}`);
+    console.warn(`[lynx-web] cannot find styleinfo for cssid ${cssId}`);
   }
   return declarations.map(([property, value]) => `${property}:${value};`).join(
     '',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: `decodeCssInJs` function will no longer throw an error, this is to avoid affecting the execution of `cssId -1` when `enableCssSelector: false`

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
