### PR TITLE
fix: properly cleanup __DestroyLifetime listeners and listCallbacks in snapshotDestroyList

### DIFF
--- a/.changeset/tender-otters-cheat.md
+++ b/.changeset/tender-otters-cheat.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+fix: properly cleanup `__DestroyLifetime` listeners and listCallbacks in `snapshotDestroyList`.

--- a/packages/react/runtime/__test__/list.test.jsx
+++ b/packages/react/runtime/__test__/list.test.jsx
@@ -443,12 +443,10 @@ describe(`list componentAtIndex`, () => {
     __pendingListUpdates.flush();
 
     a.removeChild(b);
-    expect(() => {
-      elementTree.triggerComponentAtIndex(listRef, 0);
-    }).toThrowErrorMatchingInlineSnapshot(`[Error: componentAtIndex called on removed list]`);
-    expect(() => {
-      elementTree.triggerEnqueueComponent(listRef, 0);
-    }).toThrowErrorMatchingInlineSnapshot(`[Error: enqueueComponent called on removed list]`);
+
+    expect(listRef.componentAtIndex()).toBe(-1);
+    expect(listRef.enqueueComponent()).toBeUndefined();
+    expect(listRef.componentAtIndexes()).toBeUndefined();
   });
 
   it('should reuse and hydrate', () => {
@@ -4408,5 +4406,46 @@ describe('clear __UpdateListCallbacks', () => {
     expect(listElement.componentAtIndex).toBeNull();
     expect(listElement.enqueueComponent).toBeNull();
     expect(listElement.componentAtIndexes).toBeNull();
+  });
+
+  it('should remove __DestroyLifetime listener when list is destroyed via removeChild', () => {
+    const s0 = __SNAPSHOT__(
+      <view>
+        {HOLE}
+      </view>,
+    );
+    const s1 = __SNAPSHOT__(
+      <view>
+        <text>test</text>
+        <list>{HOLE}</list>
+      </view>,
+    );
+
+    const root = new SnapshotInstance(s0);
+    root.ensureElements();
+
+    const a = new SnapshotInstance(s1);
+    root.insertBefore(a);
+
+    expect(lynx.getNative().addEventListener).toHaveBeenCalledWith(
+      '__DestroyLifetime',
+      expect.any(Function),
+    );
+
+    const listElement = a.__elements[3];
+    expect(listElement.componentAtIndex).not.toBeNull();
+    expect(listElement.enqueueComponent).not.toBeNull();
+    expect(listElement.componentAtIndexes).not.toBeNull();
+
+    root.removeChild(a);
+
+    expect(lynx.getNative().removeEventListener).toHaveBeenCalledWith(
+      '__DestroyLifetime',
+      expect.any(Function),
+    );
+
+    expect(listElement.componentAtIndex()).toBe(-1);
+    expect(listElement.enqueueComponent()).toBeUndefined();
+    expect(listElement.componentAtIndexes()).toBeUndefined();
   });
 });

--- a/packages/react/runtime/src/list.ts
+++ b/packages/react/runtime/src/list.ts
@@ -52,9 +52,14 @@ export function componentAtIndexFactory(
   ) => {
     const signMap = gSignMap[listID];
     const recycleMap = gRecycleMap[listID];
+
     if (!signMap || !recycleMap) {
+      /* v8 ignore start */
+      // Theoretically unreachable since snapshotDestroyList clears componentAtIndex with a noop function.
+      // Kept as a safeguard in case the callback is somehow invoked after list removal.
       throw new Error('componentAtIndex called on removed list');
     }
+    /* v8 ignore end */
 
     const platformInfo = childCtx.__listItemPlatformInfo ?? {};
 

--- a/packages/react/runtime/src/list.ts
+++ b/packages/react/runtime/src/list.ts
@@ -53,8 +53,8 @@ export function componentAtIndexFactory(
     const signMap = gSignMap[listID];
     const recycleMap = gRecycleMap[listID];
 
+    /* v8 ignore start */
     if (!signMap || !recycleMap) {
-      /* v8 ignore start */
       // Theoretically unreachable since snapshotDestroyList clears componentAtIndex with a noop function.
       // Kept as a safeguard in case the callback is somehow invoked after list removal.
       throw new Error('componentAtIndex called on removed list');

--- a/packages/react/runtime/src/snapshot/list.ts
+++ b/packages/react/runtime/src/snapshot/list.ts
@@ -6,6 +6,8 @@ import { hydrate } from '../hydrate.js';
 import { componentAtIndexFactory, enqueueComponentFactory, gRecycleMap, gSignMap } from '../list.js';
 import type { SnapshotInstance } from '../snapshot.js';
 
+const destroyLifetimeHandlerMap = new Map<number, () => void>();
+
 export function snapshotCreateList(
   pageId: number,
   _ctx: SnapshotInstance,
@@ -24,9 +26,12 @@ export function snapshotCreateList(
   const listID = __GetElementUniqueID(list);
 
   if (typeof lynx !== 'undefined' && typeof lynx.getNative === 'function') {
-    lynx.getNative()?.addEventListener('__DestroyLifetime', () => {
+    const cb = () => {
       __UpdateListCallbacks(list, null, null, null);
-    });
+      destroyLifetimeHandlerMap.delete(listID);
+    };
+    lynx.getNative()?.addEventListener('__DestroyLifetime', cb);
+    destroyLifetimeHandlerMap.set(listID, cb);
   }
 
   gSignMap[listID] = signMap;
@@ -38,6 +43,17 @@ export function snapshotDestroyList(si: SnapshotInstance): void {
   const [, elementIndex] = si.__snapshot_def.slot[0]!;
   const list = si.__elements![elementIndex]!;
   const listID = __GetElementUniqueID(list);
+
+  __UpdateListCallbacks(list, () => -1, () => {}, () => {});
+
+  if (typeof lynx !== 'undefined' && typeof lynx.getNative === 'function') {
+    const cb = destroyLifetimeHandlerMap.get(listID);
+    if (cb) {
+      lynx.getNative()?.removeEventListener('__DestroyLifetime', cb);
+      destroyLifetimeHandlerMap.delete(listID);
+    }
+  }
+
   delete gSignMap[listID];
   delete gRecycleMap[listID];
 }

--- a/packages/react/testing-library/src/__tests__/list.test.jsx
+++ b/packages/react/testing-library/src/__tests__/list.test.jsx
@@ -529,10 +529,6 @@ describe('list', () => {
     act(() => {
       setHide(true);
     });
-
-    expect(() => {
-      elementTree.leaveListItem(list, uid0);
-    }).toThrowErrorMatchingInlineSnapshot(`[Error: enqueueComponent called on removed list]`);
   });
 });
 


### PR DESCRIPTION


<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup of list destruction so listeners are removed and no lingering handlers remain.
  * List public methods now return safe default values after a list is removed instead of throwing.

* **Tests**
  * Updated tests to reflect post-removal behavior and the improved listener cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
