### PR TITLE
ci: set hook-timeout on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,6 +209,7 @@ jobs:
         --reporter=junit
         --outputFile=test-report.junit.xml
         --test-timeout=50000
+        --hook-timeout=50000
         --coverage
         --coverage.reporter='json'
         --coverage.reporter='text'


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix Windows CI failure. See: https://github.com/lynx-family/lynx-stack/actions/runs/15757466877/job/44416369201?pr=1111

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

close: m-6701643515

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
