### PR TITLE
feat(tailwind-preset): add filter utilities and update related infrastructure

### DIFF
--- a/.changeset/nasty-trees-sin.md
+++ b/.changeset/nasty-trees-sin.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/tailwind-preset": patch
+---
+
+Add filter utilities: `blur-*`, `grayscale-*`.
+
+- Note: On Lynx, filter functions are mutually exclusive, only one can be active at a time.

--- a/packages/third-party/tailwind-preset/README.md
+++ b/packages/third-party/tailwind-preset/README.md
@@ -61,34 +61,32 @@ This can be verified in three ways:
 
 #### 2. Add/Remove it from the preset
 
-##### 2.1 If it's part of a core Tailwind plugin:
+##### 2.1 If enabling a Tailwind core plugin
 
 - Add it to `DEFAULT_CORE_PLUGINS` array in `src/core.ts`
-- Add the property to `supportedProperties` in `src/__tests__/config.test.ts`
-- Add the utility mapping to `cssPropertyValueToTailwindUtility`
 
-##### 2.2 If it needs custom handling
+##### 2.2 If it requires custom handling
 
-If it belongs to the Lynx core plugin set:
+###### Lynx core plugins
 
-_(e.g. plugins that provide Lynx-compatible support for Tailwind utilities, including partial core plugin coverage and platform-specific extensions)_
+For plugins that are considered **part of the Lynx core preset** — either implementing Tailwind core utilities or providing Lynx-specific functionality
 
 - Create a new plugin in `src/plugins/lynx/`
-- Use shared plugin helpers and utils from `src/helpers.ts` and `src/plugin-utils/`
-- Export the plugin from `src/plugins/lynx/index.ts`
-- Add it to the plugin registry in `src/plugins/lynx/plugin-registry.ts`.
-  This ensures a stable sorting order for the core set.
-- It will be auto-included in `src/core.ts` based on registry order
+- Use shared helpers from `src/helpers.ts` and `src/plugin-utils/` where applicable
+- Export it from `src/plugins/lynx/index.ts`
+- Register it in `src/plugins/lynx/plugin-registry.ts`\
+  _(This ensures a stable sorting order for the core set)_
+- It will be automatically included in `src/core.ts` via the Lynx plugin registry
 
-If it's a non-core / custom plugin:
+###### Non-core / Custom plugin categories
 
-_(e.g. experimental, category-specific)_
+For plugins that are **not part of the Lynx core preset** — such as experimental features, app-specific utilities, or standalone plugin groups:
 
-- These plugins require manual registration and ordering in `src/core.ts`.
+- These plugins require explicit registration and ordering
 - Create a new category folder under `src/plugins/` (e.g. `src/plugins/experimental/`)
-- Add the plugin there, and optionally extract shared logic into `plugin-utils/`
-- Export the plugin in `src/plugins/{category}/index.ts`
-- Define a `plugin-registry.ts` in that folder to explicitly register plugins in the desired order
+- Add the plugin in that folder, and optionally extract shared logic into `plugin-utils/`
+- Export the plugin from `src/plugins/{category}/index.ts`
+- Define a `plugin-registry.ts` in the same folder to control plugin order
 - Import the registry in `src/core.ts` and include it in the appropriate position
 
 #### 3. Adding Tests

--- a/packages/third-party/tailwind-preset/README.md
+++ b/packages/third-party/tailwind-preset/README.md
@@ -61,17 +61,35 @@ This can be verified in three ways:
 
 #### 2. Add/Remove it from the preset
 
-If it's part of a core Tailwind plugin:
+##### 2.1 If it's part of a core Tailwind plugin:
 
-- Add it to `corePlugins` in `src/lynx.ts`
+- Add it to `DEFAULT_CORE_PLUGINS` array in `src/core.ts`
 - Add the property to `supportedProperties` in `src/__tests__/config.test.ts`
 - Add the utility mapping to `cssPropertyValueToTailwindUtility`
 
-If it needs custom handling e.g. Lynx only support a partial set of the core plugin defined classes, or we need extensions e.g. `.linear`:
+##### 2.2 If it needs custom handling
+
+If it belongs to the Lynx core plugin set:
+
+_(e.g. plugins that provide Lynx-compatible support for Tailwind utilities, including partial core plugin coverage and platform-specific extensions)_
 
 - Create a new plugin in `src/plugins/lynx/`
