### PR TITLE
ci(benchmark/react): check `Codspeed` before use it

### DIFF
--- a/benchmark/react/plugins/pluginScriptLoad.mjs
+++ b/benchmark/react/plugins/pluginScriptLoad.mjs
@@ -24,7 +24,9 @@ const runAfterLoadScript = (() => {
   r.flush = () => { for (const cb of q) { cb(); } };
   return r;
 })();
-Codspeed.startBenchmark();
+if (typeof Codspeed !== "undefined") {
+  Codspeed.startBenchmark();
+}
 `;
           },
         }),
@@ -40,8 +42,10 @@ Codspeed.startBenchmark();
             const chunkName = filename.replace(/^\.rspeedy\//, '');
             // dprint-ignore
             return `\
-Codspeed.stopBenchmark();
-Codspeed.setExecutedBenchmark(\`${caseDir}::\${${JSON.stringify(chunkName)}}_LoadScript\`);
+if (typeof Codspeed !== "undefined") {
+  Codspeed.stopBenchmark();
+  Codspeed.setExecutedBenchmark(\`${caseDir}::\${${JSON.stringify(chunkName)}}_LoadScript\`);
+}
 runAfterLoadScript.flush();
 `;
           },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents runtime errors when an optional benchmarking tool is absent by conditionally running its instrumentation.
  * Ensures script-load and footer instrumentation execute only if the tool is available, while preserving normal behavior (including flush) when it is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
