### PR TITLE
fix(webpack/react-refresh): make `mode: 'development'` work

### DIFF
--- a/.changeset/easy-parts-follow.md
+++ b/.changeset/easy-parts-follow.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-refresh-webpack-plugin": patch
+---
+
+Should apply the plugin when using `mode: 'development'` with `NODE_ENV=production`.

--- a/packages/webpack/react-refresh-webpack-plugin/src/ReactRefreshRspackPlugin.ts
+++ b/packages/webpack/react-refresh-webpack-plugin/src/ReactRefreshRspackPlugin.ts
@@ -117,10 +117,10 @@ export class ReactRefreshRspackPlugin {
    * @param compiler - the rspack compiler
    */
   apply(compiler: Compiler): void {
-    if (
-      process.env['NODE_ENV'] === 'production'
-      || compiler.options.mode === 'production'
-    ) {
+    const isDev = process.env['NODE_ENV'] === 'development'
+      || compiler.options.mode === 'development';
+
+    if (!isDev) {
       return;
     }
 

--- a/packages/webpack/react-refresh-webpack-plugin/src/ReactRefreshWebpackPlugin.ts
+++ b/packages/webpack/react-refresh-webpack-plugin/src/ReactRefreshWebpackPlugin.ts
@@ -96,10 +96,10 @@ export class ReactRefreshWebpackPlugin {
    * @param compiler - the webpack compiler
    */
   apply(compiler: Compiler): void {
-    if (
-      process.env['NODE_ENV'] === 'production'
-      || compiler.options.mode === 'production'
-    ) {
+    const isDev = process.env['NODE_ENV'] === 'development'
+      || compiler.options.mode === 'development';
+
+    if (!isDev) {
       return;
     }
 


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Should apply the refresh plugin when `mode: 'development'` is set or `rspeedy build --mode development` is used.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

See: https://github.com/lynx-family/lynx-stack/actions/runs/16141963144/job/45551741090?pr=1246

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
