### PR TITLE
fix(testing-library): should switch to another thread when dispatching

### DIFF
--- a/.changeset/dull-moles-live.md
+++ b/.changeset/dull-moles-live.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/testing-environment": patch
+---
+
+Fix the thread switching bug in `lynx.getCoreContext` and `lynx.getJSContext`.

--- a/packages/testing-library/testing-environment/src/index.ts
+++ b/packages/testing-library/testing-environment/src/index.ts
@@ -142,16 +142,25 @@ function createPolyfills() {
     type,
     data,
   }) => {
-    const isMainThread = __MAIN_THREAD__;
-    lynxTestingEnv.switchToBackgroundThread();
+    const origin = __MAIN_THREAD__ ? 'CoreContext' : 'JSContext';
+    // Switch to another thread
+    if (origin === 'CoreContext') {
+      lynxTestingEnv.switchToBackgroundThread();
+    } else {
+      lynxTestingEnv.switchToMainThread();
+    }
 
     // Ensure the code is running on the background thread
     ee.emit(type, {
       data: data,
+      origin,
     });
 
-    if (isMainThread) {
+    // Finish executing, restore the original thread state
+    if (origin === 'CoreContext') {
       lynxTestingEnv.switchToMainThread();
+    } else {
+      lynxTestingEnv.switchToBackgroundThread();
     }
   };
   // @ts-ignore
@@ -224,6 +233,18 @@ function injectMainThreadGlobals(target?: any, polyfills?: any) {
   target.lynx = {
     performance,
     getCoreContext: (() => CoreContext),
+    /*
+
+    background thread -> main thread:
+    lynx.getJSContext().addEventListener("message", (e: Event) => {
+      console.log('message', e)
+      });
+    main thread -> background thread:
+    lynx.getJSContext().postMessage({
+      type: 'message',
+      data: [3, 4, 5]
+    });
+    */
     getJSContext: (() => JsContext),
     reportError: (e: Error) => {
       throw e;
@@ -321,6 +342,17 @@ function injectBackgroundThreadGlobals(target?: any, polyfills?: any) {
         },
       };
     }),
+    /*
+    main thread -> background thread:
+    lynx.getCoreContext().addEventListener("message", (e: Event) => {
+      console.log('message', e)
+    });
+    background thread -> main thread:
+    lynx.getCoreContext().postMessage({
+      type: 'message',
+      data: [1, 2, 3]
+    });
+    */
     getCoreContext: (() => CoreContext),
     getJSContext: (() => JsContext),
     getJSModule: (moduleName) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In the real Lynx App, `lynx.getCoreContext` and `lynx.getJSContext` works in the following way:

```js

if (__BACKGROUND__) {
  lynx.getCoreContext().addEventListener("message", (e: Event) => {
    console.log('message', e)
    // {
    //   "type": "message",
    //     "data": {
    //     "type": "message",
    //       "data": [
    //         4,
    //         5,
    //         6
    //       ]
    //   },
    //   "origin": "CoreContext"
    // }
  });
  lynx.getCoreContext().postMessage({
    type: 'message',
    data: [1, 2, 3]
  });
} else {
  lynx.getJSContext().addEventListener("message", (e: Event) => {
    console.log('message', e)
  });
  // {
  //   "type": "message",
  //     "data": {
  //     "type": "message",
  //       "data": [
  //         1,
  //         2,
  //         3
  //       ]
  //   },
  //   "origin": "JSContext"
  // }
  lynx.getJSContext().postMessage({
    type: 'message',
    data: [3, 4, 5]
  });
}
```

We should switch to another thread when `postMessage`/`dispatchEvent` is called

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
