### PR TITLE
fix(rspeedy/react): only inject hot clients on needed

### DIFF
--- a/.changeset/cold-frogs-flash.md
+++ b/.changeset/cold-frogs-flash.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Dev servers now honor `dev.hmr` and `dev.liveReload` when deciding whether to load hot clients.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Dev servers now respect dev.hmr and dev.liveReload settings when deciding whether to load hot clients.
  * When both are disabled, hot clients are not loaded; when only HMR is disabled, CSS HMR is off but live reload remains active.

* **Tests**
  * Added tests verifying hot client behavior when HMR and/or live reload are disabled.

* **Chores**
  * Prepared a patch version bump with a changeset entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
