### PR TITLE
fix(rstest): normalize partial compat and add global jsx-runtime aliases

### DIFF
--- a/.changeset/fix-rstest-jsx-runtime-alias.md
+++ b/.changeset/fix-rstest-jsx-runtime-alias.md
@@ -1,0 +1,7 @@
+---
+'@lynx-js/react-alias-rsbuild-plugin': patch
+---
+
+fix(rstest): add global fallback aliases for `@lynx-js/react/jsx-runtime` and `@lynx-js/react/jsx-dev-runtime`
+
+`pluginReactAlias` only aliased these entries inside layer-specific rules (`issuerLayer: BACKGROUND/MAIN_THREAD`). In rstest mode there are no layers, so JSX transformed by the testing loader—which emits `import { jsx } from '@lynx-js/react/jsx-runtime'`—could not be resolved, causing a `Cannot find module '@lynx-js/react/jsx-runtime'` error. Added global (non-layer-specific) fallback aliases pointing to the background jsx-runtime.

--- a/.changeset/fix-rstest-testing-loader-compat.md
+++ b/.changeset/fix-rstest-testing-loader-compat.md
@@ -1,0 +1,7 @@
+---
+'@lynx-js/react-webpack-plugin': patch
+---
+
+fix(rstest): normalize partial `compat` options in the testing loader
+
+The testing loader forwards `compat` directly to `transformReactLynxSync` without normalization. When `compat` is supplied as a partial object, the required `target` field is absent and the WASM transform throws `Error: Missing field 'target'`. Added the same normalization already present in `getCommonOptions` for the background/main-thread loaders: fills in `target: 'MIXED'` and all other required fields with sensible defaults.

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -691,6 +691,8 @@ describe('pluginReactLynx', () => {
           "@lynx-js/react/debug$": false,
           "@lynx-js/react/experimental/lazy/import$": "<ROOT>/packages/react/runtime/lazy/import.js",
           "@lynx-js/react/internal$": "<ROOT>/packages/react/runtime/lib/internal.js",
+          "@lynx-js/react/jsx-dev-runtime": "<ROOT>/packages/react/runtime/jsx-dev-runtime/index.js",
+          "@lynx-js/react/jsx-runtime": "<ROOT>/packages/react/runtime/jsx-runtime/index.js",
           "@lynx-js/react/legacy-react-runtime$": "<ROOT>/packages/react/runtime/lib/legacy-react-runtime/index.js",
           "@lynx-js/react/runtime-components$": "<ROOT>/packages/react/components/lib/index.js",
           "@lynx-js/react/worklet-runtime/bindings$": "<ROOT>/packages/react/runtime/lib/worklet-runtime/bindings/index.js",

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -171,6 +171,8 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
             '@lynx-js/react$',
             reactLepus.background,
           )
+          .set('@lynx-js/react/jsx-runtime', jsxRuntime.background)
+          .set('@lynx-js/react/jsx-dev-runtime', jsxDevRuntime.background)
 
         if (reactCompat) {
           chain

--- a/packages/rspeedy/plugin-react-alias/test/index.test.ts
+++ b/packages/rspeedy/plugin-react-alias/test/index.test.ts
@@ -55,6 +55,26 @@ describe('React - alias', () => {
     )
 
     expect(config.resolve.alias).toHaveProperty(
+      '@lynx-js/react/jsx-runtime',
+      expect.stringContaining(
+        '/packages/react/runtime/jsx-runtime/index.js'.replaceAll(
+          '/',
+          path.sep,
+        ),
+      ),
+    )
+
+    expect(config.resolve.alias).toHaveProperty(
+      '@lynx-js/react/jsx-dev-runtime',
+      expect.stringContaining(
+        '/packages/react/runtime/jsx-dev-runtime/index.js'.replaceAll(
+          '/',
+          path.sep,
+        ),
+      ),
+    )
+
+    expect(config.resolve.alias).toHaveProperty(
       '@lynx-js/react/internal$',
       expect.stringContaining(
         '/packages/react/runtime/lib/internal.js'.replaceAll('/', path.sep),

--- a/packages/webpack/react-webpack-plugin/src/loaders/testing.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/testing.ts
@@ -34,6 +34,22 @@ function testingLoader(
       this.resourcePath,
     ),
   );
+  const normalizedCompat = typeof compat === 'object'
+    ? {
+      target: 'MIXED' as const,
+      addComponentElement: compat.addComponentElement ?? false,
+      additionalComponentAttributes: compat.additionalComponentAttributes ?? [],
+      componentsPkg: compat.componentsPkg ?? ['@lynx-js/react-components'],
+      disableDeprecatedWarning: compat.disableDeprecatedWarning ?? false,
+      newRuntimePkg: compat.newRuntimePkg ?? '@lynx-js/react',
+      oldRuntimePkg: compat.oldRuntimePkg ?? ['@lynx-js/react-runtime'],
+      simplifyCtorLikeReactLynx2: compat.simplifyCtorLikeReactLynx2 ?? false,
+      ...(typeof compat.removeComponentAttrRegex === 'string' && {
+        removeComponentAttrRegex: compat.removeComponentAttrRegex,
+      }),
+      darkMode: compat.darkMode ?? false,
+    }
+    : (compat ?? false);
   const result = transformReactLynxSync(
     content,
     {
@@ -52,7 +68,7 @@ function testingLoader(
       directiveDCE: false,
       defineDCE,
       shake,
-      compat,
+      compat: normalizedCompat,
       engineVersion,
       worklet: {
         filename,

--- a/packages/webpack/react-webpack-plugin/src/loaders/testing.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/testing.ts
@@ -34,7 +34,7 @@ function testingLoader(
       this.resourcePath,
     ),
   );
-  const normalizedCompat = compat !== null && typeof compat === 'object'
+  const normalizedCompat = typeof compat === 'object'
     ? {
       target: 'MIXED' as const,
       addComponentElement: compat.addComponentElement ?? false,

--- a/packages/webpack/react-webpack-plugin/src/loaders/testing.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/testing.ts
@@ -34,7 +34,7 @@ function testingLoader(
       this.resourcePath,
     ),
   );
-  const normalizedCompat = typeof compat === 'object'
+  const normalizedCompat = compat !== null && typeof compat === 'object'
     ? {
       target: 'MIXED' as const,
       addComponentElement: compat.addComponentElement ?? false,

--- a/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
@@ -1,0 +1,109 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Invoke the testing loader synchronously by wrapping the callback pattern.
+ */
+function runTestingLoader(
+  content: string,
+  options: Record<string, unknown>,
+): Promise<{ code: string; map?: string }> {
+  return new Promise((resolve, reject) => {
+    // Dynamically import the built loader
+    const loaderPath = path.resolve(
+      __dirname,
+      '../lib/loaders/testing.js',
+    );
+    import(loaderPath).then(
+      (
+        mod: {
+          default: (this: Record<string, unknown>, content: string) => void;
+        },
+      ) => {
+        const loader = mod.default;
+
+        const ctx: Record<string, unknown> = {
+          getOptions: () => options,
+          resourcePath: path.resolve(__dirname, 'fixture.tsx'),
+          rootContext: __dirname,
+          sourceMap: false,
+          hot: false,
+          experiments: undefined,
+          emitError: (err: Error) => reject(err),
+          // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
+          emitWarning: () => {},
+          callback: (
+            err: Error | null,
+            code?: string,
+            map?: string,
+          ) => {
+            if (err) reject(err);
+            else resolve({ code: code!, map });
+          },
+        };
+
+        loader.call(ctx, content);
+      },
+    ).catch(reject);
+  });
+}
+
+describe('testing loader', () => {
+  it('handles partial compat object (missing target) without throwing', async () => {
+    const jsxContent = `
+      import { View } from '@lynx-js/react';
+      export function App() {
+        return <view />;
+      }
+    `;
+
+    // Partial compat without required `target` field — this was the bug
+    const result = await runTestingLoader(jsxContent, {
+      compat: {
+        componentsPkg: ['@byted-lynx/react-components'],
+        newRuntimePkg: '@lynx-js/react',
+        oldRuntimePkg: ['@byted-lynx/react-runtime'],
+        // intentionally missing: target, addComponentElement, etc.
+      },
+      engineVersion: '3.2',
+    });
+
+    expect(result.code).toBeTruthy();
+  });
+
+  it('handles compat: false without throwing', async () => {
+    const jsxContent = `
+      export function App() {
+        return <view />;
+      }
+    `;
+
+    const result = await runTestingLoader(jsxContent, {
+      compat: false,
+      engineVersion: '3.2',
+    });
+
+    expect(result.code).toBeTruthy();
+  });
+
+  it('handles missing compat (defaults to false) without throwing', async () => {
+    const jsxContent = `
+      export function App() {
+        return <view />;
+      }
+    `;
+
+    const result = await runTestingLoader(jsxContent, {
+      engineVersion: '3.2',
+    });
+
+    expect(result.code).toBeTruthy();
+  });
+});

--- a/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
@@ -93,21 +93,6 @@ describe('testing loader', () => {
     expect(result.code).toBeTruthy();
   });
 
-  it('handles compat: null without throwing', async () => {
-    const jsxContent = `
-      export function App() {
-        return <view />;
-      }
-    `;
-
-    const result = await runTestingLoader(jsxContent, {
-      compat: null,
-      engineVersion: '3.2',
-    });
-
-    expect(result.code).toBeTruthy();
-  });
-
   it('handles missing compat (defaults to false) without throwing', async () => {
     const jsxContent = `
       export function App() {

--- a/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
@@ -93,6 +93,21 @@ describe('testing loader', () => {
     expect(result.code).toBeTruthy();
   });
 
+  it('handles compat: null without throwing', async () => {
+    const jsxContent = `
+      export function App() {
+        return <view />;
+      }
+    `;
+
+    const result = await runTestingLoader(jsxContent, {
+      compat: null,
+      engineVersion: '3.2',
+    });
+
+    expect(result.code).toBeTruthy();
+  });
+
   it('handles missing compat (defaults to false) without throwing', async () => {
     const jsxContent = `
       export function App() {


### PR DESCRIPTION
## Summary

Two bugs that prevented `withLynxConfig()` from working in rstest environments:

- **`@lynx-js/react-alias-rsbuild-plugin`**: `pluginReactAlias` only aliased `@lynx-js/react/jsx-runtime` and `@lynx-js/react/jsx-dev-runtime` inside layer-specific rules (`issuerLayer: BACKGROUND/MAIN_THREAD`). In rstest mode there are no layers, so JSX transformed by the testing loader—which emits `import { jsx } from '@lynx-js/react/jsx-runtime'`—could not be resolved (`Cannot find module '@lynx-js/react/jsx-runtime'`). Added global fallback aliases pointing to the background jsx-runtime.

- **`@lynx-js/react-webpack-plugin` (testing loader)**: The testing loader forwarded `compat` directly to `transformReactLynxSync` without normalization. When `compat` is supplied as a partial object, the required `target` field is absent and the WASM transform throws `Error: Missing field 'target'`. Added the same normalization already present in `getCommonOptions` for the background/main-thread loaders.

## Test plan

- [ ] `pnpm --filter @lynx-js/react-alias-rsbuild-plugin test` — new assertions verify `@lynx-js/react/jsx-runtime` and `@lynx-js/react/jsx-dev-runtime` are present as global aliases
- [ ] `pnpm --filter @lynx-js/react-webpack-plugin test` — new `test/testing-loader.test.ts` covers partial compat (missing `target`), `compat: false`, and missing compat cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure JSX runtime modules (@lynx-js/react/jsx-runtime and jsx-dev-runtime) resolve in testing/rstest mode via fallback aliasing.
  * Normalize partial compat configurations in the testing loader so required fields (e.g., target) are filled and WASM transform failures are prevented.

* **Tests**
  * Added tests verifying loader behavior with partial, false, and omitted compat options and updated alias snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->