### PR TITLE
ci: use `--testTimeout` instead of `--test-timeout`

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -84,7 +84,8 @@ jobs:
       runs-on: lynx-ubuntu-24.04-medium
       run: >
         pnpm run test
-        --test-timeout=50000
+        --testTimeout=50000
+        --hookTimeout=50000
         --reporter=dot
         --reporter=junit
         --outputFile=test-report.junit.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
         --outputFile=test-report.junit.xml
         --coverage.reporter='json'
         --coverage.reporter='text'
-        --test-timeout=50000
+        --testTimeout=50000
         --no-cache
         --logHeapUsage
         --silent
@@ -208,8 +208,8 @@ jobs:
         --reporter=dot
         --reporter=junit
         --outputFile=test-report.junit.xml
-        --test-timeout=50000
-        --hook-timeout=50000
+        --testTimeout=50000
+        --hookTimeout=50000
         --coverage
         --coverage.reporter='json'
         --coverage.reporter='text'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ _This works with any code ran in Node, so will work with most JS testing framewo
 
 See [Debugging Vitest](https://vitest.dev/guide/debugging.html) for more details.
 
-You can combine debug with `--project` or `.only` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by setting `--test-timeout`.
+You can combine debug with `--project` or `.only` to debug a subset of tests. If you plan to stay long in the debugger (which you'll likely do!), you may increase the test timeout by setting `--testTimeout`.
 
 To overwrite any test fixtures when fixing a bug or anything, add the `--update`
 


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Vitest docs: https://vitest.dev/guide/cli.html#testtimeout

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
