### PR TITLE
fix(webpack/react): deduplicate lazy bundles for same file imported via different paths

### DIFF
--- a/.changeset/chatty-dryers-find.md
+++ b/.changeset/chatty-dryers-find.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/react-webpack-plugin": patch
+---
+
+fix: deduplicate lazy bundles when the same file is imported via different paths

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/Foo.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/Foo.jsx
@@ -1,0 +1,5 @@
+export function Foo() {
+  return 'Foo Component';
+}
+
+export default Foo;

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/index.jsx
@@ -1,0 +1,37 @@
+/// <reference types="vitest/globals" />
+
+import { readdir, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+// Import using relative path from same directory
+// This dynamic import triggers chunk creation for ./Foo.jsx
+import('./Foo.jsx');
+
+// Import using subdirectory importer (which uses ../Foo.jsx)
+// This creates another import path to the same file
+import { loadFooFromSubdir } from './subdir/importer.jsx';
+
+it('should generate only ONE async bundle for Foo', async () => {
+  // Ensure loadFooFromSubdir is used to prevent tree-shaking
+  expect(loadFooFromSubdir).toBeDefined();
+
+  // The async bundles are generated in the 'async' folder relative to __dirname
+  const asyncDir = resolve(__dirname, 'async');
+  const asyncTemplates = await readdir(asyncDir);
+
+  // Filter to only .bundle files (exclude other artifacts)
+  const bundles = asyncTemplates.filter(f => f.endsWith('.bundle'));
+
+  // Key assertion: ./Foo.jsx and ../Foo.jsx should produce SINGLE bundle
+  // because they resolve to the same file
+  expect(bundles).toHaveLength(1);
+});
+
+it('should have correct imports in the compiled code', async () => {
+  // Verify that webpack code references both imports
+  const mainFile = await readFile(__filename, 'utf-8');
+
+  // The import statements should exist in the compiled code
+  expect(mainFile).toContain('./Foo.jsx');
+  expect(mainFile).toContain('./subdir/importer.jsx');
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/rspack.config.js
@@ -1,0 +1,28 @@
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { createConfig } from '../../../create-react-config.js';
+
+const config = createConfig();
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...config,
+  output: {
+    ...config.output,
+    chunkFilename: '.rspeedy/async/[name].js',
+  },
+  plugins: [
+    ...config.plugins,
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: ['main__main-thread', 'main__background'],
+      filename: 'main/template.js',
+      intermediate: '.rspeedy/main',
+    }),
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/subdir/importer.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/subdir/importer.jsx
@@ -1,0 +1,7 @@
+// Import using relative path going up one directory
+const FooPromise = import('../Foo.jsx');
+
+export async function loadFooFromSubdir() {
+  const { Foo } = await FooPromise;
+  return Foo();
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/test.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    // We do not run main-thread.js since the async chunk has been modified by LynxTemplatePlugin.
+    // 'main__main-thread.js',
+    'main__background.js',
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/src/LynxAsyncChunksRuntimeModule.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxAsyncChunksRuntimeModule.ts
@@ -2,12 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { RuntimeModule } from 'webpack';
+import type { Chunk, RuntimeModule } from 'webpack';
 
 import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
 
 type LynxAsyncChunksRuntimeModule = new(
-  getChunkName: (chunkName: string) => string,
+  getChunkName: (chunkName: string, chunk: Chunk) => string,
 ) => RuntimeModule;
 
 export function createLynxAsyncChunksRuntimeModule(
@@ -15,7 +15,7 @@ export function createLynxAsyncChunksRuntimeModule(
 ): LynxAsyncChunksRuntimeModule {
   return class LynxAsyncChunksRuntimeModule extends webpack.RuntimeModule {
     constructor(
-      public getChunkName: (chunkName: string) => string,
+      public getChunkName: (chunkName: string, chunk: Chunk) => string,
     ) {
       super('Lynx async chunks', webpack.RuntimeModule.STAGE_ATTACH);
     }
@@ -29,7 +29,7 @@ ${RuntimeGlobals.lynxAsyncChunkIds} = {${
         Array.from(chunk.getAllAsyncChunks())
           .filter(c => c.name !== null && c.name !== undefined)
           .map(c => {
-            const filename = this.getChunkName(c.name!);
+            const filename = this.getChunkName(c.name!, c);
 
             // Modified from https://github.com/webpack/webpack/blob/11449f02175f055a4540d76aa4478958c4cb297e/lib/runtime/GetChunkFilenameRuntimeModule.js#L154-L157
             const chunkPath = compilation.getPath(filename, {


### PR DESCRIPTION
(WIP)

When the same file is imported via different relative paths (e.g., `./Foo.jsx`
from index.jsx and `../Foo.jsx` from subdir/importer.jsx), they now produce
a single bundle instead of duplicates.

The fix extends the `asyncChunkName` hook to receive ChunkGroup information,
allowing the ReactWebpackPlugin to normalize chunk names based on resolved
module paths rather than raw import strings.

Closes: https://github.com/lynx-family/lynx-stack/issues/455

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

@coderabbitai summary

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
