### PR TITLE
fix(web): updateGlobalProps will update globalProps also

### DIFF
--- a/.changeset/gold-goats-remain.md
+++ b/.changeset/gold-goats-remain.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: lynx-view `updateGlobalProps` method will also update globalProps, so `reload()` will use the latest updated globalProps.

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -280,6 +280,7 @@ export class LynxView extends HTMLElement {
    */
   updateGlobalProps(data: Cloneable) {
     this.#instance?.updateGlobalProps(data);
+    this.globalProps = data;
   }
 
   /**

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -4,6 +4,7 @@
 import { swipe, dragAndHold } from './utils.js';
 import { test, expect } from './coverage-fixture.js';
 import type { Page } from '@playwright/test';
+import type { LynxView } from '../../web-core/src/index.js';
 const ENABLE_MULTI_THREAD = !!process.env['ENABLE_MULTI_THREAD'];
 const wait = async (ms: number) => {
   await new Promise((resolve) => {
@@ -144,6 +145,26 @@ test.describe('reactlynx3 tests', () => {
     test('basic-dataprocessor', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);
+      expect(await page.locator('#target').getAttribute('style')).toContain(
+        'green',
+      );
+    });
+    test('basic-globalProps-reload', async ({ page }, { title }) => {
+      await goto(page, 'basic-globalProps');
+      await wait(100);
+      expect(await page.locator('#target').getAttribute('style')).toContain(
+        'pink',
+      );
+      await page.evaluate(() => {
+        (document.querySelector('lynx-view') as LynxView)?.updateGlobalProps({
+          backgroundColor: 'green',
+        });
+      });
+      await wait(500);
+      await page.evaluate(() => {
+        (document.querySelector('lynx-view') as LynxView)?.reload();
+      });
+      await wait(500);
       expect(await page.locator('#target').getAttribute('style')).toContain(
         'green',
       );


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: lynx-view `updateGlobalProps` method will also update globalProps, so `reload()` will use the latest updated globalProps.

#1112 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
