### PR TITLE
fix: should only recycle off-screen list-item in recursive hydration

### DIFF
--- a/.changeset/plenty-kiwis-live.md
+++ b/.changeset/plenty-kiwis-live.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Should only recycle off-screen `list-item` in recursive hydration.

--- a/packages/react/runtime/__test__/list.test.jsx
+++ b/packages/react/runtime/__test__/list.test.jsx
@@ -1945,6 +1945,11 @@ describe('list reload', () => {
     expect(signMap.get(__GetElementUniqueID(d1.__element_root))).toBe(d2_); // note: d1 is reused by d2_
     expect(signMap.get(__GetElementUniqueID(d2_.__element_root))).toBe(d2_);
     expect(signMap.get(__GetElementUniqueID(d3_.__element_root))).toBe(d3_);
+    // d1 was enqueued as well, so it should be in the recycling pool
+    expect([...recycleSignMap.keys()]).toStrictEqual([
+      __GetElementUniqueID(d3.__element_root),
+      __GetElementUniqueID(d1.__element_root),
+    ]);
   });
 });
 

--- a/packages/react/runtime/__test__/list.test.jsx
+++ b/packages/react/runtime/__test__/list.test.jsx
@@ -1774,6 +1774,11 @@ describe('list reload', () => {
     hydrate(b, bb);
     b.unRenderElements();
 
+    // Should only update `list-item` in the recycling pool
+    // Should not add the on-screen `list-item` to the recycling pool,
+    expect([...recycleSignMap.keys()]).toStrictEqual([__GetElementUniqueID(d3.__element_root)]);
+    expect(recycleSignMap.get(__GetElementUniqueID(d3.__element_root))).not.toBe(d3);
+
     // The one rendered <list-item/> should be removed
     expect(root).toMatchInlineSnapshot(`
       <view>
@@ -1940,7 +1945,6 @@ describe('list reload', () => {
     expect(signMap.get(__GetElementUniqueID(d1.__element_root))).toBe(d2_); // note: d1 is reused by d2_
     expect(signMap.get(__GetElementUniqueID(d2_.__element_root))).toBe(d2_);
     expect(signMap.get(__GetElementUniqueID(d3_.__element_root))).toBe(d3_);
-    expect(recycleSignMap.get(__GetElementUniqueID(d3_.__element_root))).toBe(d3_);
   });
 });
 

--- a/packages/react/runtime/src/hydrate.ts
+++ b/packages/react/runtime/src/hydrate.ts
@@ -332,7 +332,12 @@ export function hydrate(before: SnapshotInstance, after: SnapshotInstance, optio
               }
               if (recycleMap.has(a.type)) {
                 const recycleSignMap = recycleMap.get(a.type)!;
-                recycleSignMap.set(listItemID, b);
+                // Should only update `list-item` in the recycling pool
+                // Because if an on-screen `list-item` is added to the recycling pool,
+                // it could cause a blank screen when reused next time, as it may still be visible.
+                if (recycleSignMap.has(listItemID)) {
+                  recycleSignMap.set(listItemID, b);
+                }
               }
             }
           },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Refined hydration so only off-screen list items are considered for recycling, preventing visible items from being reused and improving reload stability.
- Tests
  - Updated tests to assert the tightened recycling behavior during hydration.
- Chores
  - Added a changeset for a patch release of @lynx-js/react.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
