### PR TITLE
chore: enable `strictDepBuilds: true`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,11 +37,11 @@ overrides:
   "@rsbuild/core>@rspack/core": "$@rspack/core"
   "path-serializer": "^0.5.0"
 
-strictDepBuilds: true
-
 patchedDependencies:
   "@napi-rs/cli@2.18.4": "patches/@napi-rs__cli@2.18.4.patch"
   "@rollup/plugin-typescript": "patches/@rollup__plugin-typescript.patch"
+
+strictDepBuilds: true
 
 onlyBuiltDependencies:
   - dprint

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,5 +49,7 @@ onlyBuiltDependencies:
   - wasm-pack
 
 ignoredBuiltDependencies:
+  - "@biomejs/biome"
+  - "@swc/core"
   - core-js
   - unrs-resolver

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,8 @@ overrides:
   "@rsbuild/core>@rspack/core": "$@rspack/core"
   "path-serializer": "^0.5.0"
 
+strictDepBuilds: true
+
 patchedDependencies:
   "@napi-rs/cli@2.18.4": "patches/@napi-rs__cli@2.18.4.patch"
   "@rollup/plugin-typescript": "patches/@rollup__plugin-typescript.patch"
@@ -44,6 +46,7 @@ patchedDependencies:
 onlyBuiltDependencies:
   - dprint
   - esbuild
+  - wasm-pack
 
 ignoredBuiltDependencies:
   - core-js


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Enforce all dependencies with `postinstall` to be reviewed.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

See: https://pnpm.io/settings#strictdepbuilds

> When `strictDepBuilds` is enabled, the installation will exit with a non-zero exit code if any dependencies have unreviewed build scripts (aka postinstall scripts).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency build settings to enforce stricter builds and refine which dependencies are built or ignored. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->