### PR TITLE
chore(web): extract shared logic of loadTemplate

### DIFF
--- a/.changeset/young-doodles-strive.md
+++ b/.changeset/young-doodles-strive.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-core-server": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+chore: extract shared logic from web-core and web-core-server's loadTemplate into a unified generateTemplate function

--- a/packages/web-platform/web-constants/src/utils/generateTemplate.ts
+++ b/packages/web-platform/web-constants/src/utils/generateTemplate.ts
@@ -1,0 +1,210 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { globalMuteableVars } from '../constants.js';
+import type { LynxTemplate } from '../types/LynxModule.js';
+
+const mainThreadInjectVars = [
+  'lynx',
+  'globalThis',
+  '_ReportError',
+  '_SetSourceMapRelease',
+  '__AddConfig',
+  '__AddDataset',
+  '__GetAttributes',
+  '__GetComponentID',
+  '__GetDataByKey',
+  '__GetDataset',
+  '__GetElementConfig',
+  '__GetElementUniqueID',
+  '__GetID',
+  '__GetTag',
+  '__SetAttribute',
+  '__SetConfig',
+  '__SetDataset',
+  '__SetID',
+  '__UpdateComponentID',
+  '__GetConfig',
+  '__UpdateListCallbacks',
+  '__AppendElement',
+  '__ElementIsEqual',
+  '__FirstElement',
+  '__GetChildren',
+  '__GetParent',
+  '__InsertElementBefore',
+  '__LastElement',
+  '__NextElement',
+  '__RemoveElement',
+  '__ReplaceElement',
+  '__ReplaceElements',
+  '__SwapElement',
+  '__CreateComponent',
+  '__CreateElement',
+  '__CreatePage',
+  '__CreateView',
+  '__CreateText',
+  '__CreateRawText',
+  '__CreateImage',
+  '__CreateScrollView',
+  '__CreateWrapperElement',
+  '__CreateList',
+  '__AddEvent',
+  '__GetEvent',
+  '__GetEvents',
+  '__SetEvents',
+  '__AddClass',
+  '__SetClasses',
+  '__GetClasses',
+  '__AddInlineStyle',
+  '__SetInlineStyles',
+  '__SetCSSId',
+  '__OnLifecycleEvent',
+  '__FlushElementTree',
+  '__LoadLepusChunk',
+  'SystemInfo',
+  '_I18nResourceTranslation',
+  '_AddEventListener',
+];
+
+const backgroundInjectVars = [
+  'NativeModules',
+  'globalThis',
+  'lynx',
+  'lynxCoreInject',
+  'SystemInfo',
+];
+
+const backgroundInjectWithBind = [
+  'Card',
+  'Component',
+];
+
+async function generateJavascriptUrl<T extends Record<string, string>>(
+  obj: T,
+  injectVars: string[],
+  injectWithBind: string[],
+  muteableVars: readonly string[],
+  createJsModuleUrl: (content: string) => string,
+): Promise<T>;
+async function generateJavascriptUrl<T extends Record<string, string>>(
+  obj: T,
+  injectVars: string[],
+  injectWithBind: string[],
+  muteableVars: readonly string[],
+  createJsModuleUrl: (content: string, name: string) => Promise<string>,
+  templateName: string,
+): Promise<T>;
+async function generateJavascriptUrl<T extends Record<string, string>>(
+  obj: T,
+  injectVars: string[],
+  injectWithBind: string[],
+  muteableVars: readonly string[],
+  createJsModuleUrl:
+    | ((content: string) => string)
+    | ((content: string, name: string) => Promise<string>),
+  templateName?: string,
+): Promise<T> {
+  injectVars = injectVars.concat(muteableVars);
+  const generateModuleContent = (content: string) =>
+    [
+      '//# allFunctionsCalledOnLoad\n',
+      'globalThis.module.exports = function(lynx_runtime) {',
+      'const module= {exports:{}};let exports = module.exports;',
+      'var {',
+      injectVars.join(','),
+      '} = lynx_runtime;',
+      ...injectWithBind.map(nm =>
+        `const ${nm} = lynx_runtime.${nm}?.bind(lynx_runtime);`
+      ),
+      ';var globDynamicComponentEntry = \'__Card__\';',
+      'var {__globalProps} = lynx;',
+      'lynx_runtime._updateVars=()=>{',
+      ...muteableVars.map(nm =>
+        `${nm} = lynx_runtime.__lynxGlobalBindingValues.${nm};`
+      ),
+      '};\n',
+      content,
+      '\n return module.exports;}',
+    ].join('');
+  if (!templateName) {
+    createJsModuleUrl;
+  }
+  const processEntry = templateName
+    ? async ([name, content]: [string, string]) => [
+      name,
+      await (createJsModuleUrl as (
+        content: string,
+        name: string,
+      ) => Promise<string>)(
+        generateModuleContent(content),
+        `${templateName}-${name.replaceAll('/', '')}.js`,
+      ),
+    ]
+    : async ([name, content]: [string, string]) => [
+      name,
+      await (createJsModuleUrl as (content: string) => string)(
+        generateModuleContent(content),
+      ),
+    ];
+  return Promise.all(Object.entries(obj).map(processEntry)).then(
+    Object.fromEntries,
+  );
+}
+
+export async function generateTemplate(
+  template: LynxTemplate,
+  createJsModuleUrl: (content: string) => string,
+): Promise<LynxTemplate>;
+export async function generateTemplate(
+  template: LynxTemplate,
+  createJsModuleUrl: (content: string, name: string) => Promise<string>,
+  templateName: string,
+): Promise<LynxTemplate>;
+export async function generateTemplate(
+  template: LynxTemplate,
+  createJsModuleUrl:
+    | ((content: string) => string)
+    | ((content: string, name: string) => Promise<string>),
+  templateName?: string,
+): Promise<LynxTemplate> {
+  if (!templateName) {
+    return {
+      ...template,
+      lepusCode: await generateJavascriptUrl(
+        template.lepusCode,
+        mainThreadInjectVars,
+        [],
+        globalMuteableVars,
+        createJsModuleUrl as (content: string) => string,
+      ),
+      manifest: await generateJavascriptUrl(
+        template.manifest,
+        backgroundInjectVars,
+        backgroundInjectWithBind,
+        [],
+        createJsModuleUrl as (content: string) => string,
+      ),
+    };
+  }
+
+  return {
+    ...template,
+    lepusCode: await generateJavascriptUrl(
+      template.lepusCode,
+      mainThreadInjectVars,
+      [],
+      globalMuteableVars,
+      createJsModuleUrl as (content: string, name: string) => Promise<string>,
+      templateName,
+    ),
+    manifest: await generateJavascriptUrl(
+      template.manifest,
+      backgroundInjectVars,
+      backgroundInjectWithBind,
+      [],
+      createJsModuleUrl as (content: string, name: string) => Promise<string>,
+      templateName,
+    ),
+  };
+}

