### PR TITLE
perf(react-runtime): streamline delayed-event replay handling

### DIFF
--- a/packages/react/runtime/src/lifecycle/destroy.ts
+++ b/packages/react/runtime/src/lifecycle/destroy.ts
@@ -24,9 +24,7 @@ function destroyBackground(): void {
   // Clear delayed events which should not be executed after destroyed.
   // This is important when the page is performing a reload.
   delayedLifecycleEvents.length = 0;
-  if (delayedEvents) {
-    delayedEvents.length = 0;
-  }
+  delayedEvents.length = 0;
   if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
     profileEnd();
   }

--- a/packages/react/runtime/src/lifecycle/event/delayEvents.ts
+++ b/packages/react/runtime/src/lifecycle/event/delayEvents.ts
@@ -1,10 +1,9 @@
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-let delayedEvents: [handlerName: string, data: EventDataType][] | undefined;
+const delayedEvents: [handlerName: string, data: EventDataType][] = [];
 
 function delayedPublishEvent(handlerName: string, data: EventDataType): void {
-  delayedEvents ??= [];
   delayedEvents.push([handlerName, data]);
 }
 

--- a/packages/react/runtime/src/lynx/tt.ts
+++ b/packages/react/runtime/src/lynx/tt.ts
@@ -130,20 +130,17 @@ function onLifecycleEventImpl(type: LifecycleConstant, data: unknown): void {
 
       // TODO: It seems `delayedEvents` and `delayedLifecycleEvents` should be merged into one array to ensure the proper order of events.
       flushDelayedLifecycleEvents();
-      if (delayedEvents) {
-        delayedEvents.forEach((args) => {
-          const [handlerName, data] = args;
-          // eslint-disable-next-line prefer-const
-          let [idStr, ...rest] = handlerName.split(':');
-          while (jsReadyEventIdSwap[idStr!]) idStr = jsReadyEventIdSwap[idStr!]?.toString();
-          try {
-            publishEvent([idStr, ...rest].join(':'), data);
-          } catch (e) {
-            lynx.reportError(e as Error);
-          }
-        });
-        delayedEvents.length = 0;
+      for (const [handlerName, data] of delayedEvents) {
+        // eslint-disable-next-line prefer-const
+        let [idStr, ...rest] = handlerName.split(':');
+        while (jsReadyEventIdSwap[idStr!]) idStr = jsReadyEventIdSwap[idStr!]?.toString();
+        try {
+          publishEvent([idStr, ...rest].join(':'), data);
+        } catch (e) {
+          lynx.reportError(e as Error);
+        }
       }
+      delayedEvents.length = 0;
 
       lynxCoreInject.tt.publishEvent = publishEvent;
       lynxCoreInject.tt.publicComponentEvent = publicComponentEvent;

--- a/packages/react/runtime/src/lynx/tt.ts
+++ b/packages/react/runtime/src/lynx/tt.ts
@@ -131,11 +131,12 @@ function onLifecycleEventImpl(type: LifecycleConstant, data: unknown): void {
       // TODO: It seems `delayedEvents` and `delayedLifecycleEvents` should be merged into one array to ensure the proper order of events.
       flushDelayedLifecycleEvents();
       for (const [handlerName, data] of delayedEvents) {
-        // eslint-disable-next-line prefer-const
-        let [idStr, ...rest] = handlerName.split(':');
-        while (jsReadyEventIdSwap[idStr!]) idStr = jsReadyEventIdSwap[idStr!]?.toString();
+        const i = handlerName.indexOf(':');
+
+        let idStr = handlerName.slice(0, i);
+        while (jsReadyEventIdSwap[idStr]) idStr = '' + jsReadyEventIdSwap[idStr];
         try {
-          publishEvent([idStr, ...rest].join(':'), data);
+          publishEvent(idStr + handlerName.slice(i), data);
         } catch (e) {
           lynx.reportError(e as Error);
         }


### PR DESCRIPTION
This PR extracts a focused slice from the bundle-size work and keeps it to two commits:\n\n1. Eagerly initialize the delayed-event queue and simplify destroy-time cleanup so delayed events can always be cleared without null guards.\n2. Compact first-screen delayed-event remapping by replacing split/rest/join reconstruction with index/slice-based string handling.\n\nThe goal is to keep the delayed-event replay path smaller and easier to reason about without changing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event cleanup to ensure delayed events are always properly cleared.

* **Performance**
  * Optimized event initialization and processing to reduce runtime overhead and eliminate unnecessary conditional checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->