### PR TITLE
ci(benchmark): increase timeout to 30 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,6 +237,7 @@ jobs:
     uses: ./.github/workflows/workflow-website.yml
   done:
     needs:
+      - benchmark
       - code-style-check
       - eslint
       - playwright-linux

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   nodejs-benchmark:
     permissions: {}
-    timeout-minutes: 10
+    timeout-minutes: 30
     # CodSpeed does not support merge_group event.
     #
     # Error: Event merge_group is not supported by CodSpeed


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to require benchmark completion before finalizing test runs, ensuring pipeline status reflects performance checks.
  * Extended benchmark job timeout from 10 to 30 minutes to reduce timeouts on slower environments and improve reliability.

* **Tests**
  * Improved CI stability around performance validation; no changes to product functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