--- a/packages/web-platform/web-constants/src/utils/index.ts
+++ b/packages/web-platform/web-constants/src/utils/index.ts
@@ -4,3 +4,4 @@
 
 export { LynxCrossThreadContext } from './LynxCrossThreadContext.js';
 export { dispatchMarkTiming, flushMarkTiming } from './markTiming.js';
+export { generateTemplate } from './generateTemplate.js';

--- a/packages/web-platform/web-core-server/src/utils/loadTemplate.ts
+++ b/packages/web-platform/web-core-server/src/utils/loadTemplate.ts
@@ -1,4 +1,4 @@
-import { globalMuteableVars, type LynxTemplate } from '@lynx-js/web-constants';
+import { generateTemplate, type LynxTemplate } from '@lynx-js/web-constants';
 import os from 'node:os';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -15,123 +15,6 @@ async function createJsModuleUrl(content: string, filename: string) {
   return fileUrl;
 }
 
-async function generateJavascriptUrl<T extends Record<string, string>>(
-  obj: T,
-  injectVars: string[],
-  injectWithBind: string[],
-  muteableVars: readonly string[],
-  templateName: string,
-) {
-  injectVars = injectVars.concat(muteableVars);
-  return Object.fromEntries(
-    await Promise.all(
-      Object.entries(obj).map(async ([name, content]) => {
-        return [
-          name,
-          await createJsModuleUrl(
-            [
-              '//# allFunctionsCalledOnLoad\n',
-              'globalThis.module.exports = function(lynx_runtime) {',
-              'const module= {exports:{}};let exports = module.exports;',
-              'var {',
-              injectVars.join(','),
-              '} = lynx_runtime;',
-              ...injectWithBind.map((nm) =>
-                `const ${nm} = lynx_runtime.${nm}?.bind(lynx_runtime);`
-              ),
-              ';var globDynamicComponentEntry = \'__Card__\';',
-              'var {__globalProps} = lynx;',
-              'lynx_runtime._updateVars=()=>{',
-              ...muteableVars.map((nm) =>
-                `${nm} = lynx_runtime.__lynxGlobalBindingValues.${nm};`
-              ),
-              '};\n',
-              content,
-              '\n return module.exports;}',
-            ].join(''),
-            `${templateName}-${name.replaceAll('/', '')}.js`,
-          ),
-        ];
-      }),
-    ),
-  ) as T;
-}
-
-const mainThreadInjectVars = [
-  'lynx',
-  'globalThis',
-  '_ReportError',
-  '_SetSourceMapRelease',
-  '__AddConfig',
-  '__AddDataset',
-  '__GetAttributes',
-  '__GetComponentID',
-  '__GetDataByKey',
-  '__GetDataset',
-  '__GetElementConfig',
-  '__GetElementUniqueID',
-  '__GetID',
-  '__GetTag',
-  '__SetAttribute',
-  '__SetConfig',
-  '__SetDataset',
-  '__SetID',
-  '__UpdateComponentID',
-  '__GetConfig',
-  '__UpdateListCallbacks',
-  '__AppendElement',
-  '__ElementIsEqual',
-  '__FirstElement',
-  '__GetChildren',
-  '__GetParent',
-  '__InsertElementBefore',
-  '__LastElement',
-  '__NextElement',
-  '__RemoveElement',
-  '__ReplaceElement',
-  '__ReplaceElements',
-  '__SwapElement',
-  '__CreateComponent',
-  '__CreateElement',
-  '__CreatePage',
-  '__CreateView',
-  '__CreateText',
-  '__CreateRawText',
-  '__CreateImage',
-  '__CreateScrollView',
-  '__CreateWrapperElement',
-  '__CreateList',
-  '__AddEvent',
-  '__GetEvent',
-  '__GetEvents',
-  '__SetEvents',
-  '__AddClass',
-  '__SetClasses',
-  '__GetClasses',
-  '__AddInlineStyle',
-  '__SetInlineStyles',
-  '__SetCSSId',
-  '__OnLifecycleEvent',
-  '__FlushElementTree',
-  '__LoadLepusChunk',
-  'SystemInfo',
-  '_I18nResourceTranslation',
-  '_AddEventListener',
-];
-
-const backgroundInjectVars = [
-  'NativeModules',
-  'globalThis',
-  'lynx',
-  'lynxCoreInject',
-  'SystemInfo',
-];
-
-const backgroundInjectWithBind = [
-  'Card',
-  'Component',
-];
-
 export async function loadTemplate(
   rawTemplate: LynxTemplate,
   templateName: string = Math.random().toString(36).substring(2, 7),
@@ -140,23 +23,12 @@ export async function loadTemplate(
     return templateCache.get(rawTemplate)!;
   }
   templateName += Math.random().toString(36).substring(2, 7);
-  const decodedTemplate: LynxTemplate = templateCache.get(rawTemplate) ?? {
-    ...rawTemplate,
-    lepusCode: await generateJavascriptUrl(
-      rawTemplate.lepusCode,
-      mainThreadInjectVars,
-      [],
-      globalMuteableVars,
+  const decodedTemplate: LynxTemplate = templateCache.get(rawTemplate)
+    ?? await generateTemplate(
+      rawTemplate,
+      createJsModuleUrl,
       templateName + '-lepusCode',
-    ),
-    manifest: await generateJavascriptUrl(
-      rawTemplate.manifest,
-      backgroundInjectVars,
-      backgroundInjectWithBind,
-      [],
-      templateName + '-manifest',
-    ),
-  };
+    );
   templateCache.set(rawTemplate, decodedTemplate);
   /**
    * This will cause a memory leak, which is expected.

--- a/packages/web-platform/web-core/src/utils/loadTemplate.ts
+++ b/packages/web-platform/web-core/src/utils/loadTemplate.ts
@@ -1,151 +1,24 @@
-import { globalMuteableVars, type LynxTemplate } from '@lynx-js/web-constants';
+import { generateTemplate, type LynxTemplate } from '@lynx-js/web-constants';
 
-const TemplateCache: Record<string, LynxTemplate> = {};
+const templateCache: Record<string, LynxTemplate> = {};
 
 function createJsModuleUrl(content: string): string {
   return URL.createObjectURL(new Blob([content], { type: 'text/javascript' }));
 }
 
-function generateJavascriptUrl<T extends Record<string, string>>(
-  obj: T,
-  injectVars: string[],
-  injectWithBind: string[],
-  muteableVars: readonly string[],
-) {
-  injectVars = injectVars.concat(muteableVars);
-  return Object.fromEntries(
-    Object.entries(obj).map(([name, content]) => {
-      return [
-        name,
-        createJsModuleUrl(
-          [
-            '//# allFunctionsCalledOnLoad\n',
-            'globalThis.module.exports = function(lynx_runtime) {',
-            'const module= {exports:{}};let exports = module.exports;',
-            'var {',
-            injectVars.join(','),
-            '} = lynx_runtime;',
-            ...injectWithBind.map((nm) =>
-              `const ${nm} = lynx_runtime.${nm}?.bind(lynx_runtime);`
-            ),
-            ';var globDynamicComponentEntry = \'__Card__\';',
-            'var {__globalProps} = lynx;',
-            'lynx_runtime._updateVars=()=>{',
-            ...muteableVars.map((nm) =>
-              `${nm} = lynx_runtime.__lynxGlobalBindingValues.${nm};`
-            ),
-            '};\n',
-            content,
-            '\n return module.exports;}',
-          ].join(''),
-        ),
-      ];
-    }),
-  ) as T;
-}
-
-const mainThreadInjectVars = [
-  'lynx',
-  'globalThis',
-  '_ReportError',
-  '_SetSourceMapRelease',
-  '__AddConfig',
-  '__AddDataset',
-  '__GetAttributes',
-  '__GetComponentID',
-  '__GetDataByKey',
-  '__GetDataset',
-  '__GetElementConfig',
-  '__GetElementUniqueID',
-  '__GetID',
-  '__GetTag',
-  '__SetAttribute',
-  '__SetConfig',
-  '__SetDataset',
-  '__SetID',
-  '__UpdateComponentID',
-  '__GetConfig',
-  '__UpdateListCallbacks',
-  '__AppendElement',
-  '__ElementIsEqual',
-  '__FirstElement',
-  '__GetChildren',
-  '__GetParent',
-  '__InsertElementBefore',
-  '__LastElement',
-  '__NextElement',
-  '__RemoveElement',
-  '__ReplaceElement',
-  '__ReplaceElements',
-  '__SwapElement',
-  '__CreateComponent',
-  '__CreateElement',
-  '__CreatePage',
-  '__CreateView',
-  '__CreateText',
-  '__CreateRawText',
-  '__CreateImage',
-  '__CreateScrollView',
-  '__CreateWrapperElement',
-  '__CreateList',
-  '__AddEvent',
-  '__GetEvent',
-  '__GetEvents',
-  '__SetEvents',
-  '__AddClass',
-  '__SetClasses',
-  '__GetClasses',
-  '__AddInlineStyle',
-  '__SetInlineStyles',
-  '__SetCSSId',
-  '__OnLifecycleEvent',
-  '__FlushElementTree',
-  '__LoadLepusChunk',
-  'SystemInfo',
-  '_I18nResourceTranslation',
-  '_AddEventListener',
-];
-
-const backgroundInjectVars = [
-  'NativeModules',
-  'globalThis',
-  'lynx',
-  'lynxCoreInject',
-  'SystemInfo',
-];
-
-const backgroundInjectWithBind = [
-  'Card',
-  'Component',
-];
-
 export async function loadTemplate(
   url: string,
   customTemplateLoader?: (url: string) => Promise<LynxTemplate>,
 ): Promise<LynxTemplate> {
-  const cachedTemplate = TemplateCache[url];
+  const cachedTemplate = templateCache[url];
   if (cachedTemplate) return cachedTemplate;
   const template = customTemplateLoader
     ? await customTemplateLoader(url)
     : (await (await fetch(url, {
       method: 'GET',
     })).json()) as LynxTemplate;
-  const decodedTemplate: LynxTemplate = {
-    ...template,
-    lepusCode: generateJavascriptUrl(
-      template.lepusCode,
-      mainThreadInjectVars,
-      [],
-      globalMuteableVars,
-    ),
-    manifest: generateJavascriptUrl(
-      template.manifest,
-      backgroundInjectVars,
-      backgroundInjectWithBind,
-      [],
-    ),
-  };
-  TemplateCache[url] = decodedTemplate;
+  const decodedTemplate = await generateTemplate(template, createJsModuleUrl);
+  templateCache[url] = decodedTemplate;
   /**
    * This will cause a memory leak, which is expected.
    * We cannot ensure that the `URL.createObjectURL` created url will never be used, therefore here we keep it for the entire lifetime of this page.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

chore: extract shared logic from web-core and web-core-server's loadTemplate into a unified generateTemplate function

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
