### PR TITLE
fix(rspeedy/core): remove all `NODE_ENV`

### DIFF
--- a/.changeset/every-boxes-help.md
+++ b/.changeset/every-boxes-help.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Fix `rspeedy build --mode development` failed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,10 +147,12 @@ jobs:
         cd create-rspeedy-regression
         pnpm install --registry=http://localhost:4873
         pnpm run build
+        pnpm run build --mode development
         npx --registry http://localhost:4873 create-rspeedy-canary@latest --template react-vitest-rltl --dir create-rspeedy-regression-vitest-rltl
         cd create-rspeedy-regression-vitest-rltl
         pnpm install --registry=http://localhost:4873
         pnpm run build
+        pnpm run build --mode development
         pnpm run test
   test-react:
     needs: build

--- a/packages/rspeedy/core/src/cli/inspect.ts
+++ b/packages/rspeedy/core/src/cli/inspect.ts
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 import { logger } from '@rsbuild/core'
-import type { RsbuildMode } from '@rsbuild/core'
 import type { Command } from 'commander'
 
 import type { CommonOptions } from './commands.js'
@@ -27,7 +26,7 @@ export async function inspect(
 
     await rspeedy.inspectConfig({
       mode: inspectOptions.mode
-        ?? process.env['NODE_ENV'] as RsbuildMode
+        ?? rspeedy.getRspeedyConfig().mode
         ?? 'development',
       verbose: inspectOptions.verbose ?? false,
       outputPath: inspectOptions.output!,

--- a/packages/rspeedy/core/src/config/defaults.ts
+++ b/packages/rspeedy/core/src/config/defaults.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { mergeRsbuildConfig } from '@rsbuild/core'
+import type { RsbuildMode } from '@rsbuild/core'
 
 import type { Filename } from './output/filename.js'
 
@@ -9,6 +10,15 @@ import type { Config } from './index.js'
 
 export function applyDefaultRspeedyConfig(config: Config): Config {
   const ret = mergeRsbuildConfig({
+    mode: ((): RsbuildMode => {
+      if (config.mode) {
+        return config.mode
+      }
+      const nodeEnv = process.env['NODE_ENV']
+      return nodeEnv === 'production' || nodeEnv === 'development'
+        ? nodeEnv
+        : 'none'
+    })(),
     output: {
       // We are applying the default filename to the config
       // since some plugin(e.g.: `@lynx-js/qrcode-rsbuild-plugin`) will read

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -81,8 +81,7 @@ export async function applyDefaultPlugins(
     }),
   ]
 
-  // TODO: replace with `isDev()` helper
-  if (process.env['NODE_ENV'] === 'development') {
+  if (config.mode === 'development') {
     debug('apply Rspeedy default development plugins')
     promises.push(applyDefaultDevPlugins(rsbuildInstance, config))
   }

--- a/packages/rspeedy/core/src/plugins/swc.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/swc.plugin.ts
@@ -11,6 +11,7 @@ export function pluginSwc(): RsbuildPlugin {
     name: 'lynx:rsbuild:swc',
     setup(api) {
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+        const isProd = config.mode === 'production'
         return mergeRsbuildConfig(config, {
           tools: {
             swc(config) {
@@ -19,7 +20,7 @@ export function pluginSwc(): RsbuildPlugin {
               config.jsc ??= {}
 
               // TODO(target): use configuration
-              config.jsc.target = getESVersionTarget()
+              config.jsc.target = getESVersionTarget(isProd)
             },
           },
         })

--- a/packages/rspeedy/core/src/plugins/target.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/target.plugin.ts
@@ -11,15 +11,15 @@ export function pluginTarget(): RsbuildPlugin {
   return {
     name: 'lynx:rsbuild:target',
     setup(api) {
-      api.modifyBundlerChain((options, { environment }) => {
+      api.modifyBundlerChain((options, { environment, isProd }) => {
         if (isWeb(environment)) {
           options.target([
-            getESVersionTarget(),
+            getESVersionTarget(isProd),
             // Add `target: 'web'` to make Rsbuild inject HMR related code.
             'web',
           ])
         } else {
-          options.target([getESVersionTarget()])
+          options.target([getESVersionTarget(isProd)])
         }
       })
     },

--- a/packages/rspeedy/core/src/utils/getESVersionTarget.ts
+++ b/packages/rspeedy/core/src/utils/getESVersionTarget.ts
@@ -1,6 +1,6 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-export function getESVersionTarget(): 'es2015' | 'es2019' {
-  return process.env['NODE_ENV'] === 'production' ? 'es2015' : 'es2019'
+export function getESVersionTarget(isProd: boolean): 'es2015' | 'es2019' {
+  return isProd ? 'es2015' : 'es2019'
 }

--- a/packages/rspeedy/core/test/cli/build.test.ts
+++ b/packages/rspeedy/core/test/cli/build.test.ts
@@ -294,7 +294,7 @@ describe('CLI - build', () => {
       expect(core.createRsbuild).toBeCalledWith(expect.objectContaining({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         rsbuildConfig: expect.objectContaining({
-          mode: undefined,
+          mode: 'production',
         }),
       }))
     })

--- a/packages/rspeedy/core/test/plugins/swc.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/swc.plugin.test.ts
@@ -9,7 +9,44 @@ import { getLoaderOptions } from '../getLoaderOptions.js'
 
 describe('Plugins - SWC', () => {
   test('defaults', async () => {
-    const rsbuild = await createStubRspeedy({})
+    const rsbuild = await createStubRspeedy({
+      mode: 'production',
+    })
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(getLoaderOptions(config, 'builtin:swc-loader'))
+      .toMatchInlineSnapshot(`
+        {
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<WORKSPACE>/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "output": {
+              "charset": "utf8",
+            },
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "target": "es2015",
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        }
+      `)
+  })
+
+  test('defaults development', async () => {
+    const rsbuild = await createStubRspeedy({
+      mode: 'development',
+    })
 
     const config = await rsbuild.unwrapConfig()
 

--- a/website/docs/en/guide/cli.md
+++ b/website/docs/en/guide/cli.md
@@ -171,7 +171,7 @@ Inspect Rspeedy config succeed, open following files to view the content:
 
 ### Specifying Mode
 
-By default, the inspect command outputs the configuration for the development mode. You can add the `--env production` option to output the configuration for the production mode:
+By default, the inspect command outputs the configuration for the development mode. You can add the `--mode production` option to output the configuration for the production mode:
 
 ```bash
 rspeedy inspect --mode production

--- a/website/docs/zh/guide/cli.md
+++ b/website/docs/zh/guide/cli.md
@@ -169,7 +169,7 @@ Inspect Rspeedy config succeed, open following files to view the content:
 
 ### 指定模式
 
-默认情况下，inspect 命令会输出开发模式的配置。可以通过添加 `--env production` 选项来输出生产模式的配置：
+默认情况下，inspect 命令会输出开发模式的配置。可以通过添加 `--mode production` 选项来输出生产模式的配置：
 
 ```bash
 rspeedy inspect --mode production


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Use `config.mode` instead of `NODE_ENV`.

This would make `rspeedy build --mode development` and `mode: 'development'` in `lynx.config.js` work.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

See: https://github.com/lynx-family/lynx-stack/actions/runs/16141963144/job/45551741090?pr=1246

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
