### PR TITLE
fix(webpack/chunk-loading): enable `onceForChunk`

### DIFF
--- a/.changeset/ten-cases-care.md
+++ b/.changeset/ten-cases-care.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/chunk-loading-webpack-plugin": patch
+---
+
+Avoid adding runtime module multiple times for one chunk.

--- a/packages/webpack/chunk-loading-webpack-plugin/src/ChunkLoadingWebpackPlugin.ts
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/ChunkLoadingWebpackPlugin.ts
@@ -46,8 +46,7 @@ export class ChunkLoadingWebpackPluginImpl {
       const ChunkLoadingRuntimeModule = createChunkLoadingRuntimeModule(
         compiler.webpack,
       );
-      // TODO(colinaaa): enable this after https://github.com/web-infra-dev/rspack/issues/9849 is fixed.
-      // const onceForChunkSet = new WeakSet<Chunk>();
+      const onceForChunkSet = new WeakSet<Chunk>();
 
       const globalChunkLoading = compilation.outputOptions.chunkLoading;
       /**
@@ -63,8 +62,8 @@ export class ChunkLoadingWebpackPluginImpl {
       };
 
       const handler = (chunk: Chunk, runtimeRequirements: Set<string>) => {
-        // if (onceForChunkSet.has(chunk)) return;
-        // onceForChunkSet.add(chunk);
+        if (onceForChunkSet.has(chunk)) return;
+        onceForChunkSet.add(chunk);
         if (!isEnabledForChunk(chunk)) return;
         runtimeRequirements.add(RuntimeGlobals.getChunkUpdateScriptFilename);
         runtimeRequirements.add(RuntimeGlobals.moduleFactoriesAddOnly);


### PR DESCRIPTION
@coderabbitai summary

> [!NOTE]
> This is not a minor change since we already bump the peerDependencies requirement in #921. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
