### PR TITLE
chore(benchmark): should bypass `ECOSYSTEM_CI` env

### DIFF
--- a/packages/lynx/benchx_cli/turbo.json
+++ b/packages/lynx/benchx_cli/turbo.json
@@ -4,6 +4,7 @@
   "tasks": {
     "build": {
       "env": ["ECOSYSTEM_CI"],
+      "passThroughEnv": ["ECOSYSTEM_CI"],
       "dependsOn": [],
       "inputs": ["scripts/build.mjs"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
rspack-ecosystem-ci still failed: https://github.com/web-infra-dev/rspack/actions/runs/17580812353/job/49936891783. We should bypass the `ECOSYSTEM_CI` env to `build.mjs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Build process now reads the ECOSYSTEM_CI environment variable and passes it to child processes during automated builds.
  - Applies to CI/automated build environments; local builds remain unaffected.
  - Other build settings unchanged; no impact on application features or behavior.
  - No action required from end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
