### PR TITLE
fix: update rpx unit calculation and support container-based viewport…

### DIFF
--- a/.changeset/red-pears-kiss.md
+++ b/.changeset/red-pears-kiss.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: transformVH not work with cqw unit as the base length

--- a/.changeset/warm-zoos-prove.md
+++ b/.changeset/warm-zoos-prove.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: the default value of rpx is supposed to be 1/750 cqw

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -394,6 +394,7 @@ test.describe('reactlynx3 tests', () => {
       const lynxView = await page.locator('lynx-view');
       await lynxView.evaluate((node) => {
         node.style.width = '50px';
+        node.style.setProperty('--rpx-unit', '1cqw');
       });
       const target = await page.locator('#target');
       await expect(target).toHaveCSS('height', '10px'); // 20cqw, 50 / 100 * 20 = 10px
@@ -406,6 +407,7 @@ test.describe('reactlynx3 tests', () => {
       const lynxView = await page.locator('lynx-view');
       await lynxView.evaluate((node) => {
         node.style.width = '50px';
+        node.style.setProperty('--rpx-unit', '1cqw');
       });
       const target = await page.locator('#target');
       await expect(target).toHaveCSS('height', '10px'); // 20cqw, 50 / 100 * 20 = 10px
@@ -450,7 +452,25 @@ test.describe('reactlynx3 tests', () => {
       await wait(500); // Wait for the reload to rebuild the CSS properly
       await expect(target).not.toHaveCSS('width', '25px');
       await expect(target).not.toHaveCSS('height', '50px');
+
+      // now make sure the cqw/cqh work
+      await lynxView.evaluate((node: any) => {
+        node.transformVW = true;
+        node.transformVH = true;
+        node.style.height = '500px';
+        node.style.weight = '500px';
+        node.style.minHeight = '500px';
+        node.style.minWidth = '500px';
+        node.style.setProperty('--vh-unit', '1cqh');
+        node.style.setProperty('--vw-unit', '1cqw');
+        node.reload();
+      });
+      await wait(500); // Wait for the reload to rebuild the CSS properly
+
+      await expect(target).toHaveCSS('width', '250px');
+      await expect(target).toHaveCSS('height', '250px');
     });
+
     test('basic-image', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -458,7 +458,7 @@ test.describe('reactlynx3 tests', () => {
         node.transformVW = true;
         node.transformVH = true;
         node.style.height = '500px';
-        node.style.weight = '500px';
+        node.style.width = '500px';
         node.style.minHeight = '500px';
         node.style.minWidth = '500px';
         node.style.setProperty('--vh-unit', '1cqh');

--- a/packages/web-platform/web-core/css/index.css
+++ b/packages/web-platform/web-core/css/index.css
@@ -10,10 +10,14 @@ lynx-view {
   width: 100%;
   container-name: lynx-view;
   container-type: inline-size;
-  --rpx-unit: 1cqw;
+  --rpx-unit: calc(1cqw / 7.5);
   --ppx-unit: 1cqw;
-  --vw-unit: 1vw;
-  --vh-unit: 1vh;
+  --vw-unit: 1cqw;
+  --vh-unit: 1cqh;
+}
+
+lynx-view[transform-vh] {
+  container-type: size;
 }
 
 lynx-view[ssr] {
@@ -38,31 +42,6 @@ lynx-view::part(page) {
   --ppx-unit: inherit;
   --vw-unit: inherit;
   --vh-unit: inherit;
-}
-
-@property --rem-unit {
-  syntax: "<length>";
-  inherits: true;
-}
-
-@property --rpx-unit {
-  syntax: "<length>";
-  inherits: true;
-}
-
-@property --ppx-unit {
-  syntax: "<length>";
-  inherits: true;
-}
-
-@property --vw-unit {
-  syntax: "<length>";
-  inherits: true;
-}
-
-@property --vh-unit {
-  syntax: "<length>";
-  inherits: true;
 }
 
 @property --lynx-display {


### PR DESCRIPTION
… units for transformVH

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sizing behavior when using container-based length units so transforms produce correct dimensions.
  * Corrected the default responsive-pixel (rpx) scale.

* **Style**
  * Updated default measurement unit values and container sizing behavior for more consistent layouts.

* **Tests**
  * Strengthened end-to-end tests to validate updated sizing and unit behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
