### PR TITLE
fix(tailwind-preset): set default transform css vars on * instead of :root to avoid inheritance

### DIFF
--- a/.changeset/modern-squids-love.md
+++ b/.changeset/modern-squids-love.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/tailwind-preset": patch
+---
+
+Fixed transform-related CSS variables previously defined on `:root`; they are now reset on `*` to prevent inheritance between parent and child elements.

--- a/.changeset/modern-squids-love.md
+++ b/.changeset/modern-squids-love.md
@@ -3,5 +3,3 @@
 ---
 
 Fixed transform-related CSS variables previously defined on `:root`; they are now reset on `*` to prevent inheritance between parent and child elements.
-
-Raised peer `tailwindcss` to `^3.4.12` to align with upstream change that ensures defaults are injected at the beginning of the base layer.

--- a/.changeset/modern-squids-love.md
+++ b/.changeset/modern-squids-love.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed transform-related CSS variables previously defined on `:root`; they are now reset on `*` to prevent inheritance between parent and child elements.
+
+Raised peer `tailwindcss` to `^3.4.12` to align with upstream change that ensures defaults are injected at the beginning of the base layer.

--- a/examples/tailwindcss/src/App.tsx
+++ b/examples/tailwindcss/src/App.tsx
@@ -29,13 +29,15 @@ export function App() {
           >
             Translate & Scale
           </text>
-          <text
-            className={cn(
-              'text-primary-content text-xl translate-x-10',
-            )}
-          >
-            Translate
-          </text>
+          <view className='translate-y-4'>
+            <text
+              className={cn(
+                'text-primary-content text-xl translate-x-10',
+              )}
+            >
+              Translate
+            </text>
+          </view>
           <text
             className={'text-primary-content text-xl rotate-x-45 rotate-y-45'}
           >

--- a/examples/tailwindcss/src/App.tsx
+++ b/examples/tailwindcss/src/App.tsx
@@ -30,11 +30,7 @@ export function App() {
             Translate & Scale
           </text>
           <view className='translate-y-4'>
-            <text
-              className={cn(
-                'text-primary-content text-xl translate-x-10',
-              )}
-            >
+            <text className='text-primary-content text-xl translate-x-10'>
               Translate
             </text>
           </view>

--- a/examples/tailwindcss/tailwind.config.ts
+++ b/examples/tailwindcss/tailwind.config.ts
@@ -2,7 +2,7 @@ import type { Config } from 'tailwindcss';
 
 import preset from '@lynx-js/tailwind-preset';
 
-export default {
+const config: Config = {
   content: [],
   presets: [preset],
   theme: {
@@ -64,4 +64,6 @@ export default {
       },
     },
   },
-} satisfies Config;
+};
+
+export default config;

--- a/packages/third-party/tailwind-preset/package.json
+++ b/packages/third-party/tailwind-preset/package.json
@@ -39,6 +39,6 @@
     "tailwindcss": "^3.4.17"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.4.12"
+    "tailwindcss": "^3.4.0"
   }
 }

--- a/packages/third-party/tailwind-preset/package.json
+++ b/packages/third-party/tailwind-preset/package.json
@@ -39,6 +39,6 @@
     "tailwindcss": "^3.4.17"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.12"
   }
 }

--- a/packages/third-party/tailwind-preset/src/plugins/lynx/defaults.ts
+++ b/packages/third-party/tailwind-preset/src/plugins/lynx/defaults.ts
@@ -4,12 +4,11 @@
 import { cssTransformDefault } from './transform.js';
 import { createPlugin } from '../../helpers.js';
 import type { Plugin } from '../../helpers.js';
-// import { cssTransformValue } from './transform.js';
 
 export const defaults: Plugin = createPlugin(({ addBase }) => {
   addBase(
     {
-      ':root': {
+      '*': {
         ...cssTransformDefault,
         // Lynx does not support Nested CSS Variables, uncomment in the future
         // '--tw-transform': cssTransformValue,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents unwanted inheritance of transform-related CSS variables between parent and child elements, reducing unexpected layout shifts in nested components.
- Style
  - Example app: Adjusted demo label positioning to add a slight vertical offset alongside the existing horizontal offset.
- Chores
  - Added a changeset entry for a patch release of the Tailwind preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
