### PR TITLE
fix(webpack/external): globDynamicComponentEntry is not defined

### DIFF
--- a/.changeset/tired-knives-cross.md
+++ b/.changeset/tired-knives-cross.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Fix `globDynamicComponentEntry is not defined` error when minify is enabled in external bundle consumer.

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/MainThreadRuntimeWrapperWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/MainThreadRuntimeWrapperWebpackPlugin.ts
@@ -33,7 +33,9 @@ export class MainThreadRuntimeWrapperWebpackPlugin {
     new BannerPlugin({
       test: this.options.test ?? /\.js$/,
       raw: true,
-      banner: `(function () {   
+      banner: `(function () {
+  // TODO: remove this after \`useModuleWrapper\` supports MTS
+  var globDynamicComponentEntry = '__Card__';
   const module = { exports: {} }
   const exports = module.exports`,
     }).apply(compiler)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a runtime error ("globDynamicComponentEntry is not defined") that occurred when minification was enabled for external bundle consumers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
