### PR TITLE
feat(create-rspeedy): use TS project references

### DIFF
--- a/.changeset/tough-wings-brake.md
+++ b/.changeset/tough-wings-brake.md
@@ -1,0 +1,5 @@
+---
+"create-rspeedy": patch
+---
+
+Use TypeScript [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) in templates.

--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -15,6 +15,7 @@
       ".vscode/settings.json",
       "tsconfig.json",
       "tsconfig.build.json",
+      "tsconfig.node.json",
       "api-extractor.json",
     ],
   },

--- a/packages/rspeedy/create-rspeedy/template-common/gitignore
+++ b/packages/rspeedy/create-rspeedy/template-common/gitignore
@@ -11,3 +11,6 @@ dist/
 .vscode/*
 !.vscode/extensions.json
 .idea
+
+# TypeScript
+*.tsbuildinfo

--- a/packages/rspeedy/create-rspeedy/template-react-ts/src/tsconfig.json
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/src/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+
+    "noEmit": true,
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"],
+}

--- a/packages/rspeedy/create-rspeedy/template-react-ts/tsconfig.json
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "@lynx-js/react",
-    "module": "node16",
-    "moduleResolution": "node16",
-
     "strict": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
@@ -12,5 +7,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
   },
-  "exclude": ["dist/"],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./src" },
+  ],
+  "files": [],
 }

--- a/packages/rspeedy/create-rspeedy/template-react-ts/tsconfig.node.json
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+
+    // Rspeedy uses Node.js's module resolution
+    "module": "node16",
+    "moduleResolution": "node16",
+    "erasableSyntaxOnly": true,
+
+    // Node.js 18+
+    "lib": ["es2023"],
+    "target": "es2022",
+
+    "noEmit": true,
+  },
+  "include": ["./lynx.config.ts"],
+}

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/src/tsconfig.json
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/src/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+
+    "noEmit": true,
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"],
+}

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/tsconfig.json
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/tsconfig.json
@@ -1,17 +1,17 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "@lynx-js/react",
-
-    "module": "node18",
-    "moduleResolution": "node16",
-
     "strict": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
 
     "esModuleInterop": true,
     "skipLibCheck": true,
+
+    "noEmit": true,
   },
-  "exclude": ["dist/"],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./src" },
+  ],
+  "files": [],
 }

--- a/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/tsconfig.node.json
+++ b/packages/rspeedy/create-rspeedy/template-react-vitest-rltl-ts/tsconfig.node.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+
+    // Rspeedy uses Node.js's module resolution
+    "module": "node16",
+    "moduleResolution": "node16",
+    "erasableSyntaxOnly": true,
+
+    // Node.js 18+
+    "lib": ["es2023"],
+    "target": "es2022",
+
+    "noEmit": true,
+  },
+  "include": [
+    "./lynx.config.ts",
+    "./vitest.config.ts",
+  ],
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Enabled TypeScript Project References in React TS and React + Vitest templates for improved IDE performance and build reliability.
* Improvements
  * Introduced separate Node-focused TypeScript configs and streamlined template tsconfig setups for clearer project structure and faster incremental builds.
* Chores
  * Updated template .gitignore to exclude TypeScript build info files.
  * Adjusted formatting configuration to support additional TypeScript config files.
  * Prepared a patch release for create-rspeedy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

See more background at: https://github.com/lynx-family/lynx-stack/issues/1441

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
