### PR TITLE
feat(tailwind-preset): enable lynxUIPlugins by default

### DIFF
--- a/.changeset/chatty-eyes-rescue.md
+++ b/.changeset/chatty-eyes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/tailwind-preset": minor
+---
+
+Enable `lynxUIPlugins` (incl. `uiVariants`) by default. Bridges missing pseudo/data-attribute selectors in Lynx and provides state/structure variants out-of-the-box.

--- a/.changeset/chatty-eyes-rescue.md
+++ b/.changeset/chatty-eyes-rescue.md
@@ -2,4 +2,13 @@
 "@lynx-js/tailwind-preset": minor
 ---
 
-Enable `lynxUIPlugins` (incl. `uiVariants`) by default. Bridges missing pseudo/data-attribute selectors in Lynx and provides state/structure variants out-of-the-box.
+Enable `lynxUIPlugins` (incl. `uiVariants`) by default. Fills the gap left by missing pseudo- and data-attribute selectors in Lynx, offering state and structural variants out of the box.
+
+Opt-out globally or per plugin:
+
+```ts
+// disable all UI plugins
+createLynxPreset({ lynxUIPlugins: false });
+// or disable one plugin
+createLynxPreset({ lynxUIPlugins: { uiVariants: false } });
+```

--- a/packages/third-party/tailwind-preset/README.md
+++ b/packages/third-party/tailwind-preset/README.md
@@ -44,7 +44,7 @@ export default config;
 
 ### Plugin Defaults
 
-Like Tailwind itself, all Lynx plugins (including UI plugins such as `uiVariants`) are **enabled by default** when not explicitly configured.
+In this preset, all Lynx plugins (including UI plugins such as `uiVariants`) are **enabled by default** when not explicitly configured.
 You can disable individual plugins by setting them to `false`, or override their options with an object.
 
 ```ts
@@ -119,6 +119,13 @@ createLynxPreset({
       },
     },
   },
+});
+```
+
+```ts
+// keep defaults explicitly (same as `true`)
+createLynxPreset({
+  lynxUIPlugins: {},
 });
 ```
 

