### PR TITLE
fix(rspeedy): disable lazyCompilation by default

### DIFF
--- a/.changeset/short-insects-attack.md
+++ b/.changeset/short-insects-attack.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+fix: disable lazyCompilation by default, because it has not yet been adapted in rspeedy.

--- a/.changeset/short-insects-attack.md
+++ b/.changeset/short-insects-attack.md
@@ -2,4 +2,4 @@
 "@lynx-js/rspeedy": patch
 ---
 
-fix: disable lazyCompilation by default, because it has not yet been adapted in rspeedy.
+Disable lazyCompilation by default.

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -17,6 +17,7 @@ export function toRsbuildConfig(
 ): UndefinedOnPartialDeep<RsbuildConfig> {
   return {
     dev: {
+      lazyCompilation: false,
       watchFiles: config.dev?.watchFiles,
       // We expect to use different default writeToDisk with Rsbuild
       writeToDisk: config.dev?.writeToDisk ?? true,

--- a/packages/rspeedy/core/test/config/lazyCompilation.test.ts
+++ b/packages/rspeedy/core/test/config/lazyCompilation.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { RsbuildPlugin } from '@rsbuild/core'
+import { describe, expect, test } from 'vitest'
+
+import { createStubRspeedy } from '../createStubRspeedy.js'
+
+describe('lazyCompilation', () => {
+  test('defaults', async () => {
+    const rspeedy = await createStubRspeedy({})
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.lazyCompilation).toBeFalsy()
+  })
+
+  test('override with plugin', async () => {
+    const rspeedy = await createStubRspeedy({
+      plugins: [
+        {
+          name: 'test',
+          setup(api) {
+            api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+              return mergeRsbuildConfig(config, {
+                dev: {
+                  lazyCompilation: {
+                    imports: true,
+                  },
+                },
+              })
+            })
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.lazyCompilation).toStrictEqual({
+      imports: true,
+    })
+  })
+})

--- a/packages/rspeedy/core/test/config/rsbuild.test.ts
+++ b/packages/rspeedy/core/test/config/rsbuild.test.ts
@@ -14,6 +14,7 @@ describe('Config - toRsBuildConfig', () => {
       })
       expect(rsbuildConfig.dev).toMatchInlineSnapshot(`
         {
+          "lazyCompilation": false,
           "progressBar": true,
           "watchFiles": undefined,
           "writeToDisk": true,


### PR DESCRIPTION
Rsbuild enable `lazyCompilation.imports` by default in v1.5.0. However, we should disable lazyCompilation in rspeedy by default, because it has not yet been adapted in rspeedy.

![img_v3_02pp_7c94cf3e-084a-4d86-91ad-a424db4adacg](https://github.com/user-attachments/assets/775d3c09-5255-4c9e-b41c-52fc56920f46)


https://github.com/web-infra-dev/rsbuild/releases/tag/v1.5.0

`lazyCompilation` should be supported in https://github.com/lynx-family/lynx-stack/pull/174 
## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an opt-in dev setting for lazy compilation (disabled by default) with plugin override support.

- **Bug Fixes**
  - Disabled lazy compilation by default in development to avoid issues; existing dev behaviors unchanged.

- **Tests**
  - Added tests validating default and plugin-overridden lazy compilation and updated snapshots.

- **Chores**
  - Prepared a patch release changeset for @lynx-js/rspeedy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->