### PR TITLE
fix(rspeedy/react)!: remove `experiments.layers`

### DIFF
--- a/.changeset/sharp-plants-repair.md
+++ b/.changeset/sharp-plants-repair.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": minor
+---
+
+**BREAKING CHANGE**: Require `@lynx-js/rspeedy` 0.12.0.

--- a/packages/rspeedy/plugin-react/src/loaders.ts
+++ b/packages/rspeedy/plugin-react/src/loaders.ts
@@ -21,15 +21,6 @@ export function applyLoaders(
   } = options
 
   api.modifyBundlerChain((chain, { CHAIN_ID }) => {
-    const experiments = chain.get(
-      'experiments',
-    ) as Rspack.Configuration['experiments']
-
-    chain.experiments({
-      ...experiments,
-      layers: true,
-    })
-
     const rule = chain.module.rules.get(CHAIN_ID.RULE.JS)
     // The Rsbuild default loaders:
     // - Rspack:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * This release requires @lynx-js/rspeedy version 0.12.0 or higher
  * Rsbuild experiments configuration is no longer automatically managed by the React plugin

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolve the deprecated warning of Rspack 1.6:

```
(node:48125) DeprecationWarning: `experiments.layers` config has been deprecated and will be removed in Rspack v2.0. Feature layers will be always enabled. Please remove this option from your Rspack configuration.
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
