### PR TITLE
feat(x-markdown): add markdown rendering support and tests

### DIFF
--- a/.changeset/nasty-lizards-refuse.md
+++ b/.changeset/nasty-lizards-refuse.md
@@ -1,0 +1,20 @@
+---
+"@lynx-js/web-elements": patch
+"@lynx-js/web-core": patch
+---
+
+feat: add x-markdown support
+
+Add opt-in support for the `x-markdown` element on Lynx Web, including
+Markdown rendering together with its related styling, interaction, animation,
+truncation, range rendering, and effect capabilities exposed through the
+component API.
+
+Update the `web-core`, `web-core-wasm`, and `web-mainthread-apis` runtime
+paths to use the shared property-or-attribute setter from `web-constants`, so
+custom elements such as `x-markdown` can receive structured property values
+correctly instead of being forced through string-only attribute updates.
+
+```javascript
+import '@lynx-js/web-elements/XMarkdown';
+```

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -3199,12 +3199,16 @@ test.describe('reactlynx3 tests', () => {
       // input/bindinput test-case start
       test('basic-element-x-input-bindinput', async ({ page }, { title }) => {
         await goto(page, title);
-        await page.locator('input').press('Enter');
-        await wait(200);
-        await page.locator('input').fill('foobar');
-        await wait(200);
-        const result = await page.locator('.result').first().innerText();
-        expect(result).toBe('foobar-6-6');
+        const input = page.locator('input');
+        const result = page.locator('.result').first();
+
+        // Firefox CI can be slower to finish mounting/binding handlers; wait for initial render first.
+        await expect(input).toBeVisible();
+        await expect(input).toHaveValue('bindinput');
+
+        await input.press('Enter');
+        await input.fill('foobar');
+        await expect(result).toHaveText('foobar-6-6');
       });
       // input/bindinput test-case start for <input>
       test('basic-element-input-bindinput', async ({ page }, { title }) => {

--- a/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerSetNativePropsHandler.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerSetNativePropsHandler.ts
@@ -1,14 +1,15 @@
 // Copyright 2023 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { Rpc } from '@lynx-js/web-worker-rpc';
+import { Rpc } from '@lynx-js/web-worker-rpc';
 import { queryNodes } from './queryNodes.js';
-import { setNativePropsEndpoint } from '../../endpoints.js';
 import type { LynxViewInstance } from '../LynxViewInstance.js';
+import { setElementPropertyOrAttribute } from '../utils/setElementPropertyOrAttribute.js';
+import { setNativePropsEndpoint } from '../../endpoints.js';
 
 function applyNativeProps(element: Element, nativeProps: Record<string, any>) {
   for (const key in nativeProps) {
-    const value = nativeProps[key] as string;
+    const value = nativeProps[key];
     if (key === 'text' && element?.tagName === 'X-TEXT') {
       if (
         element.firstElementChild
@@ -23,7 +24,7 @@ function applyNativeProps(element: Element, nativeProps: Record<string, any>) {
     ) {
       (element as HTMLElement).style.setProperty(key, value);
     } else {
-      element.setAttribute(key, value);
+      setElementPropertyOrAttribute(element, key, value);
     }
   }
 }

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
@@ -1,4 +1,5 @@
 import { wasmInstance } from '../../wasm.js';
+import { setElementPropertyOrAttribute } from '../utils/setElementPropertyOrAttribute.js';
 
 import {
   AnimationOperation,
@@ -447,11 +448,7 @@ export function createElementAPI(
           }
         });
       } else {
-        if (value == null) {
-          element.removeAttribute(name);
-        } else {
-          element.setAttribute(name, value.toString());
-        }
+        setElementPropertyOrAttribute(element, name, value);
         if (name === 'exposure-id') {
           if (value != null) {
             mtsBinding.markExposureRelatedElementByUniqueId(

--- a/packages/web-platform/web-core/ts/client/mainthread/utils/setElementPropertyOrAttribute.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/utils/setElementPropertyOrAttribute.ts
@@ -1,0 +1,25 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const setElementPropertyOrAttribute = (
+  element: Element,
+  key: string,
+  value: unknown,
+) => {
+  if (value == null) {
+    element.removeAttribute(key);
+    return;
+  }
+
+  if (
+    key in element
+    && typeof value !== 'string'
+    && typeof value !== 'number'
+    && typeof value !== 'boolean'
+  ) {
+    (element as unknown as Record<string, unknown>)[key] = value;
+  } else {
+    element.setAttribute(key, String(value));
+  }
+};

--- a/packages/web-platform/web-elements/index.css
+++ b/packages/web-platform/web-elements/index.css
@@ -13,6 +13,7 @@
 @import url("./src/elements/XSvg/x-svg.css");
 @import url("./src/elements/XImage/x-image.css");
 @import url("./src/elements/XInput/x-input.css");
+@import url("./src/elements/XMarkdown/x-markdown.css");
 @import url("./src/elements/XOverlayNg/x-overlay-ng.css");
 @import url("./src/elements/XRefreshView/x-refresh-view.css");
 @import url("./src/elements/XSwiper/x-swiper.css");

--- a/packages/web-platform/web-elements/package.json
+++ b/packages/web-platform/web-elements/package.json
@@ -59,6 +59,11 @@
       "types": "./dist/elements/XInput/index.d.ts",
       "default": "./dist/elements/XInput/index.js"
     },
+    "./XMarkdown": {
+      "@lynx-js/source-field": "./src/elements/XMarkdown/index.ts",
+      "types": "./dist/elements/XMarkdown/index.d.ts",
+      "default": "./dist/elements/XMarkdown/index.js"
+    },
     "./XOverlayNg": {
       "@lynx-js/source-field": "./src/elements/XOverlayNg/index.ts",
       "types": "./dist/elements/XOverlayNg/index.d.ts",
@@ -135,11 +140,16 @@
     "test:install": "playwright install --with-deps chromium firefox webkit",
     "test:update": "playwright test --ui --update-snapshots"
   },
+  "dependencies": {
+    "dompurify": "^3.3.1",
+    "markdown-it": "^14.1.0"
+  },
   "devDependencies": {
     "@lynx-js/playwright-fixtures": "workspace:*",
     "@playwright/test": "^1.58.2",
     "@rsbuild/core": "catalog:rsbuild",
     "@rsbuild/plugin-source-build": "1.0.4",
+    "@types/markdown-it": "^14.1.1",
     "nyc": "^17.1.0",
     "tslib": "^2.8.1"
   },

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdown.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdown.ts
@@ -1,0 +1,425 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component } from '../../element-reactive/index.js';
+import { CommonEventsAndMethods } from '../common/CommonEventsAndMethods.js';
+import { templateXMarkdown } from '../htmlTemplates.js';
+import {
+  parseMarkdownStyle,
+  serializeMarkdownStyle,
+  XMarkdownAttributes,
+} from './XMarkdownAttributes.js';
+import type { MarkdownStyleConfig } from './XMarkdownAttributes.js';
+
+type SelectionRoot = ShadowRoot & { getSelection?: () => Selection | null };
+type SelectionWithComposedRanges = Selection & {
+  getComposedRanges?: (...args: unknown[]) => StaticRange[];
+};
+
+const getComposedRange = (
+  selection: Selection,
+  shadowRoot: ShadowRoot | null,
+): StaticRange | null => {
+  const getComposedRanges = (selection as SelectionWithComposedRanges)
+    .getComposedRanges;
+  if (!shadowRoot || typeof getComposedRanges !== 'function') return null;
+  try {
+    return getComposedRanges.call(selection, {
+      shadowRoots: [shadowRoot],
+    })[0] ?? null;
+  } catch {
+    try {
+      return getComposedRanges.call(selection, shadowRoot)[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+};
+
+const createRangeByOffsets = (
+  doc: Document,
+  root: HTMLElement,
+  start: number,
+  end: number,
+): Range | null => {
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let pos = 0;
+  let startNode: Text | null = null;
+  let startOffset = 0;
+  let endNode: Text | null = null;
+  let endOffset = 0;
+  let node = walker.nextNode() as Text | null;
+
+  while (node) {
+    const len = node.nodeValue?.length ?? 0;
+    if (!startNode && pos + len >= start) {
+      startNode = node;
+      startOffset = start - pos;
+    }
+    if (pos + len >= end) {
+      endNode = node;
+      endOffset = end - pos;
+      break;
+    }
+    pos += len;
+    node = walker.nextNode() as Text | null;
+  }
+
+  if (!startNode) return null;
+  if (!endNode) {
+    endNode = startNode;
+    endOffset = startOffset;
+  }
+
+  const range = doc.createRange();
+  range.setStart(
+    startNode,
+    Math.max(0, Math.min(startOffset, startNode.length)),
+  );
+  range.setEnd(endNode, Math.max(0, Math.min(endOffset, endNode.length)));
+  return range;
+};
+
+const getRenderedPrefixLengthForSourceOffset = (
+  source: string,
+  rendered: string,
+  sourceOffset: number,
+) => {
+  let renderedIndex = 0;
+  const limit = Math.max(0, Math.min(sourceOffset, source.length));
+
+  for (let sourceIndex = 0; sourceIndex < limit; sourceIndex += 1) {
+    if (renderedIndex >= rendered.length) break;
+    if (source[sourceIndex] === rendered[renderedIndex]) {
+      renderedIndex += 1;
+    }
+  }
+
+  return renderedIndex;
+};
+
+const mapSourceRangeToCharRange = (
+  source: string,
+  rendered: string,
+  start: number,
+  end: number,
+): { start: number; end: number } => {
+  const renderedStart = getRenderedPrefixLengthForSourceOffset(
+    source,
+    rendered,
+    start,
+  );
+  const renderedEnd = getRenderedPrefixLengthForSourceOffset(
+    source,
+    rendered,
+    end,
+  );
+  return {
+    start: renderedStart,
+    end: Math.max(renderedStart, renderedEnd),
+  };
+};
+
+const isSelectionNodeInsideHost = (
+  dom: XMarkdown,
+  shadowRoot: ShadowRoot | null,
+  node: Node | null,
+) =>
+  !!node
+  && (
+    node === dom
+    || node === shadowRoot
+    || dom.contains(node)
+    || !!shadowRoot?.contains(node)
+  );
+
+const getRangeInRoot = (
+  dom: XMarkdown,
+  root: HTMLElement,
+  selection: Selection | null,
+): Range | null => {
+  if (!selection) return null;
+  const shadowRoot = dom.shadowRoot as SelectionRoot | null;
+  const sourceRange = getComposedRange(selection, shadowRoot)
+    ?? (selection.rangeCount > 0 ? selection.getRangeAt(0) : null);
+  if (!sourceRange) return null;
+  if (
+    !root.contains(sourceRange.startContainer)
+    || !root.contains(sourceRange.endContainer)
+  ) {
+    if (
+      !isSelectionNodeInsideHost(dom, shadowRoot, sourceRange.startContainer)
+      || !isSelectionNodeInsideHost(dom, shadowRoot, sourceRange.endContainer)
+      || !isSelectionNodeInsideHost(dom, shadowRoot, selection.anchorNode)
+      || !isSelectionNodeInsideHost(dom, shadowRoot, selection.focusNode)
+    ) {
+      return null;
+    }
+    const selectedText = selection.toString();
+    if (!selectedText) {
+      return null;
+    }
+    const start = root.textContent?.indexOf(selectedText) ?? -1;
+    if (start < 0) return null;
+    return createRangeByOffsets(
+      dom.ownerDocument,
+      root,
+      start,
+      start + selectedText.length,
+    );
+  }
+  const range = dom.ownerDocument.createRange();
+  range.setStart(sourceRange.startContainer, sourceRange.startOffset);
+  range.setEnd(sourceRange.endContainer, sourceRange.endOffset);
+  return range;
+};
+
+const getSelectionCandidates = (dom: XMarkdown): Selection[] => {
+  const shadowRoot = dom.shadowRoot as SelectionRoot | null;
+  const shadowSelection =
+    shadowRoot && typeof shadowRoot.getSelection === 'function'
+      ? shadowRoot.getSelection()
+      : null;
+  const documentSelection = dom.ownerDocument.getSelection();
+  return [shadowSelection, documentSelection].filter(
+    (selection, index, selections): selection is Selection =>
+      !!selection && selections.indexOf(selection) === index,
+  );
+};
+
+const getSelectionForRoot = (
+  dom: XMarkdown,
+  root: HTMLElement,
+): { selection: Selection; range: Range } | null => {
+  for (const selection of getSelectionCandidates(dom)) {
+    const range = getRangeInRoot(dom, root, selection);
+    if (range) return { selection, range };
+  }
+  return null;
+};
+
+const getPreferredSelectionTarget = (dom: XMarkdown): Selection | null => {
+  const candidates = getSelectionCandidates(dom);
+  return candidates[0] ?? null;
+};
+
+@Component<typeof XMarkdown>(
+  'x-markdown',
+  [CommonEventsAndMethods, XMarkdownAttributes],
+  templateXMarkdown,
+)
+export class XMarkdown extends HTMLElement {
+  static readonly notToFilterFalseAttributes = new Set(['content-complete']);
+
+  #getMarkdownStyle() {
+    return parseMarkdownStyle(this.getAttribute('markdown-style'));
+  }
+
+  #setMarkdownStyle(value: MarkdownStyleConfig | string | null) {
+    const serialized = serializeMarkdownStyle(value);
+    if (serialized === null) {
+      this.removeAttribute('markdown-style');
+    } else {
+      this.setAttribute('markdown-style', serialized);
+    }
+  }
+
+  get markdownStyle(): MarkdownStyleConfig {
+    return this.#getMarkdownStyle();
+  }
+
+  set markdownStyle(value: MarkdownStyleConfig | string | null) {
+    this.#setMarkdownStyle(value);
+  }
+
+  get ['markdown-style'](): MarkdownStyleConfig {
+    return this.#getMarkdownStyle();
+  }
+
+  set ['markdown-style'](value: MarkdownStyleConfig | string | null) {
+    this.#setMarkdownStyle(value);
+  }
+
+  /**
+   * 获取当前渲染内容中的所有图片 URL。
+   */
+  getImages(): string[] {
+    const root = this.shadowRoot?.querySelector(
+      '#markdown-root',
+    ) as HTMLElement | null;
+    if (!root) return [];
+    return Array.from(root.querySelectorAll('img'))
+      .map((img) => img.getAttribute('src') || '')
+      .filter((v) => !!v) as string[];
+  }
+
+  getContent(params?: { start?: number; end?: number }): { content: string } {
+    const content = this.getAttribute('content') ?? '';
+    const s = Math.max(0, params?.start ?? 0);
+    const eInclusive = params?.end ?? (content.length - 1);
+    const e = Math.min(content.length, eInclusive + 1);
+    const slice = e >= s ? content.slice(s, e) : '';
+    return { content: slice };
+  }
+
+  pauseAnimation() {
+    this.setAttribute('animation-paused', 'true');
+  }
+
+  resumeAnimation(params?: { animationStep?: number }) {
+    if (params?.animationStep !== undefined) {
+      this.setAttribute('initial-animation-step', String(params.animationStep));
+    }
+    if (this.getAttribute('animation-type') !== 'typewriter') {
+      this.setAttribute('animation-type', 'typewriter');
+    }
+    const velocity = this.getAttribute('animation-velocity');
+    if (!velocity || Number(velocity) <= 0) {
+      this.setAttribute('animation-velocity', '40');
+    }
+    this.removeAttribute('animation-paused');
+  }
+
+  getSelectedText(): string {
+    const root = this.shadowRoot?.querySelector('#markdown-root') as
+      | HTMLElement
+      | null;
+    if (!root) return '';
+    const result = getSelectionForRoot(this, root);
+    return result?.range.toString() ?? '';
+  }
+
+  getTextBoundingRect(
+    params?: { start?: number; end?: number; indexType?: 'char' | 'source' },
+  ): { boundingRect: DOMRect } | null {
+    const root = this.shadowRoot?.querySelector('#markdown-root') as
+      | HTMLElement
+      | null;
+    if (!root) return null;
+    const doc = this.ownerDocument;
+    const createRangeByChar = (s: number, e: number): Range | null => {
+      const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+      let pos = 0;
+      let startNode: Text | null = null;
+      let startOffset = 0;
+      let endNode: Text | null = null;
+      let endOffset = 0;
+      let node = walker.nextNode() as Text | null;
+      while (node) {
+        const len = node.nodeValue?.length ?? 0;
+        if (!startNode && pos + len >= s) {
+          startNode = node;
+          startOffset = s - pos;
+        }
+        if (pos + len >= e) {
+          endNode = node;
+          endOffset = e - pos;
+          break;
+        }
+        pos += len;
+        node = walker.nextNode() as Text | null;
+      }
+      if (!startNode) return null;
+      if (!endNode) {
+        endNode = startNode;
+        endOffset = startOffset;
+      }
+      const r = doc.createRange();
+      r.setStart(
+        startNode,
+        Math.max(0, Math.min(startOffset, startNode.length)),
+      );
+      r.setEnd(endNode, Math.max(0, Math.min(endOffset, endNode.length)));
+      return r;
+    };
+    if (params?.start !== undefined || params?.end !== undefined) {
+      const s = Math.max(0, params?.start ?? 0);
+      const e = Math.max(s, params?.end ?? s);
+      const rangeOffsets = params?.indexType === 'source'
+        ? mapSourceRangeToCharRange(
+          this.getAttribute('content') ?? '',
+          root.textContent ?? '',
+          s,
+          e,
+        )
+        : { start: s, end: e };
+      if (!rangeOffsets) return null;
+      const r = createRangeByChar(rangeOffsets.start, rangeOffsets.end);
+      if (!r) return null;
+      return { boundingRect: r.getBoundingClientRect() };
+    }
+    const result = getSelectionForRoot(this, root);
+    if (!result) return null;
+    return { boundingRect: result.range.getBoundingClientRect() };
+  }
+
+  setTextSelection(
+    params: { startX: number; startY: number; endX: number; endY: number },
+  ) {
+    const doc = this.ownerDocument as any;
+    const getRangeAtPoint = (x: number, y: number): Range | null => {
+      if (doc.caretRangeFromPoint) return doc.caretRangeFromPoint(x, y);
+      if (doc.caretPositionFromPoint) {
+        const pos = doc.caretPositionFromPoint(x, y);
+        if (!pos) return null;
+        const r = this.ownerDocument.createRange();
+        r.setStart(pos.offsetNode, pos.offset);
+        r.collapse(true);
+        return r;
+      }
+      return null;
+    };
+    const r1 = getRangeAtPoint(params.startX, params.startY);
+    const r2 = getRangeAtPoint(params.endX, params.endY);
+    if (r1 && r2) {
+      const sel = getPreferredSelectionTarget(this);
+      if (!sel) return;
+      sel.removeAllRanges();
+      const range = this.ownerDocument.createRange();
+      range.setStart(r1.startContainer, r1.startOffset);
+      range.setEnd(r2.startContainer, r2.startOffset);
+      sel.addRange(range);
+    }
+  }
+
+  getParseResult(
+    params: { tags: string[] },
+  ): Record<string, { start: number; end: number }[]> {
+    const root = this.shadowRoot?.querySelector('#markdown-root') as
+      | HTMLElement
+      | null;
+    if (!root) return {};
+    const text = root.textContent || '';
+    const result: Record<string, { start: number; end: number }[]> = {};
+    const doc = this.ownerDocument;
+    const calcOffset = (node: Node): { start: number; end: number } => {
+      const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+      let pos = 0;
+      let start = -1;
+      let end = -1;
+      let current = walker.nextNode();
+      while (current) {
+        const len = (current.nodeValue || '').length;
+        if (current === node || node.contains(current)) {
+          if (start < 0) {
+            start = pos;
+          }
+          end = pos + len;
+        }
+        pos += len;
+        current = walker.nextNode();
+      }
+      return {
+        start: Math.max(0, Math.min(start, text.length)),
+        end: Math.max(0, Math.min(end, text.length)),
+      };
+    };
+    for (const tag of params.tags) {
+      const nodes = Array.from(root.querySelectorAll(tag));
+      result[tag] = nodes.map((el) => calcOffset(el));
+    }
+    return result;
+  }
+}

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
@@ -1,0 +1,1422 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import type MarkdownIt from 'markdown-it';
+import type createDOMPurify from 'dompurify';
+import {
+  boostedQueueMicrotask,
+  genDomGetter,
+  registerAttributeHandler,
+} from '../../element-reactive/index.js';
+import type { XMarkdown } from './XMarkdown.js';
+
+type MarkdownItCtor = typeof MarkdownIt;
+type DOMPurifyCtor = typeof createDOMPurify;
+
+let MarkdownItLoaded: MarkdownItCtor | undefined;
+let DOMPurifyLoaded: DOMPurifyCtor | undefined;
+let depsLoading: Promise<void> | undefined;
+let depsLoaded = false;
+let depsError: unknown;
+
+const loadDeps = () => {
+  if (depsLoaded) return Promise.resolve();
+  if (depsLoading) return depsLoading;
+  depsLoading = import(
+    /* webpackChunkName: "xmarkdown-deps" */
+    './XMarkdownDeps.js'
+  ).then((deps) => {
+    MarkdownItLoaded = deps.MarkdownIt;
+    DOMPurifyLoaded = deps.createDOMPurify;
+    depsLoaded = true;
+  }).catch((err) => {
+    depsError = err;
+  });
+  return depsLoading;
+};
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+
+const escapeHtmlAttr = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('\'', '&#39;');
+
+const decodeHtmlEntities = (value: string) =>
+  value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#34;', '"')
+    .replaceAll('&apos;', '\'')
+    .replaceAll('&#39;', '\'')
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>');
+
+const normalizeClassList = (value: string) => {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  const safe = parts.filter((part) => /^[A-Za-z0-9_-]+$/.test(part));
+  return safe.join(' ');
+};
+
+const sanitizeAllowedHtml = (value: string) => {
+  if (!value) return value;
+  if (
+    value.includes('<!--')
+    || value.includes('<!')
+    || value.includes('<?')
+    || value.includes('<%')
+  ) {
+    return escapeHtml(value);
+  }
+
+  const tagNameRe = /<\s*\/?\s*([A-Za-z][\w-]*)\b[^>]*>/g;
+  let match: RegExpExecArray | null = null;
+  let hasTag = false;
+  while ((match = tagNameRe.exec(value))) {
+    hasTag = true;
+    const name = (match[1] ?? '').toLowerCase();
+    if (name !== 'span' && name !== 'p') {
+      return escapeHtml(value);
+    }
+  }
+  if (!hasTag) {
+    return value.includes('<') ? escapeHtml(value) : value;
+  }
+
+  const openTagRe = /<(span|p)\b([^>]*?)(\/?)>/gi;
+  return value.replace(openTagRe, (_m, rawName, rawAttrs, rawSelfClose) => {
+    const name = String(rawName).toLowerCase();
+    const attrs = decodeHtmlEntities(String(rawAttrs ?? ''));
+    const classMatch = /\bclass\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(
+      attrs,
+    );
+    const rawClass = (classMatch?.[1] ?? classMatch?.[2] ?? classMatch?.[3])
+      ?? '';
+    const normalized = normalizeClassList(rawClass);
+    const classAttr = normalized
+      ? ` class="${escapeHtmlAttr(normalized)}"`
+      : '';
+    const selfClose = String(rawSelfClose ?? '') === '/';
+    if (selfClose) return `<${name}${classAttr}></${name}>`;
+    return `<${name}${classAttr}>`;
+  });
+};
+
+const applyRawHtmlPolicy = (tokens: any[]) => {
+  for (const token of tokens) {
+    if (token?.type === 'html_inline' || token?.type === 'html_block') {
+      token.content = sanitizeAllowedHtml(String(token.content ?? ''));
+    }
+    if (Array.isArray(token?.children)) {
+      applyRawHtmlPolicy(token.children);
+    }
+  }
+};
+
+const renderMarkdown = (parser: MarkdownIt, content: string) => {
+  const env = {};
+  const tokens = parser.parse(content, env);
+  applyRawHtmlPolicy(tokens);
+  return parser.renderer.render(tokens, parser.options, env);
+};
+let markdownParser: MarkdownIt | null = null;
+let markdownParserError: unknown;
+let htmlSanitizer: ReturnType<DOMPurifyCtor> | null = null;
+const getMarkdownParser = () => {
+  if (markdownParser || markdownParserError) return markdownParser;
+  if (!MarkdownItLoaded) return null;
+  try {
+    markdownParser = new MarkdownItLoaded({
+      html: true,
+      linkify: true,
+    });
+    markdownParser.enable(['table', 'strikethrough']);
+  } catch (error) {
+    markdownParserError = error;
+  }
+  return markdownParser;
+};
+
+const getHtmlSanitizer = () => {
+  if (htmlSanitizer) return htmlSanitizer;
+  if (!DOMPurifyLoaded) return null;
+  htmlSanitizer = DOMPurifyLoaded(window)!;
+  return htmlSanitizer;
+};
+
+const sanitizeHtml = (value: string) => {
+  const sanitizer = getHtmlSanitizer();
+  if (!sanitizer) return value;
+  return sanitizer.sanitize(value, {
+    USE_PROFILES: { html: true },
+  }) as string;
+};
+
+type MarkdownSelectionDetail = {
+  start: number;
+  end: number;
+  direction: 'forward' | 'backward';
+};
+
+type SelectionRoot = ShadowRoot & { getSelection?: () => Selection | null };
+type SelectionWithComposedRanges = Selection & {
+  getComposedRanges?: (...args: unknown[]) => StaticRange[];
+};
+
+const emptySelectionDetail = (): MarkdownSelectionDetail => ({
+  start: -1,
+  end: -1,
+  direction: 'forward',
+});
+
+const getComposedRange = (
+  selection: Selection,
+  shadowRoot: ShadowRoot | null,
+): StaticRange | null => {
+  const getComposedRanges = (selection as SelectionWithComposedRanges)
+    .getComposedRanges;
+  if (!shadowRoot || typeof getComposedRanges !== 'function') return null;
+  try {
+    return getComposedRanges.call(selection, {
+      shadowRoots: [shadowRoot],
+    })[0] ?? null;
+  } catch {
+    try {
+      return getComposedRanges.call(selection, shadowRoot)[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+};
+
+const createRangeByOffsets = (
+  doc: Document,
+  root: HTMLElement,
+  start: number,
+  end: number,
+) => {
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let pos = 0;
+  let startNode: Text | null = null;
+  let startOffset = 0;
+  let endNode: Text | null = null;
+  let endOffset = 0;
+  let node = walker.nextNode() as Text | null;
+
+  while (node) {
+    const len = node.nodeValue?.length ?? 0;
+    if (!startNode && pos + len >= start) {
+      startNode = node;
+      startOffset = start - pos;
+    }
+    if (pos + len >= end) {
+      endNode = node;
+      endOffset = end - pos;
+      break;
+    }
+    pos += len;
+    node = walker.nextNode() as Text | null;
+  }
+
+  if (!startNode) return null;
+  if (!endNode) {
+    endNode = startNode;
+    endOffset = startOffset;
+  }
+
+  const range = doc.createRange();
+  range.setStart(
+    startNode,
+    Math.max(0, Math.min(startOffset, startNode.length)),
+  );
+  range.setEnd(endNode, Math.max(0, Math.min(endOffset, endNode.length)));
+  return range;
+};
+
+const isSelectionNodeInsideHost = (
+  dom: HTMLElement,
+  shadowRoot: ShadowRoot | null,
+  node: Node | null,
+) =>
+  !!node
+  && (
+    node === dom
+    || node === shadowRoot
+    || dom.contains(node)
+    || !!shadowRoot?.contains(node)
+  );
+
+const getRangeInRoot = (
+  doc: Document,
+  dom: HTMLElement,
+  root: HTMLElement,
+  shadowRoot: ShadowRoot | null,
+  selection: Selection | null,
+) => {
+  if (!selection) return null;
+  const sourceRange = getComposedRange(selection, shadowRoot)
+    ?? (selection.rangeCount > 0 ? selection.getRangeAt(0) : null);
+  if (!sourceRange) return null;
+  if (
+    !root.contains(sourceRange.startContainer)
+    || !root.contains(sourceRange.endContainer)
+  ) {
+    if (
+      !isSelectionNodeInsideHost(dom, shadowRoot, sourceRange.startContainer)
+      || !isSelectionNodeInsideHost(dom, shadowRoot, sourceRange.endContainer)
+      || !isSelectionNodeInsideHost(dom, shadowRoot, selection.anchorNode)
+      || !isSelectionNodeInsideHost(dom, shadowRoot, selection.focusNode)
+    ) {
+      return null;
+    }
+    const selectedText = selection.toString();
+    if (!selectedText) {
+      return null;
+    }
+    const start = root.textContent?.indexOf(selectedText) ?? -1;
+    if (start < 0) return null;
+    return createRangeByOffsets(doc, root, start, start + selectedText.length);
+  }
+  const range = doc.createRange();
+  range.setStart(sourceRange.startContainer, sourceRange.startOffset);
+  range.setEnd(sourceRange.endContainer, sourceRange.endOffset);
+  return range;
+};
+
+const getBoundaryOffset = (
+  doc: Document,
+  root: HTMLElement,
+  node: Node | null,
+  offset: number,
+) => {
+  if (!node || !root.contains(node)) return null;
+  const range = doc.createRange();
+  range.selectNodeContents(root);
+  try {
+    range.setEnd(node, offset);
+  } catch {
+    return null;
+  }
+  return range.toString().length;
+};
+
+const getSelectionDetail = (
+  dom: HTMLElement,
+  root: HTMLElement,
+): MarkdownSelectionDetail => {
+  const doc = dom.ownerDocument;
+  const shadowRoot = dom.shadowRoot;
+  const shadowSelection = (shadowRoot as SelectionRoot | null)?.getSelection?.()
+    ?? null;
+  const documentSelection = doc.getSelection();
+  const selectionCandidates = [
+    shadowSelection,
+    documentSelection,
+  ].filter((selection, index, selections): selection is Selection =>
+    !!selection && selections.indexOf(selection) === index
+  );
+
+  let range: Range | null = null;
+  let selection: Selection | null = null;
+  for (const candidate of selectionCandidates) {
+    const nextRange = getRangeInRoot(doc, dom, root, shadowRoot, candidate);
+    if (nextRange && !nextRange.collapsed) {
+      range = nextRange;
+      selection = candidate;
+      break;
+    }
+  }
+  if (!range || !selection) {
+    return emptySelectionDetail();
+  }
+
+  const start = getBoundaryOffset(
+    doc,
+    root,
+    range.startContainer,
+    range.startOffset,
+  );
+  const end = getBoundaryOffset(doc, root, range.endContainer, range.endOffset);
+  if (start === null || end === null || start === end) {
+    return emptySelectionDetail();
+  }
+
+  const anchor = getBoundaryOffset(
+    doc,
+    root,
+    selection.anchorNode,
+    selection.anchorOffset,
+  );
+  const focus = getBoundaryOffset(
+    doc,
+    root,
+    selection.focusNode,
+    selection.focusOffset,
+  );
+
+  return {
+    start: Math.min(start, end),
+    end: Math.max(start, end),
+    direction: anchor !== null && focus !== null && anchor > focus
+      ? 'backward'
+      : 'forward',
+  };
+};
+
+const preprocessInlineView = (html: string) =>
+  html.replace(
+    /src\s*=\s*"inlineview:\/\/([^"]+)"/g,
+    (_m, id) => `data-inlineview="${id}"`,
+  );
+
+const unitlessCssProperties = new Set([
+  'font-weight',
+  'line-height',
+  'opacity',
+  'z-index',
+  'flex',
+  'flex-grow',
+  'flex-shrink',
+  'order',
+]);
+
+const selectorMap: Record<string, string | string[]> = {
+  normalText: '.markdown-body',
+  link: '.markdown-body a',
+  inlineCode: '.markdown-body code:not(pre code)',
+  codeBlock: ['.markdown-body pre', '.markdown-body pre code'],
+  h1: '.markdown-body h1',
+  h2: '.markdown-body h2',
+  h3: '.markdown-body h3',
+  h4: '.markdown-body h4',
+  h5: '.markdown-body h5',
+  h6: '.markdown-body h6',
+  quote: '.markdown-body blockquote',
+  orderedList: '.markdown-body ol',
+  unorderedList: '.markdown-body ul',
+  listItem: '.markdown-body li',
+  image: '.markdown-body img',
+  span: '.markdown-body span',
+  p: '.markdown-body p',
+  // Extended selectors
+  table: '.markdown-body table',
+  thead: '.markdown-body thead',
+  tbody: '.markdown-body tbody',
+  tr: '.markdown-body tr',
+  th: '.markdown-body th',
+  td: '.markdown-body td',
+  imageCaption: '.markdown-body .md-image-caption',
+};
+
+const normalizeColor = (value: string) => {
+  const hex = value.trim();
+  if (/^[0-9a-fA-F]{6,8}$/.test(hex)) {
+    return `#${hex}`;
+  }
+  return value;
+};
+
+const camelToKebab = (value: string) =>
+  value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+
+const toCssValue = (property: string, value: unknown) => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') {
+    return unitlessCssProperties.has(property) ? `${value}` : `${value}px`;
+  }
+  if (typeof value === 'string') {
+    if (property.includes('color')) {
+      return normalizeColor(value);
+    }
+    return value;
+  }
+  return null;
+};
+
+export type MarkdownStyleMap = Record<string, Record<string, unknown>>;
+export type MarkdownStyleConfig = MarkdownStyleMap & {
+  truncation?: { content?: string; truncationType?: 'text' | 'view' };
+  typewriterCursor?: { customCursor?: string; verticalAlign?: string };
+};
+
+export const parseMarkdownStyle = (value: string | null | undefined) => {
+  if (!value) return {} as MarkdownStyleConfig;
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as MarkdownStyleConfig;
+    }
+  } catch {
+    return {} as MarkdownStyleConfig;
+  }
+  return {} as MarkdownStyleConfig;
+};
+
+export const serializeMarkdownStyle = (
+  value: string | MarkdownStyleConfig | null | undefined,
+) => {
+  if (value === null || value === undefined) return null;
+  return typeof value === 'string' ? value : JSON.stringify(value);
+};
+
+const buildMarkdownStyleCss = (
+  style: Record<string, Record<string, unknown>>,
+) => {
+  const rules: string[] = [];
+  for (const [key, properties] of Object.entries(style)) {
+    if (!properties || typeof properties !== 'object') continue;
+    let selectors: string[] = [];
+    if (key.startsWith('.') || key.startsWith('#')) {
+      selectors = [`.markdown-body ${key}`];
+    } else if (selectorMap[key]) {
+      selectors = Array.isArray(selectorMap[key])
+        ? (selectorMap[key] as string[])
+        : [selectorMap[key] as string];
+    } else {
+      continue;
+    }
+    const declarations = Object.entries(properties)
+      .map(([property, value]) => {
+        const cssProperty = camelToKebab(property);
+        const cssValue = toCssValue(cssProperty, value);
+        return cssValue ? `${cssProperty}: ${cssValue};` : null;
+      })
+      .filter(Boolean)
+      .join('');
+    if (!declarations) continue;
+    for (const selector of selectors) {
+      rules.push(`${selector} {${declarations}}`);
+    }
+  }
+  return rules.join('\n');
+};
+
+export class XMarkdownAttributes {
+  static observedAttributes = [
+    'content',
+    'markdown-style',
+    'content-id',
+    // Optional: allow enabling text selection within content
+    'text-selection',
+    // Typewriter / animation
+    'animation-type',
+    'animation-velocity',
+    'animation-paused',
+    'initial-animation-step',
+    'content-complete',
+    'typewriter-dynamic-height',
+    'typewriter-height-transition-duration',
+    // Overflow
+    'text-maxline',
+    // Range rendering
+    'content-range',
+    // Effect
+    'markdown-effect',
+  ];
+
+  readonly #dom: XMarkdown;
+  readonly #root = genDomGetter(() => this.#dom.shadowRoot!, '#markdown-root');
+  readonly #style = genDomGetter(
+    () => this.#dom.shadowRoot!,
+    '#markdown-style',
+  );
+
+  #pendingRender = false;
+  #content = '';
+  #renderedContent = '';
+  #contentId?: string;
+  #eventsAttached = false;
+  #selectionEventAttached = false;
+  #appendRemainder = '';
+  #appendFlushTimer?: ReturnType<typeof setTimeout>;
+  #appendFlushDelay = 60;
+  #currentMarkdownCss = '';
+  #textSelection = false;
+  #selectionSyncTimer?: ReturnType<typeof setTimeout>;
+  #lastSelectionSignature?: string;
+  #truncationConfig:
+    | { content?: string; truncationType?: 'text' | 'view' }
+    | null = null;
+  #truncationEl?: HTMLElement;
+  // Typewriter state
+  #animationType: 'none' | 'typewriter' = 'none';
+  #animationVelocity = 40; // chars per second
+  #animationTimer?: ReturnType<typeof setInterval>;
+  #animationStep = 0;
+  #animationStarted = false;
+  #animationPaused = false;
+  #contentComplete = true;
+  #maxAnimationStep = 0;
+  #typewriterDynamicHeight = false;
+  #typewriterHeightTransition = 0; // seconds
+  #typewriterCursorConfig:
+    | { customCursor?: string; verticalAlign?: string }
+    | null = null;
+  #typewriterCursorEl?: HTMLElement;
+  // Overflow state
+  #textMaxline = 0;
+  #overflowEmitted = false;
+  // Range rendering: inclusive [start, end)
+  #contentRange?: [number, number];
+  // Markdown effect
+  #markdownEffect: any = null;
+
+  constructor(dom: XMarkdown) {
+    this.#dom = dom;
+  }
+
+  connectedCallback() {
+    this.#ensureEvents();
+  }
+
+  dispose() {
+    this.#clearAppendFlushTimer();
+    this.#stopTypewriterTimer();
+    clearTimeout(this.#selectionSyncTimer);
+    this.#selectionSyncTimer = undefined;
+    if (this.#eventsAttached) {
+      const root = this.#root();
+      root.removeEventListener('click', this.#handleClick);
+      this.#eventsAttached = false;
+    }
+    if (this.#selectionEventAttached) {
+      document.removeEventListener(
+        'selectionchange',
+        this.#handleSelectionChange,
+      );
+      document.removeEventListener('mouseup', this.#handleSelectionGestureEnd);
+      document.removeEventListener('touchend', this.#handleSelectionGestureEnd);
+      document.removeEventListener('keyup', this.#handleSelectionGestureEnd);
+      this.#selectionEventAttached = false;
+    }
+  }
+
+  #ensureEvents() {
+    if (this.#eventsAttached) return;
+    const root = this.#root();
+    root.addEventListener('click', this.#handleClick);
+    this.#eventsAttached = true;
+    if (!this.#selectionEventAttached) {
+      document.addEventListener('selectionchange', this.#handleSelectionChange);
+      document.addEventListener('mouseup', this.#handleSelectionGestureEnd);
+      document.addEventListener('touchend', this.#handleSelectionGestureEnd);
+      document.addEventListener('keyup', this.#handleSelectionGestureEnd);
+      this.#selectionEventAttached = true;
+    }
+  }
+
+  #handleClick = (event: MouseEvent) => {
+    const target = event.target as Element | null;
+    if (!target) return;
+    const root = this.#root();
+    const anchor = target.closest('a');
+    if (anchor && root.contains(anchor)) {
+      event.preventDefault();
+      this.#dom.dispatchEvent(
+        new CustomEvent('bindlink', {
+          detail: {
+            url: anchor.getAttribute('href') ?? '',
+            content: anchor.textContent ?? '',
+            contentId: this.#contentId,
+          },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      return;
+    }
+    const image = target.closest('img');
+    if (image && root.contains(image)) {
+      this.#dom.dispatchEvent(
+        new CustomEvent('bindimageTap', {
+          detail: {
+            url: image.getAttribute('src') ?? '',
+            contentId: this.#contentId,
+          },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  };
+
+  #emitSelectionChange() {
+    if (!this.#textSelection) return;
+    try {
+      const root = this.#root();
+      const detail = getSelectionDetail(this.#dom, root);
+      const signature = `${detail.start}:${detail.end}:${detail.direction}`;
+      if (signature === this.#lastSelectionSignature) return;
+      this.#lastSelectionSignature = signature;
+      this.#dom.dispatchEvent(
+        new CustomEvent('bindselectionchange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    } catch {
+      /* noop */
+    }
+  }
+
+  #scheduleSelectionSync = () => {
+    clearTimeout(this.#selectionSyncTimer);
+    this.#selectionSyncTimer = setTimeout(() => {
+      this.#selectionSyncTimer = undefined;
+      this.#emitSelectionChange();
+    }, 0);
+  };
+
+  #handleSelectionChange = () => {
+    this.#emitSelectionChange();
+    this.#scheduleSelectionSync();
+  };
+
+  #handleSelectionGestureEnd = () => {
+    this.#emitSelectionChange();
+    this.#scheduleSelectionSync();
+  };
+
+  #scheduleRender() {
+    if (this.#pendingRender) return;
+    this.#pendingRender = true;
+    if (!depsLoaded && !depsError) {
+      loadDeps().then(() => {
+        this.#pendingRender = false;
+        this.#render();
+      });
+      return;
+    }
+    boostedQueueMicrotask(() => {
+      this.#pendingRender = false;
+      this.#render();
+    });
+  }
+
+  #render() {
+    const root = this.#root();
+    if (!this.#content) {
+      this.#resetTypewriterState();
+      root.innerHTML = '';
+      this.#renderedContent = '';
+      this.#appendRemainder = '';
+      this.#clearAppendFlushTimer();
+      return;
+    }
+    // Typewriter animation takes precedence over incremental append
+    if (this.#animationType === 'typewriter') {
+      this.#renderTypewriter(root);
+      return;
+    }
+    const parser = getMarkdownParser();
+    if (!parser) {
+      const content = this.#contentRange
+        ? this.#content.slice(this.#contentRange[0], this.#contentRange[1])
+        : this.#content;
+      root.textContent = content;
+      this.#renderedContent = content;
+      this.#appendRemainder = '';
+      this.#clearAppendFlushTimer();
+      return;
+    }
+    if (this.#canAppendIncrementally()) {
+      this.#appendIncrementally(root);
+      return;
+    }
+    const content = this.#contentRange
+      ? this.#content.slice(this.#contentRange[0], this.#contentRange[1])
+      : this.#content;
+    const rendered = renderMarkdown(parser, content);
+    root.innerHTML = sanitizeHtml(preprocessInlineView(rendered));
+    this.#injectInlineViews(root);
+    this.#renderedContent = content;
+    this.#appendRemainder = '';
+    this.#clearAppendFlushTimer();
+    this.#dispatchParseEnd();
+    this.#applyPostRenderPolicies(root);
+  }
+
+  #canAppendIncrementally() {
+    if (!this.#renderedContent) return false;
+    if (!this.#content.startsWith(this.#renderedContent)) return false;
+    if (this.#content.length === this.#renderedContent.length) return false;
+    return true;
+  }
+
+  #appendIncrementally(root: HTMLElement) {
+    const delta = this.#content.slice(this.#renderedContent.length);
+    if (!delta) return;
+    const lastNewlineIndex = delta.lastIndexOf('\n');
+    if (lastNewlineIndex === -1) {
+      this.#appendRemainder = delta;
+      this.#scheduleAppendFlush();
+      return;
+    }
+    const chunk = delta.slice(0, lastNewlineIndex + 1);
+    if (chunk) {
+      const parser = getMarkdownParser();
+      if (!parser) return;
+      const html = renderMarkdown(parser, chunk);
+      this.#appendHtml(root, html);
+      this.#renderedContent += chunk;
+    }
+    this.#appendRemainder = delta.slice(lastNewlineIndex + 1);
+    if (this.#appendRemainder) {
+      this.#scheduleAppendFlush();
+    } else {
+      this.#clearAppendFlushTimer();
+    }
+  }
+
+  #scheduleAppendFlush() {
+    this.#clearAppendFlushTimer();
+    this.#appendFlushTimer = setTimeout(() => {
+      this.#appendFlushTimer = undefined;
+      this.#flushAppendRemainder();
+    }, this.#appendFlushDelay);
+  }
+
+  #clearAppendFlushTimer() {
+    if (this.#appendFlushTimer) {
+      clearTimeout(this.#appendFlushTimer);
+      this.#appendFlushTimer = undefined;
+    }
+  }
+
+  #resetTypewriterState() {
+    this.#stopTypewriterTimer();
+    this.#animationStarted = false;
+    this.#animationStep = 0;
+    this.#maxAnimationStep = 0;
+    this.#removeTypewriterCursor();
+  }
+
+  #flushAppendRemainder() {
+    if (!this.#appendRemainder) return;
+    if (!this.#content.startsWith(this.#renderedContent)) return;
+    const expectedLength = this.#renderedContent.length
+      + this.#appendRemainder.length;
+    if (this.#content.length !== expectedLength) return;
+    const root = this.#root();
+    const parser = getMarkdownParser();
+    if (!parser) return;
+    const html = renderMarkdown(parser, this.#appendRemainder);
+    this.#appendHtml(root, html);
+    this.#renderedContent += this.#appendRemainder;
+    this.#appendRemainder = '';
+    this.#dispatchParseEnd();
+    this.#applyPostRenderPolicies(this.#root());
+  }
+
+  #appendHtml(root: HTMLElement, html: string) {
+    const template = document.createElement('template');
+    template.innerHTML = sanitizeHtml(preprocessInlineView(html));
+    root.append(template.content);
+    this.#applyPostRenderPolicies(root);
+    this.#injectInlineViews(root);
+  }
+
+  #applyMarkdownEffect(root: HTMLElement) {
+    if (!this.#markdownEffect || this.#markdownEffect.type !== 'text-mask') {
+      return;
+    }
+
+    if (
+      this.#contentComplete !== false
+      && this.#animationStep >= this.#maxAnimationStep
+    ) {
+      return;
+    }
+
+    const { color, rangeStart, rangeEnd } = this.#markdownEffect;
+    if (!color || typeof rangeStart !== 'number') {
+      return;
+    }
+
+    const existingEffects = root.querySelectorAll('.md-text-mask-effect');
+    existingEffects.forEach((effect) => {
+      const content = effect.querySelector('.md-text-mask-effect-content');
+      const parent = effect.parentNode;
+      if (!content || !parent) return;
+      while (content.firstChild) {
+        parent.insertBefore(content.firstChild, effect);
+      }
+      parent.removeChild(effect);
+    });
+
+    // Collect all text nodes
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const textNodes: Text[] = [];
+    while (walker.nextNode()) {
+      const node = walker.currentNode as Text;
+      // Ignore text nodes inside the typewriter cursor or truncation marker
+      const parent = node.parentElement;
+      if (
+        parent === root
+        && (node.nodeValue?.trim() ?? '') === ''
+      ) {
+        continue;
+      }
+      if (
+        parent
+        && (parent.closest('.md-typewriter-cursor')
+          || parent.closest('.md-truncation')
+          || parent.closest('.md-text-mask-effect-overlay'))
+      ) {
+        continue;
+      }
+      textNodes.push(node);
+    }
+
+    const totalLength = textNodes.reduce(
+      (sum, node) => sum + (node.nodeValue?.length ?? 0),
+      0,
+    );
+    const normalizedStart = rangeStart < 0
+      ? totalLength + rangeStart
+      : rangeStart;
+    const normalizedEndRaw = typeof rangeEnd === 'number'
+      ? (rangeEnd < 0 ? totalLength + rangeEnd : rangeEnd)
+      : normalizedStart;
+    const effectStart = Math.max(0, Math.min(totalLength, normalizedStart));
+    const effectEnd = Math.max(
+      effectStart,
+      Math.min(totalLength, normalizedEndRaw + 1),
+    );
+
+    if (effectEnd <= effectStart) {
+      return;
+    }
+
+    let cursor = 0;
+    const nodesToWrap: Array<
+      { node: Text; startOffset: number; endOffset: number }
+    > = [];
+    textNodes.forEach((textNode) => {
+      const textLength = textNode.nodeValue?.length ?? 0;
+      const nodeStart = cursor;
+      const nodeEnd = cursor + textLength;
+      const startOffset = Math.max(effectStart, nodeStart) - nodeStart;
+      const endOffset = Math.min(effectEnd, nodeEnd) - nodeStart;
+      if (startOffset < endOffset) {
+        nodesToWrap.push({
+          node: textNode,
+          startOffset,
+          endOffset,
+        });
+      }
+      cursor = nodeEnd;
+    });
+
+    if (nodesToWrap.length === 0) {
+      return;
+    }
+
+    // Wrap them
+    const appliedEffects: Array<{
+      content: HTMLElement;
+      overlay: HTMLElement;
+    }> = [];
+
+    for (const { node, startOffset, endOffset } of nodesToWrap.reverse()) {
+      let targetNode = node;
+      if (startOffset > 0) {
+        targetNode = node.splitText(startOffset);
+      }
+      const targetLength = endOffset - startOffset;
+      if (targetLength < (targetNode.nodeValue?.length ?? 0)) {
+        targetNode.splitText(targetLength);
+      }
+      const originalText = targetNode.nodeValue ?? '';
+      const span = document.createElement('span');
+      span.className = 'md-text-mask-effect';
+
+      const content = document.createElement('span');
+      content.className = 'md-text-mask-effect-content';
+
+      const overlay = document.createElement('span');
+      overlay.className = 'md-text-mask-effect-overlay';
+      overlay.setAttribute('aria-hidden', 'true');
+      overlay.textContent = originalText;
+      overlay.style.background = color;
+
+      const parent = targetNode.parentNode;
+      if (parent) {
+        parent.insertBefore(span, targetNode);
+        content.appendChild(targetNode);
+        span.append(content, overlay);
+        appliedEffects.unshift({
+          content,
+          overlay,
+        });
+      }
+    }
+
+    if (appliedEffects.length === 0) {
+      return;
+    }
+
+    const segmentWidths = appliedEffects.map(({ content }) =>
+      content.getBoundingClientRect().width
+    );
+    const totalEffectWidth = segmentWidths.reduce(
+      (sum, width) => sum + width,
+      0,
+    );
+
+    if (totalEffectWidth <= 0) {
+      return;
+    }
+
+    let offsetX = 0;
+    appliedEffects.forEach(({ overlay }, index) => {
+      overlay.style.backgroundRepeat = 'no-repeat';
+      overlay.style.backgroundSize = `${totalEffectWidth}px 100%`;
+      overlay.style.backgroundPosition = `${-offsetX}px 0`;
+      offsetX += segmentWidths[index] ?? 0;
+    });
+  }
+
+  #dispatchParseEnd() {
+    this.#dom.dispatchEvent(
+      new CustomEvent('bindparseEnd', {
+        detail: { id: this.#contentId },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  #applyPostRenderPolicies(root: HTMLElement) {
+    this.#applyMarkdownEffect(root);
+
+    // Overflow detection for line clamp
+    if (this.#textMaxline > 0) {
+      // give layout a tick
+      queueMicrotask(() => {
+        try {
+          const overflow = root.scrollHeight > root.clientHeight + 1;
+          if (overflow && !this.#overflowEmitted) {
+            this.#overflowEmitted = true;
+            this.#dom.dispatchEvent(
+              new CustomEvent('bindoverflow', {
+                detail: { type: 'ellipsis' },
+                bubbles: true,
+                composed: true,
+              }),
+            );
+          }
+        } catch {
+          /* noop */
+        }
+      });
+    } else {
+      this.#overflowEmitted = false;
+    }
+    // Dynamic height transition for typewriter
+    if (this.#animationType === 'typewriter' && this.#typewriterDynamicHeight) {
+      const dur = this.#typewriterHeightTransition;
+      if (dur > 0) {
+        (root.style as any).transition = `height ${dur}s ease`;
+      }
+    } else {
+      root.style.transition = '';
+    }
+    // Truncation tail marker
+    if (this.#textMaxline > 0) {
+      if (!this.#ensureTruncationMarker(root)) {
+        this.#removeTruncationMarker();
+      }
+    } else {
+      this.#removeTruncationMarker();
+    }
+  }
+
+  #renderTypewriter(root: HTMLElement) {
+    // Prepare max steps considering content range
+    const [start, end] = this.#contentRange
+      ? this.#contentRange
+      : [0, this.#content.length];
+    this.#maxAnimationStep = Math.max(0, end - start);
+    // Start if not started
+    if (!this.#animationStarted) {
+      this.#animationStarted = true;
+      this.#dom.dispatchEvent(
+        new CustomEvent('binddrawStart', { bubbles: true, composed: true }),
+      );
+      if (!this.#animationPaused) {
+        this.#startTypewriterTimer();
+      }
+    }
+    const visible = this.#content.slice(start, start + this.#animationStep);
+    const parser = getMarkdownParser();
+    if (!parser) {
+      root.textContent = visible;
+    } else {
+      root.innerHTML = sanitizeHtml(
+        preprocessInlineView(renderMarkdown(parser, visible)),
+      );
+    }
+
+    this.#appendTypewriterCursor(root);
+
+    this.#applyPostRenderPolicies(root);
+    if (this.#animationStep >= this.#maxAnimationStep) {
+      this.#stopTypewriterTimer();
+      if (this.#contentComplete !== false) {
+        this.#dom.dispatchEvent(
+          new CustomEvent('binddrawEnd', { bubbles: true, composed: true }),
+        );
+      }
+    }
+  }
+
+  #startTypewriterTimer() {
+    this.#stopTypewriterTimer();
+    const interval = Math.max(
+      10,
+      Math.floor(1000 / Math.max(1, this.#animationVelocity)),
+    );
+    this.#animationTimer = setInterval(() => {
+      if (this.#animationStep < this.#maxAnimationStep) {
+        this.#animationStep += 1;
+        this.#dom.dispatchEvent(
+          new CustomEvent('bindanimationStep', {
+            detail: {
+              animationStep: this.#animationStep,
+              maxAnimationStep: this.#maxAnimationStep,
+            },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        // Re-render slice only
+        const root = this.#root();
+        this.#renderTypewriter(root);
+      } else {
+        this.#stopTypewriterTimer();
+      }
+    }, interval);
+  }
+
+  #stopTypewriterTimer() {
+    if (this.#animationTimer) {
+      clearInterval(this.#animationTimer);
+      this.#animationTimer = undefined;
+    }
+  }
+
+  #applyMarkdownStyle(value: string | null) {
+    const parsed = parseMarkdownStyle(value);
+    this.#truncationConfig = (parsed as any).truncation ?? null;
+    this.#typewriterCursorConfig = (parsed as any).typewriterCursor ?? null;
+    const { truncation, typewriterCursor, ...cssParts } = parsed as any;
+    this.#currentMarkdownCss = buildMarkdownStyleCss(cssParts);
+    this.#updateStyleTag();
+  }
+
+  #updateStyleTag() {
+    const styleTag = this.#style();
+    let css = this.#currentMarkdownCss || '';
+    if (this.#textSelection) {
+      css += '\n.markdown-body { user-select: text; }';
+    }
+    if (this.#textMaxline > 0) {
+      css +=
+        `\n.markdown-body { display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: ${this.#textMaxline}; overflow: hidden; }`;
+    }
+    styleTag.textContent = css;
+  }
+
+  @registerAttributeHandler('content', true)
+  _handleContent(newVal: string | null) {
+    const content = newVal ?? '';
+    const contentChanged = content !== this.#content;
+    this.#content = content;
+    if (contentChanged && this.#animationType === 'typewriter') {
+      this.#resetTypewriterState();
+    }
+    this.#scheduleRender();
+  }
+
+  @registerAttributeHandler('markdown-effect', true)
+  _handleMarkdownEffect(newVal: string | null) {
+    try {
+      this.#markdownEffect = newVal ? JSON.parse(newVal) : null;
+    } catch {
+      this.#markdownEffect = null;
+    }
+    this.#scheduleRender();
+  }
+
+  @registerAttributeHandler('markdown-style', true)
+  _handleMarkdownStyle(newVal: string | null) {
+    this.#applyMarkdownStyle(newVal);
+  }
+
+  @registerAttributeHandler('content-id', true)
+  _handleContentId(newVal: string | null) {
+    this.#contentId = newVal ?? undefined;
+  }
+
+  @registerAttributeHandler('text-selection', true)
+  _handleTextSelection(newVal: string | null) {
+    // Treat presence and value !== 'false' as true
+    this.#textSelection = !!(newVal && newVal !== 'false');
+    if (!this.#textSelection) {
+      clearTimeout(this.#selectionSyncTimer);
+      this.#selectionSyncTimer = undefined;
+      this.#lastSelectionSignature = undefined;
+    }
+    this.#updateStyleTag();
+  }
+
+  @registerAttributeHandler('animation-type', true)
+  _handleAnimationType(newVal: string | null) {
+    const v = (newVal ?? 'none').toLowerCase();
+    this.#animationType = v === 'typewriter' ? 'typewriter' : 'none';
+    this.#animationStarted = false;
+    this.#stopTypewriterTimer();
+    this.#scheduleRender();
+  }
+
+  @registerAttributeHandler('animation-velocity', true)
+  _handleAnimationVelocity(newVal: string | null) {
+    const n = Number(newVal);
+    if (!Number.isNaN(n) && n > 0) this.#animationVelocity = n;
+    if (
+      this.#animationType === 'typewriter'
+      && !this.#animationPaused
+      && this.#animationTimer
+    ) {
+      this.#startTypewriterTimer();
+    }
+  }
+
+  @registerAttributeHandler('animation-paused', true)
+  _handleAnimationPaused(newVal: string | null) {
+    this.#animationPaused = !!(newVal && newVal !== 'false');
+    if (this.#animationPaused) {
+      this.#stopTypewriterTimer();
+      return;
+    }
+    if (
+      this.#animationType === 'typewriter'
+      && this.#animationStarted
+      && this.#animationStep < this.#maxAnimationStep
+    ) {
+      this.#startTypewriterTimer();
+    }
+  }
+
+  @registerAttributeHandler('initial-animation-step', true)
+  _handleInitialAnimationStep(newVal: string | null) {
+    const n = Number(newVal);
+    this.#animationStep = Number.isNaN(n) ? 0 : Math.max(0, Math.floor(n));
+  }
+
+  @registerAttributeHandler('content-complete', true)
+  _handleContentComplete(newVal: string | null) {
+    this.#contentComplete = !(newVal === 'false');
+  }
+
+  @registerAttributeHandler('typewriter-dynamic-height', true)
+  _handleTypewriterDynamicHeight(newVal: string | null) {
+    this.#typewriterDynamicHeight = !!(newVal && newVal !== 'false');
+  }
+
+  @registerAttributeHandler('typewriter-height-transition-duration', true)
+  _handleTypewriterHeightTransition(newVal: string | null) {
+    const n = Number(newVal);
+    this.#typewriterHeightTransition = Number.isNaN(n) ? 0 : Math.max(0, n);
+  }
+
+  @registerAttributeHandler('text-maxline', true)
+  _handleTextMaxline(newVal: string | null) {
+    const n = Number(newVal);
+    this.#textMaxline = Number.isNaN(n) ? 0 : Math.max(0, Math.floor(n));
+    this.#updateStyleTag();
+  }
+
+  @registerAttributeHandler('content-range', true)
+  _handleContentRange(newVal: string | null) {
+    if (!newVal) {
+      this.#contentRange = undefined;
+    } else {
+      try {
+        const parsed = JSON.parse(newVal);
+        if (Array.isArray(parsed) && parsed.length === 2) {
+          const s = Number(parsed[0]);
+          const e = Number(parsed[1]);
+          if (!Number.isNaN(s) && !Number.isNaN(e) && e >= s) {
+            this.#contentRange = [Math.max(0, s), Math.max(0, e)];
+          }
+        }
+      } catch {
+        // Support "start,end" form
+        const parts = newVal.split(',');
+        if (parts.length === 2) {
+          const s = Number(parts[0]);
+          const e = Number(parts[1]);
+          if (!Number.isNaN(s) && !Number.isNaN(e) && e >= s) {
+            this.#contentRange = [Math.max(0, s), Math.max(0, e)];
+          }
+        }
+      }
+    }
+    this.#scheduleRender();
+  }
+
+  #injectInlineViews(root: HTMLElement) {
+    try {
+      const imgs = Array.from(
+        root.querySelectorAll('img'),
+      ) as HTMLImageElement[];
+      for (const img of imgs) {
+        const inlineId = img.getAttribute('data-inlineview');
+        if (inlineId) {
+          const id = inlineId;
+          const view = this.#dom.querySelector(`#${CSS.escape(id)}`);
+          if (view) {
+            const container = document.createElement('span');
+            container.className = 'md-inline-view';
+            const vAlign = (view as HTMLElement).getAttribute('vertical-align')
+              || (view as HTMLElement).style.verticalAlign
+              || '';
+            if (vAlign) {
+              (container.style as any).verticalAlign = vAlign;
+            }
+            const slot = document.createElement('slot');
+            const slotName = `md-inline-view-${id}`;
+            slot.name = slotName;
+            (view as HTMLElement).slot = slotName;
+            container.appendChild(slot);
+            img.replaceWith(container);
+          }
+        }
+      }
+    } catch {
+      /* noop */
+    }
+  }
+
+  #ensureTruncationMarker(root: HTMLElement) {
+    const overflow = root.scrollHeight > root.clientHeight + 1;
+    if (!overflow) return false;
+    if (!this.#truncationEl) {
+      const span = document.createElement('span');
+      span.className = 'md-truncation';
+      this.#truncationEl = span;
+      root.appendChild(span);
+    }
+    const cfg = this.#truncationConfig || {};
+    const span = this.#truncationEl!;
+    span.textContent = '';
+    span.innerHTML = '';
+    if ((cfg as any).truncationType === 'view' && (cfg as any).content) {
+      const view = this.#dom.querySelector(
+        `#${CSS.escape(String((cfg as any).content))}`,
+      );
+      if (view) span.appendChild(view);
+      else span.textContent = '…';
+    } else if ((cfg as any).content) {
+      span.textContent = String((cfg as any).content);
+    } else {
+      span.textContent = '…';
+    }
+    return true;
+  }
+
+  #removeTruncationMarker() {
+    if (this.#truncationEl && this.#truncationEl.parentNode) {
+      this.#truncationEl.parentNode.removeChild(this.#truncationEl);
+    }
+    this.#truncationEl = undefined;
+  }
+
+  #appendTypewriterCursor(root: HTMLElement) {
+    if (
+      this.#contentComplete !== false
+      && this.#animationStep >= this.#maxAnimationStep
+    ) {
+      this.#removeTypewriterCursor();
+      return;
+    }
+
+    const cfg = this.#typewriterCursorConfig || {};
+    const customCursor = cfg.customCursor;
+
+    if (customCursor === 'none') {
+      this.#removeTypewriterCursor();
+      return;
+    }
+
+    if (!this.#typewriterCursorEl) {
+      const span = document.createElement('span');
+      span.className = 'md-typewriter-cursor';
+      this.#typewriterCursorEl = span;
+      if (cfg.verticalAlign) {
+        span.style.verticalAlign = cfg.verticalAlign;
+      }
+      if (customCursor) {
+        // Look in light DOM or shadow DOM
+        const view = this.#dom.querySelector(`#${CSS.escape(customCursor)}`)
+          || root.querySelector(`#${CSS.escape(customCursor)}`);
+        if (view) {
+          span.appendChild(view);
+        } else {
+          span.textContent = '…';
+        }
+      } else {
+        span.textContent = '…';
+      }
+    }
+
+    // Find the right place to insert the cursor
+    let target: HTMLElement = root;
+    while (true) {
+      let lastNode = target.lastChild;
+      // Skip empty text nodes at the end
+      while (lastNode) {
+        if (
+          lastNode.nodeType === Node.TEXT_NODE
+          && (!lastNode.textContent || lastNode.textContent.trim() === '')
+        ) {
+          lastNode = lastNode.previousSibling;
+        } else {
+          break;
+        }
+      }
+
+      if (
+        lastNode
+        && lastNode.nodeType === Node.ELEMENT_NODE
+        && !['IMG', 'BR', 'HR', 'INPUT', 'TABLE', 'PRE', 'CODE'].includes(
+          (lastNode as HTMLElement).tagName,
+        )
+      ) {
+        target = lastNode as HTMLElement;
+      } else {
+        break;
+      }
+    }
+    target.appendChild(this.#typewriterCursorEl);
+  }
+
+  #removeTypewriterCursor() {
+    if (this.#typewriterCursorEl && this.#typewriterCursorEl.parentNode) {
+      this.#typewriterCursorEl.parentNode.removeChild(this.#typewriterCursorEl);
+    }
+    this.#typewriterCursorEl = undefined;
+  }
+}

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownDeps.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownDeps.ts
@@ -1,0 +1,15 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+// Keep runtime interop consistent with dynamic import usage in XMarkdownAttributes.
+import * as mdModule from 'markdown-it';
+import * as dpModule from 'dompurify';
+
+export const MarkdownIt =
+  ((mdModule as unknown as { default?: unknown }).default ?? mdModule) as any;
+
+export const createDOMPurify =
+  ((dpModule as unknown as { default?: unknown }).default ?? dpModule) as any;

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/index.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * @module elements/XMarkdown
+ *
+ * `x-markdown` renders markdown content with minimal styling.
+ * It supports the `content` and `markdown-style` attributes.
+ */
+export { XMarkdown } from './XMarkdown.js';

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/x-markdown.css
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/x-markdown.css
@@ -1,0 +1,15 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+x-markdown {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  color: inherit;
+}
+
+x-markdown::part(root) {
+  width: 100%;
+}

--- a/packages/web-platform/web-elements/src/elements/all.ts
+++ b/packages/web-platform/web-elements/src/elements/all.ts
@@ -16,3 +16,4 @@ import './XViewpagerNg/index.js';
 import './XList/index.js';
 import './XList/ListItem.js';
 import './XWebView/index.js';
+import './XMarkdown/index.js';

--- a/packages/web-platform/web-elements/src/elements/htmlTemplates.ts
+++ b/packages/web-platform/web-elements/src/elements/htmlTemplates.ts
@@ -306,6 +306,92 @@ export const templateXSwiper = `<style>
 export const templateXText =
   `<div id="inner-box" part="inner-box"><slot part="slot"></slot><slot name="inline-truncation"></slot></div>`;
 
+export const templateXMarkdown = `<style>
+  :host {
+    display: block;
+  }
+  .markdown-body {
+    display: block;
+    line-height: 1.4;
+    color: inherit;
+    word-break: break-word;
+    position: relative;
+  }
+  .markdown-body p {
+    margin: 0 0 0.75em 0;
+  }
+  .markdown-body h1,
+  .markdown-body h2,
+  .markdown-body h3,
+  .markdown-body h4,
+  .markdown-body h5,
+  .markdown-body h6 {
+    margin: 0.8em 0 0.4em 0;
+  }
+  .markdown-body ul,
+  .markdown-body ol {
+    margin: 0 0 0.75em 1.5em;
+  }
+  .markdown-body pre {
+    margin: 0 0 0.75em 0;
+    padding: 8px 12px;
+    border-radius: 6px;
+    background: #f6f8fa;
+    overflow: auto;
+  }
+  .markdown-body code {
+    font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Consolas,
+      "Liberation Mono", monospace;
+  }
+  .markdown-body pre code {
+    display: block;
+    padding: 0;
+  }
+  .markdown-body img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
+  .markdown-body .md-inline-view {
+    display: inline-block;
+    vertical-align: baseline;
+  }
+  .markdown-body .md-truncation {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    background-color: inherit;
+  }
+  .markdown-body .md-image-figure {
+    margin: 0 0 0.75em 0;
+  }
+  .markdown-body .md-image-caption {
+    margin-top: 4px;
+    color: #666;
+    font-size: 0.875em;
+  }
+  .markdown-body .md-text-mask-effect {
+    position: relative;
+    display: inline-block;
+  }
+  .markdown-body .md-text-mask-effect-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    user-select: none;
+    white-space: pre;
+    color: transparent;
+    -webkit-background-clip: text;
+    background-clip: text;
+  }
+  .markdown-body a {
+    color: #0366d6;
+    text-decoration: underline;
+  }
+</style>
+<style id="markdown-style"></style>
+<div id="markdown-root" part="root" class="markdown-body"></div>`;
+
 export const templateInlineImage = templateXImage;
 
 export const templateXTextarea = `<style>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/basic.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/basic.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const content =
+        `# Title\n\nthis is **bold** and *italic*.\n\n- item 1\n- item 2\n\ninline code: \`code\`.\n\n\`\`\`\nblock code\n\`\`\``;
+      document.getElementById('markdown').setAttribute(
+        'content',
+        content,
+      );
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/events.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/events.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown" content-id="case-1"></x-markdown>
+    </x-view>
+    <script>
+    window._bindlink_detail = null;
+      window._bindimage_detail = null;
+      const content =
+        `this is [link](https://example.com).\n\n![img](/tests/fixtures/resources/firefox-logo.png)`;
+      const markdown = document.getElementById('markdown');
+      markdown.addEventListener('bindlink', (event) => {
+        window._bindlink_detail = event.detail;
+      });
+      markdown.addEventListener('bindimageTap', (event) => {
+        window._bindimage_detail = event.detail;
+      });
+      markdown.setAttribute('content', content);
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/html-tags.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/html-tags.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const content =
+        `### Hello <span class="mark-red other" style="color: red" onclick="noop()">World</span>
+
+<p class="mark-help" style="font-size: 12px">Paragraph</p>
+
+<div class="not-allowed">Not allowed</div>`;
+
+      const style = {
+        '.mark-red': {
+          color: 'ff0000',
+        },
+        '.mark-help': {
+          color: '00aa00',
+        },
+      };
+
+      const markdown = document.getElementById('markdown');
+      markdown.setAttribute('content', content);
+      markdown.setAttribute('markdown-style', JSON.stringify(style));
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/image.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/image.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const content =
+        `![alt text](/tests/fixtures/resources/firefox-logo.png)`;
+      document.getElementById('markdown').setAttribute(
+        'content',
+        content,
+      );
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/incremental.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/incremental.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    customElements.whenDefined('x-markdown').then(() => {
+        const markdown = document.getElementById('markdown');
+        markdown.setAttribute('content', 'Line 1\n');
+      });
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview-class.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview-class.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>inlineview class</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+    <style>
+    .content {
+      display: inline-block;
+      width: 24px;
+      height: 24px;
+      background-color: rgb(255, 0, 0);
+    }
+    </style>
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown" style="width: 300px">
+        <x-view id="content-view" class="content"></x-view>
+      </x-markdown>
+    </x-view>
+    <script>
+    const content = '![](inlineview://content-view)';
+      const el = document.getElementById('markdown');
+      el.setAttribute('content', content);
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>inlineview</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown" style="width: 300px">
+        <x-view
+          id="badge"
+          vertical-align="middle"
+          style="display: inline-block; width: 10px; height: 10px; background: rgb(255, 0, 0)"
+        ></x-view>
+      </x-markdown>
+    </x-view>
+    <script>
+    const content = 'inline view here ![](inlineview://badge) next';
+      const el = document.getElementById('markdown');
+      el.setAttribute('content', content);
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/menu.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/menu.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+Licensed under the Apache License Version 2.0 that can be found in the
+LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+    <style>
+    .page {
+      background: white;
+      min-height: 100vh;
+      padding: 24px;
+      position: relative;
+    }
+
+    #menu {
+      align-items: center;
+      background: rgb(80, 80, 80);
+      border-radius: 4px;
+      color: white;
+      display: flex;
+      gap: 8px;
+      padding: 4px 8px;
+      pointer-events: none;
+      position: absolute;
+      user-select: none;
+      visibility: hidden;
+    }
+
+    #menu-divider {
+      background: rgba(255, 255, 255, 0.4);
+      height: 16px;
+      width: 1px;
+    }
+    </style>
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown
+        id="markdown"
+        text-selection="true"
+      ></x-markdown>
+      <div id="menu">
+        <span>全选</span>
+        <div id="menu-divider"></div>
+        <span>复制</span>
+      </div>
+    </x-view>
+    <script>
+    const content =
+        `# Title\n\nthis is **bold** and *italic*.\n\nthis paragraph is used to verify menu positioning.`;
+      const markdown = document.getElementById('markdown');
+      const menu = document.getElementById('menu');
+      let isPointerSelecting = false;
+
+      const getSelection = () => (
+        markdown.shadowRoot?.getSelection?.() ?? document.getSelection()
+      );
+
+      const isSelectingMarkdown = (event) =>
+        event.composedPath?.().includes(markdown) ?? false;
+
+      const setRange = (selector, start, end) => {
+        const textNode = markdown.shadowRoot?.querySelector(selector)
+          ?.firstChild;
+        if (!textNode) {
+          throw new Error(`missing text node for ${selector}`);
+        }
+        const selection = getSelection();
+        if (!selection) {
+          throw new Error('missing selection');
+        }
+        const range = document.createRange();
+        range.setStart(textNode, start);
+        range.setEnd(textNode, end);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      };
+
+      const hideMenu = () => {
+        menu.style.visibility = 'hidden';
+      };
+
+      const updateMenu = (detail) => {
+        if (detail.start === -1 || detail.end === -1) {
+          hideMenu();
+          return;
+        }
+        const rect = markdown.getTextBoundingRect({
+          start: detail.start,
+          end: detail.end,
+        })?.boundingRect;
+        if (!rect) {
+          hideMenu();
+          return;
+        }
+        menu.style.left = `${rect.left + rect.width / 2 - 30}px`;
+        menu.style.top = `${rect.top + rect.height / 2 - 10}px`;
+        menu.style.visibility = 'visible';
+      };
+
+      const syncMenu = () => {
+        updateMenu(window._menu_detail ?? { start: -1, end: -1 });
+      };
+
+      window._menu_detail = null;
+
+      window._selectShadowText = (selector, start, end) => {
+        setRange(selector, start, end);
+        document.dispatchEvent(new Event('selectionchange'));
+      };
+
+      window._selectShadowTextByMouseup = (selector, start, end) => {
+        setRange(selector, start, end);
+        document.dispatchEvent(new Event('selectionchange'));
+        document.dispatchEvent(
+          new MouseEvent('mouseup', { bubbles: true }),
+        );
+      };
+
+      window._selectShadowTextToMenu = () => {
+        const textNode = markdown.shadowRoot?.querySelector('h1')
+          ?.firstChild;
+        const menuTextNode = menu.querySelector('span:last-child')
+          ?.firstChild;
+        if (!textNode || !menuTextNode) {
+          throw new Error('missing selection nodes');
+        }
+        const selection = getSelection();
+        if (!selection) {
+          throw new Error('missing selection');
+        }
+        const range = document.createRange();
+        range.setStart(textNode, 0);
+        range.setEnd(menuTextNode, menuTextNode.textContent?.length ?? 0);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        document.dispatchEvent(new Event('selectionchange'));
+      };
+
+      window._clearShadowText = () => {
+        const selection = getSelection();
+        selection?.removeAllRanges();
+        document.dispatchEvent(new Event('selectionchange'));
+      };
+
+      window._getMenuState = () => ({
+        visibility: getComputedStyle(menu).visibility,
+        left: getComputedStyle(menu).left,
+        top: getComputedStyle(menu).top,
+        labels: Array.from(menu.querySelectorAll('span')).map((node) =>
+          node.textContent?.trim() ?? ''
+        ),
+        detail: window._menu_detail,
+        selectedText: markdown.getSelectedText(),
+      });
+
+      document.addEventListener('mousedown', (event) => {
+        if (!isSelectingMarkdown(event)) {
+          return;
+        }
+        isPointerSelecting = true;
+        hideMenu();
+      });
+
+      document.addEventListener('mouseup', () => {
+        if (!isPointerSelecting) {
+          return;
+        }
+        isPointerSelecting = false;
+        syncMenu();
+      });
+
+      markdown.addEventListener('bindselectionchange', (event) => {
+        window._menu_detail = event.detail;
+        if (isPointerSelecting) {
+          hideMenu();
+          return;
+        }
+        updateMenu(event.detail);
+      });
+
+      markdown.setAttribute('content', content);
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/style.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/style.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const content =
+        `this is [link](https://example.com).\n\ninline code: \`code\`.`;
+      const style = {
+        normalText: {
+          fontSize: 20,
+        },
+        link: {
+          color: 'ff0000',
+        },
+        inlineCode: {
+          color: '0000ff',
+          backgroundColor: 'eeeeee',
+        },
+      };
+      const markdown = document.getElementById('markdown');
+      markdown.setAttribute('content', content);
+      markdown.setAttribute('markdown-style', JSON.stringify(style));
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/table.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/table.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const content = `
+| A | B |
+| - | - |
+| 1 | 2 |
+`;
+      document.getElementById('markdown').setAttribute(
+        'content',
+        content,
+      );
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/text-selection.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/text-selection.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+Licensed under the Apache License Version 2.0 that can be found in the
+LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown
+        id="markdown"
+        text-selection="true"
+      ></x-markdown>
+    </x-view>
+    <script>
+    const content =
+        `# Title\n\nthis is **bold** and *italic*.\n\n- item 1\n- item 2\n\ninline code: \`code\`.\n\n\`\`\`\nblock code\n\`\`\``;
+      const markdown = document.getElementById('markdown');
+
+      const getSelection = () => (
+        markdown.shadowRoot?.getSelection?.() ?? document.getSelection()
+      );
+
+      const getTextNode = (selector) => {
+        const textNode = markdown.shadowRoot?.querySelector(selector)
+          ?.firstChild;
+        if (!textNode) {
+          throw new Error(`missing text node for ${selector}`);
+        }
+        return textNode;
+      };
+
+      const setRange = (selector, start, end) => {
+        const textNode = getTextNode(selector);
+        const selection = getSelection();
+        if (!selection) throw new Error('missing selection');
+        const range = document.createRange();
+        range.setStart(textNode, start);
+        range.setEnd(textNode, end);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      };
+
+      window._selection_detail = null;
+      window._selection_count = 0;
+
+      window._resetSelectionState = () => {
+        window._selection_detail = null;
+        window._selection_count = 0;
+      };
+
+      window._selectShadowText = (selector, start, end) => {
+        setRange(selector, start, end);
+        document.dispatchEvent(new Event('selectionchange'));
+      };
+
+      window._selectShadowTextByMouseup = (selector, start, end) => {
+        setRange(selector, start, end);
+        document.dispatchEvent(
+          new MouseEvent('mouseup', { bubbles: true }),
+        );
+      };
+
+      window._setTextSelection = (selector, start, end) => {
+        const textNode = getTextNode(selector);
+        const descriptor = Object.getOwnPropertyDescriptor(
+          Document.prototype,
+          'caretRangeFromPoint',
+        );
+        Object.defineProperty(document, 'caretRangeFromPoint', {
+          configurable: true,
+          value: (x) => {
+            const range = document.createRange();
+            range.setStart(textNode, x <= start ? start : end);
+            range.collapse(true);
+            return range;
+          },
+        });
+        try {
+          markdown.setTextSelection({
+            startX: start,
+            startY: 0,
+            endX: end,
+            endY: 0,
+          });
+        } finally {
+          if (descriptor) {
+            Object.defineProperty(
+              document,
+              'caretRangeFromPoint',
+              descriptor,
+            );
+          } else {
+            delete document.caretRangeFromPoint;
+          }
+        }
+        document.dispatchEvent(new Event('selectionchange'));
+      };
+
+      window._getSelectionState = () => {
+        const rect = markdown.getTextBoundingRect();
+        return {
+          detail: window._selection_detail,
+          count: window._selection_count,
+          selectedText: markdown.getSelectedText(),
+          rect: rect?.boundingRect
+            ? {
+              width: rect.boundingRect.width,
+              height: rect.boundingRect.height,
+            }
+            : null,
+          styleText: markdown.shadowRoot?.querySelector('#markdown-style')
+            ?.textContent ?? '',
+        };
+      };
+
+      markdown.addEventListener('bindselectionchange', (event) => {
+        console.log('bindselectionchange', event);
+        window._selection_detail = event.detail;
+        window._selection_count += 1;
+      });
+
+      markdown.setAttribute('content', content);
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/truncate.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/truncate.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>truncate</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown" style="width: 180px"></x-markdown>
+    </x-view>
+    <script>
+    const text =
+        'This is a very very very very very long line that should wrap to multiple lines for testing.';
+      const content = `# Title\n\n${text}`;
+      const style = { truncation: { content: 'Read more' } };
+      const el = document.getElementById('markdown');
+      el.setAttribute('content', content);
+      el.setAttribute('markdown-style', JSON.stringify(style));
+      el.setAttribute('text-maxline', '1');
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-cursor.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-cursor.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>typewriter cursor</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown">
+        <view id="cursor" style="border: 1px solid red; padding: 4px"></view>
+      </x-markdown>
+    </x-view>
+    <script>
+    const el = document.getElementById('markdown');
+      el.addEventListener(
+        'binddrawStart',
+        () => (window._drawStart = true),
+      );
+      el.addEventListener('binddrawEnd', () => (window._drawEnd = true));
+      el.setAttribute(
+        'content',
+        `# Title\n\nthis is **bold** and *italic*.`,
+      );
+      el.setAttribute('animation-type', 'typewriter');
+      el.setAttribute('animation-velocity', '20');
+      el.setAttribute(
+        'markdown-style',
+        JSON.stringify({
+          typewriterCursor: {
+            customCursor: 'cursor',
+          },
+        }),
+      );
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-effect.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-effect.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>typewriter-effect</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const el = document.getElementById('markdown');
+      el.addEventListener(
+        'binddrawStart',
+        () => (window._drawStart = true),
+      );
+      el.addEventListener('bindanimationStep', (e) => {
+        if (e.detail.animationStep >= e.detail.maxAnimationStep) {
+          window._animationComplete = true;
+        }
+      });
+      el.setAttribute(
+        'content',
+        `# Title\n\nthis is **bold** and *italic*.TTTTT`,
+      );
+      el.setAttribute('animation-type', 'typewriter');
+      el.setAttribute('animation-velocity', '20');
+      el.setAttribute('content-complete', 'false');
+      el.setAttribute(
+        'markdown-style',
+        JSON.stringify({
+          typewriterCursor: {
+            customCursor: 'none',
+          },
+        }),
+      );
+      el.setAttribute(
+        'markdown-effect',
+        JSON.stringify({
+          type: 'text-mask',
+          color:
+            'linear-gradient(90deg, #ffffff00 0%, rgb(255, 255, 255) 100%)',
+          rangeStart: -4,
+          rangeEnd: -1,
+        }),
+      );
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-keep-cursor.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-keep-cursor.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>typewriter-keep-cursor</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown">
+        <view id="cursor" style="border: 1px solid red; padding: 4px"></view>
+      </x-markdown>
+    </x-view>
+    <script>
+    const el = document.getElementById('markdown');
+      el.addEventListener(
+        'binddrawStart',
+        () => (window._drawStart = true),
+      );
+      el.addEventListener('bindanimationStep', (e) => {
+        if (e.detail.animationStep >= e.detail.maxAnimationStep) {
+          window._animationComplete = true;
+        }
+      });
+      el.setAttribute(
+        'content',
+        `# Title\n\nthis is **bold** and *italic*.`,
+      );
+      el.setAttribute('animation-type', 'typewriter');
+      el.setAttribute('animation-velocity', '20');
+      el.setAttribute('content-complete', 'false');
+      el.setAttribute(
+        'markdown-style',
+        JSON.stringify({
+          typewriterCursor: {
+            customCursor: 'cursor',
+          },
+        }),
+      );
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-pause-resume.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-pause-resume.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>typewriter pause resume</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const el = document.getElementById('markdown');
+      window._animationSteps = [];
+      el.addEventListener('bindanimationStep', (event) => {
+        window._animationSteps.push(event.detail.animationStep);
+      });
+      el.setAttribute('content', 'pause resume animation');
+      el.setAttribute('animation-type', 'typewriter');
+      el.setAttribute('animation-velocity', '10');
+      el.setAttribute('content-complete', 'true');
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-reset-content.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-reset-content.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>typewriter reset content</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const el = document.getElementById('markdown');
+      const getRootText = () =>
+        el.shadowRoot?.querySelector('#markdown-root')?.textContent ?? '';
+
+      window._newAnimationSteps = [];
+      window._reassigned = false;
+      window._textAfterReassign = null;
+
+      let didResetContent = false;
+
+      el.addEventListener('bindanimationStep', (event) => {
+        if (window._reassigned) {
+          window._newAnimationSteps.push(event.detail.animationStep);
+        }
+
+        if (didResetContent || event.detail.animationStep < 3) {
+          return;
+        }
+
+        didResetContent = true;
+        el.setAttribute('content', '');
+
+        setTimeout(() => {
+          el.setAttribute('content', 'zebra');
+          window._reassigned = true;
+          queueMicrotask(() => {
+            window._textAfterReassign = getRootText();
+          });
+        }, 0);
+      });
+
+      el.setAttribute('content', 'initial typing content');
+      el.setAttribute(
+        'markdown-style',
+        JSON.stringify({
+          typewriterCursor: {
+            customCursor: 'none',
+          },
+        }),
+      );
+      el.setAttribute('animation-type', 'typewriter');
+      el.setAttribute('animation-velocity', '20');
+      el.setAttribute('content-complete', 'true');
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-trailing-text.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-trailing-text.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>typewriter trailing text</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const el = document.getElementById('markdown');
+      el.addEventListener('binddrawEnd', () => (window._drawEnd = true));
+      el.setAttribute(
+        'content',
+        `# Title\n\nthis is **bold** and *i`,
+      );
+      el.setAttribute('animation-type', 'typewriter');
+      el.setAttribute('animation-velocity', '20');
+      el.setAttribute('content-complete', 'false');
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>typewriter</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown"></x-markdown>
+    </x-view>
+    <script>
+    const el = document.getElementById('markdown');
+      el.addEventListener(
+        'binddrawStart',
+        () => (window._drawStart = true),
+      );
+      el.addEventListener('binddrawEnd', () => (window._drawEnd = true));
+      el.setAttribute(
+        'content',
+        `# Title\n\nthis is **bold** and *italic*.\n\n- item 1\n- item 2\n\ninline code: \`code\`.\n\n\`\`\`\nblock code\n\`\`\``,
+      );
+      el.setAttribute('animation-type', 'typewriter');
+      el.setAttribute('animation-velocity', '20');
+      el.setAttribute('content-complete', 'true');
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/x-markdown.spec.ts
+++ b/packages/web-platform/web-elements/tests/x-markdown.spec.ts
@@ -1,0 +1,846 @@
+import { test, expect } from '@lynx-js/playwright-fixtures';
+import type { Page } from '@playwright/test';
+
+const goto = async (page: Page, fixtureName: string) => {
+  await page.goto(`tests/fixtures/${fixtureName}.html`, { waitUntil: 'load' });
+  await page.evaluate(() => document.fonts.ready);
+};
+
+const getShadowText = async (page: Page, selector: string) =>
+  page.evaluate((value) => {
+    const element = document.querySelector('x-markdown');
+    return element?.shadowRoot?.querySelector(value)?.textContent ?? '';
+  }, selector);
+
+const getShadowCount = async (page: Page, selector: string) =>
+  page.evaluate((value) => {
+    const element = document.querySelector('x-markdown');
+    return element?.shadowRoot?.querySelectorAll(value).length ?? 0;
+  }, selector);
+
+const appendContent = async (page: Page, suffix: string) => {
+  await page.evaluate((value) => {
+    const element = document.querySelector('x-markdown');
+    const content = element?.getAttribute('content') ?? '';
+    element?.setAttribute('content', `${content}${value}`);
+  }, suffix);
+};
+
+const captureFirstChild = async (page: Page) => {
+  await page.evaluate(() => {
+    const element = document.querySelector('x-markdown');
+    const root = element?.shadowRoot?.querySelector('#markdown-root');
+    (window as any).__markdown_first_child = root?.firstElementChild ?? null;
+  });
+};
+
+const isFirstChildSame = async (page: Page) =>
+  page.evaluate(() => {
+    const element = document.querySelector('x-markdown');
+    const root = element?.shadowRoot?.querySelector('#markdown-root');
+    return root?.firstElementChild === (window as any).__markdown_first_child;
+  });
+
+const selectShadowText = async (
+  page: Page,
+  selector: string,
+  startOffset: number,
+  endOffset: number,
+) => {
+  await page.evaluate(
+    ({ value, start, end }) => {
+      (window as any)._selectShadowText(value, start, end);
+    },
+    { value: selector, start: startOffset, end: endOffset },
+  );
+};
+
+const selectShadowTextByMouseup = async (
+  page: Page,
+  selector: string,
+  startOffset: number,
+  endOffset: number,
+) => {
+  await page.evaluate(
+    ({ value, start, end }) => {
+      (window as any)._selectShadowTextByMouseup(value, start, end);
+    },
+    { value: selector, start: startOffset, end: endOffset },
+  );
+};
+
+const setTextSelection = async (
+  page: Page,
+  selector: string,
+  startOffset: number,
+  endOffset: number,
+) => {
+  await page.evaluate(
+    ({ value, start, end }) => {
+      (window as any)._setTextSelection(value, start, end);
+    },
+    { value: selector, start: startOffset, end: endOffset },
+  );
+};
+
+const clearShadowText = async (page: Page) => {
+  await page.evaluate(() => {
+    (window as any)._clearShadowText?.();
+  });
+};
+
+test.describe('x-markdown', () => {
+  test('should render basic markdown', async ({ page }) => {
+    await goto(page, 'x-markdown/basic');
+    const markdown = page.locator('x-markdown');
+
+    await expect(markdown.locator('h1')).toHaveText('Title');
+    await expect(markdown.locator('strong')).toHaveText('bold');
+    await expect(markdown.locator('em')).toHaveText('italic');
+    await expect(markdown.locator('li')).toHaveCount(2);
+    await expect(markdown.locator('code').first()).toContainText('code');
+  });
+
+  test('should apply markdown-style updates', async ({ page }) => {
+    await goto(page, 'x-markdown/style');
+    const markdown = page.locator('x-markdown');
+
+    const link = markdown.locator('a');
+    await expect(link).toHaveCSS('color', 'rgb(255, 0, 0)');
+
+    const inlineCode = markdown.locator('code').first();
+    await expect(inlineCode).toHaveCSS('color', 'rgb(0, 0, 255)');
+    await expect(inlineCode).toHaveCSS(
+      'background-color',
+      'rgb(238, 238, 238)',
+    );
+
+    await markdown.evaluate((el) => {
+      el.setAttribute(
+        'markdown-style',
+        JSON.stringify({ link: { color: '0000ff' } }),
+      );
+    });
+    await expect(link).toHaveCSS('color', 'rgb(0, 0, 255)');
+  });
+
+  test('should support markdown-style property updates', async ({ page }) => {
+    await goto(page, 'x-markdown/style');
+    const markdown = page.locator('x-markdown');
+
+    const link = markdown.locator('a');
+    const propertyValue = await markdown.evaluate((el: any) => {
+      el['markdown-style'] = { link: { color: '00ff00' } };
+      return el.markdownStyle;
+    });
+
+    expect(propertyValue).toEqual({ link: { color: '00ff00' } });
+    await expect(link).toHaveCSS('color', 'rgb(0, 255, 0)');
+    await expect(markdown).toHaveAttribute(
+      'markdown-style',
+      JSON.stringify({ link: { color: '00ff00' } }),
+    );
+  });
+
+  test('should render image', async ({ page }) => {
+    await goto(page, 'x-markdown/image');
+    const markdown = page.locator('x-markdown');
+
+    const image = markdown.locator('img');
+    await expect(image).toHaveAttribute(
+      'src',
+      '/tests/fixtures/resources/firefox-logo.png',
+    );
+  });
+
+  test('should update content on attribute change', async ({ page }) => {
+    await goto(page, 'x-markdown/basic');
+    const markdown = page.locator('x-markdown');
+
+    await markdown.evaluate((el) => {
+      el.setAttribute('content', '# Updated');
+    });
+    await expect(markdown.locator('h1')).toHaveText('Updated');
+  });
+
+  test('should only allow span and p html tags in markdown content', async ({ page }) => {
+    await goto(page, 'x-markdown/html-tags');
+    const markdown = page.locator('x-markdown');
+
+    const span = markdown.locator('span.mark-red');
+    await expect(span).toHaveText('World');
+    await expect(span).not.toHaveAttribute('style', /.+/);
+    await expect(span).not.toHaveAttribute('onclick', /.+/);
+
+    const p = markdown.locator('p.mark-help');
+    await expect(p).toHaveText('Paragraph');
+    await expect(p).not.toHaveAttribute('style', /.+/);
+
+    await expect(markdown.locator('div.not-allowed')).toHaveCount(0);
+    await expect(markdown).toContainText(
+      '<div class="not-allowed">Not allowed</div>',
+    );
+  });
+
+  test('should fire bindlink and bindimageTap events', async ({ page }) => {
+    await goto(page, 'x-markdown/events');
+    const markdown = page.locator('x-markdown');
+
+    await markdown.locator('a').click();
+    await page.waitForFunction(() => (window as any)._bindlink_detail !== null);
+    const linkDetail = await page.evaluate(() =>
+      (window as any)._bindlink_detail
+    );
+    expect(linkDetail.url).toBe('https://example.com');
+    expect(linkDetail.content).toBe('link');
+    expect(linkDetail.contentId).toBe('case-1');
+
+    await markdown.locator('img').click();
+    await page.waitForFunction(() =>
+      (window as any)._bindimage_detail !== null
+    );
+    const imageDetail = await page.evaluate(() =>
+      (window as any)._bindimage_detail
+    );
+    expect(imageDetail.url).toContain(
+      '/tests/fixtures/resources/firefox-logo.png',
+    );
+    expect(imageDetail.contentId).toBe('case-1');
+  });
+
+  test.describe('programmatic shadow selection', () => {
+    test.beforeEach(async ({ browserName }) => {
+      test.skip(
+        browserName === 'webkit',
+        'programmatic shadow selection is unsupported in webkit',
+      );
+    });
+
+    test('should enable text selection and fire selectionchange', async ({ page }) => {
+      await goto(page, 'x-markdown/text-selection');
+      await page.evaluate(() => {
+        (window as any)._resetSelectionState();
+        document.querySelector('x-markdown')?.setAttribute(
+          'text-selection',
+          'true',
+        );
+      });
+
+      const selectionStateBeforeSelect = await page.evaluate(() =>
+        (window as any)._getSelectionState()
+      );
+      expect(selectionStateBeforeSelect.styleText).toContain(
+        'user-select: text;',
+      );
+
+      await selectShadowText(page, 'h1', 0, 5);
+      await page.waitForFunction(() =>
+        (window as any)._selection_detail !== null
+      );
+
+      const selectionState = await page.evaluate(() =>
+        (window as any)._getSelectionState()
+      );
+
+      expect(selectionState.detail).toMatchObject({
+        start: 0,
+        end: 5,
+        direction: 'forward',
+      });
+      expect(selectionState.selectedText).toBe('Title');
+      expect(selectionState.rect?.width ?? 0).toBeGreaterThan(0);
+      expect(selectionState.rect?.height ?? 0).toBeGreaterThan(0);
+    });
+
+    test('should fire selectionchange on mouseup in web', async ({ page }) => {
+      await goto(page, 'x-markdown/text-selection');
+      await page.evaluate(() => {
+        (window as any)._resetSelectionState();
+        document.querySelector('x-markdown')?.setAttribute(
+          'text-selection',
+          'true',
+        );
+      });
+
+      await selectShadowTextByMouseup(page, 'h1', 0, 5);
+      await page.waitForFunction(() =>
+        (window as any)._selection_detail?.end === 5
+      );
+
+      const selectionState = await page.evaluate(() =>
+        (window as any)._getSelectionState()
+      );
+
+      expect(selectionState.detail).toMatchObject({
+        start: 0,
+        end: 5,
+        direction: 'forward',
+      });
+      expect(selectionState.selectedText).toBe('Title');
+    });
+
+    test('should show and position menu on selectionchange', async ({ page }) => {
+      await goto(page, 'x-markdown/menu');
+
+      const initialMenuState = await page.evaluate(() =>
+        (window as any)._getMenuState()
+      );
+      expect(initialMenuState.visibility).toBe('hidden');
+      expect(initialMenuState.labels).toEqual(['全选', '复制']);
+
+      await selectShadowText(page, 'h1', 0, 5);
+      await page.waitForFunction(() =>
+        (window as any)._getMenuState().visibility === 'visible'
+      );
+
+      const menuState = await page.evaluate(() =>
+        (window as any)._getMenuState()
+      );
+      expect(menuState.detail).toMatchObject({
+        start: 0,
+        end: 5,
+        direction: 'forward',
+      });
+      expect(Number.parseFloat(menuState.left)).toBeGreaterThan(0);
+      expect(Number.parseFloat(menuState.top)).toBeGreaterThan(0);
+
+      await clearShadowText(page);
+      await page.waitForFunction(() =>
+        (window as any)._getMenuState().visibility === 'hidden'
+      );
+    });
+
+    test('should defer menu display until mouseup during pointer selection', async ({ page }) => {
+      await goto(page, 'x-markdown/menu');
+
+      await page.locator('x-markdown').dispatchEvent('mousedown');
+      await selectShadowText(page, 'h1', 0, 5);
+
+      const menuStateWhileSelecting = await page.evaluate(() =>
+        (window as any)._getMenuState()
+      );
+      expect(menuStateWhileSelecting.visibility).toBe('hidden');
+
+      await page.evaluate(() => {
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      });
+      await page.waitForFunction(() =>
+        (window as any)._getMenuState().visibility === 'visible'
+      );
+    });
+
+    test('should clear selection when selection extends outside markdown', async ({ page }) => {
+      await goto(page, 'x-markdown/menu');
+
+      await selectShadowText(page, 'h1', 0, 5);
+      await page.waitForFunction(() =>
+        (window as any)._getMenuState().visibility === 'visible'
+      );
+
+      await page.evaluate(() => {
+        (window as any)._selectShadowTextToMenu();
+      });
+      await page.waitForFunction(() => {
+        const menuState = (window as any)._getMenuState();
+        return (
+          menuState.visibility === 'hidden'
+          && menuState.detail?.start === -1
+          && menuState.detail?.end === -1
+        );
+      });
+
+      const menuState = await page.evaluate(() =>
+        (window as any)._getMenuState()
+      );
+      expect(menuState.selectedText).toBe('');
+    });
+  });
+
+  test('should not fire selectionchange when text-selection is false', async ({ page }) => {
+    await goto(page, 'x-markdown/text-selection');
+    await page.evaluate(() => {
+      (window as any)._resetSelectionState();
+      document.querySelector('x-markdown')?.setAttribute(
+        'text-selection',
+        'false',
+      );
+    });
+
+    const selectionStateBeforeSelect = await page.evaluate(() =>
+      (window as any)._getSelectionState()
+    );
+    expect(selectionStateBeforeSelect.styleText).not.toContain(
+      'user-select: text;',
+    );
+
+    await selectShadowText(page, 'h1', 0, 5);
+    await page.waitForTimeout(50);
+
+    const selectionState = await page.evaluate(() =>
+      (window as any)._getSelectionState()
+    );
+    expect(selectionState.count).toBe(0);
+  });
+
+  test.describe('selection methods', () => {
+    test.beforeEach(async ({ browserName }) => {
+      test.skip(browserName !== 'chromium', 'selection automation is flaky');
+    });
+
+    test('should getSelectedText return current selection text', async ({ page }) => {
+      await goto(page, 'x-markdown/text-selection');
+      await page.evaluate(() => {
+        (window as any)._resetSelectionState();
+      });
+
+      await selectShadowText(page, 'h1', 0, 5);
+      await page.waitForFunction(() =>
+        (window as any)._selection_detail?.end === 5
+      );
+
+      const selectedText = await page.evaluate(() => {
+        const el = document.querySelector('x-markdown') as any;
+        return el.getSelectedText();
+      });
+
+      expect(selectedText).toBe('Title');
+    });
+
+    test('should setTextSelection update current selection', async ({ page }) => {
+      await goto(page, 'x-markdown/text-selection');
+      await setTextSelection(page, 'h1', 0, 5);
+      await page.waitForFunction(() => {
+        const el = document.querySelector('x-markdown') as any;
+        return el?.getSelectedText() === 'Title';
+      });
+
+      const selectionState = await page.evaluate(() => {
+        const el = document.querySelector('x-markdown') as any;
+        return {
+          selectedText: el.getSelectedText(),
+          nativeSelectedText: el.shadowRoot?.getSelection?.()?.toString()
+            ?? document.getSelection()?.toString()
+            ?? '',
+        };
+      });
+
+      expect(selectionState.selectedText).toBe('Title');
+      expect(selectionState.nativeSelectedText).toBe('Title');
+    });
+  });
+
+  test('should append content incrementally', async ({ page }) => {
+    await goto(page, 'x-markdown/basic');
+    expect(await getShadowText(page, 'h1')).toBe('Title');
+    await captureFirstChild(page);
+    await appendContent(page, '\n\n## More');
+    await page.waitForFunction(() => {
+      const element = document.querySelector('x-markdown');
+      const root = element?.shadowRoot;
+      return root?.querySelector('h2')?.textContent === 'More';
+    });
+    expect(await isFirstChildSame(page)).toBe(true);
+  });
+
+  test('should re-render when content diverges', async ({ page }) => {
+    await goto(page, 'x-markdown/basic');
+    await captureFirstChild(page);
+    await page.evaluate(() => {
+      const element = document.querySelector('x-markdown');
+      element?.setAttribute('content', '# Title\n\nReplaced');
+    });
+    await page.waitForFunction(() => {
+      const element = document.querySelector('x-markdown');
+      return element?.shadowRoot?.querySelector('p')?.textContent
+        === 'Replaced';
+    });
+    expect(await isFirstChildSame(page)).toBe(false);
+  });
+
+  test('should batch append by newline boundary', async ({ page }) => {
+    await goto(page, 'x-markdown/incremental');
+    expect(await getShadowCount(page, 'p')).toBe(1);
+    await appendContent(page, 'Line 2');
+    await page.waitForTimeout(20);
+    expect(await getShadowCount(page, 'p')).toBe(1);
+    await page.waitForTimeout(80);
+    expect(await getShadowCount(page, 'p')).toBe(2);
+  });
+
+  test('should render tables', async ({ page }) => {
+    await goto(page, 'x-markdown/table');
+    const markdown = page.locator('x-markdown');
+    await expect(markdown.locator('table')).toHaveCount(1);
+  });
+
+  test('should support basic methods', async ({ page }) => {
+    await goto(page, 'x-markdown/basic');
+    const content = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown') as any;
+      return el.getContent({ start: 0, end: 6 }).content;
+    });
+    expect(content).toBe('# Title');
+    const images = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown') as any;
+      return el.getImages();
+    });
+    expect(Array.isArray(images)).toBeTruthy();
+  });
+
+  test('should return full text ranges for nested markdown tags', async ({ page }) => {
+    await goto(page, 'x-markdown/basic');
+    const content = [
+      'Hello <span>nested only</span>',
+      '',
+      'Hello **bold** tail',
+    ].join('\n');
+
+    await page.evaluate((value) => {
+      const el = document.querySelector('x-markdown') as any;
+      el.setAttribute('content', value);
+    }, content);
+    await page.waitForFunction(() => {
+      const el = document.querySelector('x-markdown');
+      const root = el?.shadowRoot?.querySelector('#markdown-root');
+      return root?.textContent?.includes('Hello nested only')
+        && root?.textContent?.includes('Hello bold tail');
+    });
+
+    const ranges = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown') as any;
+      const rendered = el.shadowRoot?.querySelector('#markdown-root')
+        ?.textContent ?? '';
+      return {
+        rendered,
+        result: el.getParseResult({ tags: ['p', 'strong', 'span'] }),
+      };
+    });
+
+    const firstParagraphText = 'Hello nested only';
+    const secondParagraphText = 'Hello bold tail';
+    const boldText = 'bold';
+    const nestedSpanText = 'nested only';
+
+    expect(ranges.result.p).toHaveLength(2);
+    expect(
+      ranges.rendered.slice(ranges.result.p[0].start, ranges.result.p[0].end),
+    ).toBe(firstParagraphText);
+    expect(
+      ranges.rendered.slice(ranges.result.p[1].start, ranges.result.p[1].end),
+    ).toBe(secondParagraphText);
+
+    expect(ranges.result.strong).toHaveLength(1);
+    expect(
+      ranges.rendered.slice(
+        ranges.result.strong[0].start,
+        ranges.result.strong[0].end,
+      ),
+    ).toBe(boldText);
+
+    expect(ranges.result.span).toHaveLength(1);
+    expect(
+      ranges.rendered.slice(
+        ranges.result.span[0].start,
+        ranges.result.span[0].end,
+      ),
+    ).toBe(nestedSpanText);
+    expect(ranges.result.span[0].end).toBeGreaterThan(
+      ranges.result.span[0].start,
+    );
+  });
+
+  test('should support source indices in getTextBoundingRect', async ({ page }) => {
+    await goto(page, 'x-markdown/basic');
+    const rects = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown') as any;
+      const source = el.getAttribute('content') ?? '';
+      const rendered = el.shadowRoot?.querySelector('#markdown-root')
+        ?.textContent ?? '';
+      const sourceToken = '**bold**';
+      const renderedToken = 'bold';
+      const sourceStart = source.indexOf(sourceToken);
+      const charStart = rendered.indexOf(renderedToken);
+      const toPlainRect = (rect: DOMRect | undefined | null) =>
+        rect
+          ? {
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
+          }
+          : null;
+
+      return {
+        sourceRect: toPlainRect(
+          el.getTextBoundingRect({
+            start: sourceStart,
+            end: sourceStart + sourceToken.length,
+            indexType: 'source',
+          })?.boundingRect,
+        ),
+        charRect: toPlainRect(
+          el.getTextBoundingRect({
+            start: charStart,
+            end: charStart + renderedToken.length,
+            indexType: 'char',
+          })?.boundingRect,
+        ),
+      };
+    });
+
+    expect(rects.sourceRect).not.toBeNull();
+    expect(rects.charRect).not.toBeNull();
+    expect(rects.sourceRect?.width).toBeGreaterThan(0);
+    expect(rects.sourceRect?.height).toBeGreaterThan(0);
+    expect(rects.sourceRect?.left).toBeCloseTo(rects.charRect?.left ?? 0, 3);
+    expect(rects.sourceRect?.top).toBeCloseTo(rects.charRect?.top ?? 0, 3);
+    expect(rects.sourceRect?.width).toBeCloseTo(rects.charRect?.width ?? 0, 3);
+    expect(rects.sourceRect?.height).toBeCloseTo(
+      rects.charRect?.height ?? 0,
+      3,
+    );
+  });
+
+  test('should getImages return image sources', async ({ page }) => {
+    await goto(page, 'x-markdown/image');
+    const images = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown') as any;
+      return el.getImages();
+    });
+    expect(images).toEqual([
+      '/tests/fixtures/resources/firefox-logo.png',
+    ]);
+  });
+
+  test('should inject inline view and keep vertical-align', async ({ page }) => {
+    await goto(page, 'x-markdown/inlineview');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('x-markdown');
+      const root = el && (el as any).shadowRoot;
+      return !!root && !!root.querySelector('.md-inline-view');
+    });
+    const va = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown')!;
+      const root = el.shadowRoot as ShadowRoot;
+      const inline = root.querySelector('.md-inline-view') as
+        | HTMLElement
+        | null;
+      return inline ? getComputedStyle(inline).verticalAlign : '';
+    });
+    expect(va).toBe('middle');
+  });
+
+  test('should apply class styles to inline view', async ({ page }) => {
+    await goto(page, 'x-markdown/inlineview-class');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('x-markdown');
+      const slot = el?.shadowRoot?.querySelector(
+        '.md-inline-view slot',
+      ) as HTMLSlotElement | null;
+      return slot?.assignedElements().some((node) =>
+        (node as HTMLElement).id === 'content-view'
+      ) ?? false;
+    });
+
+    const inlineView = page.locator('#content-view');
+    await expect(inlineView).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+    await expect(inlineView).toHaveCSS('width', '24px');
+    await expect(inlineView).toHaveCSS('height', '24px');
+  });
+
+  test('should clamp and append truncation marker', async ({ page }) => {
+    await goto(page, 'x-markdown/truncate');
+    const markerText = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown')!;
+      const root = el.shadowRoot as ShadowRoot;
+      const marker = root.querySelector('.md-truncation');
+      return marker?.textContent || '';
+    });
+    expect(markerText).toBe('Read more');
+  });
+
+  test('should fire typewriter drawStart/drawEnd', async ({ page }) => {
+    await goto(page, 'x-markdown/typewriter');
+    await page.waitForFunction(() => (window as any)._drawStart === true);
+    await page.waitForFunction(() => (window as any)._drawEnd === true);
+    await expect(page.locator('x-markdown').locator('h1')).toHaveText('Title');
+  });
+
+  test('should pause and resume typewriter animation', async ({ page }) => {
+    await goto(page, 'x-markdown/typewriter-pause-resume');
+    await page.waitForFunction(
+      () => ((window as any)._animationSteps?.length ?? 0) >= 2,
+    );
+
+    const pausedStep = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown') as
+        | (HTMLElement & { pauseAnimation: () => void })
+        | null;
+      el?.pauseAnimation();
+      const steps = (window as any)._animationSteps ?? [];
+      return steps[steps.length - 1] ?? 0;
+    });
+
+    await page.waitForTimeout(300);
+
+    const stepAfterPause = await page.evaluate(() => {
+      const steps = (window as any)._animationSteps ?? [];
+      return steps[steps.length - 1] ?? 0;
+    });
+    expect(stepAfterPause).toBe(pausedStep);
+
+    await page.evaluate(() => {
+      const el = document.querySelector('x-markdown') as
+        | (HTMLElement & { resumeAnimation: () => void })
+        | null;
+      el?.resumeAnimation();
+    });
+
+    await page.waitForFunction(
+      (step) => {
+        const steps = (window as any)._animationSteps ?? [];
+        return (steps[steps.length - 1] ?? 0) > step;
+      },
+      pausedStep,
+    );
+  });
+
+  test('should reset typewriter state when content is cleared and reassigned', async ({ page }) => {
+    await goto(page, 'x-markdown/typewriter-reset-content');
+    await page.waitForFunction(() => (window as any)._reassigned === true);
+    await page.waitForFunction(
+      () => ((window as any)._newAnimationSteps?.length ?? 0) >= 1,
+    );
+
+    const state = await page.evaluate(() => ({
+      textAfterReassign: (window as any)._textAfterReassign,
+      firstNewStep: (window as any)._newAnimationSteps?.[0] ?? null,
+    }));
+
+    expect(state.textAfterReassign).toBe('');
+    expect(state.firstNewStep).toBe(1);
+  });
+
+  test('should render custom typewriter cursor', async ({ page }) => {
+    await goto(page, 'x-markdown/typewriter-cursor');
+    await page.waitForFunction(() => (window as any)._drawStart === true);
+    await page.waitForTimeout(1500);
+
+    const cursorRendered = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown')!;
+      const root = el.shadowRoot as ShadowRoot;
+      const cursor = root.querySelector('#cursor');
+      return !!cursor;
+    });
+    expect(cursorRendered).toBe(true);
+    await page.waitForTimeout(1000);
+    const cursor = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown')!;
+      const root = el.shadowRoot as ShadowRoot;
+      const cursor = root.querySelector('#cursor');
+      return cursor;
+    });
+    expect(cursor).toBeNull();
+  });
+
+  test('should render typewriter cursor after trailing text node', async ({ page }) => {
+    await goto(page, 'x-markdown/typewriter-trailing-text');
+    await page.waitForTimeout(500);
+
+    const isCorrectParent = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown')!;
+      const root = el.shadowRoot as ShadowRoot;
+      const cursor = root.querySelector('.md-typewriter-cursor');
+      if (!cursor) return false;
+
+      const parent = cursor.parentElement;
+      return parent && parent.tagName === 'P';
+    });
+
+    expect(isCorrectParent).toBe(true);
+  });
+
+  test('should not hide cursor when content-complete is false', async ({ page }) => {
+    await goto(page, 'x-markdown/typewriter-keep-cursor');
+    await page.waitForFunction(() => (window as any)._drawStart === true);
+    await page.waitForFunction(() =>
+      (window as any)._animationComplete === true
+    );
+    const isComplete = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown')!;
+      return el.getAttribute('content-complete');
+    });
+    expect(isComplete).toBe('false');
+    const cursorRendered = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown')!;
+      const root = el.shadowRoot as ShadowRoot;
+      const cursor = root.querySelector('.md-typewriter-cursor');
+      return !!cursor;
+    });
+    expect(cursorRendered).toBe(true);
+  });
+
+  test('should render markdown effect', async ({ page }) => {
+    await goto(page, 'x-markdown/typewriter-effect');
+    await page.waitForFunction(() => (window as any)._drawStart === true);
+    await page.waitForFunction(() =>
+      (window as any)._animationComplete === true
+    );
+
+    const effectState = await page.evaluate(() => {
+      const el = document.querySelector('x-markdown')!;
+      const root = el.shadowRoot as ShadowRoot;
+      const effects = Array.from(
+        root.querySelectorAll('.md-text-mask-effect'),
+      ) as HTMLElement[];
+      const overlays = Array.from(
+        root.querySelectorAll('.md-text-mask-effect-overlay'),
+      ) as HTMLElement[];
+      const contents = Array.from(
+        root.querySelectorAll('.md-text-mask-effect-content'),
+      ) as HTMLElement[];
+      return {
+        rendered: effects.length > 0,
+        effectCount: effects.length,
+        overlayText: overlays.map((overlay) => overlay.textContent ?? '').join(
+          '',
+        ),
+        contentText: contents.map((content) => content.textContent ?? '').join(
+          '',
+        ),
+        overlayBackgrounds: overlays.map((overlay) => {
+          const styles = getComputedStyle(overlay);
+          return {
+            backgroundImage: styles.backgroundImage,
+            backgroundSize: styles.backgroundSize,
+            backgroundPosition: styles.backgroundPosition,
+          };
+        }),
+      };
+    });
+    expect(effectState.rendered).toBe(true);
+    expect(effectState.effectCount).toBeGreaterThan(0);
+    expect(effectState.overlayText).toBe('TTTT');
+    expect(effectState.contentText).toBe('TTTT');
+    expect(effectState.overlayBackgrounds.length).toBeGreaterThan(0);
+    expect(effectState.overlayBackgrounds[0]?.backgroundImage).toContain(
+      'linear-gradient',
+    );
+    if (effectState.overlayBackgrounds.length > 1) {
+      expect(
+        new Set(
+          effectState.overlayBackgrounds.map(
+            (overlay) => overlay.backgroundSize,
+          ),
+        ).size,
+      ).toBe(1);
+      expect(
+        new Set(
+          effectState.overlayBackgrounds.map(
+            (overlay) => overlay.backgroundPosition,
+          ),
+        ).size,
+      ).toBeGreaterThan(1);
+    }
+  });
+});

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -4606,6 +4606,25 @@ test.describe('reactlynx3 tests', () => {
         },
       );
     });
