### PR TITLE
feat(tailwind-preset): enhanced uiVariants (group/peer/parent, prefix handling)

### DIFF
--- a/.changeset/plain-paws-peel.md
+++ b/.changeset/plain-paws-peel.md
@@ -1,0 +1,11 @@
+---
+"@lynx-js/tailwind-preset": minor
+---
+
+Added `group-*`, `peer-*`, and `parent-*` modifiers (ancestor, sibling, and direct-parent scopes) for `uiVariants` plugin.
+
+Fixed prefix handling in prefixed projects — `ui-*` state markers are not prefixed, while scope markers (`.group`/`.peer`) honor `config('prefix')`.
+
+Removed slash-based naming modifiers on self (non-standard); slash modifiers remain supported for scoped markers (e.g. `group/menu`, `peer/tab`).
+
+Bumped peer dependency to `tailwindcss@^3.4.0` (required for use of internal features).

--- a/.changeset/plain-paws-peel.md
+++ b/.changeset/plain-paws-peel.md
@@ -6,6 +6,6 @@ Added `group-*`, `peer-*`, and `parent-*` modifiers (ancestor, sibling, and dire
 
 Fixed prefix handling in prefixed projects — `ui-*` state markers are not prefixed, while scope markers (`.group`/`.peer`) honor `config('prefix')`.
 
-Removed slash-based naming modifiers on self (non-standard); slash modifiers remain supported for scoped markers (e.g. `group/menu`, `peer/tab`).
+**BREAKING**: Removed slash-based naming modifiers on self (non-standard); slash modifiers remain supported for scoped markers (e.g. `group/menu`, `peer/tab`).
 
 Bumped peer dependency to `tailwindcss@^3.4.0` (required for use of internal features).

--- a/packages/third-party/tailwind-preset/README.md
+++ b/packages/third-party/tailwind-preset/README.md
@@ -17,13 +17,13 @@ This preset is not a 1:1 port of Tailwind's core. Instead, it provides a **Lynx-
 
 ```ts
 // tailwind.config.ts
+import type { Config } from 'tailwindcss';
 import preset from '@lynx-js/tailwind-preset';
 
-const config: Config = {
+export default {
   content: ['./src/**/*.{ts,tsx}'],
   presets: [preset],
-};
-export default config;
+} satisfies Config;
 ```
 
 ```ts

--- a/packages/third-party/tailwind-preset/README.md
+++ b/packages/third-party/tailwind-preset/README.md
@@ -19,17 +19,19 @@ This preset is not a 1:1 port of Tailwind's core. Instead, it provides a **Lynx-
 // tailwind.config.ts
 import preset from '@lynx-js/tailwind-preset';
 
-export default {
+const config: Config = {
   content: ['./src/**/*.{ts,tsx}'],
   presets: [preset],
 };
+export default config;
 ```
 
 ```ts
 // tailwind.config.ts
+import type { Config } from 'tailwindcss';
 import { createLynxPreset } from '@lynx-js/tailwind-preset';
 
-export default {
+const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   presets: [
     createLynxPreset({
@@ -37,6 +39,7 @@ export default {
     }),
   ],
 };
+export default config;
 ```
 
 ## Integration Notes

--- a/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -87,7 +87,7 @@ When enabled with `true`, the plugin registers the following default variants:
 
 These defaults are designed to support common component states and layout roles found in design systems and headless UI libraries.
 
-## Basic Usagle Examples
+## Basic Usage Examples
 
 ```tsx
 // Generates: .ui-open:bg-blue-500
@@ -127,7 +127,7 @@ Beyond the **self state** shown in the basic examples, the `uiVariants` plugin d
   Require a marker class on the ancestor (`group`) or sibling (`peer`).
   These **scope markers adopt your project prefix**, while `ui-*` state markers remain unprefixed.
 
-Learn more in Tailwind‘s own docs [`group-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state) and [`peer-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state)modifiers, as well as the underlying [plugin mechanism for parent and sibling states](https://v3.tailwindcss.com/docs/plugins#parent-and-sibling-states).
+Learn more in Tailwind‘s own docs [`group-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state) and [`peer-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state) modifiers, as well as the underlying [plugin mechanism for parent and sibling states](https://v3.tailwindcss.com/docs/plugins#parent-and-sibling-states).
 
 ### Self
 
@@ -180,7 +180,7 @@ It lets a child react to its **immediate container's** state without requiring a
 Add a **marker class** to any ancestor and style descendants based on that ancestor’s `ui-*` state.
 
 - In **prefixed** projects the marker is **prefixed**: `.tw-group`.
-- The `ui-*` **state** is remains **unprefixed** (behaves like `data-*` / `aria-*`)
+- The `ui-*` **state** remains **unprefixed** (behaves like `data-*` / `aria-*`)
 - The `group-ui-*` variant label also remains **unprefixed**, following Tailwind's own `group-*` pattern.
 
 ```tsx
@@ -207,13 +207,13 @@ Compiles to:
 Add a **marker class** to the peer element and style siblings after it.
 
 - In **prefixed** projects the marker is **prefixed**: `.tw-peer`.
-- The `ui-*` **state** is remains **unprefixed** (behaves like `data-*` / `aria-*`)
+- The `ui-*` **state** remains **unprefixed** (behaves like `data-*` / `aria-*`)
 - The `peer-ui-*` variant label also remains **unprefixed**, following Tailwind's own `peer-*` pattern.
 
 ```tsx
 <Field className='flex items-center gap-2'>
   <Checkbox className='peer' />
-  <Label className='peer-ui-checked:text-rose-600'>Enable alerts</span>
+  <Label className='peer-ui-checked:text-rose-600'>Enable alerts</Label>
 </Field>;
 ```
 
@@ -299,4 +299,4 @@ Under the hood we set Tailwind's internal `INTERNAL_FEATURES.respectPrefix = fal
 - **Parent**: `parent-ui-open:bg-*` (parent has `ui-open`)
 - **Group**: `group-ui-open:bg-*` (ancestor has `.group` / `.tw-group`)
 - **Peer**: `peer-ui-checked:bg-*` (sibling has `.peer` / `.tw-peer`)
-- **Named scopes**: `group-ui-open/menu:*`, `peer-ui-active/tab:*` (marker on DOM: `.group/menu` / `.tw-group/menu`, `.peer/tab` / `.tw-peer/menu`)
+- **Named scopes**: `group-ui-open/menu:*`, `peer-ui-active/tab:*` (marker on DOM: `.group/menu` / `.tw-group/menu`, `.peer/tab` / `.tw-peer/tab`)

--- a/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -87,7 +87,7 @@ When enabled with `true`, the plugin registers the following default variants:
 
 These defaults are designed to support common component states and layout roles found in design systems and headless UI libraries.
 
-## Usage Examples
+## Basic Usagle Examples
 
 ```tsx
 // Generates: .ui-open:bg-blue-500
@@ -105,7 +105,198 @@ These variants enable component-aware styling by aligning Tailwind utilities wit
 To make these variants effective, your component needs to append the corresponding `ui-*` class dynamically based on its internal state or configuration. For example:
 
 ```tsx
-<Popover className={isOpen ? 'ui-open container' : 'container'}>
-  <div className='ui-open:bg-blue-500 ui-side-left:border-l' />
+<Popover className={isOpen ? 'container ui-open' : 'container'}>
+  <view className='ui-open:bg-blue-500 ui-side-left:border-l' />
 </Popover>;
 ```
+
+## Advanced Usage Examples
+
+Beyond the **self state** shown in the basic examples, the `uiVariants` plugin defines **three scopes in total** for styling based on context:
+
+- **Self state** → `ui-*` variants
+
+  Never prefixed. Behaves like `data-*` / `aria-*`.
+
+- **Direct parent scope** → `parent-*` modifiers
+
+  Style an element based on its immediate parent’s `ui-*` state.
+
+- **Ancestor / sibling scopes** → `group-*` and `peer-*` modifiers
+
+  Require a marker class on the ancestor (`group`) or sibling (`peer`).
+  These **scope markers adopt your project prefix**, while `ui-*` state markers remain unprefixed.
+
+Learn more in Tailwind‘s own docs [`group-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state) and [`peer-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state)modifiers, as well as the underlying [plugin mechanism for parent and sibling states](https://v3.tailwindcss.com/docs/plugins#parent-and-sibling-states).
+
+### Self
+
+```tsx
+// Styles apply when the same element has `ui-open`
+<view className='ui-open:bg-blue-500' />;
+```
+
+Compiles to:
+
+```css
+.ui-open\:bg-blue-500.ui-open {
+  background-color: #3b82f6;
+}
+```
+
+### Direct-parent: `parent-*`
+
+Style a child based on its **direct parent's** state. The parent carries the `ui-*` class; you use `parent-ui-*:...` on the child. There is **no** `parent` marker class to add.
+
+```tsx
+<view className='ui-open'>
+  <view className='parent-ui-open:bg-emerald-500' />
+</view>;
+```
+
+Compiles to:
+
+```css
+.ui-open > .parent-ui-open\:bg-emerald-500 {
+  background-color: #10b981;
+}
+```
+
+#### Why add `parent-*`?
+
+The `parent-*` modifier fills the gap between self and group scopes.
+It lets a child react to its **immediate container's** state without requiring any extra marker class:
+
+- **Clear mental model** — "my direct parent controls me."
+- **Safer matching** — avoids accidental wide matches that ancestor‐based `group-*` could introduce.
+- **Efficient** — one level lookup is cheaper than scanning arbitrary ancestor chains.
+- **Prefix simplicity** — no special prefixing rules are needed beyond the parent's `ui-*` state.
+
+> Note: Tailwind itself does not provide a `parent-*` modifier.
+> This scope is introduced by `uiVariants` plugin to complement Tailwind's existing `group-*` (ancestor) and `peer-*` (sibling) patterns.
+
+### Ancestor: `group-*`
+
+Add a **marker class** to any ancestor and style descendants based on that ancestor’s `ui-*` state.
+
+- In **prefixed** projects the marker is **prefixed**: `.tw-group`.
+- The `ui-*` **state** is remains **unprefixed** (behaves like `data-*` / `aria-*`)
+- The `group-ui-*` variant label also remains **unprefixed**, following Tailwind's own `group-*` pattern.
+
+```tsx
+<Ancestor className='group'>
+  <view>
+    {/* Somewhere inside the tree */}
+    <Self className='group-ui-open:bg-indigo-500' />
+  </view>
+</Ancestor>;
+```
+
+Compiles to:
+
+```css
+.group.ui-open .group-ui-open\:bg-indigo-500 {
+  background-color: #6366f1;
+}
+```
+
+> Mental model: **scope markers are part of your app shell** (and adopt your project prefix); **states are part of the component library** (and must be portable → never prefixed).
+
+### Sibling: `peer-*`
+
+Add a **marker class** to the peer element and style siblings after it.
+
+- In **prefixed** projects the marker is **prefixed**: `.tw-peer`.
+- The `ui-*` **state** is remains **unprefixed** (behaves like `data-*` / `aria-*`)
+- The `peer-ui-*` variant label also remains **unprefixed**, following Tailwind's own `peer-*` pattern.
+
+```tsx
+<Field className='flex items-center gap-2'>
+  <Checkbox className='peer' />
+  <Label className='peer-ui-checked:text-rose-600'>Enable alerts</span>
+</Field>;
+```
+
+Compiles to:
+
+```css
+.peer.ui-checked ~ .peer-ui-checked\:text-rose-600 {
+  color: #e11d48;
+}
+```
+
+### Named `group-*`/`peer-*` with slash `/`
+
+You can create **named scope markers** to disambiguate multiple groups/peers. Slash labels are **kept** for scoped markers (standard Tailwind pattern), and the marker still respects your project prefix.
+
+```tsx
+{/* Mark two separate groups */}
+<Dialog className='group/dialog'>
+  <Menu className='group/menu'>
+    <Button className='group-ui-open/menu:bg-amber-500'>Menu Button</Button>
+  </Menu>
+  <Button className='group-ui-open/dialog:bg-sky-500'>Dialog Button</Button>
+</Dialog>;
+```
+
+### Mixed example
+
+```tsx
+<Ancestor className='tw-group/sheet'>
+  <Parent className={open ? 'ui-open' : 'ui-closed'}>
+    {/* highlights only when this node is open */}
+    <StylingOnSelf className='ui-open:ring-2 ui-closed:opacity-60' />
+
+    {/* highlights ONLY when the direct parent is open */}
+    <StylingOnParent className='parent-ui-open:bg-green-500' />
+
+    {/* requires an ancestor with .group/sheet somewhere above */}
+    <StylingOnAncestor className='group-ui-open/sheet:shadow-lg' />
+
+    {/* needs a preceding sibling with the .peer marker */}
+    <StylingOnSibling className='peer-ui-open:shadow-sm' />
+  </Parent>
+</Ancestor>;
+```
+
+### Prefix behavior at a glance
+
+| What                                         | Gets project prefix? | Example marker class                   | Why                                                         |
+| -------------------------------------------- | -------------------- | -------------------------------------- | ----------------------------------------------------------- |
+| `ui-*` states                                | **No**               | `ui-open`, `ui-checked`                | Behave like `data-*`/`aria-*`; must be portable across apps |
+| Scope markers: `group`, `peer` (incl. named) | **Yes**              | `tw-group`, `tw-group/menu`, `tw-peer` | Part of app structure; align with Tailwind prefixing        |
+
+**Do**:
+
+```tsx
+// Prefix ON markers and utilities:
+<view className="tw-group">
+  <view className="group-ui-selected:tw-bg-blue-500" />
+</view>
+
+// Prefix OFF on states:
+<view className="ui-active">
+  <view className="ui-active:tw-text-red-500" />
+</view>
+```
+
+**Don't**:
+
+```tsx
+// 🚫 Wrong: prefixed state class (would break library portability)
+<view className='tw-ui-active' />;
+```
+
+### Why `ui-*` is never prefixed
+
+We treat `ui-*` as a **state surface**, equivalent to `data-*` / `aria-*`. Libraries can ship `ui-*` classes in their markup without worrying about the host app's Tailwind `prefix`. Meanwhile, **scope markers** (`group`, `peer`) belong to the **host layout**, so they follow your `prefix`.
+
+Under the hood we set Tailwind's internal `INTERNAL_FEATURES.respectPrefix = false` for `ui-*` selectors so they won't be auto-prefixed, while we **explicitly** build prefixed selectors for `group`/`peer` (including named scopes).
+
+### Quick reference
+
+- **Self**: `ui-open:bg-*`
+- **Parent**: `parent-ui-open:bg-*` (parent has `ui-open`)
+- **Group**: `group-ui-open:bg-*` (ancestor has `.group` / `.tw-group`)
+- **Peer**: `peer-ui-checked:bg-*` (sibling has `.peer` / `.tw-peer`)
+- **Named scopes**: `group-ui-open/menu:*`, `peer-ui-active/tab:*` (marker on DOM: `.group/menu` / `.tw-group/menu`, `.peer/tab` / `.tw-peer/menu`)

--- a/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -127,7 +127,7 @@ Beyond the **self state** shown in the basic examples, the `uiVariants` plugin d
   Require a marker class on the ancestor (`group`) or sibling (`peer`).
   These **scope markers adopt your project prefix**, while `ui-*` state markers remain unprefixed.
 
-Learn more in Tailwind‘s own docs [`group-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state) and [`peer-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state) modifiers, as well as the underlying [plugin mechanism for parent and sibling states](https://v3.tailwindcss.com/docs/plugins#parent-and-sibling-states).
+Learn more in Tailwind's own docs [`group-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state) and [`peer-*`](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state) modifiers, as well as the underlying [plugin mechanism for parent and sibling states](https://v3.tailwindcss.com/docs/plugins#parent-and-sibling-states).
 
 ### Self
 
@@ -184,7 +184,7 @@ Add a **marker class** to any ancestor and style descendants based on that ances
 - The `group-ui-*` variant label also remains **unprefixed**, following Tailwind's own `group-*` pattern.
 
 ```tsx
-<Ancestor className='group'>
+<Ancestor className='group ui-open'>
   <view>
     {/* Somewhere inside the tree */}
     <Self className='group-ui-open:bg-indigo-500' />
@@ -212,7 +212,7 @@ Add a **marker class** to the peer element and style siblings after it.
 
 ```tsx
 <Field className='flex items-center gap-2'>
-  <Checkbox className='peer' />
+  <Checkbox className='peer ui-checked' />
   <Label className='peer-ui-checked:text-rose-600'>Enable alerts</Label>
 </Field>;
 ```
@@ -231,8 +231,8 @@ You can create **named scope markers** to disambiguate multiple groups/peers. Sl
 
 ```tsx
 {/* Mark two separate groups */}
-<Dialog className='group/dialog'>
-  <Menu className='group/menu'>
+<Dialog className='group/dialog ui-open'>
+  <Menu className='group/menu ui-open'>
     <Button className='group-ui-open/menu:bg-amber-500'>Menu Button</Button>
   </Menu>
   <Button className='group-ui-open/dialog:bg-sky-500'>Dialog Button</Button>
@@ -242,7 +242,7 @@ You can create **named scope markers** to disambiguate multiple groups/peers. Sl
 ### Mixed example
 
 ```tsx
-<Ancestor className='tw-group/sheet'>
+<Ancestor className='tw-group/sheet ui-open'>
   <Parent className={open ? 'ui-open' : 'ui-closed'}>
     {/* highlights only when this node is open */}
     <StylingOnSelf className='ui-open:ring-2 ui-closed:opacity-60' />
@@ -270,7 +270,7 @@ You can create **named scope markers** to disambiguate multiple groups/peers. Sl
 
 ```tsx
 // Prefix ON markers and utilities:
-<view className="tw-group">
+<view className="tw-group ui-selected">
   <view className="group-ui-selected:tw-bg-blue-500" />
 </view>
 
@@ -291,7 +291,7 @@ You can create **named scope markers** to disambiguate multiple groups/peers. Sl
 
 We treat `ui-*` as a **state surface**, equivalent to `data-*` / `aria-*`. Libraries can ship `ui-*` classes in their markup without worrying about the host app's Tailwind `prefix`. Meanwhile, **scope markers** (`group`, `peer`) belong to the **host layout**, so they follow your `prefix`.
 
-Under the hood we set Tailwind's internal `INTERNAL_FEATURES.respectPrefix = false` for `ui-*` selectors so they won't be auto-prefixed, while we **explicitly** build prefixed selectors for `group`/`peer` (including named scopes).
+Under the hood the plugin ensures `ui-*` selectors are never prefixed, while `group`/`peer` markers respect your project prefix.
 
 ### Quick reference
 

--- a/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -105,9 +105,7 @@ These variants enable component-aware styling by aligning Tailwind utilities wit
 To make these variants effective, your component needs to append the corresponding `ui-*` class dynamically based on its internal state or configuration. For example:
 
 ```tsx
-<Popover className={isOpen ? 'container ui-open' : 'container'}>
-  <view className='ui-open:bg-blue-500 ui-side-left:border-l' />
-</Popover>;
+<Popover className={clsx('ui-open:bg-blue-500', isOpen && 'ui-open')} />;
 ```
 
 ## Advanced Usage Examples
@@ -120,7 +118,7 @@ Beyond the **self state** shown in the basic examples, the `uiVariants` plugin d
 
 - **Direct parent scope** → `parent-*` modifiers
 
-  Style an element based on its immediate parent’s `ui-*` state.
+  Style an element based on its immediate parent's `ui-*` state.
 
 - **Ancestor / sibling scopes** → `group-*` and `peer-*` modifiers
 

--- a/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -273,8 +273,8 @@ You can create **named scope markers** to disambiguate multiple groups/peers. Sl
 </view>
 
 // Prefix OFF on states:
-<view className="ui-active">
-  <view className="ui-active:tw-text-red-500" />
+<view className="ui-selected">
+  <view className="group-ui-selected:tw-text-blue-500 ui-active:tw-text-red-500 ui-active" />
 </view>
 ```
 

--- a/packages/third-party/tailwind-preset/package.json
+++ b/packages/third-party/tailwind-preset/package.json
@@ -39,6 +39,6 @@
     "tailwindcss": "^3.4.17"
   },
   "peerDependencies": {
-    "tailwindcss": "^3"
+    "tailwindcss": "^3.4.0"
   }
 }

--- a/packages/third-party/tailwind-preset/src/__tests__/plugins/lynx-ui/stateVariant.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/plugins/lynx-ui/stateVariant.test.ts
@@ -125,18 +125,16 @@ describe('uiVariants plugin', () => {
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
     expect(Object.keys(variants)).toEqual(
-      expect(Object.keys(variants)).toEqual(
-        expect.arrayContaining([
-          'custom',
-          'group-custom',
-          'peer-custom',
-          'parent-custom',
-          'custom-side',
-          'group-custom-side',
-          'peer-custom-side',
-          'parent-custom-side',
-        ]),
-      ),
+      expect.arrayContaining([
+        'custom',
+        'group-custom',
+        'peer-custom',
+        'parent-custom',
+        'custom-side',
+        'group-custom-side',
+        'peer-custom-side',
+        'parent-custom-side',
+      ]),
     );
 
     expect(variants['custom']?.('open', {})).toBe('&.custom-open');

--- a/packages/third-party/tailwind-preset/src/__tests__/plugins/lynx-ui/stateVariant.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/plugins/lynx-ui/stateVariant.test.ts
@@ -45,8 +45,8 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants).sort()).toEqual(
-      ['ui', 'group-ui', 'peer-ui', 'parent-ui'].sort(),
+    expect(Object.keys(variants)).toEqual(
+      expect.arrayContaining(['ui', 'group-ui', 'peer-ui', 'parent-ui']),
     );
 
     const group = variants['group-ui'];
@@ -63,17 +63,19 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants).sort()).toEqual(
-      [
-        'ui',
-        'group-ui',
-        'peer-ui',
-        'parent-ui',
-        'ui-side',
-        'group-ui-side',
-        'peer-ui-side',
-        'parent-ui-side',
-      ].sort(),
+    expect(Object.keys(variants)).toEqual(
+      expect.arrayContaining(
+        [
+          'ui',
+          'group-ui',
+          'peer-ui',
+          'parent-ui',
+          'ui-side',
+          'group-ui-side',
+          'peer-ui-side',
+          'parent-ui-side',
+        ],
+      ),
     );
 
     expect(variants['ui']?.('open', {})).toBe('&.ui-open');
@@ -85,19 +87,21 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants).sort()).toEqual(
-      [
-        'unknown',
-        'group-unknown',
-        'peer-unknown',
-        'parent-unknown',
-      ].sort(),
+    expect(Object.keys(variants)).toEqual(
+      expect.arrayContaining(
+        [
+          'unknown',
+          'group-unknown',
+          'peer-unknown',
+          'parent-unknown',
+        ],
+      ),
     );
 
     const self = variants['unknown'];
     const group = variants['group-unknown'];
-    const peer = variants['group-unknown'];
-    const parent = variants['group-unknown'];
+    const peer = variants['peer-unknown'];
+    const parent = variants['parent-unknown'];
 
     expect(self?.('whatever')).toBe('');
     expect(self?.('open')).toBe('');
@@ -121,7 +125,18 @@ describe('uiVariants plugin', () => {
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
     expect(Object.keys(variants)).toEqual(
-      expect.arrayContaining(['custom', 'custom-side']),
+      expect(Object.keys(variants)).toEqual(
+        expect.arrayContaining([
+          'custom',
+          'group-custom',
+          'peer-custom',
+          'parent-custom',
+          'custom-side',
+          'group-custom-side',
+          'peer-custom-side',
+          'parent-custom-side',
+        ]),
+      ),
     );
 
     expect(variants['custom']?.('open', {})).toBe('&.custom-open');
@@ -145,7 +160,7 @@ describe('uiVariants plugin', () => {
   // `modifier` is only meaningful for group-* and peer-* variants
   // self and parent do not support it
   it('supports modifier syntax in group- and peer- variants only', () => {
-    const { api } = runPlugin(uiVariants);
+    const { api } = runPlugin(uiVariants({ prefixes: ['ui'] }));
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
     const group = variants['group-ui'];
@@ -200,17 +215,19 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants).sort()).toEqual(
-      [
-        'x',
-        'group-x',
-        'peer-x',
-        'parent-x',
-        'y',
-        'group-y',
-        'peer-y',
-        'parent-y',
-      ].sort(),
+    expect(Object.keys(variants)).toEqual(
+      expect.arrayContaining(
+        [
+          'x',
+          'group-x',
+          'peer-x',
+          'parent-x',
+          'y',
+          'group-y',
+          'peer-y',
+          'parent-y',
+        ].sort(),
+      ),
     );
 
     expect(variants['x']?.('one', {})).toBe('&.x-one');

--- a/packages/third-party/tailwind-preset/src/__tests__/plugins/lynx-ui/stateVariant.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/plugins/lynx-ui/stateVariant.test.ts
@@ -29,7 +29,9 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants)).toEqual(['ui']);
+    expect(Object.keys(variants)).toEqual(
+      expect.arrayContaining(['ui']),
+    );
 
     const ui = variants['ui'];
     expect(ui?.('checked', {})).toBe('&.ui-checked');
@@ -38,12 +40,41 @@ describe('uiVariants plugin', () => {
     expect(ui?.('readonly', {})).toBe('&.ui-readonly');
   });
 
+  it('registers group, peer, and parent variants', () => {
+    const plugin = uiVariants({ prefixes: ['ui'] });
+    const { api } = runPlugin(plugin);
+    const variants = extractVariants(vi.mocked(api.matchVariant));
+
+    expect(Object.keys(variants).sort()).toEqual(
+      ['ui', 'group-ui', 'peer-ui', 'parent-ui'].sort(),
+    );
+
+    const group = variants['group-ui'];
+    const peer = variants['peer-ui'];
+    const parent = variants['parent-ui'];
+
+    expect(group?.('open')).toBe(':merge(.group).ui-open &');
+    expect(peer?.('open')).toBe(':merge(.peer).ui-open ~ &');
+    expect(parent?.('open')).toBe('.ui-open > &');
+  });
+
   it('registers variants from array of known prefixes', () => {
     const plugin = uiVariants({ prefixes: ['ui', 'ui-side'] });
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants)).toEqual(['ui', 'ui-side']);
+    expect(Object.keys(variants).sort()).toEqual(
+      [
+        'ui',
+        'group-ui',
+        'peer-ui',
+        'parent-ui',
+        'ui-side',
+        'group-ui-side',
+        'peer-ui-side',
+        'parent-ui-side',
+      ].sort(),
+    );
 
     expect(variants['ui']?.('open', {})).toBe('&.ui-open');
     expect(variants['ui-side']?.('left', {})).toBe('&.ui-side-left');
@@ -54,11 +85,28 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants)).toEqual(['unknown']);
+    expect(Object.keys(variants).sort()).toEqual(
+      [
+        'unknown',
+        'group-unknown',
+        'peer-unknown',
+        'parent-unknown',
+      ].sort(),
+    );
 
-    const unknown = variants['unknown'];
-    expect(unknown?.('whatever')).toBe('');
-    expect(unknown?.('open')).toBe('');
+    const self = variants['unknown'];
+    const group = variants['group-unknown'];
+    const peer = variants['group-unknown'];
+    const parent = variants['group-unknown'];
+
+    expect(self?.('whatever')).toBe('');
+    expect(self?.('open')).toBe('');
+    expect(group?.('whatever')).toBe('');
+    expect(group?.('checked')).toBe('');
+    expect(peer?.('whatever')).toBe('');
+    expect(peer?.('disabled')).toBe('');
+    expect(parent?.('whatever')).toBe('');
+    expect(parent?.('active')).toBe('');
   });
 
   it('allows function-based prefixes config with default inheritance', () => {
@@ -72,7 +120,9 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants)).toEqual(['custom', 'custom-side']);
+    expect(Object.keys(variants)).toEqual(
+      expect.arrayContaining(['custom', 'custom-side']),
+    );
 
     expect(variants['custom']?.('open', {})).toBe('&.custom-open');
     expect(variants['custom']?.('custom-state', {})).toBe(
@@ -92,14 +142,51 @@ describe('uiVariants plugin', () => {
     expect(ui?.({ foo: 'bar' }, {})).toBe('');
   });
 
-  it('supports modifier syntax', () => {
+  // `modifier` is only meaningful for group-* and peer-* variants
+  // self and parent do not support it
+  it('supports modifier syntax in group- and peer- variants only', () => {
     const { api } = runPlugin(uiVariants);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    const ui = variants['ui'];
-    expect(ui?.('selected', { modifier: 'some-id' })).toBe(
-      '&.ui-selected\\/some-id',
+    const group = variants['group-ui'];
+    const peer = variants['peer-ui'];
+    const self = variants['ui'];
+    const parent = variants['parent-ui'];
+
+    expect(group?.('selected', { modifier: 'menu' })).toBe(
+      ':merge(.group\\/menu).ui-selected &',
     );
+    expect(peer?.('selected', { modifier: 'tab' })).toBe(
+      ':merge(.peer\\/tab).ui-selected ~ &',
+    );
+
+    // Self & Parent variant should ignore modifier — no escaped suffix
+    expect(self?.('selected', { modifier: 'should-not-affect' })).toBe(
+      '&.ui-selected',
+    );
+
+    expect(parent?.('selected', { modifier: 'should-not-affect' })).toBe(
+      '.ui-selected > &',
+    );
+  });
+
+  it('respects Tailwind prefix in group and peer variants, but not in ui variants themselves', () => {
+    const plugin = uiVariants({ prefixes: ['ui'] });
+    const { api } = runPlugin(plugin, { config: { prefix: 'tw-' } });
+
+    const variants = extractVariants(vi.mocked(api.matchVariant));
+    const self = variants['ui'];
+    const group = variants['group-ui'];
+    const peer = variants['peer-ui'];
+    const parent = variants['parent-ui'];
+
+    // Self
+    expect(self?.('open')).toBe('&.ui-open');
+    // Group/Peer
+    expect(group?.('open')).toBe(':merge(.tw-group).ui-open &');
+    expect(peer?.('open')).toBe(':merge(.tw-peer).ui-open ~ &');
+    // Parent
+    expect(parent?.('open')).toBe('.ui-open > &');
   });
 
   it('registers variants from object prefixes with array/string map', () => {
@@ -113,7 +200,18 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants)).toEqual(['x', 'y']);
+    expect(Object.keys(variants).sort()).toEqual(
+      [
+        'x',
+        'group-x',
+        'peer-x',
+        'parent-x',
+        'y',
+        'group-y',
+        'peer-y',
+        'parent-y',
+      ].sort(),
+    );
 
     expect(variants['x']?.('one', {})).toBe('&.x-one');
     expect(variants['x']?.('two', {})).toBe('&.x-two');
@@ -147,12 +245,16 @@ describe('uiVariants plugin', () => {
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    const test = variants['test'];
-    expect(test?.('a', {})).toBe('&.test-valid');
-    expect(test?.('b', {})).toBe('');
-    expect(test?.('c', {})).toBe('');
-    expect(test?.('d', {})).toBe('');
-    expect(test?.('e', {})).toBe('');
+    const all = ['test', 'group-test', 'peer-test', 'parent-test'];
+
+    for (const prefix of all) {
+      const fn = variants[prefix];
+      expect(fn?.('a', {})).toContain('valid');
+      expect(fn?.('b', {})).toBe('');
+      expect(fn?.('c', {})).toBe('');
+      expect(fn?.('d', {})).toBe('');
+      expect(fn?.('e', {})).toBe('');
+    }
   });
 
   it('returns empty string when mapped value is undefined', () => {

--- a/packages/third-party/tailwind-preset/src/helpers.ts
+++ b/packages/third-party/tailwind-preset/src/helpers.ts
@@ -132,7 +132,13 @@ export type { ShadowPart };
 /**
  * @internal Tailwind implementation detail. Use via TW_NO_PREFIX to avoid prefixing of class candidates.
  */
-export { INTERNAL_FEATURES };
-export const TW_NO_PREFIX = {
+
+interface InternalFeatures {
+  [INTERNAL_FEATURES]: {
+    respectPrefix: false;
+  };
+}
+
+export const TW_NO_PREFIX: InternalFeatures = {
   [INTERNAL_FEATURES]: { respectPrefix: false },
-} as const;
+};

--- a/packages/third-party/tailwind-preset/src/helpers.ts
+++ b/packages/third-party/tailwind-preset/src/helpers.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { INTERNAL_FEATURES } from 'tailwindcss/lib/lib/setupContextUtils.js';
 import _createUtilityPlugin from 'tailwindcss/lib/util/createUtilityPlugin.js';
 import {
   formatBoxShadowValue,
@@ -126,3 +127,7 @@ export const transformThemeValue: (key: ThemeKey) => ValueTransformer =
   _transformThemeValue;
 export { parseBoxShadowValue, formatBoxShadowValue };
 export type { ShadowPart };
+
+/* ──────────────── for handling variants that do not respect the project prefix ─────────── */
+
+export { INTERNAL_FEATURES };

--- a/packages/third-party/tailwind-preset/src/helpers.ts
+++ b/packages/third-party/tailwind-preset/src/helpers.ts
@@ -129,5 +129,10 @@ export { parseBoxShadowValue, formatBoxShadowValue };
 export type { ShadowPart };
 
 /* ──────────────── for handling variants that do not respect the project prefix ─────────── */
-
+/**
+ * @internal Tailwind implementation detail. Use via TW_NO_PREFIX to avoid prefixing of class candidates.
+ */
 export { INTERNAL_FEATURES };
+export const TW_NO_PREFIX = {
+  [INTERNAL_FEATURES]: { respectPrefix: false },
+} as const;

--- a/packages/third-party/tailwind-preset/src/index.d.ts
+++ b/packages/third-party/tailwind-preset/src/index.d.ts
@@ -78,3 +78,7 @@ declare module 'tailwindcss/lib/util/parseBoxShadowValue.js' {
 
   export default defaultExport;
 }
+
+declare module 'tailwindcss/lib/lib/setupContextUtils.js' {
+  export const INTERNAL_FEATURES: unique symbol;
+}

--- a/packages/third-party/tailwind-preset/src/index.d.ts
+++ b/packages/third-party/tailwind-preset/src/index.d.ts
@@ -80,5 +80,6 @@ declare module 'tailwindcss/lib/util/parseBoxShadowValue.js' {
 }
 
 declare module 'tailwindcss/lib/lib/setupContextUtils.js' {
+  /** Internal Tailwind symbol — not a public API; subject to change across patch releases. */
   export const INTERNAL_FEATURES: unique symbol;
 }

--- a/packages/third-party/tailwind-preset/src/plugins/lynx-ui/uiVariants.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx-ui/uiVariants.ts
@@ -118,7 +118,9 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
           (value: string) => {
             const mapped = valueMap[value];
             if (!mapped || typeof mapped !== 'string') return '';
-            return `&.${prefix}-${mapped}`;
+
+            const cls = escapeClassName(`${prefix}-${mapped}`);
+            return `&.${cls}`;
           },
           {
             values: valueMap,
@@ -138,8 +140,9 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
             const groupSelector = modifier
               ? `:merge(.${projectPrefix}group\\/${escapeClassName(modifier)})`
               : `:merge(.${projectPrefix}group)`;
+            const cls = escapeClassName(`${prefix}-${mapped}`);
 
-            return `${groupSelector}.${prefix}-${mapped} &`;
+            return `${groupSelector}.${cls} &`;
           },
           {
             values: valueMap,
@@ -160,7 +163,9 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
               ? `:merge(.${projectPrefix}peer\\/${escapeClassName(modifier)})`
               : `:merge(.${projectPrefix}peer)`;
 
-            return `${peerSelector}.${prefix}-${mapped} ~ &`;
+            const cls = escapeClassName(`${prefix}-${mapped}`);
+
+            return `${peerSelector}.${cls} ~ &`;
           },
           {
             values: valueMap,
@@ -178,7 +183,9 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
           (value: string) => {
             const mapped = valueMap[value];
             if (!mapped || typeof mapped !== 'string') return '';
-            return `.${prefix}-${mapped} > &`;
+
+            const cls = escapeClassName(`${prefix}-${mapped}`);
+            return `.${cls} > &`;
           },
           {
             values: valueMap,

--- a/packages/third-party/tailwind-preset/src/plugins/lynx-ui/uiVariants.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx-ui/uiVariants.ts
@@ -23,7 +23,7 @@
  * - Custom mappings via object syntax
  */
 
-import { INTERNAL_FEATURES, createPlugin } from '../../helpers.js';
+import { TW_NO_PREFIX, createPlugin } from '../../helpers.js';
 import type { PluginWithOptions } from '../../helpers.js';
 import type { KeyValuePairOrList } from '../../types/plugin-types.js';
 
@@ -92,7 +92,10 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
     ({ matchVariant, e: escapeClassName, config }) => {
       options = options ?? {};
 
-      const projectPrefix: string = config('prefix') ?? '';
+      const cfgPrefix = config('prefix');
+      const projectPrefix: string = typeof cfgPrefix === 'string'
+        ? cfgPrefix
+        : '';
 
       const resolvedPrefixes = normalizePrefixes(options?.prefixes);
 
@@ -119,8 +122,7 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
           },
           {
             values: valueMap,
-            // @ts-expect-error hack internal api
-            [INTERNAL_FEATURES]: { respectPrefix: false },
+            ...TW_NO_PREFIX,
           },
         );
 
@@ -141,8 +143,7 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
           },
           {
             values: valueMap,
-            // @ts-expect-error hack internal api
-            [INTERNAL_FEATURES]: { respectPrefix: false },
+            ...TW_NO_PREFIX,
           },
         );
 
@@ -163,8 +164,7 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
           },
           {
             values: valueMap,
-            // @ts-expect-error hack internal api
-            [INTERNAL_FEATURES]: { respectPrefix: false },
+            ...TW_NO_PREFIX,
           },
         );
 
@@ -172,7 +172,7 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
         // Matches when the *direct parent* element has the given state class
         // Example: `.ui-open > &`
 
-        // Not Tailwind Default Variants, added for performance considerantion on Lynx
+        // Not Tailwind Default Variants, added for performance consideration on Lynx
         matchVariant(
           `parent-${prefix}`,
           (value: string) => {
@@ -182,8 +182,7 @@ const uiVariants: PluginWithOptions<UIVariantsOptions> = createPlugin
           },
           {
             values: valueMap,
-            // @ts-expect-error hack internal api
-            [INTERNAL_FEATURES]: { respectPrefix: false },
+            ...TW_NO_PREFIX,
           },
         );
       }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UI variant modifiers: group-*, peer-*, and parent-* (ancestor, sibling, direct-parent); group/peer support optional named modifiers.

* **Bug Fixes**
  * Prefix handling: ui-* state markers remain unprefixed; group/peer selectors honor the configured Tailwind prefix.

* **Docs**
  * Expanded usage examples, quick reference, and guidance for self/parent/group/peer scopes; README samples updated with typed config examples.

* **Tests**
  * Expanded coverage for variants, modifiers, prefix mappings, and edge cases.

* **Chores**
  * Bumped Tailwind CSS peer dependency to ^3.4.0; minor version release.

* **Deprecations**
  * Removed slash-based modifiers for self variants; slash syntax retained for scoped markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Examples (quick overview)

**Self**

```tsx
<Button className='ui-open:bg-blue-500' />;
```

```css
.ui-open\:bg-blue-500.ui-open {
  background-color: #3b82f6;
}
```

**Parent**

```tsx
<Parent className='ui-open'>
  <Child className='parent-ui-open:bg-green-500' />
</Parent>;
```

```css
.ui-open > .parent-ui-open\:bg-green-500 {
  background-color: #10b981;
}
```

**Group (Ancestor)**

```tsx
<Ancestor className='group ui-open'>
  <Parent>
    <Item className='group-ui-open:opacity-50' />
  </Parent>
</Ancestor>;
```

```css
.group.ui-open .group-ui-open\:opacity-50 {
  opacity: 0.5;
}
```

With example project prefix `tw-`:

```tsx
<Ancestor className='tw-group ui-open'>
  <Parent>
    <Item className='group-ui-open:tw-opacity-50' />
  </Parent>
</Ancestor>;
```

```css
.tw-group.ui-open .group-ui-open\:tw-opacity-50 {
  opacity: 0.5;
}
```

**Peer (Sibling)**

```tsx
<Input className="peer ui-checked" />
<Label className="peer-ui-checked:text-rose-600" />
```

```css
.peer.ui-checked ~ .peer-ui-checked\:text-rose-600 {
  color: #e11d48;
}
```

With example project prefix `tw-`:

```tsx
<Input className="tw-peer ui-checked" />
<Label className="peer-ui-checked:tw-text-rose-600" />
```

```css
.tw-peer.ui-checked ~ .peer-ui-checked\:tw-text-rose-600 {
  color: #e11d48;
}
```
## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
