### PR TITLE
feat: support path() for `createQuerySelector`

### DIFF
--- a/.changeset/get-path-info-api.md
+++ b/.changeset/get-path-info-api.md
@@ -1,0 +1,12 @@
+---
+"@lynx-js/web-constants": patch
+"@lynx-js/web-core": patch
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/web-tests": patch
+---
+
+feat: support path() for `createQuerySelector`
+
+- Added `getPathInfo` API to `NativeApp` and its cross-thread handler for retrieving the path from a DOM node to the root.
+- Implemented endpoint and handler registration in both background and UI threads.
+- Implemented `nativeApp.getPathInfo()`

--- a/.changeset/get-path-info-api.md
+++ b/.changeset/get-path-info-api.md
@@ -2,7 +2,6 @@
 "@lynx-js/web-constants": patch
 "@lynx-js/web-core": patch
 "@lynx-js/web-worker-runtime": patch
-"@lynx-js/web-tests": patch
 ---
 
 feat: support path() for `createQuerySelector`

--- a/packages/web-platform/web-constants/src/endpoints.ts
+++ b/packages/web-platform/web-constants/src/endpoints.ts
@@ -124,6 +124,17 @@ export const setNativePropsEndpoint = createRpcEndpoint<
   void
 >('__setNativeProps', false, true);
 
+export const getPathInfoEndpoint = createRpcEndpoint<
+  [
+    type: IdentifierType,
+    identifier: string,
+    component_id: string,
+    first_only: boolean,
+    root_unique_id?: number | undefined,
+  ],
+  InvokeCallbackRes
+>('__getPathInfo', false, true);
+
 export const nativeModulesCallEndpoint = createRpcEndpoint<
   [name: string, data: Cloneable, moduleName: string],
   any

