### PR TITLE
chore: remove `wasm-pack` from npm dependencies

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -37,6 +37,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@9ca1734d8940023f074414ee621fd530c4ce10f2 # v2
+        with:
+          tool: wasm-pack
       - name: Install
         run: |
           npm install -g corepack@latest

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -37,10 +37,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
-      - name: Install wasm-pack
+      - name: Install wasm-bindgen and wasm-pack
         uses: taiki-e/install-action@9ca1734d8940023f074414ee621fd530c4ce10f2 # v2
         with:
-          tool: wasm-pack
+          tool: wasm-bindgen,wasm-pack
       - name: Install
         run: |
           npm install -g corepack@latest

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -95,10 +95,10 @@ jobs:
             turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
             turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-
             turbo-v4-${{ runner.os }}-
-      - name: Install wasm-pack
+      - name: Install wasm-bindgen and wasm-pack
         uses: taiki-e/install-action@9ca1734d8940023f074414ee621fd530c4ce10f2 # v2
         with:
-          tool: wasm-pack
+          tool: wasm-bindgen,wasm-pack
       - name: Install
         run: |
           npm install -g corepack@latest

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -95,6 +95,10 @@ jobs:
             turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
             turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-
             turbo-v4-${{ runner.os }}-
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@9ca1734d8940023f074414ee621fd530c4ce10f2 # v2
+        with:
+          tool: wasm-pack
       - name: Install
         run: |
           npm install -g corepack@latest

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -22,9 +22,6 @@
     "README.md"
   ],
   "scripts": {
-    "build": "wasm-pack build --target web --out-dir dist --out-name index"
-  },
-  "devDependencies": {
-    "wasm-pack": "^0.13.1"
+    "build": "cargo install wasm-pack && wasm-pack build --target web --out-dir dist --out-name index"
   }
 }

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -22,6 +22,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "cargo install wasm-pack && wasm-pack build --target web --out-dir dist --out-name index"
+    "build": "wasm-pack build --target web --out-dir dist --out-name index",
+    "build:wasm-pack": "wasm-pack --version || cargo install wasm-pack"
   }
 }

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "wasm-pack build --target web --out-dir dist --out-name index --mode no-install",
-    "build:wasm-bindgen": "wasm-bindgen --version || cargo install wasm-bindgen",
+    "build:wasm-bindgen": "wasm-bindgen --version || cargo install wasm-bindgen-cli",
     "build:wasm-pack": "wasm-pack --version || cargo install wasm-pack"
   }
 }

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -22,7 +22,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "wasm-pack build --target web --out-dir dist --out-name index",
+    "build": "wasm-pack build --target web --out-dir dist --out-name index --mode no-install",
     "build:wasm-pack": "wasm-pack --version || cargo install wasm-pack"
   }
 }

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "build": "wasm-pack build --target web --out-dir dist --out-name index --mode no-install",
+    "build:wasm-bindgen": "wasm-bindgen --version || cargo install wasm-bindgen",
     "build:wasm-pack": "wasm-pack --version || cargo install wasm-pack"
   }
 }

--- a/packages/web-platform/web-style-transformer/turbo.json
+++ b/packages/web-platform/web-style-transformer/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": [
-        "^build"
+        "build:wasm-pack"
       ],
       "inputs": [
         "src"
@@ -12,6 +12,10 @@
       "outputs": [
         "dist"
       ]
+    },
+    "build:wasm-pack": {
+      "dependsOn": [],
+      "cache": false
     }
   }
 }

--- a/packages/web-platform/web-style-transformer/turbo.json
+++ b/packages/web-platform/web-style-transformer/turbo.json
@@ -15,7 +15,8 @@
     },
     "build:wasm-pack": {
       "dependsOn": [],
-      "cache": false
+      "inputs": [],
+      "outputs": []
     }
   }
 }

