### PR TITLE
ci(web-tests): disable watch static on CI

### DIFF
--- a/packages/web-platform/web-tests/rspack.config.js
+++ b/packages/web-platform/web-tests/rspack.config.js
@@ -210,22 +210,27 @@ const config = {
       {
         directory: path.join(__dirname, 'resources'),
         publicPath: '/resources',
+        watch: !isCI,
       },
       {
         directory: path.join(__dirname, 'tests', 'web-elements'),
         publicPath: '/web-element-tests',
+        watch: !isCI,
       },
       {
         directory: path.join(__dirname, 'node_modules'),
         publicPath: '/node_modules',
+        watch: !isCI,
       },
       {
         directory: path.join(__dirname, 'dist'),
         publicPath: '/dist',
+        watch: !isCI,
       },
       {
         directory: path.join(__dirname, 'tests', 'common.css'),
         publicPath: '/common.css',
+        watch: !isCI,
       },
     ],
     hot: false,


### PR DESCRIPTION
Fix the "Error: ENOSPC: System limit for number of file watchers reached" error. See: https://github.com/lynx-family/lynx-stack/actions/runs/17559407684/job/49872470993?pr=1682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Local test runner now auto-refreshes when static assets change in non-CI environments, improving feedback during development.
* **Chores**
  * Updated development server configuration to watch multiple static directories outside CI, ensuring changes to resources, test fixtures, dependencies, build output, and shared styles are detected automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
