### PR TITLE
fix(web): LynxView.updateData() cannot trigger dataProcessor

### DIFF
--- a/.changeset/free-schools-remain.md
+++ b/.changeset/free-schools-remain.md
@@ -1,0 +1,17 @@
+---
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/web-constants": patch
+"@lynx-js/web-elements": patch
+"@lynx-js/web-core": minor
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix:
+
+1. `LynxView.updateData()` cannot trigger `dataProcessor`.
+
+2. **This is a break change:** The second parameter of `LynxView.updateData()` has been changed from `UpdateDataType` to `string`, which is the `processorName` (default is `default` which will use `defaultDataProcessor`). This change is to better align with Native. The current complete type is as follows:
+
+```ts
+LynxView.updateData(data: Cloneable, processorName?: string | undefined, callback?: (() => void) | undefined): void
+```

--- a/packages/web-platform/web-constants/src/endpoints.ts
+++ b/packages/web-platform/web-constants/src/endpoints.ts
@@ -16,6 +16,7 @@ import type {
   LynxTemplate,
   MarkTiming,
 } from './types/index.js';
+import type { UpdateDataOptions } from './types/UpdateDataOptions.js';
 
 export const postExposureEndpoint = createRpcEndpoint<
   [{ exposures: ExposureWorkerEvent[]; disExposures: ExposureWorkerEvent[] }],
@@ -61,7 +62,7 @@ export const mainThreadStartEndpoint = createRpcEndpoint<
 >('mainThreadStart', false, false);
 
 export const updateDataEndpoint = createRpcEndpoint<
-  [Cloneable, Record<string, string>],
+  [Cloneable, UpdateDataOptions | undefined],
   void
 >('updateData', false, true);
 

--- a/packages/web-platform/web-constants/src/types/MainThreadGlobalThis.ts
+++ b/packages/web-platform/web-constants/src/types/MainThreadGlobalThis.ts
@@ -10,6 +10,7 @@ import type { FlushElementTreeOptions } from './FlushElementTreeOptions.js';
 import type { I18nResourceTranslationOptions } from './index.js';
 import type { MainThreadLynx } from './MainThreadLynx.js';
 import type { ProcessDataCallback } from './ProcessDataCallback.js';
+import type { UpdateDataOptions } from './UpdateDataOptions.js';
 
 type ElementPAPIEventHandler =
   | string
@@ -401,6 +402,6 @@ export interface MainThreadGlobalThis {
   ) => unknown;
   // the following methods is assigned by the main thread user code
   renderPage: ((data: unknown) => void) | undefined;
-  updatePage?: (data: Cloneable, options?: Record<string, string>) => void;
+  updatePage?: (data: Cloneable, options?: UpdateDataOptions) => void;
   runWorklet?: (obj: unknown, event: unknown) => void;
 }

--- a/packages/web-platform/web-constants/src/types/UpdateDataOptions.ts
+++ b/packages/web-platform/web-constants/src/types/UpdateDataOptions.ts
@@ -3,28 +3,7 @@ export const enum NativeUpdateDataType {
   RESET = 1,
 }
 
