### PR TITLE
fix(web-core): preserve css var fallback values

### DIFF
--- a/.changeset/short-planes-cut.md
+++ b/.changeset/short-planes-cut.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: preserve CSS variable fallback values when encoding web-core stylesheets so declarations like `var(--token, rgba(...))` are emitted with their fallback intact.

--- a/packages/web-platform/web-core/tests/__snapshots__/encode.spec.ts.snap
+++ b/packages/web-platform/web-core/tests/__snapshots__/encode.spec.ts.snap
@@ -22,4 +22,4 @@ exports[`encodeCSS > scoped css, 2 css id 1`] = `".foo:where([l-css-id="1"]):not
 
 exports[`encodeCSS > scoped css, import non existing 1`] = `".foo:where([l-css-id="1"]):not([l-e-name]),.foo:where([l-css-id="20"]):not([l-e-name]),.foo:where([l-css-id="2"]):not([l-e-name]){background:red;}"`;
 
-exports[`encodeCSS > should encode KeyframesRule with CSS variables 1`] = `"@keyframes my-animation-with-vars{from{--my-var:0;opacity:{{--my-var}};}to{--my-var:1;opacity:{{--my-var}};}}"`;
+exports[`encodeCSS > should encode KeyframesRule with CSS variables 1`] = `"@keyframes my-animation-with-vars{from{--my-var:0;opacity:var(--my-var);}to{--my-var:1;opacity:var(--my-var);}}"`;

--- a/packages/web-platform/web-core/tests/encode.spec.ts
+++ b/packages/web-platform/web-core/tests/encode.spec.ts
@@ -149,6 +149,28 @@ describe('encodeCSS', () => {
     expect(decodedString.trim()).toMatchSnapshot();
   });
 
+  test('should preserve fallback values in css var for keyframes', () => {
+    const css = `
+      @keyframes my-animation-with-vars-fallback {
+        from {
+          opacity: var(--my-var, .6);
+        }
+        to {
+          opacity: var(--my-var, 1);
+        }
+      }
+    `;
+    const cssMap = {
+      '1': CSS.parse(css).root,
+    };
+    const buffer = encodeCSS(cssMap);
+    const decodedString = get_style_content(
+      decode_style_info(buffer, undefined, true),
+    );
+    expect(decodedString).toContain('opacity:var(--my-var, .6);');
+    expect(decodedString).toContain('opacity:var(--my-var, 1);');
+  });
+
   test('should handle complex selectors', () => {
     const css = `
       div > .foo + #bar[attr="val"]::before:hover {
@@ -175,6 +197,24 @@ describe('encodeCSS', () => {
     const buffer = encodeCSS(cssMap);
     expect(buffer).toBeInstanceOf(Uint8Array);
     expect(buffer.length).toBeGreaterThan(0);
+  });
+
+  test('should preserve fallback values in css var for color', () => {
+    const css = `
+      .foo {
+        color: var(--Text-TextQuaternary, rgba(22, 24, 35, .6));
+      }
+    `;
+    const cssMap = {
+      '1': CSS.parse(css).root,
+    };
+    const buffer = encodeCSS(cssMap);
+    const decodedString = get_style_content(
+      decode_style_info(buffer, undefined, true),
+    );
+    expect(decodedString).toContain(
+      'color:var(--Text-TextQuaternary, rgba(22,24,35,.6));',
+    );
   });
 
   test('should handle ::placeholder selector', () => {
@@ -264,6 +304,24 @@ describe('encodeCSS', () => {
       decode_style_info(buffer, undefined, true),
     );
     expect(decodedString.trim()).toMatchSnapshot();
+  });
+
+  test('font-face should preserve fallback values in css var', () => {
+    const cssMap = {
+      '0': CSS.parse(`
+        @font-face {
+          font-family: var(--font-family, "MyFont");
+          src: url("myfont.woff");
+        }
+      `).root,
+    };
+    const buffer = encodeCSS(cssMap);
+    const decodedString = get_font_face_content(
+      decode_style_info(buffer, undefined, true),
+    );
+    expect(decodedString).toContain(
+      'font-family:var(--font-family, "MyFont");',
+    );
   });
 
   test('keyframes-rule', () => {

--- a/packages/web-platform/web-core/ts/encode/encodeCSS.ts
+++ b/packages/web-platform/web-core/ts/encode/encodeCSS.ts
@@ -9,6 +9,19 @@ import {
 // @ts-ignore
 export * from '../../binary/encode/encode.js';
 
+function restoreCSSVarValue(decl: CSS.Declaration): string {
+  return decl.value.replaceAll(/\{\{(--[^}]+)\}\}/g, (_, varName: string) => {
+    const isCSSVarDecl = 'type' in decl && decl.type === 'css_var';
+
+    if (!isCSSVarDecl) {
+      return `var(${varName})`;
+    }
+
+    const fallback = decl.defaultValueMap?.[varName];
+    return fallback ? `var(${varName}, ${fallback})` : `var(${varName})`;
+  });
+}
+
 export function encodeCSS(
   cssMap: Record<string, CSS.LynxStyleNode[]>,
 ): Uint8Array {
@@ -66,7 +79,10 @@ export function encodeCSS(
           }
 
           for (const decl of keyframesStyle.style) {
-            keyFrameChildrenRule.push_declaration(decl.name, decl.value);
+            keyFrameChildrenRule.push_declaration(
+              decl.name,
+              restoreCSSVarValue(decl),
+            );
           }
           rule.push_rule_children(keyFrameChildrenRule);
         }
@@ -74,7 +90,7 @@ export function encodeCSS(
       } else if (node.type === 'FontFaceRule') {
         const rule = new Rule('FontFaceRule');
         for (const decl of node.style) {
-          rule.push_declaration(decl.name, decl.value);
+          rule.push_declaration(decl.name, restoreCSSVarValue(decl));
         }
         rawStyleInfo.push_rule(parsedCssId, rule);
       } else if (node.type === 'StyleRule') {
@@ -129,11 +145,7 @@ export function encodeCSS(
 
         // Declarations
         for (const decl of node.style) {
-          const value = decl.value.replaceAll(
-            /\{\{--([^}]+)\}\}/g,
-            'var(--$1)',
-          );
-          rule.push_declaration(decl.name, value);
+          rule.push_declaration(decl.name, restoreCSSVarValue(decl));
         }
 
         // Variables


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stylesheet encoding so CSS variable fallbacks (e.g., var(--token, rgba(...))) are preserved end-to-end during encoding/decoding.

* **Tests**
  * Added tests confirming CSS variable fallbacks are retained across encoding/decoding roundtrips, covering keyframes, standard style rules, and @font-face rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