--- a/packages/web-platform/web-style-transformer/turbo.json
+++ b/packages/web-platform/web-style-transformer/turbo.json
@@ -4,6 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": [
+        "build:wasm-bindgen",
         "build:wasm-pack"
       ],
       "inputs": [
@@ -12,6 +13,11 @@
       "outputs": [
         "dist"
       ]
+    },
+    "build:wasm-bindgen": {
+      "dependsOn": [],
+      "inputs": [],
+      "outputs": []
     },
     "build:wasm-pack": {
       "dependsOn": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,11 +787,7 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.33)(@vitest/ui@3.2.4)(jsdom@26.1.0)(sass-embedded@1.89.2)(terser@5.31.6)
 
-  packages/web-platform/web-style-transformer:
-    devDependencies:
-      wasm-pack:
-        specifier: ^0.13.1
-        version: 0.13.1
+  packages/web-platform/web-style-transformer: {}
 
   packages/web-platform/web-tests:
     devDependencies:
@@ -3577,9 +3573,6 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@0.26.1:
-    resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
-
   axios@1.10.0:
     resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
 
@@ -3618,10 +3611,6 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  binary-install@1.1.0:
-    resolution: {integrity: sha512-rkwNGW+3aQVSZoD0/o3mfPN6Yxh3Id0R/xzTVBVVpGNlVz8EGwusksxRlbk/A5iKTZt9zkMn3qIqmAt3vpfbzg==}
-    engines: {node: '>=10'}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -3777,10 +3766,6 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
-
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -4861,10 +4846,6 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
-
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -6083,26 +6064,9 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   motion-dom@12.18.1:
     resolution: {integrity: sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==}
@@ -7606,10 +7570,6 @@ packages:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -8073,10 +8033,6 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
-
-  wasm-pack@0.13.1:
-    resolution: {integrity: sha512-P9exD4YkjpDbw68xUhF3MDm/CC/3eTmmthyG5bHJ56kalxOTewOunxTke4SyF8MTXV6jUtNjXggPgrGmMtczGg==}
-    hasBin: true
 
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
@@ -11059,12 +11015,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  axios@0.26.1:
-    dependencies:
-      follow-redirects: 1.15.6
-    transitivePeerDependencies:
-      - debug
-
   axios@1.10.0:
     dependencies:
       follow-redirects: 1.15.6
@@ -11119,14 +11069,6 @@ snapshots:
   big.js@5.2.2: {}
 
   binary-extensions@2.3.0: {}
-
-  binary-install@1.1.0:
-    dependencies:
-      axios: 0.26.1
-      rimraf: 3.0.2
-      tar: 6.2.1
-    transitivePeerDependencies:
-      - debug
 
   bl@4.1.0:
     dependencies:
@@ -11306,8 +11248,6 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.0.2
-
-  chownr@2.0.0: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -12565,10 +12505,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
 
   fs.realpath@1.0.0: {}
 
@@ -14213,20 +14149,7 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  minipass@5.0.0: {}
-
   minipass@7.1.2: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-
-  mkdirp@1.0.4: {}
 
   motion-dom@12.18.1:
     dependencies:
@@ -15875,15 +15798,6 @@ snapshots:
 
   tapable@2.2.2: {}
 
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-
   term-size@2.2.1: {}
 
   terser-webpack-plugin@5.3.14(@swc/core@1.7.35(@swc/helpers@0.5.17))(webpack@5.99.9(@swc/core@1.7.35(@swc/helpers@0.5.17))):
@@ -16392,12 +16306,6 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
-
-  wasm-pack@0.13.1:
-    dependencies:
-      binary-install: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   watchpack@2.4.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,7 +46,6 @@ strictDepBuilds: true
 onlyBuiltDependencies:
   - dprint
   - esbuild
-  - wasm-pack
 
 ignoredBuiltDependencies:
   - "@biomejs/biome"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment workflows to ensure the `wasm-pack` and `wasm-bindgen` tools are installed automatically.
  * Modified package scripts to check for and install `wasm-pack` and `wasm-bindgen` if missing.
  * Adjusted build task dependencies for improved clarity and maintainability.
  * Cleaned up dependency configurations related to `wasm-pack`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->