### PR TITLE
feat: rename LynxTemplatePlugin class to LynxBundlePlugin

### DIFF
--- a/.changeset/rename-class-lynx-bundle-plugin.md
+++ b/.changeset/rename-class-lynx-bundle-plugin.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": minor
+---
+
+Rename class `LynxTemplatePlugin` to `LynxBundlePlugin`. The old name `LynxTemplatePlugin` is kept as a deprecated alias for backward compatibility.

--- a/packages/webpack/css-extract-webpack-plugin/src/CssExtractRspackPlugin.ts
+++ b/packages/webpack/css-extract-webpack-plugin/src/CssExtractRspackPlugin.ts
@@ -11,7 +11,7 @@ import type {
   RspackError,
 } from '@rspack/core';
 
-import { CSS, LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin';
+import { CSS, LynxBundlePlugin } from '@lynx-js/template-webpack-plugin';
 
 /**
  * The options for {@link @lynx-js/css-extract-webpack-plugin#CssExtractRspackPlugin}
@@ -24,7 +24,7 @@ interface CssExtractRspackPluginOptions
   /**
    * plugins passed to parser
    */
-  cssPlugins: Parameters<typeof LynxTemplatePlugin.convertCSSChunksToMap>[1];
+  cssPlugins: Parameters<typeof LynxBundlePlugin.convertCSSChunksToMap>[1];
 
   /**
    * The name of non-initial CSS chunk files
@@ -162,7 +162,7 @@ class CssExtractRspackPluginImpl {
       if (
         this.isHMREnabled(compiler)
       ) {
-        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+        const hooks = LynxBundlePlugin.getLynxTemplatePluginHooks(
           // @ts-expect-error Rspack to Webpack Compilation
           compilation,
         );
@@ -178,7 +178,7 @@ class CssExtractRspackPluginImpl {
             if (!hotUpdateFilePath) {
               continue;
             }
-            const css = LynxTemplatePlugin.convertCSSChunksToMap(
+            const css = LynxBundlePlugin.convertCSSChunksToMap(
               content,
               options.cssPlugins,
               Boolean(

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -9,7 +9,7 @@ import type { Chunk, Compilation, Compiler } from '@rspack/core';
 import invariant from 'tiny-invariant';
 
 import type { ExtractStrConfig } from '@lynx-js/react/transform';
-import { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin';
+import { LynxBundlePlugin } from '@lynx-js/template-webpack-plugin';
 import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
 
 import { LAYERS } from './layer.js';
@@ -257,7 +257,7 @@ class ReactWebpackPlugin {
 
       // TODO: replace LynxTemplatePlugin types with Rspack
       // @ts-expect-error Rspack x Webpack compilation not match
-      const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+      const hooks = LynxBundlePlugin.getLynxTemplatePluginHooks(compilation);
 
       const { RawSource, ConcatSource } = compiler.webpack.sources;
       hooks.beforeEncode.tap(

--- a/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
+++ b/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
@@ -45,6 +45,18 @@ export interface EncodeOptions {
 }
 
 // @public
+export class LynxBundlePlugin {
+    constructor(options?: LynxTemplatePluginOptions | undefined);
+    apply(compiler: Compiler): void;
+    static convertCSSChunksToMap(cssChunks: string[], plugins: CSS.Plugin[], enableCSSSelector: boolean): {
+        cssMap: Record<string, CSS.LynxStyleNode[]>;
+        cssSource: Record<string, string>;
+    };
+    static defaultOptions: Readonly<Required<LynxTemplatePluginOptions>>;
+    static getLynxTemplatePluginHooks(compilation: Compilation): TemplateHooks;
+}
+
+// @public
 export class LynxEncodePlugin {
     constructor(options?: LynxEncodePluginOptions | undefined);
     apply(compiler: Compiler): void;
@@ -64,17 +76,10 @@ export interface LynxEncodePluginOptions {
     inlineScripts?: InlineChunkConfig | undefined;
 }
 
-// @public
-export class LynxTemplatePlugin {
-    constructor(options?: LynxTemplatePluginOptions | undefined);
-    apply(compiler: Compiler): void;
-    static convertCSSChunksToMap(cssChunks: string[], plugins: CSS.Plugin[], enableCSSSelector: boolean): {
-        cssMap: Record<string, CSS.LynxStyleNode[]>;
-        cssSource: Record<string, string>;
-    };
-    static defaultOptions: Readonly<Required<LynxTemplatePluginOptions>>;
-    static getLynxTemplatePluginHooks(compilation: Compilation): TemplateHooks;
-}
+// Warning: (ae-missing-release-tag) "LynxTemplatePlugin" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
+export const LynxTemplatePlugin: typeof LynxBundlePlugin;
 
 // @public
 export interface LynxTemplatePluginOptions {

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -4,7 +4,7 @@
 
 import type { Chunk, Compiler } from 'webpack';
 
-import { LynxTemplatePlugin } from './LynxTemplatePlugin.js';
+import { LynxBundlePlugin } from './LynxTemplatePlugin.js';
 import { getRequireModuleAsyncCachePolyfill } from './polyfill/requireModuleAsync.js';
 
 // https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/src/types/config.ts#L1029
@@ -97,7 +97,7 @@ export class LynxEncodePluginImpl {
       || compiler.options.mode === 'development';
 
     compiler.hooks.thisCompilation.tap(this.name, compilation => {
-      const templateHooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+      const templateHooks = LynxBundlePlugin.getLynxTemplatePluginHooks(
         compilation,
       );
 

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -64,7 +64,7 @@ const LynxTemplatePluginHooksMap = new WeakMap<Compilation, TemplateHooks>();
  *     compiler.hooks.compilation.tap("MyPlugin", (compilation) => {
  *       console.log("The compiler is starting a new compilation...");
  *
- *       LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation).beforeEmit.tapAsync(
+ *       LynxBundlePlugin.getLynxTemplatePluginHooks(compilation).beforeEmit.tapAsync(
  *         "MyPlugin", // <-- Set a meaningful name here for stacktraces
  *         (data, cb) => {
  *           // Manipulate the content
@@ -139,7 +139,7 @@ export interface TemplateHooks {
 
 /**
  * Add hooks to the webpack compilation object to allow foreign plugins to
- * extend the LynxTemplatePlugin
+ * extend the LynxBundlePlugin
  */
 function createLynxTemplatePluginHooks(): TemplateHooks {
   return {
@@ -332,11 +332,11 @@ interface EncodeRawData {
 }
 
 /**
- * LynxTemplatePlugin
+ * LynxBundlePlugin
  *
  * @public
  */
-export class LynxTemplatePlugin {
+export class LynxBundlePlugin {
   constructor(private options?: LynxTemplatePluginOptions | undefined) {}
 
   /**
@@ -355,18 +355,18 @@ export class LynxTemplatePlugin {
   }
 
   /**
-   * `defaultOptions` is the default options that the {@link LynxTemplatePlugin} uses.
+   * `defaultOptions` is the default options that the {@link LynxBundlePlugin} uses.
    *
    * @example
    * `defaultOptions` can be used to change part of the option and keep others as the default value.
    *
    * ```js
    * // webpack.config.js
-   * import { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
+   * import { LynxBundlePlugin } from '@lynx-js/template-webpack-plugin'
    * export default {
    *   plugins: [
-   *     new LynxTemplatePlugin({
-   *       ...LynxTemplatePlugin.defaultOptions,
+   *     new LynxBundlePlugin({
+   *       ...LynxBundlePlugin.defaultOptions,
    *       enableRemoveCSSScope: true,
    *     }),
    *   ],
@@ -439,10 +439,17 @@ export class LynxTemplatePlugin {
   apply(compiler: Compiler): void {
     new LynxTemplatePluginImpl(
       compiler,
-      Object.assign({}, LynxTemplatePlugin.defaultOptions, this.options),
+      Object.assign({}, LynxBundlePlugin.defaultOptions, this.options),
     );
   }
 }
+
+/**
+ * @deprecated Use {@link LynxBundlePlugin} instead.
+ *
+ * @public
+ */
+export const LynxTemplatePlugin: typeof LynxBundlePlugin = LynxBundlePlugin;
 
 interface Hash {
   /**
@@ -530,7 +537,7 @@ class LynxTemplatePluginImpl {
         compiler.webpack,
       );
 
-      const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+      const hooks = LynxBundlePlugin.getLynxTemplatePluginHooks(compilation);
 
       compilation.hooks.runtimeRequirementInTree.for(
         RuntimeGlobals.lynxAsyncChunkIds,
@@ -630,7 +637,7 @@ class LynxTemplatePluginImpl {
       return asyncChunkGroups;
     }
 
-    const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+    const hooks = LynxBundlePlugin.getLynxTemplatePluginHooks(compilation);
 
     asyncChunkGroups = groupBy(
       compilation.chunkGroups
@@ -658,7 +665,7 @@ class LynxTemplatePluginImpl {
 
     const intermediateRoot = path.dirname(this.#options.intermediate);
 
-    const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+    const hooks = LynxBundlePlugin.getLynxTemplatePluginHooks(compilation);
 
     // We cache the encoded template so that it will not be encoded twice
     if (!LynxTemplatePluginImpl.#encodedTemplate.has(compilation)) {
@@ -831,7 +838,7 @@ class LynxTemplatePluginImpl {
       ),
       customSections: {},
     };
-    const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+    const hooks = LynxBundlePlugin.getLynxTemplatePluginHooks(
       compilation,
     );
 

--- a/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
@@ -7,11 +7,7 @@ import type { Compilation, Compiler } from 'webpack';
 import type { LynxStyleNode } from '@lynx-js/css-serializer';
 import type { TasmJSONInfo } from '@lynx-js/web-core-wasm/encode';
 
-import {
-  LynxTemplatePlugin,
-  isDebug,
-  isRsdoctor,
-} from './LynxTemplatePlugin.js';
+import { LynxBundlePlugin, isDebug, isRsdoctor } from './LynxTemplatePlugin.js';
 import { genStyleInfo } from './web/genStyleInfo.js';
 
 export class WebEncodePlugin {
@@ -26,7 +22,7 @@ export class WebEncodePlugin {
     compiler.hooks.thisCompilation.tap(
       WebEncodePlugin.name,
       (compilation) => {
-        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+        const hooks = LynxBundlePlugin.getLynxTemplatePluginHooks(
           compilation,
         );
 

--- a/packages/webpack/template-webpack-plugin/src/index.ts
+++ b/packages/webpack/template-webpack-plugin/src/index.ts
@@ -11,7 +11,7 @@
 import { Plugins } from '@lynx-js/css-serializer';
 import * as CSS from '@lynx-js/css-serializer';
 
-export { LynxTemplatePlugin } from './LynxTemplatePlugin.js';
+export { LynxBundlePlugin, LynxTemplatePlugin } from './LynxTemplatePlugin.js';
 export type {
   LynxTemplatePluginOptions,
   TemplateHooks,


### PR DESCRIPTION
## Summary
- Rename the `LynxTemplatePlugin` class to `LynxBundlePlugin` to align with official Lynx terminology
- Keep `LynxTemplatePlugin` as a deprecated export alias for backward compatibility
- Update internal consumers to use the new name
- Test configs continue using the old name via the alias (no unnecessary churn)

## Test plan
- [x] Build passes for `@lynx-js/template-webpack-plugin`
- [x] All 328 tests pass for `@lynx-js/template-webpack-plugin`
- [x] Backward compat alias works (test configs still pass without changes)