### PR TITLE
feat(react/runtime): integrate with `preact/debug`

### DIFF
--- a/.changeset/grumpy-owls-argue.md
+++ b/.changeset/grumpy-owls-argue.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Make `preact/debug` work with `@lynx-js/react`.

--- a/packages/react/runtime/__test__/debug/children-with-same-key.test.jsx
+++ b/packages/react/runtime/__test__/debug/children-with-same-key.test.jsx
@@ -1,0 +1,43 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - children with the same key attribute', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  const consoleError = vi.spyOn(console, 'error');
+
+  await import('preact/debug');
+  const { root } = await import('../../src/index');
+
+  function Bar() {
+    return (
+      <>
+        {Array.from({ length: 5 }).fill(1).map(i => <view key={i} />)}
+      </>
+    );
+  }
+
+  function Foo(props) {
+    return props.children;
+  }
+
+  function App() {
+    return (
+      <Foo>
+        <Bar />
+      </Foo>
+    );
+  }
+
+  root.render(<App />);
+
+  expect(consoleError).toBeCalledWith(
+    `Following component has two or more children with the same key attribute: "1". This may cause glitches and misbehavior in rendering process. Component: 
+
+<Bar />
+
+  in Bar
+  in App
+`,
+  );
+});

--- a/packages/react/runtime/__test__/debug/hooks-in-render.test.jsx
+++ b/packages/react/runtime/__test__/debug/hooks-in-render.test.jsx
@@ -1,0 +1,13 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - Hook can only be invoked from render methods', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  await import('preact/debug');
+  const { useState } = await import('../../src/index');
+
+  expect(() => useState(0)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Hook can only be invoked from render methods.]`,
+  );
+});

--- a/packages/react/runtime/__test__/debug/hooks-invalid-args.test.jsx
+++ b/packages/react/runtime/__test__/debug/hooks-invalid-args.test.jsx
@@ -1,0 +1,33 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - Invalid argument passed to hook', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  await import('preact/debug');
+  const { root, useEffect, useState } = await import('../../src/index');
+
+  function Bar() {
+    useState(0);
+    useEffect(() => {}, [
+      NaN,
+    ]);
+    return null;
+  }
+
+  function Foo(props) {
+    return props.children;
+  }
+
+  function App() {
+    return (
+      <Foo>
+        <Bar />
+      </Foo>
+    );
+  }
+
+  expect(() => root.render(<App />)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Invalid argument passed to hook. Hooks should not be called with NaN in the dependency array. Hook index 1 in component Bar was called with NaN.]`,
+  );
+});

--- a/packages/react/runtime/__test__/debug/jsx-twice.test.jsx
+++ b/packages/react/runtime/__test__/debug/jsx-twice.test.jsx
@@ -1,0 +1,55 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - Invalid type passed to createElement()', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  await import('preact/debug');
+  const { root } = await import('../../src/index');
+
+  const a = { b: <view />, arr: [], obj: {}, regexp: /foo/ };
+
+  function Bar() {
+    return <a.b />;
+  }
+
+  function Foo(props) {
+    return props.children;
+  }
+
+  function App() {
+    return (
+      <Foo>
+        <Bar />
+      </Foo>
+    );
+  }
+
+  expect(() => root.render(<App />)).toThrowErrorMatchingInlineSnapshot(
+    `
+    [Error: Invalid type passed to createElement(): [object Object]
+
+    Did you accidentally pass a JSX literal as JSX twice?
+
+      let My#text = <__Card__:__snapshot_a94a8_test_1 />;
+      let vnode = <My#text />;
+
+    This usually happens when you export a JSX literal and not the component.
+
+      in #text
+      in Bar
+      in App
+    ]
+  `,
+  );
+
+  expect(() => root.render(<a.arr />)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Invalid type passed to createElement(): array]`,
+  );
+  expect(() => root.render(<a.obj />)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Invalid type passed to createElement(): [object Object]]`,
+  );
+  expect(() => root.render(<a.regexp />)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Invalid type passed to createElement(): /foo/]`,
+  );
+});

--- a/packages/react/runtime/__test__/debug/missing-suspense.test.jsx
+++ b/packages/react/runtime/__test__/debug/missing-suspense.test.jsx
@@ -1,0 +1,35 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - Missing Suspense', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  await import('preact/debug');
+  const { lazy, root } = await import('../../src/index');
+
+  const Foo = lazy(() => Promise.reject({ default: 'Foo' }));
+
+  function Bar(props) {
+    return props.children;
+  }
+
+  function App() {
+    return (
+      <Bar>
+        <Foo />
+      </Bar>
+    );
+  }
+
+  expect(() => root.render(<App />)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Missing Suspense. The throwing component was: Lazy]`,
+  );
+
+  function Baz() {
+    throw Promise.resolve('Baz');
+  }
+
+  expect(() => root.render(<Baz />)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Missing Suspense. The throwing component was: Baz]`,
+  );
+});

--- a/packages/react/runtime/__test__/debug/object-as-child.test.jsx
+++ b/packages/react/runtime/__test__/debug/object-as-child.test.jsx
@@ -1,0 +1,35 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - Objects are not valid as a child', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  await import('preact/debug');
+  const { root } = await import('../../src/index');
+
+  function Bar() {
+    return { foo: 'foo', bar: 'bar', baz: 'baz' };
+  }
+
+  function Foo(props) {
+    return props.children;
+  }
+
+  function App() {
+    return (
+      <Foo>
+        <Bar />
+      </Foo>
+    );
+  }
+
+  expect(() => root.render(<App />)).toThrowErrorMatchingInlineSnapshot(
+    `
+    [Error: Objects are not valid as a child. Encountered an object with the keys {foo,bar,baz,__,__b,__i,__u,__d}.
+
+      in Bar
+      in App
+    ]
+  `,
+  );
+});

--- a/packages/react/runtime/__test__/debug/set-state-in-ctor.test.jsx
+++ b/packages/react/runtime/__test__/debug/set-state-in-ctor.test.jsx
@@ -1,0 +1,40 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - this.setState in constructor', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  const consoleWarn = vi.spyOn(console, 'warn');
+  await import('preact/debug');
+  const { root, Component } = await import('../../src/index');
+
+  class Bar extends Component {
+    constructor(props) {
+      super(props);
+
+      this.setState({});
+    }
+  }
+
+  function Foo(props) {
+    return props.children;
+  }
+
+  function App() {
+    return (
+      <Foo>
+        <Bar />
+      </Foo>
+    );
+  }
+
+  root.render(<App />);
+
+  expect(consoleWarn).toBeCalledWith(
+    `Calling "this.setState" inside the constructor of a component is a no-op and might be a bug in your application. Instead, set "this.state = {}" directly.
+
+  in Bar
+  in App
+`,
+  );
+});

--- a/packages/react/runtime/__test__/debug/too-many-rerenders.test.jsx
+++ b/packages/react/runtime/__test__/debug/too-many-rerenders.test.jsx
@@ -1,0 +1,33 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - Too many re-renders', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  await import('preact/debug');
+  const { root, useState } = await import('../../src/index');
+
+  function Bar() {
+    const [cnt, setCnt] = useState(0);
+
+    setCnt(curr => curr + 1);
+
+    return <text>{cnt}</text>;
+  }
+
+  function Foo(props) {
+    return props.children;
+  }
+
+  function App() {
+    return (
+      <Foo>
+        <Bar />
+      </Foo>
+    );
+  }
+
+  expect(() => root.render(<App />)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Too many re-renders. This is limited to prevent an infinite loop which may lock up your browser. The component causing this is: Bar]`,
+  );
+});

