### PR TITLE
Revert "fix(react): avoid some unexpected `__SetAttribute` when attribute value is `undefined`"

### DIFF
--- a/.changeset/calm-lies-dig.md
+++ b/.changeset/calm-lies-dig.md
@@ -1,9 +1,0 @@
----
-"@lynx-js/react": patch
----
-
-Avoid some unexpected `__SetAttribute` when `undefined` is passed as a attribute value to intrinsic elements, for example:
-
-```jsx
-<image async-mode={undefined} />;
-```

--- a/packages/react/runtime/__test__/lifecycle/reload.test.jsx
+++ b/packages/react/runtime/__test__/lifecycle/reload.test.jsx
@@ -301,7 +301,7 @@ describe('reload', () => {
             [
               "rLynxFirstScreen",
               {
-                "root": "{"id":-9,"type":"root","children":[{"id":-13,"type":"__Card__:__snapshot_a94a8_test_2","values":{"0":{"dataX":"WorldX"}},"children":[{"id":-10,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-15,"type":null,"values":{"0":"Enjoy"}}]},{"id":-11,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-16,"type":null,"values":{"0":"World"}}]},{"id":-12,"type":"wrapper","children":[{"id":-14,"type":"__Card__:__snapshot_a94a8_test_1","values":{"0":{"attr":{"dataX":"WorldX"}}}}]}]}]}",
+                "root": "{"id":-9,"type":"root","children":[{"id":-13,"type":"__Card__:__snapshot_a94a8_test_2","values":[{"dataX":"WorldX"}],"children":[{"id":-10,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-15,"type":null,"values":["Enjoy"]}]},{"id":-11,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-16,"type":null,"values":["World"]}]},{"id":-12,"type":"wrapper","children":[{"id":-14,"type":"__Card__:__snapshot_a94a8_test_1","values":[{"attr":{"dataX":"WorldX"}}]}]}]}]}",
               },
             ],
           ],
@@ -710,7 +710,7 @@ describe('reload', () => {
             [
               "rLynxFirstScreen",
               {
-                "root": "{"id":-9,"type":"root","children":[{"id":-15,"type":"__Card__:__snapshot_a94a8_test_5","children":[{"id":-13,"type":"__Card__:__snapshot_a94a8_test_2","values":{"0":{"dataX":"WorldX"}},"children":[{"id":-10,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-16,"type":null,"values":{"0":"Enjoy"}}]},{"id":-11,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-17,"type":null,"values":{"0":"World"}}]},{"id":-12,"type":"wrapper","children":[{"id":-14,"type":"__Card__:__snapshot_a94a8_test_1","values":{"0":{"attr":{"dataX":"WorldX"}}}}]}]}]}]}",
+                "root": "{"id":-9,"type":"root","children":[{"id":-15,"type":"__Card__:__snapshot_a94a8_test_5","children":[{"id":-13,"type":"__Card__:__snapshot_a94a8_test_2","values":[{"dataX":"WorldX"}],"children":[{"id":-10,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-16,"type":null,"values":["Enjoy"]}]},{"id":-11,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-17,"type":null,"values":["World"]}]},{"id":-12,"type":"wrapper","children":[{"id":-14,"type":"__Card__:__snapshot_a94a8_test_1","values":[{"attr":{"dataX":"WorldX"}}]}]}]}]}]}",
               },
             ],
           ],
@@ -1312,7 +1312,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
                 "-8": -16,
                 "-9": -17,
               },
-              "root": "{"id":-17,"type":"root","children":[{"id":-21,"type":"__Card__:__snapshot_a94a8_test_2","values":{"0":{"dataX":"WorldX"}},"children":[{"id":-18,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-23,"type":null,"values":{"0":"Hello 2"}}]},{"id":-19,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-24,"type":null,"values":{"0":"World"}}]},{"id":-20,"type":"wrapper","children":[{"id":-22,"type":"__Card__:__snapshot_a94a8_test_1","values":{"0":{"attr":{"dataX":"WorldX"}}}}]}]}]}",
+              "root": "{"id":-17,"type":"root","children":[{"id":-21,"type":"__Card__:__snapshot_a94a8_test_2","values":[{"dataX":"WorldX"}],"children":[{"id":-18,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-23,"type":null,"values":["Hello 2"]}]},{"id":-19,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-24,"type":null,"values":["World"]}]},{"id":-20,"type":"wrapper","children":[{"id":-22,"type":"__Card__:__snapshot_a94a8_test_1","values":[{"attr":{"dataX":"WorldX"}}]}]}]}]}",
             },
           ],
         ]
