### PR TITLE
feat(web): add _SetSourceMapRelease(errInfo) MTS API.

### DIFF
--- a/.changeset/forty-jars-scream.md
+++ b/.changeset/forty-jars-scream.md
@@ -1,0 +1,12 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-core-server": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+feat: add `_SetSourceMapRelease(errInfo)` MTS API.
+
+You can get `errInfo.release` through `e.detail.release` in the error event callback of lynx-view.
+
+The `_SetSourceMapRelease` function is not complete yet, because it is currently limited by the Web platform and some functions and some props such as `err.stack` do not need to be supported for the time being.

--- a/packages/web-platform/web-constants/src/endpoints.ts
+++ b/packages/web-platform/web-constants/src/endpoints.ts
@@ -79,7 +79,7 @@ export const BackgroundThreadStartEndpoint = createRpcEndpoint<[
  * Error message, info
  */
 export const reportErrorEndpoint = createRpcEndpoint<
-  [Error, unknown],
+  [Error, unknown, string],
   void
 >('reportError', false, false);
 

--- a/packages/web-platform/web-constants/src/types/MainThreadGlobalThis.ts
+++ b/packages/web-platform/web-constants/src/types/MainThreadGlobalThis.ts
@@ -267,6 +267,10 @@ export type GetTemplatePartsPAPI = (
   templateElement: WebFiberElementImpl,
 ) => Record<string, WebFiberElementImpl> | undefined;
 
+interface JSErrorInfo {
+  release: string;
+}
+
 export interface MainThreadGlobalThis {
   __AddEvent: AddEventPAPI;
   __GetEvent: GetEventPAPI;
@@ -327,6 +331,7 @@ export interface MainThreadGlobalThis {
   ssrEncode?: () => string;
   ssrHydrate?: (encodeData?: string) => void;
   _ReportError: (error: Error, _: unknown) => void;
+  _SetSourceMapRelease: (errInfo: JSErrorInfo) => void;
   __OnLifecycleEvent: (lifeCycleEvent: Cloneable) => void;
   __LoadLepusChunk: (path: string) => boolean;
   __FlushElementTree: (

--- a/packages/web-platform/web-core-server/src/utils/loadTemplate.ts
+++ b/packages/web-platform/web-core-server/src/utils/loadTemplate.ts
@@ -61,6 +61,7 @@ const mainThreadInjectVars = [
   'lynx',
   'globalThis',
   '_ReportError',
+  '_SetSourceMapRelease',
   '__AddConfig',
   '__AddDataset',
   '__GetAttributes',

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -439,7 +439,7 @@ export class LynxView extends HTMLElement {
               napiModulesCall: (...args) => {
                 return this.#onNapiModulesCall?.(...args);
               },
-              onError: (error: Error) => {
+              onError: (error: Error, release: string) => {
                 this.dispatchEvent(
                   new CustomEvent('error', {
                     detail: {
@@ -450,6 +450,7 @@ export class LynxView extends HTMLElement {
                         },
                       },
                       error,
+                      release,
                     },
                   }),
                 );

--- a/packages/web-platform/web-core/src/uiThread/createRenderAllOnUI.ts
+++ b/packages/web-platform/web-core/src/uiThread/createRenderAllOnUI.ts
@@ -26,7 +26,7 @@ export function createRenderAllOnUI(
     timeStamp?: number,
   ) => void,
   callbacks: {
-    onError?: (err: Error) => void;
+    onError?: (err: Error, release: string) => void;
   },
 ) {
   if (!globalThis.module) {
@@ -48,8 +48,8 @@ export function createRenderAllOnUI(
     document.createElement.bind(document),
     () => {},
     markTimingInternal,
-    (err) => {
-      callbacks.onError?.(err);
+    (err, _, release) => {
+      callbacks.onError?.(err, release);
     },
     triggerI18nResourceFallback,
     (initI18nResources: InitI18nResources) => {

--- a/packages/web-platform/web-core/src/uiThread/createRenderMultiThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/createRenderMultiThread.ts
@@ -12,7 +12,7 @@ export function createRenderMultiThread(
   mainThreadRpc: Rpc,
   shadowRoot: ShadowRoot,
   callbacks: {
-    onError?: (err: Error) => void;
+    onError?: (err: Error, release: string) => void;
   },
 ) {
   registerReportErrorHandler(

--- a/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/registerReportErrorHandler.ts
+++ b/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/registerReportErrorHandler.ts
@@ -6,12 +6,12 @@ import type { Rpc } from '@lynx-js/web-worker-rpc';
 
 export function registerReportErrorHandler(
   rpc: Rpc,
-  onError?: (e: Error) => void,
+  onError?: (e: Error, release: string) => void,
 ) {
   rpc.registerHandler(
     reportErrorEndpoint,
-    (e) => {
-      onError?.(e);
+    (e, _, release) => {
+      onError?.(e, release);
     },
   );
 }

--- a/packages/web-platform/web-core/src/uiThread/startUIThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/startUIThread.ts
@@ -22,7 +22,7 @@ import { createRenderAllOnUI } from './createRenderAllOnUI.js';
 export type StartUIThreadCallbacks = {
   nativeModulesCall: NativeModulesCall;
   napiModulesCall: NapiModulesCall;
-  onError?: (err: Error) => void;
+  onError?: (err: Error, release: string) => void;
   customTemplateLoader?: (url: string) => Promise<LynxTemplate>;
 };
 

--- a/packages/web-platform/web-core/src/utils/loadTemplate.ts
+++ b/packages/web-platform/web-core/src/utils/loadTemplate.ts
@@ -48,6 +48,7 @@ const mainThreadInjectVars = [
   'lynx',
   'globalThis',
   '_ReportError',
+  '_SetSourceMapRelease',
   '__AddConfig',
   '__AddDataset',
   '__GetAttributes',

--- a/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
+++ b/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
@@ -619,6 +619,7 @@ export function createMainThreadGlobalThis(
     return pageElement;
   };
 
+  let release = '';
   const isCSSOG = !pageConfig.enableCSSSelector;
   const mtsGlobalThis: MainThreadGlobalThis = {
     __AddEvent,
@@ -679,7 +680,8 @@ export function createMainThreadGlobalThis(
       ...config.browserConfig,
     },
     lynx: createMainThreadLynx(config),
-    _ReportError: callbacks._ReportError,
+    _ReportError: (err, _) => callbacks._ReportError(err, _, release),
+    _SetSourceMapRelease: (errInfo) => release = errInfo?.release,
     __OnLifecycleEvent: callbacks.__OnLifecycleEvent,
     __FlushElementTree,
     __lynxGlobalBindingValues: lynxGlobalBindingValues,

--- a/packages/web-platform/web-tests/shell-project/mainthread-test.ts
+++ b/packages/web-platform/web-tests/shell-project/mainthread-test.ts
@@ -130,7 +130,7 @@ function initializeMainThreadTest() {
         docu.commit();
         decodeOperation(elementOperations);
       },
-      _ReportError: function(error: string, info?: unknown): void {
+      _ReportError: function(): void {
         document.body.innerHTML = '';
       },
       __OnLifecycleEvent() {
@@ -146,6 +146,7 @@ function initializeMainThreadTest() {
         });
       },
       createElement: docu.createElement.bind(docu),
+      _I18nResourceTranslation: () => {},
     },
   });
   const originalGlobalThis = globalThis;

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -667,6 +667,28 @@ test.describe('reactlynx3 tests', () => {
       await wait(500);
       expect(offset).toBe(true);
     });
+    test('api-set-release', async ({ page }, { title }) => {
+      let success = false;
+      await page.on('console', async (msg) => {
+        const event = await msg.args()[0]?.evaluate((e) => {
+          return {
+            type: e.type,
+            release: e.detail?.release,
+          };
+        });
+        if (!event || event.type !== 'error') {
+          return;
+        }
+        if (
+          typeof event.release === 'string' && event.release === '1'
+        ) {
+          success = true;
+        }
+      });
+      await goto(page, title);
+      await wait(500);
+      expect(success).toBe(true);
+    });
 
     test('api-preheat', async ({ page }, { title }) => {
       await goto(page, title);

--- a/packages/web-platform/web-tests/tests/react/api-set-release/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-set-release/index.jsx
@@ -1,0 +1,13 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+function App() {
+  if (__MAIN_THREAD__) {
+    _SetSourceMapRelease({ release: '1' });
+  }
+  throw new Error('error');
+}
+
+root.render(<App></App>);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

feat: add `_SetSourceMapRelease(errInfo)` MTS API.

You can get `errInfo.release` through `e.detail.release` in the error event callback of lynx-view.

The `_SetSourceMapRelease` function is not complete yet, because it is currently limited by the Web platform and some functions and some props such as `err.stack` do not need to be supported for the time being.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
