### PR TITLE
feat(template-webpack-plugin): apply inlineScripts to WebEncodePlugin

### DIFF
--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -241,9 +241,17 @@ export function applyEntry(
     }
 
     if (isWeb) {
+      let inlineScripts
+      if (experimental_isLazyBundle) {
+        // TODO: support inlineScripts in lazyBundle
+        inlineScripts = true
+      } else {
+        inlineScripts = environment.config.output?.inlineScripts ?? true
+      }
+
       chain
         .plugin(PLUGIN_NAME_WEB)
-        .use(WebEncodePlugin, [])
+        .use(WebEncodePlugin, [{ inlineScripts }])
         .end()
     }
 

--- a/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
+++ b/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
@@ -171,10 +171,13 @@ export interface TemplateHooks {
 //
 // @public (undocumented)
 export class WebEncodePlugin {
+    constructor(options?: WebEncodePluginOptions);
     // (undocumented)
     apply(compiler: Compiler): void;
     // (undocumented)
     static BEFORE_ENCODE_HOOK_STAGE: number;
+    // (undocumented)
+    static defaultOptions: Readonly<Required<WebEncodePluginOptions>>;
     deleteDebuggingAssets(compilation: Compilation, assets: ({
         name: string;
     } | undefined)[]): void;
@@ -182,6 +185,18 @@ export class WebEncodePlugin {
     static ENCODE_HOOK_STAGE: number;
     // (undocumented)
     static name: string;
+    // (undocumented)
+    protected options: Required<WebEncodePluginOptions>;
+}
+
+// @public
+export interface WebEncodePluginOptions {
+    // (undocumented)
+    encodeBinary?: string;
+    // Warning: (ae-forgotten-export) The symbol "InlineChunkConfig_2" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    inlineScripts?: InlineChunkConfig_2 | undefined;
 }
 
 // Warnings were encountered during analysis:

--- a/packages/webpack/template-webpack-plugin/src/index.ts
+++ b/packages/webpack/template-webpack-plugin/src/index.ts
@@ -17,5 +17,6 @@ export type {
 export { LynxEncodePlugin } from './LynxEncodePlugin.js';
 export type { LynxEncodePluginOptions } from './LynxEncodePlugin.js';
 export { WebEncodePlugin } from './WebEncodePlugin.js';
+export type { WebEncodePluginOptions } from './WebEncodePlugin.js';
 export * as CSSPlugins from './css/plugins/index.js';
 export * as CSS from './css/index.js';

--- a/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/external/foo.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/external/foo.js
@@ -1,0 +1,3 @@
+export function foo() {
+  return 42;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/external/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/external/index.js
@@ -1,0 +1,39 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="vitest/globals" />
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+it('should have correct chunk content', async () => {
+  const { foo } = await import(
+    /* webpackChunkName: 'foo:background' */
+    './foo.js'
+  );
+  expect(foo()).toBe(42);
+});
+
+it('should generate correct web template with external scripts', async () => {
+  const outputPath = resolve(__dirname, 'main.bundle');
+  expect(existsSync(outputPath)).toBeTruthy();
+
+  const content = await readFile(outputPath, 'utf-8');
+  const bundleData = JSON.parse(content);
+
+  expect(bundleData).toHaveProperty('manifest');
+  expect(bundleData.manifest).toHaveProperty('/app-service.js');
+
+  // Check that external script file exists (this means scripts were not inlined)
+  const externalScriptPath = resolve(
+    __dirname,
+    'foo:background.rspack.bundle.js',
+  );
+  expect(existsSync(externalScriptPath)).toBeTruthy();
+
+  const externalContent = await readFile(externalScriptPath, 'utf-8');
+  expect(externalContent).toContain('function foo()');
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/external/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/external/rspack.config.js
@@ -1,0 +1,32 @@
+import { LynxTemplatePlugin, WebEncodePlugin } from '../../../../src';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  devtool: false,
+  mode: 'development',
+  plugins: [
+    new WebEncodePlugin({
+      inlineScripts: false,
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      intermediate: '.rspeedy/main',
+    }),
+    /**
+     * @param {import('@rspack/core').Compiler} compiler - Rspack Compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap('test', (compilation) => {
+        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+          compilation,
+        );
+        hooks.asyncChunkName.tap(
+          'test',
+          chunkName =>
+            chunkName
+              .replace(':background', ''),
+        );
+      });
+    },
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/inline/foo.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/inline/foo.js
@@ -1,0 +1,3 @@
+export function foo() {
+  return 42;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/inline/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/inline/index.js
@@ -1,0 +1,32 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="vitest/globals" />
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+it('should have correct chunk content', async () => {
+  const { foo } = await import(
+    /* webpackChunkName: 'foo:background' */
+    './foo.js'
+  );
+  expect(foo()).toBe(42);
+});
+
+it('should generate correct web template with inlined scripts', async () => {
+  const outputPath = resolve(__dirname, 'main.bundle');
+  expect(existsSync(outputPath)).toBeTruthy();
+
+  const content = await readFile(outputPath, 'utf-8');
+  const bundleData = JSON.parse(content);
+
+  expect(bundleData).toHaveProperty('manifest');
+  expect(bundleData.manifest).toHaveProperty('/app-service.js');
+
+  // When inlineScripts is true, the script content should be inlined
+  expect(bundleData.manifest['/app-service.js']).toContain('function foo()');
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/inline/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web-inline-scripts/inline/rspack.config.js
@@ -1,0 +1,32 @@
+import { LynxTemplatePlugin, WebEncodePlugin } from '../../../../src';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  devtool: false,
+  mode: 'development',
+  plugins: [
+    new WebEncodePlugin({
+      inlineScripts: true,
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      intermediate: '.rspeedy/main',
+    }),
+    /**
+     * @param {import('@rspack/core').Compiler} compiler - Rspack Compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap('test', (compilation) => {
+        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+          compilation,
+        );
+        hooks.asyncChunkName.tap(
+          'test',
+          chunkName =>
+            chunkName
+              .replace(':background', ''),
+        );
+      });
+    },
+  ],
+};


### PR DESCRIPTION
Closes #1228

## Summary

- Apply `inlineScripts` functionality to `WebEncodePlugin` to match the capabilities of `LynxEncodePlugin`. This feature allows fine-grained control over which scripts should be inlined into the web bundle versus kept as external files.
  
## Changes Made

### Core Implementation
  - **Added `WebEncodePluginOptions` interface** with `encodeBinary` and `inlineScripts` properties
  - **Implemented `InlineChunkConfig` type support** for boolean, RegExp, function, and object configurations
  - **Added constructor** to accept options with default values (`inlineScripts: true`, `encodeBinary: 'napi'`)
  - **Implemented `#shouldInlineScript` method** with identical logic to `LynxEncodePlugin`

## API Usage

  ```ts
  new WebEncodePlugin({
    inlineScripts: true,  // boolean
  })

  new WebEncodePlugin({
    inlineScripts: /background\.js$/,  // RegExp
  })

  new WebEncodePlugin({
    inlineScripts: ({ name, size }) => size < 1000,  // function
  })

  new WebEncodePlugin({
    inlineScripts: {  // object
      enable: true,
      test: /background\.js$/
    }
  })
```

## Checklist

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).

References
  - Based on patterns from #874 and #883 
