### PR TITLE
chore: remove pnpm plugins

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,6 @@ overrides:
   '@rspack/core': 1.4.11
   '@rsbuild/core>@rspack/core': 1.4.11
 
-pnpmfileChecksum: sha256-ZfwGjIvQgPR9mEJg5iihJauZ5iv1Ogj5lI/dgVj7pgI=
-
 patchedDependencies:
   '@napi-rs/cli@2.18.4':
     hash: ba947eb1c48b2a85834e99f92cbbae896722ce61fd5ae67507a3be9041959ebd

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,9 +17,6 @@ packages:
   - packages/webpack/*
   - website
 
-configDependencies:
-  "@pnpm/plugin-trusted-deps": 0.1.0+sha512-OK05vSZpezQHcS7Y0T5A25QXDbBRtRq52s76eOkMgp9v8ifNrIR8pjIGqrUFUn0PwKLt2i+U1LPYB+RWi1xjaQ==
-
 # From `@pnpm/plugin-better-defaults`
 enablePrePostScripts: false
 ignorePatchFailures: false


### PR DESCRIPTION
The Renovate seems to stop working after https://github.com/lynx-family/lynx-stack/pull/1447 is merged.

```
ExecError: Command failed: install-tool pnpm 10.14.0
Interrupted by SIGTERM
    at ChildProcess.<anonymous> (/usr/local/renovate/lib/util/exec/common.ts:111:11)
    at ChildProcess.emit (node:events:530:35)
    at ChildProcess.emit (node:domain:489:12)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)
```

See: https://developer.mend.io/github/lynx-family/lynx-stack/-/job/862c55c4-90b1-4597-b714-ac28b0d97884

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
