### PR TITLE
feat(react/runtime): support using a host element as direct child of Suspense

### DIFF
--- a/.changeset/fast-coats-swim.md
+++ b/.changeset/fast-coats-swim.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+feat: Support using a host element as direct child of Suspense

--- a/packages/react/runtime/__test__/lynx/suspense.test.jsx
+++ b/packages/react/runtime/__test__/lynx/suspense.test.jsx
@@ -1,0 +1,1635 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { render, Component } from 'preact';
+import { Suspense } from '../../src/index';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { replaceCommitHook } from '../../src/lifecycle/patch/commit';
+import { injectUpdateMainThread } from '../../src/lifecycle/patch/updateMainThread';
+import '../../src/lynx/component';
+import { __root } from '../../src/root';
+import { setupPage, SnapshotInstance, snapshotInstanceManager } from '../../src/snapshot';
+import { globalEnvManager } from '../utils/envManager';
+import { elementTree } from '../utils/nativeMethod';
+import { backgroundSnapshotInstanceManager } from '../../src/snapshot';
+import { prettyFormatSnapshotPatch } from '../../src/debug/formatPatch';
+import { createSuspender } from '../createSuspender';
+
+beforeAll(() => {
+  setupPage(__CreatePage('0', 0));
+  injectUpdateMainThread();
+  replaceCommitHook();
+});
+
+beforeEach(() => {
+  globalEnvManager.resetEnv();
+  vi.useFakeTimers({ toFake: ['setTimeout'] });
+});
+
+afterEach(() => {
+  vi.runAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  elementTree.clear();
+});
+
+describe('suspense', () => {
+  /**
+   * Tests the basic functionality of the `Suspense` component.
+   *
+   * This test covers the entire lifecycle of a suspended component:
+   * 1. The initial render on the main thread.
+   * 2. The background thread starts rendering and encounters the suspended component.
+   * 3. Hydration occurs on the main thread, creating a placeholder wrapper element.
+   * 4. The fallback UI is rendered from the background thread.
+   * 5. The promise is resolved, and the actual content is rendered from the
+   *    background thread, replacing the fallback.
+   */
+  it('should render fallback and content correctly', async () => {
+    const { Suspender, suspended } = createSuspender();
+
+    function Comp() {
+      return (
+        <Suspense fallback={<text>loading</text>}>
+          <Suspender>
+            <text>foo</text>
+          </Suspender>
+        </Suspense>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper />
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render fallback
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <text>
+              <raw-text
+                text="loading"
+              />
+            </text>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render children
+    {
+      globalEnvManager.switchToBackground();
+      suspended.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <text>
+              <raw-text
+                text="foo"
+              />
+            </text>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+
+  /**
+   * This test case verifies that `Suspense` works correctly when its direct
+   * child is a host element (e.g., `<view>`) instead of a component.
+   *
+   * It follows the complete lifecycle:
+   * 1. Initial render on the main thread.
+   * 2. Background thread starts rendering, encountering the suspended component.
+   * 3. Hydration on the main thread, which should render the `<view>` element
+   *    inside a wrapper, but not its suspended children.
+   * 4. The fallback UI is rendered from the background thread. The test asserts
+   *    the snapshot patch includes a `PreventDestroy` operation to keep the
+   *    host element (`<view>`) from being incorrectly destroyed.
+   * 5. The promise is resolved, and the actual children are rendered from the
+   *    background thread, replacing the fallback.
+   */
+  it('should support a host element as a direct child', async () => {
+    const { Suspender, suspended } = createSuspender();
+
+    function Comp() {
+      return (
+        <Suspense fallback={<text>loading</text>}>
+          <view attr={`an attr`}>
+            <Suspender>
+              <text>foo</text>
+            </Suspender>
+          </view>
+        </Suspense>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view
+              attr="an attr"
+            />
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render fallback
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+      const data = JSON.parse(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).patchList[0].snapshotPatch;
+      // A `PreventDestroy` op is inserted to keep the wrapper element alive
+      expect(prettyFormatSnapshotPatch(data)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 4,
+            "op": "CreateElement",
+            "type": "div",
+          },
+          {
+            "childId": 2,
+            "op": "RemoveChild",
+            "parentId": -1,
+          },
+          {
+            "id": 5,
+            "op": "CreateElement",
+            "type": "wrapper",
+          },
+          {
+            "id": 6,
+            "op": "CreateElement",
+            "type": "__Card__:__snapshot_a94a8_test_3",
+          },
+          {
+            "beforeId": null,
+            "childId": 6,
+            "op": "InsertBefore",
+            "parentId": 5,
+          },
+          {
+            "beforeId": null,
+            "childId": 5,
+            "op": "InsertBefore",
+            "parentId": -1,
+          },
+        ]
+      `);
+      vi.runAllTimers();
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <text>
+              <raw-text
+                text="loading"
+              />
+            </text>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render children
+    {
+      globalEnvManager.switchToBackground();
+      suspended.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+      const data = JSON.parse(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).patchList[0].snapshotPatch;
+      expect(prettyFormatSnapshotPatch(data)).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 2,
+            "op": "CreateElement",
+            "type": "wrapper",
+          },
+          {
+            "id": 3,
+            "op": "CreateElement",
+            "type": "__Card__:__snapshot_a94a8_test_4",
+          },
+          {
+            "id": 3,
+            "op": "SetAttributes",
+            "values": [
+              "an attr",
+            ],
+          },
+          {
+            "beforeId": null,
+            "childId": 3,
+            "op": "InsertBefore",
+            "parentId": 2,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+          },
+          {
+            "childId": 5,
+            "op": "RemoveChild",
+            "parentId": -1,
+          },
+          {
+            "id": 7,
+            "op": "CreateElement",
+            "type": "__Card__:__snapshot_a94a8_test_5",
+          },
+          {
+            "beforeId": null,
+            "childId": 7,
+            "op": "InsertBefore",
+            "parentId": 3,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+          },
+        ]
+      `);
+      vi.runAllTimers();
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view
+              attr="an attr"
+            >
+              <text>
+                <raw-text
+                  text="foo"
+                />
+              </text>
+            </view>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+
+  /**
+   * This test case ensures that when a `Suspense` component is unmounted,
+   * all its managed elements are correctly cleaned up from the snapshot
+   * instance managers on both the main and background threads.
+   *
+   * The test follows these steps:
+   * 1. Renders a component containing a `Suspense` boundary, initially visible.
+   * 2. The `Suspense` boundary goes through its complete lifecycle: hydration,
+   *    rendering a fallback, and finally rendering its children.
+   * 3. The component is re-rendered to hide the `Suspense` boundary, triggering
+   *    its unmount.
+   * 4. It asserts that the corresponding elements are removed from the main
+   *    thread's element tree.
+   * 5. It verifies that the snapshot instances on both the main and background
+   *    threads are properly removed after the unmount, preventing
+   *    memory leaks.
+   */
+  it('should clean up elements when unmounted', async () => {
+    const { Suspender, suspended } = createSuspender();
+
+    function Comp({ show }) {
+      return show && (
+        <Suspense fallback={<text>loading</text>}>
+          <view attr={`an attr`}>
+            <Suspender>
+              <text>foo</text>
+            </Suspender>
+          </view>
+        </Suspense>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp show={true} />;
+      renderPage();
+      // `-2` and `-3` are two wrappers created by `createElement` in suspense.
+      // TODO: remove them from `snapshotInstanceManager`.
+      expect([...snapshotInstanceManager.values.keys()]).toMatchInlineSnapshot(`
+        [
+          -1,
+          -2,
+          -3,
+        ]
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp show={true} />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render fallback
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render children
+    {
+      globalEnvManager.switchToBackground();
+      suspended.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+      vi.runAllTimers();
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view
+              attr="an attr"
+            >
+              <text>
+                <raw-text
+                  text="foo"
+                />
+              </text>
+            </view>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+      expect([...backgroundSnapshotInstanceManager.values.keys()]).toMatchInlineSnapshot(`
+        [
+          2,
+          3,
+          -1,
+          4,
+          7,
+        ]
+      `);
+    }
+
+    // remove suspense
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      render(<Comp show={false} />, __root);
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+      expect([...snapshotInstanceManager.values.keys()]).toMatchInlineSnapshot(`
+        [
+          -1,
+          -2,
+          -3,
+          4,
+        ]
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+      expect([...backgroundSnapshotInstanceManager.values.keys()]).toMatchInlineSnapshot(`
+        [
+          -1,
+          4,
+        ]
+      `);
+      expect(backgroundSnapshotInstanceManager.values.get(4).type).toBe('div');
+    }
+  });
+
+  /**
+   * This test case is forked from `should correctly remove elements after suspense destroyed`
+   * with an additional step to verify that the `Suspense` component can be correctly
+   * mounted again after being unmounted.
+   *
+   * It tests the full lifecycle: mount -> unmount -> remount.
+   * 1. Renders a component with a `Suspense` boundary, initially visible.
+   * 2. The `Suspense` boundary goes through its complete lifecycle: hydration,
+   *    rendering a fallback, and finally rendering its children.
+   * 3. The component is re-rendered to hide the `Suspense` boundary, triggering
+   *    its unmount. All associated elements should be cleaned up.
+   * 4. The component is re-rendered again to show the `Suspense` boundary.
+   * 5. It asserts that the `Suspense` boundary and its children are correctly
+   *    re-rendered, ensuring that the unmount/remount cycle does not leave the
+   *    component in an inconsistent state.
+   */
+  it('should support being unmounted and remounted', async () => {
+    const { Suspender, suspended } = createSuspender();
+
+    function Comp({ show }) {
+      return show && (
+        <Suspense fallback={<text>loading</text>}>
+          <view attr={`an attr`}>
+            <Suspender>
+              <text>foo</text>
+            </Suspender>
+          </view>
+        </Suspense>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp show={true} />;
+      renderPage();
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp show={true} />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render fallback
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render children
+    {
+      globalEnvManager.switchToBackground();
+      suspended.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+      vi.runAllTimers();
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view
+              attr="an attr"
+            >
+              <text>
+                <raw-text
+                  text="foo"
+                />
+              </text>
+            </view>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // remove suspense
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      render(<Comp show={false} />, __root);
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // add suspense back
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      render(<Comp show={true} />, __root);
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view
+              attr="an attr"
+            >
+              <text>
+                <raw-text
+                  text="foo"
+                />
+              </text>
+            </view>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+
+  /**
+   * Verifies that `Suspense` still works correctly when the `fallback` prop is
+   * not provided.
+   *
+   * This test is a variation of `should support a host element as a direct child`,
+   * but without a fallback. The expected behavior is that nothing is rendered
+   * until the promise is resolved.
+   *
+   * 1. Initial render on the main thread.
+   * 2. Background thread starts rendering and encounters the suspended component.
+   * 3. Hydration on the main thread renders the `<view>` element inside a
+   *    wrapper, but not its suspended children.
+   * 4. Since there is no fallback, the UI remains unchanged until the promise
+   *    is resolved.
+   * 5. The promise is resolved, and the actual children are rendered from the
+   *    background thread.
+   */
+  it('should render nothing when fallback is not provided', async () => {
+    const { Suspender, suspended } = createSuspender();
+
+    function Comp() {
+      return (
+        <Suspense>
+          <view attr={`an attr`}>
+            <Suspender>
+              <text>foo</text>
+            </Suspender>
+          </view>
+        </Suspense>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view
+              attr="an attr"
+            />
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render fallback
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+      const data = JSON.parse(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).patchList[0].snapshotPatch;
+      vi.runAllTimers();
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper />
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render children
+    {
+      globalEnvManager.switchToBackground();
+      suspended.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+      const data = JSON.parse(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).patchList[0].snapshotPatch;
+      vi.runAllTimers();
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view
+              attr="an attr"
+            >
+              <text>
+                <raw-text
+                  text="foo"
+                />
+              </text>
+            </view>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+
+  /**
+   * This test case verifies that multiple `Suspense` components can be placed
+   * at the same level in the component tree without interfering with each
+   * other.
+   *
+   * It follows these steps:
+   * 1. Renders a component with two parallel `Suspense` boundaries.
+   * 2. Both `Suspense` boundaries go through their initial lifecycle: hydration
+   *    and rendering fallbacks.
+   * 3. The first `Suspense` boundary's promise is resolved, and it renders its
+   *    children. The test asserts that the second `Suspense` boundary remains
+   *    in its fallback state.
+   * 4. The second `Suspense` boundary's promise is resolved, and it renders
+   *    its children. The test asserts that the first `Suspense` boundary's
+   *    content is unaffected.
+   */
+  it('should not interfere with other parallel suspense components', async () => {
+    const { Suspender: Suspender1, suspended: suspended1 } = createSuspender();
+    const { Suspender: Suspender2, suspended: suspended2 } = createSuspender();
+
+    function Comp() {
+      return (
+        <view>
+          <Suspense fallback={<text>loading 1</text>}>
+            <Suspender1>
+              <text>foo</text>
+            </Suspender1>
+          </Suspense>
+          <Suspense fallback={<text>loading 2</text>}>
+            <Suspender2>
+              <text>bar</text>
+            </Suspender2>
+          </Suspense>
+        </view>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view />
+        </page>
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <wrapper />
+            <wrapper />
+          </view>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render fallback
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(2);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange1 = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange1[0]](rLynxChange1[1]);
+      const rLynxChange2 = lynx.getNativeApp().callLepusMethod.mock.calls[1];
+      globalThis[rLynxChange2[0]](rLynxChange2[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <wrapper>
+              <text>
+                <raw-text
+                  text="loading 1"
+                />
+              </text>
+            </wrapper>
+            <wrapper>
+              <text>
+                <raw-text
+                  text="loading 2"
+                />
+              </text>
+            </wrapper>
+          </view>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange1[2]();
+      rLynxChange2[2]();
+      vi.runAllTimers();
+    }
+
+    // render children 1
+    {
+      globalEnvManager.switchToBackground();
+      suspended1.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <wrapper>
+              <text>
+                <raw-text
+                  text="foo"
+                />
+              </text>
+            </wrapper>
+            <wrapper>
+              <text>
+                <raw-text
+                  text="loading 2"
+                />
+              </text>
+            </wrapper>
+          </view>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render children 2
+    {
+      globalEnvManager.switchToBackground();
+      suspended2.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <wrapper>
+              <text>
+                <raw-text
+                  text="foo"
+                />
+              </text>
+            </wrapper>
+            <wrapper>
+              <text>
+                <raw-text
+                  text="bar"
+                />
+              </text>
+            </wrapper>
+          </view>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+
+  /**
+   * Tests the behavior of nested `Suspense` components.
+   *
+   * This test verifies that the nearest `Suspense` boundary correctly
+   * captures the suspended state.
+   *
+   * 1. Renders a component with a nested `Suspense` boundary.
+   * 2. The inner `Suspense` boundary suspends and renders its fallback.
+   * 3. The test asserts that the outer `Suspense` boundary does not show its
+   *    fallback, and the inner one does.
+   * 4. The promise is resolved, and the final content is rendered.
+   */
+  it('should handle nested suspense components correctly', async () => {
+    const { Suspender, suspended } = createSuspender();
+
+    function Comp() {
+      return (
+        <Suspense fallback={<text>loading outer</text>}>
+          <view>
+            <Suspense fallback={<text>loading inner</text>}>
+              <Suspender>
+                <text>foo</text>
+              </Suspender>
+            </Suspense>
+          </view>
+        </Suspense>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view>
+              <wrapper />
+            </view>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render fallback
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view>
+              <wrapper>
+                <text>
+                  <raw-text
+                    text="loading inner"
+                  />
+                </text>
+              </wrapper>
+            </view>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render children
+    {
+      globalEnvManager.switchToBackground();
+      suspended.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <view>
+              <wrapper>
+                <text>
+                  <raw-text
+                    text="foo"
+                  />
+                </text>
+              </wrapper>
+            </view>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+
+  /**
+   * Tests the behavior of `Suspense` when the async task is already
+   * completed before the initial render.
+   *
+   * In this scenario, the fallback content should not be displayed.
+   */
+  it('should not show fallback if promise is already resolved', async () => {
+    const { Suspender, suspended } = createSuspender();
+
+    function Comp() {
+      return (
+        <Suspense fallback={<text>loading</text>}>
+          <Suspender>
+            <text>foo</text>
+          </Suspender>
+        </Suspense>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      await suspended.resolve();
+      render(<Comp />, __root);
+    }
+
+    // hydrate and render children
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <text>
+              <raw-text
+                text="foo"
+              />
+            </text>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+
+  /**
+   * Tests the interaction between `Suspense` and an Error Boundary.
+   *
+   * When a child of `Suspense` throws a real error (not a promise), it
+   * should be caught by an outer Error Boundary.
+   */
+  it('should be caught by an error boundary on error', async () => {
+    class ErrorBoundary extends Component {
+      state = { error: null };
+
+      static getDerivedStateFromError(error) {
+        return { error };
+      }
+
+      render() {
+        if (this.state.error) {
+          return <text>Error: {this.state.error.message}</text>;
+        }
+        return this.props.children;
+      }
+    }
+
+    function Thrower() {
+      throw new Error('test error');
+    }
+
+    function Comp() {
+      return (
+        <ErrorBoundary>
+          <Suspense fallback={<text>loading</text>}>
+            <Thrower />
+          </Suspense>
+        </ErrorBoundary>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+      await Promise.resolve().then(() => {});
+    }
+
+    // hydrate and render error fallback
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <text>
+            <raw-text
+              text="Error: "
+            />
+            <wrapper>
+              <raw-text
+                text="test error"
+              />
+            </wrapper>
+          </text>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+
+  /**
+   * Verifies that `Suspense` can correctly update its children from one
+   * element to another after the initial content has been rendered.
+   *
+   * This test ensures that once a `Suspense` boundary has resolved, subsequent
+   * updates to its children are handled correctly without re-triggering the
+   * fallback state.
+   *
+   * 1. Renders a `Suspense` component and waits for it to resolve and show
+   *    its initial children.
+   * 2. Triggers a re-render with a different set of children.
+   * 3. Asserts that the UI correctly updates to display the new children.
+   */
+  it('should update children from one element to another', async () => {
+    const { Suspender, suspended } = createSuspender();
+
+    function Comp({ content }) {
+      return (
+        <Suspense fallback={<text>loading</text>}>
+          <Suspender>
+            {content}
+          </Suspender>
+        </Suspense>
+      );
+    }
+
+    // Initial render with the first element
+    {
+      __root.__jsx = <Comp content={<text>foo</text>} />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        />
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp content={<text>foo</text>} />, __root);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper />
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render fallback
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <text>
+              <raw-text
+                text="loading"
+              />
+            </text>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // render children
+    {
+      globalEnvManager.switchToBackground();
+      suspended.resolve();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <text>
+              <raw-text
+                text="foo"
+              />
+            </text>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+
+    // Update to the second element
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      render(<Comp content={<text>bar</text>} />, __root);
+      await Promise.resolve().then(() => {});
+      expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
+
+      // rLynxChange
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <wrapper>
+            <text>
+              <raw-text
+                text="bar"
+              />
+            </text>
+          </wrapper>
+        </page>
+      `);
+
+      // rLynxChange callback
+      globalEnvManager.switchToBackground();
+      rLynxChange[2]();
+      vi.runAllTimers();
+    }
+  });
+});

--- a/packages/react/runtime/src/backgroundSnapshot.ts
+++ b/packages/react/runtime/src/backgroundSnapshot.ts
@@ -51,6 +51,7 @@ export class BackgroundSnapshotInstance {
   private __lastChild: BackgroundSnapshotInstance | null = null;
   private __previousSibling: BackgroundSnapshotInstance | null = null;
   private __nextSibling: BackgroundSnapshotInstance | null = null;
+  private __removed_from_tree?: boolean;
 
   get parentNode(): BackgroundSnapshotInstance | null {
     return this.__parent;
@@ -68,25 +69,28 @@ export class BackgroundSnapshotInstance {
     return child.parentNode === this;
   }
 
-  // TODO: write tests for this
   // This will be called in `lazy`/`Suspense`.
-  // We currently ignore this since we did not find a way to test.
-  /* v8 ignore start */
   appendChild(child: BackgroundSnapshotInstance): void {
     return this.insertBefore(child);
   }
-  /* v8 ignore stop */
 
   insertBefore(
     node: BackgroundSnapshotInstance,
     beforeNode?: BackgroundSnapshotInstance,
   ): void {
-    __globalSnapshotPatch?.push(
-      SnapshotOperation.InsertBefore,
-      this.__id,
-      node.__id,
-      beforeNode?.__id,
-    );
+    if (node.__removed_from_tree) {
+      node.__removed_from_tree = false;
+      // This is only called by `lazy`/`Suspense` through `appendChild` so beforeNode is always undefined.
+      /* v8 ignore next */
+      reconstructInstanceTree([node], this.__id, beforeNode?.__id);
+    } else {
+      __globalSnapshotPatch?.push(
+        SnapshotOperation.InsertBefore,
+        this.__id,
+        node.__id,
+        beforeNode?.__id,
+      );
+    }
 
     // If the node already has a parent, remove it from its current parent
     const p = node.__parent;
@@ -137,6 +141,7 @@ export class BackgroundSnapshotInstance {
       this.__id,
       node.__id,
     );
+    node.__removed_from_tree = true;
 
     if (node.__parent !== this) {
       throw new Error('The node to be removed is not a child of this node.');
@@ -361,24 +366,6 @@ export function hydrate(
 ): SnapshotPatch {
   initGlobalSnapshotPatch();
 
-  const helper2 = (afters: BackgroundSnapshotInstance[], parentId: number, targetId?: number) => {
-    for (const child of afters) {
-      const id = child.__id;
-      __globalSnapshotPatch!.push(SnapshotOperation.CreateElement, child.type, id);
-      const values = child.__values;
-      if (values) {
-        child.__values = undefined;
-        child.setAttribute('values', values);
-      }
-      const extraProps = child.__extraProps;
-      for (const key in extraProps) {
-        child.setAttribute(key, extraProps[key]);
-      }
-      helper2(child.childNodes, id);
-      __globalSnapshotPatch!.push(SnapshotOperation.InsertBefore, parentId, id, targetId);
-    }
-  };
-
   const helper = (
     before: SerializedSnapshotInstance,
     after: BackgroundSnapshotInstance,
@@ -488,7 +475,7 @@ export function hydrate(
             beforeChildNodes,
             diffResult,
             (node, target) => {
-              helper2([node], before.id, target?.id);
+              reconstructInstanceTree([node], before.id, target?.id);
               return undefined as unknown as SerializedSnapshotInstance;
             },
             node => {
@@ -518,4 +505,22 @@ export function hydrate(
   // Hydration should not trigger ref updates. They were incorrectly triggered when using `setAttribute` to add values to the patch list.
   clearQueuedRefs();
   return takeGlobalSnapshotPatch()!;
+}
+
+function reconstructInstanceTree(afters: BackgroundSnapshotInstance[], parentId: number, targetId?: number): void {
+  for (const child of afters) {
+    const id = child.__id;
+    __globalSnapshotPatch!.push(SnapshotOperation.CreateElement, child.type, id);
+    const values = child.__values;
+    if (values) {
+      child.__values = undefined;
+      child.setAttribute('values', values);
+    }
+    const extraProps = child.__extraProps;
+    for (const key in extraProps) {
+      child.setAttribute(key, extraProps[key]);
+    }
+    reconstructInstanceTree(child.childNodes, id);
+    __globalSnapshotPatch!.push(SnapshotOperation.InsertBefore, parentId, id, targetId);
+  }
 }

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -9,7 +9,6 @@ import {
   Component,
   Fragment,
   PureComponent,
-  Suspense,
   cloneElement,
   createContext,
   createElement,
@@ -34,6 +33,7 @@ import {
   useState,
 } from './hooks/react.js';
 import { loadLazyBundle } from './lynx/lazy-bundle.js';
+import { Suspense } from './lynx/suspense.js';
 
 export { Component, createContext } from 'preact';
 export { PureComponent } from 'preact/compat';

--- a/packages/react/runtime/src/internal.ts
+++ b/packages/react/runtime/src/internal.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { createElement, lazy } from 'preact/compat';
+import { Suspense, createElement, lazy } from 'preact/compat';
 import type { FC } from 'react';
 
 import './lynx.js';
@@ -10,7 +10,6 @@ import './lynx.js';
 import { factory as factory2 } from './compat/componentIs.js';
 import { useMemo } from './hooks/react.js';
 import { loadLazyBundle } from './lynx/lazy-bundle.js';
-import { Suspense } from './lynx/suspense.js';
 import { __root } from './root.js';
 import { DynamicPartType } from './snapshot/dynamicPartType.js';
 import { snapshotCreateList } from './snapshot/list.js';

--- a/packages/react/runtime/src/internal.ts
+++ b/packages/react/runtime/src/internal.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { Suspense, createElement, lazy } from 'preact/compat';
+import { createElement, lazy } from 'preact/compat';
 import type { FC } from 'react';
 
 import './lynx.js';
@@ -10,6 +10,7 @@ import './lynx.js';
 import { factory as factory2 } from './compat/componentIs.js';
 import { useMemo } from './hooks/react.js';
 import { loadLazyBundle } from './lynx/lazy-bundle.js';
+import { Suspense } from './lynx/suspense.js';
 import { __root } from './root.js';
 import { DynamicPartType } from './snapshot/dynamicPartType.js';
 import { snapshotCreateList } from './snapshot/list.js';

--- a/packages/react/runtime/src/lynx/suspense.ts
+++ b/packages/react/runtime/src/lynx/suspense.ts
@@ -1,0 +1,44 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { FunctionComponent, VNode } from 'preact';
+import { Suspense as PreactSuspense, createElement as createElementBackground } from 'preact/compat';
+import { useRef } from 'preact/hooks';
+
+import { createElement as createElementMainThread } from '@lynx-js/react/lepus';
+
+import type { BackgroundSnapshotInstance } from '../backgroundSnapshot.js';
+import { globalBackgroundSnapshotInstancesToRemove } from '../lifecycle/patch/commit.js';
+
+export const Suspense: FunctionComponent<{ children: VNode | VNode[]; fallback: VNode }> = (
+  { children, fallback },
+) => {
+  const __createElement =
+    (__MAIN_THREAD__ ? createElementMainThread : createElementBackground) as typeof createElementBackground;
+  const childrenRef = useRef<BackgroundSnapshotInstance>();
+
+  // @ts-expect-error wrapper is a valid element type
+  const newChildren = __createElement('wrapper', {
+    ref: (bsi: BackgroundSnapshotInstance) => {
+      if (bsi) {
+        childrenRef.current = bsi;
+      }
+    },
+  }, children);
+
+  // @ts-expect-error wrapper is a valid element type
+  const newFallback = __createElement('wrapper', {
+    ref: (bsi: BackgroundSnapshotInstance) => {
+      if (bsi && childrenRef.current) {
+        const i = globalBackgroundSnapshotInstancesToRemove.indexOf(childrenRef.current.__id);
+        if (i !== -1) {
+          globalBackgroundSnapshotInstancesToRemove.splice(i, 1);
+        }
+        childrenRef.current = undefined;
+      }
+    },
+  }, fallback);
+
+  return __createElement(PreactSuspense, { fallback: newFallback }, newChildren);
+};

--- a/packages/react/testing-library/src/__tests__/lazy-bundle/index.test.jsx
+++ b/packages/react/testing-library/src/__tests__/lazy-bundle/index.test.jsx
@@ -34,12 +34,14 @@ describe('lazy bundle', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
-    <view>
-      <text>
-        loading...
-      </text>
-    </view>
-  `);
+      <view>
+        <wrapper>
+          <text>
+            loading...
+          </text>
+        </wrapper>
+      </view>
+    `);
 
     await waitForElementToBeRemoved(() => screen.getByText('loading...'), {
       timeout: 50_000,
@@ -47,12 +49,14 @@ describe('lazy bundle', () => {
 
     expect(container.firstChild).toMatchInlineSnapshot(`
       <view>
-        <text>
-          Hello from LazyComponent
-        </text>
-        <text>
-          Hello from LazyComponent
-        </text>
+        <wrapper>
+          <text>
+            Hello from LazyComponent
+          </text>
+          <text>
+            Hello from LazyComponent
+          </text>
+        </wrapper>
       </view>
     `);
   });


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using a host element as a direct child of the Suspense component.

* **Bug Fixes**
  * Improved handling of Suspense fallback and content transitions, ensuring correct UI updates and cleanup in various scenarios.

* **Tests**
  * Introduced comprehensive tests for Suspense, covering rendering, hydration, parallel and nested boundaries, and error handling.
  * Updated test snapshots to reflect changes in element hierarchy with wrapper elements.

* **Refactor**
  * Enhanced internal logic for background snapshot management and subtree reconstruction to ensure robust element handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
