### PR TITLE
fix(web): mts && bts events can be binded both

### DIFF
--- a/.changeset/social-deer-brush.md
+++ b/.changeset/social-deer-brush.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-mainthread-apis": patch
+---
+
+fix: mts && bts events can be binded both

--- a/packages/web-platform/web-mainthread-apis/ts/createMainThreadGlobalThis.ts
+++ b/packages/web-platform/web-mainthread-apis/ts/createMainThreadGlobalThis.ts
@@ -210,48 +210,59 @@ export function createMainThreadGlobalThis(
       currentTarget as any as HTMLElement,
     );
     if (runtimeInfo) {
-      const hname = isCapture
+      const handlerInfos = (isCapture
         ? runtimeInfo.eventHandlerMap[lynxEventName]?.capture
-          ?.handler
-        : runtimeInfo.eventHandlerMap[lynxEventName]?.bind
-          ?.handler;
-      const crossThreadEvent = createCrossThreadEvent(
-        event as MinimalRawEventObject,
-        lynxEventName,
-      );
-      if (typeof hname === 'string') {
-        const parentComponentUniqueId = Number(
-          currentTarget.getAttribute(parentComponentUniqueIdAttribute)!,
-        );
-        const parentComponent = lynxUniqueIdToElement[parentComponentUniqueId]!
-          .deref()!;
-        const componentId =
-          parentComponent?.getAttribute(lynxTagAttribute) !== 'page'
-            ? parentComponent?.getAttribute(componentIdAttribute) ?? undefined
-            : undefined;
-        if (componentId) {
-          callbacks.publicComponentEvent(
-            componentId,
-            hname,
-            crossThreadEvent,
+        : runtimeInfo.eventHandlerMap[lynxEventName]?.bind) as unknown as {
+          handler: string | { type: 'worklet'; value: unknown };
+        }[];
+      let stopPropagation = false;
+      if (handlerInfos) {
+        for (const handlerInfo of handlerInfos) {
+          const hname = handlerInfo.handler;
+          const crossThreadEvent = createCrossThreadEvent(
+            event as MinimalRawEventObject,
+            lynxEventName,
           );
-        } else {
-          callbacks.publishEvent(
-            hname,
-            crossThreadEvent,
-          );
+          if (typeof hname === 'string') {
+            const parentComponentUniqueId = Number(
+              currentTarget.getAttribute(parentComponentUniqueIdAttribute)!,
+            );
+            const parentComponent =
+              lynxUniqueIdToElement[parentComponentUniqueId]!
+                .deref()!;
+            const componentId =
+              parentComponent?.getAttribute(lynxTagAttribute) !== 'page'
+                ? parentComponent?.getAttribute(componentIdAttribute)
+                  ?? undefined
+                : undefined;
+            if (componentId) {
+              callbacks.publicComponentEvent(
+                componentId,
+                hname,
+                crossThreadEvent,
+              );
+            } else {
+              callbacks.publishEvent(
+                hname,
+                crossThreadEvent,
+              );
+            }
+            if (handlerInfos.length === 1) {
+              stopPropagation = true;
+            }
+          } else if (hname) {
+            (crossThreadEvent as MainThreadScriptEvent).target.elementRefptr =
+              event.target;
+            if (crossThreadEvent.currentTarget) {
+              (crossThreadEvent as MainThreadScriptEvent).currentTarget!
+                .elementRefptr = event.currentTarget;
+            }
+            (mtsRealm.globalWindow as typeof globalThis & MainThreadGlobalThis)
+              .runWorklet?.(hname.value, [crossThreadEvent]);
+          }
         }
-        return true;
-      } else if (hname) {
-        (crossThreadEvent as MainThreadScriptEvent).target.elementRefptr =
-          event.target;
-        if (crossThreadEvent.currentTarget) {
-          (crossThreadEvent as MainThreadScriptEvent).currentTarget!
-            .elementRefptr = event.currentTarget;
-        }
-        (mtsRealm.globalWindow as typeof globalThis & MainThreadGlobalThis)
-          .runWorklet?.(hname.value, [crossThreadEvent]);
       }
+      return stopPropagation;
     }
     return false;
   };
@@ -285,9 +296,10 @@ export function createMainThreadGlobalThis(
       componentAtIndex: undefined,
       enqueueComponent: undefined,
     };
-    const currentHandler = isCapture
+    const handlerList = (isCapture
       ? runtimeInfo.eventHandlerMap[eventName]?.capture
-      : runtimeInfo.eventHandlerMap[eventName]?.bind;
+      : runtimeInfo.eventHandlerMap[eventName]?.bind) as unknown as any[];
+    const currentHandler = handlerList && handlerList.length > 0;
     const currentRegisteredHandler = isCatch
       ? (isCapture ? catchCaptureHandler : defaultCatchHandler)
       : (isCapture ? captureHandler : defaultHandler);
@@ -304,6 +316,13 @@ export function createMainThreadGlobalThis(
           || eventName === 'uidisappear';
         if (isExposure && element.getAttribute('exposure-id') === '-1') {
           mtsGlobalThis.__SetAttribute(element, 'exposure-id', null);
+        }
+        if (runtimeInfo.eventHandlerMap[eventName]) {
+          if (isCapture) {
+            runtimeInfo.eventHandlerMap[eventName]!.capture = undefined;
+          } else {
+            runtimeInfo.eventHandlerMap[eventName]!.bind = undefined;
+          }
         }
       }
     } else {
@@ -336,10 +355,28 @@ export function createMainThreadGlobalThis(
           bind: undefined,
         };
       }
-      if (isCapture) {
-        runtimeInfo.eventHandlerMap[eventName]!.capture = info;
+      let targetList = (isCapture
+        ? runtimeInfo.eventHandlerMap[eventName]!.capture
+        : runtimeInfo.eventHandlerMap[eventName]!.bind) as unknown as any[];
+
+      if (!Array.isArray(targetList)) {
+        targetList = targetList ? [targetList] : [];
+      }
+
+      const typeOfNew = typeof newEventHandler;
+      const index = targetList.findIndex((h: any) =>
+        typeof h.handler === typeOfNew
+      );
+      if (index !== -1) {
+        targetList[index] = info;
       } else {
-        runtimeInfo.eventHandlerMap[eventName]!.bind = info;
+        targetList.push(info);
+      }
+
+      if (isCapture) {
+        runtimeInfo.eventHandlerMap[eventName]!.capture = targetList as any;
+      } else {
+        runtimeInfo.eventHandlerMap[eventName]!.bind = targetList as any;
       }
     }
     elementToRuntimeInfoMap.set(element, runtimeInfo);
@@ -354,10 +391,13 @@ export function createMainThreadGlobalThis(
     if (runtimeInfo) {
       eventName = eventName.toLowerCase();
       const isCapture = eventType.startsWith('capture');
-      const handler = isCapture
+      const handler = (isCapture
         ? runtimeInfo.eventHandlerMap[eventName]?.capture
-        : runtimeInfo.eventHandlerMap[eventName]?.bind;
-      return handler?.handler;
+        : runtimeInfo.eventHandlerMap[eventName]?.bind) as unknown as any[];
+      if (Array.isArray(handler)) {
+        return handler[0]?.handler;
+      }
+      return (handler as any)?.handler;
     } else {
       return undefined;
     }
@@ -374,13 +414,18 @@ export function createMainThreadGlobalThis(
     for (const [lynxEventName, info] of Object.entries(eventHandlerMap)) {
       for (const atomInfo of [info.bind, info.capture]) {
         if (atomInfo) {
-          const { type, handler } = atomInfo;
-          if (handler) {
-            eventInfos.push({
-              type: type as LynxEventType,
-              name: lynxEventName,
-              function: handler,
-            });
+          const handlerList = (Array.isArray(atomInfo)
+            ? atomInfo
+            : [atomInfo]) as any[];
+          for (const item of handlerList) {
+            const { type, handler } = item;
+            if (handler) {
+              eventInfos.push({
+                type: type as LynxEventType,
+                name: lynxEventName,
+                function: handler,
+              });
+            }
           }
         }
       }

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -116,6 +116,16 @@ test.describe('reactlynx3 tests', () => {
       await wait(100);
       await expect(await target.getAttribute('style')).toContain('pink');
     });
+    test('basic-bindtap-simultaneous', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      const target = page.locator('#target');
+      await target.click();
+      await wait(100);
+      await expect(await target.getAttribute('style')).toContain('green'); // BTS check
+      await expect(await target.getAttribute('data-mts-clicked')).toBe('true'); // MTS check
+      await expect(page.locator('#bts-status')).toHaveText('BTS Clicked');
+    });
     test('basic-bindtap-detail', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);

--- a/packages/web-platform/web-tests/tests/react/basic-bindtap-simultaneous/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-bindtap-simultaneous/index.jsx
@@ -1,0 +1,37 @@
+import { useState, root } from '@lynx-js/react';
+
+function App() {
+  const [btsClicked, setBtsClicked] = useState(false);
+
+  const handleBtsTap = () => {
+    setBtsClicked(true);
+    console.log('BTS Clicked');
+  };
+
+  const handleMtsTap = (event) => {
+    'main thread';
+    event.currentTarget.setAttribute('data-mts-clicked', 'true');
+    console.log('MTS Clicked');
+  };
+
+  return (
+    <view>
+      <view
+        id='target'
+        bindtap={handleBtsTap}
+        main-thread:bindtap={handleMtsTap}
+        style={{
+          height: '100px',
+          width: '100px',
+          background: btsClicked ? 'green' : 'red',
+        }}
+        data-mts-clicked='false'
+      />
+      <text id='bts-status'>
+        {btsClicked ? 'BTS Clicked' : 'BTS Not Clicked'}
+      </text>
+    </view>
+  );
+}
+
+root.render(<App />);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed support for simultaneously binding main-thread and bind events to the same element.

* **Tests**
  * Added test coverage for concurrent main-thread and bind tap event binding and handler execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
