### PR TITLE
fix(react): resolve early 'this' access issue in main thread functions

### DIFF
--- a/.changeset/slow-birds-improve.md
+++ b/.changeset/slow-birds-improve.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react": patch
+---
+
+fix: Main thread functions cannot access properties on `this` before hydration completes.
+
+This fixes the `cannot convert to object` error.

--- a/packages/react/transform/crates/swc_plugin_worklet/gen_stmt.rs
+++ b/packages/react/transform/crates/swc_plugin_worklet/gen_stmt.rs
@@ -136,7 +136,7 @@ impl StmtGen {
     }
 
     let worklet_props = extracted_this_expr.expect_object().props;
-    if target == TransformTarget::JS && !worklet_props.is_empty() {
+    if !worklet_props.is_empty() {
       props.push(
         SpreadElement {
           dot3_token: DUMMY_SP,

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_extract_ident_from_this_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_extract_ident_from_this_lepus.js
@@ -1,7 +1,10 @@
 import { loadWorkletRuntime as __loadWorkletRuntime } from "@lynx-js/react";
 var loadWorkletRuntime = __loadWorkletRuntime;
 let onTapLepus = {
-    _wkltId: "a123:test:1"
+    _wkltId: "a123:test:1",
+    ...{
+        a: this.a
+    }
 };
 loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry) && registerWorkletInternal("main-thread", "a123:test:1", function(event: ReactLynx.Worklet.ITouchEvent) {
     const onTapLepus = lynxWorkletImpl._workletMap["a123:test:1"].bind(this);

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_extract_member_expr_2_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_extract_member_expr_2_lepus.js
@@ -7,7 +7,27 @@ let onTapLepus = {
         eeee,
         ffff
     },
-    _wkltId: "a123:test:1"
+    _wkltId: "a123:test:1",
+    ...{
+        aaaa: this.aaaa,
+        bbbb: {
+            cccc: {
+                dddd: this.bbbb.cccc.dddd
+            }
+        },
+        eeee: this.eeee,
+        ffff: this.ffff,
+        hhhh: {
+            'iiii': this.hhhh['iiii'],
+            kkkk: this.hhhh.kkkk
+        },
+        llll: this.llll,
+        mmmm: {
+            nnnn: {
+                'oooo': this.mmmm.nnnn['oooo']
+            }
+        }
+    }
 };
 loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry) && registerWorkletInternal("main-thread", "a123:test:1", function() {
     const onTapLepus = lynxWorkletImpl._workletMap["a123:test:1"].bind(this);

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_skip_shared_identifiers_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_skip_shared_identifiers_lepus.js
@@ -7,7 +7,10 @@ let worklet = {
     _c: {
         y1
     },
-    _wkltId: "a77b:test:1"
+    _wkltId: "a77b:test:1",
+    ...{
+        y1: this.y1
+    }
 };
 loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry) && registerWorkletInternal("main-thread", "a77b:test:1", function(event: Event) {
     const worklet = lynxWorkletImpl._workletMap["a77b:test:1"].bind(this);

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_transform_in_class_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_transform_in_class_lepus.js
@@ -3,7 +3,10 @@ var loadWorkletRuntime = __loadWorkletRuntime;
 class App extends Component {
     a = 1;
     onTapLepus = {
-        _wkltId: "a77b:test:1"
+        _wkltId: "a77b:test:1",
+        ...{
+            a: this.a
+        }
     };
 }
 loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry) && registerWorkletInternal("main-thread", "a77b:test:1", function(event) {

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_transform_in_class_property_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_transform_in_class_property_lepus.js
@@ -6,7 +6,10 @@ class App extends Component {
         _c: {
             a
         },
-        _wkltId: "a77b:test:1"
+        _wkltId: "a77b:test:1",
+        ...{
+            a: this.a
+        }
     };
 }
 loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry) && registerWorkletInternal("main-thread", "a77b:test:1", function(event) {

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_transform_lepus_alias.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_transform_lepus_alias.js
@@ -4,7 +4,10 @@ let worklet = {
     _c: {
         y1
     },
-    _wkltId: "a77b:test:1"
+    _wkltId: "a77b:test:1",
+    ...{
+        y1: this.y1
+    }
 };
 loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry) && registerWorkletInternal("main-thread", "a77b:test:1", function(event: Event) {
     const worklet = lynxWorkletImpl._workletMap["a77b:test:1"].bind(this);

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_transform_lepus_general.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_transform_lepus_general.js
@@ -4,7 +4,10 @@ let worklet = {
     _c: {
         y1
     },
-    _wkltId: "a77b:test:1"
+    _wkltId: "a77b:test:1",
+    ...{
+        y1: this.y1
+    }
 };
 loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry) && registerWorkletInternal("main-thread", "a77b:test:1", function(event: Event) {
     const worklet = lynxWorkletImpl._workletMap["a77b:test:1"].bind(this);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue preventing main thread functions from accessing properties on `this` before hydration completes, resolving "cannot convert to object" errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
