### PR TITLE
chore: simplify alias test

### DIFF
--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -682,43 +682,56 @@ describe('pluginReactLynx', () => {
 
   it('should handle alias', async () => {
     const config = await rslib.inspectConfig()
-    expect(config.origin.bundlerConfigs[0]!.resolve!.alias)
-      .toMatchInlineSnapshot(`
-        {
-          "@lynx-js/preact-devtools$": false,
-          "@lynx-js/react$": "<ROOT>/packages/react/runtime/lib/index.js",
-          "@lynx-js/react/compat$": "<ROOT>/packages/react/runtime/compat/index.js",
-          "@lynx-js/react/debug$": false,
-          "@lynx-js/react/experimental/lazy/import$": "<ROOT>/packages/react/runtime/lazy/import.js",
-          "@lynx-js/react/internal$": "<ROOT>/packages/react/runtime/lib/internal.js",
-          "@lynx-js/react/jsx-dev-runtime": "<ROOT>/packages/react/runtime/jsx-dev-runtime/index.js",
-          "@lynx-js/react/jsx-runtime": "<ROOT>/packages/react/runtime/jsx-runtime/index.js",
-          "@lynx-js/react/legacy-react-runtime$": "<ROOT>/packages/react/runtime/lib/legacy-react-runtime/index.js",
-          "@lynx-js/react/runtime-components$": "<ROOT>/packages/react/components/lib/index.js",
-          "@lynx-js/react/worklet-runtime/bindings$": "<ROOT>/packages/react/runtime/lib/worklet-runtime/bindings/index.js",
-          "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-          "preact$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/dist/preact.mjs",
-          "preact/compat$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/compat/dist/compat.mjs",
-          "preact/compat/client$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/compat/client.mjs",
-          "preact/compat/jsx-dev-runtime$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/compat/jsx-dev-runtime.mjs",
-          "preact/compat/jsx-runtime$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/compat/jsx-runtime.mjs",
-          "preact/compat/scheduler$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/compat/scheduler.mjs",
-          "preact/compat/server$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/compat/server.mjs",
-          "preact/debug$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/debug/dist/debug.mjs",
-          "preact/devtools$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/devtools/dist/devtools.mjs",
-          "preact/jsx-dev-runtime$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/jsx-runtime/dist/jsxRuntime.mjs",
-          "preact/jsx-runtime$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/jsx-runtime/dist/jsxRuntime.mjs",
-          "preact/test-utils$": "<ROOT>/node_modules/<PNPM_INNER>/@lynx-js/internal-preact/test-utils/dist/testUtils.mjs",
-          "react$": "<ROOT>/packages/react/runtime/lib/index.js",
-          "react-compiler-runtime": "<ROOT>/node_modules/<PNPM_INNER>/react-compiler-runtime",
-          "use-sync-external-store$": "<ROOT>/packages/use-sync-external-store/index.js",
-          "use-sync-external-store/shim$": "<ROOT>/packages/use-sync-external-store/index.js",
-          "use-sync-external-store/shim/with-selector$": "<ROOT>/packages/use-sync-external-store/with-selector.js",
-          "use-sync-external-store/shim/with-selector.js$": "<ROOT>/packages/use-sync-external-store/with-selector.js",
-          "use-sync-external-store/with-selector$": "<ROOT>/packages/use-sync-external-store/with-selector.js",
-          "use-sync-external-store/with-selector.js$": "<ROOT>/packages/use-sync-external-store/with-selector.js",
+    const alias = Object.fromEntries(
+      Object.entries(config.origin.bundlerConfigs[0]!.resolve!.alias!).map((
+        [key, value],
+      ) => {
+        if (typeof value === 'string' && key.startsWith('preact')) {
+          // Simplify the path to only keep the part starting from 'preact/'
+          return [
+            key,
+            value.replaceAll(path.sep, '/').replace(/.*(preact\/.*)/, '$1'),
+          ]
         }
-      `)
+        return [key, value]
+      }),
+    )
+    expect(alias).toMatchInlineSnapshot(`
+      {
+        "@lynx-js/preact-devtools$": false,
+        "@lynx-js/react$": "<ROOT>/packages/react/runtime/lib/index.js",
+        "@lynx-js/react/compat$": "<ROOT>/packages/react/runtime/compat/index.js",
+        "@lynx-js/react/debug$": false,
+        "@lynx-js/react/experimental/lazy/import$": "<ROOT>/packages/react/runtime/lazy/import.js",
+        "@lynx-js/react/internal$": "<ROOT>/packages/react/runtime/lib/internal.js",
+        "@lynx-js/react/jsx-dev-runtime": "<ROOT>/packages/react/runtime/jsx-dev-runtime/index.js",
+        "@lynx-js/react/jsx-runtime": "<ROOT>/packages/react/runtime/jsx-runtime/index.js",
+        "@lynx-js/react/legacy-react-runtime$": "<ROOT>/packages/react/runtime/lib/legacy-react-runtime/index.js",
+        "@lynx-js/react/runtime-components$": "<ROOT>/packages/react/components/lib/index.js",
+        "@lynx-js/react/worklet-runtime/bindings$": "<ROOT>/packages/react/runtime/lib/worklet-runtime/bindings/index.js",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+        "preact$": "preact/dist/preact.mjs",
+        "preact/compat$": "preact/compat/dist/compat.mjs",
+        "preact/compat/client$": "preact/compat/client.mjs",
+        "preact/compat/jsx-dev-runtime$": "preact/compat/jsx-dev-runtime.mjs",
+        "preact/compat/jsx-runtime$": "preact/compat/jsx-runtime.mjs",
+        "preact/compat/scheduler$": "preact/compat/scheduler.mjs",
+        "preact/compat/server$": "preact/compat/server.mjs",
+        "preact/debug$": "preact/debug/dist/debug.mjs",
+        "preact/devtools$": "preact/devtools/dist/devtools.mjs",
+        "preact/jsx-dev-runtime$": "preact/jsx-runtime/dist/jsxRuntime.mjs",
+        "preact/jsx-runtime$": "preact/jsx-runtime/dist/jsxRuntime.mjs",
+        "preact/test-utils$": "preact/test-utils/dist/testUtils.mjs",
+        "react$": "<ROOT>/packages/react/runtime/lib/index.js",
+        "react-compiler-runtime": "<ROOT>/node_modules/<PNPM_INNER>/react-compiler-runtime",
+        "use-sync-external-store$": "<ROOT>/packages/use-sync-external-store/index.js",
+        "use-sync-external-store/shim$": "<ROOT>/packages/use-sync-external-store/index.js",
+        "use-sync-external-store/shim/with-selector$": "<ROOT>/packages/use-sync-external-store/with-selector.js",
+        "use-sync-external-store/shim/with-selector.js$": "<ROOT>/packages/use-sync-external-store/with-selector.js",
+        "use-sync-external-store/with-selector$": "<ROOT>/packages/use-sync-external-store/with-selector.js",
+        "use-sync-external-store/with-selector.js$": "<ROOT>/packages/use-sync-external-store/with-selector.js",
+      }
+    `)
   })
 
   it('should handle macros', () => {

--- a/packages/rspeedy/plugin-react-alias/test/index.test.ts
+++ b/packages/rspeedy/plugin-react-alias/test/index.test.ts
@@ -93,108 +93,33 @@ describe('React - alias', () => {
       '@lynx-js/react/debug$',
     )
 
-    expect(config.resolve.alias).toHaveProperty(
-      'preact$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/dist/preact.mjs'.replaceAll('/', path.sep),
-      ),
+    const preactAlias = Object.fromEntries(
+      Object.entries(config.resolve.alias)
+        .filter(([key]) => key.startsWith('preact'))
+        .map(([key, value]) => [
+          key,
+          typeof value === 'string'
+            ? value.replaceAll(path.sep, '/').replace(/.*(preact\/.*)/, '$1')
+            : value,
+        ]),
     )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/dist/compat.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/debug$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/debug/dist/debug.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/devtools$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/devtools/dist/devtools.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).not.toHaveProperty(
-      'preact/hooks$',
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/test-utils$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/test-utils/dist/testUtils.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/jsx-runtime$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/jsx-runtime/dist/jsxRuntime.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/jsx-dev-runtime$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/jsx-runtime/dist/jsxRuntime.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/client$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/client.mjs'.replaceAll('/', path.sep),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/server$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/server.mjs'.replaceAll('/', path.sep),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/jsx-runtime$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/jsx-runtime.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/jsx-dev-runtime$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/jsx-dev-runtime.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/scheduler$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/scheduler.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
+
+    expect(preactAlias).toMatchInlineSnapshot(`
+      {
+        "preact$": "preact/dist/preact.mjs",
+        "preact/compat$": "preact/compat/dist/compat.mjs",
+        "preact/compat/client$": "preact/compat/client.mjs",
+        "preact/compat/jsx-dev-runtime$": "preact/compat/jsx-dev-runtime.mjs",
+        "preact/compat/jsx-runtime$": "preact/compat/jsx-runtime.mjs",
+        "preact/compat/scheduler$": "preact/compat/scheduler.mjs",
+        "preact/compat/server$": "preact/compat/server.mjs",
+        "preact/debug$": "preact/debug/dist/debug.mjs",
+        "preact/devtools$": "preact/devtools/dist/devtools.mjs",
+        "preact/jsx-dev-runtime$": "preact/jsx-runtime/dist/jsxRuntime.mjs",
+        "preact/jsx-runtime$": "preact/jsx-runtime/dist/jsxRuntime.mjs",
+        "preact/test-utils$": "preact/test-utils/dist/testUtils.mjs",
+      }
+    `)
   })
 
   test('alias with production', async () => {
@@ -353,15 +278,15 @@ describe('React - alias', () => {
         ),
       ),
     )
-    expect(backgroundRule.resolve.alias).toHaveProperty(
-      'preact/hooks',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/hooks/dist/hooks.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
+    const preactHooks = backgroundRule.resolve.alias['preact/hooks']
+    expect(
+      typeof preactHooks === 'string'
+        ? preactHooks.replaceAll(path.sep, '/').replace(
+          /.*(preact\/.*)/,
+          '$1',
+        )
+        : preactHooks,
+    ).toBe('preact/hooks/dist/hooks.mjs')
   })
 
   test.skip('alias once', async () => {

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -111,108 +111,37 @@ describe('Config', () => {
       ),
     )
 
-    expect(config.resolve.alias).toHaveProperty(
-      'preact$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/dist/preact.mjs'.replaceAll('/', path.sep),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/dist/compat.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/debug$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/debug/dist/debug.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/devtools$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/devtools/dist/devtools.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
     expect(config.resolve.alias).not.toHaveProperty(
       'preact/hooks$',
     )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/test-utils$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/test-utils/dist/testUtils.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
+
+    const preactAlias = Object.fromEntries(
+      Object.entries(config.resolve.alias)
+        .filter(([key]) => key.startsWith('preact'))
+        .map(([key, value]) => [
+          key,
+          typeof value === 'string'
+            ? value.replaceAll(path.sep, '/').replace(/.*(preact\/.*)/, '$1')
+            : value,
+        ]),
     )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/jsx-runtime$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/jsx-runtime/dist/jsxRuntime.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/jsx-dev-runtime$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/jsx-runtime/dist/jsxRuntime.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/client$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/client.mjs'.replaceAll('/', path.sep),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/server$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/server.mjs'.replaceAll('/', path.sep),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/jsx-runtime$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/jsx-runtime.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/jsx-dev-runtime$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/jsx-dev-runtime.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
-    expect(config.resolve.alias).toHaveProperty(
-      'preact/compat/scheduler$',
-      expect.stringContaining(
-        '@lynx-js/internal-preact/compat/scheduler.mjs'.replaceAll(
-          '/',
-          path.sep,
-        ),
-      ),
-    )
+
+    expect(preactAlias).toMatchInlineSnapshot(`
+      {
+        "preact$": "preact/dist/preact.mjs",
+        "preact/compat$": "preact/compat/dist/compat.mjs",
+        "preact/compat/client$": "preact/compat/client.mjs",
+        "preact/compat/jsx-dev-runtime$": "preact/compat/jsx-dev-runtime.mjs",
+        "preact/compat/jsx-runtime$": "preact/compat/jsx-runtime.mjs",
+        "preact/compat/scheduler$": "preact/compat/scheduler.mjs",
+        "preact/compat/server$": "preact/compat/server.mjs",
+        "preact/debug$": "preact/debug/dist/debug.mjs",
+        "preact/devtools$": "preact/devtools/dist/devtools.mjs",
+        "preact/jsx-dev-runtime$": "preact/jsx-runtime/dist/jsxRuntime.mjs",
+        "preact/jsx-runtime$": "preact/jsx-runtime/dist/jsxRuntime.mjs",
+        "preact/test-utils$": "preact/test-utils/dist/testUtils.mjs",
+      }
+    `)
     expect(config.resolve.alias).toHaveProperty(
       'use-sync-external-store$',
       expect.stringContaining(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated and simplified tests across multiple packages: replaced many per-key, path-dependent assertions for preact-related aliases with a single normalized snapshot/assertion. Alias values are normalized (path separators unified and environment-specific prefixes removed, extracting the canonical preact/... portion), making expectations platform-independent and less brittle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
