### PR TITLE
feat: init ctxNotFoundEventListener before each test in testing library

### DIFF
--- a/.changeset/mighty-years-bake.md
+++ b/.changeset/mighty-years-bake.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Initialize `ctxNotFoundEventListener` before each test in testing library

--- a/packages/react/testing-library/src/__tests__/lynx.test.jsx
+++ b/packages/react/testing-library/src/__tests__/lynx.test.jsx
@@ -1,4 +1,11 @@
-import { describe } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '..';
+import {
+  __globalSnapshotPatch,
+  initGlobalSnapshotPatch,
+  SnapshotOperation,
+} from '../../../runtime/lib/lifecycle/patch/snapshotPatch';
+import { prettyFormatSnapshotPatch } from '../../../runtime/lib/debug/formatPatch';
 
 describe('lynx global API', () => {
   it('getJSModule should work', () => {
@@ -21,6 +28,54 @@ describe('lynx global API', () => {
             },
           },
         ],
+      ]
+    `);
+  });
+  it('background ctxNotFoundEventListener works', () => {
+    const oldCallLepusMethod = lynx.getNativeApp().callLepusMethod;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod').mockImplementation((...args) => {
+      if (args[0] === 'rLynxChange' && args[1].patchOptions.isHydration) {
+        const data = JSON.parse(args[1].data);
+        data.patchList[0].snapshotPatch.push(
+          SnapshotOperation.InsertBefore,
+          1e10,
+          1e10,
+          null,
+        );
+        args[1].data = JSON.stringify(data);
+      }
+      oldCallLepusMethod(...args);
+    });
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynx, 'reportError');
+    const reportErrorCalls = lynxTestingEnv.backgroundThread.lynx.reportError.mock.calls;
+
+    expect(() => render(<view />)).toThrowErrorMatchingInlineSnapshot(
+      `[Error: snapshotPatchApply failed: ctx not found, snapshot type: 'null']`,
+    );
+
+    const snapshotPatch = JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch;
+    const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+    expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+      [
+        {
+          "id": 2,
+          "op": "CreateElement",
+          "type": "__Card__:__snapshot_d4b6f_test_1",
+        },
+        {
+          "beforeId": null,
+          "childId": 2,
+          "op": "InsertBefore",
+          "parentId": -1,
+        },
+        {
+          "beforeId": null,
+          "childId": 10000000000,
+          "op": "InsertBefore",
+          "parentId": 10000000000,
+        },
       ]
     `);
   });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added coverage for background context-not-found event listener, including snapshot formatting and error handling during hydration failures.
  - Expanded test utilities and assertions to validate emitted patches and error outputs.
- Chores
  - Standardized test environment reset to reinitialize event listeners for context-not-found handling before each run.
  - Prepared a patch release entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
