### PR TITLE
fix: avoid DEV_ONLY_SetSnapshotEntryName on standalone lazy bundle

### DIFF
--- a/.changeset/fast-bears-relate.md
+++ b/.changeset/fast-bears-relate.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Avoid DEV_ONLY_SetSnapshotEntryName on standalone lazy bundle.

--- a/packages/react/runtime/__test__/snapshotPatch.test.jsx
+++ b/packages/react/runtime/__test__/snapshotPatch.test.jsx
@@ -1609,13 +1609,14 @@ describe('lazy snapshot', () => {
     const si = new SnapshotInstance(uniqueId);
     expect(si.type).toBe('https://example.com/main.lynx.bundle:snapshot-1');
   });
-  it('standalone lazy bundle snapshotCreatorMap set should not generate DEV_ONLY_AddSnapshot', () => {
+  it('standalone lazy bundle snapshotCreatorMap set should not generate DEV_ONLY_AddSnapshot and DEV_ONLY_SetSnapshotEntryName', () => {
     initGlobalSnapshotPatch();
     expect(__globalSnapshotPatch).toMatchInlineSnapshot(`[]`);
 
     const globDynamicComponentEntry = 'https://example.com/main.lynx.bundle';
+    const uniqID = `${globDynamicComponentEntry}:${'__snapshot_835da_eff1e_1'}`;
 
-    snapshotCreatorMap[`${globDynamicComponentEntry}:${'__snapshot_835da_eff1e_1'}`] = (uniqID) => {
+    snapshotCreatorMap[uniqID] = (uniqID) => {
       globalThis.createSnapshot(
         uniqID,
         /* v8 ignore start */
@@ -1634,6 +1635,10 @@ describe('lazy snapshot', () => {
       );
     };
 
+    expect(__globalSnapshotPatch.length).toBe(0);
+
+    vi.stubGlobal('__JS__', true);
+    snapshotCreatorMap[uniqID](uniqID);
     expect(__globalSnapshotPatch.length).toBe(0);
 
     deinitGlobalSnapshotPatch();

--- a/packages/react/runtime/src/snapshot.ts
+++ b/packages/react/runtime/src/snapshot.ts
@@ -238,7 +238,11 @@ export function createSnapshot(
   }
   // For Lazy Bundle, their entryName is not DEFAULT_ENTRY_NAME.
   // We need to set the entryName correctly for HMR
-  if (__DEV__ && __JS__ && __globalSnapshotPatch && entryName && entryName !== DEFAULT_ENTRY_NAME) {
+  if (
+    __DEV__ && __JS__ && __globalSnapshotPatch && entryName && entryName !== DEFAULT_ENTRY_NAME
+    // `uniqID` will be `https://example.com/main.lynx.bundle:__snapshot_835da_eff1e_1` when loading a standalone lazy bundle after hydration.
+    && !uniqID.includes(':')
+  ) {
     __globalSnapshotPatch.push(
       SnapshotOperation.DEV_ONLY_SetSnapshotEntryName,
       uniqID,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Same as https://github.com/lynx-family/lynx-stack/pull/2048, we should not apply DEV_ONLY_SetSnapshotEntryName for standalone lazy bundle.

## Patch Release

* **Bug Fixes**
  * Fixed snapshot handling for standalone lazy bundles by preventing unnecessary patch generation during hydration cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
