### PR TITLE
chore: fix typo in eslint.config.js

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -217,7 +217,7 @@ export default tseslint.config(
         'error',
         {
           ignoreCase: false,
-          ignoreDeclarationSort: true, // don"t want to sort import lines, use eslint-plugin-import instead
+          ignoreDeclarationSort: true, // don't want to sort import lines, use eslint-plugin-import instead
           ignoreMemberSort: false,
           memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
           allowSeparatedGroups: true,


### PR DESCRIPTION
fix typo: `don"t` to `don't`

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Corrected a minor typo in an internal linting configuration comment. No functional, behavioral, or UI changes. Performance and stability unaffected. No user action required.
  * Development tooling remains consistent; this update is purely maintenance to keep comments clear.
  * There are no configuration or rule changes, so builds and code checks behave exactly as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