@@ -1515,7 +1515,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
                 "-5": -13,
                 "-9": -17,
               },
-              "root": "{"id":-17,"type":"root","children":[{"id":-21,"type":"__Card__:__snapshot_a94a8_test_7","children":[{"id":-18,"type":"__Card__:__snapshot_a94a8_test_8","values":{"0":{"item-key":0}},"children":[{"id":-22,"type":"__Card__:__snapshot_a94a8_test_6","values":{"0":"a"}}]},{"id":-19,"type":"__Card__:__snapshot_a94a8_test_8","values":{"0":{"item-key":1}},"children":[{"id":-23,"type":"__Card__:__snapshot_a94a8_test_6","values":{"0":"b"}}]},{"id":-20,"type":"__Card__:__snapshot_a94a8_test_8","values":{"0":{"item-key":2}},"children":[{"id":-24,"type":"__Card__:__snapshot_a94a8_test_6","values":{"0":"c"}}]}]}]}",
+              "root": "{"id":-17,"type":"root","children":[{"id":-21,"type":"__Card__:__snapshot_a94a8_test_7","children":[{"id":-18,"type":"__Card__:__snapshot_a94a8_test_8","values":[{"item-key":0}],"children":[{"id":-22,"type":"__Card__:__snapshot_a94a8_test_6","values":["a"]}]},{"id":-19,"type":"__Card__:__snapshot_a94a8_test_8","values":[{"item-key":1}],"children":[{"id":-23,"type":"__Card__:__snapshot_a94a8_test_6","values":["b"]}]},{"id":-20,"type":"__Card__:__snapshot_a94a8_test_8","values":[{"item-key":2}],"children":[{"id":-24,"type":"__Card__:__snapshot_a94a8_test_6","values":["c"]}]}]}]}",
             },
           ],
         ]
@@ -1679,7 +1679,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
                 "-2": -10,
                 "-6": -14,
               },
-              "root": "{"id":-10,"type":"root","children":[{"id":-14,"type":"__Card__:__snapshot_a94a8_test_9","children":[{"id":-11,"type":"__Card__:__snapshot_a94a8_test_10","values":{"0":{"item-key":0}},"children":[{"id":-15,"type":"__Card__:__snapshot_a94a8_test_6","values":{"0":"a"}}]},{"id":-12,"type":"__Card__:__snapshot_a94a8_test_10","values":{"0":{"item-key":1}},"children":[{"id":-16,"type":"__Card__:__snapshot_a94a8_test_6","values":{"0":"b"}}]},{"id":-13,"type":"__Card__:__snapshot_a94a8_test_10","values":{"0":{"item-key":2}},"children":[{"id":-17,"type":"__Card__:__snapshot_a94a8_test_6","values":{"0":"c"}}]}]}]}",
+              "root": "{"id":-10,"type":"root","children":[{"id":-14,"type":"__Card__:__snapshot_a94a8_test_9","children":[{"id":-11,"type":"__Card__:__snapshot_a94a8_test_10","values":[{"item-key":0}],"children":[{"id":-15,"type":"__Card__:__snapshot_a94a8_test_6","values":["a"]}]},{"id":-12,"type":"__Card__:__snapshot_a94a8_test_10","values":[{"item-key":1}],"children":[{"id":-16,"type":"__Card__:__snapshot_a94a8_test_6","values":["b"]}]},{"id":-13,"type":"__Card__:__snapshot_a94a8_test_10","values":[{"item-key":2}],"children":[{"id":-17,"type":"__Card__:__snapshot_a94a8_test_6","values":["c"]}]}]}]}",
             },
           ],
         ]
