### PR TITLE
feat: support web preview in rspeedy dev

### DIFF
--- a/.changeset/twenty-places-pump.md
+++ b/.changeset/twenty-places-pump.md
@@ -4,5 +4,4 @@
 
 feat: support web preview in rspeedy dev
 
-- support web preview in rspeedy dev (experimental)
 - print URLs with labels

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -153,7 +153,13 @@ export function pluginDev(
                     }
                   }
                 }
-                return finalUrls
+                return finalUrls.map((urlInfo) => {
+                  // capitalize the first letter of label
+                  const label = urlInfo.label.charAt(0).toUpperCase()
+                    + urlInfo.label.slice(1)
+                  urlInfo.label = label
+                  return urlInfo
+                })
               },
             },
           })

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -709,7 +709,7 @@ describe('Plugins - Dev', () => {
     await server.waitDevCompileDone()
 
     expect(printedUrls).toContainEqual({
-      'label': 'lynx',
+      'label': 'Lynx',
       'url': 'http://example.com:8080/main.lynx.bundle',
     })
   })
@@ -758,7 +758,7 @@ describe('Plugins - Dev', () => {
     await server.waitDevCompileDone()
 
     expect(printedUrls).toContainEqual({
-      'label': 'web',
+      'label': 'Web',
       'url': 'http://example.com:8080/main.web.bundle',
     })
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental web preview support in dev mode.
  * Enhanced dev server URL display: per-entry, per-environment URLs with descriptive labels (including a Web Preview link for web entries).

* **Tests**
  * Added tests to validate printed URLs and Web Preview entries are emitted as expected.

* **Chores**
  * Added a patch-level changelog entry documenting the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
