### PR TITLE
feat: `extractStr` is only supported in `all-in-one` chunkSplit strategy

### DIFF
--- a/.changeset/twelve-dancers-learn.md
+++ b/.changeset/twelve-dancers-learn.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Throw error when `extractStr` is `true` and `chunkSplit.strategy` is not `all-in-one` since extracted string of different entries cannot be safely shared in a common chunk.

--- a/.changeset/twelve-dancers-learn.md
+++ b/.changeset/twelve-dancers-learn.md
@@ -2,4 +2,4 @@
 "@lynx-js/react-rsbuild-plugin": patch
 ---
 
-Throw error when `extractStr` is `true` and `chunkSplit.strategy` is not `all-in-one` since extracted string of different entries cannot be safely shared in a common chunk.
+Change `extractStr` to `false` when `performance.chunkSplit.strategy` is not `all-in-one`.

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -9,7 +9,6 @@ import type {
   RsbuildPluginAPI,
   Rspack,
 } from '@rsbuild/core'
-import { logger } from '@rsbuild/core'
 import type { UndefinedOnPartialDeep } from 'type-fest'
 
 import { LAYERS, ReactWebpackPlugin } from '@lynx-js/react-webpack-plugin'
@@ -60,7 +59,7 @@ export function applyEntry(
     experimental_isLazyBundle,
   } = options
 
