### PR TITLE
fix: increment `vnode._original` to make sure the component is re-ren…

### DIFF
--- a/.changeset/full-clubs-train.md
+++ b/.changeset/full-clubs-train.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+When `runWithForce` is called, we should increment `vnode._original` to make sure the component is re-rendered. This can fix the issue that the component is not re-rendered when updateGlobalProps is called and the root vnode is not a component vnode.

--- a/packages/react/runtime/__test__/lifecycle/updateGlobalProps.test.jsx
+++ b/packages/react/runtime/__test__/lifecycle/updateGlobalProps.test.jsx
@@ -2,16 +2,17 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { beforeEach } from 'vitest';
+import { beforeEach, beforeAll, afterEach, vi } from 'vitest';
 import { __root } from '../../src/root';
 import { globalEnvManager } from '../utils/envManager';
 import { describe } from 'vitest';
 import { it } from 'vitest';
 import { expect } from 'vitest';
 import { render } from 'preact';
-import { waitSchedule } from '../utils/nativeMethod';
-import { beforeAll } from 'vitest';
+import { waitSchedule, elementTree } from '../utils/nativeMethod';
 import { replaceCommitHook } from '../../src/lifecycle/patch/commit';
+import { wrapWithLynxComponent, ComponentFromReactRuntime } from '../../src/compat/lynxComponent';
+import { deinitGlobalSnapshotPatch } from '../../src/lifecycle/patch/snapshotPatch';
 
 beforeAll(() => {
   replaceCommitHook();
@@ -19,6 +20,12 @@ beforeAll(() => {
 
 beforeEach(() => {
   globalEnvManager.resetEnv();
+});
+
+afterEach(() => {
+  deinitGlobalSnapshotPatch();
+  elementTree.clear();
+  vi.restoreAllMocks();
 });
 
 describe('updateGlobalProps', () => {
@@ -99,6 +106,207 @@ describe('updateGlobalProps', () => {
               text="light"
             />
           </text>
+        </page>
+      `);
+    }
+  });
+
+  it('should update global props with root page element', async () => {
+    lynx.__globalProps = { theme: 'dark' };
+
+    class C extends ComponentFromReactRuntime {
+      render() {
+        return <text>{lynx.__globalProps.theme}</text>;
+      }
+    }
+
+    const jsx = (
+      <page class={lynx.__globalProps.theme}>
+        <C />
+        <text>{lynx.__globalProps.theme}</text>
+      </page>
+    );
+    // main thread render
+    {
+      __root.__jsx = jsx;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          class="dark"
+          cssId="default-entry-from-native:0"
+        >
+          <text>
+            <raw-text
+              text="dark"
+            />
+          </text>
+          <text>
+            <raw-text
+              text="dark"
+            />
+          </text>
+        </page>
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      __root.__jsx = jsx;
+      render(jsx, __root);
+    }
+
+    // hydrate
+    {
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    }
+
+    // rLynxChange
+    {
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      await waitSchedule();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          class="dark"
+          cssId="default-entry-from-native:0"
+        >
+          <text>
+            <raw-text
+              text="dark"
+            />
+          </text>
+          <text>
+            <raw-text
+              text="dark"
+            />
+          </text>
+        </page>
+      `);
+    }
+
+    // updateGlobalProps with addComponentElement enabled
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      await waitSchedule();
+
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+
+      // cannot update elements in root render
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          class="dark"
+          cssId="default-entry-from-native:0"
+        >
+          <text>
+            <raw-text
+              text="light"
+            />
+          </text>
+          <text>
+            <raw-text
+              text="dark"
+            />
+          </text>
+        </page>
+      `);
+    }
+  });
+
+  it('should update global props with addComponentElement enabled', async () => {
+    lynx.__globalProps = { theme: 'dark' };
+
+    class C extends ComponentFromReactRuntime {
+      render() {
+        return <text>{lynx.__globalProps.theme}</text>;
+      }
+    }
+
+    const jsx = wrapWithLynxComponent((__c) => <view>{__c}</view>, <C />);
+
+    // main thread render
+    {
+      __root.__jsx = jsx;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="dark"
+              />
+            </text>
+          </view>
+        </page>
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      __root.__jsx = jsx;
+      render(jsx, __root);
+    }
+
+    // hydrate
+    {
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    }
+
+    // rLynxChange
+    {
+      globalEnvManager.switchToMainThread();
+      globalThis.__OnLifecycleEvent.mockClear();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      expect(globalThis.__OnLifecycleEvent).not.toBeCalled();
+      await waitSchedule();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="dark"
+              />
+            </text>
+          </view>
+        </page>
+      `);
+    }
+
+    // updateGlobalProps with addComponentElement enabled
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      await waitSchedule();
+
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="light"
+              />
+            </text>
+          </view>
         </page>
       `);
     }

--- a/packages/react/runtime/src/lynx/runWithForce.ts
+++ b/packages/react/runtime/src/lynx/runWithForce.ts
@@ -31,6 +31,9 @@ export function runWithForce(cb: () => void): void {
 
     const c = oldVNode[COMPONENT];
     if (c) {
+      if (vnode[ORIGINAL] != null && oldVNode[ORIGINAL] === vnode[ORIGINAL]) {
+        vnode[ORIGINAL] += 1;
+      }
       c[FORCE] = true;
     } else {
       // mount phase of a new Component


### PR DESCRIPTION
#2125 

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure components reliably re-render when global properties are updated in edge cases where previous updates could be skipped.

* **Tests**
  * Expanded lifecycle tests to cover more update scenarios, hydration flows, and propagation of global prop changes.

* **Changelog**
  * Added a patch release entry documenting the behavioral fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
