### PR TITLE
ci: run rust check earlier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,6 @@ jobs:
         --logHeapUsage
         --silent
   test-rust:
-    needs: build
     uses: ./.github/workflows/rust.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration by allowing the Rust test job to run independently of the build job, reducing wait times and accelerating feedback in PRs.
* **Tests**
  * Test execution order in CI updated; test steps remain unchanged.
* **Note**
  * No user-facing functionality changes; behavior of the application remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

We don't need `turbo build` for rust tests. Run it earlier to speed-up CI.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