-- Export it in `src/plugins/lynx/index.ts`
-- Add it to the plugins array in `src/core.ts`
+- Use shared plugin helpers and utils from `src/helpers.ts` and `src/plugin-utils/`
+- Export the plugin from `src/plugins/lynx/index.ts`
+- Add it to the plugin registry in `src/plugins/lynx/plugin-registry.ts`.
+  This ensures a stable sorting order for the core set.
+- It will be auto-included in `src/core.ts` based on registry order
+
+If it's a non-core / custom plugin:
+
+_(e.g. experimental, category-specific)_
+
+- These plugins require manual registration and ordering in `src/core.ts`.
+- Create a new category folder under `src/plugins/` (e.g. `src/plugins/experimental/`)
+- Add the plugin there, and optionally extract shared logic into `plugin-utils/`
+- Export the plugin in `src/plugins/{category}/index.ts`
+- Define a `plugin-registry.ts` in that folder to explicitly register plugins in the desired order
+- Import the registry in `src/core.ts` and include it in the appropriate position
 
 #### 3. Adding Tests
 

--- a/packages/third-party/tailwind-preset/src/__tests__/plugin-utils/create-function-call-utility.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/plugin-utils/create-function-call-utility.test.ts
@@ -11,19 +11,30 @@ describe('createFunctionCallUtility', () => {
     expect(fn('1.5')).toEqual({ transform: 'scale(1.5)' });
   });
 
