### PR TITLE
feat: implement lazy loading for sync externals and improve diagnostics

### DIFF
--- a/.changeset/lazy-fetch-bundle.md
+++ b/.changeset/lazy-fetch-bundle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/externals-loading-webpack-plugin": minor
+---
+
+Support lazy loading for fetchBundle resources.

--- a/examples/react-externals/lynx.config.js
+++ b/examples/react-externals/lynx.config.js
@@ -123,5 +123,6 @@ export default defineConfig({
   output: {
     filenameHash: 'contenthash:8',
     cleanDistPath: false,
+    minify: false,
   },
 });

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-eager-loading/index.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-eager-loading/index.js
@@ -1,0 +1,31 @@
+it('should eager load async externals', async () => {
+  lynx.fetchBundle.mockClear();
+  lynx.loadScript.mockClear();
+  // remove cache created by other test cases
+  delete lynx[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')][Symbol.for('Foo')];
+
+  expect(lynx.fetchBundle).toHaveBeenCalledTimes(0);
+  expect(lynx.loadScript).toHaveBeenCalledTimes(0);
+
+  // For async externals, the fetch should start immediately upon import/require resolution
+  // because the generated code accesses the property which triggers createLoadExternalAsync
+  const ns = await import('@lynx-js/foo');
+
+  // Even without accessing any properties on 'ns', the fetch should have implicitly started
+  // because Rspack runtime accesses the external to export it.
+  expect(lynx.fetchBundle).toHaveBeenCalledTimes(1);
+  expect(lynx.loadScript).toHaveBeenCalledTimes(1);
+
+  // Accessing property should work (it might await the promise internally if we handled it,
+  // but here we just check eager start)
+  // Note: createLoadExternalAsync returns a Promise, so the default export is likely that Promise or the result.
+  // In the mock setup, loadScript returns the module object directly because createLoadExternalAsync
+  // implementation in the plugin awaits the fetch.
+
+  // Wait, correct checking:
+  // The plugin generates: createLoadExternalAsync(...)
+  // which returns `new Promise(...)`.
+  // So `ns.default` should be that Promise (if Rspack treats it as default export of CJS).
+
+  expect(ns.default).toBeDefined();
+});

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-eager-loading/rspack.config.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-eager-loading/rspack.config.js
@@ -1,0 +1,25 @@
+import { createConfig } from '../../../helpers/create-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...createConfig(
+    {
+      backgroundLayer: 'background',
+      mainThreadLayer: 'main-thread',
+      externals: {
+        '@lynx-js/foo': {
+          libraryName: 'Foo',
+          url: 'foo',
+          async: true,
+          background: {
+            sectionPath: 'background',
+          },
+          mainThread: {
+            sectionPath: 'mainThread',
+          },
+        },
+      },
+    },
+  ),
+};

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-eager-loading/test.config.cjs
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-eager-loading/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main:main-thread.js',
+    'main:background.js',
+  ],
+};

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/filter-duplicate-externals/index.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/filter-duplicate-externals/index.js
@@ -18,14 +18,14 @@ it('should filter duplicate externals', async () => {
   );
   expect(
     background.split(
-      `lynx[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')]["Foo"]`
-        + ' = ',
+      `Object.defineProperty(lynx[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')],`
+        + ' "Foo",',
     ).length - 1,
   ).toBe(1);
   expect(
     mainThread.split(
-      `lynx[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')]["Foo"] `
-        + '= ',
+      `Object.defineProperty(lynx[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')],`
+        + ' "Foo",',
     ).length - 1,
   ).toBe(1);
 });

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/globalObject-customize/index.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/globalObject-customize/index.js
@@ -16,14 +16,14 @@ it('should mount to externals library to globalThis', async () => {
   );
   expect(
     background.split(
-      `globalThis[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')]["Foo"]`
-        + ' = ',
+      `Object.defineProperty(globalThis[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')],`
+        + ' "Foo",',
     ).length - 1,
   ).toBe(1);
   expect(
     mainThread.split(
-      `globalThis[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')]["Foo"] `
-        + '= ',
+      `Object.defineProperty(globalThis[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')],`
+        + ' "Foo",',
     ).length - 1,
   ).toBe(1);
 });

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading-sync/index.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading-sync/index.js
@@ -1,0 +1,31 @@
+it('should lazy load sync externals', async () => {
+  lynx.fetchBundle.mockClear();
+  lynx.loadScript.mockClear();
+  // remove cache created by other test cases
+  delete lynx[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')][Symbol.for('Foo')];
+
+  // With import/await, Rspack might handle resolution.
+  // If the externals plugin works, accessing `foo` properties triggers get().
+  // However, getting the namespace object itself might not trigger get() on the default export proxy yet.
+  const ns = await import('@lynx-js/foo');
+
+  // If we haven't accessed properties of the PROXY yet, count should be 0.
+  expect(lynx.fetchBundle).toHaveBeenCalledTimes(0);
+  expect(lynx.loadScript).toHaveBeenCalledTimes(0);
+
+  // The proxy is the default export because it's a CJS-style external (module.exports = proxy)
+  // and the proxy hides keys, so named exports aren't enumerable.
+  const { default: foo } = ns;
+
+  // Accessing property on the proxy (default export) should trigger fetch
+  const result = foo.add(1, 2);
+  expect(result).toBe(3);
+
+  // NOW it definitely should have fetched if it is an external.
+  expect(lynx.fetchBundle).toHaveBeenCalledTimes(1);
+  expect(lynx.loadScript).toHaveBeenCalledTimes(1);
+
+  // Second access should use cache
+  expect(foo.add(2, 3)).toBe(5);
+  expect(lynx.fetchBundle).toHaveBeenCalledTimes(1);
+});

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading-sync/rspack.config.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading-sync/rspack.config.js
@@ -1,0 +1,25 @@
+import { createConfig } from '../../../helpers/create-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...createConfig(
+    {
+      backgroundLayer: 'background',
+      mainThreadLayer: 'main-thread',
+      externals: {
+        '@lynx-js/foo': {
+          libraryName: 'Foo',
+          url: 'foo',
+          async: false,
+          background: {
+            sectionPath: 'background',
+          },
+          mainThread: {
+            sectionPath: 'mainThread',
+          },
+        },
+      },
+    },
+  ),
+};

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading-sync/test.config.cjs
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading-sync/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main:main-thread.js',
+    'main:background.js',
+  ],
+};

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading/index.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading/index.js
@@ -1,0 +1,26 @@
+it('should lazy load externals', async () => {
+  lynx.fetchBundle.mockClear();
+  lynx.loadScript.mockClear();
+  // remove cache created by other test cases
+  delete lynx[Symbol.for('__LYNX_EXTERNAL_GLOBAL__')][Symbol.for('Foo')];
+
+  expect(lynx.fetchBundle).toHaveBeenCalledTimes(0);
+  expect(lynx.loadScript).toHaveBeenCalledTimes(0);
+
+  // Now, dynamically import the external.
+  const { add } = await import('foo');
+
+  expect(lynx.fetchBundle).toHaveBeenCalledTimes(1);
+  expect(lynx.loadScript).toHaveBeenCalledTimes(1);
+
+  // Use the imported function to make sure it's working
+  expect(add(1, 2)).toBe(3);
+
+  // a second import
+  const { add: add2 } = await import('foo');
+
+  expect(lynx.fetchBundle).toHaveBeenCalledTimes(1);
+  expect(lynx.loadScript).toHaveBeenCalledTimes(1);
+
+  expect(add2(2, 3)).toBe(5);
+});

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading/rspack.config.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading/rspack.config.js
@@ -1,0 +1,25 @@
+import { createConfig } from '../../../helpers/create-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...createConfig(
+    {
+      backgroundLayer: 'background',
+      mainThreadLayer: 'main-thread',
+      externals: {
+        'foo': {
+          libraryName: 'Foo',
+          url: 'foo',
+          async: true,
+          background: {
+            sectionPath: 'background',
+          },
+          mainThread: {
+            sectionPath: 'mainThread',
+          },
+        },
+      },
+    },
+  ),
+};

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading/test.config.cjs
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/lazy-loading/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main:main-thread.js',
+    'main:background.js',
+  ],
+};

