### PR TITLE
fix(web): register attr of width is set to height incorrectly

### DIFF
--- a/.changeset/nine-numbers-push.md
+++ b/.changeset/nine-numbers-push.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: register attr of width is set to height incorrectly

--- a/packages/web-platform/web-elements/src/XCanvas/CanvasAttributes.ts
+++ b/packages/web-platform/web-elements/src/XCanvas/CanvasAttributes.ts
@@ -34,7 +34,7 @@ export class CanvasAttributes
   @registerAttributeHandler('height', true)
   handleHeight = bindToAttribute(this.#getCanvas, 'height');
 
-  @registerAttributeHandler('height', true)
+  @registerAttributeHandler('width', true)
   handleWidth = bindToAttribute(this.#getCanvas, 'width');
 
   #resizeHandler: ResizeObserverCallback = (entries: ResizeObserverEntry[]) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected canvas width attribute binding so width updates now apply and trigger correctly, resolving cases where width changes had no effect or were mistakenly tied to height. Ensures consistent resizing behavior and alignment with observed attributes.

* **Chores**
  * Added a changeset to publish a patch release for @lynx-js/web-elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
