### PR TITLE
fix(web): onNativeModulesCall should use promise to return ret

### DIFF
--- a/.changeset/old-squids-spend.md
+++ b/.changeset/old-squids-spend.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: when `onNativeModulesCall` is delayed in mounting, the NativeModules execution result may be undefined.

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -208,7 +208,7 @@ export class LynxView extends HTMLElement {
       for (const callInfo of this.#cachedNativeModulesCall) {
         callInfo.resolve(handler.apply(undefined, callInfo.args));
       }
-    }
+   this.#cachedNativeModulesCall.clear()
   }
 
   #nativeModulesMap: NativeModulesMap = {};

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -204,11 +204,10 @@ export class LynxView extends HTMLElement {
   }
   set onNativeModulesCall(handler: NativeModulesCall) {
     this.#onNativeModulesCall = handler;
-    if (this.#cachedNativeModulesCall) {
-      for (const callInfo of this.#cachedNativeModulesCall) {
-        callInfo.resolve(handler.apply(undefined, callInfo.args));
-      }
-   this.#cachedNativeModulesCall.clear()
+    for (const callInfo of this.#cachedNativeModulesCall) {
+      callInfo.resolve(handler.apply(undefined, callInfo.args));
+    }
+    this.#cachedNativeModulesCall = [];
   }
 
   #nativeModulesMap: NativeModulesMap = {};

--- a/packages/web-platform/web-tests/shell-project/index.ts
+++ b/packages/web-platform/web-tests/shell-project/index.ts
@@ -33,14 +33,28 @@ if (casename) {
       lynxView.setAttribute('lynx-group-id', '2');
     }
     lynxView.injectStyleRules = [`.injected-style-rules{background:green}`];
-    lynxView.onNativeModulesCall = (name, data, moduleName) => {
-      if (name === 'getColor' && moduleName === 'CustomModule') {
-        return data.color;
-      }
-      if (name === 'getColor' && moduleName === 'bridge') {
-        return data.color;
-      }
-    };
+    if (casename === 'api-nativemodules-call-delay') {
+      setTimeout(() => {
+        lynxView.onNativeModulesCall = (name, data, moduleName) => {
+          if (name === 'getColor' && moduleName === 'CustomModule') {
+            return data.color;
+          }
+          if (name === 'getColor' && moduleName === 'bridge') {
+            return data.color;
+          }
+        };
+      }, 2500);
+    } else {
+      lynxView.onNativeModulesCall = (name, data, moduleName) => {
+        if (name === 'getColor' && moduleName === 'CustomModule') {
+          return data.color;
+        }
+        if (name === 'getColor' && moduleName === 'bridge') {
+          return data.color;
+        }
+      };
+    }
+
     if (casename.includes('custom-template-loader')) {
       lynxView.customTemplateLoader = async () => {
         const template: LynxTemplate = {

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -548,6 +548,15 @@ test.describe('reactlynx3 tests', () => {
         await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
       },
     );
+    test(
+      'api-nativemodules-call-delay',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(3000);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
     test('api-SelectorQuery', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(500);

--- a/packages/web-platform/web-tests/tests/react/api-nativemodules-call-delay/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-nativemodules-call-delay/index.jsx
@@ -1,0 +1,25 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useEffect, useState } from '@lynx-js/react';
+
+function App() {
+  const [color, setColor] = useState('pink');
+  useEffect(() => {
+    NativeModules.CustomModule.getColor({ color: 'green' }, (color) => {
+      setColor(color);
+    });
+  }, []);
+  return (
+    <view
+      id='target'
+      style={{
+        height: '100px',
+        width: '100px',
+        background: color,
+      }}
+    />
+  );
+}
+
+root.render(<App></App>);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the execution result of NativeModules could be undefined if the callback was delayed during the mounting phase.

* **New Features**
  * Enhanced handling of delayed NativeModules calls by caching and resolving them asynchronously.

* **Tests**
  * Added a new test case to verify correct handling of delayed NativeModules callbacks.
  * Introduced a new React test component to simulate and validate delayed native module calls.

* **Chores**
  * Updated documentation to reflect the patch addressing the NativeModules callback timing issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
