### PR TITLE
feat: remove element api calls alog by default

### DIFF
--- a/.changeset/tough-cases-help.md
+++ b/.changeset/tough-cases-help.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/testing-environment": patch
+"@lynx-js/react-webpack-plugin": patch
+"@lynx-js/react": patch
+---
+
+Remove element api calls alog by default, and only enable it when `__ALOG_ELEMENT_API__` is defined to `true` or environment variable `REACT_ALOG_ELEMENT_API` is set to `true`.

--- a/packages/react/runtime/src/alog/index.ts
+++ b/packages/react/runtime/src/alog/index.ts
@@ -1,10 +1,8 @@
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { initElementPAPICallAlog } from './elementPAPICall.js';
 import { initRenderAlog } from './render.js';
 
 export function initAlog(): void {
   initRenderAlog();
-  initElementPAPICallAlog();
 }

--- a/packages/react/runtime/src/lynx.ts
+++ b/packages/react/runtime/src/lynx.ts
@@ -5,6 +5,7 @@ import { options } from 'preact';
 // to make sure preact's hooks to register earlier than ours
 import './hooks/react.js';
 
+import { initElementPAPICallAlog } from './alog/elementPAPICall.js';
 import { initAlog } from './alog/index.js';
 import { setupComponentStack } from './debug/component-stack.js';
 import { initProfileHook } from './debug/profile.js';
@@ -51,6 +52,9 @@ if (typeof __MAIN_THREAD__ !== 'undefined' && __MAIN_THREAD__ && typeof __PROFIL
 if (typeof __ALOG__ !== 'undefined' && __ALOG__) {
   // We are logging both main-thread and background.
   initAlog();
+}
+if (typeof __ALOG_ELEMENT_API__ !== 'undefined' && __ALOG_ELEMENT_API__) {
+  initElementPAPICallAlog();
 }
 
 if (typeof __BACKGROUND__ !== 'undefined' && __BACKGROUND__) {

--- a/packages/react/runtime/types/types.d.ts
+++ b/packages/react/runtime/types/types.d.ts
@@ -20,6 +20,7 @@ declare global {
   declare const __MAIN_THREAD__: boolean;
   declare const __PROFILE__: boolean;
   declare const __ALOG__: boolean | undefined;
+  declare const __ALOG_ELEMENT_API__: boolean | undefined;
   declare const __ENABLE_SSR__: boolean;
 
   declare function __CreatePage(componentId: string, cssId: number): FiberElement;

--- a/packages/react/testing-library/src/vitest-global-setup.js
+++ b/packages/react/testing-library/src/vitest-global-setup.js
@@ -110,7 +110,9 @@ globalThis.onInjectMainThreadGlobals = (target) => {
 
   target.globalPipelineOptions = undefined;
 
-  initElementPAPICallAlog(target);
+  if (typeof __ALOG_ELEMENT_API__ !== 'undefined' && __ALOG_ELEMENT_API__) {
+    initElementPAPICallAlog(target);
+  }
 };
 globalThis.onInjectBackgroundThreadGlobals = (target) => {
   if (onInjectBackgroundThreadGlobals) {

--- a/packages/testing-library/testing-environment/src/index.ts
+++ b/packages/testing-library/testing-environment/src/index.ts
@@ -240,6 +240,7 @@ function injectMainThreadGlobals(target?: any, polyfills?: any) {
   target.__DEV__ = true;
   target.__PROFILE__ = true;
   target.__ALOG__ = true;
+  target.__ALOG_ELEMENT_API__ = true;
   target.__JS__ = false;
   target.__LEPUS__ = true;
   target.__BACKGROUND__ = false;
@@ -378,6 +379,7 @@ function injectBackgroundThreadGlobals(target?: any, polyfills?: any) {
   target.__DEV__ = true;
   target.__PROFILE__ = true;
   target.__ALOG__ = true;
+  target.__ALOG_ELEMENT_API__ = true;
   target.__JS__ = true;
   target.__LEPUS__ = false;
   target.__BACKGROUND__ = true;

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -184,6 +184,10 @@ class ReactWebpackPlugin {
       ),
       // User can enable ALog by environment variable `REACT_ALOG=true`
       __ALOG__: JSON.stringify(Boolean(process.env['REACT_ALOG'])),
+      // User can enable ALog of element API calls by environment variable `REACT_ALOG_ELEMENT_API=true`
+      __ALOG_ELEMENT_API__: JSON.stringify(
+        Boolean(process.env['REACT_ALOG_ELEMENT_API']),
+      ),
       __EXTRACT_STR__: JSON.stringify(Boolean(options.extractStr)),
       __FIRST_SCREEN_SYNC_TIMING__: JSON.stringify(
         options.firstScreenSyncTiming,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

Element API calls are too verbose, user may not need this information when enabling alog, so we provide an extra option to enable it seperately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Element API calls are now disabled by default and can be enabled via the `REACT_ALOG_ELEMENT_API` environment variable for granular control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
