### PR TITLE
fix(rspeedy/react): resolve correct `@lynx-js/react/refresh`

### DIFF
--- a/.changeset/cold-clocks-train.md
+++ b/.changeset/cold-clocks-train.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Fix using wrong version of `@lynx-js/react/refresh`.


### PR DESCRIPTION
Following up #1711, resolve alias for `@lynx-js/react/refresh` from `@lynx-js/react` instead of using `require.resolve`.

@coderabbitai summary

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
