### PR TITLE
fix: rename uniqueId to uid in LynxCrossThreadEvent and WASMJSBinding

### DIFF
--- a/.changeset/web-core-unique-id.md
+++ b/.changeset/web-core-unique-id.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: Change uniqueId to uid in LynxCrossThreadEventTarget

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -1278,12 +1278,12 @@ describe('Element APIs', () => {
         currentTarget: expect.objectContaining({
           id: 'child_id',
           dataset: expect.any(Object),
-          uniqueId: expect.any(Number),
+          uid: expect.any(Number),
         }),
         target: expect.objectContaining({
           id: 'child_id',
           dataset: expect.any(Object),
-          uniqueId: expect.any(Number),
+          uid: expect.any(Number),
         }),
       }),
       expect.any(Number),

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
@@ -57,7 +57,7 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     return {
       dataset: Object.assign(Object.create(null), dataset),
       id: element.id || null,
-      uniqueId,
+      uid: uniqueId,
     };
   }
 

--- a/packages/web-platform/web-core/ts/types/EventType.ts
+++ b/packages/web-platform/web-core/ts/types/EventType.ts
@@ -15,7 +15,7 @@ export interface LynxCrossThreadEventTarget {
     [key: string]: Cloneable;
   };
   id: string | null;
-  uniqueId: number;
+  uid: number;
 }
 
 export interface LynxCrossThreadEvent<


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event target property naming in the `@lynx-js/web-core` package (patch release).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