-export const enum UpdateDataType {
-  // default
-  Unknown = 0,
-
-  // update by `setState` or `setData`
-  UpdateExplicitByUser = 1,
-
-  // update by lynx_core from ctor
-  UpdateByKernelFromCtor = 1 << 1,
-
-  // update by lynx_core from render
-  UpdateByKernelFromRender = 1 << 2,
-
-  // update by hydrate
-  UpdateByKernelFromHydrate = 1 << 3,
-
-  // update by `getDerivedStateFromProps`
-  UpdateByKernelFromGetDerived = 1 << 4,
-
-  // update by conflict detected
-  UpdateByKernelFromConflict = 1 << 5,
-
-  // update by HMR
-  UpdateByKernelFromHMR = 1 << 6,
+export interface UpdateDataOptions {
+  type?: NativeUpdateDataType;
+  processorName?: string;
 }

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -19,7 +19,6 @@ import {
   type NapiModulesMap,
   type NativeModulesCall,
   type NativeModulesMap,
-  type UpdateDataType,
 } from '@lynx-js/web-constants';
 
 export type INapiModulesCall = (
@@ -274,10 +273,10 @@ export class LynxView extends HTMLElement {
    */
   updateData(
     data: Cloneable,
-    updateDataType: UpdateDataType,
+    processorName?: string,
     callback?: () => void,
   ) {
-    this.#instance?.updateData(data, updateDataType, callback);
+    this.#instance?.updateData(data, processorName, callback);
   }
 
   /**

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -10,7 +10,6 @@ import type {
   NapiModulesMap,
   NativeModulesMap,
   sendGlobalEventEndpoint,
-  UpdateDataType,
 } from '@lynx-js/web-constants';
 import {
   startUIThread,
@@ -39,7 +38,7 @@ export interface LynxViewConfigs {
 export interface LynxView {
   updateData(
     data: Cloneable,
-    updateDataType: UpdateDataType,
+    processorName?: string,
     callback?: () => void,
   ): void;
   dispose(): Promise<void>;

--- a/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/createUpdateData.ts
+++ b/packages/web-platform/web-core/src/uiThread/crossThreadHandlers/createUpdateData.ts
@@ -4,25 +4,16 @@
 
 import type { RpcCallType } from '@lynx-js/web-worker-rpc';
 import type { LynxView } from '../../apis/createLynxView.js';
-import {
-  updateDataEndpoint,
-  type Cloneable,
-  type UpdateDataType,
-} from '@lynx-js/web-constants';
+import { updateDataEndpoint, type Cloneable } from '@lynx-js/web-constants';
 
 export function createUpdateData(
   updateDataMainThread: RpcCallType<typeof updateDataEndpoint>,
-  updateDataBackground: RpcCallType<typeof updateDataEndpoint>,
 ): LynxView['updateData'] {
   return (
     data: Cloneable,
-    _updateDataType: UpdateDataType,
+    processorName?: string,
     callback?: () => void,
   ) => {
-    Promise.all([
-      // There is no need to process options for now, as they have default values.
-      updateDataMainThread(data, {}),
-      updateDataBackground(data, {}),
-    ]).then(() => callback?.());
+    updateDataMainThread(data, { processorName }).then(() => callback?.());
   };
 }

--- a/packages/web-platform/web-core/src/uiThread/startBackground.ts
+++ b/packages/web-platform/web-core/src/uiThread/startBackground.ts
@@ -2,7 +2,6 @@ import {
   getCacheI18nResourcesKey,
   markTimingEndpoint,
   sendGlobalEventEndpoint,
-  updateDataEndpoint,
   updateI18nResourceEndpoint,
   type Cloneable,
   type I18nResourceTranslationOptions,
@@ -64,7 +63,6 @@ export function startBackground(
 
   const sendGlobalEvent = backgroundRpc.createCall(sendGlobalEventEndpoint);
   const markTiming = backgroundRpc.createCall(markTimingEndpoint);
-  const updateDataBackground = backgroundRpc.createCall(updateDataEndpoint);
   const updateI18nResourceBackground = (
     data: InitI18nResources,
     options: I18nResourceTranslationOptions,
@@ -80,7 +78,6 @@ export function startBackground(
   return {
     sendGlobalEvent,
     markTiming,
-    updateDataBackground,
     updateI18nResourceBackground,
   };
 }

--- a/packages/web-platform/web-core/src/uiThread/startUIThread.ts
+++ b/packages/web-platform/web-core/src/uiThread/startUIThread.ts
@@ -49,7 +49,6 @@ export function startUIThread(
   const {
     markTiming,
     sendGlobalEvent,
-    updateDataBackground,
     updateI18nResourceBackground,
   } = startBackground(
     backgroundRpc,
@@ -104,7 +103,7 @@ export function startUIThread(
     });
   });
   return {
-    updateData: createUpdateData(updateDataMainThread, updateDataBackground),
+    updateData: createUpdateData(updateDataMainThread),
     dispose: createDispose(
       backgroundRpc,
       terminateWorkers,

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -1040,9 +1040,7 @@ test.describe('reactlynx3 tests', () => {
       await expect(target).toHaveCSS('background-color', 'rgb(255, 192, 203)'); // pink
       await page.evaluate(() => {
         // @ts-expect-error
-        globalThis.lynxView.updateData({ mockData: 'updatedData' }, 1, () => {
-          console.log('update Data success');
-        });
+        globalThis.lynxView.updateData({ mockData: 'updatedData' });
       });
       await wait(50);
       await expect(target).toHaveCSS(
@@ -1071,13 +1069,76 @@ test.describe('reactlynx3 tests', () => {
       await wait(1000);
       await page.evaluate(() => {
         // @ts-expect-error
-        globalThis.lynxView.updateData({ mockData: 'updatedData' }, 0, () => {
-          console.log('update Data success');
-        });
+        globalThis.lynxView.updateData(
+          { mockData: 'updatedData' },
+          'default',
+          () => {
+            console.log('update Data success');
+          },
+        );
       });
       await wait(100);
       await expect(successCallback).toBe(true);
     });
+
+    // use default
+    test('api-updateData-processData', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      const target = page.locator('#target');
+      await wait(100);
+      await expect(target).toHaveCSS(
+        'background-color',
+        'rgb(255, 192, 203)',
+      ); // pink
+      await page.evaluate(() => {
+        // @ts-expect-error
+        globalThis.lynxView.updateData({ mockData: 'updatedData' });
+      });
+      await expect(target).toHaveCSS(
+        'background-color',
+        'rgb(0, 128, 0)',
+      ); // green;
+    });
+    // not use default
+    test(
+      'api-updateData-processData-not-default',
+      async ({ page }, { title }) => {
+        await goto(page, 'api-updateData-processData');
+        await wait(100);
+        const target = page.locator('#target');
+        await wait(100);
+        await expect(target).toHaveCSS(
+          'background-color',
+          'rgb(255, 192, 203)',
+        ); // pink
+        await page.evaluate(() => {
+          // @ts-expect-error
+          globalThis.lynxView.updateData(
+            { mockData: 'updatedData' },
+            'useless',
+          );
+        });
+        await wait(100);
+        await expect(target).toHaveCSS(
+          'background-color',
+          'rgb(255, 192, 203)',
+        ); // pink
+        await wait(100);
+        await page.evaluate(() => {
+          // @ts-expect-error
+          globalThis.lynxView.updateData(
+            { mockData: 'updatedData' },
+            'processData',
+          );
+        });
+        await wait(100);
+        await expect(target).toHaveCSS(
+          'background-color',
+          'rgb(0, 128, 0)',
+        ); // green;
+      },
+    );
 
     test('basic-at-rule-animation', async ({ page }, { title }) => {
       await goto(page, title);

--- a/packages/web-platform/web-tests/tests/react/api-updateData-processData/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-updateData-processData/index.jsx
@@ -1,0 +1,40 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useInitData } from '@lynx-js/react';
+
+function App() {
+  const initData = useInitData();
+  return (
+    <view
+      id='target'
+      style={{
+        height: '100px',
+        width: '100px',
+        background: initData.mockData === 'processData' ? 'green' : 'pink',
+      }}
+    />
+  );
+}
+
+lynx.registerDataProcessors({
+  defaultDataProcessor: (rawData) => {
+    if (rawData.mockData === 'updatedData') {
+      return {
+        mockData: 'processData',
+      };
+    }
+    return rawData;
+  },
+  dataProcessors: {
+    processData: (rawData) => {
+      if (rawData.mockData === 'updatedData') {
+        return {
+          mockData: 'processData',
+        };
+      }
+      return rawData;
+    },
+  },
+});
+root.render(<App></App>);

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -117,7 +117,7 @@ export async function createNativeApp(
         tt,
       );
       registerUpdateDataHandler(
-        uiThreadRpc,
+        mainThreadRpc,
         tt,
       );
       registerSendGlobalEventHandler(

--- a/packages/web-platform/web-worker-runtime/src/mainThread/crossThreadHandlers/registerUpdateDataHandler.ts
+++ b/packages/web-platform/web-worker-runtime/src/mainThread/crossThreadHandlers/registerUpdateDataHandler.ts
@@ -1,20 +1,17 @@
 // Copyright 2023 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import {
-  updateDataEndpoint,
-  type MainThreadGlobalThis,
-} from '@lynx-js/web-constants';
+import { updateDataEndpoint } from '@lynx-js/web-constants';
 import type { Rpc } from '@lynx-js/web-worker-rpc';
 
 export function registerUpdateDataHandler(
-  rpc: Rpc,
-  runtime: MainThreadGlobalThis,
+  mainThreadRpc: Rpc,
+  handleUpdatedData: ReturnType<
+    typeof import('@lynx-js/web-mainthread-apis').prepareMainThreadAPIs
+  >['handleUpdatedData'],
 ): void {
-  rpc.registerHandler(
+  mainThreadRpc.registerHandler(
     updateDataEndpoint,
-    (...args) => {
-      runtime.updatePage?.(...args);
-    },
+    (newData, options) => handleUpdatedData(newData, options),
   );
 }

--- a/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
+++ b/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
@@ -17,7 +17,6 @@ import {
   multiThreadExposureChangedEndpoint,
   lynxUniqueIdAttribute,
   type JSRealm,
-  type MainThreadGlobalThis,
   loadTemplateMultiThread,
 } from '@lynx-js/web-constants';
 import { Rpc } from '@lynx-js/web-worker-rpc';
@@ -92,7 +91,7 @@ export async function startMainThreadWorker(
     multiThreadExposureChangedEndpoint,
   );
   const loadTemplate = uiThreadRpc.createCall(loadTemplateMultiThread);
-  const { startMainThread } = prepareMainThreadAPIs(
+  const { startMainThread, handleUpdatedData } = prepareMainThreadAPIs(
     backgroundThreadRpc,
     document, // rootDom
     document,
@@ -121,7 +120,7 @@ export async function startMainThreadWorker(
       await startMainThread(config);
       registerUpdateDataHandler(
         uiThreadRpc,
-        globalThis as typeof globalThis & MainThreadGlobalThis,
+        handleUpdatedData,
       );
     },
   );


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Data updates can target a named processor and use a unified handling path to ensure processed results are applied consistently across threads.

- **Breaking Changes**
  - updateData's second parameter is now an optional processorName string; previous enum-based parameter removed and replaced by options including processorName.

- **Tests**
  - Added tests for default and explicit processor paths.

- **Chores**
  - Patch/minor release notes updated for related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
