### PR TITLE
feat: always inline the bts that contains runtime module

### DIFF
--- a/.changeset/social-coins-taste.md
+++ b/.changeset/social-coins-taste.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Always inline the background script that contains rspack runtime module.

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/index.js
@@ -23,9 +23,11 @@ it('should inline foo, but not inline bar', async () => {
   const { manifest } = JSON.parse(content);
 
   expect(manifest).toHaveProperty('/app-service.js');
-  expect(Object.keys(manifest).length).toBe(2);
+  expect(Object.keys(manifest).length).toBe(3);
   expect(manifest['/app-service.js']).toBeTruthy();
   expect(manifest['/foo.js']).toBeTruthy();
+  // it is inlined because rspack.bundle.js has rspack runtime module which needs to be loaded synchronously
+  expect(manifest['/rspack.bundle.js']).toBeTruthy();
 
   it('inlined scripts should not have syntax error', () => {
     eval(manifest['/app-service.js']);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

Follows https://github.com/lynx-family/lynx-stack/pull/1504, we should inline the script that contains rspack runtime module to ensure cache layer in https://github.com/lynx-family/lynx-stack/pull/1370 works properly.

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime-containing background scripts are now always inlined to ensure reliable, synchronous loading. Non-runtime scripts continue to follow existing inlining heuristics.
* **Tests**
  * Updated expectations to account for an additional manifest entry and to verify the inlined runtime module is present.
* **Chores**
  * Added a patch-level changeset entry for the package to document the behavioral update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
