### PR TITLE
fix: undefined factory error when loading a standalone lazy bundle after hydration

### DIFF
--- a/.changeset/khaki-hands-report.md
+++ b/.changeset/khaki-hands-report.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix `undefined factory (react:background)/./node_modules/.pnpm/@lynx-js+react...` error when loading a standalone lazy bundle after hydration.

--- a/packages/react/runtime/src/snapshot.ts
+++ b/packages/react/runtime/src/snapshot.ts
@@ -140,9 +140,13 @@ export let snapshotCreatorMap: Record<string, (uniqId: string) => string> = {};
 if (__DEV__ && __JS__) {
   snapshotCreatorMap = new Proxy(snapshotCreatorMap, {
     set(target, prop: string, value: (uniqId: string) => string) {
-      // `__globalSnapshotPatch` does not exist before hydration,
-      // so the snapshot of the first screen will not be sent to the main thread.
-      if (__globalSnapshotPatch) {
+      if (
+        // `__globalSnapshotPatch` does not exist before hydration,
+        // so the snapshot of the first screen will not be sent to the main thread.
+        __globalSnapshotPatch
+        // `prop` will be `https://example.com/main.lynx.bundle:__snapshot_835da_eff1e_1` when loading a standalone lazy bundle after hydration.
+        && !prop.includes(':')
+      ) {
         __globalSnapshotPatch.push(
           SnapshotOperation.DEV_ONLY_AddSnapshot,
           prop,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an undefined factory error when loading a standalone lazy bundle after hydration by skipping first-screen snapshot updates for lazy-loaded bundles.

* **Tests**
  * Updated snapshot-patch tests to validate behavior when lazy bundles are loaded after hydration and to assert empty patch state in that scenario.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fix a regression introduced by https://github.com/lynx-family/lynx-stack/pull/1899

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
