### PR TITLE
docs: remove chunks: 'all' in splitChunks

### DIFF
--- a/packages/rspeedy/core/src/config/performance/chunk-split.ts
+++ b/packages/rspeedy/core/src/config/performance/chunk-split.ts
@@ -84,7 +84,6 @@ export interface ChunkSplit {
    *           react: {
    *             test: /node_modules[\\/](@lynx-js[\\/]react|react-router)[\\/]/,
    *             name: 'lib-react',
-   *             chunks: 'all',
    *           },
    *         },
    *       },
@@ -193,7 +192,6 @@ export interface ChunkSplitCustom {
    *           react: {
    *             test: /node_modules[\\/](@lynx-js[\\/]react|react-router)[\\/]/,
    *             name: 'lib-react',
-   *             chunks: 'all',
    *           },
    *         },
    *       },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->



When splitChunk is configured with 'chunks: all', the initial chunks of main-thread.js may attempt to load this splitChunk. However, since we don't perform chunk splitting in the main thread, this will result in errors.



This comment could mislead developers, as we're not actually using 'chunks: all' but rather the default value 'async'.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
