### PR TITLE
test(rspeedy/qrcode): increase timeout

### DIFF
--- a/packages/rspeedy/plugin-qrcode/test/index.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/index.test.ts
@@ -504,7 +504,7 @@ async function usingDevServer(rsbuild: RsbuildInstance) {
       await vi.waitUntil(() => done, { timeout: timeout ?? 5000 })
     },
     async waitDevCompileSuccess(timeout?: number) {
-      await vi.waitUntil(() => !hasErrors, { timeout: timeout ?? 1000 })
+      await vi.waitUntil(() => !hasErrors, { timeout: timeout ?? 5000 })
     },
     hasErrors,
     async [Symbol.asyncDispose]() {


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix flaky test on Windows.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

See: https://github.com/lynx-family/lynx-stack/actions/runs/15991415461/job/45105579759

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
