### PR TITLE
feat: support to dump the css og system's style

### DIFF
--- a/.changeset/hot-plants-accept.md
+++ b/.changeset/hot-plants-accept.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/offscreen-document": patch
+"@lynx-js/web-core-server": patch
+---
+
+feat: support to dump the css og system's style

--- a/packages/web-platform/offscreen-document/src/webworker/OffscreenElement.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/OffscreenElement.ts
@@ -13,6 +13,7 @@ export const ancestorDocument = Symbol('ancestorDocument');
 export const _attributes = Symbol('_attributes');
 export const _children = Symbol('_children');
 export const innerHTML = Symbol('innerHTML');
+export const _cssRuleContents = Symbol('_cssRuleContents');
 export const uniqueId = Symbol('uniqueId');
 const _style = Symbol('_style');
 
@@ -26,6 +27,7 @@ export class OffscreenElement extends EventTarget {
   private readonly [_attributes] = new Map<string, string>();
   private _parentElement: OffscreenElement | null = null;
   readonly [_children]: OffscreenElement[] = [];
+  [_cssRuleContents]?: string[];
   #sheet?: OffscreenStyleSheet;
   /**
    * @private
@@ -68,6 +70,10 @@ export class OffscreenElement extends EventTarget {
               },
             },
           });
+          if (!this[_cssRuleContents]) {
+            this[_cssRuleContents] = [];
+          }
+          this[_cssRuleContents].splice(index, 0, rule);
           this[ancestorDocument][operations].push(
             OperationType.sheetInsertRule,
             uid,
@@ -279,5 +285,8 @@ export class OffscreenElement extends EventTarget {
       (child as OffscreenElement).remove();
     }
     this[innerHTML] = text;
+    if (this[_cssRuleContents]) {
+      this[_cssRuleContents] = [];
+    }
   }
 }

--- a/packages/web-platform/offscreen-document/src/webworker/index.ts
+++ b/packages/web-platform/offscreen-document/src/webworker/index.ts
@@ -6,6 +6,7 @@ export {
   _attributes,
   innerHTML,
   _children,
+  _cssRuleContents,
   OffscreenElement,
 } from './OffscreenElement.js';
 export type * from './OffscreenEvent.js';

--- a/packages/web-platform/web-core-server/src/dumpHTMLString.ts
+++ b/packages/web-platform/web-core-server/src/dumpHTMLString.ts
@@ -2,6 +2,7 @@ import {
   _attributes,
   _children,
   innerHTML,
+  _cssRuleContents,
   type OffscreenDocument,
   type OffscreenElement,
 } from '@lynx-js/offscreen-document/webworker';
@@ -36,6 +37,9 @@ function getInnerHTMLImpl(
       ? templateImpl(Object.fromEntries(element[_attributes].entries()))
       : templateImpl;
     buffer.push('<template shadowrootmode="open">', template, '</template>');
+  }
+  if (element[_cssRuleContents]?.length) {
+    buffer.push(...element[_cssRuleContents]);
   }
   if (element[innerHTML]) {
     buffer.push(element[innerHTML]);

--- a/packages/web-platform/web-tests/tests/server.vitest.spec.ts
+++ b/packages/web-platform/web-tests/tests/server.vitest.spec.ts
@@ -14,4 +14,9 @@ describe('server-tests', () => {
       expect(html).toMatchSnapshot();
     });
   }
+
+  test('config-css-selector-false-exchange-class', async () => {
+    const html = await genTemplate('config-css-selector-false-exchange-class');
+    expect(html).toContain('[l-uid="2"]');
+  });
 });


### PR DESCRIPTION
Implement SSR for Web #52


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including CSS rule contents when dumping the system's style as part of HTML output.

* **Tests**
  * Introduced a new test to verify that CSS rule contents are correctly included in the dumped HTML string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->