### PR TITLE
feat(rspeedy/core): support fine-grained `output.dataUriLimit`

### DIFF
--- a/.changeset/warm-shoes-move.md
+++ b/.changeset/warm-shoes-move.md
@@ -1,0 +1,18 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Add `output.dataUriLimit.*` for fine-grained control of asset inlining.
+
+```js
+import { defineConfig } from '@lynx-js/rspeedy';
+
+export default defineConfig({
+  output: {
+    dataUriLimit: {
+      image: 5000,
+      media: 0,
+    },
+  },
+});
+```

--- a/packages/rspeedy/core/etc/rspeedy.api.md
+++ b/packages/rspeedy/core/etc/rspeedy.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { CreateRsbuildOptions } from '@rsbuild/core';
+import type { DataUriLimit } from '@rsbuild/core';
 import type { DistPathConfig } from '@rsbuild/core';
 import type { InlineChunkConfig } from '@rsbuild/core';
 import { logger } from '@rsbuild/core';
@@ -240,7 +241,7 @@ export interface Output {
     cleanDistPath?: boolean | undefined;
     copy?: Rspack.CopyRspackPluginOptions | Rspack.CopyRspackPluginOptions['patterns'] | undefined;
     cssModules?: CssModules | undefined;
-    dataUriLimit?: number | undefined;
+    dataUriLimit?: number | DataUriLimit | undefined;
     distPath?: DistPath | undefined;
     filename?: string | Filename | undefined;
     filenameHash?: boolean | string | undefined;

--- a/packages/rspeedy/core/src/config/output/index.ts
+++ b/packages/rspeedy/core/src/config/output/index.ts
@@ -213,7 +213,7 @@ export interface Output {
    * Disable inlining of all media but not images.
    *
    * ```ts title="lynx.config.ts"
-* import { defineConfig } from '@lynx-js/rspeedy'
+   * import { defineConfig } from '@lynx-js/rspeedy'
    *
    * export default defineConfig({
    *   output: {
@@ -223,7 +223,7 @@ export interface Output {
    *     },
    *   },
    * })
-   *
+   * ```
    */
   dataUriLimit?: number | DataUriLimit | undefined
 

--- a/packages/rspeedy/core/src/config/output/index.ts
+++ b/packages/rspeedy/core/src/config/output/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { InlineChunkConfig, Rspack } from '@rsbuild/core'
+import type { DataUriLimit, InlineChunkConfig, Rspack } from '@rsbuild/core'
 
 import type { CssModules } from './css-modules.js'
 import type { DistPath } from './dist-path.js'
@@ -207,8 +207,25 @@ export interface Output {
    *   },
    * })
    * ```
+   *
+   * @example
+   *
+   * Disable inlining of all media but not images.
+   *
+   * ```ts title="lynx.config.ts"
+   * import { defineConfig } from '@byted-lynx/rspeedy'
+   *
+   * export default defineConfig({
+   *   output: {
+   *     dataUriLimit: {
+   *       image: 5000,
+   *       media: 0,
+   *     },
+   *   },
+   * })
+   * ```
    */
-  dataUriLimit?: number | undefined
+  dataUriLimit?: number | DataUriLimit | undefined
 
   /**
    * Set the directory of the dist files.

--- a/packages/rspeedy/core/src/config/output/index.ts
+++ b/packages/rspeedy/core/src/config/output/index.ts
@@ -213,7 +213,7 @@ export interface Output {
    * Disable inlining of all media but not images.
    *
    * ```ts title="lynx.config.ts"
-   * import { defineConfig } from '@byted-lynx/rspeedy'
+* import { defineConfig } from '@lynx-js/rspeedy'
    *
    * export default defineConfig({
    *   output: {
@@ -223,7 +223,7 @@ export interface Output {
    *     },
    *   },
    * })
-   * ```
+   *
    */
   dataUriLimit?: number | DataUriLimit | undefined
 

--- a/packages/rspeedy/core/test/config/output.test-d.ts
+++ b/packages/rspeedy/core/test/config/output.test-d.ts
@@ -112,6 +112,17 @@ describe('Config - Output', () => {
     assertType<Output>({
       dataUriLimit: Number.MAX_SAFE_INTEGER,
     })
+
+    assertType<Output>({
+      dataUriLimit: {},
+    })
+
+    assertType<Output>({
+      dataUriLimit: {
+        assets: 0,
+        image: Number.POSITIVE_INFINITY,
+      },
+    })
   })
 
   test('output.distPath', () => {

--- a/packages/rspeedy/core/test/config/validate.test.ts
+++ b/packages/rspeedy/core/test/config/validate.test.ts
@@ -802,6 +802,18 @@ describe('Config Validation', () => {
         { dataUriLimit: Number.NaN },
         { dataUriLimit: Number.POSITIVE_INFINITY },
         { dataUriLimit: Number.MAX_SAFE_INTEGER },
+        {
+          dataUriLimit: {},
+        },
+        {
+          dataUriLimit: {
+            assets: 0,
+            image: 10,
+            svg: 100,
+            font: 1000,
+            media: 10000,
+          },
+        },
         { cssModules: { auto: true } },
         { cssModules: { auto: false } },
         { cssModules: { auto: /module/ } },
@@ -1055,7 +1067,7 @@ describe('Config Validation', () => {
           [Error: Invalid configuration.
 
           Invalid config on \`$input.output.dataUriLimit\`.
-            - Expect to be (number | undefined)
+            - Expect to be (DataUriLimit | number | undefined)
             - Got: string
           ]
         `)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added granular control for asset inlining via output.dataUriLimit: accept either a single number or an object to set per-type limits (assets, image, svg, font, media). Backward compatible with numeric option.

- Documentation
  - Updated examples showing per-type thresholds and disabling inlining for specific asset types.

- Tests
  - Expanded tests to validate the new object-based configuration alongside the numeric option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