@@ -1872,7 +1872,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
             "rLynxFirstScreen",
             {
               "jsReadyEventIdSwap": {},
-              "root": "{"id":-17,"type":"root","children":[{"id":-21,"type":"__Card__:__snapshot_a94a8_test_2","values":{"0":{"dataX":"WorldX"}},"children":[{"id":-18,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-23,"type":null,"values":{"0":"Hello 2"}}]},{"id":-19,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-24,"type":null,"values":{"0":"World"}}]},{"id":-20,"type":"wrapper","children":[{"id":-22,"type":"__Card__:__snapshot_a94a8_test_1","values":{"0":{"attr":{"dataX":"WorldX"}}}}]}]}]}",
+              "root": "{"id":-17,"type":"root","children":[{"id":-21,"type":"__Card__:__snapshot_a94a8_test_2","values":[{"dataX":"WorldX"}],"children":[{"id":-18,"type":"__Card__:__snapshot_a94a8_test_3","children":[{"id":-23,"type":null,"values":["Hello 2"]}]},{"id":-19,"type":"__Card__:__snapshot_a94a8_test_4","children":[{"id":-24,"type":null,"values":["World"]}]},{"id":-20,"type":"wrapper","children":[{"id":-22,"type":"__Card__:__snapshot_a94a8_test_1","values":[{"attr":{"dataX":"WorldX"}}]}]}]}]}",
             },
           ],
         ]

--- a/packages/react/runtime/__test__/preact.test.jsx
+++ b/packages/react/runtime/__test__/preact.test.jsx
@@ -751,34 +751,4 @@ describe('document - dual-runtime', () => {
       );
     }).toThrowErrorMatchingInlineSnapshot(`[Error: unreachable]`);
   });
-
-  it('should not emit patch about `undefined` not being `null`', () => {
-    const jsx = t => (
-      <view>
-        <text>Hello</text>
-        <text>
-          <raw-text text={t} />
-        </text>
-      </view>
-    );
-
-    setupDocument();
-    const root = document.createElement('root');
-    render(jsx(undefined), root);
-
-    setupBackgroundDocument();
-    const backgroundRoot = document.createElement('root');
-    render(jsx(undefined), backgroundRoot);
-
-    BackgroundSnapshotInstance.prototype.toJSON = backgroundSnapshotInstanceToJSON;
-    expect(backgroundRoot).toMatchInlineSnapshot(`
-      <root>
-        <__Card__:__snapshot_a94a8_test_28 />
-      </root>
-    `);
-    delete BackgroundSnapshotInstance.prototype.toJSON;
-
-    expect(hydrate(JSON.parse(JSON.stringify(root)), backgroundRoot))
-      .toMatchInlineSnapshot(`[]`);
-  });
 });

--- a/packages/react/runtime/__test__/snapshot/event.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/event.test.jsx
@@ -1161,7 +1161,7 @@ describe('event when firstScreenSyncTiming is jsReady', () => {
                 "-5": -8,
                 "-6": -9,
               },
-              "root": "{"id":-7,"type":"root","children":[{"id":-8,"type":"__Card__:__snapshot_a94a8_test_12","children":[{"id":-9,"type":"__Card__:__snapshot_a94a8_test_11","values":{"0":"-9:0:"}}]}]}",
+              "root": "{"id":-7,"type":"root","children":[{"id":-8,"type":"__Card__:__snapshot_a94a8_test_12","children":[{"id":-9,"type":"__Card__:__snapshot_a94a8_test_11","values":["-9:0:"]}]}]}",
             },
           ],
         ]
@@ -1271,7 +1271,7 @@ describe('call `root.render()` async', () => {
             "rLynxFirstScreen",
             {
               "jsReadyEventIdSwap": {},
-              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_14","children":[{"id":-3,"type":"__Card__:__snapshot_a94a8_test_13","values":{"0":"-3:0:"}}]}]}",
+              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_14","children":[{"id":-3,"type":"__Card__:__snapshot_a94a8_test_13","values":["-3:0:"]}]}]}",
             },
           ],
         ]

--- a/packages/react/runtime/__test__/snapshot/ref.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/ref.test.jsx
@@ -115,7 +115,7 @@ describe('element ref', () => {
             "rLynxFirstScreen",
             {
               "jsReadyEventIdSwap": {},
-              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_3","values":{"0":"react-ref--2-0","1":"react-ref--2-1"}}]}",
+              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_3","values":["react-ref--2-0","react-ref--2-1"]}]}",
             },
           ],
         ]
