### PR TITLE
feat: export startTransition to support tanstackRouter

### DIFF
--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -18,6 +18,7 @@ import {
   forwardRef,
   isValidElement,
   memo,
+  startTransition,
   useSyncExternalStore,
 } from 'preact/compat';
 
@@ -74,6 +75,7 @@ export default {
   forwardRef,
   Suspense,
   lazy,
+  startTransition,
   createElement,
 };
 
@@ -86,6 +88,7 @@ export {
   forwardRef,
   Suspense,
   lazy,
+  startTransition,
   createElement,
   cloneElement,
   useSyncExternalStore,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

[TanStack Router](https://tanstack.com/router/latest) relies on `React.startTransition`, so this PR exports it from `preact/compat`.

Related issues:
 #1127 and  https://github.com/lynx-family/lynx-stack/issues/735#issuecomment-2863301861

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