+    test.describe('x-markdown', () => {
+      test(
+        'basic-element-x-markdown-markdown-style',
+        async ({ page }, { title }) => {
+          await goto(page, title);
+          await wait(200);
+
+          const markdown = page.locator('x-markdown');
+          await expect(markdown).toHaveAttribute(
+            'markdown-style',
+            JSON.stringify({ link: { color: '00ff00' } }),
+          );
+          await expect(markdown.locator('a')).toHaveCSS(
+            'color',
+            'rgb(0, 255, 0)',
+          );
+        },
+      );
+    });
     test.describe('x-audio-tt', () => {
       test('basic-element-x-audio-tt-play', async ({ page }, { title }) => {
         // test.skip(true, 'lynx.createSelectorQuery is not supported'); // FIXME

--- a/packages/web-platform/web-tests/tests/react/basic-element-x-markdown-markdown-style/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-element-x-markdown-markdown-style/index.jsx
@@ -1,0 +1,24 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+const markdownStyle = {
+  link: {
+    color: '00ff00',
+  },
+};
+
+function App() {
+  return (
+    <view>
+      <x-markdown
+        id='markdown'
+        content={'[link](https://example.com)'}
+        markdown-style={markdownStyle}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1467,6 +1467,13 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.13)(@vitest/ui@3.2.4)(jsdom@27.4.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.31.6)
 
   packages/web-platform/web-elements:
+    dependencies:
+      dompurify:
+        specifier: ^3.3.1
+        version: 3.3.1
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
     devDependencies:
       '@lynx-js/playwright-fixtures':
         specifier: workspace:*
@@ -1480,6 +1487,9 @@ importers:
       '@rsbuild/plugin-source-build':
         specifier: 1.0.4
         version: 1.0.4(@rsbuild/core@1.7.5)
+      '@types/markdown-it':
+        specifier: ^14.1.1
+        version: 14.1.1
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -4492,11 +4502,20 @@ packages:
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
   '@types/loader-utils@2.0.6':
     resolution: {integrity: sha512-cgu0Xefgq9O5FjFR78jgI6X31aPjDWCaJ6LCfRtlj6BtyVVWiXagysSYlPACwGKAzRwsFLjKXcj4iGfcVt6cLw==}
 
+  '@types/markdown-it@14.1.1':
+    resolution: {integrity: sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
@@ -4574,6 +4593,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/uglify-js@3.17.5':
     resolution: {integrity: sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==}
@@ -5893,6 +5915,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -7452,6 +7477,9 @@ packages:
     resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   lint-staged@16.2.7:
     resolution: {integrity: sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==}
     engines: {node: '>=20.17'}
@@ -7567,6 +7595,10 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -7630,6 +7662,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -8537,6 +8572,10 @@ packages:
     resolution: {integrity: sha512-Q3NLegA9XM6usW+dYQRG1g9uEHiYUzcCVBJDJ7yMcWRqVU9LYZUWdqbwMZfmTCFC5PZLQpLAmhvRcQRl3exqkw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -9776,6 +9815,9 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=4.8.0 <5.10.0'
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -12980,14 +13022,23 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
 
+  '@types/linkify-it@5.0.0': {}
+
   '@types/loader-utils@2.0.6':
     dependencies:
       '@types/node': 24.10.13
       '@types/webpack': 4.41.40
 
+  '@types/markdown-it@14.1.1':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/mdx@2.0.13': {}
 
@@ -13062,6 +13113,9 @@ snapshots:
       tapable: 2.3.0
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/uglify-js@3.17.5':
     dependencies:
@@ -14447,6 +14501,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -16373,6 +16431,10 @@ snapshots:
 
   lines-and-columns@2.0.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   lint-staged@16.2.7:
     dependencies:
       commander: 14.0.3
@@ -16488,6 +16550,15 @@ snapshots:
       tmpl: 1.0.5
 
   markdown-extensions@2.0.0: {}
+
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -16670,6 +16741,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.12.2: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -17689,6 +17762,8 @@ snapshots:
       package-manager-detector: 1.6.0
       picocolors: 1.1.1
       sade: 1.8.1
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -19117,6 +19192,8 @@ snapshots:
       package-manager-detector: 0.2.11
       randexp: 0.5.3
       typescript: 5.9.3
+
+  uc.micro@2.1.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in x-markdown component for rich Markdown: headings, lists, tables, images, inline views, sanitization, truncation/"Read more", incremental updates, and customizable styles with bundled stylesheet.
  * Typewriter animation with configurable cursor, runtime controls, selection helpers, and programmatic selection APIs.
  * Emits events for link clicks, image taps, animation lifecycle, and selection changes.

* **Tests**
  * Added comprehensive Playwright fixtures and tests for rendering, interactions, animations, selection, and sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