-  it('allows empty string', () => {
+  it('returns null on empty string by default', () => {
     const fn = createFunctionCallUtility('transform', 'rotate');
-    expect(fn('')).toEqual({ transform: 'rotate()' });
+    expect(fn('')).toBeNull();
+    expect(fn('   ')).toBeNull();
   });
 
-  it('handles special characters in input', () => {
+  it('returns fallback on empty string when provided', () => {
+    const fn = createFunctionCallUtility('transform', 'rotate', {
+      emptyFallback: 'none',
+    });
+    expect(fn('')).toEqual({ transform: 'none' });
+    expect(fn('   ')).toEqual({ transform: 'none' });
+  });
+
+  it('trims surrounding whitespace by default', () => {
+    const fn = createFunctionCallUtility('transform', 'translate');
+    expect(fn(' 10px ')).toEqual({ transform: 'translate(10px)' });
+    expect(fn('\t20%  \n')).toEqual({ transform: 'translate(20%)' });
+  });
+
+  it('handles complex values with parentheses and variables', () => {
     const fn = createFunctionCallUtility('transform', 'translate');
     expect(fn('calc(50% - 10px)')).toEqual({
       transform: 'translate(calc(50% - 10px))',
-    });
-
-    expect(fn(' 10px ')).toEqual({
-      transform: 'translate( 10px )',
     });
 
     expect(fn('var(--tw-my-var)')).toEqual({
@@ -39,5 +50,13 @@ describe('createFunctionCallUtility', () => {
     expect(clipPathFn('M0,0 L10,10')).toEqual({
       'clip-path': 'path(M0,0 L10,10)',
     });
+  });
+
+  it('returns null on non-string input', () => {
+    const fn = createFunctionCallUtility('transform', 'rotate');
+    expect(fn(null)).toBeNull();
+    expect(fn(undefined)).toBeNull();
+    expect(fn(42 as any)).toBeNull();
+    expect(fn({} as any)).toBeNull();
   });
 });

--- a/packages/third-party/tailwind-preset/src/__tests__/plugin-utils/get-modifier-repeater-map.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/plugin-utils/get-modifier-repeater-map.test.ts
@@ -77,4 +77,23 @@ describe('getModifierRepeaterMap', () => {
       [cssProp]: '300ms 300ms 300ms',
     });
   });
+
+  it('returns only base utility when modifierMap is undefined', () => {
+    const map = getModifierRepeaterMap(
+      cssProp,
+      'duration',
+      undefined,
+      {
+        repeatedModifier: 'n',
+      },
+    );
+    expect(Object.keys(map)).toEqual(['duration']); // base only
+  });
+
+  it('handles empty modifierMap and ensures entries line is covered', () => {
+    const map = getModifierRepeaterMap(cssProp, 'duration', {}, {
+      repeatedModifier: 'n',
+    });
+    expect(Object.keys(map)).toEqual(['duration']); // base only
+  });
 });

--- a/packages/third-party/tailwind-preset/src/__tests__/plugins/blur.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/plugins/blur.test.ts
@@ -1,0 +1,65 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, it, vi } from 'vitest';
+
+import { blur } from '../../plugins/lynx/blur.js';
+import { runPlugin } from '../utils/run-plugin.js';
+
+describe('blur plugin', () => {
+  it('covers all branches', () => {
+    const { api } = runPlugin(blur, {
+      theme: {
+        blur: {
+          sm: '4px',
+          none: '',
+          lg: '16px',
+        },
+      },
+    });
+
+    const matchUtilities = vi.mocked(api.matchUtilities);
+
+    type UtilityFn = (value: unknown) => Record<string, string> | null;
+
+    const utils = matchUtilities.mock.calls.reduce<Record<string, UtilityFn>>(
+      (acc, call) => {
+        const group = call[0] as Record<string, UtilityFn>;
+        for (const key in group) {
+          if (group[key]) {
+            acc[key] = group[key]!;
+          }
+        }
+        return acc;
+      },
+      {},
+    );
+
+    // Invalid inputs
+    expect(utils['blur']?.(null)).toBeNull();
+    expect(utils['blur']?.(undefined)).toBeNull();
+    expect(utils['blur']?.(false)).toBeNull();
+    expect(utils['blur']?.(123)).toBeNull();
+
+    // Valid inputs
+    expect(utils['blur']?.('')).toEqual({
+      filter: 'none',
+    });
+
+    expect(utils['blur']?.('4px')).toEqual({
+      filter: 'blur(4px)',
+    });
+
+    expect(utils['blur']?.('  ')).toEqual({
+      filter: 'none',
+    });
+
+    expect(utils['blur']?.('16px')).toEqual({
+      filter: 'blur(16px)',
+    });
+
+    expect(utils['blur']?.('8px')).toEqual({
+      filter: 'blur(8px)',
+    });
+  });
+});

--- a/packages/third-party/tailwind-preset/src/__tests__/plugins/grayscale.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/plugins/grayscale.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, it, vi } from 'vitest';
+
+import { grayscale } from '../../plugins/lynx/grayscale.js';
+import { runPlugin } from '../utils/run-plugin.js';
+
+describe('grayscale plugin', () => {
+  it('covers all branches', () => {
+    const { api } = runPlugin(grayscale, {
+      theme: {
+        grayscale: {
+          none: '',
+          0: '0',
+          DEFAULT: '100%',
+        },
+      },
+    });
+
+    const matchUtilities = vi.mocked(api.matchUtilities);
+
+    type UtilityFn = (value: unknown) => Record<string, string> | null;
+
+    const utils = matchUtilities.mock.calls.reduce<Record<string, UtilityFn>>(
+      (acc, call) => {
+        const group = call[0] as Record<string, UtilityFn>;
+        for (const key in group) {
+          if (group[key]) {
+            acc[key] = group[key]!;
+          }
+        }
+        return acc;
+      },
+      {},
+    );
+
+    // Invalid input
+    expect(utils['grayscale']?.(null)).toBeNull();
+    expect(utils['grayscale']?.(undefined)).toBeNull();
+    expect(utils['grayscale']?.(false)).toBeNull();
+    expect(utils['grayscale']?.(1)).toBeNull();
+
+    // Special case: empty string / only whitespace
+    expect(utils['grayscale']?.('')).toEqual({ filter: 'none' });
+    expect(utils['grayscale']?.('   ')).toEqual({ filter: 'none' });
+
+    // Valid theme values
+    expect(utils['grayscale']?.('0')).toEqual({ filter: 'grayscale(0)' });
+    expect(utils['grayscale']?.('100%')).toEqual({ filter: 'grayscale(100%)' });
+
+    // Arbitrary value
+    expect(utils['grayscale']?.('60%')).toEqual({ filter: 'grayscale(60%)' });
+  });
+});

