### PR TITLE
chore: replace `eslint-plugin-markdown` with `@eslint/markdown`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 import js from '@eslint/js';
-import json from '@eslint/json';
 import markdown from '@eslint/markdown';
 import vitest from '@vitest/eslint-plugin';
 import headers from 'eslint-plugin-headers';
@@ -136,17 +135,8 @@ export default tseslint.config(
     },
   },
   regexpPlugin.configs['flat/recommended'],
-  json.configs.recommended,
-  markdown.configs.recommended,
-  {
-    rules: {
-      'jsdoc/require-jsdoc': 'off',
-      'jsdoc/require-returns': 'off',
-      'jsdoc/check-alignment': 'off',
-
-      'jsdoc/tag-lines': 'off',
-    },
-  },
+  ...markdown.configs.recommended,
+  ...markdown.configs.processor,
   // Rules from eslint-plugin-n
   nodePlugin.configs['flat/recommended-module'],
   {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@changesets/cli": "^2.29.5",
     "@codspeed/vitest-plugin": "^4.0.1",
     "@eslint/js": "^9.29.0",
-    "@eslint/json": "^0.12.0",
     "@eslint/markdown": "^6.6.0",
     "@microsoft/api-extractor": "catalog:",
     "@rslib/core": "^0.9.2",

--- a/packages/webpack/webpack-dev-transport/README.md
+++ b/packages/webpack/webpack-dev-transport/README.md
@@ -14,8 +14,6 @@ configuration of `webpack.config.js`.
 // LICENSE file in the root directory of this source tree.
 import { createRequire } from 'node:module';
 
-import { LynxTransportServer } from '@lynx-js/webpack-dev-transport';
-
 const require = createRequire(import.meta.url);
 export default {
   devServer: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       '@eslint/js':
         specifier: ^9.29.0
         version: 9.29.0
-      '@eslint/json':
-        specifier: ^0.12.0
-        version: 0.12.0
       '@eslint/markdown':
         specifier: ^6.6.0
         version: 6.6.0
@@ -1952,10 +1949,6 @@ packages:
     resolution: {integrity: sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.12.0':
-    resolution: {integrity: sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/core@0.13.0':
     resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1970,10 +1963,6 @@ packages:
 
   '@eslint/js@9.29.0':
     resolution: {integrity: sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/json@0.12.0':
-    resolution: {integrity: sha512-n/7dz8HFStpEe4o5eYk0tdkBdGUS/ZGb0GQCeDWN1ZmRq67HMHK4vC33b0rQlTT6xdZoX935P4vstiWVk5Ying==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/markdown@6.6.0':
@@ -2006,10 +1995,6 @@ packages:
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
-
-  '@humanwhocodes/momoa@3.3.8':
-    resolution: {integrity: sha512-/3PZzor2imi/RLLcnHztkwA79txiVvW145Ve2cp5dxRcH5qOUNJPToasqLFHniTfw4B4lT7jGDdBOPXbXYlIMQ==}
-    engines: {node: '>=18'}
 
   '@humanwhocodes/retry@0.3.1':
     resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
@@ -8897,10 +8882,6 @@ snapshots:
 
   '@eslint/config-helpers@0.2.1': {}
 
-  '@eslint/core@0.12.0':
-    dependencies:
-      '@types/json-schema': 7.0.15
-
   '@eslint/core@0.13.0':
     dependencies:
       '@types/json-schema': 7.0.15
@@ -8924,13 +8905,6 @@ snapshots:
       - supports-color
 
   '@eslint/js@9.29.0': {}
-
-  '@eslint/json@0.12.0':
-    dependencies:
-      '@eslint/core': 0.12.0
-      '@eslint/plugin-kit': 0.2.8
-      '@humanwhocodes/momoa': 3.3.8
-      natural-compare: 1.4.0
 
   '@eslint/markdown@6.6.0':
     dependencies:
@@ -8967,8 +8941,6 @@ snapshots:
       '@humanwhocodes/retry': 0.3.1
 
   '@humanwhocodes/module-importer@1.0.1': {}
-
-  '@humanwhocodes/momoa@3.3.8': {}
 
   '@humanwhocodes/retry@0.3.1': {}
 

--- a/website/docs/en/guide/assets.md
+++ b/website/docs/en/guide/assets.md
@@ -20,7 +20,7 @@ You can directly import static assets in JavaScript:
 // Import the logo.png image in the static directory
 import logo from './static/logo.png';
 
-function App() {
+export function App() {
   return <image src={logo} />; // Can be directly used in ReactLynx
 }
 ```
@@ -62,7 +62,7 @@ The `public` folder at the project root can be used to place some static assets.
 In JavaScript code, you can splice the URL via `process.env.ASSET_PREFIX`:
 
 ```js
-const logoURL = `${process.env.ASSET_PREFIX}/logo.png`;
+export const logoURL = `${process.env.ASSET_PREFIX}/logo.png`;
 ```
 
 :::warning

--- a/website/docs/en/guide/code-splitting.md
+++ b/website/docs/en/guide/code-splitting.md
@@ -81,7 +81,7 @@ export function App() {
   return (
     <view>
       <view bindtap={handleClick}>Load Component</view>
-      {shouldShow && (
+      {shouldDisplay && (
         <Suspense fallback={<text>Loading...</text>}>
           <LazyComponent />
         </Suspense>

--- a/website/docs/en/guide/typescript.md
+++ b/website/docs/en/guide/typescript.md
@@ -22,7 +22,7 @@ The [`paths`](https://www.typescriptlang.org/tsconfig/#paths) option of TypeScri
 
 After configuring, if you reference `@common/request.ts` in your code, it will be mapped to the `<project>/src/common/request.ts` path.
 
-<!-- eslint-disable-next-line import/no-unresolved -->
+<!-- eslint-disable-next-line import/no-unresolved, no-unused-vars -->
 
 ```js
 import { get } from '@common/request.js'; // The same as './common/request.js'

--- a/website/docs/zh/guide/assets.md
+++ b/website/docs/zh/guide/assets.md
@@ -16,7 +16,7 @@ Rspeedy 支持使用包括图片、字体、音频和视频等多种静态资源
 // Import the logo.png image in the static directory
 import logo from './static/logo.png';
 
-function App() {
+export function App() {
   return <image src={logo} />; // Can be directly used in ReactLynx
 }
 ```
@@ -58,7 +58,7 @@ console.log(logo); // "https://example.com/assets/logo.6c12aba3.png"
 在 JavaScript 代码中，你可以通过 `process.env.ASSET_PREFIX` 拼接这些资源的 URL：
 
 ```js
-const logoURL = `${process.env.ASSET_PREFIX}/logo.png`;
+export const logoURL = `${process.env.ASSET_PREFIX}/logo.png`;
 ```
 
 :::warning

--- a/website/docs/zh/guide/code-splitting.md
+++ b/website/docs/zh/guide/code-splitting.md
@@ -73,7 +73,7 @@ export function App() {
   return (
     <view>
       <view bindtap={handleClick}>Load Component</view>
-      {shouldShow && (
+      {shouldDisplay && (
         <Suspense fallback={<text>Loading...</text>}>
           <LazyComponent />
         </Suspense>

--- a/website/docs/zh/guide/typescript.md
+++ b/website/docs/zh/guide/typescript.md
@@ -22,7 +22,7 @@ Rspeedy 基于 Rsbuild 原生支持 TypeScript，允许你在项目中直接使�
 
 配置后，当代码中引用 `@common/request.ts` 时，将会映射到 `<project>/src/common/request.ts` 路径。
 
-<!-- eslint-disable-next-line import/no-unresolved -->
+<!-- eslint-disable-next-line import/no-unresolved, no-unused-vars -->
 
 ```js
 import { get } from '@common/request.js'; // 等同于 './common/request.js'


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

> Markdown linting is accomplished using the [@eslint/markdown](https://npmjs.com/package/@eslint/markdown) plugin, which is the next generation of the [eslint-plugin-markdown](https://npmjs.com/package/eslint-plugin-markdown) plugin that only contained a processor.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

https://eslint.org/blog/2024/10/eslint-json-markdown-support/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
