### PR TITLE
chore: mark the "multi-thread" deprecated

### DIFF
--- a/.changeset/curvy-stars-kneel.md
+++ b/.changeset/curvy-stars-kneel.md
@@ -1,0 +1,13 @@
+---
+"@lynx-js/web-core": patch
+---
+
+chore: mark the "multi-thread" deprecated
+
+**NOTICE This will be a breaking change in the future**
+
+mark the thread strategy "multi-thread" as deprecated.
+
+Please use "all-on-ui" instead. If you still want to use multi-thread mode, please try to use a cross-origin isolated iframe.
+
+A console warning will be printed if `thread-strategy` is set to `multi-thread`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,12 +87,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        thread: [MULTI_THREAD, ALL_ON_UI]
+        thread: [ALL_ON_UI]
         render: [SSR, CSR]
         shard: [1, 2, 3, 4]
-        exclude:
-          - thread: MULTI_THREAD
-            render: SSR
+        # exclude:
+        #   - thread: MULTI_THREAD
+        #     render: SSR
     with:
       runs-on: lynx-custom-container
       is-web: true

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -54,7 +54,6 @@ export type INapiModulesCall = (
  * @property {"false" | "true" | null} injectHeadLinks [optional] (attribute: "inject-head-links") @default true set it to "false" to disable injecting the <link href="" ref="stylesheet"> styles into shadowroot
  * @property {string[]} injectStyleRules [optional] the css rules which will be injected into shadowroot. Each items will be inserted by `insertRule` method. @see https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/insertRule
  * @property {number} lynxGroupId [optional] (attribute: "lynx-group-id") the background shared context id, which is used to share webworker between different lynx cards
- * @property {"all-on-ui" | "multi-thread"} threadStrategy [optional] @default "multi-thread" (attribute: "thread-strategy") controls the thread strategy for current lynx view
  * @property {(string)=>Promise<LynxTemplate>} customTemplateLoader [optional] the custom template loader, which is used to load the template
  * @property {InitI18nResources} initI18nResources [optional] (attribute: "init-i18n-resources") the complete set of i18nResources that on the container side, which can be obtained synchronously by _I18nResourceTranslation
  *
@@ -344,6 +343,7 @@ export class LynxView extends HTMLElement {
   /**
    * @param
    * @property
+   * @deprecated multi-thread is deprecated, please use "all-on-ui" instead. If you still want to use multi-thread mode, please try to use a cross-origin isolated iframe.
    */
   get threadStrategy(): 'all-on-ui' | 'multi-thread' {
     // @ts-expect-error
@@ -431,6 +431,11 @@ export class LynxView extends HTMLElement {
           const threadStrategy = (this.threadStrategy ?? 'all-on-ui') as
             | 'all-on-ui'
             | 'multi-thread';
+          if (threadStrategy === 'multi-thread') {
+            console.warn(
+              `[LynxView] multi-thread strategy is deprecated, please use "all-on-ui" instead. If you still want to use multi-thread mode, please try to use a cross-origin isolated iframe.`,
+            );
+          }
           const lynxView = createLynxView({
             threadStrategy,
             tagMap,


### PR DESCRIPTION
**NOTICE This will be a breaking change in the future**

mark the thread strategy "multi-thread" as deprecated.

Please use "all-on-ui" instead. If you still want to use multi-thread mode, please try to use a cross-origin isolated iframe.

A console warning will be printed if `thread-strategy` is set to `multi-thread`.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * The "multi-thread" thread strategy is now deprecated. Console warnings appear when this strategy is used, alerting users to the deprecation status. Migration to the "all-on-ui" strategy is recommended, with a cross-origin isolated iframe available as an alternative for continued multi-thread functionality if needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
