### PR TITLE
chore(renovate): group playwright docker image with npm packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -182,8 +182,14 @@
       "matchPackageNames": [
         "playwright",
         "@playwright/**",
+      ],
+    },
+    {
+      "groupName": "playwright monorepo",
+      "matchPackageNames": [
         "mcr.microsoft.com/playwright",
       ],
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-noble$",
     },
   ],
 


### PR DESCRIPTION
## Summary
Updates Renovate configuration to group `mcr.microsoft.com/playwright` Docker image updates with `playwright` npm package updates.

## Details
- Adds a custom `versioning` regex for `mcr.microsoft.com/playwright` to extract the semantic version from tags like `v1.59.0-noble`.
- Separates the Docker image rule from the main Playwright monorepo rule to apply the versioning strategy while keeping them in the same `groupName`.

This ensures that when Playwright updates (e.g. to 1.59.0), both the NPM packages and the Docker image are updated in a single PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Playwright dependency and container image update management through improved versioning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->