### PR TITLE
fix(react): avoid manipulate `__pendingListUpdates` unless SnapshotInstance tree is changed

### DIFF
--- a/.changeset/bright-seals-wear.md
+++ b/.changeset/bright-seals-wear.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Optimize `componentAtIndex` by a few hundreds microseconds: avoiding manipulate `__pendingListUpdates` unless SnapshotInstance tree is changed

--- a/packages/react/runtime/src/hydrate.ts
+++ b/packages/react/runtime/src/hydrate.ts
@@ -221,7 +221,7 @@ export function hydrate(before: SnapshotInstance, after: SnapshotInstance, optio
     swap[before.__id] = after.__id;
   }
 
-  __pendingListUpdates.runWithNoUpdates(() => {
+  __pendingListUpdates.runWithoutUpdates(() => {
     after.__values?.forEach((value, index) => {
       const old = before.__values![index];
       if (value !== old) {

--- a/packages/react/runtime/src/hydrate.ts
+++ b/packages/react/runtime/src/hydrate.ts
@@ -221,12 +221,14 @@ export function hydrate(before: SnapshotInstance, after: SnapshotInstance, optio
     swap[before.__id] = after.__id;
   }
 
-  after.__values?.forEach((value, index) => {
-    const old = before.__values![index];
-    if (value !== old) {
-      after.__values![index] = old;
-      after.setAttribute(index, value);
-    }
+  __pendingListUpdates.runWithNoUpdates(() => {
+    after.__values?.forEach((value, index) => {
+      const old = before.__values![index];
+      if (value !== old) {
+        after.__values![index] = old;
+        after.setAttribute(index, value);
+      }
+    });
   });
 
   const { slot } = after.__snapshot_def;
@@ -361,7 +363,9 @@ export function hydrate(before: SnapshotInstance, after: SnapshotInstance, optio
 
         // The `before` & `after` target to the same list element, so we need to
         // avoid the newly created list's (behind snapshot instance `after`) "update-list-info" being recorded.
-        delete __pendingListUpdates.values[after.__id];
+        if (__pendingListUpdates.values) {
+          delete __pendingListUpdates.values[after.__id];
+        }
       }
     }
   });

--- a/packages/react/runtime/src/pendingListUpdates.ts
+++ b/packages/react/runtime/src/pendingListUpdates.ts
@@ -17,7 +17,7 @@ export const __pendingListUpdates = {
       this.clear();
     }
   },
-  runWithNoUpdates(cb: () => void): void {
+  runWithoutUpdates(cb: () => void): void {
     const old = this.values;
     this.values = null as unknown as Record<number, ListUpdateInfo>;
     try {

--- a/packages/react/runtime/src/pendingListUpdates.ts
+++ b/packages/react/runtime/src/pendingListUpdates.ts
@@ -5,14 +5,25 @@
 import type { ListUpdateInfo } from './listUpdateInfo.js';
 
 export const __pendingListUpdates = {
-  values: {} as Record<number, ListUpdateInfo>,
+  values: {} as Record<number, ListUpdateInfo> | null,
   clear(): void {
     this.values = {};
   },
   flush(): void {
-    Object.values(this.values).forEach(update => {
-      update.flush();
-    });
-    this.clear();
+    if (this.values) {
+      Object.values(this.values).forEach(update => {
+        update.flush();
+      });
+      this.clear();
+    }
+  },
+  runWithNoUpdates(cb: () => void): void {
+    const old = this.values;
+    this.values = null as unknown as Record<number, ListUpdateInfo>;
+    try {
+      cb();
+    } finally {
+      this.values = old;
+    }
   },
 };

--- a/packages/react/runtime/src/snapshot.ts
+++ b/packages/react/runtime/src/snapshot.ts
@@ -308,7 +308,7 @@ export class SnapshotInstance {
       }
     }
 
-    __pendingListUpdates.runWithNoUpdates(() => {
+    __pendingListUpdates.runWithoutUpdates(() => {
       const values = this.__values;
       if (values) {
         this.__values = undefined;

--- a/packages/react/runtime/src/snapshot.ts
+++ b/packages/react/runtime/src/snapshot.ts
@@ -308,11 +308,13 @@ export class SnapshotInstance {
       }
     }
 
-    const values = this.__values;
-    if (values) {
-      this.__values = undefined;
-      this.setAttribute('values', values);
-    }
+    __pendingListUpdates.runWithNoUpdates(() => {
+      const values = this.__values;
+      if (values) {
+        this.__values = undefined;
+        this.setAttribute('values', values);
+      }
+    });
 
     if (isListHolder) {
       // never recurse into list's children
@@ -497,9 +499,11 @@ export class SnapshotInstance {
   insertBefore(newNode: SnapshotInstance, existingNode?: SnapshotInstance): void {
     const __snapshot_def = this.__snapshot_def;
     if (__snapshot_def.isListHolder) {
-      (__pendingListUpdates.values[this.__id] ??= new ListUpdateInfoRecording(
-        this,
-      )).onInsertBefore(newNode, existingNode);
+      if (__pendingListUpdates.values) {
+        (__pendingListUpdates.values[this.__id] ??= new ListUpdateInfoRecording(
+          this,
+        )).onInsertBefore(newNode, existingNode);
+      }
       this.__insertBefore(newNode, existingNode);
       return;
     }
@@ -554,9 +558,11 @@ export class SnapshotInstance {
   removeChild(child: SnapshotInstance): void {
     const __snapshot_def = this.__snapshot_def;
     if (__snapshot_def.isListHolder) {
-      (__pendingListUpdates.values[this.__id] ??= new ListUpdateInfoRecording(
-        this,
-      )).onRemoveChild(child);
+      if (__pendingListUpdates.values) {
+        (__pendingListUpdates.values[this.__id] ??= new ListUpdateInfoRecording(
+          this,
+        )).onRemoveChild(child);
+      }
 
       this.__removeChild(child);
       traverseSnapshotInstance(child, v => {

--- a/packages/react/runtime/src/snapshot/platformInfo.ts
+++ b/packages/react/runtime/src/snapshot/platformInfo.ts
@@ -36,13 +36,15 @@ function updateListItemPlatformInfo(
 ): void {
   const newValue = ctx.__listItemPlatformInfo = ctx.__values![index] as PlatformInfo;
 
-  const list = ctx.parentNode;
-  if (list?.__snapshot_def.isListHolder) {
-    (__pendingListUpdates.values[list.__id] ??= new ListUpdateInfoRecording(list)).onSetAttribute(
-      ctx,
-      newValue,
-      oldValue,
-    );
+  if (__pendingListUpdates.values) {
+    const list = ctx.parentNode;
+    if (list?.__snapshot_def.isListHolder) {
+      (__pendingListUpdates.values[list.__id] ??= new ListUpdateInfoRecording(list)).onSetAttribute(
+        ctx,
+        newValue,
+        oldValue,
+      );
+    }
   }
 
   // In this updater, unlike `updateSpread`, the shape of the value is guaranteed to be an fixed object.

--- a/packages/react/runtime/src/snapshot/spread.ts
+++ b/packages/react/runtime/src/snapshot/spread.ts
@@ -54,11 +54,13 @@ function updateSpread(
     const oldPlatformInfo = pick(oldValue, platformInfoAttributes);
     const platformInfo = pick(newValue, platformInfoAttributes);
     if (!isDirectOrDeepEqual(oldPlatformInfo, platformInfo)) {
-      (__pendingListUpdates.values[list.__id] ??= new ListUpdateInfoRecording(list)).onSetAttribute(
-        snapshot,
-        platformInfo,
-        oldPlatformInfo,
-      );
+      if (__pendingListUpdates.values) {
+        (__pendingListUpdates.values[list.__id] ??= new ListUpdateInfoRecording(list)).onSetAttribute(
+          snapshot,
+          platformInfo,
+          oldPlatformInfo,
+        );
+      }
       snapshot.__listItemPlatformInfo = platformInfo;
 
       // The fakeSnapshot is missing `__parent`, so no `ListUpdateInfoRecording#onSetAttribute` will be called

--- a/packages/react/testing-library/src/__tests__/list.test.jsx
+++ b/packages/react/testing-library/src/__tests__/list.test.jsx
@@ -38,25 +38,7 @@ describe('list', () => {
     const list = container.firstChild;
     expect(list.props).toMatchInlineSnapshot(`undefined`);
     const uid0 = elementTree.enterListItemAtIndex(list, 0);
-    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`
-      {
-        "2": [
-          {
-            "insertAction": [],
-            "removeAction": [],
-            "updateAction": [
-              {
-                "flush": false,
-                "from": 0,
-                "item-key": 0,
-                "to": 0,
-                "type": "__Card__:__snapshot_a9e46_test_2",
-              },
-            ],
-          },
-        ],
-      }
-    `);
+    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`{}`);
     expect(container).toMatchInlineSnapshot(`
       <page>
         <list
@@ -73,32 +55,7 @@ describe('list', () => {
       </page>
     `);
     const uid1 = elementTree.enterListItemAtIndex(list, 1);
-    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`
-      {
-        "2": [
-          {
-            "insertAction": [],
-            "removeAction": [],
-            "updateAction": [
-              {
-                "flush": false,
-                "from": 0,
-                "item-key": 0,
-                "to": 0,
-                "type": "__Card__:__snapshot_a9e46_test_2",
-              },
-              {
-                "flush": false,
-                "from": 1,
-                "item-key": 1,
-                "to": 1,
-                "type": "__Card__:__snapshot_a9e46_test_2",
-              },
-            ],
-          },
-        ],
-      }
-    `);
+    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`{}`);
     expect(container).toMatchInlineSnapshot(`
       <page>
         <list
@@ -124,32 +81,7 @@ describe('list', () => {
     expect(uid0).toMatchInlineSnapshot(`2`);
     expect(uid1).toMatchInlineSnapshot(`5`);
     elementTree.leaveListItem(list, uid0);
-    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`
-      {
-        "2": [
-          {
-            "insertAction": [],
-            "removeAction": [],
-            "updateAction": [
-              {
-                "flush": false,
-                "from": 0,
-                "item-key": 0,
-                "to": 0,
-                "type": "__Card__:__snapshot_a9e46_test_2",
-              },
-              {
-                "flush": false,
-                "from": 1,
-                "item-key": 1,
-                "to": 1,
-                "type": "__Card__:__snapshot_a9e46_test_2",
-              },
-            ],
-          },
-        ],
-      }
-    `);
+    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`{}`);
     expect(container).toMatchInlineSnapshot(`
       <page>
         <list
@@ -174,39 +106,7 @@ describe('list', () => {
     `);
     const uid2 = elementTree.enterListItemAtIndex(list, 2);
     expect(__pendingListUpdates.values).toMatchInlineSnapshot(
-      `
-      {
-        "2": [
-          {
-            "insertAction": [],
-            "removeAction": [],
-            "updateAction": [
-              {
-                "flush": false,
-                "from": 0,
-                "item-key": 0,
-                "to": 0,
-                "type": "__Card__:__snapshot_a9e46_test_2",
-              },
-              {
-                "flush": false,
-                "from": 1,
-                "item-key": 1,
-                "to": 1,
-                "type": "__Card__:__snapshot_a9e46_test_2",
-              },
-              {
-                "flush": false,
-                "from": 2,
-                "item-key": 2,
-                "to": 2,
-                "type": "__Card__:__snapshot_a9e46_test_2",
-              },
-            ],
-          },
-        ],
-      }
-    `,
+      `{}`,
     );
     expect(container).toMatchInlineSnapshot(`
       <page>


### PR DESCRIPTION
We make `__pendingListUpdates.values` nullable, and set it to null to indicate manipulating it should be avoided, in the following scenarios:

1. setAttribute when hydrate
2. setAttribute when ensureElements

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced efficiency of component rendering by reducing unnecessary updates when the component tree is unchanged.
  * Optimized internal update handling to improve execution speed.

* **Bug Fixes**
  * Prevented potential errors by adding safeguards when accessing internal update structures, ensuring more robust behavior.

* **Tests**
  * Updated test cases to reflect changes in internal update handling and to verify improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->