### PR TITLE
fix: avoid error when LynxView is removed immediately after connected

### DIFF
--- a/.changeset/fix-web-core-lynxview-disconnect.md
+++ b/.changeset/fix-web-core-lynxview-disconnect.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: avoid error when LynxView is removed immediately after connected

--- a/packages/web-platform/web-core/src/apis/LynxView.ts
+++ b/packages/web-platform/web-core/src/apis/LynxView.ts
@@ -92,7 +92,6 @@ export class LynxView extends HTMLElement {
   );
   #instance?: LynxViewInstance;
 
-  #connected = false;
   #url?: string;
   /**
    * @public
@@ -414,10 +413,13 @@ export class LynxView extends HTMLElement {
    * @private
    */
   #render() {
-    if (!this.#rendering && this.#connected) {
+    if (!this.#rendering && this.isConnected) {
       this.#rendering = true;
       queueMicrotask(() => {
         this.#rendering = false;
+        if (!this.isConnected) {
+          return;
+        }
         const ssrData = this.getAttribute('ssr');
         if (this.#instance) {
           this.disconnectedCallback();
@@ -529,7 +531,6 @@ export class LynxView extends HTMLElement {
    * @private
    */
   connectedCallback() {
-    this.#connected = true;
     this.#render();
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an error when a LynxView is removed immediately after being connected, improving stability during rapid lifecycle changes.
* **Tests**
  * Added a test to ensure no errors occur when a view is connected and then immediately disconnected, preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
