### PR TITLE
feat(rspeedy/cli): add `--root` option for project directory

### DIFF
--- a/.changeset/large-poems-buy.md
+++ b/.changeset/large-poems-buy.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Support CLI flag `--root` to specify the root of the project.

--- a/packages/rspeedy/core/test/cli/root.test.ts
+++ b/packages/rspeedy/core/test/cli/root.test.ts
@@ -1,0 +1,197 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path'
+
+import { Command } from 'commander'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { MockedFunction } from 'vitest'
+
+import type { BuildOptions } from '../../src/cli/build.js'
+
+vi.mock('../../src/cli/build.js', () => ({
+  build: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../../src/cli/dev.js', () => ({
+  dev: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../../src/cli/inspect.js', () => ({
+  inspect: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../../src/cli/preview.js', () => ({
+  preview: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('CLI - root option', () => {
+  let program: Command
+  let apply: (program: Command) => Command
+  let mockedBuild: MockedFunction<
+    (this: Command, root: string, buildOptions: BuildOptions) => Promise<void>
+  >
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    program = new Command('test')
+    const commandsModule = await import('../../src/cli/commands.js')
+    apply = commandsModule.apply
+    program.exitOverride()
+    const buildModule = await import('../../src/cli/build.js')
+    mockedBuild = vi.mocked(buildModule.build)
+  })
+
+  test('accepts short flag -r for root', async () => {
+    const cliRootInput = './my-project'
+
+    await apply(program).parseAsync([
+      'node',
+      'rspeedy',
+      'build',
+      '-r',
+      cliRootInput,
+    ])
+
+    const [calledRoot] = mockedBuild.mock.calls[0]!
+
+    expect(path.normalize(calledRoot)).toBe(
+      path.normalize(path.resolve(process.cwd(), cliRootInput)),
+    )
+  })
+
+  test('requires a value', async () => {
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() =>
+      false
+    )
+
+    await expect(
+      apply(program).parseAsync(['node', 'rspeedy', 'build', '--root']),
+    ).rejects.toThrow(/option ['"]?-r --root <root>['"]? .*argument missing/i)
+
+    expect(mockedBuild).not.toHaveBeenCalled()
+
+    writeSpy.mockRestore()
+  })
+
+  test('accepts a value', async () => {
+    const cliRootInput = './some-path'
+    await apply(program).parseAsync([
+      'node',
+      'rspeedy',
+      'build',
+      '--root',
+      cliRootInput,
+    ])
+
+    const [calledRoot, calledOptions] = mockedBuild.mock.calls[0]!
+    const actualRootPath = path.normalize(calledRoot)
+    const expectedRootPath = path.normalize(
+      path.resolve(process.cwd(), cliRootInput),
+    )
+
+    expect(actualRootPath).toBe(expectedRootPath)
+    expect(calledOptions).toEqual(
+      expect.objectContaining({ root: cliRootInput }),
+    )
+  })
+
+  test('uses cwd when root is not provided', async () => {
+    await apply(program).parseAsync(['node', 'rspeedy', 'build'])
+
+    const [calledRoot, calledOptions] = mockedBuild.mock.calls[0]!
+    const actualRootPath = path.normalize(calledRoot)
+    const expectedRootPath = path.normalize(process.cwd())
+
+    expect(actualRootPath).toBe(expectedRootPath)
+    expect(calledOptions).toEqual(expect.objectContaining({}))
+  })
+
+  test('passes relative root path to build command', async () => {
+    const cliRootInput = './my-project'
+    await apply(program).parseAsync([
+      'node',
+      'rspeedy',
+      'build',
+      '--root',
+      cliRootInput,
+    ])
+
+    const [calledRoot, calledOptions] = mockedBuild.mock.calls[0]!
+    const actualRootPath = path.normalize(calledRoot)
+    const expectedRootPath = path.normalize(
+      path.resolve(process.cwd(), cliRootInput),
+    )
+
+    expect(actualRootPath).toBe(expectedRootPath)
+    expect(calledOptions).toEqual(
+      expect.objectContaining({ root: cliRootInput }),
+    )
+  })
+
+  test('passes absolute root path to build command', async () => {
+    const cliRootInput = path.resolve('/absolute/path/to/my-project')
+    await apply(program).parseAsync([
+      'node',
+      'rspeedy',
+      'build',
+      '--root',
+      cliRootInput,
+    ])
+
+    const [calledRoot, calledOptions] = mockedBuild.mock.calls[0]!
+    const actualRootPath = path.normalize(calledRoot)
+    const expectedRootPath = path.normalize(
+      path.resolve(process.cwd(), cliRootInput),
+    )
+
+    expect(actualRootPath).toBe(expectedRootPath)
+    expect(calledOptions).toEqual(
+      expect.objectContaining({ root: cliRootInput }),
+    )
+  })
+
+  test.each(['build', 'dev', 'inspect', 'preview'])(
+    '%s command accepts --root option',
+    async (command) => {
+      const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(
+        () => false,
+      )
+      await expect(
+        apply(program).parseAsync([
+          'node',
+          'rspeedy',
+          command,
+          '--root',
+          './my-project',
+        ]),
+      ).resolves.not.toThrow()
+
+      writeSpy.mockRestore()
+    },
+  )
+
+  test('works with both --root and --config options', async () => {
+    const cliRootInput = './my-project'
+    const cliConfigPath = './custom.config.js'
+    await apply(program).parseAsync([
+      'node',
+      'rspeedy',
+      'build',
+      '--root',
+      cliRootInput,
+      '--config',
+      cliConfigPath,
+    ])
+
+    const [calledRoot, calledOptions] = mockedBuild.mock.calls[0]!
+
+    expect(path.normalize(calledRoot)).toBe(
+      path.normalize(path.resolve(process.cwd(), cliRootInput)),
+    )
+    expect(calledOptions).toEqual(
+      expect.objectContaining({
+        root: cliRootInput,
+        config: cliConfigPath,
+      }),
+    )
+  })
+})

--- a/website/docs/en/guide/cli.md
+++ b/website/docs/en/guide/cli.md
@@ -80,6 +80,7 @@ Options:
   --env-mode <mode>        specify the env mode to load the .env.[mode] file
   --no-env                 disable loading `.env` files"
   -m --mode <mode>         specify the build mode, can be `development`, `production` or `none`
+  -r --root <root>         set the project root directory (absolute path or relative to cwd)
   -h, --help               display help for command
 ```
 
@@ -103,6 +104,7 @@ Options:
   --env-mode <mode>        specify the env mode to load the .env.[mode] file
   --no-env                 disable loading `.env` files"
   -m --mode <mode>         specify the build mode, can be `development`, `production` or `none`
+  -r --root <root>         set the project root directory (absolute path or relative to cwd)
   -h, --help               display help for command
 ```
 
@@ -123,6 +125,7 @@ Options:
   --env-mode <mode>     specify the env mode to load the .env.[mode] file
   --no-env              disable loading `.env` files"
   -m --mode <mode>      specify the build mode, can be `development`, `production` or `none`
+  -r --root <root>      set the project root directory (absolute path or relative to cwd)
   -h, --help            display help for command
 ```
 
@@ -148,6 +151,7 @@ Options:
   --env-mode <mode>     specify the env mode to load the .env.[mode] file
   --no-env              disable loading `.env` files"
   -m --mode <mode>      specify the build mode, can be `development`, `production` or `none`
+  -r --root <root>      set the project root directory (absolute path or relative to cwd)
   -h, --help            display help for command
 ```
 

--- a/website/docs/zh/guide/cli.md
+++ b/website/docs/zh/guide/cli.md
@@ -78,6 +78,7 @@ Options:
   --env-mode <mode>        specify the env mode to load the .env.[mode] file
   --no-env                 disable loading `.env` files"
   -m --mode <mode>         specify the build mode, can be `development`, `production` or `none`
+  -r --root <root>         set the project root directory (absolute path or relative to cwd)
   -h, --help               display help for command
 ```
 
@@ -101,6 +102,7 @@ Options:
   --env-mode <mode>        specify the env mode to load the .env.[mode] file
   --no-env                 disable loading `.env` files"
   -m --mode <mode>         specify the build mode, can be `development`, `production` or `none`
+  -r --root <root>         set the project root directory (absolute path or relative to cwd)
   -h, --help               display help for command
 ```
 
@@ -121,6 +123,7 @@ Options:
   --env-mode <mode>     specify the env mode to load the .env.[mode] file
   --no-env              disable loading `.env` files"
   -m --mode <mode>      specify the build mode, can be `development`, `production` or `none`
+  -r --root <root>      set the project root directory (absolute path or relative to cwd)
   -h, --help            display help for command
 ```
 
@@ -146,6 +149,7 @@ Options:
   --env-mode <mode>     specify the env mode to load the .env.[mode] file
   --no-env              disable loading `.env` files"
   -m --mode <mode>      specify the build mode, can be `development`, `production` or `none`
+  -r --root <root>      set the project root directory (absolute path or relative to cwd)
   -h, --help            display help for command
 ```
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a --root (-r) option to build, dev, inspect, and preview commands.
  - Resolves provided paths (relative or absolute) to an absolute project root.
  - Defaults to the current working directory when --root is not specified.

- **Tests**
  - Added CLI tests covering root handling, argument validation, path resolution, and interaction with other options (e.g., --config).

- **Documentation**
  - Updated CLI docs to document the new --root option.

- **Chores**
  - Added a changeset entry for the patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1817

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
