### PR TITLE
test(tailwind-preset): avoid building tailwindcss in test

### DIFF
--- a/.changeset/mean-stars-care.md
+++ b/.changeset/mean-stars-care.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/tailwind-preset": patch
+---
+
+Avoid publishing test files.

--- a/packages/third-party/tailwind-preset/package.json
+++ b/packages/third-party/tailwind-preset/package.json
@@ -18,6 +18,8 @@
   "types": "./lib/lynx.d.ts",
   "files": [
     "lib",
+    "!lib/__tests__",
+    "!lib/**/*.js.map",
     "CHANGELOG.md",
     "README.md"
   ],
@@ -27,7 +29,6 @@
   },
   "devDependencies": {
     "@lynx-js/types": "3.3.0",
-    "postcss": "^8.5.4",
     "tailwindcss": "^3.4.17"
   }
 }

--- a/packages/third-party/tailwind-preset/src/__tests__/config.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/config.test.ts
@@ -1,7 +1,6 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -18,36 +17,15 @@ describe('Lynx Tailwind Preset', () => {
 
   beforeAll(() => {
     try {
-      const cwd = path.resolve(__dirname, '../../');
-      const configPath = path.resolve(__dirname, 'tailwind.config.ts');
-      const inputPath = path.resolve(__dirname, 'styles.css');
       const outputPath = path.resolve(__dirname, 'output.css');
-
-      // console.log('Working directory:', cwd);
-      // console.log('Config path:', configPath);
-      // console.log('Input path:', inputPath);
-      // console.log('Output path:', outputPath);
-
-      // Use Tailwind CLI to build CSS
-      execSync(
-        `npx tailwindcss -i ${inputPath} -o ${outputPath} -c ${configPath}`,
-        {
-          cwd,
-        },
-      );
 
       // Read the generated CSS
       compiledCSS = fs.readFileSync(outputPath, 'utf-8');
 
       // Extract classes and properties
       usedProperties = extractPropertiesFromCSS(compiledCSS);
-
-      // Cleanup only if file exists
-      if (fs.existsSync(outputPath)) {
-        fs.unlinkSync(outputPath);
-      }
     } catch (error) {
-      console.error('Failed to generate CSS:', error);
+      console.error('Failed to read output.css:', error);
       throw error;
     }
   });

--- a/packages/third-party/tailwind-preset/src/__tests__/output.css
+++ b/packages/third-party/tailwind-preset/src/__tests__/output.css
@@ -1,0 +1,298 @@
+*, ::before, ::after {
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+}
+
+::backdrop {
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+}
+
+.visible {
+  visibility: visible;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.collapse {
+  visibility: collapse;
+}
+
+.box-border {
+  box-sizing: border-box;
+}
+
+.box-content {
+  box-sizing: content-box;
+}
+
+.flex-row {
+  flex-direction: row;
+}
+
+.flex-row-reverse {
+  flex-direction: row-reverse;
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.flex-col-reverse {
+  flex-direction: column-reverse;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.flex-wrap-reverse {
+  flex-wrap: wrap-reverse;
+}
+
+.flex-nowrap {
+  flex-wrap: nowrap;
+}
+
+.content-center {
+  align-content: center;
+}
+
+.content-start {
+  align-content: flex-start;
+}
+
+.content-end {
+  align-content: flex-end;
+}
+
+.content-between {
+  align-content: space-between;
+}
+
+.content-around {
+  align-content: space-around;
+}
+
+.content-stretch {
+  align-content: stretch;
+}
+
+.items-start {
+  align-items: flex-start;
+}
+
+.items-end {
+  align-items: flex-end;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.items-baseline {
+  align-items: baseline;
+}
+
+.items-stretch {
+  align-items: stretch;
+}
+
+.justify-start {
+  justify-content: flex-start;
+}
+
+.justify-end {
+  justify-content: flex-end;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.justify-around {
+  justify-content: space-around;
+}
+
+.justify-evenly {
+  justify-content: space-evenly;
+}
+
+.justify-stretch {
+  justify-content: stretch;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.overflow-visible {
+  overflow: visible;
+}
+
+.overflow-x-hidden {
+  overflow-x: hidden;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+
+.overflow-x-visible {
+  overflow-x: visible;
+}
+
+.overflow-y-visible {
+  overflow-y: visible;
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.whitespace-normal {
+  white-space: normal;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.break-normal {
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.break-all {
+  word-break: break-all;
+}
+
+.break-keep {
+  word-break: keep-all;
+}
+
+.border-solid {
+  border-style: solid;
+}
+
+.border-dashed {
+  border-style: dashed;
+}
+
+.border-dotted {
+  border-style: dotted;
+}
+
+.border-double {
+  border-style: double;
+}
+
+.border-none {
+  border-style: none;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-start {
+  text-align: start;
+}
+
+.text-end {
+  text-align: end;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-normal {
+  font-weight: 400;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.not-italic {
+  font-style: normal;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.sticky {
+  position: sticky;
+}
+
+.no-underline {
+  text-decoration: none;
+}
+
+.line-through {
+  text-decoration: line-through;
+}
+
+.underline {
+  text-decoration: underline;
+}
+
+.block {
+  display: block;
+}
+
+.flex {
+  display: flex;
+}
+
+.grid {
+  display: grid;
+}
+
+.hidden {
+  display: none;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,9 +579,6 @@ importers:
       '@lynx-js/types':
         specifier: 3.3.0
         version: 3.3.0
-      postcss:
-        specifier: ^8.5.4
-        version: 8.5.4
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The `beforeAll` hook of `tools/tailwind-preset/src/__tests__/config.test.ts` is failing all the time on Windows.

I'm not sure why does setting `--hookTimeout` not working (#1113, ##1121).

```
 FAIL  
tools/tailwind-preset src/__tests__/config.test.ts > Lynx Tailwind Preset
Error: Hook timed out in 10000ms.
If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Also, the `__tests__` and `.js.map` are excluded from `package.json#files` to reduce package size.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
