### PR TITLE
feat: add `@lynx-js/preact-devtools` to create-rspeedy

### DIFF
--- a/.changeset/dull-needles-read.md
+++ b/.changeset/dull-needles-read.md
@@ -1,0 +1,5 @@
+---
+"create-rspeedy": patch
+---
+
+Add `@lynx-js/preact-devtools` by default.

--- a/.changeset/orange-swans-brake.md
+++ b/.changeset/orange-swans-brake.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-alias-rsbuild-plugin": patch
+---
+
+Alias `@lynx-js/preact-devtools` to `false` to reduce an import of empty webpack module.

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -12,6 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/preact-devtools": "^5.0.1-6664329",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react/src/index.tsx
+++ b/examples/react/src/index.tsx
@@ -1,3 +1,4 @@
+import '@lynx-js/preact-devtools';
 import '@lynx-js/react/debug';
 import { root } from '@lynx-js/react';
 

--- a/packages/rspeedy/create-rspeedy/template-react-js/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-js/package.json
@@ -11,6 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/preact-devtools": "^5.0.1-6664329",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*"

--- a/packages/rspeedy/create-rspeedy/template-react-js/src/index.jsx
+++ b/packages/rspeedy/create-rspeedy/template-react-js/src/index.jsx
@@ -1,3 +1,4 @@
+import '@lynx-js/preact-devtools'
 import '@lynx-js/react/debug'
 import { root } from '@lynx-js/react'
 

--- a/packages/rspeedy/create-rspeedy/template-react-ts/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/package.json
@@ -11,6 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/preact-devtools": "^5.0.1-6664329",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/create-rspeedy/template-react-ts/src/index.tsx
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/src/index.tsx
@@ -1,3 +1,4 @@
+import '@lynx-js/preact-devtools'
 import '@lynx-js/react/debug'
 import { root } from '@lynx-js/react'
 

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-js/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-js/package.json
@@ -12,6 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/preact-devtools": "^5.0.1-6664329",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-js/src/index.jsx
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-js/src/index.jsx
@@ -1,3 +1,4 @@
+import '@lynx-js/preact-devtools'
 import '@lynx-js/react/debug'
 import { root } from '@lynx-js/react'
 

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/package.json
@@ -12,6 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/preact-devtools": "^5.0.1-6664329",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/src/index.tsx
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/src/index.tsx
@@ -1,3 +1,4 @@
+import '@lynx-js/preact-devtools'
 import '@lynx-js/react/debug'
 import { root } from '@lynx-js/react'
 

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -148,6 +148,7 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
 
         if (isProd) {
           chain.resolve.alias.set('@lynx-js/react/debug$', false)
+          chain.resolve.alias.set('@lynx-js/preact-devtools$', false)
         }
 
         chain

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react
     devDependencies:
+      '@lynx-js/preact-devtools':
+        specifier: ^5.0.1-6664329
+        version: 5.0.1-6664329
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -2178,6 +2181,9 @@ packages:
 
   '@lynx-js/lynx-core@0.1.3':
     resolution: {integrity: sha512-uWzKKYJUK4Q09ZRZxWSAFINnmZb9piWPbvWF9SkLn+3snBl9u/BJa4ekPRcKWAhBmpbtxWH1x27fxe3Q3p5l3Q==}
+
+  '@lynx-js/preact-devtools@5.0.1-6664329':
+    resolution: {integrity: sha512-T+AVH31ZtIez6ue7e3vKR2bPs0ssF3T+X7GRnnOL9KP+IJoIctCjp59TNdGI8sSppT6IYo72ORFMRBUyAAE0tw==}
 
   '@lynx-js/tasm@0.0.17':
     resolution: {integrity: sha512-SiLmx6ScI8lrmVvpOq95MlbaLSWDOA5aJ6P9/60dxZoWomRXP4kGH/oGr47Gqnd35u5FyPHf6KicPIc09rnIXw==}
@@ -4429,6 +4435,9 @@ packages:
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
+  errorstacks@2.4.1:
+    resolution: {integrity: sha512-jE4i0SMYevwu/xxAuzhly/KTwtj0xDhbzB6m1xPImxTkw8wcCbgarOQPfCVMi5JKVyW7in29pNJCCJrry3Ynnw==}
+
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
     engines: {node: '>= 0.4'}
@@ -5114,6 +5123,9 @@ packages:
 
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
+
+  htm@3.1.1:
+    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -9206,6 +9218,11 @@ snapshots:
 
   '@lynx-js/lynx-core@0.1.3': {}
 
+  '@lynx-js/preact-devtools@5.0.1-6664329':
+    dependencies:
+      errorstacks: 2.4.1
+      htm: 3.1.1
+
   '@lynx-js/tasm@0.0.17': {}
 
   '@lynx-js/types@3.3.0':
@@ -11787,6 +11804,8 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
+  errorstacks@2.4.1: {}
+
   es-abstract@1.24.0:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -12762,6 +12781,8 @@ snapshots:
       obuf: 1.1.2
       readable-stream: 2.3.8
       wbuf: 1.7.3
+
+  htm@3.1.1: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preact DevTools enabled by default across React templates (JS, TS, Vitest/RTL variants) and the React example app.
  - DevTools auto-initialize in development for easier component inspection and debugging out of the box.

- **Bug Fixes**
  - Prevents Preact DevTools from being resolved in production builds to avoid bundling issues.

- **Chores**
  - Added changeset entries for patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
