### PR TITLE
fix(web): __QueryComponentImpl execute only once

### DIFF
--- a/.changeset/calm-houses-jog.md
+++ b/.changeset/calm-houses-jog.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: \_\_QueryComponentImpl in mts should execute only once for same url


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents duplicate execution when the same component URL is requested, ensuring a single load and consistent rendering.

- **Performance**
  - Deduplicates concurrent lazy-loads for identical URLs to reduce redundant work and improve load times.

- **Reliability**
  - Improves lazy-load error handling by clearing failed cache entries and avoiding cascading failures.

- **Chores**
  - Adds a patch changeset for @lynx-js/web-mainthread-apis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
