### PR TITLE
fix: handle `lynx.getJSModule` error on web platform 

### DIFF
--- a/.changeset/crazy-jeans-hunt.md
+++ b/.changeset/crazy-jeans-hunt.md
@@ -2,4 +2,4 @@
 "@lynx-js/rspeedy": patch
 ---
 
-fix: error `lynx.getJSModule` is not a function on web platform
+Fix the "lynx.getJSModule is not a function" error on Web platform

--- a/.changeset/crazy-jeans-hunt.md
+++ b/.changeset/crazy-jeans-hunt.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+fix: error `lynx.getJSModule` is not a function on web platform

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -12,6 +12,7 @@ import color from 'picocolors'
 import type { Dev } from '../config/dev/index.js'
 import type { Server } from '../config/server/index.js'
 import { debug } from '../debug.js'
+import { isLynx } from '../utils/is-lynx.js'
 import { ProvidePlugin } from '../webpack/ProvidePlugin.js'
 
 export function pluginDev(
@@ -149,11 +150,21 @@ export function pluginDev(
           .end()
           .plugin('lynx.hmr.provide')
             .use(ProvidePlugin, [
-              {
+              isLynx(environment) ? {
                 WebSocket: [
                   options?.client?.websocketTransport ?? require.resolve('@lynx-js/websocket'),
                   'default',
                 ],
+                __webpack_dev_server_client__: [
+                  require.resolve(
+                    './client/hmr/WebSocketClient.js',
+                    {
+                      paths: [rspeedyDir],
+                    },
+                  ),
+                  'default'
+                ],
+              } : {
                 __webpack_dev_server_client__: [
                   require.resolve(
                     './client/hmr/WebSocketClient.js',

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -148,23 +148,9 @@ export function pluginDev(
               )
             .end()
           .end()
-          .plugin('lynx.hmr.provide')
+          .plugin('lynx.hmr.provide.dev_server_client')
             .use(ProvidePlugin, [
-              isLynx(environment) ? {
-                WebSocket: [
-                  options?.client?.websocketTransport ?? require.resolve('@lynx-js/websocket'),
-                  'default',
-                ],
-                __webpack_dev_server_client__: [
-                  require.resolve(
-                    './client/hmr/WebSocketClient.js',
-                    {
-                      paths: [rspeedyDir],
-                    },
-                  ),
-                  'default'
-                ],
-              } : {
+              {
                 __webpack_dev_server_client__: [
                   require.resolve(
                     './client/hmr/WebSocketClient.js',
@@ -177,6 +163,17 @@ export function pluginDev(
               }
             ])
           .end()
+        if (isLynx(environment)) {
+          chain.plugin('lynx.hmr.provide.websocket')
+            .use(ProvidePlugin, [{
+              WebSocket: [
+                options?.client?.websocketTransport
+                  ?? require.resolve('@lynx-js/websocket'),
+                'default',
+              ],
+            }])
+            .end()
+        }
       })
     },
   }

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -73,8 +73,10 @@ describe('Plugins - Dev', () => {
 
     expect(vi.isMockFunction(ProvidePlugin)).toBe(true)
     expect(vi.mocked(ProvidePlugin)).toBeCalled()
-    expect(ProvidePlugin).toBeCalledWith({
+    expect(ProvidePlugin).toHaveBeenCalledWith({
       WebSocket: [require.resolve('@lynx-js/websocket'), 'default'],
+    })
+    expect(ProvidePlugin).toHaveBeenCalledWith({
       __webpack_dev_server_client__: [
         require.resolve('../../client/hmr/WebSocketClient.js'),
         'default',
@@ -522,8 +524,10 @@ describe('Plugins - Dev', () => {
 
     const { ProvidePlugin } = await import('../../src/webpack/ProvidePlugin.js')
 
-    expect(ProvidePlugin).toBeCalledWith({
+    expect(ProvidePlugin).toHaveBeenCalledWith({
       WebSocket: ['/foo', 'default'],
+    })
+    expect(ProvidePlugin).toHaveBeenCalledWith({
       __webpack_dev_server_client__: [
         require.resolve('../../client/hmr/WebSocketClient.js'),
         'default',

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -99,6 +99,27 @@ describe('Plugins - Dev', () => {
     )
   })
 
+  test('no Websocket class injected for web', async () => {
+    const rsbuild = await createStubRspeedy({
+      environments: {
+        web: {},
+      },
+    })
+
+    await rsbuild.unwrapConfig()
+
+    const { ProvidePlugin } = await import('../../src/webpack/ProvidePlugin.js')
+
+    expect(vi.isMockFunction(ProvidePlugin)).toBe(true)
+    expect(vi.mocked(ProvidePlugin)).toBeCalled()
+    expect(ProvidePlugin).toBeCalledWith({
+      __webpack_dev_server_client__: [
+        require.resolve('../../client/hmr/WebSocketClient.js'),
+        'default',
+      ],
+    })
+  })
+
   test('not inject entry and provide variables in production', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     const rsbuild = await createStubRspeedy({})


### PR DESCRIPTION


#1806

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Environment-aware dev server client setup for smoother web development.
- Bug Fixes
  - Resolved a web runtime error causing “getJSModule is not a function” during development.
  - Prevented unnecessary WebSocket injection on web to avoid startup issues.
- Tests
  - Added coverage to verify correct client configuration and absence of WebSocket injection on web.
- Chores
  - Published a patch release for @lynx-js/rspeedy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
