### PR TITLE
fix: lock wasm-bindgen-cli to 0.2.101

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install wasm-bindgen
         uses: taiki-e/install-action@14083e64ac8cf1f5e54356df00b9779b23e192a1 # v2
         with:
-          tool: wasm-bindgen
+          tool: wasm-bindgen@0.2.101
       - name: Install
         run: |
           npm install -g corepack@latest

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install wasm-bindgen
         uses: taiki-e/install-action@14083e64ac8cf1f5e54356df00b9779b23e192a1 # v2
         with:
-          tool: wasm-bindgen
+          tool: wasm-bindgen@0.2.101
       - name: Install
         run: |
           npm install -g corepack@latest

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install wasm-bindgen
         uses: taiki-e/install-action@14083e64ac8cf1f5e54356df00b9779b23e192a1 # v2
         with:
-          tool: wasm-bindgen
+          tool: wasm-bindgen@0.2.101
       - name: Install
         run: |
           npm install -g corepack@latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,9 +900,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3369,21 +3369,22 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -3395,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3405,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3418,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]

--- a/packages/web-platform/web-style-transformer/Cargo.toml
+++ b/packages/web-platform/web-style-transformer/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 inline-style-parser = { path = "../inline-style-parser" }
 js-sys = "0.3.77"
 lazy_static = "1.5.0"
-wasm-bindgen = "0.2.88"
+wasm-bindgen = "=0.2.101"
 
 [profile.release]
 opt-level = 3

--- a/packages/web-platform/web-style-transformer/package.json
+++ b/packages/web-platform/web-style-transformer/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "node scripts/build.js",
-    "build:wasm-bindgen": "wasm-bindgen --version || cargo install wasm-bindgen-cli"
+    "build:wasm-bindgen": "wasm-bindgen --version || cargo install wasm-bindgen-cli --version 0.2.101"
   },
   "dependencies": {
     "wasm-feature-detect": "^1.8.0"


### PR DESCRIPTION
[0.2.101](https://github.com/wasm-bindgen/wasm-bindgen/releases/tag/0.2.101) is the newly published version.

We are doing this to fix error in rspack-ecosystem-ci. See: https://github.com/web-infra-dev/rspack/actions/runs/17573300875/job/49913557422

```
error: 

it looks like the Rust project used to create this Wasm file was linked against
version of wasm-bindgen that uses a different bindgen format than this binary:

  rust Wasm file schema version: 0.2.100
     this binary schema version: 0.2.101

Currently the bindgen format is unstable enough that these two schema versions
must exactly match. You can accomplish this by either updating this binary or
the wasm-bindgen dependency in the Rust project.

You should be able to update the wasm-bindgen dependency with:

    cargo update -p wasm-bindgen --precise 0.2.101

don't forget to recompile your Wasm file! Alternatively, you can update the
binary with:

    cargo install -f wasm-bindgen-cli --version 0.2.100

if this warning fails to go away though and you're not sure what to do feel free
to open an issue at https://github.com/wasm-bindgen/wasm-bindgen/issues!
```

@coderabbitai summary

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
