### PR TITLE
feat: delay first componentDidMount after hydrate

### DIFF
--- a/.changeset/strong-wasps-smell.md
+++ b/.changeset/strong-wasps-smell.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Delay first componentDidMount after hydrate


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

@coderabbitai summary

In #1111, we accelerate the timing of didMount. But it may make `hydrate`/`firstScreen` in BTS happens more later than before, thus event handlers are later to be executed. We want to make hydrate before first componentDidMount again.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
