### PR TITLE
feat(web): add __GetSourceMapRelease API for nativeApp

### DIFF
--- a/.changeset/rich-boxes-sing.md
+++ b/.changeset/rich-boxes-sing.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/web-worker-runtime": patch
+"@lynx-js/web-constants": patch
+---
+
+feat: add \_\_GetSourceMapRelease API for nativeApp.

--- a/packages/web-platform/web-constants/src/types/NativeApp.ts
+++ b/packages/web-platform/web-constants/src/types/NativeApp.ts
@@ -222,6 +222,7 @@ export interface NativeApp {
 
   reportException: (error: Error, _: unknown) => void;
   __SetSourceMapRelease: (err: Error) => void;
+  __GetSourceMapRelease: (url: string) => string | undefined;
 
   queryComponent: (
     source: string,

--- a/packages/web-platform/web-tests/tests/web-core.test.ts
+++ b/packages/web-platform/web-tests/tests/web-core.test.ts
@@ -690,4 +690,27 @@ test.describe('web core tests', () => {
     await wait(500);
     expect(height).toBe('100px');
   });
+  test('source-map-release', async ({ page, browserName }) => {
+    // firefox not support
+    test.skip(browserName === 'firefox');
+    await goto(page);
+    const mainWorker = await getMainThreadWorker(page);
+    await mainWorker.evaluate(() => {
+      globalThis.runtime.renderPage = () => {};
+    });
+    const backWorker = await getBackgroundThreadWorker(page);
+    const isSuccess = await backWorker.evaluate(() => {
+      return new Promise(resolve => {
+        globalThis.runtime.lynx.getNativeApp().__SetSourceMapRelease({
+          message: 'd73160119ef7e77776246caca2a7b98e',
+        });
+        resolve(
+          globalThis.runtime.lynx.getNativeApp().__GetSourceMapRelease()
+            === 'd73160119ef7e77776246caca2a7b98e',
+        );
+      });
+    });
+    await wait(1000);
+    expect(isSuccess).toBeTruthy();
+  });
 });

--- a/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-worker-runtime/src/backgroundThread/background-apis/createNativeApp.ts
@@ -142,6 +142,7 @@ export async function createNativeApp(
     i18nResource,
     reportException: (err: Error, _: unknown) => reportError(err, _, release),
     __SetSourceMapRelease: (err: Error) => release = err.message,
+    __GetSourceMapRelease: (_url: string) => release,
     queryComponent: (source, callback) => {
       if (templateCache.has(source)) {
         callback({ __hasReady: true });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new native app interface capability to retrieve source map release information associated with specific resource URLs.

* **Tests**
  * Added test coverage validating the source map release retrieval feature and its integration with the existing system across multiple environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
