### PR TITLE
test(web): better config

### DIFF
--- a/packages/web-platform/web-tests/scripts/generate-build-command.js
+++ b/packages/web-platform/web-tests/scripts/generate-build-command.js
@@ -1,21 +1,16 @@
 // Copyright 2023 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { spawn } from 'node:child_process';
 import { glob } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { spawn } from 'node:child_process';
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
-const configFiles = [
-  ...await Array.fromAsync(glob(
-    path.join(__dirname, '..', 'tests', '*', '*.config.ts'),
-  )),
-  ...await Array.fromAsync(glob(
-    path.join(__dirname, '..', 'tests', '*', '*', '*.config.ts'),
-  )),
-];
+const configFiles = await Array.fromAsync(glob(
+  [
+    path.join(import.meta.dirname, '..', 'tests', '*', '*.config.ts'),
+    path.join(import.meta.dirname, '..', 'tests', '*', '*', '*.config.ts'),
+  ],
+));
 const command = configFiles
   .map(
     (lynxConfigFilePath) => `npx rspeedy build --config=${lynxConfigFilePath}`,
@@ -28,7 +23,7 @@ if (command.length) {
       new Promise((resolve, reject) => {
         const child = spawn(command[i], [], {
           stdio: 'inherit',
-          cwd: path.join(__dirname, '..'),
+          cwd: path.join(import.meta.dirname, '..'),
           shell: true,
         });
 

--- a/packages/web-platform/web-tests/tests/react/api.config.ts
+++ b/packages/web-platform/web-tests/tests/react/api.config.ts
@@ -3,18 +3,18 @@
 // LICENSE file in the root directory of this source tree.
 import { glob } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { defineConfig, type Config } from '@lynx-js/rspeedy';
+
+import { mergeRspeedyConfig, type Config } from '@lynx-js/rspeedy';
+
 import { commonConfig } from './commonConfig.js';
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const reactBasicCases = await Array.fromAsync(glob(
-  path.join(__dirname, 'api-*', 'index.jsx'),
+  [
+    path.join(import.meta.dirname, 'api-*', 'index.jsx'),
+  ],
 ));
 
-const _default_1: Config = defineConfig({
-  ...commonConfig(),
+const config: Config = mergeRspeedyConfig(commonConfig(), {
   source: {
     entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
       return [path.basename(path.dirname(reactBasicEntry)), {
@@ -24,4 +24,5 @@ const _default_1: Config = defineConfig({
     })),
   },
 });
-export default _default_1;
+
+export default config;

--- a/packages/web-platform/web-tests/tests/react/basic.config.ts
+++ b/packages/web-platform/web-tests/tests/react/basic.config.ts
@@ -3,18 +3,18 @@
 // LICENSE file in the root directory of this source tree.
 import { glob } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { defineConfig, type Config } from '@lynx-js/rspeedy';
+
+import { mergeRspeedyConfig, type Config } from '@lynx-js/rspeedy';
+
 import { commonConfig } from './commonConfig.js';
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const reactBasicCases = await Array.fromAsync(glob(
-  path.join(__dirname, 'basic-*', 'index.jsx'),
+  [
+    path.join(__dirname, 'basic-*', 'index.jsx'),
+  ],
 ));
 
-const _default_1: Config = defineConfig({
-  ...commonConfig(),
+const config: Config = mergeRspeedyConfig(commonConfig(), {
   source: {
     entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
       return [path.basename(path.dirname(reactBasicEntry)), {
@@ -22,6 +22,10 @@ const _default_1: Config = defineConfig({
         publicPath: '/dist/',
       }];
     })),
+    define: {
+      'process.env.PORT': JSON.stringify(process.env['PORT'] ?? 3080),
+    },
   },
 });
-export default _default_1;
+
+export default config;

--- a/packages/web-platform/web-tests/tests/react/config-css-selector-false.config.ts
+++ b/packages/web-platform/web-tests/tests/react/config-css-selector-false.config.ts
@@ -3,23 +3,28 @@
 // LICENSE file in the root directory of this source tree.
 import { glob } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { defineConfig } from '@lynx-js/rspeedy';
+
+import { mergeRspeedyConfig, type Config } from '@lynx-js/rspeedy';
+
 import { commonConfig } from './commonConfig.js';
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const reactBasicCases = await Array.fromAsync(glob(
-  path.join(__dirname, 'config-css-selector-false-*', '*.jsx'),
+  [
+    path.join(import.meta.dirname, 'config-css-selector-false-*', '*.jsx'),
+  ],
 ));
 
-export default defineConfig({
-  ...commonConfig({
+const config: Config = mergeRspeedyConfig(
+  commonConfig({
     enableCSSSelector: false,
   }),
-  source: {
-    entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
-      return [path.basename(path.dirname(reactBasicEntry)), reactBasicEntry];
-    })),
+  {
+    source: {
+      entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
+        return [path.basename(path.dirname(reactBasicEntry)), reactBasicEntry];
+      })),
+    },
   },
-});
+);
+
+export default config;

--- a/packages/web-platform/web-tests/tests/react/config-mixed-01.config.ts
+++ b/packages/web-platform/web-tests/tests/react/config-mixed-01.config.ts
@@ -3,28 +3,29 @@
 // LICENSE file in the root directory of this source tree.
 import { glob } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { defineConfig } from '@lynx-js/rspeedy';
+
+import { mergeRspeedyConfig, type Config } from '@lynx-js/rspeedy';
+
 import { commonConfig } from './commonConfig.js';
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const reactBasicCases = await Array.fromAsync(glob(
-  path.join(
-    __dirname,
-    'config-mixed-01',
-    '*.jsx',
-  ),
+  [
+    path.join(import.meta.dirname, 'config-mixed-01', '*.jsx'),
+  ],
 ));
 
-export default defineConfig({
-  ...commonConfig({
+const config: Config = mergeRspeedyConfig(
+  commonConfig({
     enableCSSSelector: false,
     enableRemoveCSSScope: false,
   }),
-  source: {
-    entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
-      return [path.basename(path.dirname(reactBasicEntry)), reactBasicEntry];
-    })),
+  {
+    source: {
+      entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
+        return [path.basename(path.dirname(reactBasicEntry)), reactBasicEntry];
+      })),
+    },
   },
-});
+);
+
+export default config;


### PR DESCRIPTION
@coderabbitai summary

1. Use `mergeRspeedyConfig` instead of spread
2. Use `import.meta.dirname`
3. Use array for `glob`

This would make it easier to extend and change test configs.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
