### PR TITLE
chore: disable build cache for bundleless

### DIFF
--- a/packages/lynx/gesture-runtime/rslib.config.ts
+++ b/packages/lynx/gesture-runtime/rslib.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
     tsconfigPath: './tsconfig.build.json',
   },
   plugins: [pluginPublint()],
+  performance: {
+    buildCache: false,
+  },
 });


### PR DESCRIPTION
Rspack would panic under bundleless mode with persistent cache enabled.

```
pnpm --filter @lynx-js/gesture-runtime run build

> @lynx-js/gesture-runtime@2.1.2 build /Users/colin/lynx-stack/packages/lynx/gesture-runtime
> rslib build

Rslib v0.19.1

info    build started...
Panic occurred at runtime. Please file an issue on GitHub with the backtrace below: https://github.com/web-infra-dev/rspack/issues: panicked at crates/rspack_core/src/module_graph/mod.rs:582:26:
Dependency with ID DependencyId(125) not found
/Users/colin/lynx-stack/packages/lynx/gesture-runtime:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @lynx-js/gesture-runtime@2.1.2 build: `rslib build`
Command failed with signal "SIGABRT"
start   generating declaration files... (esm)
fish: Job 1, 'pnpm --filter @lynx-js/gesture-…' terminated by signal SIGABRT (Abort)
```

This should be fixed by https://github.com/web-infra-dev/rspack/pull/12820.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modified build performance configuration settings to adjust caching behavior during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
