### PR TITLE
fix: spread inside list-item cause redundant snapshot patch

### DIFF
--- a/.changeset/tasty-towns-guess.md
+++ b/.changeset/tasty-towns-guess.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix spread props inside list-item caused redundant snapshot patch

--- a/packages/react/runtime/src/snapshot/spread.ts
+++ b/packages/react/runtime/src/snapshot/spread.ts
@@ -77,14 +77,14 @@ function updateSpread(
     }
   }
 
-  if (!snapshot.__elements) {
-    return;
-  }
-
   if ('__spread' in newValue) {
     // first screen
     newValue = transformSpread(snapshot, index, newValue);
     snapshot.__values![index] = newValue;
+  }
+
+  if (!snapshot.__elements) {
+    return;
   }
 
   const dataset: Record<string, unknown> = {};

--- a/packages/react/testing-library/src/__tests__/list.test.jsx
+++ b/packages/react/testing-library/src/__tests__/list.test.jsx
@@ -793,4 +793,84 @@ describe('list - deferred <list-item/> should render as normal', () => {
       </page>
     `);
   });
+
+  it('spread props inside list-item should not trigger redundant snapshot patch', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    const useThemeColor = () => 'red';
+    const ThemedView = (props) => {
+      const { style, ...otherProps } = props;
+      const { children, ...restProps } = otherProps;
+      const backgroundColor = useThemeColor();
+
+      return (
+        <view style={{ backgroundColor, ...style }} {...restProps}>
+          {children}
+        </view>
+      );
+    };
+
+    const Comp = () => {
+      const [list, setList] = useState([0, 1, 2]);
+      return (
+        <list>
+          {list.map((item) => (
+            <list-item key={item} item-key={item}>
+              <ThemedView style={{ margin: '12px' }}>
+                <text>{item}</text>
+              </ThemedView>
+            </list-item>
+          ))}
+        </list>
+      );
+    };
+
+    render(<Comp />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    expect(onLifecycleEventCalls).toMatchInlineSnapshot(`
+      [
+        [
+          [
+            "rLynxFirstScreen",
+            {
+              "jsReadyEventIdSwap": {},
+              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a9e46_test_26","children":[{"id":-3,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":0}],"children":[{"id":-4,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"},"__spread":true}],"children":[{"id":-5,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-12,"type":null,"values":[0]}]}]}]},{"id":-6,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":1}],"children":[{"id":-7,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"},"__spread":true}],"children":[{"id":-8,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-13,"type":null,"values":[1]}]}]}]},{"id":-9,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":2}],"children":[{"id":-10,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"},"__spread":true}],"children":[{"id":-11,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-14,"type":null,"values":[2]}]}]}]}]}]}",
+            },
+          ],
+        ],
+      ]
+    `);
+    expect(onLifecycleEventCalls[0][0][0]).toBe('rLynxFirstScreen');
+    // expect(onLifecycleEventCalls[0][0][1]['root'].includes('__spread')).toBe(false);
+    expect(callLepusMethodCalls).toMatchInlineSnapshot(`
+      [
+        [
+          "rLynxChange",
+          {
+            "data": "{"patchList":[{"snapshotPatch":[3,-4,0,{"style":{"backgroundColor":"red","margin":"12px"}},3,-7,0,{"style":{"backgroundColor":"red","margin":"12px"}},3,-10,0,{"style":{"backgroundColor":"red","margin":"12px"}}],"id":2}]}",
+            "patchOptions": {
+              "isHydration": true,
+              "pipelineOptions": {
+                "dsl": "reactLynx",
+                "needTimestamps": true,
+                "pipelineID": "pipelineID",
+                "pipelineOrigin": "reactLynxHydrate",
+                "stage": "hydrate",
+              },
+              "reloadVersion": 0,
+            },
+          },
+          [Function],
+        ],
+      ]
+    `);
+    expect(callLepusMethodCalls[0][0]).toBe('rLynxChange');
+    // expect(JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch.length).toBe(0);
+  });
 });

--- a/packages/react/testing-library/src/__tests__/list.test.jsx
+++ b/packages/react/testing-library/src/__tests__/list.test.jsx
@@ -840,20 +840,21 @@ describe('list - deferred <list-item/> should render as normal', () => {
             "rLynxFirstScreen",
             {
               "jsReadyEventIdSwap": {},
-              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a9e46_test_26","children":[{"id":-3,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":0}],"children":[{"id":-4,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"},"__spread":true}],"children":[{"id":-5,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-12,"type":null,"values":[0]}]}]}]},{"id":-6,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":1}],"children":[{"id":-7,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"},"__spread":true}],"children":[{"id":-8,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-13,"type":null,"values":[1]}]}]}]},{"id":-9,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":2}],"children":[{"id":-10,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"},"__spread":true}],"children":[{"id":-11,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-14,"type":null,"values":[2]}]}]}]}]}]}",
+              "root": "{"id":-1,"type":"root","children":[{"id":-2,"type":"__Card__:__snapshot_a9e46_test_26","children":[{"id":-3,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":0}],"children":[{"id":-4,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"}}],"children":[{"id":-5,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-12,"type":null,"values":[0]}]}]}]},{"id":-6,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":1}],"children":[{"id":-7,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"}}],"children":[{"id":-8,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-13,"type":null,"values":[1]}]}]}]},{"id":-9,"type":"__Card__:__snapshot_a9e46_test_27","values":[{"item-key":2}],"children":[{"id":-10,"type":"__Card__:__snapshot_a9e46_test_25","values":[{"style":{"backgroundColor":"red","margin":"12px"}}],"children":[{"id":-11,"type":"__Card__:__snapshot_a9e46_test_28","children":[{"id":-14,"type":null,"values":[2]}]}]}]}]}]}",
             },
           ],
         ],
       ]
     `);
     expect(onLifecycleEventCalls[0][0][0]).toBe('rLynxFirstScreen');
-    // expect(onLifecycleEventCalls[0][0][1]['root'].includes('__spread')).toBe(false);
+    expect(onLifecycleEventCalls[0][0][1]['root'].includes('__spread')).toBe(false);
+
     expect(callLepusMethodCalls).toMatchInlineSnapshot(`
       [
         [
           "rLynxChange",
           {
-            "data": "{"patchList":[{"snapshotPatch":[3,-4,0,{"style":{"backgroundColor":"red","margin":"12px"}},3,-7,0,{"style":{"backgroundColor":"red","margin":"12px"}},3,-10,0,{"style":{"backgroundColor":"red","margin":"12px"}}],"id":2}]}",
+            "data": "{"patchList":[{"snapshotPatch":[],"id":2}]}",
             "patchOptions": {
               "isHydration": true,
               "pipelineOptions": {
@@ -871,6 +872,6 @@ describe('list - deferred <list-item/> should render as normal', () => {
       ]
     `);
     expect(callLepusMethodCalls[0][0]).toBe('rLynxChange');
-    // expect(JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch.length).toBe(0);
+    expect(JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch.length).toBe(0);
   });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary updates during hydration when spreading props inside list items, improving performance and avoiding visual flicker.

* **Tests**
  * Added test coverage to ensure prop spreading in list items does not trigger redundant updates during hydration.

* **Chores**
  * Added a changeset to publish a patch release for @lynx-js/react.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
