### PR TITLE
fix(web): pixelWidth and pixelHeight use client instead of screen

### DIFF
--- a/.changeset/wet-rocks-bathe.md
+++ b/.changeset/wet-rocks-bathe.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/web-core": patch
+"@lynx-js/web-explorer": patch
+---
+
+fix: pixelWidth and pixelHeight use client instead of screen

--- a/packages/web-platform/web-core/src/apis/createLynxView.ts
+++ b/packages/web-platform/web-core/src/apis/createLynxView.ts
@@ -17,8 +17,8 @@ import {
 } from '../uiThread/startUIThread.js';
 import type { RpcCallType } from '@lynx-js/web-worker-rpc';
 const pixelRatio = window.devicePixelRatio;
-const screenWidth = window.screen.availWidth * pixelRatio;
-const screenHeight = window.screen.availHeight * pixelRatio;
+const screenWidth = document.documentElement.clientWidth * pixelRatio;
+const screenHeight = document.documentElement.clientHeight * pixelRatio;
 
 export interface LynxViewConfigs {
   templateUrl: string;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pixelWidth and pixelHeight calculations to accurately measure available viewport space for proper UI rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
