### PR TITLE
ci(release): remove `npm i -g npm@latest`

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -123,7 +123,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install
         run: |
-          npm install -g corepack@latest npm@latest
+          npm install -g corepack@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
       - name: Download Turbo Cache
@@ -151,7 +151,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.repository == 'lynx-family/lynx-stack'
-    environment: main branch
+    environment: npm
     permissions:
       contents: read
       pull-requests: read
@@ -170,7 +170,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install
         run: |
-          npm install -g corepack@latest npm@latest
+          npm install -g corepack@latest
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
       - name: Download Turbo Cache


### PR DESCRIPTION
Following up #1190. We are using Node.js v24 in release, which already have `npm` v11 that support OIDC.

@coderabbitai summary

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
