### PR TITLE
fix(web): class name contain special char not work

### DIFF
--- a/.changeset/poor-carrots-build.md
+++ b/.changeset/poor-carrots-build.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+fix: when enableCSSSelector is false, the CSS style with className h-[40px] will not work.
+
+This is because when the CSS selector contains special characters (such as `\`, `[`, `]`, `/`, `(`, `)`), the CSS style needs to be escaped with the character `\`, but the className does not need this.
+
+The escape characters are filtered during building to ensure that that two parts are completely consistent.

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -1256,6 +1256,15 @@ test.describe('reactlynx3 tests', () => {
       },
     );
     test(
+      'config-css-selector-false-specital-char',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('height', '40px');
+      },
+    );
+    test(
       'config-splitchunk-single-vendor',
       async ({ page }, { title }) => {
         test.skip(

--- a/packages/web-platform/web-tests/tests/react/config-css-selector-false-specital-char/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-css-selector-false-specital-char/index.css
@@ -1,0 +1,9 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.h-\[40px\] {
+  height: 40px;
+}

--- a/packages/web-platform/web-tests/tests/react/config-css-selector-false-specital-char/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-css-selector-false-specital-char/index.jsx
@@ -1,0 +1,19 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, root } from '@lynx-js/react';
+import './index.css';
+export default class Root extends Component {
+  render() {
+    return (
+      <view
+        id='target'
+        class='h-[40px]'
+        style={{ hwidth: '100px', backgroundColor: 'red' }}
+      />
+    );
+  }
+}
+root.render(<Root />);

--- a/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
@@ -50,7 +50,11 @@ export class WebEncodePlugin {
         }, (encodeOptions) => {
           const { encodeData } = encodeOptions;
           const { cssMap } = encodeData.css;
-          const styleInfo = genStyleInfo(cssMap);
+          const pageConfig = {
+            ...encodeData.compilerOptions,
+            ...encodeData.sourceContent.config,
+          };
+          const styleInfo = genStyleInfo(cssMap, pageConfig.enableCSSSelector);
 
           const [name, content] = last(Object.entries(encodeData.manifest))!;
 
@@ -73,10 +77,7 @@ export class WebEncodePlugin {
             },
             customSections: encodeData.customSections,
             cardType: encodeData.sourceContent.dsl.substring(0, 5),
-            pageConfig: {
-              ...encodeData.compilerOptions,
-              ...encodeData.sourceContent.config,
-            },
+            pageConfig,
           });
           return encodeOptions;
         });

--- a/packages/webpack/template-webpack-plugin/src/web/genStyleInfo.ts
+++ b/packages/webpack/template-webpack-plugin/src/web/genStyleInfo.ts
@@ -2,11 +2,14 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { ClassSelector, IdSelector } from 'css-tree';
+
 import type { CSSRule, OneInfo, StyleInfo } from './StyleInfo.js';
 import * as CSS from '../css/index.js';
 
 export function genStyleInfo(
   cssMap: Record<string, CSS.LynxStyleNode[]>,
+  enableCSSSelector: boolean,
 ): StyleInfo {
   return Object.fromEntries(
     Object.entries(cssMap).map(([cssId, nodes]) => {
@@ -86,6 +89,24 @@ export function genStyleInfo(
                 pseudoClassSelectors = [];
                 pseudoElementSelectors = [];
               } else {
+                /**
+                 * .h-\[40px\] {
+                 * }
+                 * ===>
+                 * .h-[40px] {
+                 * }
+                 */
+                if (
+                  !enableCSSSelector
+                  && (selector as ClassSelector | IdSelector).name
+                ) {
+                  (selector as ClassSelector | IdSelector).name =
+                    (selector as ClassSelector | IdSelector).name
+                      .replace(
+                        /\\([\\[\]()/:])/g,
+                        (_, char: string) => char,
+                      );
+                }
                 plainSelectors.push(CSS.csstree.generate(selector));
               }
             }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: when enableCSSSelector is false, the CSS style with className h-[40px] will not work.

This is because when the CSS selector contains special characters (such as `\`, `[`, `]`, `/`, `(`, `)`), the CSS style needs to be escaped with the character `\`, but the className does not need this.

The escape characters are filtered during building to ensure that that two parts are completely consistent.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
