### PR TITLE
fix: event coordinates relative to lynx-view container

### DIFF
--- a/packages/web-platform/web-core-wasm/ts/client/mainthread/crossThreadHandlers/registerInvokeUIMethodHandler.ts
+++ b/packages/web-platform/web-core-wasm/ts/client/mainthread/crossThreadHandlers/registerInvokeUIMethodHandler.ts
@@ -7,28 +7,32 @@ import { ErrorCode } from '../../../constants.js';
 import { invokeUIMethodEndpoint } from '../../endpoints.js';
 import type { LynxViewInstance } from '../LynxViewInstance.js';
 
-const methodAlias: Record<
-  string,
-  (element: Element, params: unknown) => unknown
-> = {
-  'boundingClientRect': (element) => {
-    const rect = element.getBoundingClientRect();
-    return {
-      id: element.id,
-      width: rect.width,
-      height: rect.height,
-      left: rect.left,
-      right: rect.right,
-      top: rect.top,
-      bottom: rect.bottom,
-    };
-  },
-};
+function createMethodAlias(
+  lynxViewInstance: LynxViewInstance,
+): Record<string, (element: Element, params: unknown) => unknown> {
+  return {
+    'boundingClientRect': (element) => {
+      const rect = element.getBoundingClientRect();
+      const containerRect = lynxViewInstance.rootDom.host
+        .getBoundingClientRect();
+      return {
+        id: element.id,
+        width: rect.width,
+        height: rect.height,
+        left: rect.left - containerRect.left,
+        right: rect.right - containerRect.left,
+        top: rect.top - containerRect.top,
+        bottom: rect.bottom - containerRect.top,
+      };
+    },
+  };
+}
 
 export function registerInvokeUIMethodHandler(
   rpc: Rpc,
   lynxViewInstance: LynxViewInstance,
 ) {
+  const methodAlias = createMethodAlias(lynxViewInstance);
   rpc.registerHandler(
     invokeUIMethodEndpoint,
     (

--- a/packages/web-platform/web-core-wasm/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
+++ b/packages/web-platform/web-core-wasm/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
@@ -169,7 +169,10 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
         | DecoratedHTMLElement
         | null;
     }
-    const eventObject = createCrossThreadEvent(event);
+    const eventObject = createCrossThreadEvent(
+      event,
+      () => this.lynxViewInstance.rootDom.host.getBoundingClientRect(),
+    );
     this.wasmContext?.common_event_handler(
       eventObject,
       bubblePath.slice(0, bubblePathLength),

--- a/packages/web-platform/web-core-wasm/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
+++ b/packages/web-platform/web-core-wasm/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
@@ -25,6 +25,7 @@ function toCloneableObject(obj: any): CloneableObject {
 
 export function createCrossThreadEvent(
   domEvent: MinimalRawEventObject,
+  getContainerRect?: () => DOMRect,
 ): LynxCrossThreadEvent {
   const type = domEvent.type;
   const params: Cloneable = {};
@@ -48,35 +49,52 @@ export function createCrossThreadEvent(
     const touch = [...touchEvent.touches as unknown as Touch[]];
     const targetTouches = [...touchEvent.targetTouches as unknown as Touch[]];
     const changedTouches = [...touchEvent.changedTouches as unknown as Touch[]];
+    const adjustTouch = (t: CloneableObject): CloneableObject => {
+      if (getContainerRect) {
+        const rect = getContainerRect();
+        return {
+          ...t,
+          clientX: (t.clientX as number) - rect.left,
+          clientY: (t.clientY as number) - rect.top,
+          pageX: (t.pageX as number) - rect.left,
+          pageY: (t.pageY as number) - rect.top,
+        };
+      }
+      return t;
+    };
     Object.assign(otherProperties, {
-      touches: isTrusted ? touch.map(toCloneableObject) : touch,
+      touches: isTrusted
+        ? touch.map(toCloneableObject).map(adjustTouch)
+        : touch,
       targetTouches: isTrusted
-        ? targetTouches.map(
-          toCloneableObject,
-        )
+        ? targetTouches.map(toCloneableObject).map(adjustTouch)
         : targetTouches,
       changedTouches: isTrusted
-        ? changedTouches.map(
-          toCloneableObject,
-        )
+        ? changedTouches.map(toCloneableObject).map(adjustTouch)
         : changedTouches,
     });
   } else if (type.startsWith('mouse')) {
     const mouseEvent = domEvent as MouseEvent;
+    const rect = getContainerRect?.();
+    const offsetX = rect?.left ?? 0;
+    const offsetY = rect?.top ?? 0;
     Object.assign(otherProperties, {
       button: mouseEvent.button,
       buttons: mouseEvent.buttons,
-      x: mouseEvent.x,
-      y: mouseEvent.y,
-      pageX: mouseEvent.pageX,
-      pageY: mouseEvent.pageY,
-      clientX: mouseEvent.clientX,
-      clientY: mouseEvent.clientY,
+      x: mouseEvent.clientX - offsetX,
+      y: mouseEvent.clientY - offsetY,
+      pageX: mouseEvent.clientX - offsetX,
+      pageY: mouseEvent.clientY - offsetY,
+      clientX: mouseEvent.clientX - offsetX,
+      clientY: mouseEvent.clientY - offsetY,
     });
   } else if (type === 'click') {
+    const rect = getContainerRect?.();
+    const offsetX = rect?.left ?? 0;
+    const offsetY = rect?.top ?? 0;
     detail = {
-      x: (domEvent as MouseEvent).x,
-      y: (domEvent as MouseEvent).y,
+      x: (domEvent as MouseEvent).clientX - offsetX,
+      y: (domEvent as MouseEvent).clientY - offsetY,
     };
   }
 

--- a/packages/web-platform/web-core-wasm/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
+++ b/packages/web-platform/web-core-wasm/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
@@ -54,10 +54,10 @@ export function createCrossThreadEvent(
         const rect = getContainerRect();
         return {
           ...t,
-          clientX: (t.clientX as number) - rect.left,
-          clientY: (t.clientY as number) - rect.top,
-          pageX: (t.pageX as number) - rect.left,
-          pageY: (t.pageY as number) - rect.top,
+          clientX: (t['clientX'] as number) - rect.left,
+          clientY: (t['clientY'] as number) - rect.top,
+          pageX: (t['pageX'] as number) - rect.left,
+          pageY: (t['pageY'] as number) - rect.top,
         };
       }
       return t;

--- a/packages/web-platform/web-mainthread-apis/ts/createMainThreadGlobalThis.ts
+++ b/packages/web-platform/web-mainthread-apis/ts/createMainThreadGlobalThis.ts
@@ -176,6 +176,9 @@ export function createMainThreadGlobalThis(
     mtsRealm,
     document,
   } = config;
+  const getContainerRect = (): DOMRect =>
+    ((rootDom as ShadowRoot).host ?? rootDom as Element)
+      .getBoundingClientRect();
   const { elementTemplate, lepusCode } = lynxTemplate;
   const lynxUniqueIdToElement: WeakRef<HTMLElement>[] =
     ssrHydrateInfo?.lynxUniqueIdToElement ?? [];
@@ -222,6 +225,7 @@ export function createMainThreadGlobalThis(
           const crossThreadEvent = createCrossThreadEvent(
             event as MinimalRawEventObject,
             lynxEventName,
+            getContainerRect,
           );
           if (typeof hname === 'string') {
             const parentComponentUniqueId = Number(
@@ -720,16 +724,17 @@ export function createMainThreadGlobalThis(
     try {
       if (method === 'boundingClientRect') {
         const rect = (element as HTMLElement).getBoundingClientRect();
+        const containerRect = getContainerRect();
         callback({
           code: ErrorCode.SUCCESS,
           data: {
             id: (element as HTMLElement).id,
             width: rect.width,
             height: rect.height,
-            left: rect.left,
-            right: rect.right,
-            top: rect.top,
-            bottom: rect.bottom,
+            left: rect.left - containerRect.left,
+            right: rect.right - containerRect.left,
+            top: rect.top - containerRect.top,
+            bottom: rect.bottom - containerRect.top,
           },
         });
         return;

--- a/packages/web-platform/web-mainthread-apis/ts/utils/createCrossThreadEvent.ts
+++ b/packages/web-platform/web-mainthread-apis/ts/utils/createCrossThreadEvent.ts
@@ -27,6 +27,7 @@ function toCloneableObject(obj: any): CloneableObject {
 export function createCrossThreadEvent(
   domEvent: MinimalRawEventObject,
   eventName: string,
+  getContainerRect?: () => DOMRect,
 ): LynxCrossThreadEvent {
   const targetElement = domEvent.target as HTMLElement;
   const currentTargetElement = (domEvent
@@ -55,35 +56,52 @@ export function createCrossThreadEvent(
     const touch = [...touchEvent.touches as unknown as Touch[]];
     const targetTouches = [...touchEvent.targetTouches as unknown as Touch[]];
     const changedTouches = [...touchEvent.changedTouches as unknown as Touch[]];
+    const adjustTouch = (t: CloneableObject): CloneableObject => {
+      if (getContainerRect) {
+        const rect = getContainerRect();
+        return {
+          ...t,
+          clientX: (t.clientX as number) - rect.left,
+          clientY: (t.clientY as number) - rect.top,
+          pageX: (t.pageX as number) - rect.left,
+          pageY: (t.pageY as number) - rect.top,
+        };
+      }
+      return t;
+    };
     Object.assign(otherProperties, {
-      touches: isTrusted ? touch.map(toCloneableObject) : touch,
+      touches: isTrusted
+        ? touch.map(toCloneableObject).map(adjustTouch)
+        : touch,
       targetTouches: isTrusted
-        ? targetTouches.map(
-          toCloneableObject,
-        )
+        ? targetTouches.map(toCloneableObject).map(adjustTouch)
         : targetTouches,
       changedTouches: isTrusted
-        ? changedTouches.map(
-          toCloneableObject,
-        )
+        ? changedTouches.map(toCloneableObject).map(adjustTouch)
         : changedTouches,
     });
   } else if (type.startsWith('mouse')) {
     const mouseEvent = domEvent as MouseEvent;
+    const rect = getContainerRect?.();
+    const offsetX = rect?.left ?? 0;
+    const offsetY = rect?.top ?? 0;
     Object.assign(otherProperties, {
       button: mouseEvent.button,
       buttons: mouseEvent.buttons,
-      x: mouseEvent.x,
-      y: mouseEvent.y,
-      pageX: mouseEvent.pageX,
-      pageY: mouseEvent.pageY,
-      clientX: mouseEvent.clientX,
-      clientY: mouseEvent.clientY,
+      x: mouseEvent.clientX - offsetX,
+      y: mouseEvent.clientY - offsetY,
+      pageX: mouseEvent.clientX - offsetX,
+      pageY: mouseEvent.clientY - offsetY,
+      clientX: mouseEvent.clientX - offsetX,
+      clientY: mouseEvent.clientY - offsetY,
     });
   } else if (type === 'click') {
+    const rect = getContainerRect?.();
+    const offsetX = rect?.left ?? 0;
+    const offsetY = rect?.top ?? 0;
     detail = {
-      x: (domEvent as MouseEvent).x,
-      y: (domEvent as MouseEvent).y,
+      x: (domEvent as MouseEvent).clientX - offsetX,
+      y: (domEvent as MouseEvent).clientY - offsetY,
     };
   }
   const currentTargetDatasetString = currentTargetElement?.getAttribute(

--- a/packages/web-platform/web-mainthread-apis/ts/utils/createCrossThreadEvent.ts
+++ b/packages/web-platform/web-mainthread-apis/ts/utils/createCrossThreadEvent.ts
@@ -61,10 +61,10 @@ export function createCrossThreadEvent(
         const rect = getContainerRect();
         return {
           ...t,
-          clientX: (t.clientX as number) - rect.left,
-          clientY: (t.clientY as number) - rect.top,
-          pageX: (t.pageX as number) - rect.left,
-          pageY: (t.pageY as number) - rect.top,
+          clientX: (t['clientX'] as number) - rect.left,
+          clientY: (t['clientY'] as number) - rect.top,
+          pageX: (t['pageX'] as number) - rect.left,
+          pageY: (t['pageY'] as number) - rect.top,
         };
       }
       return t;


### PR DESCRIPTION
## Summary

Fixed tap/touch/mouse event coordinates to be relative to the `<lynx-view>` container instead of viewport origin. When `<lynx-view>` is embedded with offset (e.g., `margin: 200px 300px`), `detail.x/y`, `clientX/clientY`, and `pageX/pageY` now correctly reflect position within the view, not the viewport. Also fixed `boundingClientRect` to return container-relative values.

## Changes

- Pass container rect callback to `createCrossThreadEvent` in both web-mainthread-apis and web-core-wasm
- Subtract container offset from click, mouse, and touch event coordinates
- Adjust `InvokeUIMethod.boundingClientRect` to return container-relative positions
- Backward compatible: no offset applied when container rect callback is not provided

## Checklist

- [x] Tests updated (existing behavior unchanged; coordinates now correct for offset containers)
- [x] Documentation updated (not required for this fix)
- [x] Changeset added (not required for this fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Events and UI measurements now account for container offsets: touch, mouse, and click coordinates (including multi-touch lists) and element bounding rectangles are computed relative to their container, improving positioning accuracy in nested or shadowed layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->