### PR TITLE
fix: rename exposed symbol to LynxBundlePlugin

### DIFF
--- a/.changeset/expose-symbol-rename.md
+++ b/.changeset/expose-symbol-rename.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/config-rsbuild-plugin": patch
+---
+
+Rename exposed symbol from `LynxTemplatePlugin` to `LynxBundlePlugin` with backward compatibility for the old symbol name.

--- a/packages/rspeedy/plugin-config/src/pluginLynxConfig.ts
+++ b/packages/rspeedy/plugin-config/src/pluginLynxConfig.ts
@@ -112,11 +112,17 @@ export function pluginLynxConfig(
       api.expose(Symbol.for('lynx.config'), { config })
 
       api.modifyBundlerChain(chain => {
-        const exposed = api.useExposed<
+        const exposedNew = api.useExposed<
+          { LynxBundlePlugin: typeof LynxTemplatePlugin }
+        >(
+          Symbol.for('LynxBundlePlugin'),
+        )
+        const exposedOld = api.useExposed<
           { LynxTemplatePlugin: typeof LynxTemplatePlugin }
         >(
           Symbol.for('LynxTemplatePlugin'),
         )
+        const exposed = exposedNew ?? exposedOld
 
         if (!exposed) {
           let pkgName = 'Rspeedy and plugins'
@@ -131,7 +137,7 @@ export function pluginLynxConfig(
 
           throw new Error(
             `\
-[pluginLynxConfig] No \`LynxTemplatePlugin\` exposed to ${
+[pluginLynxConfig] No \`LynxBundlePlugin\` exposed to ${
               link(
                 'the plugin API',
                 'https://rsbuild.rs/plugins/dev/core#apiexpose',
@@ -150,7 +156,9 @@ See ${
           )
         }
 
-        const { LynxTemplatePlugin: LynxTemplatePluginClass } = exposed
+        const LynxTemplatePluginClass = 'LynxBundlePlugin' in exposed
+          ? exposed.LynxBundlePlugin
+          : exposed.LynxTemplatePlugin
 
         chain.plugin('lynx:config').use(LynxConfigWebpackPlugin<Config>, [
           {

--- a/packages/rspeedy/plugin-config/test/pluginLynxConfig.test.ts
+++ b/packages/rspeedy/plugin-config/test/pluginLynxConfig.test.ts
@@ -11,7 +11,7 @@ import { compilerOptionsKeys, configKeys } from '@lynx-js/type-config'
 
 vi.mock('../src/LynxConfigWebpackPlugin.js')
 describe('pluginLynxConfig', () => {
-  test('should throw error when no LynxTemplatePlugin exposed', async () => {
+  test('should throw error when no LynxBundlePlugin exposed', async () => {
     const { pluginLynxConfig } = await import('../src/pluginLynxConfig.js')
 
     const rspeedy = await createRspeedy({
@@ -24,7 +24,7 @@ describe('pluginLynxConfig', () => {
 
     await expect(() => rspeedy.initConfigs()).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-      [Error: [pluginLynxConfig] No \`LynxTemplatePlugin\` exposed to the plugin API (​https://rsbuild.rs/plugins/dev/core#apiexpose​).
+      [Error: [pluginLynxConfig] No \`LynxBundlePlugin\` exposed to the plugin API (​https://rsbuild.rs/plugins/dev/core#apiexpose​).
 
       Please upgrade Rspeedy and plugins to latest version.
 
@@ -50,7 +50,7 @@ describe('pluginLynxConfig', () => {
 
     await expect(() => rspeedy.initConfigs()).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-      [Error: [pluginLynxConfig] No \`LynxTemplatePlugin\` exposed to the plugin API (​https://rsbuild.rs/plugins/dev/core#apiexpose​).
+      [Error: [pluginLynxConfig] No \`LynxBundlePlugin\` exposed to the plugin API (​https://rsbuild.rs/plugins/dev/core#apiexpose​).
 
       Please upgrade @lynx-js/react-rsbuild-plugin to latest version.
 
@@ -80,7 +80,7 @@ describe('pluginLynxConfig', () => {
 
     await expect(() => rspeedy.initConfigs()).rejects
       .toThrowErrorMatchingInlineSnapshot(`
-      [Error: [pluginLynxConfig] No \`LynxTemplatePlugin\` exposed to the plugin API (​https://rsbuild.rs/plugins/dev/core#apiexpose​).
+      [Error: [pluginLynxConfig] No \`LynxBundlePlugin\` exposed to the plugin API (​https://rsbuild.rs/plugins/dev/core#apiexpose​).
 
       Please upgrade @lynx-js/vue-rsbuild-plugin to latest version.
 
@@ -95,7 +95,7 @@ describe('pluginLynxConfig', () => {
     )
     const { pluginLynxConfig } = await import('../src/pluginLynxConfig.js')
 
-    const LynxTemplatePlugin = vi.fn()
+    const getLynxTemplatePluginHooks = vi.fn()
 
     const rspeedy = await createRspeedy({
       rspeedyConfig: {
@@ -104,8 +104,8 @@ describe('pluginLynxConfig', () => {
           {
             name: 'test',
             setup(api: RsbuildPluginAPI) {
-              api.expose(Symbol.for('LynxTemplatePlugin'), {
-                LynxTemplatePlugin,
+              api.expose(Symbol.for('LynxBundlePlugin'), {
+                LynxBundlePlugin: { getLynxTemplatePluginHooks },
               })
             },
           },
@@ -117,7 +117,7 @@ describe('pluginLynxConfig', () => {
 
     expect(LynxConfigWebpackPlugin).toHaveBeenCalledWith(
       {
-        LynxTemplatePlugin,
+        LynxTemplatePlugin: { getLynxTemplatePluginHooks },
         config: {
           enableAccessibilityElement: true,
         },

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -389,15 +389,15 @@ export function pluginReactLynx(
         }
 
         api.expose(Symbol.for('LAYERS'), LAYERS)
-        // Only expose `LynxTemplatePlugin.getLynxTemplatePluginHooks` to avoid
-        // other breaking changes in `LynxTemplatePlugin`
-        // breaks `pluginReactLynx`
-        api.expose(Symbol.for('LynxTemplatePlugin'), {
-          LynxTemplatePlugin: {
+        const exposedLynxBundlePlugin = {
+          LynxBundlePlugin: {
             getLynxTemplatePluginHooks: LynxTemplatePlugin
               .getLynxTemplatePluginHooks.bind(LynxTemplatePlugin),
           },
-        })
+        }
+        api.expose(Symbol.for('LynxBundlePlugin'), exposedLynxBundlePlugin)
+        // Backward compat: keep exposing under the old symbol
+        api.expose(Symbol.for('LynxTemplatePlugin'), exposedLynxBundlePlugin)
         const require = createRequire(import.meta.url)
 
         const { version } = require('../package.json') as { version: string }

--- a/packages/rspeedy/plugin-react/test/expose.test.ts
+++ b/packages/rspeedy/plugin-react/test/expose.test.ts
@@ -9,10 +9,10 @@ import { pluginStubRspeedyAPI } from './stub-rspeedy-api.plugin.js'
 import type { LynxTemplatePlugin, TemplateHooks } from '../src/index.js'
 
 describe('Expose', () => {
-  test('LynxTemplatePlugin', async () => {
+  test('LynxBundlePlugin', async () => {
     const { pluginReactLynx } = await import('../src/index.js')
 
-    let expose: { LynxTemplatePlugin: LynxTemplatePlugin } | undefined
+    let expose: { LynxBundlePlugin: LynxTemplatePlugin } | undefined
     let beforeEncodeArgs:
       | Parameters<Parameters<TemplateHooks['beforeEncode']['tap']>[1]>[0]
       | undefined
@@ -31,8 +31,8 @@ describe('Expose', () => {
             name: 'pluginThatUsesTemplateHooks',
             setup(api) {
               expose = api.useExposed<
-                { LynxTemplatePlugin: LynxTemplatePlugin }
-              >(Symbol.for('LynxTemplatePlugin'))
+                { LynxBundlePlugin: LynxTemplatePlugin }
+              >(Symbol.for('LynxBundlePlugin'))
               api.modifyBundlerChain(chain => {
                 const PLUGIN_NAME = 'pluginThatUsesTemplateHooks'
                 chain.plugin(PLUGIN_NAME).use({
@@ -40,7 +40,7 @@ describe('Expose', () => {
                     compiler.hooks.compilation.tap(
                       PLUGIN_NAME,
                       compilation => {
-                        const templateHooks = expose!.LynxTemplatePlugin
+                        const templateHooks = expose!.LynxBundlePlugin
                           .getLynxTemplatePluginHooks(
                             compilation as unknown as Parameters<
                               LynxTemplatePlugin['getLynxTemplatePluginHooks']
@@ -67,7 +67,7 @@ describe('Expose', () => {
     await rsbuild.initConfigs()
     expect(expose).toMatchInlineSnapshot(`
       {
-        "LynxTemplatePlugin": {
+        "LynxBundlePlugin": {
           "getLynxTemplatePluginHooks": [Function],
         },
       }
@@ -90,5 +90,40 @@ describe('Expose', () => {
         "/.rspeedy/main/background.js",
       ]
     `)
+  })
+
+  test('backward compat: old LynxTemplatePlugin symbol still works', async () => {
+    const { pluginReactLynx } = await import('../src/index.js')
+
+    let expose: { LynxBundlePlugin: LynxTemplatePlugin } | undefined
+
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        source: {
+          entry: {
+            main: new URL('./fixtures/basic.tsx', import.meta.url).pathname,
+          },
+        },
+        plugins: [
+          pluginReactLynx(),
+          pluginStubRspeedyAPI(),
+          {
+            name: 'pluginThatUsesOldSymbol',
+            setup(api) {
+              expose = api.useExposed<
+                { LynxBundlePlugin: LynxTemplatePlugin }
+              >(Symbol.for('LynxTemplatePlugin'))
+            },
+          } as RsbuildPlugin,
+        ],
+      },
+    })
+
+    await rsbuild.initConfigs()
+    expect(expose).toBeDefined()
+    expect(expose!.LynxBundlePlugin).toBeDefined()
+    expect(expose!.LynxBundlePlugin.getLynxTemplatePluginHooks).toBeTypeOf(
+      'function',
+    )
   })
 })


### PR DESCRIPTION
## Summary
- Rename exposed symbol from `LynxTemplatePlugin` to `LynxBundlePlugin` with backward compatibility
- Producer (`pluginReactLynx`) exposes under both new and old symbol names
- Consumer (`pluginLynxConfig`) uses fallback pattern: `useExposed('LynxBundlePlugin') ?? useExposed('LynxTemplatePlugin')`

## Test plan
- [x] Build passes for `@lynx-js/react-rsbuild-plugin`
- [x] Tests pass for `@lynx-js/react-rsbuild-plugin`  
- [x] Tests pass for `@lynx-js/config-rsbuild-plugin`
- [x] Backward compat verified with both old and new symbol names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed LynxBundlePlugin as the new primary public plugin API symbol for React and Config Rsbuild plugins, with improved error messaging.
  * LynxTemplatePlugin symbol fully retained for backward compatibility without requiring any code updates to existing integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->