### PR TITLE
fix(web): layoutchange result top, left was 0 incorrectly

### DIFF
--- a/.changeset/cold-spoons-invent.md
+++ b/.changeset/cold-spoons-invent.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: layoutchange event result `detail.top` and `detail.left` was `0` incorrectly

--- a/packages/web-platform/web-elements/src/common/CommonEventsAndMethods.ts
+++ b/packages/web-platform/web-elements/src/common/CommonEventsAndMethods.ts
@@ -26,10 +26,10 @@ export class CommonEventsAndMethods {
       if (!this.#resizeObserver) {
         this.#resizeObserver = new ResizeObserver(([entry]) => {
           if (entry) {
-            // The layoutchange event is the border box of the element
-            const { width, height, left, right, top, bottom } =
-              entry.contentRect;
             const id = this.#dom.id;
+            // Reuse getBoundingClientRect to get left and top, because ResizeObserver-contentRect is calculated based on padding box
+            const { top, bottom, left, right, width, height } = entry.target
+              .getBoundingClientRect();
             this.#dom.dispatchEvent(
               new CustomEvent('layoutchange', {
                 detail: {

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -1780,6 +1780,12 @@ test.describe('reactlynx3 tests', () => {
         expect(bts).toBe(true);
       },
     );
+    test('api-bindlauoutchange', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      const target = page.locator('#target');
+      await expect(target).toHaveCSS('background-color', 'rgb(0, 128, 0)'); // green
+    });
   });
 
   test.describe('configs', () => {

--- a/packages/web-platform/web-tests/tests/react/api-bindlauoutchange/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/api-bindlauoutchange/index.jsx
@@ -1,0 +1,41 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+function App() {
+  const [color, setColor] = useState('pink');
+  const handleLayoutChange = (e) => {
+    if (
+      e.detail.top === 50 && e.detail.bottom === 150 && e.detail.left === 50
+      && e.detail.right === 150 && e.detail.width === 100
+      && e.detail.height === 100
+    ) {
+      setColor('green');
+    }
+  };
+
+  return (
+    <view style={{ display: 'flex', flexDirection: 'column' }}>
+      <view
+        style={{
+          width: '100px',
+          height: '100px',
+          backgroundColor: 'green',
+          margin: '50px',
+        }}
+        bindLayoutChange={handleLayoutChange}
+      >
+      </view>
+      <view
+        style={{ width: '100px', height: '100px', backgroundColor: color }}
+        id='target'
+      >
+      </view>
+    </view>
+  );
+}
+root.render(
+  <page>
+    <App></App>
+  </page>,
+);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected layoutchange event data: detail.top and detail.left now report accurate values based on the element’s bounding rectangle, improving position reliability.

- Tests
  - Added an end-to-end test and example that validate layoutchange behavior and UI updates when expected positions are reported.

- Chores
  - Added a changeset entry for a patch release of the web elements package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