@@ -494,7 +494,7 @@ describe('element ref', () => {
             "rLynxFirstScreen",
             {
               "jsReadyEventIdSwap": {},
-              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_9","values":{"0":"react-ref--2-0","1":"react-ref--2-1","2":"react-ref--2-2"}}]}",
+              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_9","values":["react-ref--2-0","react-ref--2-1","react-ref--2-2"]}]}",
             },
           ],
         ]
@@ -1010,7 +1010,7 @@ describe('element ref in spread', () => {
               "rLynxFirstScreen",
               {
                 "jsReadyEventIdSwap": {},
-                "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_19","values":{"0":{},"1":{"ref":"react-ref--2-1"}}}]}",
+                "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a94a8_test_19","values":[{},{"ref":"react-ref--2-1"}]}]}",
               },
             ],
           ],

--- a/packages/react/runtime/src/snapshot.ts
+++ b/packages/react/runtime/src/snapshot.ts
@@ -247,7 +247,7 @@ export function traverseSnapshotInstance<I extends WithChildren>(
 export interface SerializedSnapshotInstance {
   id: number;
   type: string;
-  values?: Record<string, unknown> | undefined;
+  values?: any[] | undefined;
   extraProps?: Record<string, unknown> | undefined;
   children?: SerializedSnapshotInstance[] | undefined;
 }
@@ -625,13 +625,7 @@ export class SnapshotInstance {
     return {
       id: this.__id,
       type: this.type,
-      values: this.__values
-        // If `this.__values` is `[0, 1, 2]`, it can be transformed to `{ '0': 0, '1': 1, '2': 2 }`
-        // by `{ ...this.__values }`, so if `this.__values` is [undefined],
-        // it will be transformed to `{ '0': undefined }`, and transformed to `{}` by `JSON.stringify`.
-        // Therefore, `values[0] === undefined` is preserved during serialization.
-        ? { ...this.__values }
-        : undefined,
+      values: this.__values,
       extraProps: this.__extraProps,
       children: this.__firstChild ? this.childNodes : undefined,
     };

--- a/packages/react/testing-library/src/__tests__/act.test.jsx
+++ b/packages/react/testing-library/src/__tests__/act.test.jsx
@@ -241,17 +241,17 @@ test('fireEvent triggers useEffect calls', async () => {
                 "extraProps": undefined,
                 "id": 3,
                 "type": null,
-                "values": {
-                  "0": 0,
-                },
+                "values": [
+                  0,
+                ],
               },
             ],
             "extraProps": undefined,
             "id": 2,
             "type": "__Card__:__snapshot_e8d0a_test_4",
-            "values": {
-              "0": "2:0:",
-            },
+            "values": [
+              "2:0:",
+            ],
           },
         ],
         "extraProps": undefined,
@@ -266,26 +266,26 @@ test('fireEvent triggers useEffect calls', async () => {
             "extraProps": undefined,
             "id": 3,
             "type": null,
-            "values": {
-              "0": 0,
-            },
+            "values": [
+              0,
+            ],
           },
         ],
         "extraProps": undefined,
         "id": 2,
         "type": "__Card__:__snapshot_e8d0a_test_4",
-        "values": {
-          "0": "2:0:",
-        },
+        "values": [
+          "2:0:",
+        ],
       },
       3 => {
         "children": undefined,
         "extraProps": undefined,
         "id": 3,
         "type": null,
-        "values": {
-          "0": 0,
-        },
+        "values": [
+          0,
+        ],
       },
     }
   `);


### PR DESCRIPTION
Reverts lynx-family/lynx-stack#1311, as it causes the performance of `JSON.stringify(__root)` to degrade by about ~10%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of undefined attribute values to prevent unintended behavior in intrinsic elements.

* **Refactor**
  * Updated the serialization format of snapshot data, changing the representation of values from objects with numeric keys to arrays for improved consistency.

* **Tests**
  * Modified multiple test snapshots to reflect the new array-based format for values.
  * Removed a test case related to patch emission for undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->