--- a/packages/react/runtime/__test__/debug/undefined-component.test.jsx
+++ b/packages/react/runtime/__test__/debug/undefined-component.test.jsx
@@ -1,0 +1,40 @@
+import { expect, test, vi } from 'vitest';
+
+test('preact/debug - Undefined component passed to createElement()', async () => {
+  vi.stubGlobal('__MAIN_THREAD__', false)
+    .stubGlobal('__LEPUS__', false);
+
+  await import('preact/debug');
+  const { root } = await import('../../src/index');
+
+  const a = { b: undefined };
+
+  function Bar() {
+    return <a.b />;
+  }
+
+  function Foo(props) {
+    return props.children;
+  }
+
+  function App() {
+    return (
+      <Foo>
+        <Bar />
+      </Foo>
+    );
+  }
+
+  expect(() => root.render(<App />)).toThrowErrorMatchingInlineSnapshot(
+    `
+    [Error: Undefined component passed to createElement()
+
+    You likely forgot to export your component or might have mixed up default and named imports<#text />
+
+      in #text
+      in Bar
+      in App
+    ]
+  `,
+  );
+});

--- a/packages/react/runtime/__test__/utils/setup.js
+++ b/packages/react/runtime/__test__/utils/setup.js
@@ -16,7 +16,12 @@ function inject() {
 
 inject();
 
-afterEach(() => {
+afterEach((context) => {
+  if (context.task.name.includes('preact/debug')) {
+    // Skip preact/debug tests since there would be error
+    return;
+  }
+
   // check profile call times equal end call times
   expect(console.profile.mock.calls.length).toBe(
     console.profileEnd.mock.calls.length,

--- a/packages/react/runtime/__test__/utils/setup.js
+++ b/packages/react/runtime/__test__/utils/setup.js
@@ -18,7 +18,7 @@ inject();
 
 afterEach((context) => {
   if (context.task.name.includes('preact/debug')) {
-    // Skip preact/debug tests since there would be error
+    // Skip preact/debug tests since it would throw errors and abort the rendering process
     return;
   }
 

--- a/packages/react/runtime/src/root.ts
+++ b/packages/react/runtime/src/root.ts
@@ -8,10 +8,25 @@ import { SnapshotInstance } from './snapshot.js';
  * The internal ReactLynx's root.
  * {@link @lynx-js/react!Root | root}.
  */
-let __root: (SnapshotInstance | BackgroundSnapshotInstance) & { __jsx?: React.ReactNode; __opcodes?: any[] };
+let __root: (SnapshotInstance | BackgroundSnapshotInstance) & {
+  __jsx?: React.ReactNode;
+  __opcodes?: any[];
+
+  /**
+   * Returns the type of node.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/nodeType)
+   */
+  nodeType?: Element['nodeType'];
+};
 
 function setRoot(root: typeof __root): void {
   __root = root;
+
+  // A fake ELEMENT_NODE to make preact/debug happy.
+  if (__DEV__ && __root) {
+    __root.nodeType = 1;
+  }
 }
 
 if (__MAIN_THREAD__) {


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

This patch add a `nodeType` property for `root` which make `@lynx-js/react` work with `preact/debug`.

Corresponding tests for supported `preact/debug` checks have been added.

> [!NOTE]
> The tests are divided into separate files because `preact/debug` stores the component stack in memory, which could lead to incorrect behavior if the initial render fails.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: m-6732088176

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
