### PR TITLE
chore(renovate): remove automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,8 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":automergeStableNonMajor",
-    ":automergeTypes",
     ":maintainLockFilesWeekly",
     "helpers:pinGitHubActionDigests",
   ],
@@ -47,7 +45,6 @@
         "/@rspack/*/",
       ],
       "rangeStrategy": "pin",
-      "automerge": false,
     },
     {
       "groupName": "Rsbuild",
@@ -62,7 +59,6 @@
         "/rsbuild-plugin-*/",
       ],
       "rangeStrategy": "pin",
-      "automerge": false,
     },
     {
       "groupName": "Rspress",
@@ -102,7 +98,6 @@
         "@microsoft/api-extractor-model",
         "@microsoft/tsdoc",
       ],
-      "automerge": true,
     },
     {
       "groupName": "linting",
@@ -123,7 +118,6 @@
         "typia-rspack-plugin",
         "@samchon/openapi",
       ],
-      "automerge": false,
       "rangeStrategy": "pin",
     },
     {


### PR DESCRIPTION
@coderabbitai summary

As Renovate docs says:

> `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead
> https://docs.renovatebot.com/configuration-options/#rebasewhen

We should set `automerge` to `false` to avoid too frequent PR updates.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
