### PR TITLE
feat: support suppress BROKEN warnings during compilation

### DIFF
--- a/.changeset/friendly-cats-dance.md
+++ b/.changeset/friendly-cats-dance.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/react": patch
+---
+
+Use `disableDeprecatedWarning` option to suppress BROKEN warnings during compilation.
+
+1. BROKEN: `getNodeRef`/`getNodeRefFromRoot`/`createSelectorQuery` on component instance is broken and MUST be migrated in ReactLynx 3.0, please use ref or lynx.createSelectorQuery instead.
+2. BROKEN: `getElementById` on component instance is broken and MUST be migrated in ReactLynx 3.0, please use ref or lynx.getElementById instead.

--- a/packages/react/transform/__test__/fixture.spec.js
+++ b/packages/react/transform/__test__/fixture.spec.js
@@ -534,6 +534,21 @@ Component, View
         ]
       `);
     }
+
+    {
+      cfg.compat.disableDeprecatedWarning = true;
+      const result = await transformReactLynx(
+        `this.createSelectorQuery();
+         this.getElementById();`,
+        cfg,
+      );
+      expect(
+        await formatMessages(result.warnings, {
+          kind: 'warning',
+          color: false,
+        }),
+      ).toMatchInlineSnapshot(`[]`);
+    }
   });
 });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `disableDeprecatedWarning` option to suppress deprecation warnings during compilation.

* **Documentation**
  * Added ReactLynx 3.0 migration guidance: replace deprecated `getNodeRef`, `getNodeRefFromRoot`, `createSelectorQuery`, and `getElementById` methods with `ref` or `lynx.*` equivalents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
