### PR TITLE
feat: remove stale gestures when diff

### DIFF
--- a/.changeset/all-crabs-smell.md
+++ b/.changeset/all-crabs-smell.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/testing-environment': patch
+---
+
+Add `__RemoveGestureDetector` PAPI binding

--- a/.changeset/fair-horses-worry.md
+++ b/.changeset/fair-horses-worry.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/react': patch
+---
+
+Remove stale gestures when gestures are removed

--- a/examples/gesture/lynx.config.js
+++ b/examples/gesture/lynx.config.js
@@ -1,0 +1,26 @@
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx({
+      enableNewGesture: true,
+    }),
+    pluginQRCode({
+      schema(url) {
+        return `${url}?fullscreen=true`;
+      },
+    }),
+  ],
+  environments: {
+    web: {},
+    lynx: {
+      performance: {
+        profile: enableBundleAnalysis,
+      },
+    },
+  },
+});

--- a/examples/gesture/package.json
+++ b/examples/gesture/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@lynx-js/example-gesture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "test:type": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@lynx-js/gesture-runtime": "workspace:*",
+    "@lynx-js/react": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
+    "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/types": "3.7.0",
+    "@types/react": "^18.3.28"
+  }
+}

--- a/examples/gesture/src/App.css
+++ b/examples/gesture/src/App.css
@@ -1,0 +1,105 @@
+:root {
+  --bg: #0a1022;
+  --card: #141e3d;
+  --card-border: #2a3765;
+  --text: #eaf0ff;
+  --text-dim: #9fb0de;
+  --button: #22315f;
+  --button-active: #3c5df6;
+  --box-a: #ff8b3d;
+  --box-b: #28c6a5;
+  --box-off: #6f7b9f;
+}
+
+page {
+  background-color: var(--bg);
+}
+
+.Root {
+  min-height: 100vh;
+  padding: 36rpx 24rpx;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: center;
+}
+
+.Card {
+  width: 100%;
+  max-width: 680rpx;
+  padding: 28rpx;
+  border-radius: 24rpx;
+  background: var(--card);
+  border: 2rpx solid var(--card-border);
+  gap: 20rpx;
+}
+
+.Title {
+  color: var(--text);
+  font-size: 44rpx;
+  font-weight: 700;
+}
+
+.Description {
+  color: var(--text-dim);
+  font-size: 28rpx;
+  line-height: 38rpx;
+}
+
+.Controls {
+  flex-direction: column;
+  gap: 14rpx;
+}
+
+.Button {
+  border-radius: 16rpx;
+  background: var(--button);
+  padding: 16rpx 20rpx;
+}
+
+.Button--active {
+  background: var(--button-active);
+}
+
+.ButtonText {
+  color: #ffffff;
+  font-size: 28rpx;
+  font-weight: 600;
+}
+
+.ModeText {
+  color: var(--text);
+  font-size: 27rpx;
+}
+
+.Stage {
+  margin-top: 8rpx;
+  height: 560rpx;
+  border-radius: 18rpx;
+  border: 2rpx dashed #4e5e97;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.DragBox {
+  width: 160rpx;
+  height: 160rpx;
+  border-radius: 24rpx;
+  background: var(--box-a);
+  align-items: center;
+  justify-content: center;
+}
+
+.DragBox--diff {
+  background: var(--box-b);
+}
+
+.DragBox--removed {
+  background: var(--box-off);
+}
+
+.DragBoxText {
+  color: #111827;
+  font-size: 34rpx;
+  font-weight: 800;
+}

