### PR TITLE
ci: should not continue on build error

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -117,7 +117,6 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=32768
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        continue-on-error: true
       - name: Upload turbo summary
         if: runner.debug == '1'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Strengthened CI build enforcement: build failures now block subsequent steps. This improves reliability by preventing artifacts from being produced after a failed build, surfaces issues earlier, and provides clearer failure signals. Users can expect a more predictable release process and higher confidence in build quality, with faster feedback for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fix an regression of https://github.com/lynx-family/lynx-stack/pull/1607

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
