### PR TITLE
refactor(react/transform): remove the warning of `key`

### DIFF
--- a/.changeset/solid-squids-fall.md
+++ b/.changeset/solid-squids-fall.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Remove the "key is not on root element of snapshot" warning.

--- a/packages/react/transform/src/swc_plugin_snapshot/mod.rs
+++ b/packages/react/transform/src/swc_plugin_snapshot/mod.rs
@@ -476,27 +476,16 @@ where
         }
       }
 
-      let mut has_key: bool = false;
       // pick key from n.opening.attrs
       n.opening
         .attrs
         .retain_mut(|attr_or_spread| match attr_or_spread {
           JSXAttrOrSpread::SpreadElement(_) => true,
-          JSXAttrOrSpread::JSXAttr(JSXAttr {
-            name, value, span, ..
-          }) => match name {
+          JSXAttrOrSpread::JSXAttr(JSXAttr { name, value, .. }) => match name {
             JSXAttrName::Ident(ident_name) => match ident_name.sym.as_ref() {
               "key" => {
-                has_key = true;
                 if self.parent_element.is_none() {
                   self.key = value.take();
-                } else {
-                  // warn about key not on root element
-                  HANDLER.with(|handler| {
-                    handler
-                      .struct_span_warn(*span, "key is not on root element of snapshot")
-                      .emit()
-                  });
                 }
                 false
               }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the spurious “key is not on root element of snapshot” warning for cleaner snapshot output. Keys on non-root elements are now ignored without logging, while root-level key extraction remains unchanged.
  * No changes to public APIs or functionality; this is a non-breaking update.

* **Chores**
  * Prepared a patch release for @lynx-js/react to document the warning removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Following up #1541. Remove the warning since we already fully support using `key` anywhere

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
