### PR TITLE
fix(react/runtime): clear `delayedRunOnMainThreadData` on page destruction and reload

### DIFF
--- a/.changeset/honest-cars-find.md
+++ b/.changeset/honest-cars-find.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+fix: `ref is not initialized` error on template reload

--- a/packages/react/runtime/src/worklet/destroy.ts
+++ b/packages/react/runtime/src/worklet/destroy.ts
@@ -2,12 +2,14 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { takeDelayedRunOnMainThreadData } from './delayedRunOnMainThreadData.js';
 import { takeWorkletRefInitValuePatch } from './workletRefPool.js';
 
 export const destroyTasks: (() => void)[] = [];
 
 export function destroyWorklet(): void {
   takeWorkletRefInitValuePatch();
+  takeDelayedRunOnMainThreadData();
 
   for (const task of destroyTasks) {
     task();

--- a/packages/react/worklet-runtime/src/workletRef.ts
+++ b/packages/react/worklet-runtime/src/workletRef.ts
@@ -64,7 +64,7 @@ const getFromWorkletRefMap = <T>(
 
   /* v8 ignore next 3 */
   if (__DEV__ && value === undefined) {
-    throw new Error('Worklet: ref is not initialized: ' + id);
+    throw new Error('MainThreadRef: ref is not initialized: ' + id);
   }
   return value;
 };

--- a/packages/react/worklet-runtime/src/workletRuntime.ts
+++ b/packages/react/worklet-runtime/src/workletRuntime.ts
@@ -51,7 +51,7 @@ function registerWorklet(_type: string, id: string, worklet: (...args: unknown[]
  */
 function runWorklet(ctx: Worklet, params: ClosureValueType[]): unknown {
   if (!validateWorklet(ctx)) {
-    console.warn('Worklet: Invalid worklet object: ' + JSON.stringify(ctx));
+    console.warn('Main Thread Function: Invalid function ctx: ' + JSON.stringify(ctx));
     return;
   }
   if ('_lepusWorkletHash' in ctx) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Resolved “ref is not initialized” errors during template reloads.
  - Ensures pending main-thread tasks are cleared when a worklet is destroyed, preventing stale state and potential leaks.
  - Improved warning and error messages for clearer debugging.

- Tests
  - Added tests verifying delayed main-thread tasks are cleared on destroy.

- Chores
  - Added changeset declaring a patch release for the React package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
