### PR TITLE
feat(web): WebEncodePlugin outputs add new field: appType, version

### DIFF
--- a/.changeset/nasty-spiders-film.md
+++ b/.changeset/nasty-spiders-film.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+feat: web output add `version` field to identify the build version `appType` field to identify lazy-bundle; The WrapperPlugin is also enabled on the Web.

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -200,6 +200,29 @@ export function applyEntry(
     const enableChunkSplitting =
       rsbuildConfig.performance?.chunkSplit?.strategy !== 'all-in-one'
 
+    chain
+      .plugin(PLUGIN_NAME_RUNTIME_WRAPPER)
+      .use(RuntimeWrapperWebpackPlugin, [{
+        injectVars(vars) {
+          const UNUSED_VARS = new Set([
+            'Card',
+            'Component',
+            'ReactLynx',
+            'Behavior',
+          ])
+          return vars.map(name => {
+            if (UNUSED_VARS.has(name)) {
+              return `__${name}`
+            }
+            return name
+          })
+        },
+        targetSdkVersion,
+        // Inject runtime wrapper for all `.js` but not `main-thread.js` and `main-thread.[hash].js`.
+        test: /^(?!.*main-thread(?:\.[A-Fa-f0-9]*)?\.js$).*\.js$/,
+        experimental_isLazyBundle,
+      }])
+      .end()
     if (isLynx) {
       let inlineScripts
       if (experimental_isLazyBundle) {
@@ -211,28 +234,6 @@ export function applyEntry(
       }
 
       chain
-        .plugin(PLUGIN_NAME_RUNTIME_WRAPPER)
-        .use(RuntimeWrapperWebpackPlugin, [{
-          injectVars(vars) {
-            const UNUSED_VARS = new Set([
-              'Card',
-              'Component',
-              'ReactLynx',
-              'Behavior',
-            ])
-            return vars.map(name => {
-              if (UNUSED_VARS.has(name)) {
-                return `__${name}`
-              }
-              return name
-            })
-          },
-          targetSdkVersion,
-          // Inject runtime wrapper for all `.js` but not `main-thread.js` and `main-thread.[hash].js`.
-          test: /^(?!.*main-thread(?:\.[A-Fa-f0-9]*)?\.js$).*\.js$/,
-          experimental_isLazyBundle,
-        }])
-        .end()
         .plugin(`${LynxEncodePlugin.name}`)
         .use(LynxEncodePlugin, [{ inlineScripts }])
         .end()

--- a/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
@@ -98,6 +98,10 @@ export class WebEncodePlugin {
               },
               customSections: encodeOptions.customSections,
               elementTemplate: encodeOptions['elementTemplate'],
+              appType: (encodeOptions['pageConfig'] as Record<string, unknown>)
+                  ?.['experimental_isLazyBundle']
+                ? 'lazy'
+                : 'card',
             })),
             debugInfo: '',
           };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Web output now includes build version and an appType field (lazy or card) in the metadata.
  - Runtime wrapper is enabled across all web environments for consistent behavior.

- Chores
  - Published patch updates for two packages to deliver these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
