### PR TITLE
fix: compile flex numbers in style objects to string values

### DIFF
--- a/packages/react/transform/__test__/css/inline-style.spec.js
+++ b/packages/react/transform/__test__/css/inline-style.spec.js
@@ -50,4 +50,17 @@ describe('Parse Inline Style', () => {
       await formatMessages(result.warnings, { kind: 'warning', color: false }),
     ).toMatchInlineSnapshot(`[]`);
   });
+
+  it('should compile flex number in style object to string value', async () => {
+    const result = await transformReactLynx(
+      `\
+const style = flag ? { flex: 1, width: '100px' } : { flex: 2 };
+<view style={style} />`,
+    );
+
+    expect(result.code).toMatch(/flex:\s*['"]1['"]/);
+    expect(result.code).toMatch(/flex:\s*['"]2['"]/);
+    expect(result.code).not.toMatch(/flex:\s*1([,}\s])/);
+    expect(result.code).not.toMatch(/flex:\s*2([,}\s])/);
+  });
 });

--- a/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
@@ -131,6 +131,38 @@ fn bool_jsx_attr(value: bool) -> JSXAttrValue {
   })
 }
 
+struct FlexNumericToStringVisitor;
+
+impl VisitMut for FlexNumericToStringVisitor {
+  fn visit_mut_key_value_prop(&mut self, key_value_prop: &mut KeyValueProp) {
+    key_value_prop.value.visit_mut_with(self);
+
+    let is_flex_key = match &key_value_prop.key {
+      PropName::Ident(ident) => ident.sym.as_ref() == "flex",
+      PropName::Str(s) => s.value.to_string_lossy().as_ref() == "flex",
+      _ => false,
+    };
+
+    if !is_flex_key {
+      return;
+    }
+
+    if let Expr::Lit(Lit::Num(number)) = &*key_value_prop.value {
+      key_value_prop.value = Box::new(Expr::Lit(Lit::Str(Str {
+        span: number.span,
+        value: number.value.to_string().into(),
+        raw: None,
+      })));
+    }
+  }
+}
+
+fn normalize_flex_numeric_value(expr: &Expr) -> Expr {
+  let mut expr = expr.clone();
+  expr.visit_mut_with(&mut FlexNumericToStringVisitor);
+  expr
+}
+
 impl DynamicPart {
   fn to_updater(&self, runtime_id: Expr, target: TransformTarget, exp_index: i32) -> Expr {
     match target {
@@ -663,9 +695,9 @@ where
                           span,
                           ..
                         })) => {
-                          let expr = &**expr;
-                          if is_literal(expr) {
-                            if let Some(s) = get_string_inline_style_from_literal(expr, span) {
+                          let expr = normalize_flex_numeric_value(expr);
+                          if is_literal(&expr) {
+                            if let Some(s) = get_string_inline_style_from_literal(&expr, span) {
                               // <view style={{backgroundColor: "red"}} />;
                               // <view style={`background-color: red;`} />;
                               let s = Lit::Str(Str {
@@ -682,7 +714,7 @@ where
                             }
                           } else {
                             self.dynamic_parts.push(DynamicPart::Attr(
-                              expr.clone(),
+                              expr,
                               self.element_index,
                               attr_name.clone(),
                             ));


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of numeric `flex` values in inline styles to convert them to string literals.

* **Tests**
  * Added test coverage for numeric flex value transformation in inline style objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