--- a/packages/third-party/tailwind-preset/README.md
+++ b/packages/third-party/tailwind-preset/README.md
@@ -42,6 +42,19 @@ const config: Config = {
 export default config;
 ```
 
+### Plugin Defaults
+
+Like Tailwind itself, all Lynx plugins (including UI plugins such as `uiVariants`) are **enabled by default** when not explicitly configured.
+You can disable individual plugins by setting them to `false`, or override their options with an object.
+
+```ts
+createLynxPreset({
+  lynxUIPlugins: {
+    uiVariants: false, // disable uiVariants
+  },
+});
+```
+
 ## Integration Notes
 
 ### tailwind-merge & rsbuild-plugin-tailwindcss
@@ -71,27 +84,33 @@ export default {
 
 Beyond core utility coverage, this preset supports ecosystem-level extensions to improve component styling DX and support common Tailwind ecosystem patterns adapted for Lynx.
 
-### Enabling Lynx UI Plugins
+### Lynx UI Plugins
 
-UI plugins are not enabled by default. You can enable all plugins with:
+UI plugins (such as `uiVariants`) are **enabled by default**, consistent with Tailwind’s behavior.
+This is because Lynx currently lacks pseudo-selectors and data-attribute selectors at the core level.
+UI plugins are therefore recommended to bridge these gaps and provide practical ways to express component states.
+
+Enabling them by default does **not** change core behavior.
+If Lynx later adds native support for attribute selectors, this design choice will remain compatible and won't affect existing usage.
+
+You can still disable or configure them explicitly:
 
 ```ts
+// disable all UI plugins
 createLynxPreset({
-  lynxUIPlugins: true,
+  lynxUIPlugins: false,
 });
 ```
 
-Or enable individual plugins with their default options:
-
 ```ts
+// disable a single plugin
 createLynxPreset({
-  lynxUIPlugins: { uiVariants: true },
+  lynxUIPlugins: { uiVariants: false },
 });
 ```
 
-Or configure each plugin individually — see each plugin's documentation for available options:
-
 ```ts
+// configure a plugin with custom options
 createLynxPreset({
   lynxUIPlugins: {
     uiVariants: {

--- a/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -49,7 +49,10 @@ createLynxPreset({
 });
 ```
 
-Tip: `uiVariants: {}` (empty object) and `uiVariants: true` both enable the plugin with default options.
+> Tip: `uiVariants: {}` (empty object) and `uiVariants: true` both enable the plugin with default options.
+
+> Note: Passing an object replaces the default prefixes.
+> To extend/merge with defaults, use the function form shown below.
 
 ### Customize Prefixes and Values
 
@@ -298,7 +301,7 @@ You can create **named scope markers** to disambiguate multiple groups/peers. Sl
 **Do**:
 
 ```tsx
-// Prefix ON markers and utilities:
+// Prefix ON markers and utilities (assuming tailwind.config.ts has: prefix: 'tw-'):
 <view className="tw-group ui-selected">
   <view className="group-ui-selected:tw-bg-blue-500" />
 </view>

--- a/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -6,16 +6,45 @@ The UI Variants plugin (`uiVariants`) enables Tailwind-compatible variants based
 
 This mirrors patterns found in Headless UI or Radix UI, where internal states like `open`, `disabled`, or layout configurations like `side="left"` are surfaced via attribute selectors for styling purposes. Since Lynx doesn't support attribute selectors, this plugin provides a class-based alternative: instead of `[data-state="open"]`, you can write `ui-open:*`.
 
-## How to Enable and Customize
+## Default Behavior
 
-### Enable with Default Values
+Before **v0.4.0**, `uiVariants` was **disabled by default** and had to be enabled manually.
 
-Enable the plugin with built-in `ui-*` prefix and common component states:
+Starting with **v0.4.0**, `uiVariants` is **enabled by default**.
+You only need to configure it explicitly if you want to disable it or customize its options.
+
+## How to Customize
+
+### Enable (for < v0.4.0, or explicit opt-in)
 
 ```ts
 createLynxPreset({
   lynxUIPlugins: {
     uiVariants: true,
+  },
+});
+```
+
+### Disable
+
+```ts
+createLynxPreset({
+  lynxUIPlugins: {
+    uiVariants: false,
+  },
+});
+```
+
+### Configure Options
+
+```ts
+createLynxPreset({
+  lynxUIPlugins: {
+    uiVariants: {
+      prefixes: {
+        ui: ['open', 'checked'],
+      },
+    },
   },
 });
 ```

--- a/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/third-party/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -49,6 +49,8 @@ createLynxPreset({
 });
 ```
 
+Tip: `uiVariants: {}` (empty object) and `uiVariants: true` both enable the plugin with default options.
+
 ### Customize Prefixes and Values
 
 Use a custom mapping to align with your component state structure (e.g., `data-*` patterns):

--- a/packages/third-party/tailwind-preset/src/__tests__/core.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/core.test.ts
@@ -9,7 +9,6 @@ import {
   getReplaceablePlugins,
   isPluginReplaceable,
   resolveUIPluginEntries,
-  toEnabledLynxUIPluginSet,
   toEnabledSet,
 } from '../core.js';
 import type { LynxUIPluginsOption } from '../core.js';
@@ -70,35 +69,6 @@ describe('core plugin utilities', () => {
 });
 
 describe('lynx-ui plugin helpers', () => {
-  it('toEnabledLynxUIPluginSet handles true', () => {
-    const set = toEnabledLynxUIPluginSet(true);
-    expect([...set]).toEqual(
-      expect.arrayContaining([...ORDERED_LYNX_UI_PLUGIN_NAMES]),
-    );
-  });
-
-  it('toEnabledLynxUIPluginSet handles false', () => {
-    const set = toEnabledLynxUIPluginSet(false);
-    expect(set.size).toBe(0);
-  });
-
-  it('toEnabledLynxUIPluginSet handles array form', () => {
-    const subset = ORDERED_LYNX_UI_PLUGIN_NAMES.slice(0, 2);
-    const set = toEnabledLynxUIPluginSet(subset);
-    expect([...set]).toEqual(subset);
-  });
-
-  it.each([
-    [{ [firstUIPlugin]: true }, true],
-    [{ [firstUIPlugin]: false }, false],
-  ])(
-    'toEnabledLynxUIPluginSet handles object form %j',
-    (input, expectedHas) => {
-      const set = toEnabledLynxUIPluginSet(input);
-      expect(set.has(firstUIPlugin)).toBe(expectedHas);
-    },
-  );
-
   it('resolveUIPluginEntries handles true', () => {
     const entries = resolveUIPluginEntries(true);
     expect(entries).toEqual(

--- a/packages/third-party/tailwind-preset/src/__tests__/lynx.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/lynx.test.ts
@@ -147,7 +147,9 @@ describe('createLynxPreset - Lynx UI plugin behavior', () => {
     });
 
     expect(debugSpy).toHaveBeenCalledWith(
-      `[Lynx] enabled UI plugin: ${firstUIPlugin}`,
+      expect.stringContaining(
+        `[Lynx] enabled UI plugin: ${firstUIPlugin}`,
+      ),
     );
     LYNX_UI_PLUGIN_MAP[firstUIPlugin] = original;
     debugSpy.mockRestore();
@@ -180,14 +182,14 @@ describe('createLynxPreset - Lynx UI plugin behavior', () => {
     const original = LYNX_UI_PLUGIN_MAP.uiVariants;
     LYNX_UI_PLUGIN_MAP.uiVariants = spy;
 
-    createLynxPreset({
-      lynxUIPlugins: { uiVariants: false },
-    });
-
-    expect(spy).not.toHaveBeenCalled();
-
-    // restore
-    LYNX_UI_PLUGIN_MAP.uiVariants = original;
+    try {
+      createLynxPreset({
+        lynxUIPlugins: { uiVariants: false },
+      });
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      LYNX_UI_PLUGIN_MAP.uiVariants = original;
+    }
   });
 
   it('enables uiVariants by default even when lynxUIPlugins is an empty object', () => {
@@ -195,12 +197,13 @@ describe('createLynxPreset - Lynx UI plugin behavior', () => {
     const original = LYNX_UI_PLUGIN_MAP.uiVariants;
     LYNX_UI_PLUGIN_MAP.uiVariants = spy;
 
-    createLynxPreset({ lynxUIPlugins: {} });
-
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith({});
-
-    LYNX_UI_PLUGIN_MAP.uiVariants = original;
+    try {
+      createLynxPreset({ lynxUIPlugins: {} });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith({});
+    } finally {
+      LYNX_UI_PLUGIN_MAP.uiVariants = original;
+    }
   });
 });
 
@@ -218,7 +221,9 @@ describe('createLynxPreset - defensive branches', () => {
     try {
       createLynxPreset({ debug: true });
       expect(debugSpy).toHaveBeenCalledWith(
-        `[Lynx] invariant: missing UI plugin impl for '${firstUIPlugin}'`,
+        expect.stringContaining(
+          `[Lynx] invariant: missing UI plugin impl for '${firstUIPlugin}'`,
+        ),
       );
     } finally {
       // Restore original plugin implementation
@@ -245,7 +250,9 @@ describe('createLynxPreset - defensive branches', () => {
       });
 
       expect(warnSpy).toHaveBeenCalledWith(
-        `[Lynx] failed to initialize UI plugin '${firstUIPlugin}'`,
+        expect.stringContaining(
+          `[Lynx] failed to initialize UI plugin '${firstUIPlugin}'`,
+        ),
         expect.any(Error),
       );
     } finally {

--- a/packages/third-party/tailwind-preset/src/__tests__/lynx.test.ts
+++ b/packages/third-party/tailwind-preset/src/__tests__/lynx.test.ts
@@ -152,4 +152,47 @@ describe('createLynxPreset - Lynx UI plugin behavior', () => {
     LYNX_UI_PLUGIN_MAP[firstUIPlugin] = original;
     debugSpy.mockRestore();
   });
+
+  it('enables uiVariants by default (no options passed)', () => {
+    const spy = Object.assign(vi.fn(), { __isOptionsFunction: true as const });
+    const original = LYNX_UI_PLUGIN_MAP.uiVariants;
+    LYNX_UI_PLUGIN_MAP.uiVariants = spy;
+
+    // Call with defaults
+    createLynxPreset();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({});
+
+    // restore
+    LYNX_UI_PLUGIN_MAP.uiVariants = original;
+  });
+
+  it('does NOT enable uiVariants when explicitly disabled', () => {
+    const spy = Object.assign(vi.fn(), { __isOptionsFunction: true as const });
+    const original = LYNX_UI_PLUGIN_MAP.uiVariants;
+    LYNX_UI_PLUGIN_MAP.uiVariants = spy;
+
+    createLynxPreset({
+      lynxUIPlugins: { uiVariants: false },
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+
+    // restore
+    LYNX_UI_PLUGIN_MAP.uiVariants = original;
+  });
+
+  it('enables uiVariants by default even when lynxUIPlugins is an empty object', () => {
+    const spy = Object.assign(vi.fn(), { __isOptionsFunction: true as const });
+    const original = LYNX_UI_PLUGIN_MAP.uiVariants;
+    LYNX_UI_PLUGIN_MAP.uiVariants = spy;
+
+    createLynxPreset({ lynxUIPlugins: {} });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({});
+
+    LYNX_UI_PLUGIN_MAP.uiVariants = original;
+  });
 });

--- a/packages/third-party/tailwind-preset/src/core.ts
+++ b/packages/third-party/tailwind-preset/src/core.ts
@@ -193,21 +193,6 @@ export function toEnabledSet(
   return set;
 }
 
-export function toEnabledLynxUIPluginSet(
-  opt: LynxUIPluginsOption = true,
-): Set<LynxUIPluginName> {
-  if (opt === true) return new Set(ORDERED_LYNX_UI_PLUGIN_NAMES);
-  if (opt === false) return new Set();
-  if (Array.isArray(opt)) return new Set(opt);
-
-  const set = new Set(ORDERED_LYNX_UI_PLUGIN_NAMES);
-  for (const [k, on] of Object.entries(opt)) {
-    if (on === false) set.delete(k as LynxUIPluginName);
-    else if (on === true) set.add(k as LynxUIPluginName);
-  }
-  return set;
-}
-
 export function resolveUIPluginEntries(
   raw: LynxUIPluginsOption,
 ): {

--- a/packages/third-party/tailwind-preset/src/lynx.ts
+++ b/packages/third-party/tailwind-preset/src/lynx.ts
@@ -38,7 +38,7 @@ import { lynxTheme } from './theme.js';
  *
  * @defaultValue
  * - `lynxPlugins`: `true`
- * - `lynxUIPlugins`: `true` (since v0.4.x; includes `uiVariants`)
+ * - `lynxUIPlugins`: `true` (starting with v0.4.0; includes `uiVariants`)
  * - `debug`: `false`
  * - `theme`: `undefined`
  *
@@ -89,8 +89,24 @@ function createLynxPreset({
   // Lynx UI Plugins
   for (const [name, options] of resolveUIPluginEntries(lynxUIPlugins)) {
     const fn = LYNX_UI_PLUGIN_MAP[name];
-    plugins.push(fn(options));
-    if (debug) console.debug(`[Lynx] enabled UI plugin: ${name}`);
+
+    // Invariant: map must contain every ordered name
+    if (!fn) {
+      if (debug) {
+        const msg = `[Lynx] invariant: missing UI plugin impl for '${name}'`;
+        console.debug(msg);
+      }
+      continue;
+    }
+    try {
+      plugins.push(fn(options));
+      if (debug) console.debug(`[Lynx] enabled UI plugin: ${name}`);
+    } catch (err) {
+      // Keep the stack; no need for instanceof / String(err)
+      if (debug) {
+        console.warn(`[Lynx] failed to initialize UI plugin '${name}'`, err);
+      }
+    }
   }
 
   return {

--- a/packages/third-party/tailwind-preset/src/lynx.ts
+++ b/packages/third-party/tailwind-preset/src/lynx.ts
@@ -26,7 +26,7 @@ import { lynxTheme } from './theme.js';
 
 function createLynxPreset({
   lynxPlugins = true,
-  lynxUIPlugins = false,
+  lynxUIPlugins = true,
   debug = false,
   theme,
 }: {


### PR DESCRIPTION
## Summary

Enable `lynxUIPlugins` by default in the Tailwind preset, so that UI plugins (such as `uiVariants`) are always available without extra configuration.  
This makes component-state styling easier out of the box.

## Motivation

- Lynx core currently lacks pseudo-selectors and data-attribute selectors.  
- `uiVariants` and similar UI plugins bridge this gap, providing a recommended way to express component states.  
- Default-on ensures developers don't need to opt in to essential functionality.

## Details

- Changed default of `createLynxPreset({ lynxUIPlugins })` from `false` → `true`.  
- Per-plugin configuration and opt-out remain supported.
- Added tests covering default enablement, explicit opt-out, empty-config behavior, and defensive/error logging scenarios.
- README and plugin docs updated to explain default-enabled behavior, how to disable globally or per-plugin, configuration examples, advanced customization, and version notes.  
- Added a changeset for a minor release and simplified enablement UX.
  
## Future Compatibility

If Lynx later adds attribute selectors or pseudo-selectors at the core level, this decision remains compatible.  
UI plugins will still work as extensions, but users may choose to disable them explicitly.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
