### PR TITLE
feat: add support for __MarkTemplateElement, __MarkPartElement, and __GetTemplateParts in all-on-ui

### DIFF
--- a/.changeset/odd-carrots-slide.md
+++ b/.changeset/odd-carrots-slide.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+feat: support \_\_MarkTemplateElement, \_\_MarkPartElement and \_\_GetTemplateParts for all-on-ui

--- a/packages/web-platform/web-constants/src/constants.ts
+++ b/packages/web-platform/web-constants/src/constants.ts
@@ -18,6 +18,10 @@ export const lynxComponentConfigAttribute = 'l-comp-cfg' as const;
 
 export const lynxDisposedAttribute = 'l-disposed' as const;
 
+export const lynxElementTemplateMarkerAttribute = 'l-template' as const;
+
+export const lynxPartIdAttribute = 'l-part' as const;
+
 export const lynxDefaultDisplayLinearAttribute =
   'lynx-default-display-linear' as const;
 

--- a/packages/web-platform/web-constants/src/types/Element.ts
+++ b/packages/web-platform/web-constants/src/types/Element.ts
@@ -49,6 +49,7 @@ export interface ElementAnimationOptions {
 }
 
 export interface WebFiberElementImpl {
+  querySelectorAll?: (selectors: string) => WebFiberElementImpl[];
   getAttributeNames: () => string[];
   getAttribute: (name: string) => string | null;
   setAttribute: (name: string, value: string) => void;

--- a/packages/web-platform/web-constants/src/types/MainThreadGlobalThis.ts
+++ b/packages/web-platform/web-constants/src/types/MainThreadGlobalThis.ts
@@ -62,7 +62,7 @@ export type FirstElementPAPI = (
 
 export type GetChildrenPAPI = (
   element: WebFiberElementImpl,
-) => WebFiberElementImpl[];
+) => WebFiberElementImpl[] | null;
 
 export type GetParentPAPI = (
   element: WebFiberElementImpl,
@@ -263,15 +263,29 @@ export type SetCSSIdPAPI = (
 
 export type GetPageElementPAPI = () => WebFiberElementImpl | undefined;
 
+export type MarkTemplateElementPAPI = (
+  element: WebFiberElementImpl,
+) => void;
+
+export type MarkPartElementPAPI = (
+  element: WebFiberElementImpl,
+  partId: string,
+) => void;
+
 export type GetTemplatePartsPAPI = (
   templateElement: WebFiberElementImpl,
-) => Record<string, WebFiberElementImpl> | undefined;
+) => Record<string, WebFiberElementImpl>;
 
 interface JSErrorInfo {
   release: string;
 }
 
 export interface MainThreadGlobalThis {
+  // __GetTemplateParts currently only provied by the thread-strategy = "all-on-ui" (default)
+  __GetTemplateParts?: GetTemplatePartsPAPI;
+
+  __MarkPartElement: MarkPartElementPAPI;
+  __MarkTemplateElement: MarkTemplateElementPAPI;
   __AddEvent: AddEventPAPI;
   __GetEvent: GetEventPAPI;
   __GetEvents: GetEventsPAPI;
@@ -322,7 +336,6 @@ export interface MainThreadGlobalThis {
   __SetInlineStyles: SetInlineStylesPAPI;
   __SetCSSId: SetCSSIdPAPI;
   __GetPageElement: GetPageElementPAPI;
-  __GetTemplateParts: GetTemplatePartsPAPI;
   __globalProps: unknown;
   SystemInfo: typeof systemInfo;
   globalThis?: MainThreadGlobalThis;

--- a/packages/web-platform/web-constants/src/utils/generateTemplate.ts
+++ b/packages/web-platform/web-constants/src/utils/generateTemplate.ts
@@ -65,6 +65,9 @@ const mainThreadInjectVars = [
   'SystemInfo',
   '_I18nResourceTranslation',
   '_AddEventListener',
+  '__GetElementParts',
+  '__MarkPartElement',
+  '__GetTemplateParts',
 ];
 
 const backgroundInjectVars = [

--- a/packages/web-platform/web-mainthread-apis/src/pureElementPAPIs.ts
+++ b/packages/web-platform/web-mainthread-apis/src/pureElementPAPIs.ts
@@ -64,7 +64,7 @@ export const __FirstElement: FirstElementPAPI = /*#__PURE__*/ (
 
 export const __GetChildren: GetChildrenPAPI = /*#__PURE__*/ (
   element,
-) => element.children;
+) => element.children ? [...element.children] : null;
 
 export const __GetParent: GetParentPAPI = /*#__PURE__*/ (
   element,

--- a/packages/web-platform/web-tests/playwright.config.ts
+++ b/packages/web-platform/web-tests/playwright.config.ts
@@ -20,7 +20,7 @@ const testMatch: string | undefined = (() => {
     return '**/fp-only.spec.ts';
   }
   if (enableMultiThread || enableSSR) {
-    return '**/{react,web-core}.{test,spec}.ts';
+    return '**/{react,web-core,main-thread-apis}.{test,spec}.ts';
   }
   return undefined;
 })();


### PR DESCRIPTION

mark template elements in lynx by using a lynxElementTemplateMarkerAttribute attribute 

mark and save part elements in lynx by using a lynxPartIdAttribute

use a querySelectorAll to impl the "get parts"

#52 