### PR TITLE
chore(deps): pin unrs-resolver

### DIFF
--- a/packages/rspeedy/plugin-react-alias/package.json
+++ b/packages/rspeedy/plugin-react-alias/package.json
@@ -37,7 +37,7 @@
     "test": "pnpm -w run test --project rspeedy/react-alias"
   },
   "dependencies": {
-    "unrs-resolver": "^1.9.2"
+    "unrs-resolver": "1.9.2"
   },
   "devDependencies": {
     "@lynx-js/react": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,7 +488,7 @@ importers:
   packages/rspeedy/plugin-react-alias:
     dependencies:
       unrs-resolver:
-        specifier: ^1.9.2
+        specifier: 1.9.2
         version: 1.9.2
     devDependencies:
       '@lynx-js/react':


### PR DESCRIPTION
## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

The `napi-postinstall` v0.3.1 is a malicious version (which is a dependency of `unrs-resolver`). See: https://github.com/prettier/eslint-config-prettier/issues/339#issuecomment-3090311066

We pin the version of `unrs-resolver` in this patch to avoid the user of Rspeedy installing the  a malicious version.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->