### PR TITLE
fix: lazy bundle HMR set correct entryName

### DIFF
--- a/.changeset/itchy-candies-smoke.md
+++ b/.changeset/itchy-candies-smoke.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix the issue that lazy bundle HMR will lost CSS.

--- a/examples/react-lazy-bundle/src/App.css
+++ b/examples/react-lazy-bundle/src/App.css
@@ -32,3 +32,7 @@
 text {
   color: var(--color-text);
 }
+
+.Suspense {
+  margin-top: 21px;
+}

--- a/examples/react-lazy-bundle/src/App.tsx
+++ b/examples/react-lazy-bundle/src/App.tsx
@@ -1,6 +1,8 @@
-import { useEffect } from '@lynx-js/react';
+import { Suspense, lazy, useEffect } from '@lynx-js/react';
 
 import './App.css';
+
+const LazyComponent = lazy(() => import('./LazyComponent.js'));
 
 export function App() {
   useEffect(() => {
@@ -23,6 +25,11 @@ export function App() {
         <view className='Banner'>
           <text className='Title'>React</text>
           <text className='Subtitle'>on Lynx</text>
+        </view>
+        <view className='Suspense'>
+          <Suspense fallback={<text>Loading...</text>}>
+            <LazyComponent />
+          </Suspense>
         </view>
       </view>
     </view>

--- a/examples/react-lazy-bundle/src/LazyComponent.css
+++ b/examples/react-lazy-bundle/src/LazyComponent.css
@@ -1,0 +1,4 @@
+.LazyComponent {
+  font-weight: 700;
+  color: yellow;
+}

--- a/examples/react-lazy-bundle/src/LazyComponent.tsx
+++ b/examples/react-lazy-bundle/src/LazyComponent.tsx
@@ -1,0 +1,9 @@
+import './LazyComponent.css';
+
+export default function LazyComponent() {
+  return (
+    <view>
+      <text className='LazyComponent'>LazyComponent</text>
+    </view>
+  );
+}

--- a/packages/react/runtime/src/lifecycle/patch/snapshotPatch.ts
+++ b/packages/react/runtime/src/lifecycle/patch/snapshotPatch.ts
@@ -17,6 +17,7 @@ export const SnapshotOperation = {
 
   DEV_ONLY_AddSnapshot: 100,
   DEV_ONLY_RegisterWorklet: 101,
+  DEV_ONLY_SetSnapshotEntryName: 102,
 } as const;
 
 export const SnapshotOperationParams: Record<number, { name: string; params: string[] }> = /* @__PURE__ */ {
@@ -41,6 +42,10 @@ export const SnapshotOperationParams: Record<number, { name: string; params: str
   [SnapshotOperation.DEV_ONLY_RegisterWorklet]: {
     name: 'DEV_ONLY_RegisterWorklet',
     params: ['hash', /* string */ 'fnStr' /* string */],
+  },
+  [SnapshotOperation.DEV_ONLY_SetSnapshotEntryName]: {
+    name: 'DEV_ONLY_SetSnapshotEntryName',
+    params: ['uniqID', /* string */ 'entryName' /* string */],
   },
 } as const;
 

--- a/packages/react/runtime/src/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/lifecycle/patch/snapshotPatchApply.ts
@@ -93,6 +93,19 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
         }
         break;
       }
+      case SnapshotOperation.DEV_ONLY_SetSnapshotEntryName: {
+        if (__DEV__) {
+          const uniqID = snapshotPatch[++i] as string;
+          const entryName = snapshotPatch[++i] as string;
+
+          // HMR-related
+          // Update the evaluated snapshot entryName from JS.
+          snapshotCreatorMap[uniqID] = evaluate<(uniqId: string) => string>(
+            snapshotCreatorMap[uniqID]!.toString().replaceAll('globDynamicComponentEntry', JSON.stringify(entryName)),
+          );
+        }
+        break;
+      }
         // case SnapshotOperation.DEV_ONLY_RegisterWorklet: {
         //   // HMR-related
         //   if (__DEV__) {

--- a/packages/react/runtime/src/snapshot.ts
+++ b/packages/react/runtime/src/snapshot.ts
@@ -236,6 +236,15 @@ export function createSnapshot(
   if (!isLazySnapshotSupported) {
     uniqID = entryUniqID(uniqID, entryName);
   }
+  // For Lazy Bundle, their entryName is not DEFAULT_ENTRY_NAME.
+  // We need to set the entryName correctly for HMR
+  if (__DEV__ && __JS__ && __globalSnapshotPatch && entryName && entryName !== DEFAULT_ENTRY_NAME) {
+    __globalSnapshotPatch.push(
+      SnapshotOperation.DEV_ONLY_SetSnapshotEntryName,
+      uniqID,
+      entryName,
+    );
+  }
 
   const s: Snapshot = { create, update, slot, cssId, entryName, refAndSpreadIndexes };
   snapshotManager.values.set(uniqID, s);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

This fix follows #2048 but for non standalone lazy bundles. We now will pass the snapshotCreator function from BTS to MTS but miss the correct `globDynamicComponentEntry` field. It will fail to execute `__SetCSSId` for lazy bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lazy-loaded component example with Suspense fallback.

* **Bug Fixes**
  * Fixed CSS loss during hot module replacement for lazy bundles.

* **Style**
  * Minor layout and styling adjustments for suspense and lazy component UI.

* **Tests**
  * Added tests covering non-standalone lazy bundle snapshot behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
