### PR TITLE
ci(publish): enable npm trusted publishing

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -104,7 +104,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-publish-${{ github.ref }}
       cancel-in-progress: false
-    environment: main branch
+    environment: npm
     permissions:
       contents: write
       pull-requests: write
@@ -123,7 +123,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest npm@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
       - name: Download Turbo Cache
@@ -142,7 +142,6 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           publish: pnpm changeset publish
           title: "chore: Release ${{ steps.date.outputs.date }}"
@@ -171,7 +170,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@latest npm@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
       - name: Download Turbo Cache
@@ -193,8 +192,6 @@ jobs:
       - name: publish canary packages
         run: |
           pnpm --recursive publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   website-build:
     needs: build-all
     if: github.repository == 'lynx-family/lynx-stack'


### PR DESCRIPTION
Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

See:

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers

@coderabbitai summary

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
