### PR TITLE
feat: set JSONParse: false when extractStr is true

### DIFF
--- a/.changeset/new-boxes-roll.md
+++ b/.changeset/new-boxes-roll.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Supports extractStr for large JSON

--- a/packages/rspeedy/plugin-react/src/generator.ts
+++ b/packages/rspeedy/plugin-react/src/generator.ts
@@ -5,7 +5,12 @@ import type { RsbuildPluginAPI } from '@rsbuild/core'
 
 import { LAYERS } from '@lynx-js/react-webpack-plugin'
 
-export function applyGenerator(api: RsbuildPluginAPI): void {
+import type { PluginReactLynxOptions } from './pluginReactLynx.js'
+
+export function applyGenerator(
+  api: RsbuildPluginAPI,
+  options: Required<PluginReactLynxOptions>,
+): void {
   api.modifyBundlerChain({
     order: 'pre',
     handler: chain => {
@@ -19,6 +24,19 @@ export function applyGenerator(api: RsbuildPluginAPI): void {
         .generator({
           JSONParse: false,
         })
+
+      // If `extractStr` is enabled, we also need to apply the same rule for the background layer.
+      // It will ensure that string literals are same in both main thread and background thread.
+      if (options.extractStr) {
+        chain.module
+          .rule(`json-parse:${LAYERS.BACKGROUND}`)
+          .issuerLayer(LAYERS.BACKGROUND)
+          .test(/\.json$/)
+          .type('json')
+          .generator({
+            JSONParse: false,
+          })
+      }
     },
   })
 }

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -370,7 +370,7 @@ export function pluginReactLynx(
       applyCSS(api, resolvedOptions)
       applyEntry(api, resolvedOptions)
       applyBackgroundOnly(api)
-      applyGenerator(api)
+      applyGenerator(api, resolvedOptions)
       applyLoaders(api, resolvedOptions)
       applyRefresh(api)
       applySplitChunksRule(api)

--- a/packages/rspeedy/plugin-react/test/generator.test.ts
+++ b/packages/rspeedy/plugin-react/test/generator.test.ts
@@ -29,4 +29,45 @@ test('json generator in main-thread layer', async () => {
       JSONParse: false,
     },
   })
+  expect(config!.module!.rules).not.toContainEqual({
+    test: /\.json$/,
+    type: 'json',
+    issuerLayer: LAYERS.BACKGROUND,
+    generator: {
+      JSONParse: false,
+    },
+  })
+})
+
+test('json generator in dual-thread layer when extractStr is enabled', async () => {
+  const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+  const rsbuild = await createRsbuild({
+    rsbuildConfig: {
+      plugins: [
+        pluginStubRspeedyAPI(),
+        pluginReactLynx({
+          extractStr: true,
+        }),
+      ],
+    },
+  })
+
+  const [config] = await rsbuild.initConfigs()
+
+  expect(config!.module!.rules).toContainEqual({
+    test: /\.json$/,
+    type: 'json',
+    issuerLayer: LAYERS.MAIN_THREAD,
+    generator: {
+      JSONParse: false,
+    },
+  })
+  expect(config!.module!.rules).toContainEqual({
+    test: /\.json$/,
+    type: 'json',
+    issuerLayer: LAYERS.BACKGROUND,
+    generator: {
+      JSONParse: false,
+    },
+  })
 })


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In https://github.com/web-infra-dev/rspack/pull/9666, we added `module.generator.json.JSONParse` and set `JSONParse: false` for the main thread only to let AOT compilation speed up performance.

However, different `JSONParse` configurations in the main thread and the background thread will prevent `extractStr` from working properly.

 In this PR, when `extractStr` is enabled, we should set `JSONParse` to `false` in both the main and background threads.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
