### PR TITLE
feat: implement `__ElementFromBinary`

### DIFF
--- a/.changeset/hungry-lions-eat.md
+++ b/.changeset/hungry-lions-eat.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+---
+
+feat: support `__ElementFromBinary`

--- a/packages/web-platform/web-constants/src/types/LynxModule.ts
+++ b/packages/web-platform/web-constants/src/types/LynxModule.ts
@@ -2,8 +2,20 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import type { Cloneable } from './Cloneable.js';
+import type { LynxEventType } from './EventType.js';
 import type { PageConfig } from './PageConfig.js';
 import type { StyleInfo } from './StyleInfo.js';
+
+export type ElementTemplateData = {
+  id: string;
+  type: string;
+  class: string[];
+  idSelector: string;
+  attributes: Record<string, string>;
+  builtinAttributes: Record<string, string>;
+  children: ElementTemplateData[];
+  events: { type: LynxEventType; name: string; value: string }[];
+};
 
 export interface LynxTemplate {
   styleInfo: StyleInfo;
@@ -23,6 +35,7 @@ export interface LynxTemplate {
     '/app-service.js': string;
     [key: string]: string;
   };
+  elementTemplate: Record<string, ElementTemplateData[]>;
 }
 
 export interface LynxJSModule {

--- a/packages/web-platform/web-constants/src/types/MainThreadGlobalThis.ts
+++ b/packages/web-platform/web-constants/src/types/MainThreadGlobalThis.ts
@@ -280,7 +280,14 @@ interface JSErrorInfo {
   release: string;
 }
 
+export type ElementFromBinaryPAPI = (
+  templateId: string,
+  parentComponentUniId: number,
+) => WebFiberElementImpl[];
+
 export interface MainThreadGlobalThis {
+  __ElementFromBinary: ElementFromBinaryPAPI;
+
   // __GetTemplateParts currently only provided by the thread-strategy = "all-on-ui" (default)
   __GetTemplateParts?: GetTemplatePartsPAPI;
 

--- a/packages/web-platform/web-constants/src/utils/generateTemplate.ts
+++ b/packages/web-platform/web-constants/src/utils/generateTemplate.ts
@@ -69,6 +69,7 @@ const mainThreadInjectVars = [
   '__MarkPartElement',
   '__MarkTemplateElement',
   '__GetPageElement',
+  '__ElementFromBinary',
 ];
 
 const backgroundInjectVars = [

--- a/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
+++ b/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
@@ -708,6 +708,8 @@ export function createMainThreadGlobalThis(
     data: ElementTemplateData,
     element: WebFiberElementImpl,
   ) => void = (data, element) => {
+    const uniqueId = uniqueIdInc++;
+    element.setAttribute(lynxUniqueIdAttribute, uniqueId + '');
     for (const event of data.events) {
       const { type, name, value } = event;
       __AddEvent(element, type, name, value);

--- a/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
+++ b/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
@@ -59,6 +59,8 @@ import {
   lynxDisposedAttribute,
   type SSRHydrateInfo,
   type SSRDehydrateHooks,
+  type ElementTemplateData,
+  type ElementFromBinaryPAPI,
 } from '@lynx-js/web-constants';
 import { globalMuteableVars } from '@lynx-js/web-constants';
 import { createMainThreadLynx } from './createMainThreadLynx.js';
@@ -144,12 +146,13 @@ export interface MainThreadRuntimeConfig {
   callbacks: MainThreadRuntimeCallbacks;
   styleInfo: StyleInfo;
   customSections: LynxTemplate['customSections'];
+  elementTemplate: LynxTemplate['elementTemplate'];
   lepusCode: Record<string, LynxJSModule>;
   browserConfig: BrowserConfig;
   tagMap: Record<string, string>;
   rootDom:
     & Pick<Element, 'append' | 'addEventListener'>
-    & Partial<Pick<Element, 'querySelectorAll'>>;
+    & Partial<Pick<ShadowRoot, 'querySelectorAll' | 'cloneNode'>>;
   jsContext: LynxContextEventTarget;
   ssrHydrateInfo?: SSRHydrateInfo;
   ssrHooks?: SSRDehydrateHooks;
@@ -677,9 +680,90 @@ export function createMainThreadGlobalThis(
     return pageElement;
   };
 
+  const templateIdToTemplate: Record<string, HTMLTemplateElement> = {};
+
+  const createElementForElementTemplateData = (
+    data: ElementTemplateData,
+    parentComponentUniId: number,
+  ): WebFiberElementImpl => {
+    const element = __CreateElement(data.type, parentComponentUniId);
+    __SetID(element, data.id);
+    __SetClasses(element, data.class.join(' '));
+    for (const [key, value] of Object.entries(data.attributes)) {
+      __SetAttribute(element, key, value);
+    }
+    for (const [key, value] of Object.entries(data.builtinAttributes)) {
+      __SetAttribute(element, key, value);
+    }
+    for (const childData of data.children) {
+      __AppendElement(
+        element,
+        createElementForElementTemplateData(childData, parentComponentUniId),
+      );
+    }
+    return element;
+  };
+
+  const applyEventsForElementTemplate: (
+    data: ElementTemplateData,
+    element: WebFiberElementImpl,
+  ) => void = (data, element) => {
+    for (const event of data.events) {
+      const { type, name, value } = event;
+      __AddEvent(element, type, name, value);
+    }
+    for (let ii = 0; ii < data.children.length; ii++) {
+      const childData = data.children[ii];
+      const childElement = element.children[ii] as WebFiberElementImpl;
+      if (childData && childElement) {
+        applyEventsForElementTemplate(childData, childElement);
+      }
+    }
+  };
+
+  const __ElementFromBinary: ElementFromBinaryPAPI = (
+    templateId,
+    parentComponentUniId,
+  ) => {
+    const elementTemplateData = config.elementTemplate[templateId];
+    if (elementTemplateData) {
+      let clonedElements: WebFiberElementImpl[];
+      if (templateIdToTemplate[templateId]) {
+        clonedElements = Array.from(
+          (templateIdToTemplate[templateId].content.cloneNode(
+            true,
+          ) as DocumentFragment).children,
+        ) as unknown as WebFiberElementImpl[];
+      } else {
+        clonedElements = elementTemplateData.map(data =>
+          createElementForElementTemplateData(data, parentComponentUniId)
+        );
+        if (rootDom.cloneNode) {
+          const template = callbacks.createElement(
+            'template',
+          ) as unknown as HTMLTemplateElement;
+          template.content.append(...clonedElements as unknown as Node[]);
+          templateIdToTemplate[templateId] = template;
+          rootDom.append(template);
+          return __ElementFromBinary(templateId, parentComponentUniId);
+        }
+      }
+      for (let ii = 0; ii < clonedElements.length; ii++) {
+        const data = elementTemplateData[ii];
+        const element = clonedElements[ii];
+        if (data && element) {
+          applyEventsForElementTemplate(data, element);
+        }
+      }
+      return clonedElements;
+    }
+    return [];
+  };
+
   let release = '';
   const isCSSOG = !pageConfig.enableCSSSelector;
   const mtsGlobalThis: MainThreadGlobalThis = {
+    __ElementFromBinary,
     __GetTemplateParts: rootDom.querySelectorAll
       ? __GetTemplateParts
       : undefined,

--- a/packages/web-platform/web-mainthread-apis/src/prepareMainThreadAPIs.ts
+++ b/packages/web-platform/web-mainthread-apis/src/prepareMainThreadAPIs.ts
@@ -82,8 +82,14 @@ export function prepareMainThreadAPIs(
       tagMap,
       initI18nResources,
     } = config;
-    const { styleInfo, pageConfig, customSections, cardType, lepusCode } =
-      template;
+    const {
+      styleInfo,
+      pageConfig,
+      customSections,
+      cardType,
+      lepusCode,
+      elementTemplate,
+    } = template;
     markTimingInternal('decode_start');
     await initWasmPromise;
     const lepusCodeEntries = await Promise.all(
@@ -114,6 +120,7 @@ export function prepareMainThreadAPIs(
       tagMap,
       browserConfig,
       customSections,
+      elementTemplate,
       globalProps,
       pageConfig,
       styleInfo,

--- a/packages/web-platform/web-tests/resources/web-core.main-thread.json
+++ b/packages/web-platform/web-tests/resources/web-core.main-thread.json
@@ -26,5 +26,43 @@
     "enableParallelElement": true,
     "enableRemoveCSSScope": true,
     "targetSdkVersion": "2.10"
+  },
+  "elementTemplate": {
+    "test-template": [
+      {
+        "id": "id-1",
+        "type": "view",
+        "class": [
+          "class1",
+          "class2"
+        ],
+        "idSelector": "template-view",
+        "attributes": {
+          "attr1": "value1"
+        },
+        "builtinAttributes": {},
+        "children": [
+          {
+            "id": "id-2",
+            "type": "text",
+            "class": [],
+            "idSelector": "",
+            "attributes": {
+              "value": "Hello from template"
+            },
+            "builtinAttributes": {},
+            "children": [],
+            "events": []
+          }
+        ],
+        "events": [
+          {
+            "type": "bindEvent",
+            "name": "tap",
+            "value": "templateTap"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/packages/web-platform/web-tests/shell-project/mainthread-test.ts
+++ b/packages/web-platform/web-tests/shell-project/mainthread-test.ts
@@ -1,7 +1,10 @@
 // Copyright 2023 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-
+import {
+  customSections,
+  elementTemplate,
+} from '../resources/web-core.main-thread.json' with { type: 'json' };
 import { createMainThreadGlobalThis } from '@lynx-js/web-mainthread-apis';
 import { initOffscreenDocument } from '@lynx-js/offscreen-document/main';
 import { initWasm } from '@lynx-js/web-style-transformer';
@@ -111,7 +114,9 @@ function initializeMainThreadTest() {
       // @ts-expect-error
       root: '',
     },
-    customSections: {},
+    customSections,
+    // @ts-expect-error
+    elementTemplate,
     browserConfig: {
       pixelRatio: 0,
       pixelWidth: 0,

--- a/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
+++ b/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
@@ -1270,4 +1270,64 @@ test.describe('main thread api tests', () => {
       expect(result.targetPartExist).toBe(true);
     },
   );
+
+  test.describe('__ElementFromBinary', () => {
+    test('should create a basic element from template', async ({ page }) => {
+      const result = await page.evaluate(() => {
+        const element = globalThis.__ElementFromBinary('test-template', 0)[0];
+        return {
+          tag: globalThis.__GetTag(element),
+        };
+      });
+      expect(result.tag).toBe('view');
+    });
+
+    test('should apply attributes from template', async ({ page }) => {
+      const result = await page.evaluate(() => {
+        const element = globalThis.__ElementFromBinary('test-template', 0)[0];
+        return globalThis.__GetAttributes(element);
+      });
+      expect(result.attr1).toBe('value1');
+    });
+
+    test('should apply classes from template', async ({ page }) => {
+      const result = await page.evaluate(() => {
+        const element = globalThis.__ElementFromBinary('test-template', 0)[0];
+        return globalThis.__GetClasses(element);
+      });
+      expect(result).toEqual(['class1', 'class2']);
+    });
+
+    test('should apply id from template', async ({ page }) => {
+      const result = await page.evaluate(() => {
+        const element = globalThis.__ElementFromBinary('test-template', 0)[0];
+        return globalThis.__GetID(element);
+      });
+      expect(result).toBe('id-1');
+    });
+
+    test('should create child elements from template', async ({ page }) => {
+      const result = await page.evaluate(() => {
+        const element = globalThis.__ElementFromBinary('test-template', 0)[0];
+        const child = globalThis.__FirstElement(element);
+        return {
+          childTag: globalThis.__GetTag(child),
+          value: globalThis.__GetAttributes(child).value,
+        };
+      });
+      expect(result.childTag).toBe('text');
+      expect(result.value).toBe('Hello from template');
+    });
+
+    test('should apply events from template', async ({ page }) => {
+      const result = await page.evaluate(() => {
+        const element = globalThis.__ElementFromBinary('test-template', 0)[0];
+        const events = globalThis.__GetEvents(element);
+        return events;
+      });
+      expect(result.length).toBe(1);
+      expect(result[0].name).toBe('tap');
+      expect(result[0].type).toBe('bindEvent');
+    });
+  });
 });


### PR DESCRIPTION
[Feat] Support ElementTemplate
Fixes #1042

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for creating elements from predefined templates, including attributes, classes, IDs, nested children, and event bindings.
  * Added a new API for generating elements based on template IDs.
* **Tests**
  * Added comprehensive tests to verify element creation from templates, including validation of attributes, classes, IDs, child elements, and event bindings.
* **Chores**
  * Updated test resources and initialization to include sample templates for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
