### PR TITLE
fix(react): fix 'ctx not found' when using suspense 

### DIFF
--- a/.changeset/thirty-buttons-design.md
+++ b/.changeset/thirty-buttons-design.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/react': patch
+---
+
+Fix a bug where React throws `CtxNotFound` error when lazy bundle resolves after unmount.

--- a/packages/react/runtime/__test__/lynx/suspense.test.jsx
+++ b/packages/react/runtime/__test__/lynx/suspense.test.jsx
@@ -1503,7 +1503,7 @@ describe('suspense', () => {
     }
   });
 
-  it('repro: resolves after unmount may insertBefore on a torn-down parent', async () => {
+  it('should not update torn-down parent when lazy resolves after unmount', async () => {
     // Repro steps:
     // 1) Mount a Suspense boundary with a lazy child so it suspends and shows fallback.
     // 2) Unmount the entire subtree and apply the unmount patch on the main thread.
@@ -1614,32 +1614,7 @@ describe('suspense', () => {
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
 
       expect(prettyFormatSnapshotPatch(JSON.parse(rLynxChange[1].data).patchList[0].snapshotPatch))
-        .toMatchInlineSnapshot(`
-          [
-            {
-              "id": 3,
-              "op": "CreateElement",
-              "type": "wrapper",
-            },
-            {
-              "id": 4,
-              "op": "CreateElement",
-              "type": "__snapshot_a94a8_test_34",
-            },
-            {
-              "beforeId": null,
-              "childId": 4,
-              "op": "InsertBefore",
-              "parentId": 3,
-            },
-            {
-              "beforeId": null,
-              "childId": 3,
-              "op": "InsertBefore",
-              "parentId": -4,
-            },
-          ]
-        `);
+        .toMatchInlineSnapshot(`[]`);
 
       globalEnvManager.switchToMainThread();
 
@@ -1653,18 +1628,7 @@ describe('suspense', () => {
 
       // snapshotPatchApply should emit a ctx-not-found event back to BG,
       // which is converted into a lynx.reportError in error.ts.
-      expect(lynx.getJSContext().dispatchEvent.mock.calls).toMatchInlineSnapshot(`
-        [
-          [
-            {
-              "data": {
-                "id": -4,
-              },
-              "type": "Lynx.Error.CtxNotFound",
-            },
-          ],
-        ]
-      `);
+      expect(lynx.getJSContext().dispatchEvent.mock.calls).toMatchInlineSnapshot(`[]`);
     }
   });
 });

--- a/packages/react/runtime/src/backgroundSnapshot.ts
+++ b/packages/react/runtime/src/backgroundSnapshot.ts
@@ -67,6 +67,17 @@ export class BackgroundSnapshotInstance {
   private __nextSibling: BackgroundSnapshotInstance | null = null;
   private __removed_from_tree?: boolean;
 
+  private get isDetached(): boolean {
+    let node: BackgroundSnapshotInstance | null = this;
+    while (node) {
+      if (node.__removed_from_tree) {
+        return true;
+      }
+      node = node.__parent;
+    }
+    return false;
+  }
+
   get parentNode(): BackgroundSnapshotInstance | null {
     return this.__parent;
   }
@@ -85,7 +96,9 @@ export class BackgroundSnapshotInstance {
 
   // This will be called in `lazy`/`Suspense`.
   appendChild(child: BackgroundSnapshotInstance): void {
-    return this.insertBefore(child);
+    if (!this.isDetached) {
+      return this.insertBefore(child);
+    }
   }
 
   insertBefore(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an error that occurred when lazy components resolved after their parent component unmounted.

* **New Features**
  * `lazy` and `useState` are now exported as part of the public API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
