### PR TITLE
fix(react): remove and insert `list-item`s those `item-key` have been changed

### DIFF
--- a/.changeset/shaky-swans-end.md
+++ b/.changeset/shaky-swans-end.md
@@ -2,7 +2,7 @@
 "@lynx-js/react": patch
 ---
 
-Remove and insert `list-item`s those `item-key` have been changed.
+Remove and insert `list-item`s whose `item-key` have been changed.
 
 For example:
 

--- a/.changeset/shaky-swans-end.md
+++ b/.changeset/shaky-swans-end.md
@@ -1,0 +1,16 @@
+---
+"@lynx-js/react": patch
+---
+
+Remove and insert `list-item`s those `item-key` have been changed.
+
+For example:
+
+```diff
+-<list-item key={key /* "key1" */} item-key={itemKey /* "0xAFDFDA" */}>
++<list-item key={key /* "key1" */} item-key={itemKey /* "0xAFDFDB" */}>
+  ...
+</list-item>
+```
+
+the item-key has been changed from `0xAFDFDA` to `0xAFDFDB`, but the key remains the same. ReactLynx will think the item is the same and will not remove and insert it, but list in Lynx Engine will think the item is different and will expect it to be removed and inserted.

--- a/packages/react/runtime/__test__/list.test.jsx
+++ b/packages/react/runtime/__test__/list.test.jsx
@@ -375,6 +375,50 @@ describe(`list "update-list-info"`, () => {
         ],
       }
     `);
+
+    __pendingListUpdates.clear();
+    d1.setAttribute(0, { 'item-key': 'one' });
+    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`
+      {
+        "-1": [
+          {
+            "insertAction": [
+              {
+                "item-key": "one",
+                "position": 0,
+                "type": "__Card__:__snapshot_a94a8_test_17",
+              },
+            ],
+            "removeAction": [
+              0,
+            ],
+            "updateAction": [],
+          },
+        ],
+      }
+    `);
+
+    __pendingListUpdates.clear();
+    d3.setAttribute(0, { 'item-key': 'three' });
+    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`
+      {
+        "-1": [
+          {
+            "insertAction": [
+              {
+                "item-key": "three",
+                "position": 2,
+                "type": "__Card__:__snapshot_a94a8_test_17",
+              },
+            ],
+            "removeAction": [
+              2,
+            ],
+            "updateAction": [],
+          },
+        ],
+      }
+    `);
   });
 });
 

--- a/packages/react/runtime/src/listUpdateInfo.ts
+++ b/packages/react/runtime/src/listUpdateInfo.ts
@@ -4,6 +4,7 @@
 
 import { hydrate } from './hydrate.js';
 import { componentAtIndexFactory, enqueueComponentFactory } from './list.js';
+import type { PlatformInfo } from './snapshot/platformInfo.js';
 import type { SnapshotInstance } from './snapshot.js';
 
 export interface ListUpdateInfo {
@@ -13,7 +14,7 @@ export interface ListUpdateInfo {
     existingNode?: SnapshotInstance,
   ): void;
   onRemoveChild(child: SnapshotInstance): void;
-  onSetAttribute(child: SnapshotInstance, attr: any, oldAttr: any): void;
+  onSetAttribute(child: SnapshotInstance, attr: PlatformInfo, oldAttr?: PlatformInfo): void;
 }
 
 // class ListUpdateInfoDiffing implements ListUpdateInfo {
@@ -121,8 +122,12 @@ export class ListUpdateInfoRecording implements ListUpdateInfo {
     this.removeChild.add(child);
   }
 
-  onSetAttribute(child: SnapshotInstance, attr: any, _oldAttr: any): void {
-    this.platformInfoUpdate.set(child, attr);
+  onSetAttribute(child: SnapshotInstance, attr: PlatformInfo, oldAttr?: PlatformInfo): void {
+    if (!oldAttr || attr['item-key'] === oldAttr['item-key']) {
+      this.platformInfoUpdate.set(child, attr);
+    } else {
+      this.onInsertBefore(child, child.nextSibling ?? undefined);
+    }
   }
 
   private __toAttribute(): ListOperations {

--- a/packages/react/runtime/src/snapshot/platformInfo.ts
+++ b/packages/react/runtime/src/snapshot/platformInfo.ts
@@ -42,7 +42,7 @@ function updateListItemPlatformInfo(
       (__pendingListUpdates.values[list.__id] ??= new ListUpdateInfoRecording(list)).onSetAttribute(
         ctx,
         newValue,
-        oldValue,
+        oldValue as PlatformInfo,
       );
     }
   }

--- a/packages/react/runtime/src/snapshot/spread.ts
+++ b/packages/react/runtime/src/snapshot/spread.ts
@@ -46,12 +46,11 @@ function updateSpread(
   oldValue: Record<string, unknown> | undefined | null,
   elementIndex: number,
 ): void {
-  oldValue ??= {};
   let newValue: Record<string, unknown> = snapshot.__values![index] as Record<string, unknown>; // compiler guarantee this must be an object;
 
   const list = snapshot.parentNode;
   if (list?.__snapshot_def.isListHolder) {
-    const oldPlatformInfo = pick(oldValue, platformInfoAttributes);
+    const oldPlatformInfo = oldValue ? pick(oldValue, platformInfoAttributes) : undefined;
     const platformInfo = pick(newValue, platformInfoAttributes);
     if (!isDirectOrDeepEqual(oldPlatformInfo, platformInfo)) {
       if (__pendingListUpdates.values) {
@@ -76,6 +75,8 @@ function updateSpread(
       updateListItemPlatformInfo(fakeSnapshot, index, oldPlatformInfo, elementIndex);
     }
   }
+
+  oldValue ??= {};
 
   if (!snapshot.__elements) {
     return;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization between list items when their `item-key` changes, ensuring consistent behavior across components.
* **Documentation**
  * Updated documentation to clarify how changes to `item-key` are handled and to illustrate expected behavior with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->