### PR TITLE
feat(lynx-bundle-rslib-config): use `LAYERS` exposed by DSL plugins

### DIFF
--- a/.changeset/bitter-waves-sleep.md
+++ b/.changeset/bitter-waves-sleep.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Use `LAYERS` exposed by DSL plugins

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -41,12 +41,6 @@ export interface ExternalBundleWebpackPluginOptions {
 }
 
 // @public
-export const LAYERS: {
-    readonly BACKGROUND: "background";
-    readonly MAIN_THREAD: "main-thread";
-};
-
-// @public
 export class MainThreadRuntimeWrapperWebpackPlugin {
     constructor(options?: Partial<MainThreadRuntimeWrapperWebpackPluginOptions>);
     // (undocumented)

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -25,16 +25,6 @@ export interface EncodeOptions {
 }
 
 /**
- * The Layer name of background and main-thread.
- *
- * @public
- */
-export const LAYERS = {
-  BACKGROUND: 'background',
-  MAIN_THREAD: 'main-thread',
-} as const
-
-/**
  * The default lib config{@link LibConfig} for external bundle.
  *
  * @public
@@ -199,9 +189,27 @@ export function defineExternalBundleRslibConfig(
   }
 }
 
+interface ExposedLayers {
+  readonly BACKGROUND: string
+  readonly MAIN_THREAD: string
+}
+
 const externalBundleEntryRsbuildPlugin = (): rsbuild.RsbuildPlugin => ({
   name: 'lynx:external-bundle-entry',
+  // ensure dsl plugin has exposed LAYERS
+  enforce: 'post',
   setup(api) {
+    // Get layer names from react-rsbuild-plugin
+    const LAYERS = api.useExposed<ExposedLayers>(
+      Symbol.for('LAYERS'),
+    )
+
+    if (!LAYERS) {
+      throw new Error(
+        'external-bundle-rsbuild-plugin requires exposed `LAYERS`.',
+      )
+    }
+
     api.modifyBundlerChain((chain) => {
       // copy entries
       const entries = chain.entryPoints.entries() ?? {}
@@ -299,7 +307,7 @@ const externalBundleRsbuildPlugin = (
         .use(
           ExternalBundleWebpackPlugin,
           [
-            { 
+            {
               bundleFileName: `${libName}.lynx.bundle`,
               encode: getEncodeMode(),
               engineVersion,

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
@@ -10,7 +10,6 @@
 export {
   defineExternalBundleRslibConfig,
   defaultExternalBundleLibConfig,
-  LAYERS,
 } from './externalBundleRslibConfig.js'
 export type { EncodeOptions } from './externalBundleRslibConfig.js'
 export { ExternalBundleWebpackPlugin } from './webpack/ExternalBundleWebpackPlugin.js'


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Layer configuration removed from the package public API; runtime now reads layer names from exposed plugins.
* **New Features**
  * Switched example configs to use the simplified React Lynx plugin and added corresponding output options.
* **Tests**
  * Updated and expanded tests to exercise the React Lynx plugin and related build behavior.
* **Chores**
  * Added changesets, test setup, dev dependencies, lint ignores, and updated maintainers entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