--- a/examples/gesture/src/App.tsx
+++ b/examples/gesture/src/App.tsx
@@ -1,0 +1,171 @@
+import { PanGesture, useGesture } from '@lynx-js/gesture-runtime';
+import { useCallback, useMainThreadRef, useState } from '@lynx-js/react';
+
+import './App.css';
+
+type GestureMode = 'set' | 'diff' | 'remove';
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+export function App() {
+  const [mode, setMode] = useState<GestureMode>('set');
+  const startPointMTRef = useMainThreadRef<Point>({ x: 0, y: 0 });
+  const baseOffsetMTRef = useMainThreadRef<Point>({ x: 0, y: 0 });
+
+  const panGestureA = useGesture(PanGesture);
+  panGestureA
+    .onBegin((event) => {
+      'main thread';
+      startPointMTRef.current = {
+        x: event.params.clientX,
+        y: event.params.clientY,
+      };
+      event.currentTarget.setStyleProperty('opacity', '0.82');
+      console.info('PanGestureA onBegin', startPointMTRef.current);
+    })
+    .onUpdate((event) => {
+      'main thread';
+      const dx = event.params.clientX - startPointMTRef.current.x;
+      const dy = event.params.clientY - startPointMTRef.current.y;
+      const nextX = baseOffsetMTRef.current.x + dx;
+      const nextY = baseOffsetMTRef.current.y + dy;
+      event.currentTarget.setStyleProperty(
+        'transform',
+        `translate(${nextX}px, ${nextY}px)`,
+      );
+      console.info('PanGestureA onUpdate', dx, dy, nextX, nextY);
+    })
+    .onEnd((event) => {
+      'main thread';
+      const dx = event.params.clientX - startPointMTRef.current.x;
+      const dy = event.params.clientY - startPointMTRef.current.y;
+      baseOffsetMTRef.current = {
+        x: baseOffsetMTRef.current.x + dx,
+        y: baseOffsetMTRef.current.y + dy,
+      };
+      event.currentTarget.setStyleProperty('opacity', '1');
+      console.info('PanGestureA onEnd', baseOffsetMTRef.current);
+    });
+
+  const panGestureB = useGesture(PanGesture);
+  panGestureB
+    .onBegin((event) => {
+      'main thread';
+      startPointMTRef.current = {
+        x: event.params.clientX,
+        y: event.params.clientY,
+      };
+      event.currentTarget.setStyleProperty('opacity', '0.82');
+      console.info('PanGestureB onBegin', startPointMTRef.current);
+    })
+    .onUpdate((event) => {
+      'main thread';
+
+      const dx = event.params.clientX - startPointMTRef.current.x;
+      const nextX = baseOffsetMTRef.current.x + dx;
+      event.currentTarget.setStyleProperty(
+        'transform',
+        `translate(${nextX}px, 0px)`,
+      );
+      console.info('PanGestureB onUpdate', dx, nextX);
+    })
+    .onEnd((event) => {
+      'main thread';
+      const dx = event.params.clientX - startPointMTRef.current.x;
+      baseOffsetMTRef.current = {
+        x: baseOffsetMTRef.current.x + dx,
+        y: 0,
+      };
+      event.currentTarget.setStyleProperty('opacity', '1');
+      console.info('PanGestureB onEnd', baseOffsetMTRef.current);
+    });
+
+  const onSetGesture = useCallback(() => {
+    'background-only';
+    setMode('set');
+  }, []);
+
+  const onDiffGesture = useCallback(() => {
+    'background-only';
+    setMode('diff');
+  }, []);
+
+  const onRemoveGesture = useCallback(() => {
+    'background-only';
+    setMode('remove');
+  }, []);
+
+  const activeGesture = mode === 'set'
+    ? panGestureA
+    : (mode === 'diff'
+      ? panGestureB
+      : undefined);
+
+  const modeDescription = mode === 'set'
+    ? 'Mode A: drag in both X and Y.'
+    : (mode === 'diff'
+      ? 'Mode B: drag in X only.'
+      : 'Removed: drag should do nothing.');
+
+  const dragBoxGestureProps = activeGesture
+    ? { 'main-thread:gesture': activeGesture }
+    : {};
+
+  return (
+    <view className='Root'>
+      <view className='Card'>
+        <text className='Title'>Gesture Lifecycle Playground</text>
+        <text className='Description'>
+          Tap buttons to trigger set/diff/remove and drag the square.
+        </text>
+        <text className='Description'>
+          Verify remove semantics: after tapping "Remove Gesture", dragging
+          should produce no PanGesture logs.
+        </text>
+        <text className='Description'>
+          Verify update semantics: after tapping "Diff to Gesture B", only
+          PanGestureB logs should appear.
+        </text>
+
+        <view className='Controls'>
+          <view
+            className={`Button ${mode === 'set' ? 'Button--active' : ''}`}
+            bindtap={onSetGesture}
+          >
+            <text className='ButtonText'>Set Gesture A</text>
+          </view>
+          <view
+            className={`Button ${mode === 'diff' ? 'Button--active' : ''}`}
+            bindtap={onDiffGesture}
+          >
+            <text className='ButtonText'>Diff to Gesture B</text>
+          </view>
+          <view
+            className={`Button ${mode === 'remove' ? 'Button--active' : ''}`}
+            bindtap={onRemoveGesture}
+          >
+            <text className='ButtonText'>Remove Gesture</text>
+          </view>
+        </view>
+
+        <text className='ModeText'>{modeDescription}</text>
+
+        <view className='Stage'>
+          <view
+            className={`DragBox ${mode === 'diff' ? 'DragBox--diff' : ''} ${
+              mode === 'remove' ? 'DragBox--removed' : ''
+            }`}
+            {...dragBoxGestureProps}
+          >
+            <text className='DragBoxText'>
+              {mode === 'set' ? 'A' : (mode === 'diff' ? 'B' : 'OFF')}
+            </text>
+          </view>
+        </view>
+      </view>
+    </view>
+  );
+}

--- a/examples/gesture/src/index.tsx
+++ b/examples/gesture/src/index.tsx
@@ -1,0 +1,13 @@
+import '@lynx-js/preact-devtools';
+import '@lynx-js/react/debug';
+import { root } from '@lynx-js/react';
+
+import { App } from './App.jsx';
+
+root.render(
+  <App />,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/gesture/src/rspeedy-env.d.ts
+++ b/examples/gesture/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/gesture/tsconfig.json
+++ b/examples/gesture/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedDeclarations": false,
+  },
+  "include": ["src", "lynx.config.js"],
+  "references": [
+    { "path": "../../packages/react/tsconfig.json" },
+    { "path": "../../packages/rspeedy/core/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-qrcode/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-react/tsconfig.build.json" },
+  ],
+}

