### PR TITLE
fix(web): fix reload lynx-view when  false may cause css style lost

### DIFF
--- a/.changeset/nasty-pens-love.md
+++ b/.changeset/nasty-pens-love.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: fix reload lynx-view when `enableCSSSelector` false may cause css style lost

--- a/packages/web-platform/web-core-server/src/createLynxView.ts
+++ b/packages/web-platform/web-core-server/src/createLynxView.ts
@@ -205,6 +205,7 @@ export async function createLynxView(
         ]);
       },
     },
+    threadStrategy === 'all-on-ui',
   );
   await startMainThread({
     template,

--- a/packages/web-platform/web-core/src/uiThread/createRenderAllOnUI.ts
+++ b/packages/web-platform/web-core/src/uiThread/createRenderAllOnUI.ts
@@ -144,6 +144,8 @@ export function createRenderAllOnUI(
       return i18nResources;
     },
     loadTemplate,
+    undefined,
+    true,
   );
 
   const start = async (configs: StartMainThreadContextConfig) => {

--- a/packages/web-platform/web-mainthread-apis/ts/prepareMainThreadAPIs.ts
+++ b/packages/web-platform/web-mainthread-apis/ts/prepareMainThreadAPIs.ts
@@ -54,6 +54,7 @@ export function prepareMainThreadAPIs(
   initialI18nResources: (data: InitI18nResources) => I18nResources,
   loadTemplate: TemplateLoader,
   ssrHooks?: SSRDehydrateHooks,
+  allOnUI?: boolean,
 ) {
   const postTimingFlags = backgroundThreadRpc.createCall(
     postTimingFlagsEndpoint,
@@ -110,6 +111,7 @@ export function prepareMainThreadAPIs(
       rootDom as unknown as Node,
       document,
       ssrHydrateInfo,
+      allOnUI,
     );
     const mtsGlobalThisRef: { mtsGlobalThis: MainThreadGlobalThis } = {
       mtsGlobalThis: undefined as unknown as MainThreadGlobalThis,

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -1840,6 +1840,23 @@ test.describe('reactlynx3 tests', () => {
       },
     );
     test(
+      'config-css-selector-false-reload',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        await expect(
+          page.locator('#target'),
+        ).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+        await page.evaluate(() => {
+          document.querySelector('lynx-view')?.reload();
+        });
+        await wait(1000);
+        await expect(
+          page.locator('#target'),
+        ).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+      },
+    );
+    test(
       'config-css-remove-scope-false-import-css',
       async ({ page }, { title }) => {
         await goto(page, title);

--- a/packages/web-platform/web-tests/tests/react/config-css-selector-false-reload/index.css
+++ b/packages/web-platform/web-tests/tests/react/config-css-selector-false-reload/index.css
@@ -1,0 +1,11 @@
+/*
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+.parent {
+  width: 200px;
+  height: 200px;
+  background-color: red;
+}

--- a/packages/web-platform/web-tests/tests/react/config-css-selector-false-reload/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/config-css-selector-false-reload/index.jsx
@@ -1,0 +1,15 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, Component } from '@lynx-js/react';
+import './index.css';
+export default class App extends Component {
+  render() {
+    return (
+      <view id='target' class='parent'>
+      </view>
+    );
+  }
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
+++ b/packages/web-platform/web-worker-runtime/src/mainThread/startMainThread.ts
@@ -113,6 +113,8 @@ export async function startMainThreadWorker(
       return i18nResources;
     },
     loadTemplate,
+    undefined,
+    false,
   );
   uiThreadRpc.registerHandler(
     mainThreadStartEndpoint,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where CSS styles could be lost when reloading a lynx-view with CSS selector handling disabled, preserving styles across reloads.

* **Tests**
  * Added an end-to-end test page, stylesheet, and test case to verify styling remains unchanged after reloading the lynx-view when CSS selector configuration is disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
