### PR TITLE
feat(template-webpack-plugin): remove initialize compiler hooks

### DIFF
--- a/.changeset/thin-webs-enjoy.md
+++ b/.changeset/thin-webs-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Remove `compiler.hooks.initialize` as [it's not called in child compilers](https://github.com/web-infra-dev/rspack/blob/aa4ad886b900770787ecddd625d3e24a51b6b99c/packages/rspack/src/rspack.ts#L78).


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

1. `compiler.hooks.initialize` will not be called in child compilers, [it is only called once in main compiler](https://github.com/web-infra-dev/rspack/blob/aa4ad886b900770787ecddd625d3e24a51b6b99c/packages/rspack/src/rspack.ts#L78).
```js
// the example of using `LynxTemplatePlugin` in child compiler
import { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'

loaderContext._compilation.createChildCompiler(
  'child-compiler-name',
  {},
  [
     new LynxTemplatePlugin({ /* options */ })
  ]
)
```

2. Maybe it is not necessary to wrap in `compiler.hooks.initialize`.

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the webpack template plugin was not properly initializing in child compiler scenarios.

* **Chores**
  * Added patch-level changeset for @lynx-js/template-webpack-plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
