### PR TITLE
fix(web): \_\_ElementFromBinary should mark all elements actively

### DIFF
--- a/.changeset/silly-rockets-bet.md
+++ b/.changeset/silly-rockets-bet.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: \_\_ElementFromBinary should mark all elements actively

--- a/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
+++ b/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
@@ -693,6 +693,9 @@ export function createMainThreadGlobalThis(
       __SetAttribute(element, key, value);
     }
     for (const [key, value] of Object.entries(data.builtinAttributes || {})) {
+      if (key === 'dirtyID' && value === data.id) {
+        __MarkPartElement(element, value);
+      }
       __SetAttribute(element, key, value);
     }
     for (const childData of data.children || []) {
@@ -757,6 +760,7 @@ export function createMainThreadGlobalThis(
           applyEventsForElementTemplate(data, element);
         }
       }
+      clonedElements.forEach(__MarkTemplateElement);
       return clonedElements;
     }
     return [];

--- a/packages/web-platform/web-tests/resources/web-core.main-thread.json
+++ b/packages/web-platform/web-tests/resources/web-core.main-thread.json
@@ -50,7 +50,9 @@
             "attributes": {
               "value": "Hello from template"
             },
-            "builtinAttributes": {},
+            "builtinAttributes": {
+              "dirtyID": "id-2"
+            },
             "children": [],
             "events": []
           }

--- a/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
+++ b/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
@@ -1330,5 +1330,21 @@ test.describe('main thread api tests', () => {
       expect(result[0].name).toBe('tap');
       expect(result[0].type).toBe('bindEvent');
     });
+
+    test('should mark part element', async ({ page }) => {
+      test.skip(ENABLE_MULTI_THREAD, 'NYI for multi-thread');
+      const result = await page.evaluate(() => {
+        const element = globalThis.__ElementFromBinary('test-template', 0)[0];
+        const child = globalThis.__FirstElement(element);
+        return {
+          targetPartLength:
+            Object.keys(globalThis.__GetTemplateParts(element)).length,
+          targetPartExist: globalThis.__GetTemplateParts(element)['id-2']
+            === child,
+        };
+      });
+      expect(result.targetPartLength).toBe(1);
+      expect(result.targetPartExist).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mark template elements and their parts consistently after cloning to prevent intermittent UI inconsistencies.

* **Tests**
  * Added unit tests verifying template part elements are correctly identified.

* **Chores**
  * Added release metadata for a patch update documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
