### PR TITLE
fix(web): input event trigger twice && detail.value miss

### DIFF
--- a/.changeset/many-nails-press.md
+++ b/.changeset/many-nails-press.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/web-constants": patch
+"@lynx-js/web-elements": patch
+---
+
+fix: in lynx-view all-on-ui mode, the input event of input and textarea is triggered twice, and the first e.detail is a string, which does not conform to the expected data format.

--- a/packages/web-platform/web-constants/src/eventName.ts
+++ b/packages/web-platform/web-constants/src/eventName.ts
@@ -8,6 +8,7 @@ export const W3cEventNameToLynx: Record<string, string> = {
   overlaytouch: 'touch',
   lynxfocus: 'focus',
   lynxblur: 'blur',
+  lynxinput: 'input',
 };
 export const LynxEventNameToW3cByTagName: Record<
   string,
@@ -16,10 +17,12 @@ export const LynxEventNameToW3cByTagName: Record<
   'X-INPUT': {
     'blur': 'lynxblur',
     'focus': 'lynxfocus',
+    'input': 'lynxinput',
   },
   'X-TEXTAREA': {
     'blur': 'lynxblur',
     'focus': 'lynxfocus',
+    'input': 'lynxinput',
   },
 };
 

--- a/packages/web-platform/web-elements/src/XInput/XInputEvents.ts
+++ b/packages/web-platform/web-elements/src/XInput/XInputEvents.ts
@@ -30,7 +30,7 @@ export class XInputEvents
   );
 
   @registerAttributeHandler('input-filter', true)
-  @registerEventEnableStatusChangeHandler('input')
+  @registerEventEnableStatusChangeHandler('lynxinput')
   #handleEnableInputEvent(status: boolean | string | null) {
     const input = this.#getInputElement();
     if (status) {
@@ -83,7 +83,7 @@ export class XInputEvents
     input.value = filterValue;
     if (isComposing && !this.#sendComposingInput) return;
     this.#dom.dispatchEvent(
-      new CustomEvent('input', {
+      new CustomEvent('lynxinput', {
         ...commonComponentEventSetting,
         detail: {
           value: filterValue,
@@ -109,7 +109,7 @@ export class XInputEvents
     // if #sendComposingInput set true, #teleportInput will send detail
     if (!this.#sendComposingInput) {
       this.#dom.dispatchEvent(
-        new CustomEvent('input', {
+        new CustomEvent('lynxinput', {
           ...commonComponentEventSetting,
           detail: {
             value: filterValue,

--- a/packages/web-platform/web-elements/src/XTextarea/XTextareaEvents.ts
+++ b/packages/web-platform/web-elements/src/XTextarea/XTextareaEvents.ts
@@ -30,7 +30,7 @@ export class XTextareaEvents
   );
 
   @registerAttributeHandler('input-filter', true)
-  @registerEventEnableStatusChangeHandler('input')
+  @registerEventEnableStatusChangeHandler('lynxinput')
   #handleEnableConfirmEvent(status: string | boolean | null) {
     const textareaElement = this.#getTextareaElement();
     if (status) {
@@ -83,7 +83,7 @@ export class XTextareaEvents
     input.value = filterValue;
     if (isComposing && !this.#sendComposingInput) return;
     this.#dom.dispatchEvent(
-      new CustomEvent('input', {
+      new CustomEvent('lynxinput', {
         ...commonComponentEventSetting,
         detail: {
           value: filterValue,
@@ -109,7 +109,7 @@ export class XTextareaEvents
     // if #sendComposingInput set true, #teleportInput will send detail
     if (!this.#sendComposingInput) {
       this.#dom.dispatchEvent(
-        new CustomEvent('input', {
+        new CustomEvent('lynxinput', {
           ...commonComponentEventSetting,
           detail: {
             value: filterValue,

--- a/packages/web-platform/web-tests/tests/react/basic-element-x-input-bindinput/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-element-x-input-bindinput/index.jsx
@@ -8,6 +8,12 @@ function App() {
   const [result, setResult] = useState();
 
   const onInput = ({ detail }) => {
+    if (typeof detail !== 'object') {
+      throw new Error(
+        `detail type not match. expect object, got ${typeof detail}`,
+      );
+    }
+
     const { value, cursor, textLength, selectionStart, selectionEnd } = detail;
 
     if (value.length !== textLength) {

--- a/packages/web-platform/web-tests/tests/react/basic-element-x-textarea-bindinput/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-element-x-textarea-bindinput/index.jsx
@@ -6,6 +6,11 @@ import './index.css';
 
 function App() {
   const onInput = (e) => {
+    if (typeof e.detail !== 'object') {
+      throw new Error(
+        `detail type not match. expect object, got ${typeof detail}`,
+      );
+    }
     console.log(e);
   };
 

--- a/packages/web-platform/web-tests/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-tests/tests/web-elements.spec.ts
@@ -2701,7 +2701,7 @@ test.describe('web-elements test suite', () => {
           .locator('#target')
           .evaluateHandle((target) => {
             let detail = { value: undefined };
-            target.addEventListener('input', (e) => {
+            target.addEventListener('lynxinput', (e) => {
               detail.value = (e as any).detail.value;
             });
             return detail;

--- a/packages/web-platform/web-tests/tests/web-elements/x-textarea/event-input.html
+++ b/packages/web-platform/web-tests/tests/web-elements/x-textarea/event-input.html
@@ -34,7 +34,7 @@
     <script src="/web-elements.js" defer></script>
     <script type="module">
     document.querySelector('x-textarea').addEventListener(
-        'input',
+        'lynxinput',
         (e) => {
           document.querySelector('.result').innerHTML = e.detail.value;
         },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

#1174 

fix #1024

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: in lynx-view all-on-ui mode, the input event of input and textarea is triggered twice, and the first e.detail is a string, which does not conform to the expected data format.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
