### PR TITLE
feat: replace source build with binary download for benchx_cli

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -195,14 +195,14 @@
 
   "customManagers": [
     {
-      // See: https://docs.renovatebot.com/modules/datasource/git-refs/
+      // Update benchx_cli version from GitHub releases
+      // See: https://docs.renovatebot.com/modules/datasource/github-releases/
       "customType": "regex",
-      "managerFilePatterns": ["packages/lynx/benchx_cli/scripts/build.mjs"],
-      "matchStrings": ["const COMMIT = '(?<currentDigest>.*?)';"],
-      "currentValueTemplate": "develop",
-      "depNameTemplate": "lynx",
-      "packageNameTemplate": "https://github.com/lynx-family/lynx",
-      "datasourceTemplate": "git-refs",
+      "managerFilePatterns": ["packages/lynx/benchx_cli/scripts/build.sh"],
+      "matchStrings": ["LOCKED_VERSION=\"(?<currentValue>benchx_cli-.*?)\""],
+      "depNameTemplate": "lynx-community/benchx_cli",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "regex:^benchx_cli-(?<major>\\d{4})(?<minor>\\d{2})(?<patch>\\d{2})(?<build>\\d{4})$",
     },
     {
       "customType": "regex",

--- a/packages/lynx/benchx_cli/scripts/build.mjs
+++ b/packages/lynx/benchx_cli/scripts/build.mjs
@@ -1,134 +1,35 @@
-// Copyright 2025 The Lynx Authors. All rights reserved.
+// Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import path from 'node:path';
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
-import { $ } from 'zx';
-
-if (
-  !process.env.CI
-  // rspack-ecosystem-ci would set this
-  // https://github.com/rspack-contrib/rspack-ecosystem-ci/blob/113d2338da254ca341313a4a54afe789b45b1508/utils.ts#L108
-  || process.env['ECOSYSTEM_CI']
-) {
-  // eslint-disable-next-line n/no-process-exit
-  process.exit(0);
-}
-
+// Windows: Create noop binary
 if (process.platform === 'win32') {
-  // create a noop binary for windows
-
-  mkdirSync('./dist/bin', { recursive: true });
+  const binDir = join(__dirname, '..', 'dist', 'bin');
+  mkdirSync(binDir, { recursive: true });
   writeFileSync(
-    './dist/bin/benchx_cli',
-    `\
-#!/usr/bin/env node
-
-console.log('noop')
-`,
+    join(binDir, 'benchx_cli'),
+    '#!/usr/bin/env node\n\nconsole.log(\'noop\')\n',
   );
-
   // eslint-disable-next-line n/no-process-exit
   process.exit(0);
 }
 
-const COMMIT = '25af017a126ed087ba1bf276639f4a0b60b348fc';
-const PICK_COMMIT = '26f5fa8f92c517bce0550c34ff7a43f06c2df705';
+// Unix: Run build_unix.sh
+const result = spawnSync('bash', [join(__dirname, 'build_unix.sh')], {
+  stdio: 'inherit',
+});
 
-function checkCwd() {
-  try {
-    if (
-      JSON.parse(
-        readFileSync(
-          path.join(process.cwd(), 'package.json'),
-          'utf-8',
-        ).toString(),
-      ).name === 'benchx_cli'
-    ) {
-      return true;
-    }
-  } catch {
-    return false;
-  }
-  return false;
-}
-
-async function checkBinary() {
-  if (
-    existsSync('./dist/bin/benchx_cli')
-    && existsSync('./dist/bin/benchx_cli.commit')
-  ) {
-    const { exitCode, stdout } = await $`cat ./dist/bin/benchx_cli.commit`;
-    if (exitCode === 0 && stdout.trim() === COMMIT) {
-      return true;
-    }
-  }
-  return false;
-}
-
-if (!checkCwd()) {
-  throw new Error(
-    'This script must be run from `packages/lynx/benchx_cli` dir',
-  );
-}
-
-if (await checkBinary()) {
-  console.info('Binary is up to date');
+if (result.error) {
+  console.error('Failed to execute script "build_unix.sh":', result.error);
   // eslint-disable-next-line n/no-process-exit
-  process.exit(0);
+  process.exit(1);
 }
 
-await $`
-rm -rf dist
-rm -rf habitat
-rm -rf lynx
-`;
-
-// prepare the lynx repo
-await $`
-mkdir -p lynx
-cd lynx
-git init -b main
-git remote add origin https://github.com/lynx-family/lynx
-git fetch origin ${COMMIT}
-git checkout ${COMMIT}
-git remote add lynx-community https://github.com/lynx-community/benchx_cli
-git fetch lynx-community ${PICK_COMMIT}
-git cherry-pick -n ${PICK_COMMIT}
-`.pipe(process.stdout);
-
-// hab sync .
-await $`
-set +u
-cd lynx
-uv venv .venv
-source .venv/bin/activate
-uv pip install pip
-source tools/envsetup.sh
-tools/hab sync .
-`.pipe(process.stdout);
-
-// build from source
-await $`
-set +u
-cd lynx
-source tools/envsetup.sh
-gn gen --args=${
-  process.platform === 'darwin'
-    ? `enable_unittests=true enable_trace="perfetto" jsengine_type="quickjs" enable_frozen_mode=true use_flutter_cxx=false`
-    : `enable_unittests=true enable_trace="perfetto" jsengine_type="quickjs" enable_frozen_mode=true`
-} out/Default
-ninja -C out/Default benchx_cli
-mkdir -p ../dist/bin
-cp out/Default/benchx_cli ../dist/bin/benchx_cli
-git rev-parse HEAD > ../dist/bin/benchx_cli.commit
-rm -rf out
-`.pipe(process.stdout);
-
-// cleanup
-await $`
-rm -rf habitat
-rm -rf lynx
-`;
+// eslint-disable-next-line n/no-process-exit
+process.exit(result.status ?? 1);

--- a/packages/lynx/benchx_cli/scripts/build_unix.sh
+++ b/packages/lynx/benchx_cli/scripts/build_unix.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -e
+
+# Logic from original build.mjs:
+# if (!process.env.CI || process.env['ECOSYSTEM_CI']) process.exit(0);
+if [ -z "$CI" ] || [ -n "$ECOSYSTEM_CI" ]; then
+  exit 0
+fi
+
+# Check CWD
+if [ ! -f "package.json" ] || ! grep -q '"name": "benchx_cli"' package.json; then
+  echo "Error: This script must be run from 'packages/lynx/benchx_cli' dir"
+  exit 1
+fi
+
+LOCKED_VERSION="benchx_cli-202602132156"
+
+# Check if binary is up to date
+if [ -f "./dist/bin/benchx_cli" ] && [ -f "./dist/bin/benchx_cli.version" ]; then
+  CURRENT_VERSION=$(cat ./dist/bin/benchx_cli.version)
+  if [ "$CURRENT_VERSION" == "$LOCKED_VERSION" ]; then
+    echo "Binary is up to date"
+    exit 0
+  fi
+fi
+
+# Determine platform and arch
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+ASSET_NAME=""
+
+if [ "$OS" == "Darwin" ]; then
+  if [ "$ARCH" == "arm64" ]; then
+    ASSET_NAME="benchx_cli_Darwin_arm64.tar.gz"
+  else
+    echo "Unsupported architecture for Darwin: $ARCH"
+    exit 1
+  fi
+elif [ "$OS" == "Linux" ]; then
+  if [ "$ARCH" == "x86_64" ]; then
+    ASSET_NAME="benchx_cli_Linux_x86_64.tar.gz"
+  else
+    echo "Unsupported architecture for Linux: $ARCH"
+    exit 1
+  fi
+else
+  echo "Unsupported OS: $OS"
+  exit 1
+fi
+
+echo "Using locked version: $LOCKED_VERSION"
+echo "Downloading new binary..."
+
+rm -rf dist
+mkdir -p dist/bin
+
+URL="https://github.com/lynx-community/benchx_cli/releases/download/$LOCKED_VERSION/$ASSET_NAME"
+TAR_PATH="./dist/$ASSET_NAME"
+
+echo "Downloading $ASSET_NAME from $URL..."
+curl -L --fail --show-error --progress-bar -o "$TAR_PATH" "$URL"
+
+echo "Extracting $ASSET_NAME to ./dist/bin..."
+tar -xzf "$TAR_PATH" -C ./dist/bin
+
+rm -f "$TAR_PATH"
+echo "$LOCKED_VERSION" > ./dist/bin/benchx_cli.version
+
+echo "Binary downloaded and extracted successfully"
+echo "Binary location: $(pwd)/dist/bin/benchx_cli"

--- a/packages/lynx/benchx_cli/turbo.json
+++ b/packages/lynx/benchx_cli/turbo.json
@@ -6,7 +6,7 @@
       "env": ["ECOSYSTEM_CI"],
       "passThroughEnv": ["ECOSYSTEM_CI"],
       "dependsOn": [],
-      "inputs": ["scripts/build.mjs", "patches/*"],
+      "inputs": ["scripts/build.sh"],
       "outputs": ["dist/**"]
     }
   }


### PR DESCRIPTION
## Summary

Replaced the complex source build process for `benchx_cli` with a lightweight binary download script. This change significantly speeds up the setup process and removes build-time dependencies.

## Changes

- **Replaced `packages/lynx/benchx_cli/scripts/build.mjs` with `build.sh`**:
    - No longer builds from source (which required Ninja, Rust, etc.).
    - Downloads pre-built binaries from [lynx-community/benchx_cli](https://github.com/lynx-community/benchx_cli/releases).
    - Supports macOS (arm64) and Linux (x86_64).
    - Includes platform detection and version locking.
- **Updated `package.json`**:
    - Changed `build` script to run the new shell script.
    - Removed `zx` dependency as it's no longer needed for the build script.
- **Updated `.github/renovate.json5`**:
    - Configured Renovate to monitor the `LOCKED_VERSION` in `build.sh` against GitHub Releases instead of git tags/commits.

## Verification

- Verified that `pnpm build` in `packages/lynx/benchx_cli` correctly downloads and extracts the binary.
- Verified that the version check works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Build now fetches prebuilt benchx_cli binaries from GitHub Releases instead of compiling from source.
  * Builds use a locked-version approach tied to release tags for consistent binaries.
  * Build process switched from a Node-based flow to a shell-based workflow.
  * Platform-specific binary selection added for macOS (arm64) and Linux (x86_64).

* **Chores**
  * CI/task inputs updated to use the new shell-based build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->