### PR TITLE
fix(rspeedy/core): `output.cssModules.localIdentName` defaults to `[local]-[hash:base64:6]`

### DIFF
--- a/.changeset/fluffy-suits-throw.md
+++ b/.changeset/fluffy-suits-throw.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Set the default value of `output.cssModules.localIdentName` to `[local]-[hash:base64:6]`.

--- a/packages/rspeedy/core/src/config/defaults.ts
+++ b/packages/rspeedy/core/src/config/defaults.ts
@@ -32,6 +32,10 @@ export function applyDefaultRspeedyConfig(config: Config): Config {
 
       // inlineScripts defaults to false when chunk splitting is enabled, true otherwise
       inlineScripts: !enableChunkSplitting,
+
+      cssModules: {
+        localIdentName: '[local]-[hash:base64:6]',
+      },
     },
 
     performance: {

--- a/packages/rspeedy/core/src/config/output/css-modules.ts
+++ b/packages/rspeedy/core/src/config/output/css-modules.ts
@@ -79,7 +79,51 @@ export interface CssModules {
    *
    * @remarks
    *
+   * The default value is `'[local]-[hash:base64:6]'` which combines the original class name with a 6-character hash.
+   *
+   * Available placeholders:
+   *
+   * - `[local]`: Original class name
+   *
+   * - `[hash]`: Hash of the class name
+   *
+   * - `[path]`: File path
+   *
+   * - `[name]`: File name
+   *
+   * - `[ext]`: File extension
+   *
    * See {@link https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#localIdentName | css-loader#localIdentName} for details.
+   *
+   * @example
+   *
+   * Use only hash for shorter class names:
+   *
+   * ```js
+   * import { defineConfig } from '@lynx-js/rspeedy'
+   * export default defineConfig({
+   *   output: {
+   *     cssModules: {
+   *       localIdentName: '[hash:base64:8]',
+   *     },
+   *   },
+   * })
+   * ```
+   *
+   * @example
+   *
+   * Include file name for debugging:
+   *
+   * ```js
+   * import { defineConfig } from '@lynx-js/rspeedy'
+   * export default defineConfig({
+   *   output: {
+   *     cssModules: {
+   *       localIdentName: '[name]__[local]--[hash:base64:5]',
+   *     },
+   *   },
+   * })
+   * ```
    */
   localIdentName?: string | undefined
 }

--- a/packages/rspeedy/core/test/plugins/output.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/output.plugin.test.ts
@@ -211,7 +211,7 @@ describe('Plugins - Output', () => {
             "auto": true,
             "exportGlobals": false,
             "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -239,7 +239,7 @@ describe('Plugins - Output', () => {
             "auto": true,
             "exportGlobals": false,
             "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -267,7 +267,7 @@ describe('Plugins - Output', () => {
             "auto": false,
             "exportGlobals": false,
             "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -295,7 +295,7 @@ describe('Plugins - Output', () => {
             "auto": /module/,
             "exportGlobals": false,
             "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -325,7 +325,7 @@ describe('Plugins - Output', () => {
             "auto": [Function],
             "exportGlobals": false,
             "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -352,7 +352,7 @@ describe('Plugins - Output', () => {
             "auto": true,
             "exportGlobals": true,
             "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -380,7 +380,7 @@ describe('Plugins - Output', () => {
             "auto": true,
             "exportGlobals": false,
             "exportLocalsConvention": "asIs",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -408,7 +408,7 @@ describe('Plugins - Output', () => {
             "auto": true,
             "exportGlobals": false,
             "exportLocalsConvention": "dashesOnly",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -461,7 +461,7 @@ describe('Plugins - Output', () => {
             "auto": true,
             "exportGlobals": false,
             "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "localIdentName": "[local]-[hash:base64:6]",
             "namedExport": false,
           },
           "sourceMap": false,
@@ -487,6 +487,58 @@ describe('Plugins - Output', () => {
             "exportGlobals": false,
             "exportLocalsConvention": "camelCase",
             "localIdentName": "[local]-[hash:base64:6]",
+            "namedExport": false,
+          },
+          "sourceMap": false,
+        }
+      `)
+    })
+
+    test('output.cssModules.localIdentName default value', async () => {
+      const rsbuild = await createStubRspeedy({
+        output: {},
+      })
+
+      const config = await rsbuild.unwrapConfig()
+
+      const options = getLoaderOptions(config, /css-loader/)
+
+      expect(options).toMatchInlineSnapshot(`
+        {
+          "importLoaders": 1,
+          "modules": {
+            "auto": true,
+            "exportGlobals": false,
+            "exportLocalsConvention": "camelCase",
+            "localIdentName": "[local]-[hash:base64:6]",
+            "namedExport": false,
+          },
+          "sourceMap": false,
+        }
+      `)
+    })
+
+    test('output.cssModules.localIdentName manual override', async () => {
+      const rsbuild = await createStubRspeedy({
+        output: {
+          cssModules: {
+            localIdentName: '[path][name]__[local]-[hash:base64:8]',
+          },
+        },
+      })
+
+      const config = await rsbuild.unwrapConfig()
+
+      const options = getLoaderOptions(config, /css-loader/)
+
+      expect(options).toMatchInlineSnapshot(`
+        {
+          "importLoaders": 1,
+          "modules": {
+            "auto": true,
+            "exportGlobals": false,
+            "exportLocalsConvention": "camelCase",
+            "localIdentName": "[path][name]__[local]-[hash:base64:8]",
             "namedExport": false,
           },
           "sourceMap": false,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced CSS Modules configuration with a new default class name pattern: [local]-[hash:base64:6]. Existing projects may see updated generated class names unless overridden.

* **Documentation**
  * Expanded guidance on CSS Modules class name patterns, including available placeholders and examples.

* **Tests**
  * Updated expectations to match the new default and added tests for default behavior and manual overrides.

* **Chores**
  * Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This is a workaround for https://github.com/lynx-family/lynx/issues/3026.

close: f-6746376101

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
