### PR TITLE
fix: improve compatibility with legacy template

### DIFF
--- a/.changeset/plenty-regions-end.md
+++ b/.changeset/plenty-regions-end.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+fix: improve compatibility with legacy template
+
+avoid "object Object" error for old version rspeedy outputs

--- a/packages/web-platform/web-constants/src/utils/generateTemplate.ts
+++ b/packages/web-platform/web-constants/src/utils/generateTemplate.ts
@@ -84,14 +84,14 @@ const backgroundInjectWithBind = [
   'Component',
 ];
 
-async function generateJavascriptUrl<T extends Record<string, string>>(
+async function generateJavascriptUrl<T extends Record<string, string | {}>>(
   obj: T,
   injectVars: string[],
   injectWithBind: string[],
   muteableVars: readonly string[],
   createJsModuleUrl: (content: string) => string,
 ): Promise<T>;
-async function generateJavascriptUrl<T extends Record<string, string>>(
+async function generateJavascriptUrl<T extends Record<string, string | {}>>(
   obj: T,
   injectVars: string[],
   injectWithBind: string[],
@@ -99,7 +99,7 @@ async function generateJavascriptUrl<T extends Record<string, string>>(
   createJsModuleUrl: (content: string, name: string) => Promise<string>,
   templateName: string,
 ): Promise<T>;
-async function generateJavascriptUrl<T extends Record<string, string>>(
+async function generateJavascriptUrl<T extends Record<string, string | {}>>(
   obj: T,
   injectVars: string[],
   injectWithBind: string[],
@@ -151,7 +151,11 @@ async function generateJavascriptUrl<T extends Record<string, string>>(
         generateModuleContent(content),
       ),
     ];
-  return Promise.all(Object.entries(obj).map(processEntry)).then(
+  return Promise.all(
+    (Object.entries(obj).filter(([_, content]) =>
+      typeof content === 'string'
+    ) as [string, string][]).map(processEntry),
+  ).then(
     Object.fromEntries,
   );
 }

--- a/packages/web-platform/web-tests/resources/web-core.enable-css-selector-false.json
+++ b/packages/web-platform/web-tests/resources/web-core.enable-css-selector-false.json
@@ -3,7 +3,8 @@
   "lepusCode": {
     "root": "self.runtime = lynx_runtime;self.__lynx_worker_type = 'main'; globalThis.registerDataProcessor='pass'; self.registerDataProcessor = registerDataProcessor;",
     "manifest-chunk.js": "module.exports = 'hello';",
-    "manifest-chunk2.js": "module.exports = 'world';"
+    "manifest-chunk2.js": "module.exports = 'world';",
+    "obj-chunk": {}
   },
   "manifest": {
     "/app-service.js": "self.runtime = lynx_runtime; self.__lynx_worker_type = 'background'",


### PR DESCRIPTION
avoid "object Object" error for old version rspeedy outputs

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where legacy template outputs were incorrectly displayed as "object Object" for older rspeedy versions, ensuring proper handling of these outputs.

* **Tests**
  * Updated test resources to include cases with object values in template outputs, improving test coverage for legacy compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