--- a/packages/third-party/tailwind-preset/src/core.ts
+++ b/packages/third-party/tailwind-preset/src/core.ts
@@ -125,12 +125,12 @@ export const DEFAULT_CORE_PLUGINS: CorePluginsConfig = [
   'gap',
 
   'size',
+  // 'blur' // Defined using plugin
+  // 'grayscale' // Defined using plugin
+  // 'filter' // Defined using plugin
   /* Plugins to be customized */
 
   // 'gradientColorStops'
-  // 'blur'
-  // 'grayscale'
-  // 'filter'
   // 'accessibility'
 
   /* Plugins coming in next release */

--- a/packages/third-party/tailwind-preset/src/plugin-utils/create-function-call-utility.ts
+++ b/packages/third-party/tailwind-preset/src/plugin-utils/create-function-call-utility.ts
@@ -6,11 +6,20 @@ import type { CSSRuleObject } from '../types/tailwind-types.js';
 export function createFunctionCallUtility(
   property: string,
   fn: string,
-): (value: string) => CSSRuleObject | null {
-  return (value: string) => {
+  options?: { emptyFallback?: string },
+): (value: unknown) => CSSRuleObject | null {
+  return (value: unknown) => {
     if (typeof value !== 'string') return null;
+
+    const trimmed = value.trim();
+
+    if (trimmed === '') {
+      return options?.emptyFallback == null
+        ? null
+        : { [property]: options.emptyFallback };
+    }
     return {
-      [property]: `${fn}(${value})`,
+      [property]: `${fn}(${trimmed})`,
     };
   };
 }

--- a/packages/third-party/tailwind-preset/src/plugin-utils/get-modifier-repeater-map.ts
+++ b/packages/third-party/tailwind-preset/src/plugin-utils/get-modifier-repeater-map.ts
@@ -23,7 +23,7 @@ type UtilityFn = (value: unknown) => CSSRuleObject | null;
 export function getModifierRepeaterMap(
   cssProperty: string,
   classPrefix: string,
-  modifierMap: Record<string, string>,
+  modifierMap: Record<string, string> | undefined,
   options?: {
     repeatedModifier?: string;
   } & Omit<RepeaterOptions, 'matchValue' | 'count'>,
@@ -33,7 +33,9 @@ export function getModifierRepeaterMap(
     ...repeaterOptions
   } = options ?? {};
 
-  const entries = Object.entries(modifierMap ?? {});
+  modifierMap = modifierMap ?? {};
+
+  const entries = Object.entries(modifierMap);
   const defaultValue = modifierMap['DEFAULT'] ?? '';
 
   const namedEntries = entries.filter(([modifier]) => modifier !== 'DEFAULT');

--- a/packages/third-party/tailwind-preset/src/plugins/lynx/blur.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx/blur.ts
@@ -1,0 +1,19 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { createPlugin } from '../../helpers.js';
+import type { Plugin } from '../../helpers.js';
+import { createFunctionCallUtility } from '../../plugin-utils/create-function-call-utility.js';
+
+export const blur: Plugin = createPlugin(({ matchUtilities, theme }) => {
+  matchUtilities(
+    {
+      blur: createFunctionCallUtility('filter', 'blur', {
+        emptyFallback: 'none',
+      }),
+    },
+    {
+      values: theme('blur'),
+    },
+  );
+});

--- a/packages/third-party/tailwind-preset/src/plugins/lynx/filter.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx/filter.ts
@@ -1,0 +1,11 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { createPlugin } from '../../helpers.js';
+import type { Plugin } from '../../helpers.js';
+
+export const filter: Plugin = createPlugin(({ addUtilities }) => {
+  addUtilities({
+    '.filter-none': { filter: 'none' },
+  });
+});

--- a/packages/third-party/tailwind-preset/src/plugins/lynx/grayscale.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx/grayscale.ts
@@ -1,0 +1,16 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { createPlugin } from '../../helpers.js';
+import type { Plugin } from '../../helpers.js';
+import { createFunctionCallUtility } from '../../plugin-utils/create-function-call-utility.js';
+
+export const grayscale: Plugin = createPlugin(({ matchUtilities, theme }) => {
+  matchUtilities({
+    grayscale: createFunctionCallUtility('filter', 'grayscale', {
+      emptyFallback: 'none',
+    }),
+  }, {
+    values: theme('grayscale'),
+  });
+});

--- a/packages/third-party/tailwind-preset/src/plugins/lynx/index.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx/index.ts
@@ -33,3 +33,6 @@ export { transitionProperty } from './transitionProperty.js';
 export { transitionDuration } from './transitionDuration.js';
 export { transitionDelay } from './transitionDelay.js';
 export { transitionTimingFunction } from './transitionTimingFunction.js';
+export { filter } from './filter.js';
+export { blur } from './blur.js';
+export { grayscale } from './grayscale.js';

--- a/packages/third-party/tailwind-preset/src/plugins/lynx/plugin-registry.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx/plugin-registry.ts
@@ -57,6 +57,9 @@ export const LYNX_PLUGIN_ENTRIES: readonly LynxPluginEntry[] = [
 
   ['backgroundClip', P.backgroundClip],
   ['boxShadow', P.boxShadow],
+  ['blur', P.blur],
+  ['grayscale', P.grayscale],
+  ['filter', P.filter],
 
   ['transitionProperty', P.transitionProperty],
   ['transitionDelay', P.transitionDelay],

--- a/packages/third-party/tailwind-preset/src/plugins/lynx/soloTranslate.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx/soloTranslate.ts
@@ -17,7 +17,7 @@ export const soloTranslate: Plugin = createPlugin(
           'transform',
           'translateY',
         ),
-        'solo-translate-z': (value: string) => {
+        'solo-translate-z': (value: unknown) => {
           // Prevent use of percent values for translateZ
           if (typeof value === 'string' && value.includes('%')) return null;
           return createFunctionCallUtility('transform', 'translateZ')(value);

--- a/packages/third-party/tailwind-preset/src/theme.ts
+++ b/packages/third-party/tailwind-preset/src/theme.ts
@@ -121,4 +121,12 @@ export const lynxTheme: Partial<LynxThemeConfig> = {
     out: 'cubic-bezier(0, 0, 0.2, 1)',
     'in-out': 'cubic-bezier(0.4, 0, 0.2, 1)',
   },
+  grayscale: {
+    none: '',
+    0: '0',
+    25: '25%',
+    50: '50%',
+    75: '75%',
+    DEFAULT: '100%',
+  },
 };

--- a/packages/third-party/tailwind-preset/src/theme.ts
+++ b/packages/third-party/tailwind-preset/src/theme.ts
@@ -3,7 +3,9 @@
 // LICENSE file in the root directory of this source tree.
 import type { LynxThemeConfig } from './types/theme-types.js';
 
-export const lynxTheme: Partial<LynxThemeConfig> = {
+export const lynxTheme: Partial<LynxThemeConfig> & {
+  extend?: Partial<LynxThemeConfig>;
+} = {
   boxShadow: {
     sm: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
     DEFAULT:
@@ -102,31 +104,18 @@ export const lynxTheme: Partial<LynxThemeConfig> = {
     'background-color': 'background-color',
     'border-color': 'border-color',
   },
-  transitionDuration: {
-    DEFAULT: '150ms',
-    0: '0s',
-    75: '75ms',
-    100: '100ms',
-    150: '150ms',
-    200: '200ms',
-    300: '300ms',
-    500: '500ms',
-    700: '700ms',
-    1000: '1000ms',
-  },
-  transitionTimingFunction: {
-    DEFAULT: 'cubic-bezier(0.4, 0, 0.2, 1)',
-    linear: 'linear',
-    in: 'cubic-bezier(0.4, 0, 1, 1)',
-    out: 'cubic-bezier(0, 0, 0.2, 1)',
-    'in-out': 'cubic-bezier(0.4, 0, 0.2, 1)',
-  },
-  grayscale: {
-    none: '',
-    0: '0',
-    25: '25%',
-    50: '50%',
-    75: '75%',
-    DEFAULT: '100%',
+  extend: {
+    transitionDuration: {
+      DEFAULT: '150ms',
+    },
+    transitionTimingFunction: {
+      DEFAULT: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    },
+    grayscale: {
+      none: '',
+      25: '25%',
+      50: '50%',
+      75: '75%',
+    },
   },
 };

--- a/packages/third-party/tailwind-preset/src/types/theme-types.ts
+++ b/packages/third-party/tailwind-preset/src/types/theme-types.ts
@@ -11,6 +11,7 @@ type LynxThemeOverrides = Pick<
   ThemeConfig,
   | 'aspectRatio'
   | 'boxShadow'
+  | 'grayscale'
   | 'gridAutoColumns'
   | 'gridAutoRows'
   | 'gridTemplateColumns'


### PR DESCRIPTION
## Summary
**Feature**

Add filter utilities: `blur-*`, `grayscale-*`.

- On Lynx, filter functions are mutually exclusive.
- Replaces Tailwind's variable-based filter system.

**Refactor**

Improve `createFunctionCallUtility` robustness.

- Accepts `unknown`, trims strings, adds `emptyFallback`, returns `null` on invalid input

**Docs**

Update plugin registration guide to reflect category-based registries.


<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new utility classes for blur and grayscale filters, allowing users to apply blur and grayscale effects using Tailwind-style classes.
  * Introduced a utility class for removing all filters.
  * Extended the theme configuration with predefined grayscale levels.

* **Documentation**
  * Improved and clarified documentation on how to add or remove utilities and plugins, including guidance on plugin registration and ordering.

* **Tests**
  * Added comprehensive tests for the new blur and grayscale utilities, ensuring correct behavior for various input scenarios.
  * Enhanced utility function tests for better input handling and fallback behavior.
  * Added tests to verify safe handling of missing or empty modifier maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).