--- a/packages/webpack/externals-loading-webpack-plugin/test/diagnostic.test.ts
+++ b/packages/webpack/externals-loading-webpack-plugin/test/diagnostic.test.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+
+import { diagnosticCases } from '@lynx-js/test-tools';
+
+diagnosticCases({
+  name: 'externals-loading',
+  casePath: path.join(__dirname, 'diagnostic'),
+});

--- a/packages/webpack/externals-loading-webpack-plugin/test/diagnostic/externals-loading/conflicting-section-path/expected/rspack.txt
+++ b/packages/webpack/externals-loading-webpack-plugin/test/diagnostic/externals-loading/conflicting-section-path/expected/rspack.txt
@@ -1,0 +1,6 @@
+ERROR in × ExternalsLoadingPlugin Error: Conflicting 'sectionPath' configurations found for library "MyLib" (from URL "http://example.com/lib.bundle") in the "mainThread" layer.
+- Defined in "lib-a": "path/to/a"
+- Defined in "lib-b": "path/to/b"
+Please ensure all externals pointing to the same library bundle have a consistent 'sectionPath' for each layer.
+
+ERROR in × Conflict: Multiple assets emit different content to the same filename rspack.bundle.js

--- a/packages/webpack/externals-loading-webpack-plugin/test/diagnostic/externals-loading/conflicting-section-path/index.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/diagnostic/externals-loading/conflicting-section-path/index.js
@@ -1,0 +1,1 @@
+console.log('empty entry');

