### PR TITLE
fix: avoid injecting hot update runtime

### DIFF
--- a/.changeset/five-turtles-turn.md
+++ b/.changeset/five-turtles-turn.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Avoid injecting hot update runtime when dev.hmr or dev.liveReload is set to false.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 packages/web-platform/** @pupiltong
 packages/webpack/** @colinaaa @upupming
 packages/rspeedy/** @colinaaa @upupming
+packages/rspeedy/plugin-react/** @upupming
 packages/react/** @hzy @HuJean
 packages/react/transform/** @gaoachao
 benchmark/react/** @hzy @HuJean

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -1356,8 +1356,8 @@ describe('Config', () => {
           "main": {
             "filename": ".rspeedy/main/background.js",
             "import": [
-              "@lynx-js/react/refresh",
               "@lynx-js/webpack-dev-transport/client",
+              "@lynx-js/react/refresh",
               "@rspack/core/hot/dev-server",
               "./fixtures/basic.tsx",
             ],
@@ -1406,8 +1406,8 @@ describe('Config', () => {
           "main": {
             "filename": ".rspeedy/main/background.[contenthash].js",
             "import": [
-              "@lynx-js/react/refresh",
               "@lynx-js/webpack-dev-transport/client",
+              "@lynx-js/react/refresh",
               "@rspack/core/hot/dev-server",
               "./fixtures/basic.tsx",
             ],
@@ -2076,8 +2076,8 @@ describe('Config', () => {
             "main": {
               "filename": ".rspeedy/main/background.[contenthash:8].js",
               "import": [
-                "@lynx-js/react/refresh",
                 "@lynx-js/webpack-dev-transport/client",
+                "@lynx-js/react/refresh",
                 "@rspack/core/hot/dev-server",
                 "./src/index.js",
               ],

--- a/packages/rspeedy/plugin-react/test/hotUpdate.test.ts
+++ b/packages/rspeedy/plugin-react/test/hotUpdate.test.ts
@@ -1,0 +1,153 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test, vi } from 'vitest'
+
+import { createStubRspeedy as createRspeedy } from './createRspeedy.js'
+
+vi.stubEnv('USE_RSPACK', 'true').stubEnv('NODE_ENV', 'development')
+
+describe('hot update', () => {
+  test('should prepend hot update runtime in development mode', async () => {
+    const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        plugins: [
+          pluginReactLynx(),
+        ],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+    expect(config.entry).toMatchInlineSnapshot(`
+      {
+        "main": {
+          "filename": ".rspeedy/main/background.js",
+          "import": [
+            "@lynx-js/webpack-dev-transport/client",
+            "@lynx-js/react/refresh",
+            "@rspack/core/hot/dev-server",
+            "./src/index.js",
+          ],
+          "layer": "react:background",
+        },
+        "main__main-thread": {
+          "filename": ".rspeedy/main/main-thread.js",
+          "import": [
+            "<WORKSPACE>/packages/webpack/css-extract-webpack-plugin/runtime/hotModuleReplacement.lepus.cjs",
+            "./src/index.js",
+          ],
+          "layer": "react:main-thread",
+        },
+      }
+    `)
+  })
+
+  test('should prepend hot update runtime when liveReload is set to false', async () => {
+    const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        dev: {
+          liveReload: false,
+        },
+        plugins: [
+          pluginReactLynx(),
+        ],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+    expect(config.entry).toMatchInlineSnapshot(`
+      {
+        "main": {
+          "filename": ".rspeedy/main/background.js",
+          "import": [
+            "@lynx-js/webpack-dev-transport/client",
+            "@lynx-js/react/refresh",
+            "@rspack/core/hot/dev-server",
+            "./src/index.js",
+          ],
+          "layer": "react:background",
+        },
+        "main__main-thread": {
+          "filename": ".rspeedy/main/main-thread.js",
+          "import": [
+            "<WORKSPACE>/packages/webpack/css-extract-webpack-plugin/runtime/hotModuleReplacement.lepus.cjs",
+            "./src/index.js",
+          ],
+          "layer": "react:main-thread",
+        },
+      }
+    `)
+  })
+
+  test('should not prepend refresh runtime when hmr is set to false', async () => {
+    const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        dev: {
+          hmr: false,
+        },
+        plugins: [
+          pluginReactLynx(),
+        ],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+    expect(config.entry).toMatchInlineSnapshot(`
+      {
+        "main": {
+          "filename": ".rspeedy/main/background.js",
+          "import": [
+            "@lynx-js/webpack-dev-transport/client",
+            "./src/index.js",
+          ],
+          "layer": "react:background",
+        },
+        "main__main-thread": {
+          "filename": ".rspeedy/main/main-thread.js",
+          "import": [
+            "./src/index.js",
+          ],
+          "layer": "react:main-thread",
+        },
+      }
+    `)
+  })
+
+  test('should not prepend dev runtime when hmr and liveReload is set to false both', async () => {
+    const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        dev: {
+          hmr: false,
+          liveReload: false,
+        },
+        plugins: [
+          pluginReactLynx(),
+        ],
+      },
+    })
+
+    const [config] = await rsbuild.initConfigs()
+    expect(config.entry).toMatchInlineSnapshot(`
+      {
+        "main": {
+          "filename": ".rspeedy/main/background.js",
+          "import": [
+            "./src/index.js",
+          ],
+          "layer": "react:background",
+        },
+        "main__main-thread": {
+          "filename": ".rspeedy/main/main-thread.js",
+          "import": [
+            "./src/index.js",
+          ],
+          "layer": "react:main-thread",
+        },
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Closed https://github.com/lynx-family/lynx-stack/issues/1977

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * React plugin now respects dev.hmr and dev.liveReload flags and avoids injecting hot-update runtimes when those are disabled.

* **Bug Fix / Behavior**
  * Adjusted ordering of dev-time runtime imports to ensure correct layering of transport and refresh runtimes.

* **Tests**
  * Added comprehensive tests covering hot-update/runtime injection across HMR and live-reload configurations.

* **Chores**
  * Added a patch changeset and CODEOWNERS entry for the React plugin.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
