### PR TITLE
feat(react): support profile in production build

### DIFF
--- a/.changeset/forty-aliens-play.md
+++ b/.changeset/forty-aliens-play.md
@@ -1,0 +1,11 @@
+---
+"@lynx-js/react": patch
+---
+
+Add profile in production build:
+
+1. `diff:__COMPONENT_NAME__`: how long ReactLynx diff took.
+2. `render:__COMPONENT_NAME__`: how long your render function took.
+3. `setState`: an instant trace event, indicate when your setState was called.
+
+NOTE: `__COMPONENT_NAME__` may be unreadable when minified, setting `displayName` may help.

--- a/packages/react/runtime/__test__/debug/hook.js
+++ b/packages/react/runtime/__test__/debug/hook.js
@@ -4,10 +4,11 @@
 import { options } from 'preact';
 import { vi } from 'vitest';
 
-import { DIFF, DIFFED, RENDER } from '../../src/renderToOpcodes/constants';
+import { DIFF, DIFF2, DIFFED, RENDER } from '../../src/renderToOpcodes/constants';
 
 export const noop = vi.fn();
 
 options[DIFF] = noop;
+options[DIFF2] = noop;
 options[RENDER] = noop;
 options[DIFFED] = noop;

--- a/packages/react/runtime/__test__/debug/profile.test.jsx
+++ b/packages/react/runtime/__test__/debug/profile.test.jsx
@@ -26,14 +26,12 @@ describe('profile', () => {
   });
 
   test('original options hooks should be called', async () => {
-    vi.stubGlobal('__JS__', true);
-
     render(
       null,
       scratch,
     );
 
-    expect(noop).toBeCalledTimes(3);
+    expect(noop).toBeCalledTimes(4);
   });
 
   test('diff and render should be profiled', async () => {
@@ -59,18 +57,18 @@ describe('profile', () => {
       scratch,
     );
 
-    // render::
-    expect(console.profile).toBeCalledWith(`render::Foo`);
-    expect(console.profile).not.toBeCalledWith(`render::Bar`);
-    expect(console.profile).toBeCalledWith(`render::Baz`);
-    expect(console.profile).not.toBeCalledWith(`render::ClassComponent`);
-    expect(console.profile).toBeCalledWith(`render::Clazz`);
+    // // ReactLynx::render::
+    expect(lynx.performance.profileStart).toBeCalledWith(`ReactLynx::render::Foo`);
+    expect(lynx.performance.profileStart).not.toBeCalledWith(`ReactLynx::render::Bar`);
+    expect(lynx.performance.profileStart).toBeCalledWith(`ReactLynx::render::Baz`);
+    expect(lynx.performance.profileStart).not.toBeCalledWith(`ReactLynx::render::ClassComponent`);
+    expect(lynx.performance.profileStart).toBeCalledWith(`ReactLynx::render::Clazz`);
 
-    // diff::
-    expect(console.profile).toBeCalledWith(`diff::Foo`);
-    expect(console.profile).not.toBeCalledWith(`diff::Bar`);
-    expect(console.profile).toBeCalledWith(`diff::Baz`);
-    expect(console.profile).not.toBeCalledWith(`diff::ClassComponent`);
-    expect(console.profile).toBeCalledWith(`diff::Clazz`);
+    // // ReactLynx::diff::
+    expect(lynx.performance.profileStart).toBeCalledWith(`ReactLynx::diff::Foo`, {});
+    expect(lynx.performance.profileStart).not.toBeCalledWith(`ReactLynx::diff::Bar`);
+    expect(lynx.performance.profileStart).toBeCalledWith(`ReactLynx::diff::Baz`, {});
+    expect(lynx.performance.profileStart).not.toBeCalledWith(`ReactLynx::diff::ClassComponent`);
+    expect(lynx.performance.profileStart).toBeCalledWith(`ReactLynx::diff::Clazz`, {});
   });
 });

