### PR TITLE
fix(docs-mcp-server): resolve package path on Windows startup

### DIFF
--- a/.changeset/pink-items-deliver.md
+++ b/.changeset/pink-items-deliver.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/docs-mcp-server": patch
+---
+
+Fix Windows startup error.

--- a/packages/mcp-servers/docs-mcp-server/main.ts
+++ b/packages/mcp-servers/docs-mcp-server/main.ts
@@ -4,6 +4,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { readFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -37,8 +39,14 @@ import { fetch } from 'undici';
 
 const debug = createDebug('lynx-docs-mcp');
 
-const pkgPath = findPackage.up({ cwd: new URL('.', import.meta.url).pathname });
-const pkg = JSON.parse(await readFile(pkgPath!, 'utf-8')) as {
+const moduleDirPath = dirname(fileURLToPath(import.meta.url));
+const pkgPath = findPackage.up({ cwd: moduleDirPath });
+
+if (!pkgPath) {
+  throw new Error(`Failed to locate package.json from ${moduleDirPath}`);
+}
+
+const pkg = JSON.parse(await readFile(pkgPath, 'utf-8')) as {
   version: string;
   name: string;
   description: string;


### PR DESCRIPTION
## Summary
- Replace file URL pathname usage with `fileURLToPath(import.meta.url)` + `dirname(...)` before package discovery
- Add a guard that throws a clear error when `findPackage.up(...)` cannot resolve `package.json`
- Prevent startup crashes caused by `readFile(undefined, 'utf-8')` on Windows

## Test plan
- [x] Verified code change is minimal and scoped to `packages/mcp-servers/docs-mcp-server/main.ts`
- [x] Build/test in CI (local install blocked by repo engine requirement: Node `^22 || ^24`, current env is Node `v20.19.0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability with clearer error messages when initialization cannot find required configuration, preventing silent failures.
  * Resolved a Windows startup issue that could prevent the service from launching.

* **Chores**
  * Added release metadata for a patch update to deploy the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->