### PR TITLE
chore: integrate with arethetypeswrong

### DIFF
--- a/packages/rspeedy/plugin-react/package.json
+++ b/packages/rspeedy/plugin-react/package.json
@@ -56,6 +56,8 @@
     "@rsbuild/core": "catalog:rsbuild",
     "@rsbuild/plugin-sass": "1.3.5",
     "@rsbuild/plugin-typed-css-modules": "1.0.3",
+    "rsbuild-plugin-arethetypeswrong": "0.1.1",
+    "rsbuild-plugin-publint": "0.3.3",
     "tailwindcss": "^3.4.17",
     "type-fest": "^4.41.0",
     "typia": "9.7.1",

--- a/packages/rspeedy/plugin-react/rslib.config.ts
+++ b/packages/rspeedy/plugin-react/rslib.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from '@rslib/core'
+import { pluginAreTheTypesWrong } from 'rsbuild-plugin-arethetypeswrong'
+import { pluginPublint } from 'rsbuild-plugin-publint'
 import { TypiaRspackPlugin } from 'typia-rspack-plugin'
 
 export default defineConfig({
@@ -19,6 +21,17 @@ export default defineConfig({
       '@rsbuild/core',
     ],
   },
+  plugins: [
+    pluginAreTheTypesWrong({
+      enable: Boolean(process.env['CI']),
+      areTheTypesWrongOptions: {
+        ignoreRules: [
+          'cjs-resolves-to-esm',
+        ],
+      },
+    }),
+    pluginPublint(),
+  ],
   tools: {
     rspack: {
       plugins: [

--- a/packages/web-platform/web-core-server/package.json
+++ b/packages/web-platform/web-core-server/package.json
@@ -31,6 +31,8 @@
     "@lynx-js/web-constants": "workspace:*",
     "@lynx-js/web-elements-template": "workspace:*",
     "@lynx-js/web-mainthread-apis": "workspace:*",
-    "@lynx-js/web-worker-rpc": "workspace:*"
+    "@lynx-js/web-worker-rpc": "workspace:*",
+    "rsbuild-plugin-arethetypeswrong": "0.1.1",
+    "rsbuild-plugin-publint": "0.3.3"
   }
 }

--- a/packages/web-platform/web-core-server/rslib.config.ts
+++ b/packages/web-platform/web-core-server/rslib.config.ts
@@ -1,5 +1,7 @@
 import type { RslibConfig } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
+import { pluginAreTheTypesWrong } from 'rsbuild-plugin-arethetypeswrong';
+import { pluginPublint } from 'rsbuild-plugin-publint';
 
 const config: RslibConfig = defineConfig({
   lib: [
@@ -12,6 +14,17 @@ const config: RslibConfig = defineConfig({
     },
     sourceMap: true,
   },
+  plugins: [
+    pluginAreTheTypesWrong({
+      enable: Boolean(process.env['CI']),
+      areTheTypesWrongOptions: {
+        ignoreRules: [
+          'cjs-resolves-to-esm',
+        ],
+      },
+    }),
+    pluginPublint(),
+  ],
   tools: {
     rspack: {
       output: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,12 @@ importers:
       '@rsbuild/plugin-typed-css-modules':
         specifier: 1.0.3
         version: 1.0.3(@rsbuild/core@1.4.15)
+      rsbuild-plugin-arethetypeswrong:
+        specifier: 0.1.1
+        version: 0.1.1(@rsbuild/core@1.4.15)(typescript@5.9.2)
+      rsbuild-plugin-publint:
+        specifier: 0.3.3
+        version: 0.3.3(@rsbuild/core@1.4.15)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
@@ -695,6 +701,12 @@ importers:
       '@lynx-js/web-worker-rpc':
         specifier: workspace:*
         version: link:../web-worker-rpc
+      rsbuild-plugin-arethetypeswrong:
+        specifier: 0.1.1
+        version: 0.1.1(@rsbuild/core@1.4.15)(typescript@5.9.2)
+      rsbuild-plugin-publint:
+        specifier: 0.3.3
+        version: 0.3.3(@rsbuild/core@1.4.15)
 
   packages/web-platform/web-elements:
     dependencies:
@@ -6928,6 +6940,16 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  rsbuild-plugin-arethetypeswrong@0.1.1:
+    resolution: {integrity: sha512-5N16/v3NfXJpmhg7lL/lrWeXI+ejOiQDBD1Fyj3zBCEccV0WxET4pI4hINXFYBCGRef12rzoRxPORAVIOFEcJg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@rsbuild/core': '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
 
   rsbuild-plugin-dts@0.12.1:
     resolution: {integrity: sha512-NXY04mekD3e1FzRKxcP5c8/idjWcnNyDcdXh4VcF10F7UxsgqT/rIOV8FT1aT+JjFncAD2mXboPq20wkqJTiIw==}
@@ -14935,6 +14957,12 @@ snapshots:
       fsevents: 2.3.3
 
   rrweb-cssom@0.8.0: {}
+
+  rsbuild-plugin-arethetypeswrong@0.1.1(@rsbuild/core@1.4.15)(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
+    optionalDependencies:
+      '@rsbuild/core': 1.4.15
 
   rsbuild-plugin-dts@0.12.1(@microsoft/api-extractor@7.52.10(@types/node@22.17.1))(@rsbuild/core@1.5.0-beta.3)(typescript@5.9.2):
     dependencies:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added build-time validation plugins to improve type-checking and package publish diagnostics across relevant packages.
  - Enabled CI-aware checks to catch type and packaging issues early during builds.
  - No changes to runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
