### PR TITLE
fix: `fireEvent` type error in testing library

### DIFF
--- a/.changeset/social-forks-juggle.md
+++ b/.changeset/social-forks-juggle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+fix `fireEvent` type error in testing library

--- a/packages/react/testing-library/types/entry.d.ts
+++ b/packages/react/testing-library/types/entry.d.ts
@@ -10,8 +10,55 @@
 import { queries, Queries, BoundFunction } from '@testing-library/dom';
 import { LynxElement, type ElementTree, type LynxTestingEnv } from '@lynx-js/testing-environment';
 import { act } from 'preact/test-utils';
+import type { EventType, FireFunction, FireObject } from '@testing-library/dom';
 export * from '@testing-library/dom';
 export { ElementTree, LynxTestingEnv, act };
+
+declare type LynxEventType =
+  | 'focus'
+  | 'blur'
+  | 'scroll'
+  | 'wheel'
+  | 'tap'
+  | 'longtap'
+  | 'bgload'
+  | 'bgerror'
+  | 'touchstart'
+  | 'touchmove'
+  | 'touchcancel'
+  | 'touchend'
+  | 'longpress'
+  | 'transitionstart'
+  | 'transitioncancel'
+  | 'transitionend'
+  | 'animationstart'
+  | 'animationiteration'
+  | 'animationcancel'
+  | 'animationend'
+  | 'mousedown'
+  | 'mouseup'
+  | 'mousemove'
+  | 'mouseclick'
+  | 'mousedblclick'
+  | 'mouselongpress'
+  | 'keydown'
+  | 'keyup'
+  | 'layoutchange'
+  | 'scrolltoupper'
+  | 'scrolltolower'
+  | 'scrollend'
+  | 'contentsizechanged'
+  | 'scrolltoupperedge'
+  | 'scrolltoloweredge'
+  | 'scrolltonormalstate';
+
+declare type LynxFireObject = {
+  [K in LynxEventType]: FireObject[EventType];
+};
+
+declare const fireEvent: FireFunction & LynxFireObject;
+
+export { fireEvent, LynxEventType as EventType, LynxFireObject as FireObject };
 
 /**
  * The options for {@link render}.

--- a/packages/testing-library/examples/basic/src/__tests__/types/event.test-d.tsx
+++ b/packages/testing-library/examples/basic/src/__tests__/types/event.test-d.tsx
@@ -1,0 +1,49 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import '@testing-library/jest-dom';
+import { expect, it, vi } from 'vitest';
+import { render, fireEvent, screen } from '@lynx-js/react/testing-library';
+
+it('basic', async function() {
+  const Button = (
+    { children, onClick }: { children: JSX.Element; onClick: () => void },
+  ) => {
+    return <view bindtap={onClick}>{children}</view>;
+  };
+  const onClick = vi.fn(() => {});
+
+  // ARRANGE
+  const { container } = render(
+    <Button onClick={onClick}>
+      <text data-testid='text'>Click me</text>
+    </Button>,
+  );
+
+  expect(onClick).not.toHaveBeenCalled();
+
+  // ACT
+
+  // Method 1: Construct the Event object yourself
+  const event = new Event('catchEvent:tap');
+  Object.assign(event, {
+    eventType: 'catchEvent',
+    eventName: 'tap',
+    key: 'value',
+  });
+  expect(fireEvent(container.firstChild, event)).toBe(true);
+
+  // Method 2: Pass in event type and initialization parameters
+  fireEvent.tap(container.firstChild);
+  fireEvent.tap(container.firstChild, {
+    eventType: 'catchEvent',
+    key: 'value',
+  });
+
+  // @ts-expect-error fireEvent.click should not exist
+  expect(fireEvent.click).toBeUndefined();
+
+  // ASSERT
+  expect(onClick).toBeCalledTimes(1);
+  expect(screen.getByTestId('text')).toHaveTextContent('Click me');
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

Fixes #1595

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed TypeScript typing for testing utilities by extending event typings to include Lynx-specific events and typed per-event fireEvent helpers; no runtime changes.

- Tests
  - Added type-focused tests validating custom event handling, per-event fireEvent usage, and guarding against unsupported events.

- Chores
  - Added a changeset to publish a patch release describing the typing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
