### PR TITLE
refactor: remove ReactLynx::renderOpcodes trace

### DIFF
--- a/.changeset/full-walls-behave.md
+++ b/.changeset/full-walls-behave.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/react": patch
+---
+
+Trace refactor
+
+- Remove `ReactLynx::renderOpcodes` from the trace
+- Use `ReactLynx::transferRoot` to measure the time spent transferring the root to the background thread

--- a/benchmark/react/src/patchProfile.ts
+++ b/benchmark/react/src/patchProfile.ts
@@ -14,7 +14,6 @@ if (typeof Codspeed !== 'undefined') {
       !name
       || name === 'ReactLynx::commit'
       || name === 'ReactLynx::commitChanges'
-      || name === 'ReactLynx::transferRoot'
       || name === 'ReactLynx::BSI::setAttribute'
       || name.startsWith('OnLifecycleEvent::')
       || name.startsWith('ReactLynx::diff::')

--- a/packages/react/runtime/src/lifecycle/event/jsReady.ts
+++ b/packages/react/runtime/src/lifecycle/event/jsReady.ts
@@ -12,12 +12,14 @@ function jsReady(): void {
   isJSReady = true;
 
   if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
-    profileStart('ReactLynx::transferRoot');
     profileStart('ReactLynx::serializeRoot');
   }
   const root = JSON.stringify(__root);
   if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
     profileEnd();
+  }
+  if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
+    profileStart('ReactLynx::transferRoot');
   }
   __OnLifecycleEvent([
     LifecycleConstant.firstScreen, /* FIRST_SCREEN */

--- a/packages/react/runtime/src/lifecycle/render.ts
+++ b/packages/react/runtime/src/lifecycle/render.ts
@@ -28,14 +28,8 @@ function renderMainThread(): void {
     }
   }
 
-  if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
-    profileStart('ReactLynx::renderOpcodes');
-  }
   if (__ENABLE_SSR__) {
     __root.__opcodes = opcodes;
-  }
-  if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
-    profileEnd();
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new changeset file.

* **Refactor**
  * Adjusted runtime profiling so some startup and render timing windows have been moved and shortened.
  * Updated benchmark profiling so one additional lifecycle phase is now included in the profiling stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
