### PR TITLE
fix: map clientX and clientY to x and y in touch event detail

### DIFF
--- a/.changeset/fix-touch-detail.md
+++ b/.changeset/fix-touch-detail.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/web-core': patch
+---
+
+fix: map clientX and clientY to x and y in touch event detail

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -520,6 +520,10 @@ test.describe('reactlynx3 tests', () => {
           'background-color',
           'rgb(0, 128, 0)',
         ); // green
+        expect(page.locator('#target4'), 'has detail.x and detail.y').toHaveCSS(
+          'background-color',
+          'rgb(0, 128, 0)',
+        ); // green
       },
     );
 

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-mts-bindtouchstart/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-mts-bindtouchstart/index.jsx
@@ -6,6 +6,7 @@ function App() {
   const [hasTouch, setHasTouch] = useState(false);
   const [hasTargetTouches, setHasTargetTouches] = useState(false);
   const [hasChangedTouches, setHasChangedTouches] = useState(false);
+  const [hasDetailXY, setHasDetailXY] = useState(false);
   return (
     <view
       id='target'
@@ -19,6 +20,12 @@ function App() {
         }
         if (ev.changedTouches[0]) {
           runOnBackground(setHasChangedTouches)(true);
+        }
+        if (
+          ev.detail && typeof ev.detail.x !== 'undefined'
+          && typeof ev.detail.y !== 'undefined'
+        ) {
+          runOnBackground(setHasDetailXY)(true);
         }
       }}
     >
@@ -44,6 +51,14 @@ function App() {
           height: '100px',
           width: '100px',
           background: hasChangedTouches ? 'green' : 'pink',
+        }}
+      />
+      <view
+        id='target4'
+        style={{
+          height: '100px',
+          width: '100px',
+          background: hasDetailXY ? 'green' : 'pink',
         }}
       />
     </view>

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -54,6 +54,35 @@ describe('Element APIs', () => {
     const element = mtsGlobalThis.__CreateElement('view', 0);
     expect(mtsGlobalThis.__GetTag(element)).toBe('view');
   });
+
+  test('createCrossThreadEvent properly sets touch detail x and y', async () => {
+    const { createCrossThreadEvent } = await import(
+      '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'
+    );
+    const touchEvent = new Event('touchstart') as any;
+    touchEvent.touches = [{ clientX: 100, clientY: 200 }];
+    touchEvent.targetTouches = [];
+    touchEvent.changedTouches = [];
+
+    const lynxEvent = createCrossThreadEvent(touchEvent);
+    expect(lynxEvent.type).toBe('touchstart');
+    expect(lynxEvent.detail).toEqual({ x: 100, y: 200 });
+  });
+
+  test('createCrossThreadEvent sets empty detail if no touches', async () => {
+    const { createCrossThreadEvent } = await import(
+      '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'
+    );
+    const touchEvent = new Event('touchstart') as any;
+    touchEvent.touches = [];
+    touchEvent.targetTouches = [];
+    touchEvent.changedTouches = [];
+
+    const lynxEvent = createCrossThreadEvent(touchEvent);
+    expect(lynxEvent.type).toBe('touchstart');
+    expect(lynxEvent.detail).toEqual({});
+  });
+
   test('__CreateComponent', () => {
     const ret = mtsGlobalThis.__CreateComponent(
       0,

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
@@ -61,6 +61,12 @@ export function createCrossThreadEvent(
         )
         : changedTouches,
     });
+    if (touch[0]) {
+      detail = {
+        x: touch[0].clientX,
+        y: touch[0].clientY,
+      };
+    }
   } else if (type.startsWith('mouse')) {
     const mouseEvent = domEvent as MouseEvent;
     Object.assign(otherProperties, {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Touch events now correctly map `clientX` and `clientY` to `x` and `y` in the touch event detail object.

* **Tests**
  * Enhanced test coverage for touch event detail handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
