### PR TITLE
fix(rspeedy/react): should have profile in development

### DIFF
--- a/.changeset/lemon-feet-matter.md
+++ b/.changeset/lemon-feet-matter.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Fix `REACT_PROFILE` not taking effect.

--- a/.changeset/moody-hounds-jam.md
+++ b/.changeset/moody-hounds-jam.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Fix not having profile in development by default.

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -248,6 +248,7 @@ export function applyEntry(
     }
 
     const rsbuildConfig = api.getRsbuildConfig()
+    const userConfig = api.getRsbuildConfig('original')
 
     let extractStr = originalExtractStr
     if (
@@ -271,9 +272,30 @@ export function applyEntry(
         mainThreadChunks,
         extractStr,
         experimental_isLazyBundle,
-        profile: rsbuildConfig.performance?.profile,
+        profile: getDefaultProfile(),
       }])
+
+    function getDefaultProfile(): boolean | undefined {
+      if (userConfig.performance?.profile !== undefined) {
+        return userConfig.performance.profile
+      }
+
+      if (isDebug()) {
+        return true
+      }
+
+      return undefined
+    }
   })
+}
+
+export const isDebug = (): boolean => {
+  if (!process.env['DEBUG']) {
+    return false
+  }
+
+  const values = process.env['DEBUG'].toLocaleLowerCase().split(',')
+  return ['rspeedy', '*'].some((key) => values.includes(key))
 }
 
 // This is copied from https://github.com/web-infra-dev/rsbuild/blob/037da7b9d92e20c7136c8b2efa21eef539fa2f88/packages/core/src/plugins/html.ts#L168

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -2021,7 +2021,36 @@ describe('Config', () => {
 
       // @ts-expect-error private field
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(ReactLynxWebpackPlugin?.options.profile).toBe(false)
+      expect(ReactLynxWebpackPlugin?.options.profile).toBe(undefined)
+    })
+
+    test('with mode=development', async () => {
+      vi.stubEnv('DEBUG', '')
+
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          plugins: [
+            pluginReactLynx(),
+          ],
+          mode: 'development',
+        },
+      })
+
+      const [config] = await rspeedy.initConfigs()
+
+      const ReactLynxWebpackPlugin = config?.plugins?.find((
+        p,
+      ): p is ReactWebpackPlugin =>
+        p?.constructor.name === 'ReactWebpackPlugin'
+      )
+
+      // @ts-expect-error private field
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(ReactLynxWebpackPlugin?.options.profile).toBe(undefined)
+
+      vi.unstubAllEnvs()
     })
 
     test('with DEBUG', async () => {

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -172,8 +172,8 @@ class ReactWebpackPlugin {
       // We enable profile by default in development.
       // It can also be disabled by environment variable `REACT_PROFILE=false`
       __PROFILE__: JSON.stringify(
-        options.profile
-          ?? process.env['REACT_PROFILE']
+        process.env['REACT_PROFILE']
+          ?? options.profile
           ?? compiler.options.mode === 'development',
       ),
       // User can enable ALog by environment variable `REACT_ALOG=true`


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The `console.profile` feature should be enabled by default in `@lynx-js/react` during development.

Previously, we relied on `performance.profile` as implemented in #722. However, the default value provided by Rsbuild was set to `false`, which limited its functionality.

This update ensures that instead of relying on the normalized Rsbuild configuration, we will directly reference the original user-provided configuration.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues with the REACT_PROFILE environment variable not being properly recognized, ensuring profiling features are enabled as expected.
  * Fixed the absence of a default profile in the development environment, so a profile is now automatically available during development.

* **Tests**
  * Updated and added tests to verify correct behavior of profile settings in various environments.

* **Refactor**
  * Adjusted the logic for determining profiling behavior, prioritizing environment variables and improving configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->