### PR TITLE
feat(react/worklet): add getComputedStyle to Element

### DIFF
--- a/packages/react/worklet-runtime/src/api/element.ts
+++ b/packages/react/worklet-runtime/src/api/element.ts
@@ -35,6 +35,10 @@ export class Element {
     this.flushElementTree();
   }
 
+  public getComputedStyle(): Record<string, string> {
+    return __GetComputedStyle(this.element);
+  }
+
   public getAttribute(attributeName: string): unknown {
     return __GetAttributeByName(this.element, attributeName);
   }

--- a/packages/react/worklet-runtime/src/types/elementApi.d.ts
+++ b/packages/react/worklet-runtime/src/types/elementApi.d.ts
@@ -13,6 +13,8 @@ declare function __FlushElementTree(element?: ElementNode): void;
 
 declare function __GetAttributeByName(e: ElementNode, name: string): undefined | string;
 
+declare function __GetComputedStyle(e: ElementNode): Record<string, string>;
+
 declare function __GetAttributeNames(e: ElementNode): string[];
 
 declare function __GetPageElement(): ElementNode;


### PR DESCRIPTION
This commit introduces the `getComputedStyle` method to the `Element` class in the worklet runtime. This method allows developers to retrieve the computed styles of an element, which is essential for dynamic styling and layout calculations. The implementation calls the underlying `__GetComputedStyle` API and includes the necessary type definitions to ensure type safety.