### PR TITLE
ci: fix canary publish failed

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -63,7 +63,7 @@ jobs:
   build-all:
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     uses: ./.github/workflows/workflow-build.yml
     if: github.repository == 'lynx-family/lynx-stack'
     permissions: {}
@@ -183,7 +183,7 @@ jobs:
           path: .turbo
       - name: build
         run: |
-          corepack pnpm turbo --filter !@lynx-js/web-tests build --summarize
+          corepack pnpm turbo --filter !@lynx-js/web-tests --filter !benchx_cli --filter "!@lynx-js/benchmark-*" build --summarize
       - name: version canary packages
         env:
           # changesets-changelog-github requires a GITHUB_TOKEN


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow stability by no longer canceling in-progress runs for the same group, reducing interrupted pipelines.
  * Streamlined canary builds by excluding benchmarking and test packages, speeding up build times without affecting user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

See: https://github.com/lynx-family/lynx-stack/actions/runs/17579086231/job/49931417699

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
