### PR TITLE
fix(testing-library): fix flaky Windows tests

### DIFF
--- a/.changeset/brave-cobras-hide.md
+++ b/.changeset/brave-cobras-hide.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/testing-environment": patch
+---
+
+Fix `getJSContext` or `getCoreContext` is not a function.

--- a/packages/react/testing-library/src/__tests__/end-to-end.test.jsx
+++ b/packages/react/testing-library/src/__tests__/end-to-end.test.jsx
@@ -174,7 +174,7 @@ test('it waits for the data to be loaded', async () => {
   const loading = () => {
     return screen.getByText('Loading...');
   };
-  await waitForElementToBeRemoved(loading);
+  await waitForElementToBeRemoved(loading, { timeout: 50_000 });
   expect(document.body).toMatchInlineSnapshot(`
     <body>
       <page>

--- a/packages/react/testing-library/src/__tests__/lazy-bundle/index.test.jsx
+++ b/packages/react/testing-library/src/__tests__/lazy-bundle/index.test.jsx
@@ -41,7 +41,9 @@ describe('lazy bundle', () => {
     </view>
   `);
 
-    await waitForElementToBeRemoved(() => screen.getByText('loading...'));
+    await waitForElementToBeRemoved(() => screen.getByText('loading...'), {
+      timeout: 50_000,
+    });
 
     expect(container.firstChild).toMatchInlineSnapshot(`
       <view>

--- a/packages/testing-library/testing-environment/src/index.ts
+++ b/packages/testing-library/testing-environment/src/index.ts
@@ -202,6 +202,7 @@ function injectMainThreadGlobals(target?: any, polyfills?: any) {
 
   const {
     performance,
+    CoreContext,
     JsContext,
     __LoadLepusChunk,
   } = polyfills || {};
@@ -222,6 +223,7 @@ function injectMainThreadGlobals(target?: any, polyfills?: any) {
   target.globDynamicComponentEntry = '__Card__';
   target.lynx = {
     performance,
+    getCoreContext: (() => CoreContext),
     getJSContext: (() => JsContext),
     reportError: (e: Error) => {
       throw e;
@@ -272,6 +274,7 @@ function injectBackgroundThreadGlobals(target?: any, polyfills?: any) {
     app,
     performance,
     CoreContext,
+    JsContext,
     __LoadLepusChunk,
   } = polyfills || {};
   if (typeof target === 'undefined') {
@@ -319,6 +322,7 @@ function injectBackgroundThreadGlobals(target?: any, polyfills?: any) {
       };
     }),
     getCoreContext: (() => CoreContext),
+    getJSContext: (() => JsContext),
     getJSModule: (moduleName) => {
       if (moduleName === 'GlobalEventEmitter') {
         return globalEventEmitter;


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix the unhandled rejection on Windows ("lynx.getJSContext is not a function").

The `lynx.getJSContext` does exist on BTS, so does `lynx.getCoreContext` on MTS.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
