### PR TITLE
feat(web): support lazy bundle with CSSOG

### DIFF
--- a/.changeset/shiny-toes-punch.md
+++ b/.changeset/shiny-toes-punch.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+feat: support lazy bundle with CSSOG(`enableCSSSelector: false`).

--- a/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
+++ b/packages/web-platform/web-mainthread-apis/src/createMainThreadGlobalThis.ts
@@ -60,6 +60,7 @@ import {
   type ElementFromBinaryPAPI,
   type JSRealm,
   type QueryComponentPAPI,
+  lynxEntryNameAttribute,
 } from '@lynx-js/web-constants';
 import { createMainThreadLynx } from './createMainThreadLynx.js';
 import {
@@ -134,6 +135,7 @@ export interface MainThreadRuntimeCallbacks {
     uniqueId: number,
     newClassName: string,
     cssID: string | null,
+    entryName: string | null,
   ) => void;
   __QueryComponent: QueryComponentPAPI;
 }
@@ -544,9 +546,11 @@ export function createMainThreadGlobalThis(
   const __SetCSSIdForCSSOG: SetCSSIdPAPI = (
     elements,
     cssId,
+    entryName,
   ) => {
     for (const element of elements) {
       element.setAttribute(cssIdAttribute, cssId + '');
+      entryName && element.setAttribute(lynxEntryNameAttribute, entryName);
       const cls = element.getAttribute('class');
       cls && __SetClassesForCSSOG(element, cls);
     }
@@ -562,10 +566,12 @@ export function createMainThreadGlobalThis(
     element.setAttribute('class', newClassName);
     const cssId = element.getAttribute(cssIdAttribute);
     const uniqueId = Number(element.getAttribute(lynxUniqueIdAttribute));
+    const entryName = element.getAttribute(lynxEntryNameAttribute);
     callbacks.updateCssOGStyle(
       uniqueId,
       newClassName,
       cssId,
+      entryName,
     );
   };
 
@@ -576,10 +582,12 @@ export function createMainThreadGlobalThis(
     __SetClasses(element, classNames);
     const cssId = element.getAttribute(cssIdAttribute);
     const uniqueId = Number(element.getAttribute(lynxUniqueIdAttribute));
+    const entryName = element.getAttribute(lynxEntryNameAttribute);
     callbacks.updateCssOGStyle(
       uniqueId,
       classNames ?? '',
       cssId,
+      entryName,
     );
   };
 

--- a/packages/web-platform/web-mainthread-apis/src/prepareMainThreadAPIs.ts
+++ b/packages/web-platform/web-mainthread-apis/src/prepareMainThreadAPIs.ts
@@ -106,7 +106,6 @@ export function prepareMainThreadAPIs(
       pageConfig,
       rootDom as unknown as Node,
       document,
-      undefined,
       ssrHydrateInfo,
     );
     const mtsGlobalThisRef: { mtsGlobalThis: MainThreadGlobalThis } = {

--- a/packages/web-platform/web-mainthread-apis/src/utils/processStyleInfo.ts
+++ b/packages/web-platform/web-mainthread-apis/src/utils/processStyleInfo.ts
@@ -305,15 +305,14 @@ export function appendStyleElement(
   ) => {
     const flattenedStyleInfo = flattenStyleInfo(styleInfo);
     transformToWebCss(flattenedStyleInfo);
-    const cssOGInfo: CssOGInfo = pageConfig.enableCSSSelector
-      ? {}
-      : genCssOGInfo(flattenedStyleInfo);
+    if (!pageConfig.enableCSSSelector) {
+      lazyCSSOGInfo[entryName] = genCssOGInfo(flattenedStyleInfo);
+    }
     const newStyleSheet = genCssContent(
       flattenedStyleInfo,
       pageConfig,
       entryName,
     );
-    lazyCSSOGInfo[entryName] = cssOGInfo;
     cardStyleElement.textContent += newStyleSheet;
   };
   return { updateCssOGStyle, updateLazyComponentStyle };

--- a/packages/web-platform/web-mainthread-apis/src/utils/processStyleInfo.ts
+++ b/packages/web-platform/web-mainthread-apis/src/utils/processStyleInfo.ts
@@ -241,7 +241,6 @@ export function appendStyleElement(
   pageConfig: PageConfig,
   rootDom: Node,
   document: Document,
-  entryName?: string,
   ssrHydrateInfo?: SSRHydrateInfo,
 ) {
   const lynxUniqueIdToStyleRulesIndex: number[] =
@@ -261,6 +260,7 @@ export function appendStyleElement(
   const cssOGInfo: CssOGInfo = pageConfig.enableCSSSelector
     ? {}
     : genCssOGInfo(flattenedStyleInfo);
+  const lazyCSSOGInfo: Record<string, CssOGInfo> = {};
   let cardStyleElement: HTMLStyleElement;
   if (ssrHydrateInfo?.cardStyleElement) {
     cardStyleElement = ssrHydrateInfo.cardStyleElement;
@@ -271,22 +271,22 @@ export function appendStyleElement(
     cardStyleElement.textContent = genCssContent(
       flattenedStyleInfo,
       pageConfig,
-      entryName,
+      undefined,
     );
     rootDom.appendChild(cardStyleElement);
   }
-  const cardStyleElementSheet =
-    (cardStyleElement as unknown as HTMLStyleElement).sheet!;
   const updateCssOGStyle: (
     uniqueId: number,
     newClassName: string,
     cssID: string | null,
-  ) => void = (uniqueId, newClassName, cssID) => {
-    const newStyles = decodeCssOG(
-      newClassName,
-      cssOGInfo,
-      cssID,
-    );
+    entryName: string | null,
+  ) => void = (uniqueId, newClassName, cssID, entryName) => {
+    const cardStyleElementSheet =
+      (cardStyleElement as unknown as HTMLStyleElement).sheet!;
+    const styleMap = entryName && lazyCSSOGInfo[entryName]
+      ? lazyCSSOGInfo[entryName]
+      : cssOGInfo;
+    const newStyles = decodeCssOG(newClassName, styleMap, cssID);
     if (lynxUniqueIdToStyleRulesIndex[uniqueId] !== undefined) {
       const rule = cardStyleElementSheet
         .cssRules[lynxUniqueIdToStyleRulesIndex[uniqueId]] as CSSStyleRule;
@@ -303,15 +303,17 @@ export function appendStyleElement(
     styleInfo: StyleInfo,
     entryName: string,
   ) => {
-    const flattenedStyleInfo = flattenStyleInfo(
-      styleInfo,
-    );
+    const flattenedStyleInfo = flattenStyleInfo(styleInfo);
     transformToWebCss(flattenedStyleInfo);
+    const cssOGInfo: CssOGInfo = pageConfig.enableCSSSelector
+      ? {}
+      : genCssOGInfo(flattenedStyleInfo);
     const newStyleSheet = genCssContent(
       flattenedStyleInfo,
       pageConfig,
       entryName,
     );
+    lazyCSSOGInfo[entryName] = cssOGInfo;
     cardStyleElement.textContent += newStyleSheet;
   };
   return { updateCssOGStyle, updateLazyComponentStyle };

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -712,6 +712,124 @@ test.describe('reactlynx3 tests', () => {
         ); // pink
       },
     );
+
+    // lazy component with CSSOG
+    test(
+      'basic-lazy-component-css-selector-false-exchange-class',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 255, 0)'); // yellow
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)'); // unset
+      },
+    );
+    test(
+      'basic-lazy-component-css-selector-false-inline-css-change-same-time',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 255, 0)'); // yellow
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 0, 0)'); // red
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 255, 0)'); // yellow
+      },
+    );
+    test(
+      'basic-lazy-component-css-selector-false-inline-remove-css-remove-inline',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 0, 0)'); // red
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 0, 0)'); // red
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 255, 0)'); // yellow
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)'); // unset
+      },
+    );
+    test(
+      'basic-lazy-component-css-selector-false-multi-level-selector',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS(
+          'background-color',
+          'rgb(255, 192, 203)',
+        ); // pink
+      },
+    );
+    test(
+      'basic-lazy-component-css-selector-false-remove-all',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)'); // unset
+      },
+    );
+    test(
+      'basic-lazy-component-css-selector-false-remove-css-and-reuse-css',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 255, 0)'); // yellow
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 255, 0)'); // yellow
+      },
+    );
+    test(
+      'basic-lazy-component-css-selector-false-remove-css-and-style-collapsed',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 255, 0)'); // yellow
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
+    test(
+      'basic-lazy-component-css-selector-false-remove-inline-style-and-reuse-css',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 0, 0)'); // red
+        await target.click();
+        await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+      },
+    );
+    test(
+      'config-css-selector-false-type-selector',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        const target = page.locator('#target');
+        await expect(target).toHaveCSS('background-color', 'rgb(255, 255, 0)'); // yellow
+        await expect(target).toHaveCSS('width', '100px');
+        await expect(target).toHaveCSS('height', '100px');
+      },
+    );
   });
   test.describe('basic-css', () => {
     test('basic-css-asset-in-css', async ({ page }, { title }) => {

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-exchange-class/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-exchange-class/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-exchange-class/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-inline-css-change-same-time/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-inline-css-change-same-time/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-inline-css-change-same-time/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-inline-remove-css-remove-inline/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-inline-remove-css-remove-inline/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-inline-remove-css-remove-inline/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-multi-level-selector/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-multi-level-selector/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-multi-level-selector/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-remove-all/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-remove-all/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-remove-all/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-remove-css-and-reuse-css/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-remove-css-and-reuse-css/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-remove-css-and-reuse-css/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-remove-css-and-style-collapsed/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-remove-css-and-style-collapsed/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-remove-css-and-style-collapsed/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-remove-inline-style-and-reuse-css/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-remove-inline-style-and-reuse-css/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-remove-inline-style-and-reuse-css/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-type-selector/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false-type-selector/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, lazy, Suspense } from '@lynx-js/react';
+
+const importPath =
+  `/dist/config-lazy-component-css-selector-false-type-selector/index.web.json`;
+const LazyComponent = lazy(
+  () => {
+    return import(
+      importPath,
+      {
+        with: { type: 'component' },
+      }
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <Suspense>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false.config.ts
+++ b/packages/web-platform/web-tests/tests/react/basic-lazy-component-css-selector-false.config.ts
@@ -1,0 +1,34 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { glob } from 'node:fs/promises';
+import path from 'node:path';
+
+import { mergeRspeedyConfig, type Config } from '@lynx-js/rspeedy';
+
+import { commonConfig } from './commonConfig.js';
+
+const reactBasicCases = await Array.fromAsync(glob(
+  [
+    path.join(
+      import.meta.dirname,
+      'basic-lazy-component-css-selector-false-*',
+      '*.jsx',
+    ),
+  ],
+));
+
+const config: Config = mergeRspeedyConfig(
+  commonConfig({
+    enableCSSSelector: false,
+  }),
+  {
+    source: {
+      entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
+        return [path.basename(path.dirname(reactBasicEntry)), reactBasicEntry];
+      })),
+    },
+  },
+);
+
+export default config;

--- a/packages/web-platform/web-tests/tests/react/basic.config.ts
+++ b/packages/web-platform/web-tests/tests/react/basic.config.ts
@@ -13,10 +13,13 @@ const reactBasicCases = await Array.fromAsync(glob(
     path.join(import.meta.dirname, 'basic-*', 'index.jsx'),
   ],
 ));
+const filteredCases = reactBasicCases.filter(filePath => {
+  return !filePath.includes('basic-lazy-component-css-selector-false');
+});
 
 const config: Config = mergeRspeedyConfig(commonConfig(), {
   source: {
-    entry: Object.fromEntries(reactBasicCases.map((reactBasicEntry) => {
+    entry: Object.fromEntries(filteredCases.map((reactBasicEntry) => {
       return [path.basename(path.dirname(reactBasicEntry)), {
         import: reactBasicEntry,
         publicPath: '/dist/',

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-exchange-class/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-exchange-class/index.css
@@ -1,0 +1,13 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.background-green {
+  background-color: green;
+}
+
+.background-yellow {
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-exchange-class/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-exchange-class/index.jsx
@@ -1,0 +1,42 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, Component } from '@lynx-js/react';
+import './index.css';
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      stateId: 0,
+    };
+  }
+  handletap() {
+    this.setState({ stateId: this.state.stateId + 1 });
+  }
+  getInline() {
+    switch (this.state.stateId) {
+      default:
+        return { height: '100px', width: '100px' }; // green
+    }
+  }
+  getClass() {
+    switch (this.state.stateId) {
+      case 0:
+        return 'background-yellow background-green';
+      case 1:
+        return 'background-green background-yellow ';
+    }
+  }
+  render() {
+    return (
+      <view
+        id='target'
+        class={this.getClass()}
+        bindtap={() => {
+          this.handletap();
+        }}
+        style={this.getInline()}
+      />
+    );
+  }
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-inline-css-change-same-time/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-inline-css-change-same-time/index.css
@@ -1,0 +1,12 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+.background-green {
+  background-color: green;
+}
+
+.background-yellow {
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-inline-css-change-same-time/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-inline-css-change-same-time/index.jsx
@@ -1,0 +1,33 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, root } from '@lynx-js/react';
+import './index.css';
+export default class Root extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      flag: false,
+    };
+  }
+  handletap() {
+    this.setState({ flag: !this.state.flag });
+  }
+  render() {
+    return (
+      <view
+        id='target'
+        class={'background-yellow '
+          + (this.state.flag ? 'background-green' : '')}
+        bindtap={() => {
+          this.handletap();
+        }}
+        style={this.state.flag
+          ? { backgroundColor: 'red', height: '100px', width: '100px' }
+          : { height: '100px', width: '100px' }}
+      />
+    );
+  }
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-inline-remove-css-remove-inline/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-inline-remove-css-remove-inline/index.css
@@ -1,0 +1,12 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+.background-green {
+  background-color: green;
+}
+
+.background-yellow {
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-inline-remove-css-remove-inline/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-inline-remove-css-remove-inline/index.jsx
@@ -1,0 +1,54 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, root } from '@lynx-js/react';
+import './index.css';
+export default class Root extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      stateId: 0,
+    };
+  }
+  handletap() {
+    this.setState({ stateId: this.state.stateId + 1 });
+  }
+  getInline() {
+    switch (this.state.stateId) {
+      case 0:
+        return { height: '100px', width: '100px' }; // green
+      case 1:
+        return { backgroundColor: 'red', height: '100px', width: '100px' }; // red
+      case 2:
+        return { backgroundColor: 'red', height: '100px', width: '100px' }; // red
+      case 3:
+        return { height: '100px', width: '100px' }; // yellow
+    }
+  }
+  getClass() {
+    switch (this.state.stateId) {
+      case 0:
+        return 'background-yellow background-green';
+      case 1:
+        return 'background-yellow background-green';
+      case 2:
+        return 'background-yellow';
+      case 3:
+        return 'background-yellow';
+    }
+  }
+  render() {
+    return (
+      <view
+        id='target'
+        class={this.getClass()}
+        bindtap={() => {
+          this.handletap();
+        }}
+        style={this.getInline()}
+      />
+    );
+  }
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-multi-level-selector/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-multi-level-selector/index.css
@@ -1,0 +1,17 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.background-green {
+  background-color: green;
+}
+
+.background {
+  background-color: yellow;
+}
+
+.parent .background {
+  background-color: pink;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-multi-level-selector/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-multi-level-selector/index.jsx
@@ -1,0 +1,33 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, Component } from '@lynx-js/react';
+import './index.css';
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      stateId: 0,
+    };
+  }
+  handletap() {
+    this.setState({ stateId: this.state.stateId + 1 });
+  }
+  getInline() {
+    switch (this.state.stateId) {
+      default:
+        return { height: '100px', width: '100px' }; // green
+    }
+  }
+  render() {
+    return (
+      <view id='parent' class='parent'>
+        <view
+          id='target'
+          class='background-green background'
+          style={this.getInline()}
+        />
+      </view>
+    );
+  }
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-all/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-all/index.css
@@ -1,0 +1,13 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.background-green {
+  background-color: green;
+}
+
+.background-yellow {
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-all/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-all/index.jsx
@@ -1,0 +1,38 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, root } from '@lynx-js/react';
+import './index.css';
+export default class Root extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      stateId: 0,
+    };
+  }
+  handletap() {
+    this.setState({ stateId: this.state.stateId + 1 });
+  }
+  getClass() {
+    switch (this.state.stateId) {
+      case 0:
+        return 'background-yellow background-green';
+      case 1:
+        return '';
+    }
+  }
+  render() {
+    return (
+      <view
+        id='target'
+        class={this.getClass()}
+        bindtap={() => {
+          this.handletap();
+        }}
+        style={{ height: '100px', width: '100px' }}
+      />
+    );
+  }
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-css-and-reuse-css/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-css-and-reuse-css/index.css
@@ -1,0 +1,13 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.background-green {
+  background-color: green;
+}
+
+.background-yellow {
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-css-and-reuse-css/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-css-and-reuse-css/index.jsx
@@ -1,0 +1,31 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, root } from '@lynx-js/react';
+import './index.css';
+export default class Root extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      flag: false,
+    };
+  }
+  handletap() {
+    this.setState({ flag: !this.state.flag });
+  }
+  render() {
+    return (
+      <view
+        id='target'
+        class={'background-yellow '
+          + (this.state.flag ? 'background-green' : '')}
+        bindtap={() => {
+          this.handletap();
+        }}
+        style={{ height: '100px', width: '100px' }}
+      />
+    );
+  }
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-css-and-style-collapsed/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-css-and-style-collapsed/index.css
@@ -1,0 +1,13 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.background-green {
+  background-color: green;
+}
+
+.background-yellow {
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-css-and-style-collapsed/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-css-and-style-collapsed/index.jsx
@@ -1,0 +1,35 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, root } from '@lynx-js/react';
+import './index.css';
+export default class Root extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      flag: false,
+    };
+  }
+  handletap() {
+    this.setState({ flag: !this.state.flag });
+  }
+  render() {
+    return (
+      <view
+        id='target'
+        class={'background-yellow '
+          + (this.state.flag ? 'background-green' : '')}
+        bindtap={() => {
+          this.handletap();
+        }}
+        style={{
+          height: '100px',
+          width: '100px',
+          backgroundColor: this.state.flag ? 'yellow' : 'green',
+        }}
+      />
+    );
+  }
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-inline-style-and-reuse-css/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-inline-style-and-reuse-css/index.css
@@ -1,0 +1,13 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.background-green {
+  background-color: green;
+}
+
+.background-yellow {
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-inline-style-and-reuse-css/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-remove-inline-style-and-reuse-css/index.jsx
@@ -1,0 +1,32 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, root } from '@lynx-js/react';
+import './index.css';
+export default class Root extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      flag: false,
+    };
+  }
+  handletap() {
+    this.setState({ flag: !this.state.flag });
+  }
+  render() {
+    return (
+      <view
+        id='target'
+        class='background-yellow background-green'
+        bindtap={() => {
+          this.handletap();
+        }}
+        style={this.state.flag
+          ? { backgroundColor: 'red', height: '100px', width: '100px' }
+          : { height: '100px', width: '100px' }}
+      />
+    );
+  }
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-type-selector/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-type-selector/index.css
@@ -1,0 +1,11 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+view {
+  height: 100px;
+  width: 100px;
+  background-color: yellow;
+}

--- a/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-type-selector/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-lazy-component-css-selector-false-type-selector/index.jsx
@@ -1,0 +1,18 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, root } from '@lynx-js/react';
+import './index.css';
+export default class Root extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      stateId: 0,
+    };
+  }
+  render() {
+    return <view id='target' class='tt' />;
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-entry lazy CSS for lazy-loaded bundles when CSS-selector matching is disabled, enabling isolated styling per bundle and correct class/inline style updates.

- **Tests**
  - Adds extensive tests for lazy-component styling: class swaps, inline style changes/removals, reuse, multi-level selectors, type-selector cases, and layout assertions.

- **Chores**
  - Adds a changeset entry for a patch release of the web-mainthread APIs package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
