### PR TITLE
fix: NativeGesture callback types correction

### DIFF
--- a/.changeset/rich-signs-behave.md
+++ b/.changeset/rich-signs-behave.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/gesture-runtime': patch
+---
+
+Fix an issue that `NativeGesture` does not get correct types in callback

--- a/packages/lynx/gesture-runtime/src/gestureInterface.ts
+++ b/packages/lynx/gesture-runtime/src/gestureInterface.ts
@@ -98,7 +98,14 @@ export interface DefaultGestureChangeEvent extends GestureChangeEvent {
  * Uses the base GestureChangeEvent without additional properties.
  */
 export interface NativeGestureChangeEvent extends GestureChangeEvent {
-  // Uses base event properties
+  params: GestureChangeEvent['params'] & {
+    scrollX: number;
+    scrollY: number;
+    deltaX: number;
+    deltaY: number;
+    isAtStart: boolean;
+    isAtEnd: boolean;
+  };
 }
 
 export enum SetGestureStateType {


### PR DESCRIPTION
Fix an issue that `NativeGesture` does not get correct types in callback

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type definitions for gesture event callbacks to include accurate parameter information such as scroll position, delta values, and boundary state tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
