### PR TITLE
fix(web): x-overlay-ng prevent page scroll when visible

### DIFF
--- a/.changeset/three-bees-know.md
+++ b/.changeset/three-bees-know.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+x-overlay-ng prevent page scroll when visible

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -2823,6 +2823,86 @@ test.describe('reactlynx3 tests', () => {
           expect(await page.getByText('目前计数为 10').count()).toBe(1);
         },
       );
+      test('x-overlay-ng-prevent-page-scroll', async ({ page }, { title }) => {
+        await goto(page, 'basic-element-x-overlay-ng-prevent-page-scroll');
+        await wait(100);
+
+        // 基础滚动锁定测试
+        await test.step('single overlay scroll lock', async () => {
+          // 记录初始overflow状态
+          const initialOverflow = await page.evaluate(() =>
+            document.body.style.overflow
+          );
+
+          // 打开第一层弹层
+          await page.locator('#openOverlay1').click();
+          await wait(100);
+          expect(await page.evaluate(() => document.body.style.overflow)).toBe(
+            'hidden',
+          );
+
+          // 关闭第一层弹层
+          await page.locator('#closeOverlay1').click();
+          await wait(100);
+          expect(await page.evaluate(() => document.body.style.overflow)).toBe(
+            initialOverflow,
+          );
+        });
+
+        // 嵌套弹层滚动锁定测试
+        await test.step('nested overlays scroll lock', async () => {
+          // 打开第一层弹层
+          await page.locator('#openOverlay1').click();
+          await wait(100);
+          expect(await page.evaluate(() => document.body.style.overflow)).toBe(
+            'hidden',
+          );
+
+          // 打开第二层弹层
+          await page.locator('#openOverlay2').click();
+          await wait(100);
+          expect(await page.evaluate(() => document.body.style.overflow)).toBe(
+            'hidden',
+          );
+
+          // 关闭第二层弹层 - 仍保持锁定
+          await page.locator('#closeOverlay2').click();
+          await wait(100);
+          expect(await page.evaluate(() => document.body.style.overflow)).toBe(
+            'hidden',
+          );
+
+          // 关闭第一层弹层 - 恢复滚动
+          await page.locator('#closeOverlay1').click();
+          await wait(100);
+          expect(await page.evaluate(() => document.body.style.overflow)).not
+            .toBe('hidden');
+        });
+
+        // 非顺序关闭弹层测试
+        await test.step('non-sequential close scroll restoration', async () => {
+          // 打开第一层弹层
+          await page.locator('#openOverlay1').click();
+          await wait(100);
+
+          // 打开第二层弹层
+          await page.locator('#openOverlay2').click();
+          await wait(100);
+
+          // 直接关闭第一层弹层
+          await page.locator('#closeOverlay1').click();
+          await wait(100);
+          expect(await page.evaluate(() => document.body.style.overflow)).toBe(
+            'hidden',
+          );
+
+          // 关闭第二层弹层 - 恢复滚动
+          await page.locator('#closeOverlay2').click();
+          await wait(100);
+          expect(await page.evaluate(() => document.body.style.overflow)).not
+            .toBe('hidden');
+        });
+      });
     });
     test.describe('x-refresh-view', () => {
       test(

--- a/packages/web-platform/web-tests/tests/react/basic-element-x-overlay-ng-prevent-page-scroll/index.css
+++ b/packages/web-platform/web-tests/tests/react/basic-element-x-overlay-ng-prevent-page-scroll/index.css
@@ -1,0 +1,91 @@
+.test-card {
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 20px;
+}
+
+.h1 {
+  font-size: 18px;
+  margin: 15px 0;
+  color: #333;
+}
+
+.box {
+  padding: 15px;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.desc {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 15px;
+}
+
+.button {
+  height: 40px;
+  background-color: #007aff;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
+.button-text {
+  color: white;
+  font-size: 14px;
+}
+
+.log-container {
+  background-color: #f5f5f5;
+  padding: 10px;
+  border-radius: 4px;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.log-item {
+  font-size: 12px;
+  color: #666;
+  margin-bottom: 5px;
+}
+
+.overlay-container {
+  background-color: white;
+  border-radius: 10px;
+  width: 80%;
+  margin: 100px auto;
+  overflow: hidden;
+}
+
+.overlay-header {
+  height: 44px;
+  background-color: #f0f0f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-bottom: 1px solid #eee;
+}
+
+.overlay-title {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.overlay-content {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.dialog-overlay {
+  background-color: rgba(0, 0, 0, 0.5);
+}

--- a/packages/web-platform/web-tests/tests/react/basic-element-x-overlay-ng-prevent-page-scroll/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-element-x-overlay-ng-prevent-page-scroll/index.jsx
@@ -1,0 +1,96 @@
+import { root, useState } from '@lynx-js/react';
+import './index.css';
+
+function OverlayContent({ id, onClose, onOpenNested }) {
+  return (
+    <view class='overlay-container'>
+      <view class='overlay-header'>
+        <text class='overlay-title'>Overlay {id}</text>
+      </view>
+      <view class='overlay-content'>
+        <text>点击下方按钮测试滚动锁定逻辑</text>
+        {id === 1 && (
+          <view class='button' catchtap={onOpenNested} id='openOverlay2'>
+            <text class='button-text'>打开嵌套Overlay</text>
+          </view>
+        )}
+        <view class='button' catchtap={onClose} id={`closeOverlay${id}`}>
+          <text class='button-text'>关闭Overlay {id}</text>
+        </view>
+      </view>
+    </view>
+  );
+}
+
+function App() {
+  const [showOverlay1, setShowOverlay1] = useState(false);
+  const [showOverlay2, setShowOverlay2] = useState(false);
+  const [logs, setLogs] = useState([]);
+
+  const logAction = (action) => {
+    setLogs([...logs, `[${new Date().toLocaleTimeString()}] ${action}`]);
+  };
+
+  const toggleOverlay1 = () => {
+    setShowOverlay1(!showOverlay1);
+    logAction(showOverlay1 ? '关闭Overlay 1' : '打开Overlay 1');
+  };
+
+  const toggleOverlay2 = () => {
+    setShowOverlay2(!showOverlay2);
+    logAction(showOverlay2 ? '关闭Overlay 2' : '打开Overlay 2');
+  };
+
+  return (
+    <scroll-view scroll-y class='test-card'>
+      <text class='title'>XOverlayNg 禁止滚动测试</text>
+      <view class='box'>
+        <text class='desc'>
+          测试嵌套弹层场景下的页面滚动锁定逻辑，当前滚动状态将在控制台显示
+        </text>
+        <view class='button' catchtap={toggleOverlay1} id='toggleOverlay1'>
+          {showOverlay1
+            ? <text class='button-text'>关闭Overlay 1</text>
+            : <text class='button-text'>显示Overlay 1</text>}
+        </view>
+      </view>
+
+      <text class='h1'>操作日志</text>
+      <view class='log-container'>
+        {logs.slice(-5).map((log, index) => (
+          <text class='log-item' key={index}>{log}</text>
+        ))}
+      </view>
+
+      {/* 第一层弹层 */}
+      <x-overlay-ng
+        id='overlay1'
+        visible={showOverlay1}
+        custom-layout
+        status-bar-translucent
+        class='dialog-overlay'
+        events-pass-through={false}
+      >
+        <OverlayContent
+          id={1}
+          onClose={toggleOverlay1}
+          onOpenNested={toggleOverlay2}
+        />
+      </x-overlay-ng>
+
+      {/* 第二层弹层 */}
+      <x-overlay-ng
+        id='overlay2'
+        visible={showOverlay2}
+        custom-layout
+        status-bar-translucent
+        class='dialog-overlay'
+        events-pass-through={false}
+      >
+        <OverlayContent id={2} onClose={toggleOverlay2} />
+      </x-overlay-ng>
+    </scroll-view>
+  );
+}
+
+root.render(<App />);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overlays now prevent page scrolling when visible, ensuring a better user experience when multiple overlays are open.
  * Added a public method to allow proper cleanup of overlay scroll-lock state.

* **Bug Fixes**
  * Ensured that page scroll is restored correctly when overlays are closed, including in nested and non-sequential closing scenarios.

* **Tests**
  * Introduced comprehensive tests to verify scroll-lock behavior with single and nested overlays.

* **Style**
  * Added new styles for overlay test interfaces and components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