--- a/packages/react/runtime/__test__/gesture/processGesture.test.ts
+++ b/packages/react/runtime/__test__/gesture/processGesture.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { processGesture } from '../../src/gesture/processGesture.js';
+
+vi.mock('@lynx-js/react/worklet-runtime/bindings', () => ({
+  onWorkletCtxUpdate: vi.fn(),
+}));
+
+function createSerializedGesture(id: number) {
+  return {
+    id,
+    type: 0,
+    callbacks: {
+      onUpdate: {
+        _wkltId: 'bdd4:dd564:2',
+      },
+    },
+    __isSerialized: true,
+  };
+}
+
+function createSerializedComposedGesture(gestures: ReturnType<typeof createSerializedGesture>[]) {
+  return {
+    type: -1,
+    gestures,
+    __isSerialized: true,
+  };
+}
+
+describe('processGesture', () => {
+  let setAttribute: ReturnType<typeof vi.fn>;
+  let setGestureDetector: ReturnType<typeof vi.fn>;
+  let removeGestureDetector: ReturnType<typeof vi.fn>;
+  let hydrateCtx: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setAttribute = vi.fn();
+    setGestureDetector = vi.fn();
+    removeGestureDetector = vi.fn();
+    hydrateCtx = vi.fn();
+
+    vi.stubGlobal('__SetAttribute', setAttribute);
+    vi.stubGlobal('__SetGestureDetector', setGestureDetector);
+    vi.stubGlobal('__RemoveGestureDetector', removeGestureDetector);
+    vi.stubGlobal('lynxWorkletImpl', {
+      _hydrateCtx: hydrateCtx,
+      _jsFunctionLifecycleManager: {
+        addRef: vi.fn(),
+      },
+      _eventDelayImpl: {
+        runDelayedWorklet: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sets detector on mount with expected params', () => {
+    const dom = {} as FiberElement;
+    const gesture = createSerializedGesture(1);
+
+    processGesture(dom, gesture as any, undefined, false);
+
+    expect(setAttribute).toHaveBeenCalledWith(dom, 'has-react-gesture', true);
+    expect(setAttribute).toHaveBeenCalledWith(dom, 'flatten', false);
+    expect(setGestureDetector).toHaveBeenCalledTimes(1);
+    expect(setGestureDetector).toHaveBeenCalledWith(
+      dom,
+      1,
+      0,
+      {
+        callbacks: [
+          {
+            name: 'onUpdate',
+            callback: expect.objectContaining({
+              _wkltId: 'bdd4:dd564:2',
+            }),
+          },
+        ],
+      },
+      {
+        waitFor: [],
+        simultaneous: [],
+        continueWith: [],
+      },
+    );
+    expect(removeGestureDetector).not.toHaveBeenCalled();
+  });
+
+  it('skips attribute writes when domSet option is true', () => {
+    const dom = {} as FiberElement;
+    const gesture = createSerializedGesture(1);
+
+    processGesture(dom, gesture as any, undefined, false, { domSet: true });
+
+    expect(setAttribute).not.toHaveBeenCalled();
+    expect(setGestureDetector).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes old detector first and then sets new detector on diff', () => {
+    const dom = {} as FiberElement;
+    const gestureA = createSerializedGesture(1);
+    const gestureB = createSerializedGesture(2);
+
+    processGesture(dom, gestureA as any, undefined, false);
+    setAttribute.mockClear();
+    setGestureDetector.mockClear();
+    removeGestureDetector.mockClear();
+
+    processGesture(dom, gestureB as any, gestureA as any, false);
+
+    expect(removeGestureDetector).toHaveBeenCalledTimes(1);
+    expect(removeGestureDetector).toHaveBeenCalledWith(dom, 1);
+    expect(setGestureDetector).toHaveBeenCalledTimes(1);
+    expect(setGestureDetector).toHaveBeenCalledWith(
+      dom,
+      2,
+      0,
+      {
+        callbacks: [
+          {
+            name: 'onUpdate',
+            callback: expect.objectContaining({
+              _wkltId: 'bdd4:dd564:2',
+            }),
+          },
+        ],
+      },
+      {
+        waitFor: [],
+        simultaneous: [],
+        continueWith: [],
+      },
+    );
+  });
+
+  it('removes only old gesture detector when gesture is deleted', () => {
+    const dom = {} as FiberElement;
+    const gestureA = createSerializedGesture(1);
+    const gestureB = createSerializedGesture(2);
+
+    processGesture(dom, gestureA as any, undefined, false);
+    processGesture(dom, gestureB as any, gestureA as any, false);
+    setAttribute.mockClear();
+    setGestureDetector.mockClear();
+    removeGestureDetector.mockClear();
+
+    processGesture(dom, undefined as any, gestureB as any, false);
+
+    expect(setGestureDetector).not.toHaveBeenCalled();
+    expect(removeGestureDetector).toHaveBeenCalledTimes(1);
+    const removedIds = removeGestureDetector.mock.calls.map(([, id]) => id).sort((a, b) => a - b);
+    expect(removedIds).toEqual([2]);
+    expect(setAttribute).toHaveBeenCalledWith(dom, 'has-react-gesture', null);
+  });
+
+  it('deduplicates same-id gestures in composed gesture diff', () => {
+    const dom = {} as FiberElement;
+    const gestureA = createSerializedGesture(1);
+    const gestureADuplicate = createSerializedGesture(1);
+    const composedGesture = createSerializedComposedGesture([gestureA, gestureADuplicate]);
+
+    processGesture(dom, composedGesture as any, undefined, false);
+
+    expect(setGestureDetector).toHaveBeenCalledTimes(1);
+    expect(setGestureDetector).toHaveBeenCalledWith(
+      dom,
+      1,
+      0,
+      {
+        callbacks: [
+          {
+            name: 'onUpdate',
+            callback: expect.objectContaining({
+              _wkltId: 'bdd4:dd564:2',
+            }),
+          },
+        ],
+      },
+      {
+        waitFor: [],
+        simultaneous: [],
+        continueWith: [],
+      },
+    );
+  });
+
+  it('removes all old ids when deleting composed gesture', () => {
+    const dom = {} as FiberElement;
+    const gestureA = createSerializedGesture(1);
+    const gestureB = createSerializedGesture(2);
+    const composed = createSerializedComposedGesture([gestureA, gestureB]);
+
+    processGesture(dom, composed as any, undefined, false);
+    setAttribute.mockClear();
+    setGestureDetector.mockClear();
+    removeGestureDetector.mockClear();
+
+    processGesture(dom, undefined as any, composed as any, false);
+
+    expect(setGestureDetector).not.toHaveBeenCalled();
+    expect(removeGestureDetector).toHaveBeenCalledTimes(2);
+    const removedIds = removeGestureDetector.mock.calls.map(([, id]) => id).sort((a, b) => a - b);
+    expect(removedIds).toEqual([1, 2]);
+    expect(setAttribute).toHaveBeenCalledWith(dom, 'has-react-gesture', null);
+  });
+
+  it('removes stale detector ids before setting when gesture count shrinks on diff', () => {
+    const dom = {} as FiberElement;
+    const gestureA = createSerializedGesture(1);
+    const gestureB = createSerializedGesture(2);
+    const oldComposed = createSerializedComposedGesture([gestureA, gestureB]);
+    const newSingle = createSerializedGesture(3);
+
+    processGesture(dom, oldComposed as any, undefined, false);
+    setAttribute.mockClear();
+    setGestureDetector.mockClear();
+    removeGestureDetector.mockClear();
+
+    processGesture(dom, newSingle as any, oldComposed as any, false);
+
+    expect(removeGestureDetector).toHaveBeenCalledTimes(2);
+    expect(removeGestureDetector).toHaveBeenNthCalledWith(1, dom, 1);
+    expect(removeGestureDetector).toHaveBeenNthCalledWith(2, dom, 2);
+    expect(setGestureDetector).toHaveBeenCalledTimes(1);
+    expect(setGestureDetector).toHaveBeenCalledWith(
+      dom,
+      3,
+      0,
+      expect.any(Object),
+      {
+        waitFor: [],
+        simultaneous: [],
+        continueWith: [],
+      },
+    );
+  });
+
+  it('consumes old gestures one-to-one when ids are preserved and inserted', () => {
+    const dom = {} as FiberElement;
+    const oldGestureA = createSerializedGesture(1);
+    const oldGestureB = createSerializedGesture(2);
+    const newGestureB = createSerializedGesture(2);
+    const newGestureC = createSerializedGesture(3);
+
+    oldGestureA.callbacks.onUpdate._wkltId = 'old-a';
+    oldGestureB.callbacks.onUpdate._wkltId = 'old-b';
+    newGestureB.callbacks.onUpdate._wkltId = 'new-b';
+    newGestureC.callbacks.onUpdate._wkltId = 'new-c';
+
+    processGesture(
+      dom,
+      createSerializedComposedGesture([newGestureB, newGestureC]) as any,
+      createSerializedComposedGesture([oldGestureA, oldGestureB]) as any,
+      true,
+    );
+
+    expect(hydrateCtx).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ _wkltId: 'new-b' }),
+      expect.objectContaining({ _wkltId: 'old-b' }),
+    );
+    expect(hydrateCtx).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ _wkltId: 'new-c' }),
+      expect.objectContaining({ _wkltId: 'old-a' }),
+    );
+  });
+});

