### PR TITLE
feat:  support lazy message port assigning in web-worker-rpc

### DIFF
--- a/.changeset/curvy-knives-wink.md
+++ b/.changeset/curvy-knives-wink.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-worker-rpc": patch
+---
+
+feat: support lazy message port assigning in web-worker-rpc

--- a/packages/web-platform/web-worker-rpc/test/endpoints.js
+++ b/packages/web-platform/web-worker-rpc/test/endpoints.js
@@ -53,3 +53,10 @@ export const changeLazyHandler = createRpcEndpoint(
   true,
   false,
 );
+
+export const callbackifyEndpoint = createRpcEndpoint(
+  'callbackify',
+  false,
+  true,
+  false,
+);

--- a/packages/web-platform/web-worker-rpc/test/worker.js
+++ b/packages/web-platform/web-worker-rpc/test/worker.js
@@ -10,6 +10,7 @@ import {
   testLazy,
   addAsyncWithTransfer,
   changeLazyHandler,
+  callbackifyEndpoint,
 } from './endpoints.js';
 
 console.log('worker started');
@@ -49,6 +50,9 @@ parentPort.on('message', async (ev) => {
     });
     rpc.registerHandler(changeLazyHandler, () => {
       emptyObj.testLazy = () => 100;
+    });
+    rpc.registerHandler(callbackifyEndpoint, async (a, b) => {
+      return a + b;
     });
     privatePort.postMessage({ type: 'ready' });
   }


### PR DESCRIPTION
This is a part of #1937

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Web-worker-rpc now supports lazy message port assignment, enabling RPC initialization to be deferred until after instance creation.
  * Messages are automatically queued when no port is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
