### PR TITLE
fix(web): bindtap detail should contain x, y

### DIFF
--- a/.changeset/modern-windows-doubt.md
+++ b/.changeset/modern-windows-doubt.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: The `e.detail` in the `bindtap` callback needs to correctly include `x` and `y`.

--- a/packages/web-platform/offscreen-document/src/main/initOffscreenDocument.ts
+++ b/packages/web-platform/offscreen-document/src/main/initOffscreenDocument.ts
@@ -18,6 +18,8 @@ const otherPropertyNames = [
   'touches',
   'targetTouches',
   'changedTouches',
+  'x',
+  'y',
 ];
 const blockList = new Set([
   'isTrusted',

--- a/packages/web-platform/web-mainthread-apis/src/utils/createCrossThreadEvent.ts
+++ b/packages/web-platform/web-mainthread-apis/src/utils/createCrossThreadEvent.ts
@@ -37,6 +37,7 @@ export function createCrossThreadEvent(
   const params: Cloneable = {};
   const isTrusted = domEvent.isTrusted;
   const otherProperties: CloneableObject = {};
+  let detail = domEvent.detail ?? {};
   if (type.match(/^transition/)) {
     Object.assign(params, {
       'animation_type': 'keyframe-animation',
@@ -79,6 +80,11 @@ export function createCrossThreadEvent(
       clientX: mouseEvent.clientX,
       clientY: mouseEvent.clientY,
     });
+  } else if (type === 'click') {
+    detail = {
+      x: (domEvent as MouseEvent).x,
+      y: (domEvent as MouseEvent).y,
+    };
   }
   const currentTargetDatasetString = currentTargetElement?.getAttribute(
     lynxDatasetAttribute,
@@ -109,7 +115,7 @@ export function createCrossThreadEvent(
       }
       : null,
     // @ts-expect-error
-    detail: domEvent.detail ?? {},
+    detail,
     params,
     ...otherProperties,
   };

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -118,6 +118,17 @@ test.describe('reactlynx3 tests', () => {
       await wait(100);
       await expect(await target.getAttribute('style')).toContain('pink');
     });
+    test('basic-bindtap-detail', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      const target = page.locator('#target');
+      await target.click();
+      await wait(100);
+      await expect(await target.getAttribute('style')).toContain('green');
+      await target.click();
+      await wait(100);
+      await expect(await target.getAttribute('style')).toContain('pink');
+    });
     test('basic-event-target-id', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);

--- a/packages/web-platform/web-tests/tests/react/basic-bindtap-detail/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-bindtap-detail/index.jsx
@@ -1,0 +1,25 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useState, root } from '@lynx-js/react';
+function App() {
+  const [color, setColor] = useState('pink');
+  const handleTap = (e) => {
+    if (typeof e.detail.x === 'number' && typeof e.detail.y === 'number') {
+      setColor(color === 'pink' ? 'green' : 'pink');
+    }
+  };
+
+  return (
+    <view
+      id='target'
+      bindtap={handleTap}
+      style={{
+        height: '100px',
+        width: '100px',
+        background: color,
+      }}
+    />
+  );
+}
+root.render(<App />);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * bindtap events now include accurate x and y coordinates in event detail, so tap handlers can access pointer position.

* **Tests**
  * Added a test that verifies bindtap detail includes coordinates and that handlers respond accordingly.

* **Chores**
  * Recorded a changeset entry and ensured offscreen event handling includes x and y in transferred event data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
