### PR TITLE
feat: rename getComputedStyleByKey into getComputedStyleProperty

### DIFF
--- a/.changeset/vast-owls-smell.md
+++ b/.changeset/vast-owls-smell.md
@@ -2,12 +2,14 @@
 '@lynx-js/react': patch
 ---
 
-Add `getComputedStyleByKey` for `MainThread.Element`, now you can measure elements in sync.
+Add `getComputedStyleProperty` for `MainThread.Element` to retrieve computed style values synchronously.
+
+**Requires Lynx SDK >= 3.5**
 
 ```typescript
 function getStyle(ele: MainThread.Element) {
   'main thread';
-  const width = ele.getComputedStyleByKey('width'); // Returns 300px
-  const transformMatrix = ele.getComputedStyleByKey('transform'); // Returns matrix(2, 0, 0, 2, 200, 400)
+  const width = ele.getComputedStyleProperty('width'); // Returns 300px
+  const transformMatrix = ele.getComputedStyleProperty('transform'); // Returns matrix(2, 0, 0, 2, 200, 400)
 }
 ```

--- a/packages/react/worklet-runtime/__test__/api/element.test.js
+++ b/packages/react/worklet-runtime/__test__/api/element.test.js
@@ -109,27 +109,46 @@ describe('Element', () => {
   });
 
   it('should get computed style by key', () => {
+    globalThis.SystemInfo.lynxSdkVersion = '3.5';
     globalThis.__GetComputedStyleByKey.mockReturnValue('16px');
     const element = new Element('element-instance');
-    const value = element.getComputedStyleByKey('fontSize');
+    const value = element.getComputedStyleProperty('fontSize');
     expect(globalThis.__GetComputedStyleByKey).toHaveBeenCalledWith('element-instance', 'fontSize');
     expect(value).toBe('16px');
   });
 
   it('should get computed style for color property', () => {
+    globalThis.SystemInfo.lynxSdkVersion = '3.5';
     globalThis.__GetComputedStyleByKey.mockReturnValue('rgb(255, 0, 0)');
     const element = new Element('element-instance');
-    const value = element.getComputedStyleByKey('color');
+    const value = element.getComputedStyleProperty('color');
     expect(globalThis.__GetComputedStyleByKey).toHaveBeenCalledWith('element-instance', 'color');
     expect(value).toBe('rgb(255, 0, 0)');
   });
 
   it('should get computed style for display property', () => {
+    globalThis.SystemInfo.lynxSdkVersion = '3.5';
     globalThis.__GetComputedStyleByKey.mockReturnValue('flex');
     const element = new Element('element-instance');
-    const value = element.getComputedStyleByKey('display');
+    const value = element.getComputedStyleProperty('display');
     expect(globalThis.__GetComputedStyleByKey).toHaveBeenCalledWith('element-instance', 'display');
     expect(value).toBe('flex');
+  });
+
+  it('should throw when get computed style value with low sdk version', () => {
+    globalThis.SystemInfo.lynxSdkVersion = '3.4';
+    const element = new Element('element-instance');
+    expect(() => element.getComputedStyleProperty('width')).toThrow(
+      'getComputedStyleProperty requires Lynx sdk version 3.5',
+    );
+  });
+
+  it('should throw when get computed style value with empty key', () => {
+    globalThis.SystemInfo.lynxSdkVersion = '3.5';
+    const element = new Element('element-instance');
+    expect(() => element.getComputedStyleProperty('')).toThrow(
+      'getComputedStyleProperty: key is required',
+    );
   });
 
   it('should invoke method and resolve', async () => {

--- a/packages/react/worklet-runtime/src/api/element.ts
+++ b/packages/react/worklet-runtime/src/api/element.ts
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { Animation } from './animation/animation.js';
 import { KeyframeEffect } from './animation/effect.js';
+import { isSdkVersionGt } from '../utils/version.js';
 
 let willFlush = false;
 let shouldFlush = true;
@@ -62,7 +63,16 @@ export class Element {
     });
   }
 
-  public getComputedStyleByKey(key: string): string {
+  public getComputedStyleProperty(key: string): string {
+    if (!isSdkVersionGt(3, 4)) {
+      throw new Error(
+        'getComputedStyleProperty requires Lynx sdk version 3.5',
+      );
+    }
+
+    if (!key) {
+      throw new Error('getComputedStyleProperty: key is required');
+    }
     return __GetComputedStyleByKey(this.element, key);
   }
 


### PR DESCRIPTION
Prior #2005 we have `getComputedStyleByKey`

But there's already [ele.setStyleProperty](https://lynxjs.org/api/lynx-api/main-thread/main-thread-element.html#elementsetstyleproperty) on `MainThread.Element`. 

Changing to `getComputedStyleProperty` for symmetry.

Also, add version and params check for safety.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Element API for retrieving computed styles has been renamed and now requires Lynx SDK 3.5 or higher.
  * Added input validation: calling the API without a valid key now throws a clear error.

* **Documentation**
  * Updated samples and docs to reflect the API rename, SDK requirement, and new validation guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
