### PR TITLE
fix(rspeedy/core): avoid importing `version.js` dynamically

### DIFF
--- a/.changeset/twenty-falcons-press.md
+++ b/.changeset/twenty-falcons-press.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Avoid generating `Rsbuild vundefined` in greeting message.

--- a/packages/rspeedy/core/src/cli/main.ts
+++ b/packages/rspeedy/core/src/cli/main.ts
@@ -6,6 +6,7 @@ import { logger } from '@rsbuild/core'
 
 import { exit } from './exit.js'
 import { debug } from '../debug.js'
+import { rsbuildVersion, rspackVersion, version } from '../version.js'
 
 function initNodeEnv(argv: string[]) {
   if (!process.env['NODE_ENV']) {
@@ -32,10 +33,6 @@ export async function main(
     // biome-ignore lint/suspicious/noConsoleLog: <explanation>
     console.log()
   }
-
-  const { version, rsbuildVersion, rspackVersion } = await import(
-    '../version.js'
-  )
 
   logger.greet(
     `  Rspeedy v${version} (Rsbuild v${rsbuildVersion}, Rspack v${rspackVersion})\n`,


### PR DESCRIPTION
<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the greeting message incorrectly displayed "Rsbuild vundefined".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This is a workaround for https://github.com/web-infra-dev/rslib/issues/1497

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