--- a/packages/react/runtime/__test__/lifecycle/reload.test.jsx
+++ b/packages/react/runtime/__test__/lifecycle/reload.test.jsx
@@ -127,6 +127,9 @@ describe('reload', () => {
         {
           "data": "{"patchList":[{"id":3,"snapshotPatch":[3,-5,0,{"dataX2":"WorldX2"},3,-8,0,"update",3,-6,0,{"attr":{"dataX2":"WorldX2"}}]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "reloadVersion": 0,
           },
         }
@@ -235,6 +238,9 @@ describe('reload', () => {
         {
           "data": "{"patchList":[{"id":4,"snapshotPatch":[3,-8,0,"???"]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "reloadVersion": 0,
           },
         }
@@ -384,6 +390,9 @@ describe('reload', () => {
         {
           "data": "{"patchList":[{"id":8,"snapshotPatch":[3,-16,0,"update"]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "reloadVersion": 2,
           },
         }
@@ -530,6 +539,9 @@ describe('reload', () => {
         {
           "data": "{"patchList":[{"id":11,"snapshotPatch":[3,-5,0,{"dataX2":"WorldX2"},3,-8,0,"update",3,-6,0,{"attr":{"dataX2":"WorldX2"}}]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "reloadVersion": 2,
           },
         }
@@ -642,6 +654,9 @@ describe('reload', () => {
         {
           "data": "{"patchList":[{"id":12,"snapshotPatch":[3,-8,0,"???"]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "reloadVersion": 2,
           },
         }
@@ -795,6 +810,9 @@ describe('reload', () => {
         {
           "data": "{"patchList":[{"id":16,"snapshotPatch":[3,-17,0,"update"]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "reloadVersion": 4,
           },
         }
@@ -980,6 +998,9 @@ describe('reload', () => {
             {
               "data": "{"patchList":[{"id":19,"snapshotPatch":[3,-6,0,"d",3,-7,0,"e",3,-8,0,"f"]}]}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 4,
               },
             },

--- a/packages/react/runtime/__test__/lifecycle/updateData.test.jsx
+++ b/packages/react/runtime/__test__/lifecycle/updateData.test.jsx
@@ -140,6 +140,9 @@ describe('triggerDataUpdated', () => {
             {
               "data": "{"patchList":[{"id":3,"snapshotPatch":[3,-3,0,"update"]}],"flushOptions":{"triggerDataUpdated":true}}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 0,
               },
             },
@@ -277,6 +280,9 @@ describe('triggerDataUpdated', () => {
             {
               "data": "{"patchList":[{"id":6}],"flushOptions":{"triggerDataUpdated":true}}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 0,
               },
             },
@@ -287,6 +293,9 @@ describe('triggerDataUpdated', () => {
             {
               "data": "{"patchList":[{"id":7,"snapshotPatch":[3,-6,0,"update"]}]}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 0,
               },
             },
@@ -297,6 +306,9 @@ describe('triggerDataUpdated', () => {
             {
               "data": "{"patchList":[{"id":8,"snapshotPatch":[3,-8,0,"update"]}]}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 0,
               },
             },
@@ -467,6 +479,9 @@ describe('triggerDataUpdated', () => {
             {
               "data": "{"patchList":[{"id":11}],"flushOptions":{"triggerDataUpdated":true}}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 0,
               },
             },
@@ -477,6 +492,9 @@ describe('triggerDataUpdated', () => {
             {
               "data": "{"patchList":[{"id":12,"snapshotPatch":[3,-5,0,"update"]}]}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 0,
               },
             },
@@ -487,6 +505,9 @@ describe('triggerDataUpdated', () => {
             {
               "data": "{"patchList":[{"id":13,"snapshotPatch":[3,-7,0,"update"]}]}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 0,
               },
             },
@@ -628,6 +649,9 @@ describe('triggerDataUpdated', () => {
             {
               "data": "{"patchList":[{"id":16,"snapshotPatch":[3,-3,0,"update"]}],"flushOptions":{"triggerDataUpdated":true}}",
               "patchOptions": {
+                "flowIds": [
+                  666,
+                ],
                 "reloadVersion": 0,
               },
             },

--- a/packages/react/runtime/__test__/lynx/timing.test.jsx
+++ b/packages/react/runtime/__test__/lynx/timing.test.jsx
@@ -100,6 +100,9 @@ describe('setState timing api', () => {
       {
         "data": "{"patchList":[{"id":3,"snapshotPatch":[0,"__Card__:__snapshot_a94a8_test_2",3,0,null,4,3,4,0,1,1,3,4,null,1,-2,3,null]}],"flushOptions":{"__lynx_timing_flag":"__lynx_timing_actual_fmp"}}",
         "patchOptions": {
+          "flowIds": [
+            666,
+          ],
           "pipelineOptions": {
             "dsl": "reactLynx",
             "needTimestamps": false,
@@ -179,6 +182,9 @@ describe('attribute timing api', () => {
       {
         "data": "{"patchList":[{"id":6,"snapshotPatch":[0,"__Card__:__snapshot_a94a8_test_4",3,4,3,[{"__ltf":"__lynx_timing_actual_fmp"}],0,null,4,3,4,0,1,1,3,4,null,1,-2,3,null]}]}",
         "patchOptions": {
+          "flowIds": [
+            666,
+          ],
           "pipelineOptions": {
             "dsl": "reactLynx",
             "needTimestamps": true,
@@ -368,6 +374,9 @@ describe('attribute timing api', () => {
       {
         "data": "{"patchList":[{"id":9,"snapshotPatch":[0,"__Card__:__snapshot_a94a8_test_6",3,4,3,[{"__ltf":"__lynx_timing_actual_fmp"}],0,null,4,3,4,0,1,1,3,4,null,1,-2,3,null]}]}",
         "patchOptions": {
+          "flowIds": [
+            666,
+          ],
           "pipelineOptions": {
             "dsl": "reactLynx",
             "needTimestamps": true,
@@ -540,6 +549,9 @@ describe('attribute timing api', () => {
         {
           "data": "{"patchList":[{"id":14,"snapshotPatch":[3,-2,1,444]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "pipelineOptions": {
               "dsl": "reactLynx",
               "needTimestamps": false,
@@ -706,6 +718,9 @@ describe('attribute timing api', () => {
         {
           "data": "{"patchList":[{"id":17,"snapshotPatch":[0,"__Card__:__snapshot_a94a8_test_15",3,4,3,[{"xxx":333,"__lynx_timing_flag":"__lynx_timing_actual_fmp"}],0,null,4,3,4,0,1,1,3,4,null,1,-2,3,null]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "pipelineOptions": {
               "dsl": "reactLynx",
               "needTimestamps": true,
@@ -819,6 +834,9 @@ describe('attribute timing api', () => {
         {
           "data": "{"patchList":[{"id":18,"snapshotPatch":[3,3,0,{"xxx":666,"__lynx_timing_flag":"__lynx_timing_actual_fmp"}]}]}",
           "patchOptions": {
+            "flowIds": [
+              666,
+            ],
             "pipelineOptions": {
               "dsl": "reactLynx",
               "needTimestamps": false,

--- a/packages/react/runtime/__test__/utils/globals.js
+++ b/packages/react/runtime/__test__/utils/globals.js
@@ -1,10 +1,9 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { vi } from 'vitest';
+import { afterEach, beforeEach, expect, vi } from 'vitest';
 
 import { getJSModule } from './jsModule.ts';
-import { beforeEach, afterEach, expect } from 'vitest';
 
 const app = {
   callLepusMethod: vi.fn(),

--- a/packages/react/runtime/__test__/utils/globals.js
+++ b/packages/react/runtime/__test__/utils/globals.js
@@ -4,6 +4,7 @@
 import { vi } from 'vitest';
 
 import { getJSModule } from './jsModule.ts';
+import { beforeEach, afterEach, expect } from 'vitest';
 
 const app = {
   callLepusMethod: vi.fn(),
@@ -35,6 +36,12 @@ const performance = {
   _bindPipelineIdWithTimingFlag: vi.fn((id, flag) => {
     performance.__functionCallHistory.push(['_bindPipelineIdWithTimingFlag', id, flag]);
   }),
+
+  profileStart: vi.fn(),
+  profileEnd: vi.fn(),
+  profileMark: vi.fn(),
+  profileFlowId: vi.fn(() => 666),
+  isProfileRecording: vi.fn(() => true),
 };
 
 class SelectorQuery {
@@ -132,5 +139,25 @@ function injectGlobals() {
   console.profileEnd = vi.fn();
   console.alog = vi.fn();
 }
+
+beforeEach(() => {
+  performance.profileStart.mockClear();
+  performance.profileEnd.mockClear();
+});
+
+afterEach((context) => {
+  const skippedTasks = [
+    // Skip preact/debug tests since it would throw errors and abort the rendering process
+    'preact/debug',
+    'should remove event listener when throw in cleanup',
+  ];
+  if (skippedTasks.some(task => context.task.name.includes(task))) {
+    return;
+  }
+
+  expect(performance.profileStart.mock.calls.length).toBe(
+    performance.profileEnd.mock.calls.length,
+  );
+});
 
 injectGlobals();

--- a/packages/react/runtime/src/debug/profile.ts
+++ b/packages/react/runtime/src/debug/profile.ts
@@ -35,7 +35,7 @@ export function initProfileHook(): void {
   // attach a flowId to the component instance.
   // This allows us to trace the flow of its diffing, committing and patching.
   {
-    const sFlowID = Symbol.for('FLOW_ID');
+    const sFlowID = Symbol('FLOW_ID');
     type PatchedComponent = Component & { [sFlowID]?: number };
 
     if (__BACKGROUND__) {

--- a/packages/react/runtime/src/debug/profile.ts
+++ b/packages/react/runtime/src/debug/profile.ts
@@ -145,7 +145,7 @@ export function initProfileHook(): void {
   });
 
   if (__BACKGROUND__) {
-    const sPatchLength = Symbol.for('PATCH_LENGTH');
+    const sPatchLength = Symbol('PATCH_LENGTH');
 
     type PatchedVNode = VNode & { [sPatchLength]?: number };
 

--- a/packages/react/runtime/src/debug/profile.ts
+++ b/packages/react/runtime/src/debug/profile.ts
@@ -1,52 +1,174 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { options } from 'preact';
-import type { Component, ComponentClass, VNode } from 'preact';
+import { Component, options } from 'preact';
+import type { ComponentClass, VNode } from 'preact';
 
-import { COMPONENT, DIFF, DIFFED, RENDER } from '../renderToOpcodes/constants.js';
-import { getDisplayName } from '../utils.js';
+import type { TraceOption } from '@lynx-js/types';
+
+import { globalPatchOptions } from '../lifecycle/patch/commit.js';
+import { __globalSnapshotPatch } from '../lifecycle/patch/snapshotPatch.js';
+import { COMMIT, COMPONENT, DIFF, DIFF2, DIFFED, DIRTY, NEXT_STATE, RENDER } from '../renderToOpcodes/constants.js';
+import { getDisplayName, hook } from '../utils.js';
 
 export function initProfileHook(): void {
-  const oldDiff = options[DIFF];
-  options[DIFF] = function(vnode: VNode) {
-    // This __PROFILE__ is used for DCE testing
-    if (__PROFILE__ && typeof vnode.type === 'function') {
+  // early-exit if required profiling APIs are unavailable
+  let p;
+  /* v8 ignore start */
+  if (
+    !(p = lynx.performance)
+    || typeof p.profileStart !== 'function'
+    || typeof p.profileEnd !== 'function'
+    || typeof p.profileMark !== 'function'
+    || typeof p.profileFlowId !== 'function'
+  ) {
+    return;
+  }
+  /* v8 ignore stop */
+
+  const profileStart = p.profileStart.bind(p);
+  const profileEnd = p.profileEnd.bind(p);
+  const profileMark = p.profileMark.bind(p);
+  const profileFlowId = p.profileFlowId.bind(p);
+
+  // for each setState call, we will add a profiling trace and
+  // attach a flowId to the component instance.
+  // This allows us to trace the flow of its diffing, committing and patching.
+  {
+    const sFlowID = Symbol.for('FLOW_ID');
+    type PatchedComponent = Component & { [sFlowID]?: number };
+
+    if (__BACKGROUND__) {
+      function buildSetStateProfileMarkArgs(
+        currentState: Record<string, unknown>,
+        nextState: Record<string, unknown>,
+      ): Record<string, string> {
+        const EMPTY_OBJ = {};
+
+        currentState ??= EMPTY_OBJ;
+        nextState ??= EMPTY_OBJ;
+
+        return {
+          'current state keys': JSON.stringify(Object.keys(currentState)),
+          'next state keys': JSON.stringify(Object.keys(nextState)),
+          'changed (shallow diff) state keys': JSON.stringify(
+            // the setState is in assign manner, we assume nextState is a superset of currentState
+            Object.keys(nextState).filter(
+              key => currentState[key] !== nextState[key],
+            ),
+          ),
+        };
+      }
+
+      hook(
+        Component.prototype,
+        'setState',
+        function(this: PatchedComponent & { [NEXT_STATE]: unknown }, old, state, callback) {
+          old?.call(this, state, callback);
+
+          if (this[DIRTY]) {
+            profileMark('ReactLynx::setState', {
+              flowId: this[sFlowID] ??= profileFlowId(),
+              args: buildSetStateProfileMarkArgs(
+                this.state as Record<string, unknown>,
+                this[NEXT_STATE] as Record<string, unknown>,
+              ),
+            });
+          }
+        },
+      );
+    }
+
+    hook(options, DIFF2, (old, vnode, oldVNode) => {
       // We only add profiling trace for Component
-      console.profile(`diff::${getDisplayName(vnode.type as ComponentClass)}`);
+      if (typeof vnode.type === 'function') {
+        const profileOptions: TraceOption = {};
+
+        if (__BACKGROUND__) {
+          const c: PatchedComponent = oldVNode[COMPONENT]!;
+          if (c) {
+            const flowId = c[sFlowID];
+            delete c[sFlowID];
+            if (flowId) {
+              globalPatchOptions.flowIds ??= [];
+              globalPatchOptions.flowIds.push(flowId);
+              profileOptions.flowId = flowId;
+            }
+          }
+        }
+
+        profileStart(
+          `ReactLynx::diff::${/* #__INLINE__ */ getDisplayName(vnode.type as ComponentClass)}`,
+          profileOptions,
+        );
+      }
+      old?.(vnode, oldVNode);
+    });
+
+    hook(options, DIFFED, (old, vnode) => {
+      if (typeof vnode.type === 'function') {
+        profileEnd(); // for options[DIFF]
+      }
+      old?.(vnode);
+    });
+
+    if (__BACKGROUND__) {
+      hook(options, COMMIT, (old, vnode, commitQueue) => {
+        profileStart('ReactLynx::commit', {
+          ...globalPatchOptions.flowIds
+            ? {
+              flowId: globalPatchOptions.flowIds[0],
+              flowIds: globalPatchOptions.flowIds,
+            }
+            : {},
+        });
+        old?.(vnode, commitQueue);
+        profileEnd();
+      });
     }
-    oldDiff?.(vnode);
-  };
-  const oldDiffed = options[DIFFED];
-  options[DIFFED] = function(vnode) {
-    // This __PROFILE__ is used for DCE testing
-    if (__PROFILE__ && typeof vnode.type === 'function') {
-      console.profileEnd(); // for options[DIFF]
-    }
-    oldDiffed?.(vnode);
-  };
+  }
 
   // Profile the user-provided `render`.
-  const oldRender = options[RENDER];
-  options[RENDER] = function(vnode: VNode & { [COMPONENT]: Component }) {
-    const displayName = getDisplayName(vnode.type as ComponentClass);
+  hook(options, RENDER, (old, vnode: VNode) => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalRender = vnode[COMPONENT].render;
-    vnode[COMPONENT].render = function render(this, props, state, context) {
-      // This __PROFILE__ is used for DCE testing
-      if (__PROFILE__) {
-        console.profile(`render::${displayName}`);
-      }
+    const originalRender = vnode[COMPONENT]!.render;
+    vnode[COMPONENT]!.render = function render(this, props, state, context) {
+      profileStart(`ReactLynx::render::${/* #__INLINE__ */ getDisplayName(vnode.type as ComponentClass)}`);
       try {
         return originalRender.call(this, props, state, context);
       } finally {
-        // This __PROFILE__ is used for DCE testing
-        if (__PROFILE__) {
-          console.profileEnd();
-        }
-        vnode[COMPONENT].render = originalRender;
+        profileEnd();
+        vnode[COMPONENT]!.render = originalRender;
       }
     };
-    oldRender?.(vnode);
-  };
+    old?.(vnode);
+  });
+
+  if (__BACKGROUND__) {
+    const sPatchLength = Symbol.for('PATCH_LENGTH');
+
+    type PatchedVNode = VNode & { [sPatchLength]?: number };
+
+    hook(options, DIFF, (old, vnode: PatchedVNode) => {
+      if (typeof vnode.type === 'function' && __globalSnapshotPatch) {
+        vnode[sPatchLength] = __globalSnapshotPatch.length;
+      }
+      old?.(vnode);
+    });
+
+    hook(options, DIFFED, (old, vnode: PatchedVNode) => {
+      if (typeof vnode.type === 'function' && __globalSnapshotPatch) {
+        if (vnode[sPatchLength] === __globalSnapshotPatch.length) {
+          // "NoPatch" is a conventional name in Lynx
+          profileMark('ReactLynx::diffFinishNoPatch', {
+            args: {
+              componentName: /* #__INLINE__ */ getDisplayName(vnode.type as ComponentClass),
+            },
+          });
+        }
+        delete vnode[sPatchLength];
+      }
+      old?.(vnode);
+    });
+  }
 }

--- a/packages/react/runtime/src/lifecycle/patch/updateMainThread.ts
+++ b/packages/react/runtime/src/lifecycle/patch/updateMainThread.ts
@@ -24,6 +24,15 @@ function updateMainThread(
     return;
   }
 
+  const flowIds = patchOptions.flowIds;
+  if (flowIds) {
+    lynx.performance.profileStart('ReactLynx::patch', {
+      flowId: flowIds[0],
+      // @ts-expect-error flowIds is not defined in the type, for now
+      flowIds,
+    });
+  }
+
   setPipeline(patchOptions.pipelineOptions);
   markTiming('mtsRenderStart');
   markTiming('parseChangesStart');
@@ -57,6 +66,10 @@ function updateMainThread(
     flushOptions.pipelineOptions = patchOptions.pipelineOptions;
   }
   __FlushElementTree(__page, flushOptions);
+
+  if (flowIds) {
+    lynx.performance.profileEnd();
+  }
 }
 
 function injectUpdateMainThread(): void {

--- a/packages/react/runtime/src/lynx.ts
+++ b/packages/react/runtime/src/lynx.ts
@@ -40,9 +40,8 @@ if (__DEV__) {
   setupComponentStack();
 }
 
-// TODO: replace this with __PROFILE__
-if (__PROFILE__) {
-  // We are profiling both main-thread and background.
+// We are profiling both main-thread and background.
+if (__MAIN_THREAD__ && __PROFILE__) {
   initProfileHook();
 }
 
@@ -68,6 +67,9 @@ if (__BACKGROUND__) {
   else {
     replaceCommitHook();
     initTimingAPI();
+    if (lynx.performance?.isProfileRecording?.()) {
+      initProfileHook();
+    }
   }
 }
 

--- a/packages/react/runtime/src/renderToOpcodes/index.ts
+++ b/packages/react/runtime/src/renderToOpcodes/index.ts
@@ -17,6 +17,7 @@ import {
   COMMIT,
   COMPONENT,
   DIFF,
+  DIFF2,
   DIFFED,
   DIRTY,
   NEXT_STATE,
@@ -33,7 +34,7 @@ const isArray = /* @__PURE__ */ Array.isArray;
 const assign = /* @__PURE__ */ Object.assign;
 
 // Global state for the current render pass
-let beforeDiff, afterDiff, renderHook, ummountHook;
+let beforeDiff, beforeDiff2, afterDiff, renderHook, ummountHook;
 
 /**
  * Render Preact JSX + Components to an HTML string.
@@ -51,6 +52,7 @@ export function renderToString(vnode: any, context: any): any[] {
 
   // store options hooks once before each synchronous render call
   beforeDiff = options[DIFF];
+  beforeDiff2 = options[DIFF2];
   afterDiff = options[DIFFED];
   renderHook = options[RENDER];
   ummountHook = options.unmount;
@@ -183,6 +185,7 @@ function _renderToString(
 
   vnode[PARENT] = parent;
   if (beforeDiff) beforeDiff(vnode);
+  if (beforeDiff2) beforeDiff2(vnode, EMPTY_OBJ);
 
   let type = vnode.type,
     props = vnode.props,

--- a/packages/web-platform/web-constants/src/types/NativeApp.ts
+++ b/packages/web-platform/web-constants/src/types/NativeApp.ts
@@ -180,6 +180,21 @@ export interface NativeApp {
    */
   profileEnd: () => void;
 
+  /***
+   * Support from Lynx 3.0
+   */
+  profileMark: () => void;
+
+  /**
+   * Support from Lynx 3.0
+   */
+  profileFlowId: () => number;
+
+  /**
+   * Support from Lynx 2.18
+   */
+  isProfileRecording: () => boolean;
+
   triggerComponentEvent(id: string, params: {
     eventDetail: CloneableObject;
     eventOption: CloneableObject;

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createPerformanceApis.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createPerformanceApis.ts
@@ -13,6 +13,9 @@ export function createPerformanceApis(timingSystem: TimingSystem): Pick<
   | 'bindPipelineIdWithTimingFlag'
   | 'profileStart'
   | 'profileEnd'
+  | 'profileMark'
+  | 'profileFlowId'
+  | 'isProfileRecording'
 > {
   let inc = 0;
   const performanceApis = {
@@ -47,6 +50,17 @@ export function createPerformanceApis(timingSystem: TimingSystem): Pick<
     },
     profileEnd: () => {
       console.error('NYI: profileEnd. This is an issue of lynx-core.');
+    },
+    profileMark: () => {
+      console.error('NYI: profileMark. This is an issue of lynx-core.');
+    },
+    profileFlowId: () => {
+      console.error('NYI: profileFlowId. This is an issue of lynx-core.');
+      return 0;
+    },
+    isProfileRecording: () => {
+      console.error('NYI: isProfileRecording. This is an issue of lynx-core.');
+      return false;
     },
   };
   return performanceApis;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for advanced profiling in production builds, including new metrics for component diffing, rendering, and state updates.
  * Enhanced profiling labels for improved traceability, with suggestions for better readability in minified builds.
  * Introduced profiling instrumentation around patch application and commit phases with flow ID tracking.
  * Enabled runtime-controlled profiling initialization for background execution.
  * Added a new lifecycle hook to the rendering process for improved profiling granularity.

* **Bug Fixes**
  * Improved synchronization and accuracy of profiling start and end events to ensure reliable performance data.

* **Refactor**
  * Streamlined profiling logic and lifecycle hook management for better maintainability and encapsulation.
  * Unified commit hook replacement and improved global options state management.
  * Modernized flow ID management and replaced legacy console profiling with Lynx 3.0+ API.

* **Tests**
  * Updated and expanded test coverage to validate new profiling features and ensure accurate flow ID tracking in patch operations.
  * Added lifecycle hooks in tests to verify balanced profiling calls and updated snapshots with flow ID data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
