### PR TITLE
fix(web): decodeCssInJs will not throw an error

### DIFF
--- a/.changeset/violet-horses-march.md
+++ b/.changeset/violet-horses-march.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: `decodeCssInJs` will not throw error.
+
+Before this pr, decoding css will be strictly executed according to cssInfo, and an error will be thrown if data that does not meet the requirements is encountered. Now it is changed to console.warn, which will not block rendering.

--- a/packages/web-platform/web-mainthread-apis/src/utils/decodeCssInJs.ts
+++ b/packages/web-platform/web-mainthread-apis/src/utils/decodeCssInJs.ts
@@ -23,7 +23,7 @@ export function decodeCssInJs(
       if (oneRule) declarations.push(...oneRule);
     }
   } else {
-    throw new Error(`[lynx-web] cannot find styleinfo for cssid ${cssId}`);
+    console.warn(`[lynx-web] cannot find styleinfo for cssid ${cssId}`);
   }
   return declarations.map(([property, value]) => `${property}:${value};`).join(
     '',

--- a/packages/web-platform/web-tests/resources/web-core.enable-css-selector-false.json
+++ b/packages/web-platform/web-tests/resources/web-core.enable-css-selector-false.json
@@ -1,0 +1,30 @@
+{
+  "styleInfo": {},
+  "lepusCode": {
+    "root": "self.runtime = lynx_runtime;self.__lynx_worker_type = 'main'; globalThis.registerDataProcessor='pass'; self.registerDataProcessor = registerDataProcessor;",
+    "manifest-chunk.js": "module.exports = 'hello';",
+    "manifest-chunk2.js": "module.exports = 'world';"
+  },
+  "manifest": {
+    "/app-service.js": "self.runtime = lynx_runtime; self.__lynx_worker_type = 'background'",
+    "/manifest-chunk.js": "module.exports = 'hello';",
+    "/manifest-chunk2.js": "module.exports = 'world';"
+  },
+  "customSections": {},
+  "cardType": "react",
+  "pageConfig": {
+    "enableFiberArch": true,
+    "useLepusNG": true,
+    "enableReuseContext": true,
+    "bundleModuleMode": "ReturnByFunction",
+    "templateDebugUrl": "",
+    "debugInfoOutside": true,
+    "defaultDisplayLinear": true,
+    "enableCSSInvalidation": true,
+    "enableCSSSelector": false,
+    "enableLepusDebug": false,
+    "enableParallelElement": true,
+    "enableRemoveCSSScope": true,
+    "targetSdkVersion": "2.10"
+  }
+}

--- a/packages/web-platform/web-tests/shell-project/web-core.ts
+++ b/packages/web-platform/web-tests/shell-project/web-core.ts
@@ -64,10 +64,20 @@ const event_method = URL.createObjectURL(
   ),
 );
 
+const searchParams = new URLSearchParams(document.location.search);
+const casename = searchParams.get('casename');
+
 async function run() {
   const lepusjs = '/resources/web-core.main-thread.json';
   const lynxView = document.createElement('lynx-view') as LynxView;
-  lynxView.setAttribute('url', lepusjs);
+  if (casename === 'enable-css-selector-false') {
+    lynxView.setAttribute(
+      'url',
+      '/resources/web-core.enable-css-selector-false.json',
+    );
+  } else {
+    lynxView.setAttribute('url', lepusjs);
+  }
   ENABLE_MULTI_THREAD
     ? lynxView.setAttribute('thread-strategy', 'multi-thread')
     : lynxView.setAttribute('thread-strategy', 'all-on-ui');


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: `decodeCssInJs` will not throw error.

Before this pr, decoding css will be strictly executed according to cssInfo, and an error will be thrown if data that does not meet the requirements is encountered. Now it is changed to console.warn, which will not block rendering.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
