### PR TITLE
fix(testing-library): do not transform css imports

### DIFF
--- a/.changeset/curvy-dragons-appear.md
+++ b/.changeset/curvy-dragons-appear.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+fix css transform error in testing library

--- a/packages/react/testing-library/src/__tests__/css/index.test.jsx
+++ b/packages/react/testing-library/src/__tests__/css/index.test.jsx
@@ -34,18 +34,14 @@ describe('CSS', () => {
     `);
   });
   it('should render a component with CSS module styles object', () => {
-    expect(style3.baz).toMatchInlineSnapshot(`"_baz_60dbcc"`);
+    // Assert stable shape (prefix) rather than exact hash
+    expect(style3.baz).toMatch(/^_baz_[a-z0-9]+$/);
 
     const TestComponent = () => <text style={style3.baz}>Hello World</text>;
-
     const { container } = render(<TestComponent />);
 
-    expect(container.firstChild).toMatchInlineSnapshot(`
-      <text
-        style="_baz_60dbcc"
-      >
-        Hello World
-      </text>
-    `);
+    const node = container.firstChild;
+    expect(node).toHaveAttribute('style', style3.baz);
+    expect(node).toHaveTextContent('Hello World');
   });
 });

--- a/packages/react/testing-library/src/__tests__/css/index.test.jsx
+++ b/packages/react/testing-library/src/__tests__/css/index.test.jsx
@@ -1,6 +1,10 @@
 import '@testing-library/jest-dom';
 import { describe, expect, vi } from 'vitest';
-import { render, screen } from '..';
+import { render, screen } from '../..';
+
+import './style1.css';
+import './style2.css?common';
+import style3 from './style3.module.css';
 
 describe('CSS', () => {
   it('should render a component with CSS styles object', () => {
@@ -24,6 +28,21 @@ describe('CSS', () => {
     expect(container.firstChild).toMatchInlineSnapshot(`
       <text
         style="color: red; font-size: 20px; flex: 1;"
+      >
+        Hello World
+      </text>
+    `);
+  });
+  it('should render a component with CSS module styles object', () => {
+    expect(style3.baz).toMatchInlineSnapshot(`"_baz_60dbcc"`);
+
+    const TestComponent = () => <text style={style3.baz}>Hello World</text>;
+
+    const { container } = render(<TestComponent />);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <text
+        style="_baz_60dbcc"
       >
         Hello World
       </text>

--- a/packages/react/testing-library/src/__tests__/css/index.test.jsx
+++ b/packages/react/testing-library/src/__tests__/css/index.test.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { describe, expect, vi } from 'vitest';
-import { render, screen } from '../..';
+import { render } from '../..';
 
 import './style1.css';
 import './style2.css?common';

--- a/packages/react/testing-library/src/__tests__/css/style1.css
+++ b/packages/react/testing-library/src/__tests__/css/style1.css
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/packages/react/testing-library/src/__tests__/css/style2.css
+++ b/packages/react/testing-library/src/__tests__/css/style2.css
@@ -1,0 +1,3 @@
+.bar {
+  background-color: yellow;
+}

--- a/packages/react/testing-library/src/__tests__/css/style3.module.css
+++ b/packages/react/testing-library/src/__tests__/css/style3.module.css
@@ -1,0 +1,3 @@
+.baz {
+  color: blue;
+}

--- a/packages/react/testing-library/src/vitest.config.js
+++ b/packages/react/testing-library/src/vitest.config.js
@@ -68,11 +68,10 @@ export const createVitestConfig = async (options) => {
       enforce: 'pre',
       transform(sourceText, sourcePath) {
         const id = sourcePath;
-        if (
-          id.endsWith('.css') || id.endsWith('.less') || id.endsWith('.scss')
-        ) {
-          return '';
-        }
+        // Only transform JS files
+        // Using the same regex as rspack's `CHAIN_ID.RULE.JS` rule
+        const regex = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)(\?.*)?$/;
+        if (!regex.test(id)) return null;
 
         const { transformReactLynxSync } = require(
           '@lynx-js/react/transform',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed a CSS transform error in the React testing library, improving stability when loading styles in tests.

- Tests
  - Added tests covering global CSS and CSS Modules to ensure components render with styled classes.

- Chores
  - Prepared a patch release for the React package.

- Notes
  - Test tooling now restricts transforms to JavaScript/TypeScript files; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
