### PR TITLE
fix(rspeedy/core): use `chunkLoading: 'lynx'` for Web

### DIFF
--- a/.changeset/better-insects-grin.md
+++ b/.changeset/better-insects-grin.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+feat(web-platform): use same chunk format, aka commonjs, for web with iOS/Andorid
+
+If you're using chunk spliting settings for web, mirgrate it to "all-in-one".

--- a/.changeset/better-insects-grin.md
+++ b/.changeset/better-insects-grin.md
@@ -2,6 +2,4 @@
 "@lynx-js/rspeedy": patch
 ---
 
-feat(web-platform): use same chunk format, aka commonjs, for web with iOS/Andorid
-
-If you're using chunk spliting settings for web, mirgrate it to "all-in-one".
+Use `output.chunkLoading: 'lynx'` for `environments.web`.

--- a/packages/rspeedy/core/src/plugins/chunkLoading.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/chunkLoading.plugin.ts
@@ -7,36 +7,23 @@ import type { RsbuildPlugin } from '@rsbuild/core'
 import { LynxCacheEventsPlugin } from '@lynx-js/cache-events-webpack-plugin'
 import { ChunkLoadingWebpackPlugin } from '@lynx-js/chunk-loading-webpack-plugin'
 
-import { isLynx } from '../utils/is-lynx.js'
-import { isWeb } from '../utils/is-web.js'
-
 export function pluginChunkLoading(): RsbuildPlugin {
   return {
     name: 'lynx:rsbuild:chunk-loading',
     setup(api) {
-      api.modifyBundlerChain((chain, { environment }) => {
-        if (isWeb(environment)) {
-          chain
-            .output
-            .chunkLoading('import-scripts')
-            .end()
-          return
-        }
-
-        if (isLynx(environment)) {
-          // dprint-ignore
-          chain
-          .plugin('lynx:chunk-loading')
-            .use(ChunkLoadingWebpackPlugin)
-          .end()
-          .plugin('lynx:cache-events')
-            .use(LynxCacheEventsPlugin)
-          .end()
-          .output
-            .chunkLoading('lynx')
-            .chunkFormat('commonjs')
-          .end()
-        }
+      api.modifyBundlerChain((chain) => {
+        // dprint-ignore
+        chain
+        .plugin('lynx:chunk-loading')
+          .use(ChunkLoadingWebpackPlugin)
+        .end()
+        .plugin('lynx:cache-events')
+          .use(LynxCacheEventsPlugin)
+        .end()
+        .output
+          .chunkLoading('lynx')
+          .chunkFormat('commonjs')
+        .end()
       })
     },
   }

--- a/packages/rspeedy/core/test/plugins/chunkLoading.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/chunkLoading.plugin.test.ts
@@ -30,8 +30,7 @@ describe('Plugins - chunkLoading', () => {
 
       const config = await rspeedy.unwrapConfig()
 
-      expect(config.output?.chunkLoading).toBe('import-scripts')
-      expect(config.output?.chunkFormat).not.toBe('commonjs')
+      expect(config.output?.chunkFormat).toBe('commonjs')
       expect(config.output?.iife).not.toBe(false)
     })
 
@@ -45,8 +44,7 @@ describe('Plugins - chunkLoading', () => {
 
       const [webConfig, lynxConfig] = await rspeedy.initConfigs()
 
-      expect(webConfig?.output?.chunkLoading).toBe('import-scripts')
-      expect(webConfig?.output?.chunkFormat).not.toBe('commonjs')
+      expect(webConfig?.output?.chunkFormat).toBe('commonjs')
       expect(webConfig?.output?.iife).not.toBe(false)
 
       expect(lynxConfig?.output?.chunkLoading).toBe('lynx')

--- a/packages/web-platform/web-tests/rspack.config.js
+++ b/packages/web-platform/web-tests/rspack.config.js
@@ -221,7 +221,7 @@ const config = {
       {
         directory: path.join(__dirname, 'node_modules'),
         publicPath: '/node_modules',
-        watch: !isCI,
+        watch: false,
       },
       {
         directory: path.join(__dirname, 'dist'),


### PR DESCRIPTION
…atform

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Web now uses the same CommonJS chunk format as iOS/Android, aligning behavior across platforms.

- Refactor
  - Unified chunk-loading configuration across environments for consistent bundle output.

- Chores
  - Disabled dev server watching of node_modules static assets to reduce unnecessary reloads.
  - Bumped @lynx-js/rspeedy to a patch version.

- Tests
  - Updated tests to expect CommonJS chunk format on web.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