-  const { config } = api.useExposed<ExposedAPI>(
+  const { config, logger } = api.useExposed<ExposedAPI>(
     Symbol.for('rspeedy.api'),
   )!
   api.modifyBundlerChain((chain, { environment, isDev, isProd }) => {

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -9,6 +9,7 @@ import type {
   RsbuildPluginAPI,
   Rspack,
 } from '@rsbuild/core'
+import { logger } from '@rsbuild/core'
 import type { UndefinedOnPartialDeep } from 'type-fest'
 
 import { LAYERS, ReactWebpackPlugin } from '@lynx-js/react-webpack-plugin'
@@ -54,7 +55,7 @@ export function applyEntry(
     pipelineSchedulerConfig,
     removeDescendantSelectorScope,
     targetSdkVersion,
-    extractStr,
+    extractStr: originalExtractStr,
 
     experimental_isLazyBundle,
   } = options
@@ -240,13 +241,15 @@ export function applyEntry(
 
     const rsbuildConfig = api.getRsbuildConfig()
 
+    let extractStr = originalExtractStr
     if (
-      extractStr
-      && rsbuildConfig.performance?.chunkSplit?.strategy !== 'all-in-one'
+      rsbuildConfig.performance?.chunkSplit?.strategy !== 'all-in-one'
+      && originalExtractStr
     ) {
-      throw new Error(
-        '`extractStr` is only supported in `all-in-one` chunkSplit strategy',
+      logger.warn(
+        '`extractStr` is changed to `false` because it is only supported in `all-in-one` chunkSplit strategy, please set `performance.chunkSplit.strategy` to `all-in-one` to use `extractStr.`',
       )
+      extractStr = false
     }
 
     chain

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -240,6 +240,15 @@ export function applyEntry(
 
     const rsbuildConfig = api.getRsbuildConfig()
 
+    if (
+      extractStr
+      && rsbuildConfig.performance?.chunkSplit?.strategy !== 'all-in-one'
+    ) {
+      throw new Error(
+        '`extractStr` is only supported in `all-in-one` chunkSplit strategy',
+      )
+    }
+
     chain
       .plugin(PLUGIN_NAME_REACT)
       .after(PLUGIN_NAME_TEMPLATE)

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -1437,6 +1437,8 @@ describe('Config', () => {
     test('performance.chunkSplit.strategy: "split-by-experience" along with extractStr: true', async () => {
       const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
 
+      let config, ReactLynxWebpackPlugin
+
       let rsbuild = await createRsbuild({
         rsbuildConfig: {
           plugins: [
@@ -1452,10 +1454,18 @@ describe('Config', () => {
           },
         },
       })
+      ;[config] = await rsbuild.initConfigs()
 
-      await expect(rsbuild.initConfigs()).rejects.toMatchInlineSnapshot(
-        `[Error: \`extractStr\` is only supported in \`all-in-one\` chunkSplit strategy]`,
+      ReactLynxWebpackPlugin = config?.plugins?.find((
+        p,
+      ): p is ReactWebpackPlugin =>
+        p?.constructor.name === 'ReactWebpackPlugin'
       )
+
+      // @ts-expect-error private field
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(ReactLynxWebpackPlugin?.options.extractStr).toBe(false)
+      // expect(config).toMatchInlineSnapshot()
 
       rsbuild = await createRsbuild({
         rsbuildConfig: {
@@ -1467,8 +1477,18 @@ describe('Config', () => {
           ],
         },
       })
+      ;[config] = await rsbuild.initConfigs()
 
-      await rsbuild.initConfigs()
+      ReactLynxWebpackPlugin = config?.plugins?.find((
+        p,
+      ): p is ReactWebpackPlugin =>
+        p?.constructor.name === 'ReactWebpackPlugin'
+      )
+
+      // @ts-expect-error private field
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(ReactLynxWebpackPlugin?.options.extractStr).toBe(true)
+      // expect(config).toMatchInlineSnapshot()
 
       rsbuild = await createRsbuild({
         rsbuildConfig: {
@@ -1485,8 +1505,18 @@ describe('Config', () => {
           },
         },
       })
+      ;[config] = await rsbuild.initConfigs()
 
-      await rsbuild.initConfigs()
+      ReactLynxWebpackPlugin = config?.plugins?.find((
+        p,
+      ): p is ReactWebpackPlugin =>
+        p?.constructor.name === 'ReactWebpackPlugin'
+      )
+
+      // @ts-expect-error private field
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(ReactLynxWebpackPlugin?.options.extractStr).toBe(true)
+      // expect(config).toMatchInlineSnapshot()
     })
 
     test('tools.rspack.optimization.splitChunks: false', async () => {

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -1434,6 +1434,61 @@ describe('Config', () => {
         `)
     })
 
+    test('performance.chunkSplit.strategy: "split-by-experience" along with extractStr: true', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+      let rsbuild = await createRsbuild({
+        rsbuildConfig: {
+          plugins: [
+            pluginReactLynx({
+              extractStr: true,
+            }),
+            pluginStubRspeedyAPI(),
+          ],
+          performance: {
+            chunkSplit: {
+              strategy: 'split-by-experience',
+            },
+          },
+        },
+      })
+
+      await expect(rsbuild.initConfigs()).rejects.toMatchInlineSnapshot(
+        `[Error: \`extractStr\` is only supported in \`all-in-one\` chunkSplit strategy]`,
+      )
+
+      rsbuild = await createRsbuild({
+        rsbuildConfig: {
+          plugins: [
+            pluginReactLynx({
+              extractStr: true,
+            }),
+            pluginStubRspeedyAPI(),
+          ],
+        },
+      })
+
+      await rsbuild.initConfigs()
+
+      rsbuild = await createRsbuild({
+        rsbuildConfig: {
+          plugins: [
+            pluginReactLynx({
+              extractStr: true,
+            }),
+            pluginStubRspeedyAPI(),
+          ],
+          performance: {
+            chunkSplit: {
+              strategy: 'all-in-one',
+            },
+          },
+        },
+      })
+
+      await rsbuild.initConfigs()
+    })
+
     test('tools.rspack.optimization.splitChunks: false', async () => {
       const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In chunk split, `extractStr` will not work as expected. So we will report an error on both `extractStr` and chunk split is enabled.

For example, if a `lib-preact` is shared by entry A and entry B, they have different `__EXTRACT_STR__` array and index. if `lib-preact` follows the `__EXTRACT_STR__` of entry A, it will not work an entry B.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * String extraction is now automatically disabled when the chunk splitting strategy is not "all-in-one".
  * A warning message is shown when string extraction is forcibly disabled due to an incompatible chunk splitting strategy.

* **Tests**
  * Added tests to verify string extraction behavior across different chunk splitting strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->