### PR TITLE
feat: allow templateDebugUrl to be customized via output.publicPath or beforeEncode hook

### DIFF
--- a/.changeset/allow-debug-url-customize.md
+++ b/.changeset/allow-debug-url-customize.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+feat: allow `templateDebugUrl` to be customized via `output.publicPath` or the `beforeEncode` hook.

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -757,13 +757,31 @@ class LynxTemplatePluginImpl {
       cssPlugins,
       enableCSSSelector,
     );
+
+    let templateDebugUrl = '';
+    const debugInfoPath = path.posix.format({
+      dir: intermediate,
+      base: 'debug-info.json',
+    });
+    // TODO: Support publicPath function
+    if (
+      typeof compiler.options.output.publicPath === 'string'
+      && compiler.options.output.publicPath !== 'auto'
+      && compiler.options.output.publicPath !== '/'
+    ) {
+      templateDebugUrl = new URL(
+        debugInfoPath,
+        compiler.options.output.publicPath,
+      ).toString();
+    }
+
     const encodeRawData: EncodeRawData = {
       compilerOptions: {
         enableFiberArch: true,
         useLepusNG: true,
         enableReuseContext: true,
         bundleModuleMode: 'ReturnByFunction',
-        templateDebugUrl: '',
+        templateDebugUrl,
 
         debugInfoOutside,
         defaultDisplayLinear,
@@ -843,23 +861,6 @@ class LynxTemplatePluginImpl {
         filename: lepusCode.filename,
       },
     };
-
-    const debugInfoPath = path.posix.format({
-      dir: intermediate,
-      base: 'debug-info.json',
-    });
-
-    // TODO: Support publicPath function
-    if (
-      typeof compiler.options.output.publicPath === 'string'
-      && compiler.options.output.publicPath !== 'auto'
-      && compiler.options.output.publicPath !== '/'
-    ) {
-      resolvedEncodeOptions.compilerOptions['templateDebugUrl'] = new URL(
-        debugInfoPath,
-        compiler.options.output.publicPath,
-      ).toString();
-    }
 
     const { RawSource } = compiler.webpack.sources;
 

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-before-encode/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-before-encode/index.js
@@ -1,0 +1,26 @@
+/// <reference types="vitest/globals" />
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+it('should have debug-info.json emitted', async () => {
+  const content = await fs.readFile(
+    path.resolve(__dirname, '.rspeedy/main/debug-info.json'),
+  );
+
+  expect(content.length).not.toBe(0);
+});
+
+it('should have custom templateDebugUrl in tasm.json from hook', async () => {
+  const tasmJSON = await fs.readFile(
+    path.resolve(__dirname, '.rspeedy/main/tasm.json'),
+    'utf-8',
+  );
+
+  const { compilerOptions } = JSON.parse(tasmJSON);
+
+  expect(compilerOptions).toHaveProperty(
+    'templateDebugUrl',
+    'https://custom-hook-url.com/debug-info.json',
+  );
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-before-encode/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-before-encode/rspack.config.js
@@ -1,0 +1,3 @@
+import config from './webpack.config.js';
+
+export default config;

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-before-encode/webpack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-before-encode/webpack.config.js
@@ -1,0 +1,31 @@
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../src';
+
+/** @type {import('webpack').Configuration} */
+export default {
+  mode: 'development',
+  target: 'node',
+  output: {
+    publicPath: 'https://should-be-overridden.com/',
+  },
+  plugins: [
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      intermediate: '.rspeedy/main',
+    }),
+    {
+      apply(compiler) {
+        compiler.hooks.compilation.tap('TestPlugin', (compilation) => {
+          LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation)
+            .beforeEncode.tap(
+              'TestPlugin',
+              (data) => {
+                data.encodeData.compilerOptions.templateDebugUrl =
+                  'https://custom-hook-url.com/debug-info.json';
+                return data;
+              },
+            );
+        });
+      },
+    },
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-custom/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-custom/index.js
@@ -1,0 +1,26 @@
+/// <reference types="vitest/globals" />
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+it('should have debug-info.json emitted', async () => {
+  const content = await fs.readFile(
+    path.resolve(__dirname, '.rspeedy/main/debug-info.json'),
+  );
+
+  expect(content.length).not.toBe(0);
+});
+
+it('should have templateDebugUrl in tasm.json', async () => {
+  const tasmJSON = await fs.readFile(
+    path.resolve(__dirname, '.rspeedy/main/tasm.json'),
+    'utf-8',
+  );
+
+  const { compilerOptions } = JSON.parse(tasmJSON);
+
+  expect(compilerOptions).toHaveProperty(
+    'templateDebugUrl',
+    'https://example.com/.rspeedy/main/debug-info.json',
+  );
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-custom/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-custom/rspack.config.js
@@ -1,0 +1,3 @@
+import config from './webpack.config.js';
+
+export default config;

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-custom/webpack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-custom/webpack.config.js
@@ -1,0 +1,16 @@
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../src';
+
+/** @type {import('webpack').Configuration} */
+export default {
+  mode: 'development',
+  target: 'node',
+  output: {
+    publicPath: 'https://example.com/',
+  },
+  plugins: [
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      intermediate: '.rspeedy/main',
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary
This PR allows the `templateDebugUrl` (used for debugging Lynx templates) to be customized via:
1. The `output.publicPath` configuration in Webpack/Rspack.
2. The `beforeEncode` hook provided by `LynxTemplatePlugin`.

When a string-based `publicPath` (other than `'/'` or `'auto'`) is provided, or when modified manually via the hook, the plugin will use it as the base for the `templateDebugUrl`. The hook takes precedence over the `publicPath` configuration.

## Proposed Changes
### `@lynx-js/template-webpack-plugin`
- Modified `LynxTemplatePluginImpl` to generate `templateDebugUrl` using `output.publicPath` if it's a valid string.
- Added support for manually overriding `templateDebugUrl` in the `beforeEncode` hook.
- Added new test cases:
  - `debug-info-public-path-custom`: Verifies customization via `output.publicPath`.
  - `debug-info-before-encode`: Verifies customization via `beforeEncode` hook and ensures it overrides `output.publicPath`.

## Test Plan
Added and verified the following test cases in `packages/webpack/template-webpack-plugin/test/cases/assets/`:

1. **Custom publicPath**:
```bash
npx vitest packages/webpack/template-webpack-plugin/test/cases.test.ts -t "assets debug-info-public-path-custom" --run
```

2. **beforeEncode hook override (Precedence Test)**:
```bash
npx vitest packages/webpack/template-webpack-plugin/test/cases.test.ts -t "assets debug-info-before-encode" --run
```
*This test case sets both `publicPath` and a hook, verifying that the hook's value is the one that ends up in the final output.*

## Checklist
- [x] Added test cases
- [x] Added changeset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * templateDebugUrl can now be customized via output.publicPath or the beforeEncode hook.

* **Tests**
  * Added test coverage for custom templateDebugUrl configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->