--- a/packages/web-platform/web-constants/src/types/NativeApp.ts
+++ b/packages/web-platform/web-constants/src/types/NativeApp.ts
@@ -99,7 +99,7 @@ export const enum ErrorCode {
 
 export interface InvokeCallbackRes {
   code: ErrorCode;
-  data?: string;
+  data?: unknown;
 }
 
 export interface NativeApp {
@@ -148,6 +148,15 @@ export interface NativeApp {
     params: object,
     callback: (ret: InvokeCallbackRes) => void,
     root_unique_id: number,
+  ) => void;
+
+  getPathInfo: (
+    type: IdentifierType,
+    identifier: string,
+    component_id: string,
+    first_only: boolean,
+    callback: (ret: InvokeCallbackRes) => void,
+    root_unique_id?: number,
   ) => void;
 
   setCard(tt: NativeTTObject): void;

--- a/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/registerGetPathInfoHandler.ts
+++ b/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/registerGetPathInfoHandler.ts
@@ -1,0 +1,98 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Rpc } from '@lynx-js/web-worker-rpc';
+import {
+  ErrorCode,
+  getPathInfoEndpoint,
+  lynxDatasetAttribute,
+  lynxTagAttribute,
+} from '@lynx-js/web-constants';
+import type { InvokeCallbackRes } from '@lynx-js/web-constants';
+import { queryNodes } from './queryNodes.js';
+
+type OneNodeInfo = {
+  tag: string;
+  id?: string;
+  class?: string;
+  dataSet?: Record<string, string>;
+  index: number; // The index of the node in the parent element's children
+};
+
+type PathInfo = {
+  /**
+   * The order of the nodes in the path from the the target node to the root node.
+   */
+  path: OneNodeInfo[];
+};
+
+export function registerGetPathInfoHandler(
+  rpc: Rpc,
+  shadowRoot: ShadowRoot,
+) {
+  rpc.registerHandler(
+    getPathInfoEndpoint,
+    (
+      type,
+      identifier,
+      component_id,
+      first_only,
+      root_unique_id,
+    ): InvokeCallbackRes => {
+      let code = ErrorCode.UNKNOWN;
+      let data: PathInfo | undefined;
+
+      queryNodes(
+        shadowRoot,
+        type,
+        identifier,
+        component_id,
+        first_only,
+        root_unique_id,
+        (element) => {
+          try {
+            const path: OneNodeInfo[] = [];
+            let currentNode: Element | null = element;
+            while (currentNode) {
+              const parent: HTMLElement | null = currentNode.parentElement;
+              const parentNodeForChildren = parent ?? shadowRoot;
+              const children = Array.from(parentNodeForChildren.children);
+              const tag = currentNode.getAttribute(lynxTagAttribute)!;
+              const index = tag === 'page' ? 0 : children.indexOf(currentNode);
+              const id = currentNode.getAttribute('id') || undefined;
+              const className = currentNode.getAttribute('class') || undefined;
+              const datasetString = currentNode.getAttribute(
+                lynxDatasetAttribute,
+              );
+              const dataSet = datasetString
+                ? JSON.parse(decodeURIComponent(datasetString))
+                : undefined;
+
+              path.push({
+                tag,
+                id,
+                class: className,
+                dataSet,
+                index,
+              });
+              if (tag === 'page' || currentNode.parentNode === shadowRoot) {
+                break;
+              }
+              currentNode = parent;
+            }
+            data = { path };
+            code = ErrorCode.SUCCESS;
+          } catch (e) {
+            console.error('[lynx-web] getPathInfo: failed with', e, element);
+            code = ErrorCode.UNKNOWN;
+          }
+        },
+        (error) => {
+          code = error;
+        },
+      );
+      return { code, data };
+    },
+  );
+}

--- a/packages/web-platform/web-core/src/uiThread/startBackground.ts
+++ b/packages/web-platform/web-core/src/uiThread/startBackground.ts
@@ -19,6 +19,7 @@ import { registerDispatchLynxViewEventHandler } from './crossThreadHandlers/regi
 import { registerTriggerElementMethodEndpointHandler } from './crossThreadHandlers/registerTriggerElementMethodEndpointHandler.js';
 import type { StartUIThreadCallbacks } from './startUIThread.js';
 import { registerReportErrorHandler } from './crossThreadHandlers/registerReportErrorHandler.js';
+import { registerGetPathInfoHandler } from './crossThreadHandlers/registerGetPathInfoHandler.js';
 
 export function startBackground(
   backgroundRpc: Rpc,
@@ -48,6 +49,10 @@ export function startBackground(
   registerNapiModulesCallHandler(
     backgroundRpc,
     callbacks.napiModulesCall,
+  );
+  registerGetPathInfoHandler(
+    backgroundRpc,
+    shadowRoot,
   );
   registerDispatchLynxViewEventHandler(backgroundRpc, shadowRoot);
   registerTriggerElementMethodEndpointHandler(backgroundRpc, shadowRoot);

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -512,6 +512,13 @@ test.describe('reactlynx3 tests', () => {
         'animationstart animationiteration animationend animationstart animationiteration animationend',
       );
     });
+    test('api-get-path-info', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(500);
+      expect(await page.locator('#result').getAttribute('style')).toContain(
+        'green',
+      );
+    });
     test('api-getJSModule', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(1000);

--- a/packages/web-platform/web-tests/tests/react/api-get-path-info/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-get-path-info/index.jsx
@@ -1,0 +1,69 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+import { useEffect } from 'react';
+
+export function App() {
+  const [match, setMatch] = useState(false);
+
+  // The expected path from the target node up to the root (in reverse order)
+  // We'll check tag, id, and index for each node in the path
+  const expectedPath = [
+    { tag: 'text', id: 'target', index: 0 },
+    { tag: 'view', id: 'inner', index: 1 },
+    { tag: 'view', id: 'middle', index: 0 },
+    { tag: 'view', id: 'outer', index: 0 },
+    { tag: 'view', index: 0 },
+    { tag: 'page', index: 0 },
+  ];
+
+  useEffect(() => {
+    lynx.createSelectorQuery().select('#target').path((res, status) => {
+      try {
+        const pathArr = res.path;
+        // Only check the top N nodes (from leaf to root)
+        let isMatch = true;
+        for (let i = 0; i < expectedPath.length; i++) {
+          const node = pathArr[i];
+          const expect = expectedPath[i];
+          if (
+            !node || node.tag !== expect.tag || node.id !== expect.id
+            || node.index !== expect.index
+          ) {
+            isMatch = false;
+            break;
+          }
+        }
+        setMatch(isMatch);
+      } catch (e) {
+        setMatch(false);
+      }
+    }).exec();
+  }, []);
+
+  return (
+    <view>
+      <view id='outer'>
+        <view id='middle'>
+          <view></view>
+          <view id='inner'>
+            <text id='target' />
+          </view>
+        </view>
+      </view>
+      <view
+        style={{
+          width: '400px',
+          height: '200px',
+          background: match ? 'green' : 'pink',
+          wordBreak: 'break-all',
+        }}
+        id='result'
+      >
+      </view>
+    </view>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -28,6 +28,7 @@ import { createJSObjectDestructionObserver } from './crossThreadHandlers/createJ
 import type { TimingSystem } from './createTimingSystem.js';
 import { registerUpdateGlobalPropsHandler } from './crossThreadHandlers/registerUpdateGlobalPropsHandler.js';
 import { registerUpdateI18nResource } from './crossThreadHandlers/registerUpdateI18nResource.js';
+import { createGetPathInfo } from './crossThreadHandlers/createGetPathInfo.js';
 
 let nativeAppCount = 0;
 const sharedData: Record<string, unknown> = {};
@@ -133,6 +134,7 @@ export async function createNativeApp(
     },
     callLepusMethod,
     setNativeProps,
+    getPathInfo: createGetPathInfo(uiThreadRpc),
     invokeUIMethod: createInvokeUIMethod(uiThreadRpc),
     setCard(tt) {
       registerPublicComponentEventHandler(

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/crossThreadHandlers/createGetPathInfo.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/crossThreadHandlers/createGetPathInfo.ts
@@ -1,0 +1,35 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import {
+  ErrorCode,
+  getPathInfoEndpoint,
+  type NativeApp,
+} from '@lynx-js/web-constants';
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+
+export function createGetPathInfo(rpc: Rpc): NativeApp['getPathInfo'] {
+  return (
+    type,
+    identifier,
+    component_id,
+    first_only,
+    callback,
+    root_unique_id,
+  ) => {
+    rpc.invoke(getPathInfoEndpoint, [
+      type,
+      identifier,
+      component_id,
+      first_only,
+      root_unique_id,
+    ]).then(callback).catch((error: Error) => {
+      console.error(`[lynx-web] getPathInfo failed`, error);
+      callback({
+        code: ErrorCode.UNKNOWN,
+        data: error.message || '',
+      });
+    });
+  };
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new API to retrieve the DOM path from a specified node up to the root, accessible via a new method.
  * Added support for path-based queries in selector functionality.
* **Tests**
  * Added tests to verify the correctness of the new node path retrieval feature, including visual feedback for success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
