### PR TITLE
ci: lock `@pnpm/registry-mock` to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,8 +138,8 @@ jobs:
     with:
       runs-on: lynx-ubuntu-24.04-medium
       run: |
-        pnpm dlx @pnpm/registry-mock prepare
-        pnpm dlx @pnpm/registry-mock &
+        pnpm dlx @pnpm/registry-mock@4 prepare
+        pnpm dlx @pnpm/registry-mock@4 &
         printf '\n//localhost:4873/:_authToken="this-is-a-fake-token"\n' >> ~/.npmrc
         pnpm changeset version --snapshot regression
         node packages/tools/canary-release/snapshot.js


### PR DESCRIPTION
The `@pnpm/registry-mock` published v5 which move verdaccio to peerDependencies. This would use verdaccio v6 and result in the following error:

```
Error: Invalid storage secret key length, must be 32 characters long but is 64. 
            The secret length in Node.js 22 or higher must be 32 characters long. Please consider generate a new one. 
            Learn more at https://verdaccio.org/docs/configuration/#.verdaccio-db
```

See: https://github.com/pnpm/registry-mock/commit/2ed7531a208fc1b2517f67407ed4a780e469238f

For now, we temporarily lock to v4 to make CI pass. We should find a way to upgrade in the future.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned a mocked registry dependency to a fixed major version in the publishing workflow to improve CI stability and predictability. No changes to runtime behavior or public APIs.
* **Tests**
  * Stabilized test-publish process by fixing environment dependency versions, reducing flakiness during release checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->