### PR TITLE
fix(web): web-explorer needs to actively send an iframeReady message …

### DIFF
--- a/.changeset/few-rats-doubt.md
+++ b/.changeset/few-rats-doubt.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-explorer": patch
+---
+
+fix: web-explorer needs to actively send an iframeReady message to the parent, the parent uses `iframe load` listener cannot guarantee that the `message-listener` will complete execution.

--- a/packages/web-platform/web-explorer/index.ts
+++ b/packages/web-platform/web-explorer/index.ts
@@ -41,6 +41,11 @@ window.addEventListener('message', (ev) => {
     setLynxViewUrl(ev.data.url);
   }
 });
+const iframeId = new URLSearchParams(window.location.search).get('iframeId');
+window.parent.postMessage({
+  method: 'iframeReady',
+  iframeId,
+}, '*');
 
 function setLynxViewUrl(url: string) {
   const theme = window.matchMedia('(prefers-color-scheme: dark)').matches


### PR DESCRIPTION
…to the parent

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the iframe readiness signal was not consistently reaching the parent window, improving initialization reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
