### PR TITLE
chore: ignore vitest timestamp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ coverage
 # Vitest
 tsconfig.vitest-temp.json
 .rollup.cache
+vitest.config.ts.timestamp-*
+vitest.config.js.timestamp-*
 # Created by https://www.toptal.com/developers/gitignore/api/macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

Vitest sometimes produces intermediates and does not remove them (if we interrupt vitest by Ctrl+C):

<img width="1571" height="362" alt="image" src="https://github.com/user-attachments/assets/dd6f5b67-0800-4bc5-abea-fccb2eb43019" />

We should ignore these files.

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated ignore rules to exclude temporary timestamp files generated by the test runner, reducing repository noise and preventing accidental commits of transient artifacts.
  - Improves developer workflow with cleaner diffs and faster reviews by keeping ephemeral test outputs out of version control.
  - No impact on application behavior or public interfaces; purely maintenance-focused housekeeping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or **not required**).
