### PR TITLE
feat(rspeedy): support lynx environment variant `lynx-` and `web-`

### DIFF
--- a/.changeset/blue-bats-tease.md
+++ b/.changeset/blue-bats-tease.md
@@ -1,0 +1,6 @@
+---
+'@lynx-js/rspeedy': patch
+'@lynx-js/react-rsbuild-plugin': patch
+---
+
+Support environment variants to enable multiple configurations for the same targets.

--- a/packages/rspeedy/core/src/utils/is-lynx.ts
+++ b/packages/rspeedy/core/src/utils/is-lynx.ts
@@ -5,7 +5,8 @@
 import type { EnvironmentContext } from '@rsbuild/core'
 
 export function isLynx(environment: EnvironmentContext | string): boolean {
-  return typeof environment === 'string'
-    ? environment === 'lynx'
-    : environment.name === 'lynx'
+  const environmentName = typeof environment === 'string'
+    ? environment
+    : environment.name
+  return environmentName === 'lynx' || environmentName.startsWith('lynx-')
 }

--- a/packages/rspeedy/core/src/utils/is-web.ts
+++ b/packages/rspeedy/core/src/utils/is-web.ts
@@ -5,7 +5,8 @@
 import type { EnvironmentContext } from '@rsbuild/core'
 
 export function isWeb(environment: EnvironmentContext | string): boolean {
-  return typeof environment === 'string'
-    ? environment === 'web'
-    : environment.name === 'web'
+  const environmentName = typeof environment === 'string'
+    ? environment
+    : environment.name
+  return environmentName === 'web' || environmentName.startsWith('web-')
 }

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -61,7 +61,9 @@ export function applyEntry(
   api.modifyBundlerChain(async (chain, { environment, isDev, isProd }) => {
     const entries = chain.entryPoints.entries() ?? {}
     const isLynx = environment.name === 'lynx'
+      || environment.name.startsWith('lynx-')
     const isWeb = environment.name === 'web'
+      || environment.name.startsWith('web-')
     const { hmr, liveReload } = environment.config.dev ?? {}
     const enabledHMR = isDev && !isWeb && hmr !== false
     const enabledLiveReload = isDev && !isWeb && liveReload !== false

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -4,7 +4,7 @@
 import { createRequire } from 'node:module'
 import path from 'node:path'
 
-import type { RsbuildInstance } from '@rsbuild/core'
+import type { RsbuildInstance, Rspack } from '@rsbuild/core'
 import { describe, expect, test, vi } from 'vitest'
 
 import type { ReactWebpackPlugin } from '@lynx-js/react-webpack-plugin'
@@ -2352,6 +2352,106 @@ describe('Config', () => {
       'workletRuntimePath',
       require.resolve('@lynx-js/react/worklet-runtime'),
     )
+  })
+
+  describe('environment', () => {
+    test('lynx environment', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          environments: { lynx: {} },
+          plugins: [
+            pluginReactLynx(),
+          ],
+        },
+      })
+
+      const configs = await rspeedy.initConfigs()
+
+      expect(configs.length).toBe(1)
+
+      expect(configs[0]!.name).toBe('lynx')
+    })
+
+    test('lynx variant environment', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          environments: {
+            lynx: {},
+            'lynx-foo': { output: { distPath: 'dist/foo' } },
+          },
+          plugins: [
+            pluginReactLynx(),
+          ],
+        },
+      })
+
+      const configs = await rspeedy.initConfigs()
+
+      expect(configs.length).toBe(2)
+
+      expect(configs[0]!.name).toBe('lynx')
+      expect(configs[1]!.name).toBe('lynx-foo')
+      // only lynx output will be emitted to `.rspeedy`
+      expect(
+        (configs[1]?.entry as Record<string, Rspack.EntryDescription>)?.['main']
+          ?.filename,
+      ).toBe('.rspeedy/main/background.js')
+    })
+
+    test('web environment', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          environments: { web: {} },
+          plugins: [
+            pluginReactLynx(),
+          ],
+        },
+      })
+
+      const configs = await rspeedy.initConfigs()
+
+      expect(configs.length).toBe(1)
+
+      expect(configs[0]!.name).toBe('web')
+    })
+
+    test('web variant environment', async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          environments: {
+            web: {},
+            'web-foo': { output: { distPath: 'dist/foo' } },
+          },
+          plugins: [
+            pluginReactLynx(),
+          ],
+        },
+      })
+
+      const configs = await rspeedy.initConfigs()
+
+      expect(configs.length).toBe(2)
+
+      expect(configs[0]!.name).toBe('web')
+      expect(configs[1]!.name).toBe('web-foo')
+
+      expect(
+        (configs[0]?.entry as Record<string, Rspack.EntryDescription>)?.['main']
+          ?.filename,
+      ).toBe('main/background.js')
+      expect(
+        (configs[1]?.entry as Record<string, Rspack.EntryDescription>)?.['main']
+          ?.filename,
+      ).toBe('main/background.js')
+    })
   })
 })
 


### PR DESCRIPTION
Support lynx environment variant `lynx-` to build different lynx outputs with different lynx environment configs.

```js
import { defineConfig } from '@lynx-js/rspeedy';

export default defineConfig({
  environment: {
    lynx: {
      output: {
        distPath: { root: 'dist/default' },
      },
    },
    'lynx-foo': {
      output: {
        distPath: { root: 'dist/foo' },
        minify: false,
      },
    },
  },
});
```

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variants now supported, enabling multiple configurations for the same targets via broader environment identification (e.g., variant prefixes).

* **Tests**
  * Expanded test coverage for environment variants and configuration behaviors, including variant naming and output/emission scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
