### PR TITLE
fix: crash on chrome<96

### DIFF
--- a/.changeset/tall-experts-take.md
+++ b/.changeset/tall-experts-take.md
@@ -1,0 +1,20 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-core": patch
+---
+
+fix: crash on chrome<96
+
+https://github.com/wasm-bindgen/wasm-bindgen/issues/4211#issuecomment-2505965903
+
+https://github.com/WebAssembly/binaryen/issues/7358
+
+The rust toolchain enables WASM feature `reference types` by default.
+
+However this feature is not supported by chromium lower than version 96
+
+Therefore we found a workaround for it.
+
+In this implementation we detect if browser supports `reference types` first.
+
+If user's browser supported it, we load the wasm file with `reference types` on, otherwise we load the wasm file with `reference types` off.

--- a/packages/web-platform/web-style-transformer/index.js
+++ b/packages/web-platform/web-style-transformer/index.js
@@ -1,4 +1,23 @@
+import { referenceTypes } from 'wasm-feature-detect';
 export let wasm;
 export async function initWasm() {
-  wasm = await import('./standard.js');
+  const supportsReferenceTypes = await referenceTypes();
+  if (supportsReferenceTypes) {
+    wasm = await import(
+      /* webpackMode: "eager" */
+      /* webpackFetchPriority: "high" */
+      /* webpackChunkName: "standard-wasm-chunk" */
+      /* webpackPrefetch: true */
+      /* webpackPreload: true */
+      './standard.js'
+    );
+  } else {
+    wasm = await import(
+      /* webpackMode: "lazy" */
+      /* webpackChunkName: "legacy-wasm-chunk" */
+      /* webpackPrefetch: false */
+      /* webpackPreload: false */
+      './legacy.js'
+    );
+  }
 }

--- a/packages/web-platform/web-style-transformer/legacy.js
+++ b/packages/web-platform/web-style-transformer/legacy.js
@@ -1,0 +1,2 @@
+export * from './dist/legacy.js';
+export { memory } from './dist/legacy_bg.wasm';

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -23,8 +23,13 @@
     "README.md"
   ],
   "scripts": {
-    "build": "wasm-pack build --target bundler --out-dir dist --out-name index --mode no-install && node -e \"require('fs').rmSync('dist/.gitignore', { force: true })\"",
+    "build": "pnpm run build:standard && pnpm run build:legacy",
+    "build:legacy": "RUSTFLAGS=-Cstrip=symbols wasm-pack build --target bundler --out-dir dist --out-name legacy --mode no-install && node -e \"require('fs').rmSync('dist/.gitignore', { force: true })\"",
+    "build:standard": "wasm-pack build --target bundler --out-dir dist --out-name standard --mode no-install && node -e \"require('fs').rmSync('dist/.gitignore', { force: true })\"",
     "build:wasm-bindgen": "wasm-bindgen --version || cargo install wasm-bindgen-cli",
     "build:wasm-pack": "wasm-pack --version || cargo install wasm-pack"
+  },
+  "dependencies": {
+    "wasm-feature-detect": "^1.8.0"
   }
 }

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -23,9 +23,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "pnpm run build:standard && pnpm run build:legacy",
-    "build:legacy": "RUSTFLAGS=-Cstrip=symbols wasm-pack build --target bundler --out-dir dist --out-name legacy --mode no-install && node -e \"require('fs').rmSync('dist/.gitignore', { force: true })\"",
-    "build:standard": "wasm-pack build --target bundler --out-dir dist --out-name standard --mode no-install && node -e \"require('fs').rmSync('dist/.gitignore', { force: true })\"",
+    "build": "node scripts/build.js",
     "build:wasm-bindgen": "wasm-bindgen --version || cargo install wasm-bindgen-cli",
     "build:wasm-pack": "wasm-pack --version || cargo install wasm-pack"
   },

--- a/packages/web-platform/web-style-transformer/scripts/build.js
+++ b/packages/web-platform/web-style-transformer/scripts/build.js
@@ -1,0 +1,21 @@
+// run command and dump output
+import { execSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+execSync(
+  `wasm-pack build --target bundler --out-dir dist --out-name standard --mode no-install`,
+  { cwd: packageRoot, stdio: 'inherit' },
+);
+execSync(
+  `wasm-pack build --target bundler --out-dir dist --out-name legacy --mode no-install`,
+  {
+    env: { ...process.env, RUSTFLAGS: '-Cstrip=symbols' },
+    cwd: packageRoot,
+    stdio: 'inherit',
+  },
+);
+fs.rmSync(path.join(packageRoot, 'dist', '.gitignore'), { force: true });

--- a/packages/web-platform/web-style-transformer/standard.js
+++ b/packages/web-platform/web-style-transformer/standard.js
@@ -1,2 +1,2 @@
-export * from './dist/index.js';
-export { memory } from './dist/index_bg.wasm';
+export * from './dist/standard.js';
+export { memory } from './dist/standard_bg.wasm';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,7 +793,11 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.33)(@vitest/ui@3.2.4)(jsdom@26.1.0)(sass-embedded@1.89.2)(terser@5.31.6)
 
-  packages/web-platform/web-style-transformer: {}
+  packages/web-platform/web-style-transformer:
+    dependencies:
+      wasm-feature-detect:
+        specifier: ^1.8.0
+        version: 1.8.0
 
   packages/web-platform/web-tests:
     devDependencies:
@@ -8039,6 +8043,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  wasm-feature-detect@1.8.0:
+    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
 
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
@@ -16303,6 +16310,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  wasm-feature-detect@1.8.0: {}
 
   watchpack@2.4.2:
     dependencies:


### PR DESCRIPTION

https://github.com/wasm-bindgen/wasm-bindgen/issues/4211#issuecomment-2505965903

https://github.com/WebAssembly/binaryen/issues/7358

The rust toolchain enables WASM feature `reference types` by default.

However this feature is not supported by chromium lower than version 96

Therefore we found a workaround for it.

In this implementation we detect if browser supports `reference types` first.

If user's browser supported it, we load the wasm file with `reference types` on, otherwise we load the wasm file with `reference types` off.

relies on #819 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes on Chrome versions earlier than 96 by detecting WebAssembly reference type support and loading compatible modules accordingly.
* **New Features**
  * Introduced a legacy WebAssembly module to support browsers without reference type support.
* **Chores**
  * Enhanced build process with a new script to produce both standard and legacy WebAssembly modules.
  * Added runtime dependency for WebAssembly feature detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->