### PR TITLE
feat(template-webpack-plugin): add appType field for web bundle

### DIFF
--- a/.changeset/happy-papers-hope.md
+++ b/.changeset/happy-papers-hope.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+fix: add appType field for lazy bundle for web

--- a/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
@@ -73,6 +73,7 @@ export class WebEncodePlugin {
             },
             customSections: encodeData.customSections,
             cardType: encodeData.sourceContent.dsl.substring(0, 5),
+            appType: encodeData.sourceContent.appType,
             pageConfig: {
               ...encodeData.compilerOptions,
               ...encodeData.sourceContent.config,
@@ -90,6 +91,7 @@ export class WebEncodePlugin {
               styleInfo: encodeOptions['styleInfo'],
               manifest: encodeOptions.manifest,
               cardType: encodeOptions['cardType'],
+              appType: encodeOptions['appType'],
               pageConfig: encodeOptions['pageConfig'],
               lepusCode: {
                 // flatten the lepusCode to a single object

--- a/packages/webpack/template-webpack-plugin/test/cases/web/default-export/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/default-export/b.js
@@ -16,3 +16,11 @@ it('should card type', async () => {
       .toString();
   expect(fileContent).toContain('react');
 });
+
+it('should have app type', async () => {
+  const fileContent =
+    (await fs.readFile(path.join(__dirname, '..', 'a', 'template.js')))
+      .toString();
+  const { appType } = JSON.parse(fileContent);
+  expect(appType).toBeTruthy();
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - The webpack template plugin now includes an appType field in generated web templates and lazy bundles, providing clearer app classification without altering existing fields. Backward compatible.
- Tests
  - Added a test to validate that appType is present in the generated template output.
- Chores
  - Patch release for @lynx-js/template-webpack-plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
