### PR TITLE
ci: avoid OOM on Windows build

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           pnpm turbo build --summarize
         env:
+          NODE_OPTIONS: --max-old-space-size=32768
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
       - name: Upload turbo summary

--- a/packages/web-platform/web-tests/package.json
+++ b/packages/web-platform/web-tests/package.json
@@ -11,10 +11,9 @@
   },
   "scripts": {
     "bench": "vitest bench",
-    "build": "pnpm dlx is-ci && pnpm build:cases || echo 'Skipping build:cases in non-CI environment'",
-    "build:cases": "pnpm dlx rimraf dist && pnpm run --stream \"/^build:cases:.*/\"",
-    "build:cases:csr": "node ./scripts/generate-build-command.js",
-    "build:cases:ssr": "pnpm dlx cross-env ENABLE_SSR=1 node ./scripts/generate-build-command.js",
+    "build": "pnpm dlx premove dist && pnpm run --stream \"/^build:.*/\"",
+    "build:csr": "node ./scripts/generate-build-command.js",
+    "build:ssr": "pnpm dlx cross-env ENABLE_SSR=1 node ./scripts/generate-build-command.js",
     "coverage": "nyc report --cwd=$(realpath ../)",
     "coverage:ci": "nyc report --cwd=$(realpath ../) --reporter=lcov",
     "lh": "pnpm dlx @lhci/cli autorun",

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
     "CI",
     "COREPACK_INTEGRITY_KEYS",
     "COREPACK_NPM_REGISTRY",
-    "COREPACK_DEFAULT_TO_LATEST"
+    "COREPACK_DEFAULT_TO_LATEST",
+    "NODE_OPTIONS"
   ],
   "ui": "tui",
   "tasks": {


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

1. Increase max-old-space-size to avoid OOM in build
2. Remove "|| echo 'Skipping build:cases in non-CI environment'" as it causes the build to be marked as successful even when it fails.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

https://github.com/lynx-family/lynx-stack/actions/runs/15816546524/job/44576625549?pr=1129

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
