### PR TITLE
feat: allow user customize `react$` alias

### DIFF
--- a/.changeset/weak-mirrors-admire.md
+++ b/.changeset/weak-mirrors-admire.md
@@ -1,0 +1,17 @@
+---
+"@lynx-js/react-alias-rsbuild-plugin": patch
+---
+
+Allow customization of the `react$` alias.
+
+```js
+import { defineConfig } from '@lynx-js/rspeedy';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      react$: '@lynx-js/react/compat',
+    },
+  },
+});
+```

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -151,13 +151,16 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
           chain.resolve.alias.set('@lynx-js/preact-devtools$', false)
         }
 
-        chain
-          .resolve
-          .alias
-          .set(
+        if (!chain.resolve.alias.has('react$')) {
+          chain.resolve.alias.set(
             'react$',
             reactLepus.background,
           )
+        }
+
+        chain
+          .resolve
+          .alias
           .set(
             '@lynx-js/react$',
             reactLepus.background,

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -263,6 +263,32 @@ describe('Config', () => {
     )
   })
 
+  test('user customized `react$` alias should work', async () => {
+    const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        resolve: {
+          alias: {
+            react$: 'foo',
+          },
+        },
+        plugins: [
+          pluginReactLynx(),
+          pluginStubRspeedyAPI(),
+        ],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+
+    if (!config?.resolve?.alias) {
+      expect.fail('should have config.resolve.alias')
+    }
+
+    expect(config.resolve?.alias).toHaveProperty('react$', 'foo')
+  })
+
   test('extensionAlias with tsConfig', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     const { pluginReactLynx } = await import('../src/pluginReactLynx.js')


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

This will fix the steps in [tanstack-router docs](https://lynxjs.org/react/routing/tanstack-router.html#config) not working:

```js
export default defineConfig({
  // ...other configs
  source: {
    alias: {
      react$: require.resolve('@lynx-js/react/compat'),
    },
  },
```

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserve any user-defined react$ alias in build configuration so custom aliases are not overwritten.

- **Tests**
  - Added tests to verify a user-specified react$ alias is retained in the generated configuration.

- **Chores**
  - Added a changeset marking a patch release and documenting the ability to customize the react$ alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
