### PR TITLE
Revert "fix(rspeedy/react): move refresh loader before `builtin:swc-loader`"

### DIFF
--- a/packages/rspeedy/plugin-react/src/refresh.ts
+++ b/packages/rspeedy/plugin-react/src/refresh.ts
@@ -14,6 +14,7 @@ import {
   ReactRefreshRspackPlugin,
   ReactRefreshWebpackPlugin,
 } from '@lynx-js/react-refresh-webpack-plugin'
+import { LAYERS } from '@lynx-js/react-webpack-plugin'
 
 const PLUGIN_NAME_REACT_REFRESH = 'lynx:react:refresh'
 const require = createRequire(import.meta.url)
@@ -57,7 +58,8 @@ function applyRefreshRules<Bundler extends 'webpack' | 'rspack'>(
   .end()
     .module
       .rule('react:refresh')
-        .after(CHAIN_ID.RULE.JS)
+        .issuerLayer(LAYERS.BACKGROUND)
+        .before(CHAIN_ID.RULE.JS)
         .test(/\.[jt]sx$/)
         .exclude
           .add(/node_modules/)


### PR DESCRIPTION
Reverts lynx-family/lynx-stack#1246

This can be safely reverted because https://github.com/web-infra-dev/rspack/pull/11079

close: https://github.com/lynx-family/lynx-stack/pull/1246