### PR TITLE
chore(tailwind-preset): add missing `turbo.json`

### DIFF
--- a/.changeset/major-drinks-lead.md
+++ b/.changeset/major-drinks-lead.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/tailwind-preset": patch
+---
+
+Fix output not found when publishing.

--- a/packages/third-party/tailwind-preset/turbo.json
+++ b/packages/third-party/tailwind-preset/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": [],
+      "inputs": [
+        "src/**",
+        "!src/**/__tests__/**",
+        "rslib.config.ts"
+      ],
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix missing `dist/` in published `@lynx-js/tailwind-preset` v0.1.0.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
