### PR TITLE
ci(benchmark/react): ignore some benchmarks

### DIFF
--- a/benchmark/react/rspeedy-env.d.ts
+++ b/benchmark/react/rspeedy-env.d.ts
@@ -8,6 +8,7 @@ declare const Codspeed: {
   startBenchmark(): void;
   stopBenchmark(): void;
   setExecutedBenchmark(name: string): void;
+  zeroStats(): void;
 };
 
 declare const __REPO_FILEPATH__: string;

--- a/packages/lynx/benchx_cli/scripts/build.mjs
+++ b/packages/lynx/benchx_cli/scripts/build.mjs
@@ -30,7 +30,7 @@ console.log('noop')
 }
 
 const COMMIT = 'f557bc907f8eac7d45386d493dea9b808d98dd7d';
-const PICK_COMMIT = '471ebc337ca762e08de0d1e488e21ed79c8107c1';
+const PICK_COMMIT = '033e8243747fa0b3ffc01e4b2df321d73a30597f';
 
 function checkCwd() {
   try {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a new zeroStats method to the benchmarking interface for resetting/ignoring metric accumulation.
- Bug Fixes
  - Excluded internal profiling events from benchmarks to prevent skewed results and improve metric accuracy.
- Refactor
  - Switched benchmark naming to repository-relative prefixes for clearer identification and grouping across environments.
- Chores
  - Updated build to include a newer cherry-picked patch, ensuring the bundled binary reflects recent fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
