### PR TITLE
fix: should update signMap before __FlushElementTree

### DIFF
--- a/.changeset/healthy-maps-clean.md
+++ b/.changeset/healthy-maps-clean.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix "TypeError: cannot read property 'o' of undefined" in deferred list-item scenarios.
+
+Deferred `componentAtIndex` causes nodes that quickly appear/disappear to be enqueued without `__elements`. Update `signMap` before `__FlushElementTre` to resolve the issue.

--- a/.changeset/healthy-maps-clean.md
+++ b/.changeset/healthy-maps-clean.md
@@ -4,4 +4,4 @@
 
 Fix "TypeError: cannot read property '0' of undefined" in deferred list-item scenarios.
 
-Deferred `componentAtIndex` causes nodes that quickly appear/disappear to be enqueued without `__elements`. Update `signMap` before `__FlushElementTre` to resolve the issue.
+Deferred `componentAtIndex` causes nodes that quickly appear/disappear to be enqueued without `__elements`. Update `signMap` before `__FlushElementTree` to resolve the issue.

--- a/.changeset/healthy-maps-clean.md
+++ b/.changeset/healthy-maps-clean.md
@@ -2,6 +2,6 @@
 "@lynx-js/react": patch
 ---
 
-Fix "TypeError: cannot read property 'o' of undefined" in deferred list-item scenarios.
+Fix "TypeError: cannot read property '0' of undefined" in deferred list-item scenarios.
 
 Deferred `componentAtIndex` causes nodes that quickly appear/disappear to be enqueued without `__elements`. Update `signMap` before `__FlushElementTre` to resolve the issue.

--- a/packages/react/runtime/__test__/list.test.jsx
+++ b/packages/react/runtime/__test__/list.test.jsx
@@ -3078,7 +3078,7 @@ describe('list componentAtIndexes', () => {
     }
   });
 
-  it.only('should update signMap before __FlushElementTree when reuse occurs', () => {
+  it('should update signMap before __FlushElementTree when reuse occurs', () => {
     const b = new SnapshotInstance(s0);
     b.ensureElements();
     const listRef = b.__elements[3];

--- a/packages/react/runtime/src/list.ts
+++ b/packages/react/runtime/src/list.ts
@@ -155,6 +155,10 @@ export function componentAtIndexFactory(
       }
       const root = childCtx.__element_root!;
       applyRefQueue();
+      // In the defer `list-item` scenario, `componentAtIndex` occurs with delay.
+      // Within `componentAtIndex`, nodes that quickly appear and disappear due to re-layout will be enqueued again,
+      // causing the mapping relationship between sign and SnapshotInstance to become corrupted.
+      // This results in a SnapshotInstance without `__elements` being enqueued.
       signMap.set(sign, childCtx);
       if (!enableBatchRender) {
         const flushOptions: FlushOptions = {

--- a/packages/react/runtime/src/list.ts
+++ b/packages/react/runtime/src/list.ts
@@ -155,6 +155,7 @@ export function componentAtIndexFactory(
       }
       const root = childCtx.__element_root!;
       applyRefQueue();
+      signMap.set(sign, childCtx);
       if (!enableBatchRender) {
         const flushOptions: FlushOptions = {
           triggerLayout: true,
@@ -181,7 +182,6 @@ export function componentAtIndexFactory(
         }
         __FlushElementTree(root, flushOptions);
       }
-      signMap.set(sign, childCtx);
       return sign;
     }
 
@@ -190,6 +190,7 @@ export function componentAtIndexFactory(
     __AppendElement(list, root);
     const sign = __GetElementUniqueID(root);
     applyRefQueue();
+    signMap.set(sign, childCtx);
     if (!enableBatchRender) {
       __FlushElementTree(root, {
         triggerLayout: true,
@@ -202,7 +203,6 @@ export function componentAtIndexFactory(
         asyncFlush: true,
       });
     }
-    signMap.set(sign, childCtx);
     return sign;
   };
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Updated list rendering to update internal mappings earlier, preventing missing or corrupted items in deferred or reused list-item scenarios.

- Tests
  - Added tests that verify correct ordering between list mapping updates and element-tree flush for both standard and reuse flows.

- Chores
  - Patch release for @lynx-js/react; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
