### PR TITLE
fix(plugin-qrcode): skip interactive loop in non-TTY environments (#2201)

### DIFF
--- a/.changeset/tty-qrcode-shortcuts.md
+++ b/.changeset/tty-qrcode-shortcuts.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/qrcode-rsbuild-plugin": patch
+---
+
+Only register console shortcuts when running in TTY environments

--- a/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
+++ b/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
@@ -47,7 +47,9 @@ export async function registerConsoleShortcuts(
   gExistingShortcuts.add(options)
 
   // We should not `await` on this since it would block the NodeJS main thread.
-  void loop(options, value, devUrls)
+  if (process.stdin.isTTY && process.stdout.isTTY) {
+    void loop(options, value, devUrls)
+  }
 
   function off() {
     gExistingShortcuts.delete(options)

--- a/packages/rspeedy/plugin-qrcode/test/index.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/index.test.ts
@@ -37,8 +37,26 @@ describe('Plugins - Terminal', () => {
     vi.stubEnv('NODE_ENV', 'production')
     vi.restoreAllMocks()
     vi.mocked(isCancel).mockReturnValue(true)
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    })
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    })
 
-    return () => vi.unstubAllEnvs()
+    return () => {
+      vi.unstubAllEnvs()
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: undefined,
+        configurable: true,
+      })
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: undefined,
+        configurable: true,
+      })
+    }
   })
 
   describe('schema', () => {

--- a/packages/rspeedy/plugin-qrcode/test/preview.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/preview.test.ts
@@ -30,6 +30,25 @@ const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
 describe('Preview', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    })
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    })
+
+    return () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: undefined,
+        configurable: true,
+      })
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: undefined,
+        configurable: true,
+      })
+    }
   })
 
   test('preview with NODE_ENV=development', async () => {
@@ -228,9 +247,6 @@ describe('Preview', () => {
           pluginStubRspeedyAPI(),
           pluginQRCode(),
         ],
-        environments: {
-          lynx: {},
-        },
         source: {
           entry: {},
         },

--- a/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import type { RsbuildPluginAPI } from '@rsbuild/core'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { registerConsoleShortcuts } from '../src/shortcuts.js'
 
@@ -17,6 +17,28 @@ describe('PluginQRCode - CLI Shortcuts', () => {
       config: { filename: '[name].[platform].bundle' },
     }),
   } as unknown as RsbuildPluginAPI
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    })
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    })
+
+    return () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: undefined,
+        configurable: true,
+      })
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: undefined,
+        configurable: true,
+      })
+    }
+  })
 
   test('open page', async () => {
     vi.stubEnv('NODE_ENV', 'development')


### PR DESCRIPTION
When stdin is not a TTY (CI, piped output, Docker without -it), the interactive shortcut menu is now skipped to prevent hangs, while still printing the QR code.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin no longer blocks or prompts in non-interactive/automated environments; it skips the interactive loop to avoid hangs or unexpected prompts.

* **Chores**
  * Added a patch release note marker documenting this behavior change for the QR code plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required). not required.
- [ ] Documentation updated (or not required). not required.
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required). not required.
