### PR TITLE
ci(benchmark): disable building benchmark in EcoSystem CI

### DIFF
--- a/packages/lynx/benchx_cli/scripts/build.mjs
+++ b/packages/lynx/benchx_cli/scripts/build.mjs
@@ -7,7 +7,12 @@ import path from 'node:path';
 
 import { $ } from 'zx';
 
-if (!process.env.CI) {
+if (
+  !process.env.CI
+  // rspack-ecosystem-ci would set this
+  // https://github.com/rspack-contrib/rspack-ecosystem-ci/blob/113d2338da254ca341313a4a54afe789b45b1508/utils.ts#L108
+  || process.env['ECOSYSTEM_CI']
+) {
   // eslint-disable-next-line n/no-process-exit
   process.exit(0);
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI build behavior to exit earlier under additional CI conditions, improving compatibility with broader ecosystem CI environments.
  * No changes to application features or runtime behavior; end-users are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fix error like https://github.com/web-infra-dev/rspack/actions/runs/17576625799/job/49926722352

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
