### PR TITLE
chore: only enable bundle analysis for Lynx

### DIFF
--- a/examples/react/lynx.config.js
+++ b/examples/react/lynx.config.js
@@ -14,11 +14,12 @@ export default defineConfig({
       },
     }),
   ],
-  performance: {
-    profile: enableBundleAnalysis,
-  },
   environments: {
     web: {},
-    lynx: {},
+    lynx: {
+      performance: {
+        profile: enableBundleAnalysis,
+      },
+    },
   },
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized performance profiling configuration to be environment-specific rather than globally configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

When using multiple environments with `performance.profile: true`, the `stat.json` could be randomly generated for one of the environments. Results in incorrect bundle size check.

See: https://github.com/lynx-family/lynx-stack/pull/1966#issuecomment-3588177872

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
