### PR TITLE
fix(web): __ElementFromBinary needs to correctly apply the dataset in…

### DIFF
--- a/.changeset/thick-times-watch.md
+++ b/.changeset/thick-times-watch.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+"@lynx-js/web-constants": patch
+---
+
+fix: `__ElementFromBinary` needs to correctly apply the dataset in elementTemplate to the Element

--- a/packages/web-platform/web-constants/src/types/LynxModule.ts
+++ b/packages/web-platform/web-constants/src/types/LynxModule.ts
@@ -15,6 +15,7 @@ export type ElementTemplateData = {
   builtinAttributes?: Record<string, string>;
   children?: ElementTemplateData[];
   events?: { type: LynxEventType; name: string; value: string }[];
+  dataset?: Record<string, string>;
 };
 
 export interface LynxTemplate {

--- a/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
+++ b/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
@@ -705,6 +705,7 @@ export function createMainThreadGlobalThis(
         createElementForElementTemplateData(childData, parentComponentUniId),
       );
     }
+    data.dataset !== undefined && __SetDataset(element, data.dataset);
     return element;
   };
 

--- a/packages/web-platform/web-tests/resources/web-core.main-thread.json
+++ b/packages/web-platform/web-tests/resources/web-core.main-thread.json
@@ -63,7 +63,10 @@
             "name": "tap",
             "value": "templateTap"
           }
-        ]
+        ],
+        "dataset": {
+          "customdata": "customdata"
+        }
       }
     ]
   }

--- a/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
+++ b/packages/web-platform/web-tests/tests/main-thread-apis.test.ts
@@ -1346,6 +1346,14 @@ test.describe('main thread api tests', () => {
       expect(result.targetPartLength).toBe(1);
       expect(result.targetPartExist).toBe(true);
     });
+
+    test('should apply dataset from template', async ({ page }) => {
+      const result = await page.evaluate(() => {
+        const element = globalThis.__ElementFromBinary('test-template', 0)[0];
+        return globalThis.__GetAttributes(element)['data-customdata'];
+      });
+      expect(result).toBe('customdata');
+    });
   });
 
   test('__UpdateComponentInfo', async ({ page }, { title }) => {


### PR DESCRIPTION
… elementTemplate to the Element

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Element templates now support applying data-* attributes to created elements.
* **Bug Fixes**
  * Fixed an issue where elements generated from templates did not include dataset (data-*) attributes.
* **Tests**
  * Added tests to verify dataset attributes from templates are correctly applied to created elements.
* **Chores**
  * Updated release metadata to include patch bumps and release notes for related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
