### PR TITLE
fix: missing comma in app-service manifest on chunk split

### DIFF
--- a/.changeset/dry-candies-fetch.md
+++ b/.changeset/dry-candies-fetch.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Fix the `Syntax Error: expecting ';'` error of chunk splitting

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -187,7 +187,7 @@ export class LynxEncodePluginImpl {
           // ```
           '/app-service.js': [
             this.#appServiceBanner(),
-            ...[externalManifest, inlinedManifest].flatMap(manifest =>
+            [externalManifest, inlinedManifest].flatMap(manifest =>
               Object.keys(manifest).map(name => {
                 if (manifest === externalManifest) {
                   return `lynx.requireModuleAsync('${
@@ -199,7 +199,7 @@ export class LynxEncodePluginImpl {
                   }',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')`;
                 }
               }).join(',')
-            ),
+            ).filter(arr => arr.length).join(','),
             this.#appServiceFooter(),
           ].join(''),
           ...Object.fromEntries(

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/bar.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/bar.js
@@ -1,0 +1,3 @@
+export function bar() {
+  return 52;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/foo.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/foo.js
@@ -1,0 +1,3 @@
+export function foo() {
+  return 42;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/index.js
@@ -1,0 +1,29 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="vitest/globals" />
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { foo } from './foo.js';
+import { bar } from './bar.js';
+
+it('should generate correct foo template', async () => {
+  expect(foo()).toBe(42);
+  expect(bar()).toBe(52);
+
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/main/tasm.json');
+  expect(existsSync(tasmJSONPath)).toBeTruthy();
+
+  const content = await readFile(tasmJSONPath, 'utf-8');
+  const { manifest } = JSON.parse(content);
+
+  expect(manifest).toHaveProperty('/app-service.js');
+  expect(Object.keys(manifest).length).toBe(2);
+  expect(manifest['/app-service.js']).toBeTruthy();
+  expect(manifest['/foo.js']).toBeTruthy();
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/rspack.config.js
@@ -1,0 +1,45 @@
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../src';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  devtool: false,
+  mode: 'development',
+  output: {
+    filename: (...args) => {
+      if (args[0].chunk.name === 'main') {
+        return 'rspack.bundle.js';
+      }
+      return '[name].js';
+    },
+  },
+  optimization: {
+    splitChunks: {
+      chunks: function(chunk) {
+        return !chunk.name?.includes('__main-thread');
+      },
+      cacheGroups: {
+        foo: {
+          test: /foo\.js/,
+          priority: 0,
+          name: 'foo',
+          enforce: true,
+        },
+        bar: {
+          test: /bar\.js/,
+          priority: 0,
+          name: 'bar',
+          enforce: true,
+        },
+      },
+    },
+  },
+  plugins: [
+    new LynxEncodePlugin({
+      inlineScripts: /(foo|main)\.js$/,
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      intermediate: '.rspeedy/main',
+    }),
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/test.config.cjs
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/test.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'rspack.bundle.js',
+  ],
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Current when config regex `inlineScripts` config, we may get a wrong result such as:

```js
(function(){'use strict';function n({tt}){tt.define('/app-service.js',function(e,module,_,i,l,u,a,c,s,f,p,d,h,v,g,y,lynx){lynx.requireModuleAsync('http://1.1.1.1:8787/static/js/lib-preact-2.js')module.exports=lynx.requireModule('/.rspeedy/pages/product-list/background.e247bc2d.js',globDynamicComponentEntry?globDynamicComponentEntry:'__Card__')});return tt.require('/app-service.js');}return{init:n}})()

```

<img width="1140" height="238" alt="image" src="https://github.com/user-attachments/assets/74137458-cbe7-4240-ba11-fdd716dad39c" />

It misses a comma before the `module.exports`

<img width="1384" height="244" alt="image" src="https://github.com/user-attachments/assets/4db1677f-7d38-4538-bb4d-ba34cb894b82" />



## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
