### PR TITLE
chore: add `@lynx-js/cache-events-webpack-plugin` to project reference

### DIFF
--- a/packages/rspeedy/core/tsconfig.build.json
+++ b/packages/rspeedy/core/tsconfig.build.json
@@ -20,6 +20,7 @@
     "src",
   ],
   "references": [
+    { "path": "../../webpack/cache-events-webpack-plugin/tsconfig.build.json" },
     { "path": "../../webpack/chunk-loading-webpack-plugin/tsconfig.build.json" },
     { "path": "../../webpack/css-extract-webpack-plugin/tsconfig.build.json" },
   ],

--- a/packages/rspeedy/core/tsconfig.json
+++ b/packages/rspeedy/core/tsconfig.json
@@ -18,6 +18,7 @@
     "test/config/fixtures",
   ],
   "references": [
+    { "path": "../../webpack/cache-events-webpack-plugin/tsconfig.build.json" },
     { "path": "../../webpack/chunk-loading-webpack-plugin/tsconfig.build.json" },
     { "path": "../../webpack/css-extract-webpack-plugin/tsconfig.build.json" },
   ],


### PR DESCRIPTION
Fix the build error introduced by #1370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated internal TypeScript project references to improve build consistency and caching across packages.
  - Enhances developer tooling reliability without altering functionality.

- Notes
  - No changes to UI, behavior, or public APIs.
  - No action required for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