--- a/packages/react/runtime/__test__/gesture/processGesture.test.ts
+++ b/packages/react/runtime/__test__/gesture/processGesture.test.ts
@@ -2,10 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { processGesture } from '../../src/gesture/processGesture.js';
 
-vi.mock('@lynx-js/react/worklet-runtime/bindings', () => ({
-  onWorkletCtxUpdate: vi.fn(),
-}));
-
 function createSerializedGesture(id: number) {
   return {
     id,

--- a/packages/react/runtime/__test__/snapshot/gesture.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/gesture.test.jsx
@@ -12,11 +12,43 @@ beforeAll(() => {
   setupPage(__CreatePage('0', 0));
   injectUpdateMainThread();
   replaceCommitHook();
+  globalThis.lynxWorkletImpl = {
+    _refImpl: {
+      clearFirstScreenWorkletRefMap: vi.fn(),
+    },
+    _runOnBackgroundDelayImpl: {
+      runDelayedBackgroundFunctions: vi.fn(),
+    },
+    _hydrateCtx: vi.fn(),
+    _jsFunctionLifecycleManager: {
+      addRef: vi.fn(),
+    },
+    _eventDelayImpl: {
+      runDelayedWorklet: vi.fn(),
+      clearDelayedWorklets: vi.fn(),
+    },
+  };
 });
 
 beforeEach(() => {
   globalEnvManager.resetEnv();
   SystemInfo.lynxSdkVersion = '999.999';
+  globalThis.lynxWorkletImpl = {
+    _refImpl: {
+      clearFirstScreenWorkletRefMap: vi.fn(),
+    },
+    _runOnBackgroundDelayImpl: {
+      runDelayedBackgroundFunctions: vi.fn(),
+    },
+    _hydrateCtx: vi.fn(),
+    _jsFunctionLifecycleManager: {
+      addRef: vi.fn(),
+    },
+    _eventDelayImpl: {
+      runDelayedWorklet: vi.fn(),
+      clearDelayedWorklets: vi.fn(),
+    },
+  };
 });
 
 afterEach(() => {
@@ -357,6 +389,8 @@ describe('Gesture', () => {
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
       globalThis[rLynxChange[0]](rLynxChange[1]);
+      const textElement = __root.__element_root.children[0].children[0];
+      expect(elementTree.__GetGestureDetectorIds(textElement)).toEqual([3]);
 
       expect(__root.__element_root).toMatchInlineSnapshot(`
         <page
@@ -631,6 +665,7 @@ describe('Gesture', () => {
 
 describe('Gesture in spread', () => {
   it('normal gesture', async function() {
+    const spySetGesture = vi.spyOn(globalThis, '__SetGestureDetector');
     function Comp() {
       const gesture = {
         id: 1,
@@ -696,6 +731,29 @@ describe('Gesture in spread', () => {
 
     // Main Thread Render
     {
+      const textElement = __root.__element_root.children[0].children[0];
+      expect(spySetGesture).toHaveBeenCalledTimes(1);
+      expect(spySetGesture).toHaveBeenCalledWith(
+        textElement,
+        1,
+        0,
+        {
+          callbacks: [
+            {
+              name: 'onUpdate',
+              callback: expect.objectContaining({
+                _wkltId: 'bdd4:dd564:2',
+              }),
+            },
+          ],
+        },
+        {
+          waitFor: [],
+          simultaneous: [],
+          continueWith: [],
+        },
+      );
+
       expect(__root.__element_root).toMatchInlineSnapshot(`
         <page
           cssId="default-entry-from-native:0"
@@ -737,6 +795,8 @@ describe('Gesture in spread', () => {
     }
   });
   it('update gesture', async function() {
+    const spySetGesture = vi.spyOn(globalThis, '__SetGestureDetector');
+    const spyRemoveGesture = vi.spyOn(globalThis, '__RemoveGestureDetector');
     let _gesture = {
       id: 1,
       type: 0,
@@ -804,6 +864,8 @@ describe('Gesture in spread', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
+      spySetGesture.mockClear();
+      spyRemoveGesture.mockClear();
 
       _gesture = {
         ..._gesture,
@@ -815,45 +877,32 @@ describe('Gesture in spread', () => {
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
       globalThis[rLynxChange[0]](rLynxChange[1]);
+      const textElement = __root.__element_root.children[0].children[0];
 
-      expect(__root.__element_root).toMatchInlineSnapshot(`
-        <page
-          cssId="default-entry-from-native:0"
-        >
-          <view>
-            <text
-              flatten={false}
-              gesture={
-                {
-                  "config": {
-                    "callbacks": [
-                      {
-                        "callback": {
-                          "_execId": 10,
-                          "_wkltId": "bdd4:dd564:2",
-                        },
-                        "name": "onUpdate",
-                      },
-                    ],
-                  },
-                  "id": 2,
-                  "relationMap": {
-                    "continueWith": [],
-                    "simultaneous": [],
-                    "waitFor": [],
-                  },
-                  "type": 0,
-                }
-              }
-              has-react-gesture={true}
-            >
-              <raw-text
-                text="1"
-              />
-            </text>
-          </view>
-        </page>
-      `);
+      expect(spySetGesture).toHaveBeenCalledTimes(1);
+      const [setTarget, setGestureId, setGestureType, setConfig, setRelationMap] = spySetGesture.mock.calls[0];
+      expect(setTarget).toBe(textElement);
+      expect(setGestureType).toBe(0);
+      expect(typeof setGestureId).toBe('number');
+      expect(setConfig).toMatchObject({
+        callbacks: [
+          {
+            name: 'onUpdate',
+            callback: expect.objectContaining({
+              _wkltId: 'bdd4:dd564:2',
+            }),
+          },
+        ],
+      });
+      expect(setRelationMap).toEqual({
+        waitFor: [],
+        simultaneous: [],
+        continueWith: [],
+      });
+      expect(spyRemoveGesture).toHaveBeenCalledTimes(1);
+      expect(spyRemoveGesture).toHaveBeenCalledWith(textElement, 1);
+      expect(elementTree.__GetGestureDetectorIds(textElement)).toEqual([setGestureId]);
+      expect(textElement.props['has-react-gesture']).toBe(true);
     }
   });
   it('insert gesture', async function() {
@@ -981,6 +1030,8 @@ describe('Gesture in spread', () => {
     }
   });
   it('remove gesture', async function() {
+    const spySetGesture = vi.spyOn(globalThis, '__SetGestureDetector');
+    const spyRemoveGesture = vi.spyOn(globalThis, '__RemoveGestureDetector');
     let _gesture = {
       id: 1,
       type: 0,
@@ -1044,10 +1095,12 @@ describe('Gesture in spread', () => {
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
       globalThis[rLynxChange[0]](rLynxChange[1]);
     }
-    // update
+    // remove
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
+      spySetGesture.mockClear();
+      spyRemoveGesture.mockClear();
 
       _gesture = undefined;
 
@@ -1056,20 +1109,215 @@ describe('Gesture in spread', () => {
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
       globalThis[rLynxChange[0]](rLynxChange[1]);
+      const textElement = __root.__element_root.children[0].children[0];
+      expect(spySetGesture).not.toHaveBeenCalled();
+      expect(spyRemoveGesture).toHaveBeenCalledTimes(1);
+      expect(spyRemoveGesture).toHaveBeenCalledWith(textElement, 1);
+      expect(textElement.props['has-react-gesture']).toBeUndefined();
+      expect(elementTree.__GetGestureDetectorIds(textElement).includes(1)).toBe(false);
+    }
+  });
+  it('remove stale detector ids when gesture count shrinks on diff', async function() {
+    const spySetGesture = vi.spyOn(globalThis, '__SetGestureDetector');
+    const spyRemoveGesture = vi.spyOn(globalThis, '__RemoveGestureDetector');
 
-      expect(__root.__element_root).toMatchInlineSnapshot(`
-        <page
-          cssId="default-entry-from-native:0"
-        >
-          <view>
-            <text>
-              <raw-text
-                text="1"
-              />
-            </text>
-          </view>
-        </page>
-      `);
+    const createGesture = (id) => ({
+      id,
+      type: 0,
+      callbacks: {
+        onUpdate: {
+          _wkltId: 'bdd4:dd564:2',
+        },
+      },
+      __isGesture: true,
+      toJSON() {
+        const { toJSON, ...rest } = this;
+        return {
+          ...rest,
+          __isSerialized: true,
+        };
+      },
+    });
+
+    let useComposed = true;
+
+    function Comp() {
+      const gestureA = createGesture(1);
+      const gestureB = createGesture(2);
+      const singleGesture = createGesture(3);
+      const composedGesture = {
+        type: -1,
+        gestures: [gestureA, gestureB],
+        __isGesture: true,
+        toJSON() {
+          return {
+            type: this.type,
+            gestures: this.gestures.map(gesture => gesture.toJSON()),
+            __isSerialized: true,
+          };
+        },
+      };
+
+      const props = {
+        'main-thread:gesture': useComposed ? composedGesture : singleGesture,
+      };
+
+      return (
+        <view>
+          <text {...props}>1</text>
+        </view>
+      );
+    }
+
+    // main thread render
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+    }
+
+    // hydrate
+    {
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+    }
+
+    // update: composed(2) -> single(1), remove stale detector ids before setting new one
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      spySetGesture.mockClear();
+      spyRemoveGesture.mockClear();
+      useComposed = false;
+
+      render(<Comp />, __root);
+
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      const textElement = __root.__element_root.children[0].children[0];
+
+      expect(spySetGesture).toHaveBeenCalledTimes(1);
+      expect(spyRemoveGesture).toHaveBeenCalledTimes(2);
+      expect(spyRemoveGesture).toHaveBeenNthCalledWith(1, textElement, 1);
+      expect(spyRemoveGesture).toHaveBeenNthCalledWith(2, textElement, 2);
+      expect(elementTree.__GetGestureDetectorIds(textElement)).toEqual([3]);
+    }
+  });
+  it('updates reordered composed gesture detectors with one-to-one old matches', async function() {
+    const spySetGesture = vi.spyOn(globalThis, '__SetGestureDetector');
+
+    const createGesture = (id, wkltId) => ({
+      id,
+      type: 0,
+      callbacks: {
+        onUpdate: {
+          _wkltId: wkltId,
+        },
+      },
+      __isGesture: true,
+      toJSON() {
+        const { toJSON, ...rest } = this;
+        return {
+          ...rest,
+          __isSerialized: true,
+        };
+      },
+    });
+
+    let firstRender = true;
+
+    function Comp() {
+      const oldGestureA = createGesture(1, 'old-a');
+      const oldGestureB = createGesture(2, 'old-b');
+      const newGestureB = createGesture(2, 'new-b');
+      const newGestureC = createGesture(3, 'new-c');
+      const gesture = {
+        type: -1,
+        gestures: firstRender ? [oldGestureA, oldGestureB] : [newGestureB, newGestureC],
+        __isGesture: true,
+        toJSON() {
+          return {
+            type: this.type,
+            gestures: this.gestures.map(subGesture => subGesture.toJSON()),
+            __isSerialized: true,
+          };
+        },
+      };
+
+      return (
+        <view>
+          <text main-thread:gesture={gesture}>1</text>
+        </view>
+      );
+    }
+
+    {
+      __root.__jsx = <Comp />;
+      renderPage();
+    }
+
+    {
+      globalEnvManager.switchToBackground();
+      render(<Comp />, __root);
+    }
+
+    {
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+    }
+
+    {
+      globalEnvManager.switchToBackground();
+      lynx.getNativeApp().callLepusMethod.mockClear();
+      spySetGesture.mockClear();
+      firstRender = false;
+
+      render(<Comp />, __root);
+
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+
+      expect(spySetGesture).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        2,
+        0,
+        expect.objectContaining({
+          callbacks: [
+            expect.objectContaining({
+              callback: expect.objectContaining({ _wkltId: 'new-b' }),
+            }),
+          ],
+        }),
+        expect.any(Object),
+      );
+      expect(spySetGesture).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        3,
+        0,
+        expect.objectContaining({
+          callbacks: [
+            expect.objectContaining({
+              callback: expect.objectContaining({ _wkltId: 'new-c' }),
+            }),
+          ],
+        }),
+        expect.any(Object),
+      );
     }
   });
 });

--- a/packages/react/runtime/__test__/utils/nativeMethod.ts
+++ b/packages/react/runtime/__test__/utils/nativeMethod.ts
@@ -19,6 +19,15 @@ interface ElementOptions {
 
 export let uiSignNext = 0;
 export const parentMap = new WeakMap<Element, Element>();
+let gestureDetectorMap = new WeakMap<
+  Element,
+  Map<number, {
+    id: number;
+    type: number;
+    config: any;
+    relationMap: Record<string, number[]>;
+  }>
+>();
 // export const elementPrototype = Object.create(null);
 export const options: ElementOptions = {};
 
@@ -185,12 +194,40 @@ export const elementTree = new (class {
   }
 
   __SetGestureDetector(e: Element, id: number, type: number, config: any, relationMap: Record<string, number[]>) {
-    e.props.gesture = {
+    const detector = {
       id,
       type,
       config,
       relationMap,
     };
+    let detectors = gestureDetectorMap.get(e);
+    if (!detectors) {
+      detectors = new Map();
+      gestureDetectorMap.set(e, detectors);
+    }
+    detectors.set(id, detector);
+    e.props.gesture = detector;
+  }
+
+  __RemoveGestureDetector(e: Element, id: number) {
+    const detectors = gestureDetectorMap.get(e);
+    detectors?.delete(id);
+    if (e.props.gesture?.id === id) {
+      const latestDetector = detectors ? [...detectors.values()].at(-1) : undefined;
+      if (latestDetector) {
+        e.props.gesture = latestDetector;
+      } else {
+        delete e.props.gesture;
+      }
+    }
+  }
+
+  __GetGestureDetector(e: Element, id: number) {
+    return gestureDetectorMap.get(e)?.get(id);
+  }
+
+  __GetGestureDetectorIds(e: Element) {
+    return [...(gestureDetectorMap.get(e)?.keys() ?? [])];
   }
 
   __GetDataset(e: Element) {
@@ -317,6 +354,7 @@ export const elementTree = new (class {
   clear() {
     this.root = undefined;
     uiSignNext = 0;
+    gestureDetectorMap = new WeakMap();
   }
 
   toTree() {

--- a/packages/react/runtime/src/alog/elementPAPICall.ts
+++ b/packages/react/runtime/src/alog/elementPAPICall.ts
@@ -42,6 +42,7 @@ const fiberElementPAPINameList = [
   '__OnLifecycleEvent',
   '__QueryComponent',
   '__SetGestureDetector',
+  '__RemoveGestureDetector',
 ];
 
 export function initElementPAPICallAlog(globalWithIndex: Record<string, unknown> = globalThis): void {

--- a/packages/react/runtime/src/gesture/processGesture.ts
+++ b/packages/react/runtime/src/gesture/processGesture.ts
@@ -10,6 +10,108 @@ function isSerializedGesture(gesture: GestureKind): boolean {
   return gesture.__isSerialized ?? false;
 }
 
+function getSerializedBaseGesture(gesture: GestureKind | undefined): BaseGesture | undefined {
+  if (!gesture || !isSerializedGesture(gesture)) {
+    return undefined;
+  }
+
+  if (gesture.type !== GestureTypeInner.COMPOSED) {
+    return gesture as BaseGesture;
+  }
+
+  return undefined;
+}
+
+function appendUniqueSerializedBaseGestures(
+  gesture: GestureKind | undefined,
+  out: BaseGesture[],
+  seenIds: Set<number>,
+): void {
+  if (!gesture || !isSerializedGesture(gesture)) {
+    return;
+  }
+
+  if (gesture.type === GestureTypeInner.COMPOSED) {
+    for (const subGesture of (gesture as ComposedGesture).gestures) {
+      appendUniqueSerializedBaseGestures(subGesture, out, seenIds);
+    }
+    return;
+  }
+
+  const baseGesture = gesture as BaseGesture;
+  if (seenIds.has(baseGesture.id)) {
+    return;
+  }
+  seenIds.add(baseGesture.id);
+  out.push(baseGesture);
+}
+
+function collectOldGestureInfo(
+  oldGesture: GestureKind | undefined,
+): {
+  uniqOldBaseGestures: BaseGesture[];
+  oldBaseGesturesById: Map<number, BaseGesture>;
+} {
+  const uniqOldBaseGestures: BaseGesture[] = [];
+  const oldBaseGesturesById = new Map<number, BaseGesture>();
+  appendOldGestureInfo(oldGesture, uniqOldBaseGestures, oldBaseGesturesById);
+
+  return {
+    uniqOldBaseGestures,
+    oldBaseGesturesById,
+  };
+}
+
+function appendOldGestureInfo(
+  gesture: GestureKind | undefined,
+  out: BaseGesture[],
+  byId: Map<number, BaseGesture>,
+): void {
+  if (!gesture || !isSerializedGesture(gesture)) {
+    return;
+  }
+
+  if (gesture.type === GestureTypeInner.COMPOSED) {
+    for (const subGesture of (gesture as ComposedGesture).gestures) {
+      appendOldGestureInfo(subGesture, out, byId);
+    }
+    return;
+  }
+
+  const oldBaseGesture = gesture as BaseGesture;
+  if (!byId.has(oldBaseGesture.id)) {
+    byId.set(oldBaseGesture.id, oldBaseGesture);
+    out.push(oldBaseGesture);
+  }
+}
+
+function consumeOldBaseGesture(
+  baseGesture: BaseGesture,
+  uniqOldBaseGestures: BaseGesture[],
+  oldBaseGesturesById: Map<number, BaseGesture>,
+): BaseGesture | undefined {
+  const idMatchedOldBaseGesture = oldBaseGesturesById.get(baseGesture.id);
+  if (idMatchedOldBaseGesture) {
+    oldBaseGesturesById.delete(baseGesture.id);
+    return idMatchedOldBaseGesture;
+  }
+
+  const fallbackOldBaseGesture = uniqOldBaseGestures.find(oldBaseGesture => oldBaseGesturesById.has(oldBaseGesture.id));
+  if (!fallbackOldBaseGesture) {
+    return undefined;
+  }
+
+  oldBaseGesturesById.delete(fallbackOldBaseGesture.id);
+  return fallbackOldBaseGesture;
+}
+
+function removeGestureDetector(dom: FiberElement, id: number): void {
+  // Keep compatibility with old runtimes where remove API is not exposed.
+  if (typeof __RemoveGestureDetector === 'function') {
+    __RemoveGestureDetector(dom, id);
+  }
+}
+
 function getGestureInfo(
   gesture: BaseGesture,
   oldGesture: BaseGesture | undefined,
@@ -58,24 +160,64 @@ export function processGesture(
     domSet: boolean;
   },
 ): void {
-  if (!gesture || !isSerializedGesture(gesture)) {
+  const domSet = gestureOptions?.domSet === true;
+  const { uniqOldBaseGestures, oldBaseGesturesById } = collectOldGestureInfo(oldGesture);
+
+  // Fast path for the most common case: single base gesture update.
+  const singleBaseGesture = getSerializedBaseGesture(gesture);
+  const singleOldBaseGesture = getSerializedBaseGesture(oldGesture);
+  if (singleBaseGesture && (!oldGesture || singleOldBaseGesture)) {
+    if (!domSet) {
+      __SetAttribute(dom, 'has-react-gesture', true);
+      __SetAttribute(dom, 'flatten', false);
+    }
+
+    if (singleOldBaseGesture) {
+      // On update, remove old detector first to avoid stale callbacks.
+      removeGestureDetector(dom, singleOldBaseGesture.id);
+    }
+
+    const { config, relationMap } = getGestureInfo(singleBaseGesture, singleOldBaseGesture, isFirstScreen, dom);
+    __SetGestureDetector(
+      dom,
+      singleBaseGesture.id,
+      singleBaseGesture.type,
+      config,
+      relationMap,
+    );
     return;
   }
 
-  if (!(gestureOptions && gestureOptions.domSet)) {
+  const uniqBaseGestures: BaseGesture[] = [];
+  appendUniqueSerializedBaseGestures(gesture, uniqBaseGestures, new Set<number>());
+
+  if (uniqBaseGestures.length === 0) {
+    for (const oldBaseGesture of oldBaseGesturesById.values()) {
+      removeGestureDetector(dom, oldBaseGesture.id);
+    }
+
+    if (!domSet) {
+      __SetAttribute(dom, 'has-react-gesture', null);
+    }
+    return;
+  }
+
+  if (!domSet) {
     __SetAttribute(dom, 'has-react-gesture', true);
     __SetAttribute(dom, 'flatten', false);
   }
 
-  if (gesture.type === GestureTypeInner.COMPOSED) {
-    for (const [index, subGesture] of (gesture as ComposedGesture).gestures.entries()) {
-      processGesture(dom, subGesture, (oldGesture as ComposedGesture)?.gestures[index], isFirstScreen, {
-        domSet: true,
-      });
-    }
-  } else {
-    const baseGesture = gesture as BaseGesture;
-    const oldBaseGesture = oldGesture as BaseGesture | undefined;
+  // On update, remove old detectors first to avoid stale callbacks.
+  for (const oldBaseGesture of oldBaseGesturesById.values()) {
+    removeGestureDetector(dom, oldBaseGesture.id);
+  }
+
+  for (const baseGesture of uniqBaseGestures) {
+    const oldBaseGesture = consumeOldBaseGesture(
+      baseGesture,
+      uniqOldBaseGestures,
+      oldBaseGesturesById,
+    );
 
     const { config, relationMap } = getGestureInfo(baseGesture, oldBaseGesture, isFirstScreen, dom);
     __SetGestureDetector(

--- a/packages/react/runtime/types/types.d.ts
+++ b/packages/react/runtime/types/types.d.ts
@@ -117,6 +117,7 @@ declare global {
     config: any,
     relationMap: Record<string, number[]>,
   ): void;
+  declare function __RemoveGestureDetector(node: FiberElement, id: number): void;
 
   declare interface FiberElement {}
 

--- a/packages/testing-library/testing-environment/etc/testing-environment.api.md
+++ b/packages/testing-library/testing-environment/etc/testing-environment.api.md
@@ -48,6 +48,7 @@ export const initElementTree: () => {
     __AddDataset(e: LynxElement, key: string, value: string): void;
     __SetDataset(e: LynxElement, dataset: any): void;
     __SetGestureDetector(e: LynxElement, id: number, type: number, config: any, relationMap: Record<string, number[]>): void;
+    __RemoveGestureDetector(e: LynxElement, id: number): void;
     __GetDataset(e: LynxElement): DOMStringMap;
     __RemoveElement(parent: LynxElement, child: LynxElement): void;
     __InsertElementBefore(parent: LynxElement, child: LynxElement, ref?: LynxElement | undefined): void;

--- a/packages/testing-library/testing-environment/src/lynx/ElementPAPI.ts
+++ b/packages/testing-library/testing-environment/src/lynx/ElementPAPI.ts
@@ -315,6 +315,12 @@ export const initElementTree = () => {
       };
     }
 
+    __RemoveGestureDetector(e: LynxElement, id: number) {
+      if (e.gesture?.['id'] === id) {
+        delete e.gesture;
+      }
+    }
+
     __GetDataset(e: LynxElement) {
       return e.dataset;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,34 @@ importers:
         specifier: ^18.3.28
         version: 18.3.28
 
+  examples/gesture:
+    dependencies:
+      '@lynx-js/gesture-runtime':
+        specifier: workspace:*
+        version: link:../../packages/lynx/gesture-runtime
+      '@lynx-js/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+    devDependencies:
+      '@lynx-js/preact-devtools':
+        specifier: ^5.0.1
+        version: 5.0.1
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-qrcode
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      '@lynx-js/types':
+        specifier: 3.7.0
+        version: 3.7.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+
   examples/motion:
     dependencies:
       '@lynx-js/motion':


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a gesture-detector removal API and added an interactive Gesture Lifecycle example app with config and build scripts.

* **Bug Fixes**
  * Remove stale gesture detectors when gestures are removed, replaced, or reordered to prevent lingering state and incorrect handlers.

* **Tests**
  * Expanded unit and integration tests covering gesture lifecycle, deduplication, diffs, and detector wiring.

* **Style**
  * Added themed stylesheet for the gesture example UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
