### PR TITLE
feat(rspeedy): Support resolve.extensions

### DIFF
--- a/.changeset/clean-beds-follow.md
+++ b/.changeset/clean-beds-follow.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+rspeedy support resolve.extensions

--- a/packages/rspeedy/core/etc/rspeedy.api.md
+++ b/packages/rspeedy/core/etc/rspeedy.api.md
@@ -273,6 +273,7 @@ export interface Resolve {
     alias?: Record<string, string | false | string[]> | undefined;
     aliasStrategy?: 'prefer-tsconfig' | 'prefer-alias' | undefined;
     dedupe?: string[] | undefined;
+    extensions?: string[] | undefined;
 }
 
 export { RsbuildPlugin }

--- a/packages/rspeedy/core/src/config/resolve/index.ts
+++ b/packages/rspeedy/core/src/config/resolve/index.ts
@@ -140,4 +140,30 @@ export interface Resolve {
    * ```
    */
   dedupe?: string[] | undefined
+
+  /**
+   * Automatically resolve file extensions when importing modules. This means you can import files without explicitly writing their extensions.
+   *
+   * default: ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.json', '.cjs']
+   *
+   * For example, if importing './index', Rsbuild will try to resolve using the following order:
+   *
+   * ./index.ts
+   * ./index.tsx
+   * ./index.mjs
+   * ./index.js
+   * ./index.jsx
+   * ./index.json
+   * ./index.cjs
+   *
+   * @example
+   * ```js
+   * export default {
+   *   resolve: {
+   *     extensions: ['.ts', '.tsx', '.js'],
+   *   },
+   * }
+   * ```
+   */
+  extensions?: string[] | undefined
 }

--- a/packages/rspeedy/core/src/config/resolve/index.ts
+++ b/packages/rspeedy/core/src/config/resolve/index.ts
@@ -162,6 +162,13 @@ export interface Resolve {
    *
    * - `./index.cjs`
    *
+   * @remarks
+   * The difference between `resolve.extensions` and `tools.rspack.resolve.extensions`:
+   *
+   * `resolve.extensions`: Completely overrides Rspeedy's default resolution.
+   *
+   * `tools.rspack.resolve.extensions`: Merges with the default configuration using [`webpack-merge`](https://github.com/survivejs/webpack-merge).
+   *
    * @example
    * ```js
    * export default {

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -57,8 +57,12 @@ export function toRsbuildConfig(
     },
     resolve: {
       alias: config.resolve?.alias,
+
       aliasStrategy: config.resolve?.aliasStrategy,
+
       dedupe: config.resolve?.dedupe,
+
+      extensions: config.resolve?.extensions,
     },
     source: {
       alias: config.source?.alias,

--- a/packages/rspeedy/core/test/config/resolve/extensions.test-d.ts
+++ b/packages/rspeedy/core/test/config/resolve/extensions.test-d.ts
@@ -1,0 +1,30 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { assertType, describe, test } from 'vitest'
+
+import type { Resolve } from '../../../src/index.js'
+
+describe('Config - Resolve', () => {
+  test('extensions', () => {
+    assertType<Resolve>({})
+    assertType<Resolve>({
+      extensions: undefined,
+    })
+    assertType<Resolve>({
+      extensions: [],
+    })
+    assertType<Resolve>({
+      extensions: ['.ts', '.tsx', '.js', '.json'],
+    })
+    assertType<Resolve>({
+      // @ts-expect-error should not use `{}`
+      extensions: {},
+    })
+    assertType<Resolve>({
+      // @ts-expect-error should not use non-string values
+      extensions: [1, 2, 3],
+    })
+  })
+})

--- a/packages/rspeedy/core/test/config/resolve/extensions.test.ts
+++ b/packages/rspeedy/core/test/config/resolve/extensions.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from 'vitest'
+
+import { createStubRspeedy } from '../../createStubRspeedy.js'
+
+describe('Config - Resolve.extensions', () => {
+  test('defaults', async () => {
+    const rspeedy = await createStubRspeedy({})
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.resolve?.extensions).toMatchInlineSnapshot(`
+      [
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".js",
+        ".jsx",
+        ".json",
+        ".cjs",
+      ]
+    `)
+  })
+
+  test('resolve.extensions with string[]', async () => {
+    const customExtensions = ['.ts', '.tsx', '.js', '.json']
+    const rspeedy = await createStubRspeedy({
+      resolve: {
+        extensions: customExtensions,
+      },
+    })
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.resolve?.extensions).toEqual([...customExtensions, '.cjs'])
+  })
+
+  test('resolve.extensions with empty array', async () => {
+    const rspeedy = await createStubRspeedy({
+      resolve: {
+        extensions: [],
+      },
+    })
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.resolve?.extensions).toEqual(['.cjs'])
+  })
+})

--- a/packages/rspeedy/core/test/config/resolve/extensions.test.ts
+++ b/packages/rspeedy/core/test/config/resolve/extensions.test.ts
@@ -48,4 +48,29 @@ describe('Config - Resolve.extensions', () => {
 
     expect(config.resolve?.extensions).toEqual(['.cjs'])
   })
+
+  test('tools.rspack.resolve.extensions with custom extensions', async () => {
+    const rspeedy = await createStubRspeedy({
+      tools: {
+        rspack: {
+          resolve: {
+            extensions: ['.foo'],
+          },
+        },
+      },
+    })
+
+    const config = await rspeedy.unwrapConfig()
+
+    expect(config.resolve?.extensions).toEqual([
+      '.ts',
+      '.tsx',
+      '.mjs',
+      '.js',
+      '.jsx',
+      '.json',
+      '.cjs',
+      '.foo',
+    ])
+  })
 })

--- a/packages/rspeedy/core/test/config/validate.test.ts
+++ b/packages/rspeedy/core/test/config/validate.test.ts
@@ -1843,11 +1843,13 @@ describe('Config Validation', () => {
       ).toThrowErrorMatchingInlineSnapshot(`
         [Error: Invalid configuration.
 
+        Invalid config on \`$input.resolve.extensions\`.
+          - Expect to be (Array<string> | undefined)
+          - Got: string
+
         Unknown property: \`$input.resolve.aliasFields\` in configuration
 
         Unknown property: \`$input.resolve.conditionNames\` in configuration
-
-        Unknown property: \`$input.resolve.extensions\` in configuration
 
         Unknown property: \`$input.resolve.extensionAlias\` in configuration
         ]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

https://github.com/lynx-family/lynx-stack/issues/1688

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for configuring resolve.extensions with documented defaults and behavior (custom lists respected; ".cjs" ensured; empty list yields only ".cjs").

- Tests
  - Added unit and type-level tests verifying defaults, custom arrays, and invalid usages for resolve.extensions.

- Chores
  - Added a changeset for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