--- a/packages/webpack/externals-loading-webpack-plugin/test/diagnostic/externals-loading/conflicting-section-path/rspack.config.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/diagnostic/externals-loading/conflicting-section-path/rspack.config.js
@@ -1,0 +1,28 @@
+import { createConfig } from '../../../helpers/create-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...createConfig(
+    {
+      backgroundLayer: 'background',
+      mainThreadLayer: 'main-thread',
+      externals: {
+        'lib-a': {
+          libraryName: ['MyLib', 'a'],
+          url: 'http://example.com/lib.bundle',
+          mainThread: {
+            sectionPath: 'path/to/a',
+          },
+        },
+        'lib-b': {
+          libraryName: ['MyLib', 'b'],
+          url: 'http://example.com/lib.bundle',
+          mainThread: {
+            sectionPath: 'path/to/b', // Conflict with 'path/to/a'
+          },
+        },
+      },
+    },
+  ),
+};

--- a/packages/webpack/externals-loading-webpack-plugin/test/helpers/setup-env.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/helpers/setup-env.js
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 import { createRequire } from 'node:module';
 
+import { vi } from 'vitest';
+
 __injectGlobals(globalThis);
 
 const require = createRequire(import.meta.url);
@@ -19,16 +21,14 @@ function __injectGlobals(target) {
   target.printLogger = process.argv.includes('--verbose');
 
   target.lynx = {
-    fetchBundle: (url) => {
-      return {
-        wait: () => ({ url, code: 0, err: null }),
-        then: (callback) => callback({ url, code: 0, err: null }),
-      };
-    },
-    loadScript: (sectionPath) => {
+    fetchBundle: vi.fn(url => ({
+      wait: () => ({ url, code: 0, err: null }),
+      then: callback => callback({ url, code: 0, err: null }),
+    })),
+    loadScript: vi.fn((sectionPath) => {
       const module = CustomSections[sectionPath] ?? {};
       return module;
-    },
+    }),
   };
 
   target.Lodash = {};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

@coderabbitai summary

# External Lazy Loading

I have implemented lazy loading for **Synchronous Externals** in the `ExternalsLoadingPlugin`.

## Synchronous Externals (`async: false`)

Synchronous externals are transparently wrapped in a `Proxy`. The `fetchBundle` call (which blocks execution) is deferred until properties of the module are accessed.

## Asynchronous Externals (`async: true`)

For asynchronous externals, static imports trigger eager loading. To achieve "on-demand" loading, use **Dynamic Imports** (`import()`).

### Async Optimization Guide

To delay fetching until use:

```javascript
// Example: React Component
const App = lazy(() => import('./AsyncApp.js')); // Fetches ONLY on render
```

## Verification Summary

### Automated Tests

I added comprehensive test cases:

**1. `lazy-loading-sync`**
Verifies that `async: false` externals are strictly lazy (fetch on access).

**2. `async-eager-loading`**
Verifies that `async: true` externals load eagerly on import (correctness for static imports).

**3. `conflicting-section-path` (Diagnostic)**
Verifies that the plugin correctly detects and reports conflicting configurations (same library, different `sectionPath`).

- Snapshot `rspack.txt` confirms the error message: `ExternalsLoadingPlugin Error: Conflicting 'sectionPath' configurations found...`
- **Note**: A dummy `webpack.config.js` is used to satisfy the test runner requirements without modifying shared tooling.

### Manual Verification

- **Sync Lazy Loading**: Verified via `main-thread.js` inspection. `createLazyExternal` proxy is correctly applied.
- **Async Normal Loading**: Verified that `async: true` externals fall back to standard Rspack eager fetch.


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
