### PR TITLE
ci(release): avoid building benchmarks on publish

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -135,7 +135,7 @@ jobs:
           path: .turbo
       - name: build
         run: |
-          corepack pnpm turbo --filter !@lynx-js/web-tests build --summarize
+          corepack pnpm turbo --filter !@lynx-js/web-tests build --filter !benchx_cli --filter "!@lynx-js/benchmark-*" --summarize
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date -u +'%Y-%m-%d %H:%M:%S')"


### PR DESCRIPTION
Following up https://github.com/lynx-family/lynx-stack/pull/1629.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the main-branch deployment workflow to exclude internal benchmarking components from the publish build, reducing CI duration and minimizing unnecessary build work.
  * Improves pipeline efficiency and stability, leading to faster feedback on releases without altering application functionality or release artifacts.
  * No changes to error handling or other workflow steps; both regular and canary publish paths remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
