### PR TITLE
fix(web): capture event listener should be called before bind event l…

### DIFF
--- a/.changeset/sixty-jeans-lie.md
+++ b/.changeset/sixty-jeans-lie.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: capture and bind event listener should be trigger correctly

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -874,6 +874,23 @@ test.describe('reactlynx3 tests', () => {
         'rgb(0, 128, 0)',
       ); // green;
     });
+
+    test('basic-event-target-trigger', async ({ page }, { title }) => {
+      await goto(page, 'basic-event-trigger');
+      await page.locator('#target1').click();
+      await wait(100);
+      await expect(page.locator('#target')).toHaveText(
+        '[capture tap][bind tap]',
+      );
+    });
+    test('basic-event-child-trigger', async ({ page }, { title }) => {
+      await goto(page, 'basic-event-trigger');
+      await page.locator('#target2').click();
+      await wait(100);
+      await expect(page.locator('#target')).toHaveText(
+        '[capture tap][bind tap]',
+      );
+    });
   });
   test.describe('basic-css', () => {
     test('basic-css-asset-in-css', async ({ page }, { title }) => {

--- a/packages/web-platform/web-tests/tests/react/basic-event-trigger/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-event-trigger/index.jsx
@@ -1,0 +1,35 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+function App() {
+  const [text, setText] = useState('');
+
+  const handleCaptureTap = () => {
+    setText(text + '[capture tap]');
+  };
+  const handleTap = () => {
+    setText(text + '[bind tap]');
+  };
+
+  return (
+    <view
+      id='target1'
+      style={{ width: '400px', height: '400px', background: 'pink' }}
+      capture-bindtap={handleCaptureTap}
+      bindtap={handleTap}
+    >
+      <view
+        style={{ width: '50px', height: '50px', background: 'green' }}
+        id='target2'
+      >
+      </view>
+      <text id='target'>{text}</text>
+    </view>
+  );
+}
+root.render(
+  <page>
+    <App></App>
+  </page>,
+);


### PR DESCRIPTION
…istener

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed event listener capture and bind functionality to trigger correctly during different event phases (capturing vs. bubbling).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
