### PR TITLE
feat: share `runtime-components` exports between the main and lazy bundles

### DIFF
--- a/.changeset/cute-frogs-refuse.md
+++ b/.changeset/cute-frogs-refuse.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Share `@lynx-js/react/runtime-components` exports between the main and lazy bundles.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -66,6 +66,7 @@
     },
     "./runtime-components": {
       "types": "./components/lib/index.d.ts",
+      "lazy": "./runtime/lazy/runtime-components.js",
       "default": "./components/lib/index.js"
     },
     "./transform": {

--- a/packages/react/runtime/__test__/lazy.test.js
+++ b/packages/react/runtime/__test__/lazy.test.js
@@ -5,6 +5,7 @@ import * as ReactExports from '../lazy/react.js';
 import * as ReactCompatExports from '../lazy/compat.js';
 import * as ReactLepusExports from '../lazy/react-lepus.js';
 import * as ReactInternalExports from '../lazy/internal.js';
+import * as ReactRuntimeComponentsExports from '../lazy/runtime-components.js';
 import * as ReactJSXRuntimeExports from '../lazy/jsx-runtime.js';
 import * as ReactJSXDevRuntimeExports from '../lazy/jsx-dev-runtime.js';
 import * as ReactLegacyReactRuntimeExports from '../lazy/legacy-react-runtime.js';
@@ -62,14 +63,14 @@ describe('Lazy Exports', () => {
     );
   });
 
-  test('export APIs from "jsx-runtime"', async () => {
+  test('export APIs from "runtime-components"', async () => {
     const realAPIs = Object.assign(
       {},
-      await import('@lynx-js/react/jsx-runtime'),
+      await import('@lynx-js/react/runtime-components'),
     );
 
     expect(
-      new Set(Object.keys(ReactJSXRuntimeExports)),
+      new Set(Object.keys(ReactRuntimeComponentsExports)),
     ).toStrictEqual(
       new Set(Object.keys(realAPIs)),
     );

--- a/packages/react/runtime/lazy/import.js
+++ b/packages/react/runtime/lazy/import.js
@@ -7,6 +7,7 @@ import * as ReactInternal from '@lynx-js/react/internal';
 import * as ReactJSXDevRuntime from '@lynx-js/react/jsx-dev-runtime';
 import * as ReactJSXRuntime from '@lynx-js/react/jsx-runtime';
 import * as ReactLegacyReactRuntime from '@lynx-js/react/legacy-react-runtime';
+import * as ReactRuntimeComponents from '@lynx-js/react/runtime-components';
 import * as ReactLepusAPIs from '@lynx-js/react/lepus';
 
 import {
@@ -16,6 +17,7 @@ import {
   sExportsReact,
   sExportsReactCompat,
   sExportsReactInternal,
+  sExportsReactRuntimeComponents,
   sExportsReactLepus,
   target,
 } from './target.js';
@@ -43,6 +45,13 @@ Object.defineProperty(target, sExportsReactLepus, {
 
 Object.defineProperty(target, sExportsReactInternal, {
   value: ReactInternal,
+  enumerable: false,
+  writable: false,
+  configurable: true,
+});
+
+Object.defineProperty(target, sExportsReactRuntimeComponents, {
+  value: ReactRuntimeComponents,
   enumerable: false,
   writable: false,
   configurable: true,

--- a/packages/react/runtime/lazy/runtime-components.js
+++ b/packages/react/runtime/lazy/runtime-components.js
@@ -1,0 +1,10 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { sExportsReactRuntimeComponents, target } from './target.js';
+
+export const {
+  Page,
+  DeferredListItem,
+} = target[sExportsReactRuntimeComponents];

--- a/packages/react/runtime/lazy/target.js
+++ b/packages/react/runtime/lazy/target.js
@@ -7,6 +7,7 @@ export const sExportsReact = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react)'
 export const sExportsReactCompat = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react/compat)');
 export const sExportsReactLepus = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react/lepus)');
 export const sExportsReactInternal = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react/internal)');
+export const sExportsReactRuntimeComponents = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react/runtime-components)');
 export const sExportsJSXRuntime = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react/jsx-runtime)');
 export const sExportsJSXDevRuntime = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react/jsx-dev-runtime)');
 export const sExportsLegacyReactRuntime = Symbol.for('__REACT_LYNX_EXPORTS__(@lynx-js/react/legacy-react-runtime)');


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

The [`Page`](https://github.com/lynx-family/lynx-stack/blob/353312e019539895fa386dca2dafe5f001e10e6d/packages/react/components/src/Page.ts#L13) component has a singleton `pageMounted` variable. It should be shared between the main and lazy bundles to make it work properly in lazy bundle.

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime-components exports to be accessible from both main and lazy bundles, ensuring consistent API availability across bundle types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
