### PR TITLE
fix(react): run all pending `renderComponent` before hydrate

### DIFF
--- a/packages/react/runtime/__test__/lynx/suspense.test.jsx
+++ b/packages/react/runtime/__test__/lynx/suspense.test.jsx
@@ -101,33 +101,6 @@ describe('suspense', () => {
         <page
           cssId="default-entry-from-native:0"
         >
-          <wrapper />
-        </page>
-      `);
-
-      // rLynxChange callback
-      globalEnvManager.switchToBackground();
-      rLynxChange[2]();
-      vi.runAllTimers();
-    }
-
-    // render fallback
-    {
-      globalEnvManager.switchToBackground();
-      lynx.getNativeApp().callLepusMethod.mockClear();
-      await Promise.resolve().then(() => {});
-      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
-
-      // rLynxChange
-      globalEnvManager.switchToMainThread();
-      globalThis.__OnLifecycleEvent.mockClear();
-      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
-      globalThis[rLynxChange[0]](rLynxChange[1]);
-      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
-      expect(__root.__element_root).toMatchInlineSnapshot(`
-        <page
-          cssId="default-entry-from-native:0"
-        >
           <wrapper>
             <text>
               <raw-text
@@ -251,76 +224,6 @@ describe('suspense', () => {
           cssId="default-entry-from-native:0"
         >
           <wrapper>
-            <view
-              attr="an attr"
-            />
-          </wrapper>
-        </page>
-      `);
-
-      // rLynxChange callback
-      globalEnvManager.switchToBackground();
-      rLynxChange[2]();
-      vi.runAllTimers();
-    }
-
-    // render fallback
-    {
-      globalEnvManager.switchToBackground();
-      lynx.getNativeApp().callLepusMethod.mockClear();
-      await Promise.resolve().then(() => {});
-      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
-      const data = JSON.parse(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).patchList[0].snapshotPatch;
-      // A `PreventDestroy` op is inserted to keep the wrapper element alive
-      expect(prettyFormatSnapshotPatch(data)).toMatchInlineSnapshot(`
-        [
-          {
-            "id": 4,
-            "op": "CreateElement",
-            "type": "div",
-          },
-          {
-            "childId": -3,
-            "op": "RemoveChild",
-            "parentId": -1,
-          },
-          {
-            "id": 5,
-            "op": "CreateElement",
-            "type": "wrapper",
-          },
-          {
-            "id": 6,
-            "op": "CreateElement",
-            "type": "__Card__:__snapshot_a94a8_test_3",
-          },
-          {
-            "beforeId": null,
-            "childId": 6,
-            "op": "InsertBefore",
-            "parentId": 5,
-          },
-          {
-            "beforeId": null,
-            "childId": 5,
-            "op": "InsertBefore",
-            "parentId": -1,
-          },
-        ]
-      `);
-      vi.runAllTimers();
-
-      // rLynxChange
-      globalEnvManager.switchToMainThread();
-      globalThis.__OnLifecycleEvent.mockClear();
-      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
-      globalThis[rLynxChange[0]](rLynxChange[1]);
-      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
-      expect(__root.__element_root).toMatchInlineSnapshot(`
-        <page
-          cssId="default-entry-from-native:0"
-        >
-          <wrapper>
             <text>
               <raw-text
                 text="loading"
@@ -347,7 +250,7 @@ describe('suspense', () => {
       expect(prettyFormatSnapshotPatch(data)).toMatchInlineSnapshot(`
         [
           {
-            "id": -3,
+            "id": 2,
             "op": "CreateElement",
             "type": "wrapper",
           },
@@ -367,16 +270,16 @@ describe('suspense', () => {
             "beforeId": null,
             "childId": 3,
             "op": "InsertBefore",
-            "parentId": -3,
+            "parentId": 2,
           },
           {
             "beforeId": null,
-            "childId": -3,
+            "childId": 2,
             "op": "InsertBefore",
             "parentId": -1,
           },
           {
-            "childId": 5,
+            "childId": -3,
             "op": "RemoveChild",
             "parentId": -1,
           },
@@ -393,7 +296,7 @@ describe('suspense', () => {
           },
           {
             "beforeId": null,
-            "childId": -3,
+            "childId": 2,
             "op": "InsertBefore",
             "parentId": -1,
           },
@@ -453,14 +356,16 @@ describe('suspense', () => {
     const { Suspender, suspended } = createSuspender();
 
     function Comp({ show }) {
-      return show && (
-        <Suspense fallback={<text>loading</text>}>
-          <view attr={`an attr`}>
-            <Suspender>
-              <text>foo</text>
-            </Suspender>
-          </view>
-        </Suspense>
+      return (
+        show && (
+          <Suspense fallback={<text>loading</text>}>
+            <view attr={`an attr`}>
+              <Suspender>
+                <text>foo</text>
+              </Suspender>
+            </view>
+          </Suspense>
+        )
       );
     }
 
@@ -490,26 +395,6 @@ describe('suspense', () => {
     {
       // LifecycleConstant.firstScreen
       lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
-      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
-
-      // rLynxChange
-      globalEnvManager.switchToMainThread();
-      globalThis.__OnLifecycleEvent.mockClear();
-      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
-      globalThis[rLynxChange[0]](rLynxChange[1]);
-      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
-
-      // rLynxChange callback
-      globalEnvManager.switchToBackground();
-      rLynxChange[2]();
-      vi.runAllTimers();
-    }
-
-    // render fallback
-    {
-      globalEnvManager.switchToBackground();
-      lynx.getNativeApp().callLepusMethod.mockClear();
-      await Promise.resolve().then(() => {});
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -564,10 +449,10 @@ describe('suspense', () => {
       vi.runAllTimers();
       expect([...backgroundSnapshotInstanceManager.values.keys()]).toMatchInlineSnapshot(`
         [
+          2,
           3,
-          -1,
-          -3,
           4,
+          -1,
           7,
         ]
       `);
@@ -596,7 +481,6 @@ describe('suspense', () => {
         [
           -1,
           -2,
-          4,
         ]
       `);
 
@@ -606,8 +490,8 @@ describe('suspense', () => {
       vi.runAllTimers();
       expect([...backgroundSnapshotInstanceManager.values.keys()]).toMatchInlineSnapshot(`
         [
-          -1,
           4,
+          -1,
         ]
       `);
       expect(backgroundSnapshotInstanceManager.values.get(4).type).toBe('div');
@@ -634,14 +518,16 @@ describe('suspense', () => {
     const { Suspender, suspended } = createSuspender();
 
     function Comp({ show }) {
-      return show && (
-        <Suspense fallback={<text>loading</text>}>
-          <view attr={`an attr`}>
-            <Suspender>
-              <text>foo</text>
-            </Suspender>
-          </view>
-        </Suspense>
+      return (
+        show && (
+          <Suspense fallback={<text>loading</text>}>
+            <view attr={`an attr`}>
+              <Suspender>
+                <text>foo</text>
+              </Suspender>
+            </view>
+          </Suspense>
+        )
       );
     }
 
@@ -661,26 +547,6 @@ describe('suspense', () => {
     {
       // LifecycleConstant.firstScreen
       lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
-      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
-
-      // rLynxChange
-      globalEnvManager.switchToMainThread();
-      globalThis.__OnLifecycleEvent.mockClear();
-      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
-      globalThis[rLynxChange[0]](rLynxChange[1]);
-      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
-
-      // rLynxChange callback
-      globalEnvManager.switchToBackground();
-      rLynxChange[2]();
-      vi.runAllTimers();
-    }
-
-    // render fallback
-    {
-      globalEnvManager.switchToBackground();
-      lynx.getNativeApp().callLepusMethod.mockClear();
-      await Promise.resolve().then(() => {});
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -867,39 +733,6 @@ describe('suspense', () => {
         <page
           cssId="default-entry-from-native:0"
         >
-          <wrapper>
-            <view
-              attr="an attr"
-            />
-          </wrapper>
-        </page>
-      `);
-
-      // rLynxChange callback
-      globalEnvManager.switchToBackground();
-      rLynxChange[2]();
-      vi.runAllTimers();
-    }
-
-    // render fallback
-    {
-      globalEnvManager.switchToBackground();
-      lynx.getNativeApp().callLepusMethod.mockClear();
-      await Promise.resolve().then(() => {});
-      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
-      const data = JSON.parse(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).patchList[0].snapshotPatch;
-      vi.runAllTimers();
-
-      // rLynxChange
-      globalEnvManager.switchToMainThread();
-      globalThis.__OnLifecycleEvent.mockClear();
-      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
-      globalThis[rLynxChange[0]](rLynxChange[1]);
-      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
-      expect(__root.__element_root).toMatchInlineSnapshot(`
-        <page
-          cssId="default-entry-from-native:0"
-        >
           <wrapper />
         </page>
       `);
@@ -1039,38 +872,6 @@ describe('suspense', () => {
           cssId="default-entry-from-native:0"
         >
           <view>
-            <wrapper />
-            <wrapper />
-          </view>
-        </page>
-      `);
-
-      // rLynxChange callback
-      globalEnvManager.switchToBackground();
-      rLynxChange[2]();
-      vi.runAllTimers();
-    }
-
-    // render fallback
-    {
-      globalEnvManager.switchToBackground();
-      lynx.getNativeApp().callLepusMethod.mockClear();
-      await Promise.resolve().then(() => {});
-      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(2);
-
-      // rLynxChange
-      globalEnvManager.switchToMainThread();
-      globalThis.__OnLifecycleEvent.mockClear();
-      const rLynxChange1 = lynx.getNativeApp().callLepusMethod.mock.calls[0];
-      globalThis[rLynxChange1[0]](rLynxChange1[1]);
-      const rLynxChange2 = lynx.getNativeApp().callLepusMethod.mock.calls[1];
-      globalThis[rLynxChange2[0]](rLynxChange2[1]);
-      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
-      expect(__root.__element_root).toMatchInlineSnapshot(`
-        <page
-          cssId="default-entry-from-native:0"
-        >
-          <view>
             <wrapper>
               <text>
                 <raw-text
@@ -1091,8 +892,7 @@ describe('suspense', () => {
 
       // rLynxChange callback
       globalEnvManager.switchToBackground();
-      rLynxChange1[2]();
-      rLynxChange2[2]();
+      rLynxChange[2]();
       vi.runAllTimers();
     }
 
@@ -1245,37 +1045,6 @@ describe('suspense', () => {
     {
       // LifecycleConstant.firstScreen
       lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
-      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
-
-      // rLynxChange
-      globalEnvManager.switchToMainThread();
-      globalThis.__OnLifecycleEvent.mockClear();
-      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
-      globalThis[rLynxChange[0]](rLynxChange[1]);
-      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
-      expect(__root.__element_root).toMatchInlineSnapshot(`
-        <page
-          cssId="default-entry-from-native:0"
-        >
-          <wrapper>
-            <view>
-              <wrapper />
-            </view>
-          </wrapper>
-        </page>
-      `);
-
-      // rLynxChange callback
-      globalEnvManager.switchToBackground();
-      rLynxChange[2]();
-      vi.runAllTimers();
-    }
-
-    // render fallback
-    {
-      globalEnvManager.switchToBackground();
-      lynx.getNativeApp().callLepusMethod.mockClear();
-      await Promise.resolve().then(() => {});
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -1534,9 +1303,7 @@ describe('suspense', () => {
     function Comp({ content }) {
       return (
         <Suspense fallback={<text>loading</text>}>
-          <Suspender>
-            {content}
-          </Suspender>
+          <Suspender>{content}</Suspender>
         </Suspense>
       );
     }
@@ -1570,33 +1337,6 @@ describe('suspense', () => {
     {
       // LifecycleConstant.firstScreen
       lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
-      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
-
-      // rLynxChange
-      globalEnvManager.switchToMainThread();
-      globalThis.__OnLifecycleEvent.mockClear();
-      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
-      globalThis[rLynxChange[0]](rLynxChange[1]);
-      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
-      expect(__root.__element_root).toMatchInlineSnapshot(`
-        <page
-          cssId="default-entry-from-native:0"
-        >
-          <wrapper />
-        </page>
-      `);
-
-      // rLynxChange callback
-      globalEnvManager.switchToBackground();
-      rLynxChange[2]();
-      vi.runAllTimers();
-    }
-
-    // render fallback
-    {
-      globalEnvManager.switchToBackground();
-      lynx.getNativeApp().callLepusMethod.mockClear();
-      await Promise.resolve().then(() => {});
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange

--- a/packages/react/runtime/__test__/render.test.jsx
+++ b/packages/react/runtime/__test__/render.test.jsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { render, Component } from 'preact';
+import { render, Component, process } from 'preact';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { replaceCommitHook } from '../src/lifecycle/patch/commit';
@@ -61,6 +61,7 @@ describe('background render', () => {
 
     globalEnvManager.switchToBackground();
     root.render(<Comp />);
+    process();
     expect(__root.__firstChild.__firstChild.__values).toEqual([88]);
   });
 });

--- a/packages/react/runtime/src/lynx-api.ts
+++ b/packages/react/runtime/src/lynx-api.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { options, render } from 'preact';
+import { render } from 'preact';
 import { createContext, createElement } from 'preact/compat';
 import { useState } from 'preact/hooks';
 import type { Consumer, FC, ReactNode } from 'react';
@@ -88,24 +88,13 @@ export const root: Root = {
       __root.__jsx = jsx;
     } else {
       __root.__jsx = jsx;
-      let preactProcess: (() => void) | undefined = undefined;
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      const oldDebounceRendering = options.debounceRendering;
-      options.debounceRendering = (cb) => {
-        preactProcess = cb;
-      };
-      try {
-        if (__PROFILE__) {
-          profileStart('ReactLynx::renderBackground');
-        }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        render(jsx, __root as any);
-        if (__PROFILE__) {
-          profileEnd();
-        }
-        (preactProcess as (() => void) | undefined)?.();
-      } finally {
-        options.debounceRendering = oldDebounceRendering!;
+      if (__PROFILE__) {
+        profileStart('ReactLynx::renderBackground');
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      render(jsx, __root as any);
+      if (__PROFILE__) {
+        profileEnd();
       }
       if (__FIRST_SCREEN_SYNC_TIMING__ === 'immediately') {
         // This is for cases where `root.render()` is called asynchronously,

--- a/packages/react/runtime/src/lynx/tt.ts
+++ b/packages/react/runtime/src/lynx/tt.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { render } from 'preact';
+import { process, render } from 'preact';
 
 import { LifecycleConstant, NativeUpdateDataType } from '../lifecycleConstant.js';
 import type { FirstScreenData } from '../lifecycleConstant.js';
@@ -70,6 +70,12 @@ function onLifecycleEvent([type, data]: [LifecycleConstant, unknown]) {
 function onLifecycleEventImpl(type: LifecycleConstant, data: unknown): void {
   switch (type) {
     case LifecycleConstant.firstScreen: {
+      let processErr;
+      try {
+        process();
+      } catch (e) {
+        processErr = e;
+      }
       const { root: lepusSide, jsReadyEventIdSwap } = data as FirstScreenData;
       if (__PROFILE__) {
         profileStart('ReactLynx::hydrate');
@@ -126,6 +132,10 @@ function onLifecycleEventImpl(type: LifecycleConstant, data: unknown): void {
         });
       });
       runDelayedUiOps();
+
+      if (processErr) {
+        throw processErr;
+      }
       break;
     }
     case LifecycleConstant.globalEventFromLepus: {


### PR DESCRIPTION
Run all pending `renderComponent` before hydrate, which ensures some immediate update can be applied in `hydrate`.

As background info, ReactLynx will use tree in background-thread as the source-of-truth, so this PR is helpful if main-thread renders more than background-thread's `root.render` by avoiding unwanted node removals.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified background/non-main-thread rendering for more predictable startup.

* **Bug Fixes**
  * Deferred rethrow of certain lifecycle errors so first-screen work and hydration complete.
  * Ensures updates applied before hydration are preserved and hydration proceeds even if background processing errors.

* **Tests**
  * Added and streamlined tests covering pre-hydration updates, render flushing, and suspense/hydration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
