### PR TITLE
fix(template-webpack-plugin): pass updated css from encodeData to resolvedEncodeOptions

### DIFF
--- a/.changeset/pass-updated-css-to-encode-options.md
+++ b/.changeset/pass-updated-css-to-encode-options.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+fix: pass updated css from encodeData to resolvedEncodeOptions
+
+Previously, the initial CSS was used in resolvedEncodeOptions instead of the potentially updated CSS from encodeData after the beforeEncode hook. This fix ensures resolvedEncodeOptions receives the latest CSS data.

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -743,7 +743,7 @@ class LynxTemplatePluginImpl {
     const isDev = process.env['NODE_ENV'] === 'development'
       || compiler.options.mode === 'development';
 
-    const css = cssChunksToMap(
+    const initialCSS = cssChunksToMap(
       assetsInfoByGroups.css
         .map(chunk => compilation.getAsset(chunk.name))
         .filter((v): v is Asset => !!v)
@@ -785,7 +785,7 @@ class LynxTemplatePluginImpl {
         },
       },
       css: {
-        ...css,
+        ...initialCSS,
         chunks: assetsInfoByGroups.css,
       },
       lepusCode: {
@@ -817,7 +817,7 @@ class LynxTemplatePluginImpl {
       entryNames,
     });
 
-    const { lepusCode } = encodeData;
+    const { lepusCode, css } = encodeData;
 
     const resolvedEncodeOptions: EncodeOptions = {
       ...encodeData,

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode-css/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode-css/index.js
@@ -1,0 +1,23 @@
+/// <reference types="vitest/globals" />
+
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+it('should have updated css from beforeEncode hook in tasm.json', async () => {
+  const target = path.resolve(
+    __dirname,
+    '.rspeedy',
+    'tasm.json',
+  );
+  expect(existsSync(target)).toBe(true);
+
+  const content = await fs.readFile(target, 'utf-8');
+
+  const { css } = JSON.parse(content);
+
+  expect(css.cssMap).toHaveProperty('1');
+  expect(css.cssSource).toStrictEqual({
+    1: '/cssId/1.css',
+  });
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode-css/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode-css/rspack.config.js
@@ -1,0 +1,3 @@
+import config from './webpack.config.js';
+
+export default config;

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode-css/webpack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode-css/webpack.config.js
@@ -1,0 +1,64 @@
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../src';
+
+/** @type {import('webpack').Configuration} */
+export default {
+  target: 'node',
+  plugins: [
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin(),
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap('test', compilation => {
+        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+          compilation,
+        );
+
+        hooks.beforeEncode.tap(
+          'test-before-encode',
+          (args) => {
+            // Modify the CSS in the hook to simulate what a plugin might do
+            return {
+              ...args,
+              encodeData: {
+                ...args.encodeData,
+                css: {
+                  cssMap: {
+                    '1': [
+                      {
+                        'type': 'StyleRule',
+                        'style': [
+                          {
+                            'name': 'display',
+                            'value': 'flex',
+                            'keyLoc': {
+                              'line': 1,
+                              'column': 14,
+                            },
+                            'valLoc': {
+                              'line': 1,
+                              'column': 20,
+                            },
+                          },
+                        ],
+                        'selectorText': {
+                          'value': '.item',
+                          'loc': {
+                            'line': 1,
+                            'column': 6,
+                          },
+                        },
+                        'variables': {},
+                      },
+                    ],
+                  },
+                  cssSource: {
+                    1: '/cssId/1.css',
+                  },
+                },
+              },
+            };
+          },
+        );
+      });
+    },
+  ],
+};


### PR DESCRIPTION

Previously, the initial CSS was used in resolvedEncodeOptions instead of the potentially updated CSS from encodeData after the beforeEncode hook. This fix renames the initial CSS variable to 'initialCSS' and correctly extracts the updated 'css' from encodeData to ensure resolvedEncodeOptions receives the latest CSS data.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Encoding now uses the updated CSS produced by beforeEncode hooks instead of an earlier snapshot.

* **Tests**
  * Added a test verifying CSS injected/modified by a beforeEncode hook is included in the final encoded output.

* **Chores**
  * Added a patch changelog entry documenting the fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
