### PR TITLE
fix(react/runtime): make `loadLazyBundle` return sync `then`

### DIFF
--- a/.changeset/proud-maps-drive.md
+++ b/.changeset/proud-maps-drive.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/react': patch
+---
+
+Make `loadLazyBundle` being able to be blocking.

--- a/.changeset/proud-maps-drive.md
+++ b/.changeset/proud-maps-drive.md
@@ -2,4 +2,4 @@
 '@lynx-js/react': patch
 ---
 
-Make `loadLazyBundle` being able to be blocking.
+Make `loadLazyBundle` being able to render the content on the first screen of the background thread.

--- a/packages/react/runtime/__test__/lynx/lazy-bundle.test.js
+++ b/packages/react/runtime/__test__/lynx/lazy-bundle.test.js
@@ -1,0 +1,521 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+/* global lynx */
+
+describe('loadLazyBundle', () => {
+  describe('main thread', () => {
+    beforeEach(() => {
+      vi
+        .unstubAllGlobals()
+        .stubGlobal('__LEPUS__', true)
+        .stubGlobal('__MAIN_THREAD__', true);
+    });
+
+    test('should not have lynx.loadLazyBundle when not used', () => {
+      expect(lynx.loadLazyBundle).toBeUndefined();
+    });
+
+    test('should have lynx.loadLazyBundle', async () => {
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      expect(lynx.loadLazyBundle).toBe(loadLazyBundle);
+    });
+
+    test('blocking __QueryComponent', async () => {
+      const __QueryComponent = vi.fn();
+      __QueryComponent.mockReturnValueOnce({ evalResult: { data: 'foo' } });
+      vi.stubGlobal('__QueryComponent', __QueryComponent);
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(__QueryComponent).toBeCalledWith('foo');
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+      });
+
+      expect(thenCalled).toBeTruthy();
+
+      thenCalled = false;
+      promise2.then((data) => {
+        expect(data).toBeUndefined();
+        thenCalled = true;
+      });
+      expect(thenCalled).toBeTruthy();
+
+      expect.assertions(5);
+    });
+
+    test('blocking __QueryComponent with primitive returns', async () => {
+      const __QueryComponent = vi.fn();
+      __QueryComponent.mockReturnValueOnce({ evalResult: { data: 'foo' } });
+      vi.stubGlobal('__QueryComponent', __QueryComponent);
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(__QueryComponent).toBeCalledWith('foo');
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+        return 'bar';
+      });
+
+      expect(thenCalled).toBeTruthy();
+
+      thenCalled = false;
+      promise2.then((data) => {
+        expect(data).toBe('bar');
+        thenCalled = true;
+      });
+      expect(thenCalled).toBeTruthy();
+    });
+
+    test('blocking __QueryComponent without onFulfilled', async () => {
+      const __QueryComponent = vi.fn();
+      __QueryComponent.mockReturnValueOnce({ evalResult: { data: 'foo' } });
+      vi.stubGlobal('__QueryComponent', __QueryComponent);
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(__QueryComponent).toBeCalledWith('foo');
+
+      let thenCalled = false;
+      const promise2 = promise.then();
+
+      promise2.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+      });
+      expect(thenCalled).toBeTruthy();
+    });
+
+    test('blocking __QueryComponent with thenable returns', async () => {
+      const __QueryComponent = vi.fn();
+      __QueryComponent.mockReturnValueOnce({ evalResult: { data: 'foo' } });
+      vi.stubGlobal('__QueryComponent', __QueryComponent);
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(__QueryComponent).toBeCalledWith('foo');
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+        return {
+          then(onFulfilled) {
+            return onFulfilled('bar');
+          },
+        };
+      });
+
+      expect(thenCalled).toBeTruthy();
+
+      thenCalled = false;
+      const promise3 = promise2.then((data) => {
+        expect(data).toBe('bar');
+        thenCalled = true;
+        return Promise.resolve('baz');
+      });
+      expect(thenCalled).toBeTruthy();
+
+      thenCalled = false;
+      const promise4 = promise3.then((data) => {
+        expect(data).toBe('baz');
+        return data;
+      });
+      expect(thenCalled).toBe(false);
+
+      await expect(promise4).resolves.toBe('baz');
+      expect.assertions(8);
+    });
+
+    test('blocking __QueryComponent with throw in onFulfilled', async () => {
+      const __QueryComponent = vi.fn();
+      __QueryComponent.mockReturnValueOnce({ evalResult: { data: 'foo' } });
+      vi.stubGlobal('__QueryComponent', __QueryComponent);
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(__QueryComponent).toBeCalledWith('foo');
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+        throw new Error('err');
+      });
+
+      expect(thenCalled).toBeTruthy();
+
+      await expect(promise2).rejects.toThrow('err');
+    });
+
+    test.todo('blocking __QueryComponent with onRejected');
+    test.todo('blocking __QueryComponent with throw in onRejected');
+
+    test('non-blocking __QueryComponent', async () => {
+      const __QueryComponent = vi.fn();
+      __QueryComponent.mockReturnValueOnce(undefined);
+      vi.stubGlobal('__QueryComponent', __QueryComponent);
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(__QueryComponent).toBeCalledWith('foo');
+
+      promise.then(() => {
+        expect.fail('non-blocking __QueryComponent should never resolve');
+      }, () => {
+        expect.fail('non-blocking __QueryComponent should never reject');
+      });
+      promise.catch(() => {
+        expect.fail('non-blocking __QueryComponent should never reject');
+      });
+      promise.finally(() => {
+        expect.fail('non-blocking __QueryComponent should never finally');
+      });
+
+      await Promise.resolve();
+
+      expect.assertions(1);
+    });
+  });
+
+  describe('background thread', () => {
+    const QueryComponent = vi.fn();
+    const getDynamicComponentExports = vi.fn((data) => ({ data }));
+
+    beforeEach(() => {
+      QueryComponent.mockReset();
+
+      vi.unstubAllGlobals()
+        .stubGlobal('__LEPUS__', false)
+        .stubGlobal('__MAIN_THREAD__', false)
+        .stubGlobal('__BACKGROUND__', true)
+        .stubGlobal('__JS__', true)
+        .stubGlobal('lynx', { QueryComponent })
+        .stubGlobal('lynxCoreInject', { tt: { getDynamicComponentExports } });
+    });
+
+    test('blocking QueryComponent', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        callback({ code: 0, detail: { schema: source } });
+      });
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      let thenCalled = false;
+      promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+      });
+
+      expect(thenCalled).toBeTruthy();
+      expect.assertions(3);
+    });
+
+    test('blocking QueryComponent with error', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        callback({ code: 1, detail: { errMsg: 'error', source } });
+      });
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      const promise2 = promise.then(() => {
+        expect.fail('promise should reject');
+      });
+      expect(promise).toBeInstanceOf(Promise);
+
+      let catchCalled = false;
+      const promise3 = promise.catch((err) => {
+        expect(err).toMatchInlineSnapshot(
+          `[Error: Lazy bundle load failed: {"code":1,"detail":{"errMsg":"error","source":"foo"}}]`,
+        );
+        catchCalled = true;
+      });
+      expect(catchCalled).toBe(false); // Should be non-blocking
+
+      await expect(promise2).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Lazy bundle load failed: {"code":1,"detail":{"errMsg":"error","source":"foo"}}]`,
+      );
+
+      await promise3;
+      expect(catchCalled).toBe(true);
+    });
+
+    test('blocking QueryComponent with primitive returns', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        callback({ code: 0, detail: { schema: source } });
+      });
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+        return 'bar';
+      });
+      expect(thenCalled).toBeTruthy();
+
+      thenCalled = false;
+      const promise3 = promise2.then(data => {
+        expect(data).toBe('bar');
+        thenCalled = true;
+        return 'baz';
+      });
+      expect(thenCalled).toBe(true);
+
+      thenCalled = false;
+      promise3.then(data => {
+        expect(data).toBe('baz');
+        thenCalled = true;
+      });
+      expect(thenCalled).toBe(true);
+    });
+
+    test('blocking QueryComponent with primitive returns', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        callback({ code: 0, detail: { schema: source } });
+      });
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+        return 'bar';
+      });
+      expect(thenCalled).toBeTruthy();
+
+      thenCalled = false;
+      const promise3 = promise2.then(data => {
+        expect(data).toBe('bar');
+        thenCalled = true;
+        return 'baz';
+      });
+      expect(thenCalled).toBe(true);
+
+      thenCalled = false;
+      promise3.then(data => {
+        expect(data).toBe('baz');
+        thenCalled = true;
+      });
+      expect(thenCalled).toBe(true);
+    });
+
+    test('blocking QueryComponent with thenable returns', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        callback({ code: 0, detail: { schema: source } });
+      });
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+        return {
+          then(onFulfilled) {
+            return onFulfilled('bar');
+          },
+        };
+      });
+      expect(thenCalled).toBeTruthy();
+
+      thenCalled = false;
+      const promise3 = promise2.then(data => {
+        expect(data).toBe('bar');
+        thenCalled = true;
+        return Promise.resolve('baz');
+      });
+      expect(thenCalled).toBe(true);
+
+      thenCalled = false;
+      promise3.then(data => {
+        expect(data).toBe('baz');
+        thenCalled = true;
+      });
+      expect(thenCalled).toBe(false);
+
+      await expect(promise3).resolves.toBe('baz');
+    });
+
+    test('blocking QueryComponent with throw in onFulfilled', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        callback({ code: 0, detail: { schema: source } });
+      });
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+        throw new Error('err');
+      });
+
+      expect(thenCalled).toBeTruthy();
+
+      await expect(promise2).rejects.toThrow('err');
+    });
+
+    test.todo('blocking QueryComponent with onRejected');
+    test.todo('blocking QueryComponent with throw in onRejected');
+
+    test('non-blocking QueryComponent', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        Promise.resolve().then(() => {
+          callback({ code: 0, detail: { schema: source } });
+        });
+      });
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      let thenCalled = false;
+      const promise2 = promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+
+        return 'bar';
+      });
+      expect(thenCalled).toBe(false);
+
+      await promise;
+      expect(thenCalled).toBe(true);
+
+      thenCalled = false;
+      promise2.then((data) => {
+        expect(data).toBe('bar');
+        thenCalled = true;
+      });
+      expect(thenCalled).toBe(false);
+
+      await expect(promise2).resolves.toBe('bar');
+      expect(thenCalled).toBe(true);
+    });
+
+    test('non-blocking QueryComponent with rejections', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        Promise.resolve().then(() => {
+          callback({ code: 1, detail: { errMsg: 'error', source } });
+        });
+      });
+
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      let thenCalled = false;
+      const promise2 = promise.then(() => {
+        expect.fail('promise should not resolve');
+      }, (err) => {
+        expect(err).toMatchInlineSnapshot(
+          `[Error: Lazy bundle load failed: {"code":1,"detail":{"errMsg":"error","source":"foo"}}]`,
+        );
+        thenCalled = true;
+        return 'bar';
+      });
+      expect(thenCalled).toBe(false);
+
+      await expect(promise).rejects.toMatchInlineSnapshot(
+        `[Error: Lazy bundle load failed: {"code":1,"detail":{"errMsg":"error","source":"foo"}}]`,
+      );
+      expect(thenCalled).toBe(true);
+
+      thenCalled = false;
+      promise2.then((data) => {
+        expect(data).toBe('bar');
+        thenCalled = true;
+      });
+      expect(thenCalled).toBe(false);
+
+      await expect(promise2).resolves.toBe('bar');
+      expect(thenCalled).toBe(true);
+    });
+
+    test('lynx.getNativeLynx().QueryComponent', async () => {
+      QueryComponent.mockImplementation((source, callback) => {
+        callback({ code: 0, detail: { schema: source } });
+      });
+      vi.stubGlobal('lynx', { getNativeLynx: () => ({ QueryComponent }) });
+      const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+      const promise = loadLazyBundle('foo');
+
+      expect(QueryComponent).toBeCalledWith('foo', expect.any(Function));
+
+      let thenCalled = false;
+      promise.then(({ data }) => {
+        expect(data).toBe('foo');
+        thenCalled = true;
+      });
+
+      expect(thenCalled).toBeTruthy();
+      expect.assertions(3);
+    });
+  });
+
+  test('unreachable', async () => {
+    vi
+      .stubGlobal('__JS__', false)
+      .stubGlobal('__BACKGROUND__', false)
+      .stubGlobal('__MAIN_THREAD__', false)
+      .stubGlobal('__LEPUS__', false);
+
+    const { loadLazyBundle } = await import('../../src/lynx/lazy-bundle');
+
+    expect(() => loadLazyBundle()).toThrowErrorMatchingInlineSnapshot(`[Error: unreachable]`);
+  });
+});

--- a/packages/react/runtime/src/lynx/lazy-bundle.ts
+++ b/packages/react/runtime/src/lynx/lazy-bundle.ts
@@ -133,6 +133,8 @@ export const loadLazyBundle: <
 })();
 
 function withSyncResolvers<T>() {
+  'background-only';
+
   const resolver: {
     result: T | null;
     error: Error | null;

--- a/packages/react/runtime/src/lynx/lazy-bundle.ts
+++ b/packages/react/runtime/src/lynx/lazy-bundle.ts
@@ -33,7 +33,7 @@ export const makeSyncThen = function<T>(result: T): Promise<T>['then'] {
         // Calling `then` and passing a callback is standard behavior
         // but in Lepus runtime the callback will never be called
         // So can be simplified to code below
-        return new Promise(() => {});
+        return ret as Promise<TR1>;
 
         // TODO(hongzhiyuan.hzy): Avoid warning that cannot be turned-off, so the warning is commented
         // lynx.reportError(
@@ -90,27 +90,40 @@ export const loadLazyBundle: <
       r.then = makeSyncThen(result);
       return r;
     } else if (__JS__) {
-      return new Promise((resolve, reject) => {
-        const callback: (result: { code: number; detail: { schema: string } }) => void = result => {
-          const { code, detail } = result;
-          if (code === 0) {
-            const { schema } = detail;
-            const exports = lynxCoreInject.tt.getDynamicComponentExports(schema);
-            // `code === 0` means that the lazy bundle has been successfully parsed. However,
-            // its javascript files may still fail to run, which would prevent the retrieval of the exports object.
-            if (exports) {
-              resolve(exports as T);
-              return;
-            }
+      const resolver = withSyncResolvers<T>();
+
+      const callback: (result: { code: number; detail: { schema: string } }) => void = result => {
+        const { code, detail } = result;
+        if (code === 0) {
+          const { schema } = detail;
+          const exports = lynxCoreInject.tt.getDynamicComponentExports(schema);
+          // `code === 0` means that the lazy bundle has been successfully parsed. However,
+          // its javascript files may still fail to run, which would prevent the retrieval of the exports object.
+          if (exports) {
+            resolver.resolve(exports as T);
+            return;
           }
-          reject(new Error('Lazy bundle load failed: ' + JSON.stringify(result)));
-        };
-        if (typeof lynx.QueryComponent === 'function') {
-          lynx.QueryComponent(source, callback);
-        } else {
-          lynx.getNativeLynx().QueryComponent!(source, callback);
         }
-      });
+        resolver.reject(new Error('Lazy bundle load failed: ' + JSON.stringify(result)));
+      };
+      if (typeof lynx.QueryComponent === 'function') {
+        lynx.QueryComponent(source, callback);
+      } else {
+        lynx.getNativeLynx().QueryComponent!(source, callback);
+      }
+
+      if (resolver.result !== null) {
+        const p = Promise.resolve(resolver.result);
+        p.then = makeSyncThen(resolver.result) as Promise<Awaited<T>>['then'];
+        return p;
+      } else if (resolver.error === null) {
+        return new Promise((_resolve, _reject) => {
+          resolver.resolve = _resolve;
+          resolver.reject = _reject;
+        });
+      } else {
+        return Promise.reject(resolver.error);
+      }
     }
 
     throw new Error('unreachable');
@@ -118,6 +131,26 @@ export const loadLazyBundle: <
 
   return loadLazyBundle;
 })();
+
+function withSyncResolvers<T>() {
+  const resolver: {
+    result: T | null;
+    error: Error | null;
+    resolve(result: T): void;
+    reject(error: Error): void;
+  } = {
+    resolve: (result: T): void => {
+      resolver.result = result;
+    },
+    reject: (error: Error): void => {
+      resolver.error = error;
+    },
+    result: null,
+    error: null,
+  };
+
+  return resolver;
+}
 
 /**
  * @internal

--- a/packages/react/runtime/vitest.config.ts
+++ b/packages/react/runtime/vitest.config.ts
@@ -88,7 +88,6 @@ export default defineConfig({
         'src/debug/debug.ts',
         'src/lynx/calledByNative.ts',
         'src/lynx/component.ts',
-        'src/lynx/lazy-bundle.ts',
         'src/lynx/dynamic-js.ts',
         'src/lynx/env.ts',
         'src/lynx/tt.ts',


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Make lazy bundle being able to resolve and rendered on the first screen of background thread.

The `QueryComponent` API can support both blocking and non-blocking returns.

**Before this patch**:

- main-thread: Directly render the children of `<Suspense />`, which resolves to the content of the lazy bundle.
- background: Firstly render to the children of `<Suspense />`, which throw an error. Then the promise of `loadLazyBundle` resolves, which makes `<Suspense />` updates to render the content of the lazy bundle.

The render result would be:

Full content -> blank -> full content

which is quite weird for end-user.

**After this patch**:

Both main-thread and background would directly render the children of `<Suspense />`, which resolves to the content of the lazy bundle.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
