### PR TITLE
chore(web): list-waterfall-1000 layout count was changed to 10 for st…

### DIFF
--- a/packages/web-platform/web-tests/tests/performance.test.ts
+++ b/packages/web-platform/web-tests/tests/performance.test.ts
@@ -176,7 +176,7 @@ test.describe('performance', () => {
       const cdpSession = await goto({ page, browserName, context }, title);
       const metrics = await getMetrics(cdpSession, page);
       console.log(metrics.LayoutCount, metrics.RecalcStyleCount);
-      expect(metrics.LayoutCount, 'layout count').toBeLessThanOrEqual(7);
+      expect(metrics.LayoutCount, 'layout count').toBeLessThanOrEqual(10);
       expect(metrics.RecalcStyleCount, 'recalc count').toBeLessThanOrEqual(8);
     },
   );


### PR DESCRIPTION
…ability

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted performance test thresholds for a high-item waterfall list scenario, increasing the allowed layout operations from 7 to 10.
  * Kept all other performance assertions unchanged (including style recalculation bounds).
  * No changes to test setup or metric collection.
  * No impact on runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
