### PR TITLE
fix(rspeedy/register): should hook resolve in type stripping

### DIFF
--- a/.changeset/purple-cloths-argue.md
+++ b/.changeset/purple-cloths-argue.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Should support using `.js` extensions when loading configuration with Node.js [builtin type stripping](https://nodejs.org/api/typescript.html#type-stripping).

--- a/packages/rspeedy/core/register/data.d.ts
+++ b/packages/rspeedy/core/register/data.d.ts
@@ -6,4 +6,10 @@ import type { MessagePort } from 'node:worker_threads'
 
 export interface Data {
   port: MessagePort
+  options: Options
+}
+
+export interface Options {
+  load: boolean
+  resolve: boolean
 }

--- a/packages/rspeedy/core/register/hooks.js
+++ b/packages/rspeedy/core/register/hooks.js
@@ -12,11 +12,16 @@ import { URL } from 'node:url'
 import tsBlankSpace from 'ts-blank-space'
 
 /**
- * @type {{ active: boolean; port: import('worker_threads').MessagePort | null }}
+ * @typedef {import('./data').Options} Options
+ */
+
+/**
+ * @type {{ active: boolean; port: import('worker_threads').MessagePort | null; options: Options | null }}
  */
 const state = {
   active: true,
   port: null,
+  options: null,
 }
 
 /**
@@ -35,6 +40,7 @@ const state = {
 export const initialize = function initialize(
   data,
 ) {
+  state.options = data.options
   state.port = data.port
   data.port.on('message', onMessage)
 }
@@ -51,6 +57,10 @@ export const resolve = async function resolve(
   context,
   nextResolve,
 ) {
+  if (!state.options?.resolve) {
+    return nextResolve(specifier, context)
+  }
+
   try {
     return await nextResolve(specifier, context)
   } catch (err) {
@@ -81,6 +91,10 @@ export const resolve = async function resolve(
  * @type {import('module').LoadHook}
  */
 export const load = async function load(url, context, nextLoad) {
+  if (!state.options?.load) {
+    return nextLoad(url, context)
+  }
+
   const fullURL = parseURL(url)
 
   if (!fullURL) {

--- a/packages/rspeedy/core/register/index.d.ts
+++ b/packages/rspeedy/core/register/index.d.ts
@@ -1,4 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-export function register(): () => void
+
+import type { Options } from './data.js'
+
+export function register(options: Options): () => void

--- a/packages/rspeedy/core/register/index.js
+++ b/packages/rspeedy/core/register/index.js
@@ -10,9 +10,9 @@ import module from 'node:module'
 /**
  * Register the ESM loader for TypeScript.
  *
- * @returns {() => void} - The `unregister` function.
+ * @returns - The `unregister` function.
  */
-export function register() {
+export function register(options) {
   // eslint-disable-next-line n/no-unsupported-features/node-builtins
   if (!module.register) {
     throw new Error(
@@ -35,6 +35,7 @@ export function register() {
     {
       parentURL: import.meta.url,
       data: {
+        options,
         port: port2,
       },
       transferList: [port2],

--- a/packages/rspeedy/core/src/config/loadConfig.ts
+++ b/packages/rspeedy/core/src/config/loadConfig.ts
@@ -119,9 +119,10 @@ export async function loadConfig(
   // Note that we are using `pathToFileURL` since absolute paths must be valid file:// URLs on Windows.
   const specifier = pathToFileURL(configPath).toString()
 
-  const unregister = shouldUseNativeImport(configPath)
-    ? /** noop */ () => void 0
-    : register()
+  const unregister = register({
+    load: !shouldUseNativeImport(configPath),
+    resolve: true,
+  })
 
   try {
     const [exports, { validate }] = await Promise.all([


### PR DESCRIPTION
<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable options to control custom module loading and resolution behaviors.
  * Improved compatibility for loading configuration files with `.js` extensions in Node.js environments that support type stripping.

* **Refactor**
  * Updated registration logic to always use explicit options for load and resolve behaviors, streamlining configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

close: #1406 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
