### PR TITLE
fix(rspeedy/react): fix memory leak when using `<list />`

### DIFF
--- a/.changeset/fifty-rats-tickle.md
+++ b/.changeset/fifty-rats-tickle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Avoid IIFE in `main-thread.js` to resolve memory leak when using `<list />`.

--- a/.changeset/loose-zoos-say.md
+++ b/.changeset/loose-zoos-say.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/runtime-wrapper-webpack-plugin": patch
+---
+
+Wrap with IIFE when `output.iife: false` to avoid naming conflict.

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -400,6 +400,14 @@ export function pluginReactLynx(
           })
         }
 
+        // This is used to avoid the IIFE in main-thread.js, which would cause memory leak.
+        // TODO: remove this when required Rspeedy version bumped to ^0.10.0
+        config = mergeRsbuildConfig({
+          tools: {
+            rspack: { output: { iife: false } },
+          },
+        }, config)
+
         return config
       })
 

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -1318,6 +1318,66 @@ describe('Config', () => {
     })
   })
 
+  describe('Output IIFE', () => {
+    test('defaults', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          plugins: [
+            pluginReactLynx(),
+          ],
+        },
+      })
+
+      const [config] = await rspeedy.initConfigs()
+
+      expect(config?.output?.iife).toBe(false)
+    })
+
+    test('with output.iife: false', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          tools: {
+            rspack: {
+              output: {
+                iife: false,
+              },
+            },
+          },
+          plugins: [
+            pluginReactLynx(),
+          ],
+        },
+      })
+
+      const [config] = await rspeedy.initConfigs()
+
+      expect(config?.output?.iife).toBe(false)
+    })
+    test('with output.iife: true', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          tools: {
+            rspack: {
+              output: {
+                iife: true,
+              },
+            },
+          },
+          plugins: [
+            pluginReactLynx(),
+          ],
+        },
+      })
+
+      const [config] = await rspeedy.initConfigs()
+
+      expect(config?.output?.iife).toBe(true)
+    })
+  })
+
   describe('Bundle Splitting', () => {
     test('default', async () => {
       const { pluginReactLynx } = await import('../src/pluginReactLynx.js')

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-false/fetch.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-false/fetch.js
@@ -1,0 +1,3 @@
+export const fetch = function fetch() {
+  return 42;
+};

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-false/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-false/index.js
@@ -1,0 +1,15 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { fetch as myFetch } from './fetch.js';
+
+expect(myFetch).not.toBe(lynx.fetch);
+
+expect(myFetch()).toBe(42);
+
+const fetch = () => {
+  return 42;
+};
+
+expect(fetch()).toBe(42);

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-false/rspack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-false/rspack.config.js
@@ -1,0 +1,8 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import config from './webpack.config.js';
+
+export default config;

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-false/webpack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-false/webpack.config.js
@@ -1,0 +1,20 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { RuntimeWrapperWebpackPlugin } from '../../../../src';
+
+/** @type {import('webpack').Configuration} */
+export default {
+  plugins: [
+    new RuntimeWrapperWebpackPlugin(),
+  ],
+  output: {
+    iife: false,
+  },
+  optimization: {
+    avoidEntryIife: true,
+    concatenateModules: true,
+  },
+};

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-true/fetch.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-true/fetch.js
@@ -1,0 +1,3 @@
+export const fetch = function fetch() {
+  return 42;
+};

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-true/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-true/index.js
@@ -1,0 +1,15 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { fetch as myFetch } from './fetch.js';
+
+expect(myFetch).not.toBe(lynx.fetch);
+
+expect(myFetch()).toBe(42);
+
+const fetch = () => {
+  return 42;
+};
+
+expect(fetch()).toBe(42);

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-true/rspack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-true/rspack.config.js
@@ -1,0 +1,8 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import config from './webpack.config.js';
+
+export default config;

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-true/webpack.config.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/iife-true/webpack.config.js
@@ -1,0 +1,20 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { RuntimeWrapperWebpackPlugin } from '../../../../src';
+
+/** @type {import('webpack').Configuration} */
+export default {
+  plugins: [
+    new RuntimeWrapperWebpackPlugin(),
+  ],
+  output: {
+    iife: true,
+  },
+  optimization: {
+    avoidEntryIife: true,
+    concatenateModules: true,
+  },
+};


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix memory leak when using `<list />` by removing the IIFE wrapper in `main-thread.js`.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Maybe we should set `output.iife: false` in `@lynx-js/rspeedy`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
