### PR TITLE
feat(et): enable element template transform and bundler pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +639,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "equivalent"
@@ -1092,6 +1110,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "is-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1332,8 @@ dependencies = [
  "ctor",
  "napi-sys",
  "once_cell",
+ "serde",
+ "serde_json",
  "thread_local",
 ]
 
@@ -2066,6 +2098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2379,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
+ "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_quote_macros",
  "swc_ecma_transforms_base",
@@ -3283,6 +3322,7 @@ version = "0.1.0"
 dependencies = [
  "convert_case 0.8.0",
  "hex",
+ "insta",
  "napi",
  "napi-derive",
  "once_cell",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,10 @@
       "lazy": "./runtime/lazy/react.js",
       "default": "./runtime/lib/index.js"
     },
+    "./element-template": {
+      "types": "./runtime/lib/element-template/index.d.ts",
+      "default": "./runtime/lib/element-template/index.js"
+    },
     "./compat": {
       "types": "./runtime/compat/index.d.ts",
       "lazy": "./runtime/lazy/compat.js",
@@ -32,6 +36,10 @@
       "types": "./runtime/lib/internal.d.ts",
       "lazy": "./runtime/lazy/internal.js",
       "default": "./runtime/lib/internal.js"
+    },
+    "./element-template/internal": {
+      "types": "./runtime/lib/element-template/internal.d.ts",
+      "default": "./runtime/lib/element-template/internal.js"
     },
     "./internal/document": {
       "types": "./runtime/lib/document.d.ts",
@@ -128,6 +136,9 @@
       "compat": [
         "./runtime/compat/index.d.ts"
       ],
+      "element-template": [
+        "./runtime/lib/element-template/index.d.ts"
+      ],
       "experimental/lazy/import": [
         "./runtime/lazy/import.d.ts"
       ],
@@ -139,6 +150,9 @@
       ],
       "internal": [
         "./runtime/lib/internal.d.ts"
+      ],
+      "element-template/internal": [
+        "./runtime/lib/element-template/internal.d.ts"
       ],
       "internal/document": [
         "./runtime/lib/document.d.ts"

--- a/packages/react/transform/Cargo.toml
+++ b/packages/react/transform/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 convert_case = { workspace = true }
 hex = { workspace = true }
 indexmap = { workspace = true }
-napi = { workspace = true }
+napi = { workspace = true, features = ["serde-json"] }
 napi-derive = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }

--- a/packages/react/transform/__test__/fixture.spec.js
+++ b/packages/react/transform/__test__/fixture.spec.js
@@ -164,6 +164,34 @@ describe('ui source map', () => {
   });
 });
 
+describe('element template (experimental)', () => {
+  it('should export compiled element templates when enabled', async () => {
+    const result = await transformReactLynx('const node = <view className="foo" />;', {
+      mode: 'test',
+      pluginName: '',
+      filename: 'test.js',
+      sourcemap: false,
+      cssScope: false,
+      snapshot: {
+        preserveJsx: false,
+        runtimePkg: '@lynx-js/react',
+        filename: 'test.js',
+        target: 'LEPUS',
+        experimentalEnableElementTemplate: true,
+      },
+      jsx: true,
+      directiveDCE: false,
+      defineDCE: false,
+      shake: false,
+      compat: true,
+      worklet: false,
+      refresh: false,
+    });
+
+    expect(result.elementTemplates?.length).toBeGreaterThan(0);
+  });
+});
+
 describe('jsx', () => {
   it('should allow JSXNamespace', async () => {
     const result = await transformReactLynx('const jsx = <Foo main-thread:foo={foo} />', {

--- a/packages/react/transform/crates/swc_plugin_snapshot/Cargo.toml
+++ b/packages/react/transform/crates/swc_plugin_snapshot/Cargo.toml
@@ -19,8 +19,11 @@ regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 sha-1 = { workspace = true }
-swc_core = { workspace = true, features = ["ecma_parser", "ecma_utils", "ecma_quote", "ecma_visit", "testing_transform", "ecma_transforms_react"] }
+swc_core = { workspace = true, features = ["base", "ecma_codegen", "ecma_parser", "ecma_minifier", "ecma_transforms_typescript", "ecma_utils", "ecma_quote", "ecma_transforms_react", "ecma_transforms_optimization", "__visit", "__testing_transform"] }
 swc_plugins_shared = { path = "../swc_plugins_shared" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(swc_ast_unknown)'] }
+
+[dev-dependencies]
+insta = { version = "1.34", features = ["json"] }

--- a/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
@@ -2,7 +2,6 @@ use serde::Deserialize;
 use std::{
   cell::RefCell,
   collections::{HashMap, HashSet},
-  rc::Rc,
 };
 
 use once_cell::sync::Lazy;
@@ -17,13 +16,33 @@ use swc_core::{
   ecma::{
     ast::{JSXExpr, *},
     utils::{is_literal, prepend_stmt, private_ident},
-    visit::{VisitMut, VisitMutWith},
+    visit::{Visit, VisitMut, VisitMutWith, VisitWith},
   },
   quote, quote_expr,
 };
 
 mod attr_name;
 mod slot_marker;
+
+use serde::Serialize;
+use std::rc::Rc;
+
+#[derive(Serialize, Debug, Clone)]
+pub struct ElementTemplateAsset {
+  pub template_id: String,
+  pub compiled_template: serde_json::Value,
+  pub source_file: String,
+}
+
+const BUILTIN_RAW_TEXT_TEMPLATE_ID: &str = "__et_builtin_raw_text__";
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct UISourceMapRecord {
+  pub ui_source_map: i32,
+  pub line_number: u32,
+  pub column_number: u32,
+  pub snapshot_id: String,
+}
 
 #[cfg(feature = "napi")]
 pub mod napi;
@@ -106,19 +125,119 @@ static NO_FLATTEN_ATTRIBUTES: Lazy<HashSet<String>> = Lazy::new(|| {
   ])
 });
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct UISourceMapRecord {
-  pub ui_source_map: i32,
-  pub line_number: u32,
-  pub column_number: u32,
-  pub snapshot_id: String,
+struct DeferredListItemDetector {
+  found: bool,
+}
+
+fn jsx_element_name_matches(name: &JSXElementName, expected: &str) -> bool {
+  match name {
+    JSXElementName::Ident(ident) => ident.sym == *expected,
+    JSXElementName::JSXMemberExpr(member) => member.prop.sym == *expected,
+    _ => false,
+  }
+}
+
+fn jsx_attr_is_truthy(value: &Option<JSXAttrValue>) -> bool {
+  match value {
+    None => true,
+    Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+      expr: JSXExpr::Expr(expr),
+      ..
+    })) => match &**expr {
+      Expr::Lit(Lit::Bool(bool_value)) => bool_value.value,
+      _ => true,
+    },
+    Some(JSXAttrValue::Str(_)) => true,
+    _ => true,
+  }
+}
+
+fn element_template_attributes_contain_spread(value: Option<&serde_json::Value>) -> bool {
+  value
+    .and_then(serde_json::Value::as_array)
+    .map(|attrs| {
+      attrs
+        .iter()
+        .any(|attr| attr.get("kind").and_then(serde_json::Value::as_str) == Some("spread"))
+    })
+    .unwrap_or(false)
+}
+
+fn jsx_list_root_has_unsupported_et_runtime_attrs(n: &JSXElement) -> bool {
+  n.opening.attrs.iter().any(|attr_or_spread| {
+    if matches!(attr_or_spread, JSXAttrOrSpread::SpreadElement(_)) {
+      return true;
+    }
+
+    let JSXAttrOrSpread::JSXAttr(attr) = attr_or_spread else {
+      return false;
+    };
+
+    let attr_name = match &attr.name {
+      JSXAttrName::Ident(name) => AttrName::from(name.sym.as_ref().to_string()),
+      JSXAttrName::JSXNamespacedName(JSXNamespacedName { ns, name, .. }) => {
+        AttrName::from_ns(ns.clone().into(), name.clone().into())
+      }
+    };
+
+    matches!(
+      attr_name,
+      AttrName::Event(..)
+        | AttrName::WorkletEvent(..)
+        | AttrName::Ref
+        | AttrName::WorkletRef(..)
+        | AttrName::Gesture(..)
+    )
+  })
+}
+
+fn jsx_is_deferred_list_item(n: &JSXElement) -> bool {
+  if jsx_element_name_matches(&n.opening.name, "DeferredListItem") {
+    return true;
+  }
+
+  if !jsx_is_list_item(n) {
+    return false;
+  }
+
+  n.opening.attrs.iter().any(|attr| {
+    let JSXAttrOrSpread::JSXAttr(attr) = attr else {
+      return false;
+    };
+    let JSXAttrName::Ident(name) = &attr.name else {
+      return false;
+    };
+
+    name.sym == "defer" && jsx_attr_is_truthy(&attr.value)
+  })
+}
+
+impl Visit for DeferredListItemDetector {
+  fn visit_jsx_element(&mut self, n: &JSXElement) {
+    if self.found {
+      return;
+    }
+
+    if jsx_is_deferred_list_item(n) {
+      self.found = true;
+      return;
+    }
+
+    n.visit_children_with(self);
+  }
+}
+
+fn jsx_contains_deferred_list_item(n: &JSXElement) -> bool {
+  let mut detector = DeferredListItemDetector { found: false };
+  n.visit_with(&mut detector);
+  detector.found
 }
 
 #[derive(Debug)]
 pub enum DynamicPart {
   Attr(Expr, i32, AttrName),
   Spread(Expr, i32),
-  Slot(JSXElement, i32),
+  Slot(Vec<JSXElementChild>, i32),
   Children(Expr, i32),
   ListChildren(Expr, i32),
 }
@@ -139,6 +258,90 @@ fn bool_jsx_attr(value: bool) -> JSXAttrValue {
       value,
     })))),
   })
+}
+
+fn wrap_in_slot(slot_ident: &Ident, id: i32, children: Vec<JSXElementChild>) -> JSXElementChild {
+  let children_expr = jsx_children_to_expr(children);
+  JSXElementChild::JSXExprContainer(JSXExprContainer {
+    span: DUMMY_SP,
+    expr: JSXExpr::Expr(Box::new(quote!(
+      "$slot_ident($id, $children_expr)" as Expr,
+      slot_ident: Ident = slot_ident.clone(),
+      id: Expr = i32_to_expr(&id),
+      children_expr: Expr = children_expr,
+    ))),
+  })
+}
+
+fn expr_to_jsx_child(expr: Expr) -> JSXElementChild {
+  match expr {
+    Expr::JSXElement(jsx) => JSXElementChild::JSXElement(jsx),
+    _ => JSXElementChild::JSXExprContainer(JSXExprContainer {
+      span: DUMMY_SP,
+      expr: JSXExpr::Expr(Box::new(expr)),
+    }),
+  }
+}
+
+fn unwrap_et_slot_expr(expr: &Expr, slot_ident: &Ident) -> Option<(usize, Expr)> {
+  let Expr::Call(call_expr) = expr else {
+    return None;
+  };
+  let Callee::Expr(callee) = &call_expr.callee else {
+    return None;
+  };
+  let Expr::Ident(ident) = &**callee else {
+    return None;
+  };
+  if ident.sym != slot_ident.sym && ident.sym.as_ref() != "__etSlot" {
+    return None;
+  }
+  if call_expr.args.len() != 2 {
+    return None;
+  }
+
+  let slot_id = match &*call_expr.args[0].expr {
+    Expr::Lit(Lit::Num(Number { value, .. })) if *value >= 0.0 => *value as usize,
+    _ => return None,
+  };
+
+  Some((slot_id, *call_expr.args[1].expr.clone()))
+}
+
+fn build_et_slot_array_expr(entries: Vec<(usize, Expr)>) -> Expr {
+  let mut slots: Vec<Option<ExprOrSpread>> = vec![];
+
+  for (slot_id, child_expr) in entries {
+    if slots.len() <= slot_id {
+      slots.resize(slot_id + 1, None);
+    }
+    slots[slot_id] = Some(ExprOrSpread {
+      spread: None,
+      expr: Box::new(child_expr),
+    });
+  }
+
+  Expr::Array(ArrayLit {
+    span: DUMMY_SP,
+    elems: slots,
+  })
+}
+
+fn lower_lepus_et_children_expr(expr: Expr, slot_ident: &Ident) -> Option<Expr> {
+  let slot_entries = match expr {
+    Expr::Call(_) => vec![unwrap_et_slot_expr(&expr, slot_ident)?],
+    Expr::Array(array) => array
+      .elems
+      .iter()
+      .map(|elem| {
+        let elem = elem.as_ref()?;
+        unwrap_et_slot_expr(&elem.expr, slot_ident)
+      })
+      .collect::<Option<Vec<_>>>()?,
+    _ => return None,
+  };
+
+  Some(build_et_slot_array_expr(slot_entries))
 }
 
 impl DynamicPart {
@@ -271,6 +474,9 @@ where
   dynamic_parts: Vec<DynamicPart>,
   dynamic_part_visitor: &'a mut V,
   key: Option<JSXAttrValue>,
+  attr_slot_counter: i32,
+  element_slot_counter: i32,
+  enable_element_template: bool,
   enable_ui_source_map: bool,
   node_index_fn: F,
 }
@@ -284,6 +490,7 @@ where
     runtime_id: Expr,
     dynamic_part_count: i32,
     dynamic_part_visitor: &'a mut V,
+    enable_element_template: bool,
     enable_ui_source_map: bool,
     node_index_fn: F,
   ) -> Self {
@@ -300,6 +507,9 @@ where
       dynamic_parts: vec![],
       dynamic_part_visitor,
       key: None,
+      attr_slot_counter: 0,
+      element_slot_counter: 0,
+      enable_element_template,
       enable_ui_source_map,
       node_index_fn,
     }
@@ -319,43 +529,44 @@ where
     })
   }
 
-  fn static_stmt_from_create_call(
-    &self,
-    element: Ident,
-    callee: &str,
-    mut args: Vec<Expr>,
-    span: Span,
-  ) -> Stmt {
-    if self.enable_ui_source_map {
-      args.push(self.node_index_config_expr(span));
-    }
+  fn next_attr_slot_index(&mut self) -> i32 {
+    let idx = self.attr_slot_counter;
+    self.attr_slot_counter += 1;
+    idx
+  }
 
-    Stmt::Decl(Decl::Var(Box::new(VarDecl {
-      ctxt: SyntaxContext::default(),
-      span: DUMMY_SP,
-      kind: VarDeclKind::Const,
-      declare: false,
-      decls: vec![VarDeclarator {
-        span: DUMMY_SP,
-        definite: false,
-        name: Pat::Ident(element.into()),
-        init: Some(Box::new(Expr::Call(CallExpr {
-          ctxt: SyntaxContext::default(),
-          span: DUMMY_SP,
-          callee: Callee::Expr(Box::new(Expr::Ident(
-            IdentName::new(callee.into(), DUMMY_SP).into(),
-          ))),
-          args: args
-            .into_iter()
-            .map(|expr| ExprOrSpread {
-              spread: None,
-              expr: Box::new(expr),
-            })
-            .collect(),
-          type_args: None,
-        }))),
-      }],
-    })))
+  fn next_element_slot_index(&mut self) -> i32 {
+    let idx = self.element_slot_counter;
+    self.element_slot_counter += 1;
+    idx
+  }
+
+  fn push_dynamic_attr(&mut self, value: Expr, attr_name: AttrName) {
+    let index = if self.enable_element_template {
+      self.next_attr_slot_index()
+    } else {
+      self.element_index
+    };
+    self
+      .dynamic_parts
+      .push(DynamicPart::Attr(value, index, attr_name));
+  }
+
+  fn push_dynamic_spread(&mut self, value: Expr) {
+    let index = if self.enable_element_template {
+      self.next_attr_slot_index()
+    } else {
+      self.element_index
+    };
+    self.dynamic_parts.push(DynamicPart::Spread(value, index));
+  }
+
+  fn next_children_slot_index(&mut self) -> i32 {
+    if self.enable_element_template {
+      self.next_element_slot_index()
+    } else {
+      self.element_index
+    }
   }
 
   fn static_stmt_from_jsx_element(&mut self, n: &JSXElement, el: Ident) -> Stmt {
@@ -365,43 +576,38 @@ where
       let tag = str.value.to_string_lossy();
       match tag.as_ref() {
         "view" => {
-          static_stmt = self.static_stmt_from_create_call(
-            el.clone(),
-            "__CreateView",
-            vec![Expr::Ident(self.page_id.clone())],
-            n.opening.span,
+          static_stmt = quote!(
+            r#"const $element = __CreateView($page_id)"# as Stmt,
+            element = el.clone(),
+            page_id = self.page_id.clone(),
           );
         }
         "scroll-view" => {
-          static_stmt = self.static_stmt_from_create_call(
-            el.clone(),
-            "__CreateScrollView",
-            vec![Expr::Ident(self.page_id.clone())],
-            n.opening.span,
+          static_stmt = quote!(
+            r#"const $element = __CreateScrollView($page_id)"# as Stmt,
+            element = el.clone(),
+            page_id = self.page_id.clone(),
           );
         }
         "x-scroll-view" => {
-          static_stmt = self.static_stmt_from_create_call(
-            el.clone(),
-            "__CreateScrollView",
-            vec![Expr::Ident(self.page_id.clone())],
-            n.opening.span,
+          static_stmt = quote!(
+            r#"const $element = __CreateScrollView($page_id, { tag: "x-scroll-view" })"# as Stmt,
+            element = el.clone(),
+            page_id = self.page_id.clone(),
           );
         }
         "image" => {
-          static_stmt = self.static_stmt_from_create_call(
-            el.clone(),
-            "__CreateImage",
-            vec![Expr::Ident(self.page_id.clone())],
-            n.opening.span,
+          static_stmt = quote!(
+            r#"const $element = __CreateImage($page_id)"# as Stmt,
+            element = el.clone(),
+            page_id = self.page_id.clone(),
           );
         }
         "text" => {
-          static_stmt = self.static_stmt_from_create_call(
-            el.clone(),
-            "__CreateText",
-            vec![Expr::Ident(self.page_id.clone())],
-            n.opening.span,
+          static_stmt = quote!(
+            r#"const $element = __CreateText($page_id)"# as Stmt,
+            element = el.clone(),
+            page_id = self.page_id.clone(),
           );
         }
         "wrapper" => {
@@ -423,22 +629,35 @@ where
           );
         }
         "frame" => {
-          static_stmt = self.static_stmt_from_create_call(
-            el.clone(),
-            "__CreateFrame",
-            vec![Expr::Ident(self.page_id.clone())],
-            n.opening.span,
+          static_stmt = quote!(
+            r#"const $element = __CreateFrame($page_id)"# as Stmt,
+            element = el.clone(),
+            page_id = self.page_id.clone(),
           );
         }
         _ => {
-          static_stmt = self.static_stmt_from_create_call(
-            el.clone(),
-            "__CreateElement",
-            vec![Expr::Lit(Lit::Str(str)), Expr::Ident(self.page_id.clone())],
-            n.opening.span,
+          static_stmt = quote!(
+              r#"const $element = __CreateElement($name, $page_id)"# as Stmt,
+              element = el.clone(),
+              name: Expr = Expr::Lit(Lit::Str(str)),
+              page_id = self.page_id.clone(),
           );
         }
       };
+    }
+
+    if self.enable_ui_source_map {
+      let node_index_expr = self.node_index_config_expr(n.span);
+      if let Stmt::Decl(Decl::Var(var_decl)) = &mut static_stmt {
+        if let Some(VarDeclarator { init: Some(init), .. }) = var_decl.decls.get_mut(0) {
+          if let Expr::Call(call_expr) = init.as_mut() {
+            call_expr.args.push(ExprOrSpread {
+              spread: None,
+              expr: Box::new(node_index_expr),
+            });
+          }
+        }
+      }
     }
 
     static_stmt
@@ -452,16 +671,42 @@ where
 {
   fn visit_mut_jsx_element(&mut self, n: &mut JSXElement) {
     if jsx_is_internal_slot(n) {
-      if self.dynamic_part_count > 1 {
+      if self.dynamic_part_count > 1 || self.enable_element_template {
         n.visit_mut_children_with(self.dynamic_part_visitor);
-        self.dynamic_parts.push(DynamicPart::Slot(
-          jsx_unwrap_internal_slot(n.take()),
-          self.element_index,
-        ));
+        let id = self.next_children_slot_index();
+
+        if self.enable_element_template {
+          let wrapper = jsx_unwrap_internal_slot(n.take());
+          let children = wrapper.children;
+          if !children.is_empty() {
+            self.dynamic_parts.push(DynamicPart::Slot(children, id));
+          }
+        } else {
+          self.dynamic_parts.push(DynamicPart::Slot(
+            vec![JSXElementChild::JSXElement(Box::new(
+              jsx_unwrap_internal_slot(n.take()),
+            ))],
+            id,
+          ));
+        }
         *n = WRAPPER_NODE_2.clone();
       } else {
         *n = jsx_unwrap_internal_slot(n.take());
       }
+    }
+
+    if self.enable_element_template && self.parent_element.is_some() && jsx_is_list(n) {
+      n.visit_mut_with(self.dynamic_part_visitor);
+
+      let element_slot_index = self.next_children_slot_index();
+      self.dynamic_parts.push(DynamicPart::Children(
+        Expr::JSXElement(Box::new(n.take())),
+        element_slot_index,
+      ));
+
+      *n = WRAPPER_NODE.clone();
+      n.visit_mut_with(self);
+      return;
     }
 
     if !jsx_is_custom(n) {
@@ -523,8 +768,6 @@ where
         .any(|attr_or_spread| match attr_or_spread {
           JSXAttrOrSpread::SpreadElement(_) => true,
           JSXAttrOrSpread::JSXAttr(_) => false,
-          #[cfg(swc_ast_unknown)]
-          _ => panic!("unknown node"),
         });
 
       if jsx_is_list_item(n) {
@@ -555,14 +798,12 @@ where
               JSXAttrOrSpread::SpreadElement(_spread) => {
                 return false;
               }
-              #[cfg(swc_ast_unknown)]
-              _ => panic!("unknown node"),
             }
 
             true
           });
           if !list_item_platform_info.is_empty() {
-            self.dynamic_parts.push(DynamicPart::Attr(
+            self.push_dynamic_attr(
               Expr::Object(ObjectLit {
                 span: DUMMY_SP,
                 props: list_item_platform_info
@@ -570,9 +811,8 @@ where
                   .map(jsx_attr_to_prop)
                   .collect(),
               }),
-              self.element_index,
               AttrName::ListItemPlatformInfo,
-            ));
+            );
           }
         }
       }
@@ -593,11 +833,7 @@ where
               _ => true,
             },
             JSXAttrName::JSXNamespacedName(_) => true,
-            #[cfg(swc_ast_unknown)]
-            _ => panic!("unknown node"),
           },
-          #[cfg(swc_ast_unknown)]
-          _ => panic!("unknown node"),
         });
 
       if has_spread_element {
@@ -610,10 +846,7 @@ where
           })
           .into(),
         );
-        self.dynamic_parts.push(DynamicPart::Spread(
-          Expr::Object(spread_obj),
-          self.element_index,
-        ));
+        self.push_dynamic_spread(Expr::Object(spread_obj));
       } else {
         let el = Expr::Ident(el.clone());
 
@@ -666,11 +899,7 @@ where
                               self.static_stmts.push(RefCell::new(stmt));
                             }
                             _ => {
-                              self.dynamic_parts.push(DynamicPart::Attr(
-                                *expr.clone(),
-                                self.element_index,
-                                attr_name.clone(),
-                              ));
+                              self.push_dynamic_attr(*expr.clone(), attr_name.clone());
                             }
                           }
                         }
@@ -680,8 +909,6 @@ where
                         })) => {}
                         Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
                         Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unknown node"),
                       };
                     }
                     AttrName::Dataset(name) => {
@@ -709,11 +936,7 @@ where
                           expr: JSXExpr::Expr(expr),
                           ..
                         })) => {
-                          self.dynamic_parts.push(DynamicPart::Attr(
-                            *expr.clone(),
-                            self.element_index,
-                            attr_name.clone(),
-                          ));
+                          self.push_dynamic_attr(*expr.clone(), attr_name.clone());
                         }
                         Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
                           expr: JSXExpr::JSXEmptyExpr(_),
@@ -721,76 +944,82 @@ where
                         })) => {}
                         Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
                         Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unknown node"),
                       };
                     }
                     AttrName::Event(..) | AttrName::Ref => {
-                      self.dynamic_parts.push(DynamicPart::Attr(
-                        *jsx_attr_value((*value).clone()),
-                        self.element_index,
-                        attr_name.clone(),
-                      ));
+                      self.push_dynamic_attr(*jsx_attr_value((*value).clone()), attr_name.clone());
                     }
                     AttrName::TimingFlag => {
-                      self.dynamic_parts.push(DynamicPart::Attr(
+                      self.push_dynamic_attr(
                         *quote_expr!("{__ltf: $flag}", flag: Expr = *jsx_attr_value((*value).clone())),
-                        self.element_index,
                         attr_name.clone(),
-                      ));
+                      );
                     }
                     AttrName::Style => {
-                      match value {
-                        None => {}
-                        Some(JSXAttrValue::Str(s)) => {
-                          // <view style="width: 100rpx" />;
-                          let value = transform_jsx_attr_str(&s.value);
+                      let mut static_style_val = None;
+                      if let Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                        expr: JSXExpr::Expr(expr),
+                        span,
+                        ..
+                      })) = value
+                      {
+                        let expr = &**expr;
+                        if is_literal(expr) {
+                          if let Some(s) = get_string_inline_style_from_literal(expr, span) {
+                            static_style_val = Some((s, *span));
+                          }
+                        }
+                      }
+
+                      if let Some((s_val, span)) = static_style_val {
+                        if self.enable_element_template {
+                          *value = Some(JSXAttrValue::Str(Str {
+                            span,
+                            value: s_val.into(),
+                            raw: None,
+                          }));
+                        } else {
+                          // <view style={{backgroundColor: "red"}} />;
+                          // <view style={`background-color: red;`} />;
+                          let s = Lit::Str(Str {
+                            span,
+                            value: s_val.into(),
+                            raw: None,
+                          });
                           let stmt = quote!(
-                              r#"__SetInlineStyles($element, $value)"# as Stmt,
-                              element: Expr = el.clone(),
-                              value: Expr = Expr::Lit(Lit::Str(Str { span: s.span, value: value.into(), raw: None }))
+                            r#"__SetInlineStyles($element, $value)"# as Stmt,
+                            element: Expr = el.clone(),
+                            value: Expr = Expr::Lit(s)
                           );
                           self.static_stmts.push(RefCell::new(stmt));
                         }
-                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
-                          expr: JSXExpr::Expr(expr),
-                          span,
-                          ..
-                        })) => {
-                          let expr = &**expr;
-                          if is_literal(expr) {
-                            if let Some(s) = get_string_inline_style_from_literal(expr, span) {
-                              // <view style={{backgroundColor: "red"}} />;
-                              // <view style={`background-color: red;`} />;
-                              let s = Lit::Str(Str {
-                                span: *span,
-                                value: s.into(),
-                                raw: None,
-                              });
-                              let stmt = quote!(
+                      } else {
+                        match value {
+                          None => {}
+                          Some(JSXAttrValue::Str(s)) => {
+                            // <view style="width: 100rpx" />;
+                            let value = transform_jsx_attr_str(&s.value);
+                            let stmt = quote!(
                                 r#"__SetInlineStyles($element, $value)"# as Stmt,
                                 element: Expr = el.clone(),
-                                value: Expr = Expr::Lit(s)
-                              );
-                              self.static_stmts.push(RefCell::new(stmt));
-                            }
-                          } else {
-                            self.dynamic_parts.push(DynamicPart::Attr(
-                              expr.clone(),
-                              self.element_index,
-                              attr_name.clone(),
-                            ));
+                                value: Expr = Expr::Lit(Lit::Str(Str { span: s.span, value: value.into(), raw: None }))
+                            );
+                            self.static_stmts.push(RefCell::new(stmt));
                           }
+                          Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                            expr: JSXExpr::Expr(expr),
+                            ..
+                          })) => {
+                            self.push_dynamic_attr(*expr.clone(), attr_name.clone());
+                          }
+                          Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                            expr: JSXExpr::JSXEmptyExpr(_),
+                            ..
+                          })) => {}
+                          Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
+                          Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
                         }
-                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
-                          expr: JSXExpr::JSXEmptyExpr(_),
-                          ..
-                        })) => {}
-                        Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
-                        Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unknown node"),
-                      };
+                      }
                     }
                     AttrName::Class => {
                       match value {
@@ -817,11 +1046,7 @@ where
                             self.static_stmts.push(RefCell::new(stmt));
                           }
                           _ => {
-                            self.dynamic_parts.push(DynamicPart::Attr(
-                              *expr.clone(),
-                              self.element_index,
-                              attr_name.clone(),
-                            ));
+                            self.push_dynamic_attr(*expr.clone(), attr_name.clone());
                           }
                         },
                         Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
@@ -830,8 +1055,6 @@ where
                         })) => {}
                         Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
                         Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unknown node"),
                       };
                     }
                     AttrName::ID => {
@@ -850,11 +1073,7 @@ where
                           expr: JSXExpr::Expr(expr),
                           ..
                         })) => {
-                          self.dynamic_parts.push(DynamicPart::Attr(
-                            *expr.clone(),
-                            self.element_index,
-                            attr_name,
-                          ));
+                          self.push_dynamic_attr(*expr.clone(), attr_name);
                         }
                         Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
                           expr: JSXExpr::JSXEmptyExpr(_),
@@ -862,8 +1081,6 @@ where
                         })) => {}
                         Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
                         Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unknown node"),
                       };
                     }
                     AttrName::ListItemPlatformInfo => unreachable!("Unexpected ListItemPlatformInfo attribute in static JSX processing"),
@@ -879,28 +1096,16 @@ where
                   let attr_name: AttrName = AttrName::from_ns(ns.clone().into(), name.clone().into());
                   match attr_name {
                     AttrName::WorkletEvent(..) | AttrName::WorkletRef(..) => {
-                      self.dynamic_parts.push(DynamicPart::Attr(
-                        *jsx_attr_value((*value).clone()),
-                        self.element_index,
-                        attr_name.clone(),
-                      ));
+                      self.push_dynamic_attr(*jsx_attr_value((*value).clone()), attr_name.clone());
                     }
                     AttrName::Gesture(..) => {
-                      self.dynamic_parts.push(DynamicPart::Attr(
-                        *jsx_attr_value((*value).clone()),
-                        self.element_index,
-                        attr_name.clone(),
-                      ));
+                      self.push_dynamic_attr(*jsx_attr_value((*value).clone()), attr_name.clone());
                     }
                     _ => todo!(),
                   }
                 }
-                #[cfg(swc_ast_unknown)]
-                _ => panic!("unknown node"),
               };
             }
-            #[cfg(swc_ast_unknown)]
-            _ => panic!("unknown node"),
           });
       }
 
@@ -954,14 +1159,21 @@ where
         if self.dynamic_part_count <= 1 {
           n.visit_mut_children_with(self.dynamic_part_visitor);
           let children_expr = jsx_children_to_expr(n.children.take());
+          let element_slot_index = self.next_children_slot_index();
           if is_list {
+            if self.enable_element_template {
+              n.children = vec![JSXElementChild::JSXExprContainer(JSXExprContainer {
+                span: DUMMY_SP,
+                expr: JSXExpr::Expr(Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP })))),
+              })];
+            }
             self
               .dynamic_parts
-              .push(DynamicPart::ListChildren(children_expr, self.element_index));
+              .push(DynamicPart::ListChildren(children_expr, element_slot_index));
           } else {
             self
               .dynamic_parts
-              .push(DynamicPart::Children(children_expr, self.element_index));
+              .push(DynamicPart::Children(children_expr, element_slot_index));
           }
         } else {
           // static_stmt.replace_with(|_| {
@@ -1042,9 +1254,10 @@ where
       n.visit_mut_children_with(self.dynamic_part_visitor);
 
       if self.parent_element.is_some() {
+        let element_slot_index = self.next_children_slot_index();
         self.dynamic_parts.push(DynamicPart::Children(
           Expr::JSXElement(Box::new(n.take())),
-          self.element_index,
+          element_slot_index,
         ));
 
         // self.element_index += 1;
@@ -1066,6 +1279,21 @@ where
           element = el.clone(),
           t: Expr = t.into(),
       )));
+
+      if self.enable_ui_source_map {
+        let node_index_expr = self.node_index_config_expr(n.span);
+        let stmt = self.static_stmts.last_mut().expect("raw text create stmt exists");
+        if let Stmt::Decl(Decl::Var(var_decl)) = stmt.get_mut() {
+          if let Some(VarDeclarator { init: Some(init), .. }) = var_decl.decls.get_mut(0) {
+            if let Expr::Call(call_expr) = init.as_mut() {
+              call_expr.args.push(ExprOrSpread {
+                spread: None,
+                expr: Box::new(node_index_expr),
+              });
+            }
+          }
+        }
+      }
 
       if let Some(parent_el) = &self.parent_element {
         self.static_stmts.push(RefCell::new(quote!(
@@ -1099,6 +1327,8 @@ pub struct JSXTransformerConfig {
   pub enable_ui_source_map: bool,
   /// @internal
   pub is_dynamic_component: Option<bool>,
+  /// @internal
+  pub experimental_enable_element_template: bool,
 }
 
 impl Default for JSXTransformerConfig {
@@ -1111,6 +1341,7 @@ impl Default for JSXTransformerConfig {
       target: TransformTarget::LEPUS,
       enable_ui_source_map: false,
       is_dynamic_component: Some(false),
+      experimental_enable_element_template: false,
     }
   }
 }
@@ -1122,15 +1353,19 @@ where
   // react_transformer: Box<dyn Fold>,
   cfg: JSXTransformerConfig,
   filename_hash: String,
-  content_hash: String,
+  pub content_hash: String,
   runtime_id: Lazy<Expr>,
   runtime_components_ident: Ident,
   runtime_components_module_item: Option<ModuleItem>,
   css_id_value: Option<Expr>,
+  has_explicit_css_id: bool,
+  pub element_templates: Option<Rc<RefCell<Vec<ElementTemplateAsset>>>>,
   snapshot_counter: u32,
   current_snapshot_defs: Vec<ModuleItem>,
   current_snapshot_id: Option<Ident>,
   comments: Option<C>,
+  slot_ident: Ident,
+  used_slot: bool,
   pub ui_source_map_records: Rc<RefCell<Vec<UISourceMapRecord>>>,
   pub source_map: Option<Lrc<SourceMap>>,
 }
@@ -1149,6 +1384,7 @@ where
     comments: Option<C>,
     mode: TransformMode,
     source_map: Option<Lrc<SourceMap>>,
+    element_templates: Option<Rc<RefCell<Vec<ElementTemplateAsset>>>>,
   ) -> Self {
     JSXTransformer {
       filename_hash: calc_hash(&cfg.filename.clone()),
@@ -1164,12 +1400,16 @@ where
       },
       runtime_components_ident: private_ident!("ReactLynxRuntimeComponents"),
       runtime_components_module_item: None,
+      element_templates,
       cfg,
       css_id_value: None,
+      has_explicit_css_id: false,
       snapshot_counter: 0,
       current_snapshot_defs: vec![],
       current_snapshot_id: None,
       comments,
+      slot_ident: private_ident!("__etSlot"),
+      used_slot: false,
       ui_source_map_records: Rc::new(RefCell::new(vec![])),
       source_map,
     }
@@ -1206,12 +1446,396 @@ where
                     .expect("should have numeric cssId")
                     .into(),
                 )));
+                self.has_explicit_css_id = true;
               }
             }
           }
         }
       }
     });
+  }
+
+  fn builtin_raw_text_template_asset(&self) -> ElementTemplateAsset {
+    ElementTemplateAsset {
+      template_id: BUILTIN_RAW_TEXT_TEMPLATE_ID.to_string(),
+      compiled_template: serde_json::json!({
+        "kind": "element",
+        "tag": "raw-text",
+        "attributesArray": [
+          {
+            "kind": "attribute",
+            "key": "text",
+            "binding": "slot",
+            "attrSlotIndex": 0,
+          }
+        ],
+        "children": [],
+      }),
+      source_file: self.cfg.filename.clone(),
+    }
+  }
+
+  fn ensure_builtin_element_templates(&self) {
+    let Some(element_templates) = &self.element_templates else {
+      return;
+    };
+
+    let mut templates = element_templates.borrow_mut();
+    if templates.is_empty() {
+      return;
+    }
+
+    if templates
+      .iter()
+      .any(|template| template.template_id == BUILTIN_RAW_TEXT_TEMPLATE_ID)
+    {
+      return;
+    }
+
+    templates.push(self.builtin_raw_text_template_asset());
+  }
+
+  fn element_template_to_json(&self, expr: &Expr) -> serde_json::Value {
+    match expr {
+      Expr::Lit(lit) => match lit {
+        Lit::Str(s) => serde_json::Value::String(s.value.as_str().unwrap_or("").to_string()),
+        Lit::Num(n) => serde_json::Value::Number(serde_json::Number::from_f64(n.value).unwrap()),
+        Lit::Bool(b) => serde_json::Value::Bool(b.value),
+        Lit::Null(_) => serde_json::Value::Null,
+        _ => serde_json::Value::Null,
+      },
+      Expr::Array(arr) => {
+        let elems: Vec<serde_json::Value> = arr
+          .elems
+          .iter()
+          .map(|elem| {
+            if let Some(elem) = elem {
+              self.element_template_to_json(&elem.expr)
+            } else {
+              serde_json::Value::Null
+            }
+          })
+          .collect();
+        serde_json::Value::Array(elems)
+      }
+      Expr::Object(obj) => {
+        let mut map = serde_json::Map::new();
+        for prop in &obj.props {
+          if let PropOrSpread::Prop(prop) = prop {
+            if let Prop::KeyValue(kv) = &**prop {
+              let key;
+              if let PropName::Ident(ident) = &kv.key {
+                key = ident.sym.as_str().to_string();
+              } else if let PropName::Str(s) = &kv.key {
+                key = s.value.as_str().unwrap_or("").to_string();
+              } else {
+                continue;
+              };
+              let value = self.element_template_to_json(&kv.value);
+              map.insert(key, value);
+            }
+          }
+        }
+        serde_json::Value::Object(map)
+      }
+      _ => serde_json::Value::Null,
+    }
+  }
+
+  fn element_template_string_expr(&self, value: &str) -> Expr {
+    Expr::Lit(Lit::Str(Str {
+      span: DUMMY_SP,
+      raw: None,
+      value: value.into(),
+    }))
+  }
+
+  fn element_template_array_expr(&self, items: Vec<Expr>) -> Expr {
+    Expr::Array(ArrayLit {
+      span: DUMMY_SP,
+      elems: items
+        .into_iter()
+        .map(|expr| {
+          Some(ExprOrSpread {
+            spread: None,
+            expr: Box::new(expr),
+          })
+        })
+        .collect(),
+    })
+  }
+
+  fn element_template_static_attribute_descriptor(&self, key: &str, value: Expr) -> Expr {
+    quote!(
+      r#"{ kind: "attribute", key: $key, binding: "static", value: $value }"# as Expr,
+      key: Expr = self.element_template_string_expr(key),
+      value: Expr = value,
+    )
+  }
+
+  fn element_template_attribute_slot_descriptor(&self, key: &str, attr_slot_index: i32) -> Expr {
+    quote!(
+      r#"{ kind: "attribute", key: $key, binding: "slot", attrSlotIndex: $attr_slot_index }"# as Expr,
+      key: Expr = self.element_template_string_expr(key),
+      attr_slot_index: Expr = i32_to_expr(&attr_slot_index),
+    )
+  }
+
+  fn element_template_spread_slot_descriptor(&self, attr_slot_index: i32) -> Expr {
+    quote!(
+      r#"{ kind: "spread", binding: "slot", attrSlotIndex: $attr_slot_index }"# as Expr,
+      attr_slot_index: Expr = i32_to_expr(&attr_slot_index),
+    )
+  }
+
+  fn element_template_element_slot(&self, element_slot_index: i32) -> Expr {
+    quote!(
+      r#"{ kind: "elementSlot", tag: "slot", elementSlotIndex: $element_slot_index }"# as Expr,
+      element_slot_index: Expr = i32_to_expr(&element_slot_index),
+    )
+  }
+
+  fn element_template_element_node(
+    &self,
+    tag: &str,
+    attributes: Vec<Expr>,
+    children: Vec<Expr>,
+  ) -> Expr {
+    quote!(
+      r#"{ kind: "element", tag: $tag, attributesArray: $attributes, children: $children }"# as Expr,
+      tag: Expr = self.element_template_string_expr(tag),
+      attributes: Expr = self.element_template_array_expr(attributes),
+      children: Expr = self.element_template_array_expr(children),
+    )
+  }
+
+  fn element_template_attribute_key<'a>(&self, key: &'a str) -> &'a str {
+    if key == "className" {
+      "class"
+    } else {
+      key
+    }
+  }
+
+  fn element_template_json_to_expr(&self, value: &serde_json::Value) -> Expr {
+    match value {
+      serde_json::Value::Null => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+      serde_json::Value::Bool(value) => Expr::Lit(Lit::Bool(Bool {
+        span: DUMMY_SP,
+        value: *value,
+      })),
+      serde_json::Value::Number(value) => Expr::Lit(Lit::Num(Number {
+        span: DUMMY_SP,
+        value: value.as_f64().unwrap_or_default(),
+        raw: None,
+      })),
+      serde_json::Value::String(value) => self.element_template_string_expr(value),
+      serde_json::Value::Array(items) => self.element_template_array_expr(
+        items
+          .iter()
+          .map(|item| self.element_template_json_to_expr(item))
+          .collect(),
+      ),
+      serde_json::Value::Object(items) => Expr::Object(ObjectLit {
+        span: DUMMY_SP,
+        props: items
+          .iter()
+          .map(|(key, value)| {
+            PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+              key: PropName::Ident(IdentName::new(key.clone().into(), DUMMY_SP)),
+              value: Box::new(self.element_template_json_to_expr(value)),
+            })))
+          })
+          .collect(),
+      }),
+    }
+  }
+
+  fn element_template_from_jsx_children(
+    &self,
+    children: &[JSXElementChild],
+    attr_slot_index: &mut i32,
+    element_slot_index: &mut i32,
+  ) -> Vec<Expr> {
+    let mut out: Vec<Expr> = vec![];
+
+    for child in children {
+      match child {
+        JSXElementChild::JSXText(txt) => {
+          let s = jsx_text_to_str(&txt.value);
+          if s.trim().is_empty() {
+            continue;
+          }
+
+          out.push(self.element_template_element_node(
+            "raw-text",
+            vec![self.element_template_static_attribute_descriptor(
+              "text",
+              self.element_template_string_expr(s.as_ref()),
+            )],
+            vec![],
+          ));
+        }
+        JSXElementChild::JSXElement(el) => {
+          out.push(self.element_template_from_jsx_element_impl(
+            el,
+            attr_slot_index,
+            element_slot_index,
+            false,
+          ));
+        }
+        JSXElementChild::JSXFragment(frag) => {
+          out.extend(self.element_template_from_jsx_children(
+            &frag.children,
+            attr_slot_index,
+            element_slot_index,
+          ));
+        }
+        JSXElementChild::JSXExprContainer(JSXExprContainer {
+          expr: JSXExpr::Expr(_),
+          ..
+        }) => {
+          let idx = *element_slot_index;
+          *element_slot_index += 1;
+          out.push(self.element_template_element_slot(idx));
+        }
+        JSXElementChild::JSXExprContainer(JSXExprContainer {
+          expr: JSXExpr::JSXEmptyExpr(_),
+          ..
+        }) => {}
+        JSXElementChild::JSXSpreadChild(_) => {
+          let idx = *element_slot_index;
+          *element_slot_index += 1;
+          out.push(self.element_template_element_slot(idx));
+        }
+      }
+    }
+
+    out
+  }
+
+  fn element_template_from_jsx_element(
+    &self,
+    n: &JSXElement,
+    attr_slot_index: &mut i32,
+    element_slot_index: &mut i32,
+  ) -> Expr {
+    self.element_template_from_jsx_element_impl(n, attr_slot_index, element_slot_index, true)
+  }
+
+  fn element_template_from_jsx_element_impl(
+    &self,
+    n: &JSXElement,
+    attr_slot_index: &mut i32,
+    element_slot_index: &mut i32,
+    inject_root_metadata: bool,
+  ) -> Expr {
+    let tag_expr = jsx_name(n.opening.name.clone());
+    let tag_value = match *tag_expr {
+      Expr::Lit(Lit::Str(s)) => s.value,
+      _ => "".into(),
+    };
+
+    if tag_value == "wrapper" {
+      let idx = *element_slot_index;
+      *element_slot_index += 1;
+      return self.element_template_element_slot(idx);
+    }
+
+    let mut attribute_descriptors: Vec<Expr> = vec![];
+
+    for attr in &n.opening.attrs {
+      match attr {
+        JSXAttrOrSpread::JSXAttr(attr) => {
+          let JSXAttrName::Ident(name) = &attr.name else {
+            continue;
+          };
+
+          let key = self.element_template_attribute_key(name.sym.as_ref());
+
+          if name.sym == "__lynx_part_id" {
+            continue;
+          }
+
+          let Some(value) = &attr.value else {
+            continue;
+          };
+
+          let static_value = match value {
+            JSXAttrValue::Str(s) => Some(Expr::Lit(Lit::Str(s.clone()))),
+            JSXAttrValue::JSXExprContainer(JSXExprContainer {
+              expr: JSXExpr::Expr(expr),
+              ..
+            }) => match &**expr {
+              Expr::Lit(Lit::Str(s)) => Some(Expr::Lit(Lit::Str(s.clone()))),
+              Expr::Lit(Lit::Num(n)) => Some(Expr::Lit(Lit::Num(n.clone()))),
+              Expr::Lit(Lit::Bool(b)) => Some(Expr::Lit(Lit::Bool(*b))),
+              Expr::Lit(Lit::Null(n)) => Some(Expr::Lit(Lit::Null(n.clone()))),
+              // TODO: Support complex static values (Object, Array, Template Literal without expressions)
+              // See ElementTemplate/Todo-StaticAttributesOpts.md
+              _ => None,
+            },
+            _ => None,
+          };
+
+          if let Some(static_value) = static_value {
+            attribute_descriptors
+              .push(self.element_template_static_attribute_descriptor(key, static_value));
+          } else {
+            let idx = *attr_slot_index;
+            *attr_slot_index += 1;
+            attribute_descriptors.push(self.element_template_attribute_slot_descriptor(key, idx));
+          }
+        }
+        JSXAttrOrSpread::SpreadElement(_) => {
+          let idx = *attr_slot_index;
+          *attr_slot_index += 1;
+          attribute_descriptors.push(self.element_template_spread_slot_descriptor(idx));
+        }
+      }
+    }
+
+    let _ = inject_root_metadata;
+
+    // Optimization for text tags:
+    // If <text> (or similar) has only one static text child, use `text` attribute instead of checking children.
+    let is_text_tag = tag_value == "text"
+      || tag_value == "raw-text"
+      || tag_value == "inline-text"
+      || tag_value == "x-text"
+      || tag_value == "x-inline-text";
+    let mut text_child_optimized = false;
+
+    if is_text_tag {
+      let valid_children: Vec<&JSXElementChild> = n
+        .children
+        .iter()
+        .filter(|c| match c {
+          JSXElementChild::JSXText(t) => !jsx_text_to_str(&t.value).trim().is_empty(),
+          _ => true,
+        })
+        .collect();
+
+      if valid_children.len() == 1 {
+        if let JSXElementChild::JSXText(txt) = valid_children[0] {
+          let s = jsx_text_to_str(&txt.value);
+          attribute_descriptors.push(self.element_template_static_attribute_descriptor(
+            "text",
+            self.element_template_string_expr(s.as_ref()),
+          ));
+          text_child_optimized = true;
+        }
+      }
+    }
+
+    let children = if text_child_optimized {
+      vec![]
+    } else {
+      self.element_template_from_jsx_children(&n.children, attr_slot_index, element_slot_index)
+    };
+
+    let final_tag = tag_value.to_string_lossy().to_string();
+    self.element_template_element_node(&final_tag, attribute_descriptors, children)
   }
 }
 
@@ -1273,9 +1897,23 @@ where
 
     self.snapshot_counter += 1;
 
+    let use_element_template = self.cfg.experimental_enable_element_template;
+    let is_list_root = matches!(
+      *jsx_name(node.opening.name.clone()),
+      Expr::Lit(Lit::Str(ref s)) if s.value.to_string_lossy().as_ref() == "list"
+    );
+    let list_can_use_et_runtime = use_element_template
+      && is_list_root
+      && !jsx_contains_deferred_list_item(node)
+      && !jsx_list_root_has_unsupported_et_runtime_attrs(node);
+    let snapshot_uid_prefix = if use_element_template {
+      "_et"
+    } else {
+      "__snapshot"
+    };
     let snapshot_uid = format!(
-      "__snapshot_{}_{}_{}",
-      self.filename_hash, self.content_hash, self.snapshot_counter
+      "{}_{}_{}_{}",
+      snapshot_uid_prefix, self.filename_hash, self.content_hash, self.snapshot_counter
     );
     let snapshot_id = Ident::new(
       // format!("__snapshot_{}", snapshot_uid).into(),
@@ -1287,11 +1925,13 @@ where
     let mut wrap_dynamic_part = WrapperMarker {
       current_is_children_full_dynamic: false,
       dynamic_part_count: 0,
+      enable_element_template: self.cfg.experimental_enable_element_template,
     };
     node.visit_mut_with(&mut wrap_dynamic_part);
 
     let target = self.cfg.target;
     let runtime_id = self.runtime_id.clone();
+    let experimental_enable_element_template = self.cfg.experimental_enable_element_template;
     let filename_hash = self.filename_hash.clone();
     let content_hash = self.content_hash.clone();
     let ui_source_map_records = self.ui_source_map_records.clone();
@@ -1301,7 +1941,6 @@ where
       let ui_source_map =
         calc_hash_number(&format!("{}:{}:{}", filename_hash, content_hash, span.lo.0));
 
-      // record ui source map entry
       let mut line_number = 0;
       let mut column_number = 0;
       if span.lo.0 > 0 {
@@ -1311,6 +1950,7 @@ where
           column_number = loc.col.0 as u32 + 1;
         }
       }
+
       ui_source_map_records.borrow_mut().push(UISourceMapRecord {
         ui_source_map,
         line_number,
@@ -1324,42 +1964,51 @@ where
         raw: None,
       }))
     };
+    let (key, snapshot_creator_func, (dynamic_part_attr, dynamic_part_children)): (
+      Option<JSXAttrValue>,
+      Option<Function>,
+      (Vec<_>, Vec<_>),
+    ) = {
+      let mut dynamic_part_extractor = DynamicPartExtractor::new(
+        self.runtime_id.clone(),
+        wrap_dynamic_part.dynamic_part_count,
+        self,
+        experimental_enable_element_template,
+        self.cfg.enable_ui_source_map,
+        node_index_fn,
+      );
 
-    let mut dynamic_part_extractor = DynamicPartExtractor::new(
-      self.runtime_id.clone(),
-      wrap_dynamic_part.dynamic_part_count,
-      self,
-      self.cfg.enable_ui_source_map,
-      node_index_fn,
-    );
+      node.visit_mut_with(&mut dynamic_part_extractor);
 
-    node.visit_mut_with(&mut dynamic_part_extractor);
+      (
+        dynamic_part_extractor.key,
+        dynamic_part_extractor.snapshot_creator,
+        dynamic_part_extractor.dynamic_parts.into_iter().partition(
+          |dynamic_part| match dynamic_part {
+            DynamicPart::Attr(_, _, _) | DynamicPart::Spread(_, _) => true,
+            DynamicPart::Slot(_, _)
+            | DynamicPart::Children(_, _)
+            | DynamicPart::ListChildren(_, _) => false,
+          },
+        ),
+      )
+    };
 
-    let mut snapshot_values: Vec<Option<ExprOrSpread>> = vec![];
-    let mut snapshot_values_has_attr = false;
-    let mut snapshot_attrs: Vec<JSXAttrOrSpread> = vec![];
     let mut snapshot_children: Vec<JSXElementChild> = vec![];
     let mut snapshot_dynamic_part_def: Vec<Option<ExprOrSpread>> = vec![];
     let mut snapshot_refs_and_spread_index: Vec<Option<ExprOrSpread>> = vec![];
     let mut snapshot_slot_def: Vec<Option<ExprOrSpread>> = vec![];
+    let mut snapshot_values: Vec<Option<ExprOrSpread>> = vec![];
+    let mut snapshot_attrs: Vec<JSXAttrOrSpread> = vec![];
+    let mut snapshot_values_has_attr = false;
 
-    if let Some(key) = dynamic_part_extractor.key {
+    if let Some(key) = key {
       snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
         span: DUMMY_SP,
         name: JSXAttrName::Ident(IdentName::new("key".into(), DUMMY_SP)),
         value: Some(key),
       }));
     }
-
-    let (dynamic_part_attr, dynamic_part_children): (Vec<_>, Vec<_>) = dynamic_part_extractor
-      .dynamic_parts
-      .into_iter()
-      .partition(|dynamic_part| match dynamic_part {
-        DynamicPart::Attr(_, _, _) | DynamicPart::Spread(_, _) => true,
-        DynamicPart::Slot(_, _) | DynamicPart::Children(_, _) | DynamicPart::ListChildren(_, _) => {
-          false
-        }
-      });
 
     dynamic_part_attr
       .into_iter()
@@ -1419,11 +2068,10 @@ where
             DynamicPart::ListChildren(_, _) => {}
           }
 
-          match dynamic_part {
-            DynamicPart::Attr(value, _, attr_name) => {
-              snapshot_values.push(Some(ExprOrSpread {
-                spread: None,
-                expr: Box::new(if let AttrName::Event(_, _) = attr_name {
+          if experimental_enable_element_template {
+            match dynamic_part {
+              DynamicPart::Attr(value, _, attr_name) => {
+                let slot_value = if let AttrName::Event(_, _) = attr_name {
                   if target == TransformTarget::LEPUS {
                     quote!("1" as Expr)
                   } else {
@@ -1441,44 +2089,60 @@ where
                   }
                 } else {
                   value
-                }),
-              }));
-              snapshot_values_has_attr = true;
-              // snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
-              //   span: DUMMY_SP,
-              //   name,
-              //   value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
-              //     span: DUMMY_SP,
-              //     expr: JSXExpr::Expr(Box::new(if let AttrName::Event(_, _) = attr_name {
-              //       if target == TransformTarget::LEPUS {
-              //         Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))
-              //       } else {
-              //         value
-              //       }
-              //     } else {
-              //       value
-              //     })),
-              //   })),
-              // }));
+                };
+                snapshot_values.push(Some(ExprOrSpread {
+                  spread: None,
+                  expr: Box::new(slot_value),
+                }));
+                snapshot_values_has_attr = true;
+              }
+              DynamicPart::Spread(value, _) => {
+                snapshot_values.push(Some(ExprOrSpread {
+                  spread: None,
+                  expr: Box::new(value),
+                }));
+                snapshot_values_has_attr = true;
+              }
+              _ => {}
             }
-            DynamicPart::Spread(value, _) => {
-              snapshot_values.push(Some(ExprOrSpread {
-                spread: None,
-                expr: Box::new(value),
-              }));
-              snapshot_values_has_attr = true;
-              // snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
-              //   span: DUMMY_SP,
-              //   name,
-              //   value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
-              //     span: DUMMY_SP,
-              //     expr: JSXExpr::Expr(Box::new(value)),
-              //   })),
-              // }));
+          } else {
+            match dynamic_part {
+              DynamicPart::Attr(value, _, attr_name) => {
+                snapshot_values.push(Some(ExprOrSpread {
+                  spread: None,
+                  expr: Box::new(if let AttrName::Event(_, _) = attr_name {
+                    if target == TransformTarget::LEPUS {
+                      quote!("1" as Expr)
+                    } else {
+                      value
+                    }
+                  } else if let AttrName::Ref = attr_name {
+                    if target == TransformTarget::LEPUS {
+                      quote!("1" as Expr)
+                    } else {
+                      quote!(
+                        "$runtime_id.transformRef($value)" as Expr,
+                        runtime_id: Expr = runtime_id.clone(),
+                        value: Expr = value,
+                      )
+                    }
+                  } else {
+                    value
+                  }),
+                }));
+                snapshot_values_has_attr = true;
+              }
+              DynamicPart::Spread(value, _) => {
+                snapshot_values.push(Some(ExprOrSpread {
+                  spread: None,
+                  expr: Box::new(value),
+                }));
+                snapshot_values_has_attr = true;
+              }
+              DynamicPart::ListChildren(_, _) => {}
+              DynamicPart::Children(_, _) => {}
+              DynamicPart::Slot(_, _) => {}
             }
-            DynamicPart::ListChildren(_, _) => {}
-            DynamicPart::Children(_, _) => {}
-            DynamicPart::Slot(_, _) => {}
           }
         },
       );
@@ -1486,13 +2150,14 @@ where
     let slot_expr = match (dynamic_part_children.len(), dynamic_part_children.first()) {
       (0, _) => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
       (1, Some(DynamicPart::Children(expr, 0))) => {
-        let expr = expr.clone();
-        snapshot_children.push(match expr {
-          Expr::JSXElement(jsx) => JSXElementChild::JSXElement(jsx),
-          _ => JSXElementChild::JSXExprContainer(JSXExprContainer {
-            span: DUMMY_SP,
-            expr: JSXExpr::Expr(Box::new(expr)),
-          }),
+        let child = expr_to_jsx_child(expr.clone());
+        snapshot_children.push(if use_element_template {
+          if target != TransformTarget::LEPUS {
+            self.used_slot = true;
+          }
+          wrap_in_slot(&self.slot_ident, 0, vec![child])
+        } else {
+          child
         });
 
         quote!(
@@ -1507,12 +2172,14 @@ where
             DynamicPart::Spread(_, _) => {}
             DynamicPart::ListChildren(expr, element_index) => {
               // snapshot_values.push(None);
-              snapshot_children.push(match expr {
-                Expr::JSXElement(jsx) => JSXElementChild::JSXElement(jsx),
-                _ => JSXElementChild::JSXExprContainer(JSXExprContainer {
-                  span: DUMMY_SP,
-                  expr: JSXExpr::Expr(Box::new(expr)),
-                }),
+              let child = expr_to_jsx_child(expr);
+              snapshot_children.push(if use_element_template {
+                if target != TransformTarget::LEPUS {
+                  self.used_slot = true;
+                }
+                wrap_in_slot(&self.slot_ident, element_index, vec![child])
+              } else {
+                child
               });
               snapshot_slot_def.push(Some(ExprOrSpread {
                 spread: None,
@@ -1525,12 +2192,14 @@ where
             }
             DynamicPart::Children(expr, element_index) => {
               // snapshot_values.push(None);
-              snapshot_children.push(match expr {
-                Expr::JSXElement(jsx) => JSXElementChild::JSXElement(jsx),
-                _ => JSXElementChild::JSXExprContainer(JSXExprContainer {
-                  span: DUMMY_SP,
-                  expr: JSXExpr::Expr(Box::new(expr)),
-                }),
+              let child = expr_to_jsx_child(expr);
+              snapshot_children.push(if use_element_template {
+                if target != TransformTarget::LEPUS {
+                  self.used_slot = true;
+                }
+                wrap_in_slot(&self.slot_ident, element_index, vec![child])
+              } else {
+                child
               });
               snapshot_slot_def.push(Some(ExprOrSpread {
                 spread: None,
@@ -1541,9 +2210,16 @@ where
                 )),
               }));
             }
-            DynamicPart::Slot(jsx, element_index) => {
+            DynamicPart::Slot(children, element_index) => {
               // snapshot_values.push(None);
-              snapshot_children.push(JSXElementChild::JSXElement(Box::new(jsx)));
+              if use_element_template {
+                if target != TransformTarget::LEPUS {
+                  self.used_slot = true;
+                }
+                snapshot_children.push(wrap_in_slot(&self.slot_ident, element_index, children));
+              } else {
+                snapshot_children.extend(children);
+              }
               snapshot_slot_def.push(Some(ExprOrSpread {
                 spread: None,
                 expr: Box::new(quote!(
@@ -1568,7 +2244,7 @@ where
     } else {
       Expr::Fn(FnExpr {
         ident: None,
-        function: Box::new(dynamic_part_extractor.snapshot_creator.unwrap()),
+        function: Box::new(snapshot_creator_func.unwrap()),
       })
     };
 
@@ -1614,15 +2290,113 @@ where
         snapshot_id = snapshot_id.clone(),
         entry_snapshot_uid: Expr = entry_snapshot_uid.clone(),
     ));
-    let snapshot_def = ModuleItem::Stmt(quote!(
-        r#"$snapshot_create_call"#
-            as Stmt,
-        snapshot_create_call: Expr = snapshot_create_call,
-    ));
-
     self.current_snapshot_id = Some(snapshot_id.clone());
     self.current_snapshot_defs.push(entry_snapshot_uid_def);
-    self.current_snapshot_defs.push(snapshot_def);
+
+    if use_element_template {
+      let mut attr_slot_index: i32 = 0;
+      let mut element_slot_index: i32 = 0;
+      let template_expr =
+        self.element_template_from_jsx_element(node, &mut attr_slot_index, &mut element_slot_index);
+      let compiled_template = self.element_template_to_json(&template_expr);
+
+      let mut option_props: Vec<PropOrSpread> = vec![];
+      if self.has_explicit_css_id {
+        if let Some(css_id_expr) = &self.css_id_value {
+          option_props.push(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+            key: PropName::Ident(IdentName::new("cssId".into(), DUMMY_SP)),
+            value: Box::new(css_id_expr.clone()),
+          }))));
+        }
+      }
+      if matches!(self.cfg.is_dynamic_component, Some(true)) {
+        option_props.push(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+          key: PropName::Ident(IdentName::new("entryName".into(), DUMMY_SP)),
+          value: Box::new(quote!("globDynamicComponentEntry" as Expr)),
+        }))));
+      }
+      let list_can_use_et_runtime = list_can_use_et_runtime
+        && !element_template_attributes_contain_spread(compiled_template.get("attributesArray"));
+      if list_can_use_et_runtime {
+        option_props.push(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+          key: PropName::Ident(IdentName::new("__elementTemplateList".into(), DUMMY_SP)),
+          value: Box::new(Expr::Lit(Lit::Bool(Bool {
+            span: DUMMY_SP,
+            value: true,
+          }))),
+        }))));
+        if let Some(attributes_expr) = compiled_template.get("attributesArray") {
+          option_props.push(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+            key: PropName::Ident(IdentName::new(
+              "__elementTemplateAttributes".into(),
+              DUMMY_SP,
+            )),
+            value: Box::new(self.element_template_json_to_expr(attributes_expr)),
+          }))));
+        }
+      }
+      if !option_props.is_empty() {
+        snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
+          span: DUMMY_SP,
+          name: JSXAttrName::Ident(IdentName::new("options".into(), DUMMY_SP)),
+          value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+            span: DUMMY_SP,
+            expr: JSXExpr::Expr(Box::new(Expr::Object(ObjectLit {
+              span: DUMMY_SP,
+              props: option_props,
+            }))),
+          })),
+        }));
+      }
+
+      let suffix = snapshot_uid
+        .strip_prefix("_et_")
+        .unwrap_or(snapshot_uid.as_str());
+
+      if let Some(element_templates) = &self.element_templates {
+        element_templates.borrow_mut().push(ElementTemplateAsset {
+          template_id: format!("_et_{suffix}"),
+          compiled_template,
+          source_file: self.cfg.filename.clone(),
+        });
+      }
+    } else {
+      let snapshot_def = ModuleItem::Stmt(quote!(
+          r#"$snapshot_create_call"#
+              as Stmt,
+          snapshot_create_call: Expr = snapshot_create_call,
+      ));
+      self.current_snapshot_defs.push(snapshot_def);
+    }
+
+    let inline_children_attr = if self.cfg.experimental_enable_element_template
+      && target == TransformTarget::LEPUS
+      && !snapshot_children.is_empty()
+    {
+      let children_expr = jsx_children_to_expr(snapshot_children.clone());
+      // LEPUS ET host nodes rely on children being lowered to slot arrays.
+      // Failing fast here keeps the transform/runtime contract explicit instead
+      // of silently emitting a shape the main-thread runtime no longer accepts.
+      let lowered_children_expr = lower_lepus_et_children_expr(children_expr.clone(), &self.slot_ident)
+        .expect("LEPUS ET children should already be lowered to slot arrays");
+      Some(JSXAttrOrSpread::JSXAttr(JSXAttr {
+        span: DUMMY_SP,
+        name: JSXAttrName::Ident(IdentName::new("children".into(), DUMMY_SP)),
+        value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(lowered_children_expr)),
+        })),
+      }))
+    } else {
+      None
+    };
+
+    let rendered_children = if inline_children_attr.is_some() {
+      vec![]
+    } else {
+      snapshot_children
+    };
+    let rendered_children_is_empty = rendered_children.is_empty();
 
     *node = JSXElement {
       span: node.span(),
@@ -1631,25 +2405,42 @@ where
         span: node.span,
         attrs: {
           if snapshot_values_has_attr {
-            snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
-              span: DUMMY_SP,
-              name: JSXAttrName::Ident(IdentName::new("values".into(), DUMMY_SP)),
-              value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+            if self.cfg.experimental_enable_element_template {
+              snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
                 span: DUMMY_SP,
-                expr: JSXExpr::Expr(Box::new(Expr::Array(ArrayLit {
+                name: JSXAttrName::Ident(IdentName::new("attributeSlots".into(), DUMMY_SP)),
+                value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
                   span: DUMMY_SP,
-                  elems: snapshot_values,
-                }))),
-              })),
-            }))
+                  expr: JSXExpr::Expr(Box::new(Expr::Array(ArrayLit {
+                    span: DUMMY_SP,
+                    elems: snapshot_values,
+                  }))),
+                })),
+              }));
+            } else {
+              snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
+                span: DUMMY_SP,
+                name: JSXAttrName::Ident(IdentName::new("values".into(), DUMMY_SP)),
+                value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                  span: DUMMY_SP,
+                  expr: JSXExpr::Expr(Box::new(Expr::Array(ArrayLit {
+                    span: DUMMY_SP,
+                    elems: snapshot_values,
+                  }))),
+                })),
+              }))
+            }
           };
+          if let Some(children_attr) = inline_children_attr {
+            snapshot_attrs.push(children_attr);
+          }
           snapshot_attrs
         },
-        self_closing: wrap_dynamic_part.dynamic_part_count == 0,
+        self_closing: rendered_children_is_empty,
         type_args: None,
       },
-      children: snapshot_children,
-      closing: if wrap_dynamic_part.dynamic_part_count == 0 {
+      children: rendered_children,
+      closing: if rendered_children_is_empty {
         None
       } else {
         Some(JSXClosingElement {
@@ -1661,11 +2452,11 @@ where
   }
 
   fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
-    let mut new_items: Vec<ModuleItem> = Vec::with_capacity(n.len());
-    for mut item in n.take() {
+    let mut new_items: Vec<ModuleItem> = vec![];
+    for item in n.iter_mut() {
       item.visit_mut_with(self);
       new_items.extend(self.current_snapshot_defs.take());
-      new_items.push(item);
+      new_items.push(item.take());
     }
 
     if let Some(module_item) = &self.runtime_components_module_item {
@@ -1682,34 +2473,61 @@ where
       self.parse_directives(span);
     }
 
-    if self.css_id_value.is_none() && matches!(self.cfg.is_dynamic_component, Some(true)) {
+    if matches!(self.cfg.is_dynamic_component, Some(true)) && self.css_id_value.is_none() {
       self.css_id_value = Some(Expr::Lit(Lit::Num(0.into())));
     }
 
     n.visit_mut_children_with(self);
-
-    if let Expr::Ident(runtime_id) = &*self.runtime_id {
-      if self.snapshot_counter > 0 {
-        prepend_stmt(
-          &mut n.body,
-          ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+    if self.cfg.experimental_enable_element_template {
+      self.ensure_builtin_element_templates();
+    }
+    if let Some(Expr::Ident(runtime_id)) = Lazy::<Expr>::get(&self.runtime_id) {
+      prepend_stmt(
+        &mut n.body,
+        ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+          span: DUMMY_SP,
+          specifiers: vec![ImportSpecifier::Namespace(ImportStarAsSpecifier {
             span: DUMMY_SP,
-            specifiers: vec![ImportSpecifier::Namespace(ImportStarAsSpecifier {
-              span: DUMMY_SP,
-              local: runtime_id.clone(),
-            })],
-            src: Box::new(Str {
-              span: DUMMY_SP,
-              raw: None,
-              value: self.cfg.runtime_pkg.clone().into(),
-            }),
-            type_only: Default::default(),
-            // asserts: Default::default(),
-            with: Default::default(),
-            phase: ImportPhase::Evaluation,
-          })),
-        );
-      }
+            local: runtime_id.clone(),
+          })],
+          src: Box::new(Str {
+            span: DUMMY_SP,
+            raw: None,
+            value: self.cfg.runtime_pkg.clone().into(),
+          }),
+          type_only: Default::default(),
+          // asserts: Default::default(),
+          with: Default::default(),
+          phase: ImportPhase::Evaluation,
+        })),
+      );
+    }
+
+    if self.cfg.experimental_enable_element_template && self.used_slot {
+      prepend_stmt(
+        &mut n.body,
+        ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+          span: DUMMY_SP,
+          specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
+            span: DUMMY_SP,
+            local: self.slot_ident.clone(),
+            imported: Some(ModuleExportName::Ident(Ident::new(
+              "__etSlot".into(),
+              DUMMY_SP,
+              SyntaxContext::default(),
+            ))),
+            is_type_only: false,
+          })],
+          src: Box::new(Str {
+            span: DUMMY_SP,
+            raw: None,
+            value: self.cfg.runtime_pkg.clone().into(),
+          }),
+          type_only: Default::default(),
+          with: Default::default(),
+          phase: ImportPhase::Evaluation,
+        })),
+      );
     }
   }
 }
@@ -1757,12 +2575,12 @@ mod tests {
         visit_mut_pass(JSXTransformer::new(
           super::JSXTransformerConfig {
             preserve_jsx: true,
-            enable_ui_source_map: true,
             ..Default::default()
           },
           Some(t.comments.clone()),
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
       )
     },
@@ -1791,12 +2609,12 @@ mod tests {
         visit_mut_pass(JSXTransformer::new(
           super::JSXTransformerConfig {
             preserve_jsx: true,
-            enable_ui_source_map: true,
             ..Default::default()
           },
           Some(t.comments.clone()),
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
       )
     },
@@ -1825,12 +2643,12 @@ mod tests {
         visit_mut_pass(JSXTransformer::new(
           super::JSXTransformerConfig {
             preserve_jsx: true,
-            enable_ui_source_map: true,
             ..Default::default()
           },
           Some(t.comments.clone()),
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
       )
     },
@@ -1865,7 +2683,8 @@ mod tests {
           },
           Some(t.comments.clone()),
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
       )
     },
@@ -1902,7 +2721,8 @@ mod tests {
           },
           Some(t.comments.clone()),
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
       )
     },
@@ -1935,7 +2755,8 @@ mod tests {
           },
           Some(t.comments.clone()),
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
       )
     },
@@ -1963,7 +2784,8 @@ mod tests {
           },
           Some(t.comments.clone()),
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
       )
     },
@@ -1992,7 +2814,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     basic_component,
     // Input codes
@@ -2016,7 +2838,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     page_component,
     // Input codes
@@ -2043,7 +2865,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Development,
-      Some(t.cm.clone()),
+      None
     )),
     page_element_dev,
     // Input codes
@@ -2070,7 +2892,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     page_element,
     // Input codes
@@ -2097,7 +2919,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     basic_component_with_static_sibling,
     // Input codes
@@ -2126,7 +2948,8 @@ mod tests {
           },
           None,
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
         react::react::<&SingleThreadedComments>(
           t.cm.clone(),
@@ -2174,7 +2997,8 @@ mod tests {
           },
           None,
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
         react::react::<&SingleThreadedComments>(
           t.cm.clone(),
@@ -2218,7 +3042,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     basic_expr_container,
     // Input codes
@@ -2242,7 +3066,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     basic_expr_container_with_static_sibling,
     // Input codes
@@ -2267,7 +3091,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_inject_implicit_flatten,
     // Input codes
@@ -2302,7 +3126,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     basic_list,
     // Input codes
@@ -2329,7 +3153,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     basic_list_with_fragment,
     // Input codes
@@ -2366,6 +3190,7 @@ mod tests {
           None,
           TransformMode::Test,
           None,
+          None,
         )),
       )
     },
@@ -2392,7 +3217,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_static_extract_inline_style,
     // Input codes
@@ -2424,7 +3249,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_static_extract_dynamic_inline_style,
     // Input codes
@@ -2449,7 +3274,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_extract_css_id_without_css_id,
     // Input codes
@@ -2474,7 +3299,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_extract_css_id,
     // Input codes
@@ -2503,7 +3328,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_extract_css_id_dynamic_component,
     // Input codes
@@ -2532,7 +3357,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_extract_css_id_dynamic_component_without_css_id,
     // Input codes
@@ -2561,7 +3386,8 @@ mod tests {
           },
           None,
           TransformMode::Test,
-          Some(t.cm.clone()),
+          None,
+          None,
         )),
         react::react::<&SingleThreadedComments>(
           t.cm.clone(),
@@ -2606,6 +3432,7 @@ mod tests {
         None,
         TransformMode::Test,
         None,
+        None,
       ))
     },
     inline_style_literal,
@@ -2631,6 +3458,7 @@ mod tests {
         None,
         TransformMode::Test,
         None,
+        None,
       ))
     },
     inline_style_literal_unknown_property,
@@ -2655,6 +3483,7 @@ mod tests {
         },
         None,
         TransformMode::Test,
+        None,
         None,
       ))
     },
@@ -2709,7 +3538,7 @@ mod tests {
           },
           None,
           TransformMode::Development,
-          Some(t.cm.clone()),
+          None,
         )),
         react::react::<&SingleThreadedComments>(
           t.cm.clone(),
@@ -2762,7 +3591,7 @@ mod tests {
           },
           None,
           TransformMode::Development,
-          Some(t.cm.clone()),
+          None,
         )),
         react::react::<&SingleThreadedComments>(
           t.cm.clone(),
@@ -2817,7 +3646,7 @@ mod tests {
           },
           None,
           TransformMode::Development,
-          Some(t.cm.clone()),
+          None,
         )),
         react::react::<&SingleThreadedComments>(
           t.cm.clone(),
@@ -2872,7 +3701,7 @@ mod tests {
           },
           None,
           TransformMode::Development,
-          Some(t.cm.clone()),
+          None,
         )),
         react::react::<&SingleThreadedComments>(
           t.cm.clone(),
@@ -2925,7 +3754,7 @@ mod tests {
           },
           None,
           TransformMode::Development,
-          Some(t.cm.clone()),
+          None,
         )),
         react::react::<&SingleThreadedComments>(
           t.cm.clone(),
@@ -2972,7 +3801,7 @@ mod tests {
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_escape_newline_character,
     // Input codes
@@ -3023,7 +3852,7 @@ aaaaa
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_wrap_dynamic_key,
     // Input codes
@@ -3049,7 +3878,7 @@ aaaaa
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_set_attribute_for_text_node,
     // Input codes
@@ -3078,7 +3907,7 @@ aaaaa
       },
       Some(t.comments.clone()),
       TransformMode::Test,
-      Some(t.cm.clone()),
+      None
     )),
     should_create_raw_text_node_for_text_node,
     // Input codes

--- a/packages/react/transform/crates/swc_plugin_snapshot/napi.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/napi.rs
@@ -8,29 +8,31 @@ use swc_core::{
 use swc_plugins_shared::{target_napi::TransformTarget, transform_mode_napi::TransformMode};
 
 use crate::{
-  JSXTransformer as CoreJSXTransformer, JSXTransformerConfig as CoreJSXTransformerConfig,
+  ElementTemplateAsset as CoreElementTemplateAsset, JSXTransformer as CoreJSXTransformer,
+  JSXTransformerConfig as CoreJSXTransformerConfig,
   UISourceMapRecord as CoreUISourceMapRecord,
 };
 
 /// @internal
 #[napi(object)]
 #[derive(Clone, Debug)]
-pub struct JSXTransformerConfig {
-  /// @internal
-  pub preserve_jsx: bool,
-  /// @internal
-  pub runtime_pkg: String,
-  /// @internal
-  pub jsx_import_source: Option<String>,
-  /// @internal
-  pub filename: String,
-  /// @internal
-  #[napi(ts_type = "'LEPUS' | 'JS' | 'MIXED'")]
-  pub target: TransformTarget,
-  /// @internal
-  pub enable_ui_source_map: Option<bool>,
-  /// @internal
-  pub is_dynamic_component: Option<bool>,
+pub struct ElementTemplateAsset {
+  #[napi(js_name = "templateId")]
+  pub template_id: String,
+  #[napi(js_name = "compiledTemplate")]
+  pub compiled_template: serde_json::Value,
+  #[napi(js_name = "sourceFile")]
+  pub source_file: String,
+}
+
+impl From<CoreElementTemplateAsset> for ElementTemplateAsset {
+  fn from(val: CoreElementTemplateAsset) -> Self {
+    Self {
+      template_id: val.template_id,
+      compiled_template: val.compiled_template,
+      source_file: val.source_file,
+    }
+  }
 }
 
 /// @internal
@@ -67,6 +69,29 @@ impl From<CoreUISourceMapRecord> for UISourceMapRecord {
   }
 }
 
+/// @internal
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct JSXTransformerConfig {
+  /// @internal
+  pub preserve_jsx: bool,
+  /// @internal
+  pub runtime_pkg: String,
+  /// @internal
+  pub jsx_import_source: Option<String>,
+  /// @internal
+  pub filename: String,
+  /// @internal
+  #[napi(ts_type = "'LEPUS' | 'JS' | 'MIXED'")]
+  pub target: TransformTarget,
+  /// @internal
+  pub enable_ui_source_map: Option<bool>,
+  /// @internal
+  pub is_dynamic_component: Option<bool>,
+  /// @internal
+  pub experimental_enable_element_template: Option<bool>,
+}
+
 impl Default for JSXTransformerConfig {
   fn default() -> Self {
     Self {
@@ -77,6 +102,7 @@ impl Default for JSXTransformerConfig {
       target: TransformTarget::LEPUS,
       enable_ui_source_map: Some(false),
       is_dynamic_component: Some(false),
+      experimental_enable_element_template: None,
     }
   }
 }
@@ -91,6 +117,9 @@ impl From<JSXTransformerConfig> for CoreJSXTransformerConfig {
       target: val.target.into(),
       enable_ui_source_map: val.enable_ui_source_map.unwrap_or(false),
       is_dynamic_component: val.is_dynamic_component,
+      experimental_enable_element_template: val
+        .experimental_enable_element_template
+        .unwrap_or(false),
     }
   }
 }
@@ -105,6 +134,7 @@ impl From<CoreJSXTransformerConfig> for JSXTransformerConfig {
       target: val.target.into(),
       enable_ui_source_map: Some(val.enable_ui_source_map),
       is_dynamic_component: val.is_dynamic_component,
+      experimental_enable_element_template: Some(val.experimental_enable_element_template),
     }
   }
 }
@@ -115,6 +145,7 @@ where
 {
   inner: CoreJSXTransformer<C>,
   pub ui_source_map_records: Rc<RefCell<Vec<CoreUISourceMapRecord>>>,
+  pub element_templates: Rc<RefCell<Vec<CoreElementTemplateAsset>>>,
 }
 
 impl<C> JSXTransformer<C>
@@ -141,11 +172,23 @@ where
     mode: TransformMode,
     source_map: Option<Lrc<SourceMap>>,
   ) -> Self {
-    let inner = CoreJSXTransformer::new(cfg.into(), comments, mode.into(), source_map);
+    let element_templates = Rc::new(RefCell::new(vec![]));
+    let inner = CoreJSXTransformer::new(
+      cfg.into(),
+      comments,
+      mode.into(),
+      source_map,
+      Some(element_templates.clone()),
+    );
     Self {
       ui_source_map_records: inner.ui_source_map_records.clone(),
+      element_templates,
       inner,
     }
+  }
+
+  pub fn take_element_templates(&self) -> Vec<CoreElementTemplateAsset> {
+    self.element_templates.borrow_mut().drain(..).collect()
   }
 }
 

--- a/packages/react/transform/crates/swc_plugin_snapshot/slot_marker.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/slot_marker.rs
@@ -54,6 +54,7 @@ fn jsx_wrapped(with: &str, n: JSXElement) -> JSXElement {
 pub struct WrapperMarker {
   pub current_is_children_full_dynamic: bool,
   pub dynamic_part_count: i32,
+  pub enable_element_template: bool,
 }
 
 impl VisitMut for WrapperMarker {
@@ -142,6 +143,11 @@ impl VisitMut for WrapperMarker {
 
       let is_list = jsx_is_list(n);
       let is_children_full_dynamic = is_list || jsx_is_children_full_dynamic(n);
+      let should_wrap_element = if self.enable_element_template {
+        false
+      } else {
+        is_children_full_dynamic
+      };
       let has_dynamic_key = jsx_has_dynamic_key(n);
 
       if (is_list || has_dynamic_key) && !n.children.is_empty() {
@@ -151,13 +157,17 @@ impl VisitMut for WrapperMarker {
         })];
       }
 
-      if is_children_full_dynamic {
+      if self.enable_element_template && is_list {
+        return;
+      }
+
+      if should_wrap_element {
         self.dynamic_part_count += 1;
         *n = jsx_wrapped(INTERNAL_SLOT_STR, n.take());
       }
 
       let pre_is_children_full_dynamic = self.current_is_children_full_dynamic;
-      self.current_is_children_full_dynamic = is_children_full_dynamic;
+      self.current_is_children_full_dynamic = should_wrap_element;
       n.visit_mut_children_with(self);
       self.current_is_children_full_dynamic = pre_is_children_full_dynamic;
     }
@@ -188,6 +198,7 @@ mod tests {
         visit_mut_pass(super::WrapperMarker {
           current_is_children_full_dynamic: false,
           dynamic_part_count: 0,
+          enable_element_template: false,
         }),
       )
     },
@@ -236,6 +247,7 @@ mod tests {
         visit_mut_pass(super::WrapperMarker {
           current_is_children_full_dynamic: false,
           dynamic_part_count: 0,
+          enable_element_template: false,
         }),
       )
     },

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__json_snapshots__/array_isolation.snap
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__json_snapshots__/array_isolation.snap
@@ -1,0 +1,55 @@
+---
+source: packages/react/transform/crates/swc_plugin_snapshot/tests/element_template.rs
+expression: actual_jsons
+---
+[
+  {
+    "template_id": "_et_da39a_test_1",
+    "template": {
+      "kind": "element",
+      "tag": "view",
+      "attributesArray": [],
+      "children": [
+        {
+          "kind": "elementSlot",
+          "tag": "slot",
+          "elementSlotIndex": 0.0
+        },
+        {
+          "kind": "element",
+          "tag": "text",
+          "attributesArray": [
+            {
+              "kind": "attribute",
+              "key": "text",
+              "binding": "static",
+              "value": "Static"
+            }
+          ],
+          "children": []
+        },
+        {
+          "kind": "elementSlot",
+          "tag": "slot",
+          "elementSlotIndex": 1.0
+        }
+      ]
+    }
+  },
+  {
+    "template_id": "__et_builtin_raw_text__",
+    "template": {
+      "kind": "element",
+      "tag": "raw-text",
+      "attributesArray": [
+        {
+          "kind": "attribute",
+          "key": "text",
+          "binding": "slot",
+          "attrSlotIndex": 0
+        }
+      ],
+      "children": []
+    }
+  }
+]

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__json_snapshots__/complex_usage.snap
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__json_snapshots__/complex_usage.snap
@@ -1,0 +1,71 @@
+---
+source: packages/react/transform/crates/swc_plugin_snapshot/tests/element_template.rs
+expression: actual_jsons
+---
+[
+  {
+    "template_id": "_et_da39a_test_1",
+    "template": {
+      "kind": "element",
+      "tag": "view",
+      "attributesArray": [
+        {
+          "kind": "attribute",
+          "key": "class",
+          "binding": "static",
+          "value": "container"
+        },
+        {
+          "kind": "attribute",
+          "key": "id",
+          "binding": "slot",
+          "attrSlotIndex": 0.0
+        }
+      ],
+      "children": [
+        {
+          "kind": "element",
+          "tag": "text",
+          "attributesArray": [
+            {
+              "kind": "attribute",
+              "key": "text",
+              "binding": "static",
+              "value": "Static"
+            }
+          ],
+          "children": []
+        },
+        {
+          "kind": "element",
+          "tag": "image",
+          "attributesArray": [
+            {
+              "kind": "attribute",
+              "key": "src",
+              "binding": "slot",
+              "attrSlotIndex": 1.0
+            }
+          ],
+          "children": []
+        }
+      ]
+    }
+  },
+  {
+    "template_id": "__et_builtin_raw_text__",
+    "template": {
+      "kind": "element",
+      "tag": "raw-text",
+      "attributesArray": [
+        {
+          "kind": "attribute",
+          "key": "text",
+          "binding": "slot",
+          "attrSlotIndex": 0
+        }
+      ],
+      "children": []
+    }
+  }
+]

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__json_snapshots__/text_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__json_snapshots__/text_attributes.snap
@@ -1,0 +1,70 @@
+---
+source: packages/react/transform/crates/swc_plugin_snapshot/tests/element_template.rs
+expression: actual_jsons
+---
+[
+  {
+    "template_id": "_et_da39a_test_1",
+    "template": {
+      "kind": "element",
+      "tag": "view",
+      "attributesArray": [],
+      "children": [
+        {
+          "kind": "element",
+          "tag": "text",
+          "attributesArray": [
+            {
+              "kind": "attribute",
+              "key": "text",
+              "binding": "static",
+              "value": "Explicit Text Attribute"
+            }
+          ],
+          "children": []
+        },
+        {
+          "kind": "element",
+          "tag": "text",
+          "attributesArray": [
+            {
+              "kind": "attribute",
+              "key": "text",
+              "binding": "slot",
+              "attrSlotIndex": 0.0
+            }
+          ],
+          "children": []
+        },
+        {
+          "kind": "element",
+          "tag": "text",
+          "attributesArray": [],
+          "children": [
+            {
+              "kind": "elementSlot",
+              "tag": "slot",
+              "elementSlotIndex": 0.0
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "template_id": "__et_builtin_raw_text__",
+    "template": {
+      "kind": "element",
+      "tag": "raw-text",
+      "attributesArray": [
+        {
+          "kind": "attribute",
+          "key": "text",
+          "binding": "slot",
+          "attrSlotIndex": 0
+        }
+      ],
+      "children": []
+    }
+  }
+]

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__json_snapshots__/user_component.snap
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__json_snapshots__/user_component.snap
@@ -1,0 +1,53 @@
+---
+source: packages/react/transform/crates/swc_plugin_snapshot/tests/element_template.rs
+expression: actual_jsons
+---
+[
+  {
+    "template_id": "_et_da39a_test_2",
+    "template": {
+      "kind": "element",
+      "tag": "text",
+      "attributesArray": [
+        {
+          "kind": "attribute",
+          "key": "text",
+          "binding": "static",
+          "value": "hello"
+        }
+      ],
+      "children": []
+    }
+  },
+  {
+    "template_id": "_et_da39a_test_1",
+    "template": {
+      "kind": "element",
+      "tag": "view",
+      "attributesArray": [],
+      "children": [
+        {
+          "kind": "elementSlot",
+          "tag": "slot",
+          "elementSlotIndex": 0.0
+        }
+      ]
+    }
+  },
+  {
+    "template_id": "__et_builtin_raw_text__",
+    "template": {
+      "kind": "element",
+      "tag": "raw-text",
+      "attributesArray": [
+        {
+          "kind": "attribute",
+          "key": "text",
+          "binding": "slot",
+          "attrSlotIndex": 0
+        }
+      ],
+      "children": []
+    }
+  }
+]

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_append_entry_name_to_attribute_slots_for_dynamic_component_in_element_template_mode.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_append_entry_name_to_attribute_slots_for_dynamic_component_in_element_template_mode.js
@@ -1,0 +1,10 @@
+/**
+ * @jsxCSSId 100
+ */ import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = `${globDynamicComponentEntry}:${"_et_da39a_test_1"}`;
+<_et_da39a_test_1 options={{
+    cssId: 100,
+    entryName: globDynamicComponentEntry
+}} attributeSlots={[
+    dynamicId
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_generate_attribute_slots_for_dynamic_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_generate_attribute_slots_for_dynamic_attributes.js
@@ -1,0 +1,6 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    dynamicId,
+    value
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_background_conditional_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_background_conditional_attributes.js
@@ -1,0 +1,23 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+function App() {
+    const attrs = __BACKGROUND__ ? {
+        0: {
+            id: 'b'
+        },
+        2: {
+            data: 'extra'
+        }
+    } : {
+        0: {
+            id: 'a'
+        },
+        1: {
+            title: 'main'
+        }
+    };
+    return <_et_da39a_test_1 attributeSlots={[
+        attrs,
+        attrs
+    ]}/>;
+}

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_boolean_and_number_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_boolean_and_number_attributes.js
@@ -1,0 +1,3 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_complex_text_structure.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_complex_text_structure.js
@@ -1,0 +1,3 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_css_id.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_css_id.js
@@ -1,0 +1,7 @@
+/**
+ * @jsxCSSId 100
+ */ import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 options={{
+    cssId: 100
+}}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_dataset_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_dataset_attributes.js
@@ -1,0 +1,3 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_dynamic_class_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_dynamic_class_attributes.js
@@ -1,0 +1,5 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    dynamicClass
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_events_js.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_events_js.js
@@ -1,0 +1,6 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    handleTap,
+    handleTouch
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_events_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_events_lepus.js
@@ -1,0 +1,6 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    1,
+    1
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_id_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_id_attributes.js
@@ -1,0 +1,5 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    dynamicId
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_inline_styles.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_inline_styles.js
@@ -1,0 +1,7 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    {
+        color: dynamicColor
+    }
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_interpolated_text_with_siblings.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_interpolated_text_with_siblings.js
@@ -1,0 +1,6 @@
+<_et_da39a_test_1 children={[
+    items,
+    items.map((item)=><_et_da39a_test_2 children={[
+            item
+        ]}/>)
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_mixed_content.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_mixed_content.js
@@ -1,0 +1,5 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 children={[
+    dynamicPart
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_nested_structure_and_dynamic_content.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_nested_structure_and_dynamic_content.js
@@ -1,0 +1,10 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_2 = "_et_da39a_test_2";
+const _et_da39a_test_3 = "_et_da39a_test_3";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 children={[
+    items.map((item)=><_et_da39a_test_2 children={[
+            item
+        ]}/>),
+    showCopyright && <_et_da39a_test_3/>
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_page_element.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_page_element.js
@@ -1,0 +1,6 @@
+import * as ReactLynx from "@lynx-js/react";
+import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<ReactLynxRuntimeComponents.Page>
+        <_et_da39a_test_1/>
+    </ReactLynxRuntimeComponents.Page>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_refs_js.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_refs_js.js
@@ -1,0 +1,5 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    ReactLynx.transformRef(viewRef)
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_refs_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_refs_lepus.js
@@ -1,0 +1,5 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    1
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_sibling_user_components.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_sibling_user_components.js
@@ -1,0 +1,14 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_2 = "_et_da39a_test_2";
+const _et_da39a_test_3 = "_et_da39a_test_3";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 children={[
+    [
+        <Component>
+        <_et_da39a_test_2/>
+      </Component>,
+        <Component>
+        <_et_da39a_test_3/>
+      </Component>
+    ]
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_spread_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_spread_attributes.js
@@ -1,0 +1,9 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    {
+        ...props,
+        "data-extra": "value",
+        __spread: true
+    }
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_text_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_text_attributes.js
@@ -1,0 +1,5 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    dynamicText
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_user_component.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_handle_user_component.js
@@ -1,0 +1,8 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_2 = "_et_da39a_test_2";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 children={[
+    <Component id={1}>
+        <_et_da39a_test_2/>
+      </Component>
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_ignore_dynamic_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_ignore_dynamic_attributes.js
@@ -1,0 +1,5 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 attributeSlots={[
+    dynamicId
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_isolate_arrays_with_slot_wrapper.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_isolate_arrays_with_slot_wrapper.js
@@ -1,0 +1,12 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1 children={[
+    [
+        "a",
+        "b"
+    ],
+    [
+        "c",
+        "d"
+    ]
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_not_output_template_when_flag_is_false.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_not_output_template_when_flag_is_false.js
@@ -1,0 +1,16 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateText(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateRawText("Normal Snapshot");
+        __AppendElement(el1, el2);
+        return [
+            el,
+            el1,
+            el2
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_output_element_template_simple_js.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_output_element_template_simple_js.js
@@ -1,0 +1,3 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_output_element_template_simple_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_output_element_template_simple_lepus.js
@@ -1,0 +1,3 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_output_template_with_static_attributes.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/tests/element_template.rs/should_output_template_with_static_attributes.js
@@ -1,0 +1,3 @@
+import * as ReactLynx from "@lynx-js/react";
+const _et_da39a_test_1 = "_et_da39a_test_1";
+<_et_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/element_template.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/element_template.rs
@@ -1,0 +1,1043 @@
+use swc_core::ecma::transforms::testing::test;
+use swc_core::ecma::{
+  parser::{EsSyntax, Syntax},
+  visit::visit_mut_pass,
+};
+use swc_plugin_snapshot::{JSXTransformer, JSXTransformerConfig};
+use swc_plugins_shared::target::TransformTarget;
+use swc_plugins_shared::transform_mode::TransformMode;
+
+const BUILTIN_RAW_TEXT_TEMPLATE_ID: &str = "__et_builtin_raw_text__";
+
+fn assert_has_single_builtin_raw_text_template(
+  templates: &[swc_plugin_snapshot::ElementTemplateAsset],
+) {
+  let builtin_count = templates
+    .iter()
+    .filter(|template| template.template_id == BUILTIN_RAW_TEXT_TEMPLATE_ID)
+    .count();
+  assert_eq!(
+    builtin_count, 1,
+    "Expected exactly one builtin raw-text template, got {}",
+    builtin_count
+  );
+}
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      target: TransformTarget::LEPUS,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_output_element_template_simple_lepus,
+  // Input codes
+  r#"
+    <view class="container">
+      <text>Hello</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      target: TransformTarget::JS,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_output_element_template_simple_js,
+  // Input codes
+  r#"
+    <view class="container">
+      <text>Hello</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_output_template_with_static_attributes,
+  // Input codes
+  r#"
+    <view class="container" id="main" style="color: red;">
+        <text>Hello</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: false,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_not_output_template_when_flag_is_false,
+  // Input codes
+  r#"
+    <view>
+        <text>Normal Snapshot</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_dataset_attributes,
+  // Input codes
+  r#"
+    <view data-id="123" data-name="test" data-long-name="long-value">
+        <text>Dataset Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_nested_structure_and_dynamic_content,
+  // Input codes
+  r#"
+    <view class="wrapper">
+        <view class="header">
+            <text>Header</text>
+        </view>
+        <view class="content">
+            {/* Expression should become an elementSlot */}
+            {items.map(item => <text>{item}</text>)}
+        </view>
+        <view class="footer">
+            <text>Footer</text>
+            {/* Another slot */}
+            {showCopyright && <text>Copyright</text>}
+        </view>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_ignore_dynamic_attributes,
+  // Input codes
+  r#"
+    <view class="container" id={dynamicId} style={{color: 'red'}}>
+        <text>Dynamic Attribute Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_mixed_content,
+  // Input codes
+  r#"
+    <view>
+        <text>Start</text>
+        {dynamicPart}
+        <view>Middle</view>
+        <text>End</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_boolean_and_number_attributes,
+  // Input codes
+  r#"
+    <view disabled={true} opacity={0.5} lines={2}>
+        <text>Attribute Types Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_generate_attribute_slots_for_dynamic_attributes,
+  // Input codes
+  r#"
+    <view class="static" id={dynamicId}>
+        <text data-value={value}>Dynamic Value</text>
+        <view>Static</view>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_complex_text_structure,
+  // Input codes
+  r#"
+    <view>
+        <text>
+            Hello
+            <text>World</text>
+            !
+        </text>
+        <text>
+             First
+             <text>Second</text>
+             Third
+        </text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_spread_attributes,
+  // Input codes
+  r#"
+    <view {...props} data-extra="value">
+        <text>Spread Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      target: TransformTarget::LEPUS,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_events_lepus,
+  // Input codes
+  r#"
+    <view bindtap={handleTap} catchtouchstart={handleTouch}>
+        <text>Event Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      target: TransformTarget::JS,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_events_js,
+  // Input codes
+  r#"
+    <view bindtap={handleTap} catchtouchstart={handleTouch}>
+        <text>Event Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_inline_styles,
+  // Input codes
+  r#"
+    <view style="color: red; width: 100px;">
+        <text style={{ fontSize: '16px', fontWeight: 'bold' }}>Static Style</text>
+        <view style={{ color: dynamicColor }}>Dynamic Style</view>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      target: TransformTarget::LEPUS,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_refs_lepus,
+  // Input codes
+  r#"
+    <view ref={viewRef}>
+        <text>Ref Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      target: TransformTarget::JS,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_refs_js,
+  // Input codes
+  r#"
+    <view ref={viewRef}>
+        <text>Ref Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_css_id,
+  // Input codes
+  r#"
+/**
+ * @jsxCSSId 100
+ */
+    <view class="container">
+        <text>CSS ID Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_page_element,
+  // Input codes
+  r#"
+    <page>
+        <view>Page Element Test</view>
+    </page>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_text_attributes,
+  // Input codes
+  r#"
+    <view>
+        <text text="Explicit Text Attribute" />
+        <text text={dynamicText} />
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_dynamic_class_attributes,
+  // Input codes
+  r#"
+    <view class={dynamicClass} className="static-class">
+        <text>Dynamic Class Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_id_attributes,
+  // Input codes
+  r#"
+    <view id="static-id">
+        <text id={dynamicId}>ID Test</text>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_isolate_arrays_with_slot_wrapper,
+  // Input codes
+  r#"
+    <view>
+        {["a", "b"]}
+        <text>Static</text>
+        {["c", "d"]}
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_user_component,
+  // Input codes
+  r#"
+    <view>
+      <Component id={1}>
+        <text>hello</text>
+      </Component>
+    </view>
+    "#
+);
+
+test!(
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_interpolated_text_with_siblings,
+  // Input codes mimicking multiple-text fixture
+  r#"
+    <view>
+      <view id='1'>
+        {items}
+      </view>
+       <view id='2'>
+          {items.map((item) => <text>{item}</text>)}
+       </view>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_sibling_user_components,
+  // Input codes
+  r#"
+    <view>
+      <Component>
+        <text>Slot Content 1</text>
+      </Component>
+      <Component>
+        <text>Slot Content 2</text>
+      </Component>
+    </view>
+    "#
+);
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_handle_background_conditional_attributes,
+  // Input codes
+  r#"
+      function App() {
+        const attrs = __BACKGROUND__
+          ? {
+            0: { id: 'b' },
+            2: { data: 'extra' },
+          }
+          : {
+            0: { id: 'a' },
+            1: { title: 'main' },
+          };
+        return (
+          <view data-a={attrs} b={attrs} />
+        );
+      }
+    "#
+);
+
+#[track_caller]
+fn verify_template_json(input: &str, snapshot_name: &str) {
+  use std::cell::RefCell;
+  use std::rc::Rc;
+  use swc_core::common::{comments::SingleThreadedComments, FileName, Globals, SourceMap, GLOBALS};
+  use swc_core::ecma::parser::{lexer::Lexer, Parser, StringInput};
+  use swc_core::ecma::visit::VisitMutWith;
+
+  // Adapt UPDATE=1 to INSTA_UPDATE=always for backward compatibility/convenience
+  if std::env::var("UPDATE").as_deref() == Ok("1") {
+    std::env::set_var("INSTA_UPDATE", "always");
+  }
+
+  GLOBALS.set(&Globals::new(), || {
+    let cm = Rc::new(SourceMap::default());
+    let fm = cm.new_source_file(FileName::Anon.into(), input.to_string());
+
+    let lexer = Lexer::new(
+      Syntax::Es(EsSyntax {
+        jsx: true,
+        ..Default::default()
+      }),
+      Default::default(),
+      StringInput::from(&*fm),
+      None,
+    );
+
+    let mut parser = Parser::new_from(lexer);
+    let module_result = parser.parse_module();
+    let mut module = module_result.expect("Failed to parse module");
+
+    let comments = SingleThreadedComments::default();
+    let element_templates = Rc::new(RefCell::new(vec![]));
+
+    let mut transformer = JSXTransformer::new(
+      JSXTransformerConfig {
+        preserve_jsx: true,
+        experimental_enable_element_template: true,
+        ..Default::default()
+      },
+      Some(comments),
+      TransformMode::Test,
+      Some(element_templates.clone()),
+    );
+
+    module.visit_mut_with(&mut transformer);
+
+    let templates = element_templates.borrow();
+    assert!(!templates.is_empty(), "Should collect element templates");
+
+    // Collect all compiled templates for snapshot, including template_id
+    let actual_jsons: Vec<_> = templates
+      .iter()
+      .map(|t| {
+        serde_json::json!({
+            "template_id": t.template_id,
+            "template": t.compiled_template
+        })
+      })
+      .collect();
+
+    insta::with_settings!({
+        snapshot_path => "__json_snapshots__",
+        prepend_module_to_snapshot => false,
+    }, {
+        insta::assert_json_snapshot!(snapshot_name, actual_jsons);
+    });
+  });
+}
+
+#[test]
+fn should_verify_template_structure_complex() {
+  verify_template_json(
+    r#"
+    <view class="container" id={dynamicId}>
+        <text>Static</text>
+        <image src={url} />
+    </view>
+    "#,
+    "complex_usage",
+  );
+  verify_template_json(
+    r#"
+    <view>
+        <text text="Explicit Text Attribute" />
+        <text text={dynamicText} />
+        <text>{dynamicText2}</text>
+    </view>
+    "#,
+    "text_attributes",
+  );
+  verify_template_json(
+    r#"
+      <view>
+        <Component id={1}>
+          <text>hello</text>
+        </Component>
+      </view>
+    "#,
+    "user_component",
+  );
+  verify_template_json(
+    r#"
+    <view>
+        {["a", "b"]}
+        <text>Static</text>
+        {["c", "d"]}
+    </view>
+    "#,
+    "array_isolation",
+  );
+}
+
+#[track_caller]
+fn transform_to_code_and_templates(
+  input: &str,
+  cfg: JSXTransformerConfig,
+) -> (String, Vec<swc_plugin_snapshot::ElementTemplateAsset>) {
+  use std::cell::RefCell;
+  use std::rc::Rc;
+  use std::sync::Arc;
+  use swc_core::common::{comments::SingleThreadedComments, FileName, Globals, SourceMap, GLOBALS};
+  use swc_core::ecma::codegen::{text_writer::JsWriter, Emitter};
+  use swc_core::ecma::parser::{lexer::Lexer, Parser, StringInput};
+  use swc_core::ecma::visit::VisitMutWith;
+
+  GLOBALS.set(&Globals::new(), || {
+    let cm: Arc<SourceMap> = Arc::new(SourceMap::default());
+    let fm = cm.new_source_file(FileName::Anon.into(), input.to_string());
+
+    let lexer = Lexer::new(
+      Syntax::Es(EsSyntax {
+        jsx: true,
+        ..Default::default()
+      }),
+      Default::default(),
+      StringInput::from(&*fm),
+      None,
+    );
+
+    let mut parser = Parser::new_from(lexer);
+    let module_result = parser.parse_module();
+    let mut module = module_result.expect("Failed to parse module");
+
+    let comments = SingleThreadedComments::default();
+    let element_templates = Rc::new(RefCell::new(vec![]));
+
+    let mut transformer = JSXTransformer::new(
+      cfg,
+      Some(comments),
+      TransformMode::Test,
+      Some(element_templates.clone()),
+    );
+
+    module.visit_mut_with(&mut transformer);
+
+    let mut buf = vec![];
+    {
+      let mut emitter = Emitter {
+        cfg: swc_core::ecma::codegen::Config::default(),
+        cm: cm.clone(),
+        comments: None,
+        wr: JsWriter::new(cm.clone(), "\n", &mut buf, None),
+      };
+      emitter.emit_module(&module).expect("Failed to emit module");
+    }
+
+    let code = String::from_utf8(buf).expect("Codegen output is not valid utf8");
+    let templates: Vec<_> = element_templates.borrow_mut().drain(..).collect();
+
+    (code, templates)
+  })
+}
+
+#[test]
+fn should_not_emit_element_template_map_in_element_template_mode() {
+  let (code, templates) = transform_to_code_and_templates(
+    r#"
+      <view class="container">
+        <text>Hello</text>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+  );
+
+  assert!(!templates.is_empty(), "Should collect element templates");
+  assert_has_single_builtin_raw_text_template(&templates);
+  assert!(!code.contains("__elementTemplateMap"));
+  assert!(!code.contains("__template_"));
+  assert!(code.contains("const _et_"));
+  assert!(!code.contains("const __snapshot_"));
+
+  for template in templates {
+    if template.template_id == BUILTIN_RAW_TEXT_TEMPLATE_ID {
+      continue;
+    }
+    assert!(template.template_id.starts_with("_et_"));
+    assert!(code.contains(&format!("\"{}\"", template.template_id)));
+  }
+}
+
+#[test]
+fn should_keep_snapshot_prefix_when_element_template_disabled() {
+  let (code, templates) = transform_to_code_and_templates(
+    r#"
+      <view>
+        <text>Hello</text>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: false,
+      ..Default::default()
+    },
+  );
+
+  assert!(templates.is_empty(), "Should not collect element templates");
+  assert!(code.contains("const __snapshot_"));
+  assert!(code.contains("snapshotCreatorMap"));
+  assert!(!code.contains("const _et_"));
+}
+
+#[test]
+fn should_collect_element_templates_for_dynamic_component_in_element_template_mode() {
+  let (code, templates) = transform_to_code_and_templates(
+    r#"
+      <view class="container">
+        <text>Hello</text>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      is_dynamic_component: Some(true),
+      ..Default::default()
+    },
+  );
+
+  assert!(!templates.is_empty(), "Should collect element templates");
+  assert_has_single_builtin_raw_text_template(&templates);
+  assert!(!code.contains("__elementTemplateMap"));
+  assert!(code.contains("globDynamicComponentEntry"));
+
+  for template in templates {
+    assert!(
+      template.template_id == BUILTIN_RAW_TEXT_TEMPLATE_ID
+        || template.template_id.starts_with("_et_")
+    );
+    assert!(!template.template_id.contains(':'));
+  }
+}
+
+test!(
+  module,
+  Syntax::Es(EsSyntax {
+    jsx: true,
+    ..Default::default()
+  }),
+  |t| visit_mut_pass(JSXTransformer::new(
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      is_dynamic_component: Some(true),
+      ..Default::default()
+    },
+    Some(t.comments.clone()),
+    TransformMode::Test,
+    None,
+  )),
+  should_append_entry_name_to_attribute_slots_for_dynamic_component_in_element_template_mode,
+  // Input codes
+  r#"
+/**
+ * @jsxCSSId 100
+ */
+  <view id={dynamicId}>
+    <text>Hello</text>
+  </view>
+  "#
+);

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/element_template_contract.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/element_template_contract.rs
@@ -1,0 +1,388 @@
+use serde_json::Value;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+use swc_core::common::{comments::SingleThreadedComments, FileName, Globals, SourceMap, GLOBALS};
+use swc_core::ecma::codegen::{text_writer::JsWriter, Emitter};
+use swc_core::ecma::parser::{lexer::Lexer, EsSyntax, Parser, StringInput, Syntax};
+use swc_core::ecma::visit::VisitMutWith;
+use swc_plugin_snapshot::{ElementTemplateAsset, JSXTransformer, JSXTransformerConfig};
+use swc_plugins_shared::transform_mode::TransformMode;
+
+const BUILTIN_RAW_TEXT_TEMPLATE_ID: &str = "__et_builtin_raw_text__";
+
+fn transform_to_templates(input: &str, cfg: JSXTransformerConfig) -> Vec<ElementTemplateAsset> {
+  let (templates, _) = transform_fixture(input, cfg);
+  templates
+}
+
+fn transform_to_code(input: &str, cfg: JSXTransformerConfig) -> String {
+  let (_, code) = transform_fixture(input, cfg);
+  code
+}
+
+fn transform_fixture(
+  input: &str,
+  cfg: JSXTransformerConfig,
+) -> (Vec<ElementTemplateAsset>, String) {
+  GLOBALS.set(&Globals::new(), || {
+    let cm: Arc<SourceMap> = Arc::new(SourceMap::default());
+    let fm = cm.new_source_file(FileName::Anon.into(), input.to_string());
+    let comments = SingleThreadedComments::default();
+
+    let lexer = Lexer::new(
+      Syntax::Es(EsSyntax {
+        jsx: true,
+        ..Default::default()
+      }),
+      Default::default(),
+      StringInput::from(&*fm),
+      Some(&comments),
+    );
+
+    let mut parser = Parser::new_from(lexer);
+    let mut module = parser.parse_module().expect("Failed to parse module");
+    let element_templates = Rc::new(RefCell::new(vec![]));
+
+    let mut transformer = JSXTransformer::new(
+      cfg,
+      Some(comments),
+      TransformMode::Test,
+      Some(element_templates.clone()),
+    );
+
+    module.visit_mut_with(&mut transformer);
+
+    let mut sink = vec![];
+    let mut emitter = Emitter {
+      cfg: swc_core::ecma::codegen::Config::default(),
+      cm: cm.clone(),
+      comments: None,
+      wr: JsWriter::new(cm.clone(), "\n", &mut sink, None),
+    };
+    emitter.emit_module(&module).expect("Failed to emit module");
+
+    let templates = element_templates.borrow_mut().drain(..).collect();
+    (
+      templates,
+      String::from_utf8(sink).expect("transform output should be valid utf8"),
+    )
+  })
+}
+
+fn first_user_template_json(input: &str) -> Value {
+  first_user_template_json_with_cfg(
+    input,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+  )
+}
+
+fn first_user_template_json_with_cfg(input: &str, cfg: JSXTransformerConfig) -> Value {
+  let templates = transform_to_templates(input, cfg);
+
+  templates
+    .into_iter()
+    .find(|template| template.template_id != BUILTIN_RAW_TEXT_TEMPLATE_ID)
+    .map(|template| {
+      serde_json::to_value(template.compiled_template).expect("compiled template to json")
+    })
+    .expect("should collect a user template")
+}
+
+#[test]
+fn should_not_inject_root_css_scope_attrs_for_element_template() {
+  let template = first_user_template_json(
+    r#"
+      /**
+       * @jsxCSSId 100
+       */
+      <view>
+        <text>Hello</text>
+      </view>
+    "#,
+  );
+
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  assert!(
+    attrs
+      .iter()
+      .all(|attr| attr["key"] != "css-id" && attr["key"] != "entry-name"),
+    "root element should no longer carry css scope attrs once metadata moves to options",
+  );
+
+  let children = template["children"].as_array().expect("children array");
+  let first_child_attrs = children[0]["attributesArray"]
+    .as_array()
+    .expect("child attributesArray");
+  assert!(
+    first_child_attrs
+      .iter()
+      .all(|attr| attr["key"] != "css-id" && attr["key"] != "entry-name"),
+    "nested static elements should not receive css scope attrs",
+  );
+}
+
+#[test]
+fn should_not_inject_root_entry_name_attr_for_dynamic_component_element_template() {
+  let template = first_user_template_json_with_cfg(
+    r#"
+      /**
+       * @jsxCSSId 100
+       */
+      <view id={dynamicId}>
+        <text>Hello</text>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      is_dynamic_component: Some(true),
+      ..Default::default()
+    },
+  );
+
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  assert!(
+    attrs
+      .iter()
+      .all(|attr| attr["key"] != "entry-name" && attr["key"] != "css-id"),
+    "dynamic component root should no longer encode css scope metadata in attrs",
+  );
+}
+
+#[test]
+fn should_keep_slot_descriptor_order_for_dynamic_attr_spread_event_and_ref() {
+  let template = first_user_template_json(
+    r#"
+      <view id={dynamicId} {...props} bindtap={handleTap} ref={viewRef} />
+    "#,
+  );
+
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  assert_eq!(attrs.len(), 4);
+
+  assert_eq!(attrs[0]["kind"], "attribute");
+  assert_eq!(attrs[0]["key"], "id");
+  assert_eq!(attrs[0]["binding"], "slot");
+  assert_eq!(attrs[0]["attrSlotIndex"].as_f64(), Some(0.0));
+
+  assert_eq!(attrs[1]["kind"], "spread");
+  assert_eq!(attrs[1]["binding"], "slot");
+  assert_eq!(attrs[1]["attrSlotIndex"].as_f64(), Some(1.0));
+
+  assert_eq!(attrs[2]["kind"], "attribute");
+  assert_eq!(attrs[2]["key"], "bindtap");
+  assert_eq!(attrs[2]["binding"], "slot");
+  assert_eq!(attrs[2]["attrSlotIndex"].as_f64(), Some(2.0));
+
+  assert_eq!(attrs[3]["kind"], "attribute");
+  assert_eq!(attrs[3]["key"], "ref");
+  assert_eq!(attrs[3]["binding"], "slot");
+  assert_eq!(attrs[3]["attrSlotIndex"].as_f64(), Some(3.0));
+}
+
+#[test]
+fn should_keep_element_slot_indices_stable_for_mixed_dynamic_children() {
+  let template = first_user_template_json(
+    r#"
+      <view>
+        <text>static</text>
+        {first}
+        <image />
+        {second}
+      </view>
+    "#,
+  );
+
+  let children = template["children"].as_array().expect("children array");
+  assert_eq!(children[0]["kind"], "element");
+  assert_eq!(children[0]["tag"], "text");
+  assert_eq!(children[1]["kind"], "elementSlot");
+  assert_eq!(children[1]["elementSlotIndex"].as_f64(), Some(0.0));
+  assert_eq!(children[1]["tag"], "slot");
+  assert_eq!(children[2]["kind"], "element");
+  assert_eq!(children[2]["tag"], "image");
+  assert_eq!(children[3]["kind"], "elementSlot");
+  assert_eq!(children[3]["elementSlotIndex"].as_f64(), Some(1.0));
+  assert_eq!(children[3]["tag"], "slot");
+}
+
+#[test]
+fn should_collect_element_template_assets_for_list_children_in_et_mode() {
+  let templates = transform_to_templates(
+    r#"
+      <view>
+        <list>
+          {items.map((item) => (
+            <list-item item-key={item.id}>
+              <text>{item.name}</text>
+            </list-item>
+          ))}
+        </list>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+  );
+
+  assert!(
+    templates.len() >= 3,
+    "expected root, list-item, and list templates to be collected, got {}",
+    templates.len()
+  );
+
+  let template_jsons: Vec<_> = templates
+    .iter()
+    .map(|template| {
+      serde_json::to_value(&template.compiled_template).expect("compiled template to json")
+    })
+    .collect();
+
+  let list_template = template_jsons
+    .iter()
+    .find_map(find_list_node)
+    .unwrap_or_else(|| {
+      let template_tags: Vec<_> = template_jsons
+        .iter()
+        .map(|template| template["tag"].as_str().unwrap_or("<unknown>").to_string())
+        .collect();
+      panic!(
+        "should collect a list element in compiled templates, got root tags: {template_tags:?}"
+      );
+    });
+
+  let list_children = list_template["children"]
+    .as_array()
+    .expect("list children array");
+  assert_eq!(
+    list_children.len(),
+    1,
+    "list should expose one element slot for dynamic children"
+  );
+  assert_eq!(list_children[0]["kind"], "elementSlot");
+  assert_eq!(list_children[0]["tag"], "slot");
+  assert_eq!(list_children[0]["elementSlotIndex"].as_f64(), Some(0.0));
+}
+
+#[test]
+fn should_not_opt_deferred_list_item_trees_into_et_list_fast_path() {
+  let code = transform_to_code(
+    r#"
+      <view>
+        <list>
+          <list-item defer item-key="Ada">
+            <text>Ada</text>
+          </list-item>
+        </list>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+  );
+
+  assert!(
+    !code.contains("__elementTemplateList: true"),
+    "deferred list-item trees should not be marked for ET list fast-path, got: {code}"
+  );
+}
+
+#[test]
+fn should_keep_et_list_fast_path_for_list_item_defer_false() {
+  let code = transform_to_code(
+    r#"
+      <view>
+        <list>
+          <list-item defer={false} item-key="Ada">
+            <text>Ada</text>
+          </list-item>
+        </list>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+  );
+
+  assert!(
+    code.contains("__elementTemplateList: true"),
+    "non-deferred list-item trees should keep ET list fast-path, got: {code}"
+  );
+}
+
+#[test]
+fn should_not_keep_et_list_fast_path_for_list_item_defer_string_literal() {
+  let code = transform_to_code(
+    r#"
+      <view>
+        <list>
+          <list-item defer="false" item-key="Ada">
+            <text>Ada</text>
+          </list-item>
+        </list>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+  );
+
+  assert!(
+    !code.contains("__elementTemplateList: true"),
+    "string-literal defer should match deferred list-item semantics, got: {code}"
+  );
+}
+
+#[test]
+fn should_not_keep_et_list_fast_path_for_list_root_spread_props() {
+  let code = transform_to_code(
+    r#"
+      <view>
+        <list {...props}>
+          <list-item item-key="Ada">
+            <text>Ada</text>
+          </list-item>
+        </list>
+      </view>
+    "#,
+    JSXTransformerConfig {
+      preserve_jsx: true,
+      experimental_enable_element_template: true,
+      ..Default::default()
+    },
+  );
+
+  assert!(
+    !code.contains("__elementTemplateList: true"),
+    "list roots with spread props should not keep the ET list fast-path, got: {code}"
+  );
+}
+
+fn find_list_node<'a>(value: &'a Value) -> Option<&'a Value> {
+  if value["tag"] == "list" {
+    return Some(value);
+  }
+
+  value["children"]
+    .as_array()
+    .and_then(|children| children.iter().find_map(find_list_node))
+}

--- a/packages/react/transform/index.d.ts
+++ b/packages/react/transform/index.d.ts
@@ -598,6 +598,8 @@ export interface JsxTransformerConfig {
   enableUiSourceMap?: boolean
   /** @internal */
   isDynamicComponent?: boolean
+  /** @internal */
+  experimentalEnableElementTemplate?: boolean
 }
 export interface WorkletVisitorConfig {
   /**
@@ -653,6 +655,12 @@ export interface TransformNodiffOutput {
   errors: Array<PartialMessage>
   warnings: Array<PartialMessage>
   uiSourceMapRecords: Array<UiSourceMapRecord>
+  elementTemplates?: Array<ElementTemplateAsset>
+}
+export interface ElementTemplateAsset {
+  templateId: string
+  compiledTemplate: Record<string, unknown>
+  sourceFile: string
 }
 export function transformReactLynxSync(code: string, options?: TransformNodiffOptions | undefined | null): TransformNodiffOutput
 export function transformReactLynx(code: string, options?: TransformNodiffOptions | undefined | null): Promise<TransformNodiffOutput>

--- a/packages/react/transform/src/lib.rs
+++ b/packages/react/transform/src/lib.rs
@@ -59,7 +59,10 @@ use swc_plugin_inject::napi::{InjectVisitor, InjectVisitorConfig};
 use swc_plugin_refresh::{RefreshVisitor, RefreshVisitorConfig};
 use swc_plugin_shake::napi::{ShakeVisitor, ShakeVisitorConfig};
 use swc_plugin_snapshot::{
-  napi::{JSXTransformer, JSXTransformerConfig, UISourceMapRecord as SnapshotUISourceMapRecord},
+  napi::{
+    ElementTemplateAsset, JSXTransformer, JSXTransformerConfig,
+    UISourceMapRecord as SnapshotUISourceMapRecord,
+  },
   UISourceMapRecord as CoreUISourceMapRecord,
 };
 use swc_plugin_worklet::napi::{WorkletVisitor, WorkletVisitorConfig};
@@ -254,6 +257,8 @@ pub struct TransformNodiffOutput {
   // #[napi(ts_type = "Array<import('esbuild').PartialMessage>")]
   pub warnings: Vec<esbuild::PartialMessage>,
   pub ui_source_map_records: Vec<SnapshotUISourceMapRecord>,
+  #[napi(js_name = "elementTemplates")]
+  pub element_templates: Option<Vec<ElementTemplateAsset>>,
 }
 
 /// A multi emitter that forwards to multiple emitters.
@@ -342,6 +347,7 @@ fn transform_react_lynx_inner(
             &ui_source_map_records,
             &options.filename,
           ),
+          element_templates: None,
         };
       }
     };
@@ -452,25 +458,40 @@ fn transform_react_lynx_inner(
     );
 
     let enable_ui_source_map = snapshot_plugin_config.enable_ui_source_map.unwrap_or(false);
+    let export_element_templates = snapshot_plugin_config
+      .experimental_enable_element_template
+      .unwrap_or(false);
 
-    let snapshot_plugin = Optional::new(
-      visit_mut_pass({
-        let snapshot_plugin = JSXTransformer::new(
-          snapshot_plugin_config.clone(),
-          Some(&comments),
-          options.mode.unwrap_or(TransformMode::Production),
-          Some(cm.clone()),
-        )
-        .with_content_hash(content_hash.clone());
+    let (snapshot_plugin, element_templates_collector) = if enabled {
+      let transformer = JSXTransformer::new(
+        snapshot_plugin_config.clone(),
+        Some(&comments),
+        options.mode.unwrap_or(TransformMode::Production),
+        Some(cm.clone()),
+      )
+      .with_content_hash(content_hash.clone());
 
-        if enable_ui_source_map {
-          snapshot_plugin.with_ui_source_map_records(ui_source_map_records.clone())
-        } else {
-          snapshot_plugin
-        }
-      }),
-      enabled,
-    );
+      let transformer = if enable_ui_source_map {
+        transformer.with_ui_source_map_records(ui_source_map_records.clone())
+      } else {
+        transformer
+      };
+
+      let collector = if export_element_templates {
+        Some(transformer.element_templates.clone())
+      } else {
+        None
+      };
+
+      (Optional::new(visit_mut_pass(transformer), true), collector)
+    } else {
+      (Optional::new(visit_mut_pass(JSXTransformer::new(
+        snapshot_plugin_config.clone(),
+        Some(&comments),
+        options.mode.unwrap_or(TransformMode::Production),
+        Some(cm.clone()),
+      )), false), None)
+    };
 
     let list_plugin = Optional::new(
       visit_mut_pass(swc_plugin_list::ListVisitor::new(Some(&comments))),
@@ -664,16 +685,29 @@ fn transform_react_lynx_inner(
     );
 
     match result {
-      Ok(result) => TransformNodiffOutput {
-        code: result.code,
-        map: result.map,
-        errors: vec![],
-        warnings: vec![],
-        ui_source_map_records: clone_ui_source_map_records(
-          &ui_source_map_records,
-          &options.filename,
-        ),
-      },
+      Ok(result) => {
+        let element_templates = element_templates_collector.and_then(|collector| {
+          let templates: Vec<ElementTemplateAsset> =
+            collector.borrow_mut().drain(..).map(|template| template.into()).collect();
+          if templates.is_empty() {
+            None
+          } else {
+            Some(templates)
+          }
+        });
+
+        TransformNodiffOutput {
+          code: result.code,
+          map: result.map,
+          errors: vec![],
+          warnings: vec![],
+          ui_source_map_records: clone_ui_source_map_records(
+            &ui_source_map_records,
+            &options.filename,
+          ),
+          element_templates,
+        }
+      }
       Err(_) => {
         return TransformNodiffOutput {
           code: "".into(),
@@ -684,6 +718,7 @@ fn transform_react_lynx_inner(
             &ui_source_map_records,
             &options.filename,
           ),
+          element_templates: None,
         };
       }
     }
@@ -695,6 +730,9 @@ fn transform_react_lynx_inner(
     errors: errors.read().unwrap().clone(),
     warnings: warnings.read().unwrap().clone(),
     ui_source_map_records: clone_ui_source_map_records(&ui_source_map_records, &options.filename),
+    // Preserve the element-template assets collected in the successful transform
+    // path instead of dropping them in the final wrapper object.
+    element_templates: result.element_templates,
   };
 
   r

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -9,6 +9,7 @@ import gte from 'semver/functions/gte.js'
 
 export interface Options {
   lazy?: boolean | undefined
+  elementTemplate?: boolean | undefined
 
   LAYERS: {
     MAIN_THREAD: string
@@ -21,7 +22,7 @@ export interface Options {
 const S_PLUGIN_REACT_ALIAS = Symbol.for('@lynx-js/plugin-react-alias')
 
 export function pluginReactAlias(options: Options): RsbuildPlugin {
-  const { LAYERS, lazy, rootPath } = options ?? {}
+  const { LAYERS, lazy, rootPath, elementTemplate } = options ?? {}
 
   return {
     name: 'lynx:react-alias',
@@ -74,6 +75,8 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
           reactLepusBackground,
           reactLepusMainThread,
           reactCompat,
+          elementTemplateEntry,
+          elementTemplateInternalEntry,
         ] = await Promise.all([
           resolve('@lynx-js/react/jsx-runtime'),
           resolve('@lynx-js/react/lepus/jsx-runtime'),
@@ -86,6 +89,12 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
           resolve('@lynx-js/react/lepus'),
           gte(version, '0.111.9999')
             ? resolve('@lynx-js/react/compat')
+            : Promise.resolve(null),
+          elementTemplate
+            ? resolve('@lynx-js/react/element-template')
+            : Promise.resolve(null),
+          elementTemplate
+            ? resolve('@lynx-js/react/element-template/internal')
             : Promise.resolve(null),
         ])
 
@@ -146,11 +155,13 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
 
         // react-transform may add imports of the following entries
         // We need to add aliases for that
+        const internalEntry = '@lynx-js/react/internal'
+
         const transformedEntries = [
           // TODO: add `debug` after bump peerDependencies['@lynx-js/react'] to 0.111.1
           // 'debug',
           'experimental/lazy/import',
-          'internal',
+          internalEntry,
           'legacy-react-runtime',
           'runtime-components',
           'worklet-runtime/bindings',
@@ -158,7 +169,11 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
 
         await Promise.all(
           transformedEntries
-            .map(entry => `@lynx-js/react/${entry}`)
+            .map(entry =>
+              entry.startsWith('@lynx-js/react/')
+                ? entry
+                : `@lynx-js/react/${entry}`
+            )
             .map(entry =>
               resolve(entry).then(value => {
                 chain
@@ -168,6 +183,12 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
               })
             ),
         )
+        if (elementTemplate && elementTemplateInternalEntry) {
+          chain
+            .resolve
+            .alias
+            .set('@lynx-js/react/internal$', elementTemplateInternalEntry)
+        }
 
         if (isProd) {
           chain.resolve.alias.set('@lynx-js/react/debug$', false)
@@ -186,7 +207,9 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
           .alias
           .set(
             '@lynx-js/react$',
-            reactLepus.background,
+            elementTemplate && elementTemplateEntry
+              ? elementTemplateEntry
+              : reactLepus.background,
           )
           .set('@lynx-js/react/jsx-runtime', jsxRuntime.background)
           .set('@lynx-js/react/jsx-dev-runtime', jsxDevRuntime.background)

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -282,6 +282,8 @@ export function applyEntry(
         workletRuntimePath: await resolve(
           `@lynx-js/react/${isDev ? 'worklet-dev-runtime' : 'worklet-runtime'}`,
         ),
+        experimental_enableElementTemplate:
+          options.experimentalEnableElementTemplate,
       }])
 
     function getDefaultProfile(): boolean | undefined {

--- a/packages/rspeedy/plugin-react/src/loaders.ts
+++ b/packages/rspeedy/plugin-react/src/loaders.ts
@@ -30,8 +30,8 @@ function getLoaderOptions(
     defineDCE,
     engineVersion,
     enableUiSourceMap,
-
     experimental_isLazyBundle,
+    experimentalEnableElementTemplate,
   } = options
 
   return {
@@ -41,6 +41,7 @@ function getLoaderOptions(
     inlineSourcesContent,
     defineDCE,
     engineVersion,
+    experimental_enableElementTemplate: experimentalEnableElementTemplate,
     ...isMainThread
       ? {
         enableUiSourceMap,

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -315,6 +315,13 @@ export interface PluginReactLynxOptions {
   experimental_isLazyBundle?: boolean
 
   /**
+   * Whether to enable element template.
+   *
+   * @experimental
+   */
+  experimentalEnableElementTemplate?: boolean
+
+  /**
    * Optimize bundle size by removing unused code by Minify.mainThreadOptions and Minify.backgroundOptions.
    *
    * When optimizeBundleSize or optimizeBundleSize.mainThread is true, main-thread code will be optimized.
@@ -378,6 +385,7 @@ export function pluginReactLynx(
     globalPropsMode: 'reactive',
 
     experimental_isLazyBundle: false,
+    experimentalEnableElementTemplate: false,
     optimizeBundleSize: false,
     enableUiSourceMap: false,
   }
@@ -390,6 +398,7 @@ export function pluginReactLynx(
   return [
     pluginReactAlias({
       lazy: resolvedOptions.experimental_isLazyBundle,
+      elementTemplate: resolvedOptions.experimentalEnableElementTemplate,
       LAYERS,
     }),
     {

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -16,6 +16,38 @@ import { LAYERS } from './layer.js';
 import { createLynxProcessEvalResultRuntimeModule } from './LynxProcessEvalResultRuntimeModule.js';
 
 const require = createRequire(import.meta.url);
+const ELEMENT_TEMPLATE_BUILD_INFO = 'lynx:element-templates';
+
+interface ElementTemplateBuildInfo {
+  templateId: string;
+  compiledTemplate: Record<string, unknown>;
+}
+
+export interface ModuleWithElementTemplateBuildInfo {
+  buildInfo?: Record<string, unknown>;
+  modules?: Iterable<ModuleWithElementTemplateBuildInfo>;
+}
+
+export function collectElementTemplatesFromModule(
+  module: ModuleWithElementTemplateBuildInfo,
+): ElementTemplateBuildInfo[] {
+  const elementTemplates: ElementTemplateBuildInfo[] = [];
+  const templates = module.buildInfo?.[ELEMENT_TEMPLATE_BUILD_INFO];
+
+  if (Array.isArray(templates)) {
+    elementTemplates.push(...templates as ElementTemplateBuildInfo[]);
+  }
+
+  if (module.modules) {
+    Array.from(module.modules).forEach(nestedModule => {
+      elementTemplates.push(
+        ...collectElementTemplatesFromModule(nestedModule),
+      );
+    });
+  }
+
+  return elementTemplates;
+}
 
 /**
  * The options for ReactWebpackPlugin
@@ -392,20 +424,16 @@ class ReactWebpackPlugin {
             const collectedTemplates: Record<string, Record<string, unknown>> =
               {};
             for (const module of compilation.modules) {
-              const buildInfo = module.buildInfo as unknown as
-                | Record<string, unknown>
-                | undefined;
-              const templates = buildInfo?.['lynx:element-templates'] as
-                | Array<{
-                  templateId: string;
-                  compiledTemplate: Record<string, unknown>;
-                }>
-                | undefined;
-              if (templates) {
-                for (const template of templates) {
-                  const { templateId, compiledTemplate } = template;
-                  collectedTemplates[templateId] = compiledTemplate;
-                }
+              // Scope hoisting can move transformed modules under `module.modules`.
+              // We need to recurse here so encode sees the same template set that
+              // other build-info collectors already observe.
+              for (
+                const template of collectElementTemplatesFromModule(
+                  module as ModuleWithElementTemplateBuildInfo,
+                )
+              ) {
+                const { templateId, compiledTemplate } = template;
+                collectedTemplates[templateId] = compiledTemplate;
               }
             }
 

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -74,6 +74,13 @@ interface ReactWebpackPluginOptions {
    * The file path of `@lynx-js/react/worklet-runtime`.
    */
   workletRuntimePath: string;
+
+  /**
+   * Whether to enable element template.
+   *
+   * @experimental
+   */
+  experimental_enableElementTemplate?: boolean;
 }
 
 /**
@@ -150,6 +157,7 @@ class ReactWebpackPlugin {
       experimental_isLazyBundle: false,
       profile: undefined,
       workletRuntimePath: '',
+      experimental_enableElementTemplate: false,
     });
 
   /**
@@ -206,6 +214,9 @@ class ReactWebpackPlugin {
       __ENABLE_SSR__: JSON.stringify(options.enableSSR),
       __DISABLE_CREATE_SELECTOR_QUERY_INCOMPATIBLE_WARNING__: JSON.stringify(
         options.disableCreateSelectorQueryIncompatibleWarning,
+      ),
+      __USE_ELEMENT_TEMPLATE__: JSON.stringify(
+        options.experimental_enableElementTemplate,
       ),
     }).apply(compiler);
 
@@ -373,6 +384,37 @@ class ReactWebpackPlugin {
             ?.replaceAll(`-react__background`, '')
             ?.replaceAll(`-react__main-thread`, ''),
       );
+
+      if (options.experimental_enableElementTemplate) {
+        hooks.beforeEncode.tap(
+          this.constructor.name + '.ElementTemplate',
+          (args) => {
+            const collectedTemplates: Record<string, Record<string, unknown>> =
+              {};
+            for (const module of compilation.modules) {
+              const buildInfo = module.buildInfo as unknown as
+                | Record<string, unknown>
+                | undefined;
+              const templates = buildInfo?.['lynx:element-templates'] as
+                | Array<{
+                  templateId: string;
+                  compiledTemplate: Record<string, unknown>;
+                }>
+                | undefined;
+              if (templates) {
+                for (const template of templates) {
+                  const { templateId, compiledTemplate } = template;
+                  collectedTemplates[templateId] = compiledTemplate;
+                }
+              }
+            }
+
+            args.encodeData.elementTemplate = collectedTemplates;
+
+            return args;
+          },
+        );
+      }
     });
   }
 

--- a/packages/webpack/react-webpack-plugin/src/loaders/main-thread.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/main-thread.ts
@@ -10,6 +10,30 @@ import { UI_SOURCE_MAP_RECORDS_BUILD_INFO } from '@lynx-js/template-webpack-plug
 import { getMainThreadTransformOptions } from './options.js';
 import type { ReactLoaderOptions } from './options.js';
 
+const ELEMENT_TEMPLATE_BUILD_INFO = 'lynx:element-templates';
+
+interface ModuleWithBuildInfo {
+  buildInfo?: Record<string, unknown>;
+}
+
+function syncElementTemplateBuildInfo(
+  mod: ModuleWithBuildInfo | undefined,
+  elementTemplates: unknown[] | undefined,
+) {
+  if (!mod) {
+    return;
+  }
+
+  mod.buildInfo ??= {};
+
+  if (elementTemplates && elementTemplates.length > 0) {
+    mod.buildInfo[ELEMENT_TEMPLATE_BUILD_INFO] = elementTemplates;
+    return;
+  }
+
+  delete mod.buildInfo[ELEMENT_TEMPLATE_BUILD_INFO];
+}
+
 const mainThreadLoader: LoaderDefinitionFunction<ReactLoaderOptions> = function(
   this: LoaderContext<ReactLoaderOptions>,
   content,
@@ -34,17 +58,10 @@ const mainThreadLoader: LoaderDefinitionFunction<ReactLoaderOptions> = function(
     getMainThreadTransformOptions.call(this, swcInputSourceMap),
   );
 
-  if (result.elementTemplates && result.elementTemplates.length > 0) {
-    interface ModuleWithBuildInfo {
-      buildInfo?: Record<string, unknown>;
-    }
-    const mod = this._module as unknown as ModuleWithBuildInfo | undefined;
-
-    if (mod) {
-      mod.buildInfo ??= {};
-      mod.buildInfo['lynx:element-templates'] = result.elementTemplates;
-    }
-  }
+  syncElementTemplateBuildInfo(
+    this._module as unknown as ModuleWithBuildInfo | undefined,
+    result.elementTemplates,
+  );
 
   if (result.errors.length > 0) {
     for (const error of result.errors) {

--- a/packages/webpack/react-webpack-plugin/src/loaders/main-thread.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/main-thread.ts
@@ -34,6 +34,18 @@ const mainThreadLoader: LoaderDefinitionFunction<ReactLoaderOptions> = function(
     getMainThreadTransformOptions.call(this, swcInputSourceMap),
   );
 
+  if (result.elementTemplates && result.elementTemplates.length > 0) {
+    interface ModuleWithBuildInfo {
+      buildInfo?: Record<string, unknown>;
+    }
+    const mod = this._module as unknown as ModuleWithBuildInfo | undefined;
+
+    if (mod) {
+      mod.buildInfo ??= {};
+      mod.buildInfo['lynx:element-templates'] = result.elementTemplates;
+    }
+  }
+
   if (result.errors.length > 0) {
     for (const error of result.errors) {
       if (this.experiments?.emitDiagnostic) {

--- a/packages/webpack/react-webpack-plugin/src/loaders/options.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/options.ts
@@ -85,6 +85,13 @@ export interface ReactLoaderOptions {
    * The engine version.
    */
   engineVersion?: string | undefined;
+
+  /**
+   * Whether to enable element template.
+   *
+   * @experimental
+   */
+  experimental_enableElementTemplate?: boolean | undefined;
 }
 
 function normalizeSlashes(file: string) {
@@ -106,6 +113,7 @@ function getCommonOptions(
     inlineSourcesContent,
     isDynamicComponent,
     engineVersion,
+    experimental_enableElementTemplate,
     defineDCE = { define: {} },
   } = this.getOptions();
 
@@ -176,6 +184,8 @@ function getCommonOptions(
       runtimePkg: RUNTIME_PKG,
       filename,
       isDynamicComponent: isDynamicComponent ?? false,
+      experimentalEnableElementTemplate: experimental_enableElementTemplate
+        ?? false,
     },
     engineVersion: engineVersion ?? '',
     syntaxConfig: JSON.stringify({

--- a/packages/webpack/react-webpack-plugin/src/loaders/testing.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/testing.ts
@@ -22,6 +22,7 @@ function testingLoader(
     compat = false,
     defineDCE = { define: {} },
     engineVersion = '',
+    experimental_enableElementTemplate = false,
     shake = false,
     transformPath = '@lynx-js/react/transform',
   } = this.getOptions();
@@ -63,6 +64,7 @@ function testingLoader(
         jsxImportSource: JSX_IMPORT_SOURCE.BACKGROUND,
         filename,
         target: 'MIXED',
+        experimentalEnableElementTemplate: experimental_enableElementTemplate,
       },
       // snapshot: true,
       directiveDCE: false,

--- a/packages/webpack/react-webpack-plugin/test/ReactWebpackPlugin.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/ReactWebpackPlugin.test.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectElementTemplatesFromModule,
+} from '../src/ReactWebpackPlugin.js';
+import type { ModuleWithElementTemplateBuildInfo } from '../src/ReactWebpackPlugin.js';
+
+describe('collectElementTemplatesFromModule', () => {
+  it('collects templates from nested modules', () => {
+    const module = {
+      buildInfo: {
+        'lynx:element-templates': [
+          {
+            templateId: 'root-template',
+            compiledTemplate: { tag: 'view' },
+          },
+        ],
+      },
+      modules: [
+        {
+          buildInfo: {
+            'lynx:element-templates': [
+              {
+                templateId: 'nested-template',
+                compiledTemplate: { tag: 'text' },
+              },
+            ],
+          },
+          modules: [
+            {
+              buildInfo: {
+                'lynx:element-templates': [
+                  {
+                    templateId: 'deep-template',
+                    compiledTemplate: { tag: 'image' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } satisfies ModuleWithElementTemplateBuildInfo;
+
+    expect(collectElementTemplatesFromModule(module)).toEqual([
+      {
+        templateId: 'root-template',
+        compiledTemplate: { tag: 'view' },
+      },
+      {
+        templateId: 'nested-template',
+        compiledTemplate: { tag: 'text' },
+      },
+      {
+        templateId: 'deep-template',
+        compiledTemplate: { tag: 'image' },
+      },
+    ]);
+  });
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/define/default/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/define/default/index.jsx
@@ -5,6 +5,7 @@ it('should inject env variables', () => {
   expect(__EXTRACT_STR__).toBe(false);
   expect(__DISABLE_CREATE_SELECTOR_QUERY_INCOMPATIBLE_WARNING__).toBe(false);
   expect(__PROFILE__).toBe(false);
+  expect(__USE_ELEMENT_TEMPLATE__).toBe(false);
 
   if (__filename.includes('main-thread')) {
     // This is false in LEPUS bundle

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/index.jsx
@@ -1,0 +1,16 @@
+import { Component } from '@lynx-js/react';
+
+const name = 'world';
+const fn = vi.fn();
+
+class App extends Component {
+  render() {
+    fn();
+    return <view>Hello, {name}</view>;
+  }
+}
+
+it('should render', () => {
+  expect(fn).not.toBeCalled();
+  expect(App).toBeDefined();
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/rspack.config.js
@@ -1,0 +1,69 @@
+import { expect } from 'vitest';
+
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { createConfig } from '../../../create-react-config.js';
+
+const defaultConfig = createConfig(
+  {
+    experimental_enableElementTemplate: true,
+  },
+  {
+    experimental_enableElementTemplate: true,
+  },
+);
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: __dirname,
+  ...defaultConfig,
+  plugins: [
+    ...(defaultConfig.plugins ?? []),
+    new LynxTemplatePlugin(),
+    new LynxEncodePlugin(),
+    /**
+     * @param {import('@rspack/core').Compiler} compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap(
+        'element-template-test',
+        (compilation) => {
+          const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+            compilation,
+          );
+          hooks.beforeEncode.tap('element-template-test', (args) => {
+            if (!args.encodeData.elementTemplate) {
+              throw new Error('elementTemplate should exist');
+            }
+            expect(args.encodeData.elementTemplate)
+              .toMatchInlineSnapshot(`
+                {
+                  "_et_a99d6_54654_1": {
+                    "children": [
+                      {
+                        "attributes": {
+                          "text": "Hello, ",
+                        },
+                        "tag": "text",
+                      },
+                      {
+                        "attributes": {
+                          "part-id": 0,
+                        },
+                        "tag": "slot",
+                      },
+                    ],
+                    "tag": "view",
+                  },
+                }
+              `);
+            return args;
+          });
+        },
+      );
+    },
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main__main-thread.js',
+    'main__background.js',
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/webpack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/webpack.config.js
@@ -1,0 +1,125 @@
+import { createRequire } from 'node:module';
+
+import { expect } from 'vitest';
+
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { LAYERS, ReactWebpackPlugin } from '../../../../src';
+
+const require = createRequire(import.meta.url);
+
+/** @type {import('webpack').Configuration} */
+export default {
+  context: __dirname,
+  entry: {
+    'main__main-thread': {
+      layer: LAYERS.MAIN_THREAD,
+      import: './index.jsx',
+    },
+    'main__background': {
+      layer: LAYERS.BACKGROUND,
+      import: './index.jsx',
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.[jt]sx?$/,
+        loader: 'swc-loader',
+        options: {
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+              decorators: true,
+            },
+          },
+        },
+      },
+      {
+        test: /\.[jt]sx?$/,
+        issuerLayer: LAYERS.BACKGROUND,
+        use: [
+          {
+            loader: ReactWebpackPlugin.loaders.BACKGROUND,
+            options: {
+              experimental_enableElementTemplate: true,
+            },
+          },
+        ],
+      },
+      {
+        test: /\.[jt]sx?$/,
+        issuerLayer: LAYERS.MAIN_THREAD,
+        use: [
+          {
+            loader: ReactWebpackPlugin.loaders.MAIN_THREAD,
+            options: {
+              experimental_enableElementTemplate: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  resolve: {
+    extensionAlias: {
+      '.js': ['.js', '.ts', '.jsx'],
+    },
+  },
+  output: {
+    filename: '[name].js',
+  },
+  plugins: [
+    new ReactWebpackPlugin({
+      mainThreadChunks: ['main__main-thread.js'],
+      workletRuntimePath: require.resolve('@lynx-js/react/worklet-dev-runtime'),
+      experimental_enableElementTemplate: true,
+    }),
+    new LynxTemplatePlugin(),
+    new LynxEncodePlugin(),
+    /**
+     * @param {import('webpack').Compiler} compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap(
+        'element-template-test',
+        (compilation) => {
+          const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+            compilation,
+          );
+          hooks.beforeEncode.tap('element-template-test', (args) => {
+            if (!args.encodeData.elementTemplate) {
+              throw new Error('elementTemplate should exist');
+            }
+            expect(args.encodeData.elementTemplate)
+              .toMatchInlineSnapshot(`
+                {
+                  "_et_a99d6_54654_1": {
+                    "children": [
+                      {
+                        "attributes": {
+                          "text": "Hello, ",
+                        },
+                        "tag": "text",
+                      },
+                      {
+                        "attributes": {
+                          "part-id": 0,
+                        },
+                        "tag": "slot",
+                      },
+                    ],
+                    "tag": "view",
+                  },
+                }
+              `);
+            return args;
+          });
+        },
+      );
+    },
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/flag/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/flag/index.jsx
@@ -1,0 +1,4 @@
+it('should inject __USE_ELEMENT_TEMPLATE__', () => {
+  /* eslint-disable */
+  expect(__USE_ELEMENT_TEMPLATE__).toBe(true);
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/flag/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/flag/rspack.config.js
@@ -1,0 +1,9 @@
+import { createConfig } from '../../../create-react-config.js';
+
+export default {
+  context: __dirname,
+  ...createConfig(
+    {},
+    { experimental_enableElementTemplate: true },
+  ),
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/flag/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/flag/test.config.cjs
@@ -1,0 +1,7 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main__main-thread.js',
+    'main__background.js',
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/fixtures/mock-main-thread-transform.cjs
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/mock-main-thread-transform.cjs
@@ -1,0 +1,24 @@
+'use strict';
+
+exports.transformReactLynxSync = function transformReactLynxSync(content) {
+  const shouldEmitTemplate = content.includes('__emitTemplate');
+
+  return {
+    code: shouldEmitTemplate
+      ? 'const _et_fixture = 1;'
+      : 'const __snapshot_fixture = 1;',
+    map: undefined,
+    errors: [],
+    warnings: [],
+    uiSourceMapRecords: [],
+    elementTemplates: shouldEmitTemplate
+      ? [
+        {
+          templateId: '_et_fixture',
+          compiledTemplate: { tag: 'view' },
+          sourceFile: 'fixture.tsx',
+        },
+      ]
+      : undefined,
+  };
+};

--- a/packages/webpack/react-webpack-plugin/test/main-thread-loader.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/main-thread-loader.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function runMainThreadLoader(
+  content: string,
+  buildInfo: Record<string, unknown>,
+): Promise<{ code: string; map?: string }> {
+  return new Promise((resolve, reject) => {
+    const loaderPath = path.resolve(
+      __dirname,
+      '../lib/loaders/main-thread.js',
+    );
+    const transformPath = path.resolve(
+      __dirname,
+      './fixtures/mock-main-thread-transform.cjs',
+    );
+
+    import(loaderPath).then(
+      (
+        mod: {
+          default: (this: Record<string, unknown>, content: string) => void;
+        },
+      ) => {
+        const loader = mod.default;
+
+        const ctx: Record<string, unknown> = {
+          getOptions: () => ({
+            engineVersion: '3.2',
+            transformPath,
+          }),
+          resourcePath: path.resolve(__dirname, 'fixture.tsx'),
+          rootContext: __dirname,
+          sourceMap: false,
+          hot: false,
+          experiments: undefined,
+          emitError: (err: Error) => reject(err),
+          // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
+          emitWarning: () => {},
+          _module: { buildInfo },
+          callback: (
+            err: Error | null,
+            code?: string,
+            map?: string,
+          ) => {
+            if (err) reject(err);
+            else resolve({ code: code!, map });
+          },
+        };
+
+        loader.call(ctx, content);
+      },
+    ).catch(reject);
+  });
+}
+
+describe('main-thread loader', () => {
+  it('clears stale element-template build info when recompilation stops emitting templates', async () => {
+    const buildInfo: Record<string, unknown> = {};
+
+    await runMainThreadLoader(
+      '/* __emitTemplate */ export function App() { return null; }',
+      buildInfo,
+    );
+
+    expect(buildInfo['lynx:element-templates']).toEqual([
+      {
+        templateId: '_et_fixture',
+        compiledTemplate: { tag: 'view' },
+        sourceFile: 'fixture.tsx',
+      },
+    ]);
+
+    await runMainThreadLoader(
+      'export function App() { return null; }',
+      buildInfo,
+    );
+
+    expect(buildInfo).not.toHaveProperty('lynx:element-templates');
+  });
+});

--- a/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
@@ -106,4 +106,20 @@ describe('testing loader', () => {
 
     expect(result.code).toBeTruthy();
   });
+
+  it('forwards element-template mode to the transform', async () => {
+    const jsxContent = `
+      export function App() {
+        return <view className="foo"><text>Hello</text></view>;
+      }
+    `;
+
+    const result = await runTestingLoader(jsxContent, {
+      engineVersion: '3.2',
+      experimental_enableElementTemplate: true,
+    });
+
+    expect(result.code).toContain('const _et_');
+    expect(result.code).not.toContain('const __snapshot_');
+  });
 });

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -331,6 +331,7 @@ interface EncodeRawData {
     appType: string;
     config: Record<string, unknown>;
   };
+  elementTemplate: Record<string, unknown>;
   [k: string]: unknown;
 }
 
@@ -837,6 +838,7 @@ class LynxTemplatePluginImpl {
         }),
       ),
       customSections: {},
+      elementTemplate: {},
     };
     const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
       compilation,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,7 +310,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@1.7.5)
+        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -1178,10 +1178,10 @@ importers:
         version: link:../../web-platform/web-elements
       '@rsbuild/plugin-less':
         specifier: 1.6.0
-        version: 1.6.0(@rsbuild/core@1.7.5)
+        version: 1.6.0(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@1.7.5)
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -1196,7 +1196,7 @@ importers:
         version: 1.1.1
       rsbuild-plugin-tailwindcss:
         specifier: 0.2.4
-        version: 0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1)
+        version: 0.2.4(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))(tailwindcss@4.2.1)
       rslog:
         specifier: ^1.3.2
         version: 1.3.2
@@ -1290,7 +1290,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@1.7.5)
+        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1982,13 +1982,13 @@ importers:
         version: 7.33.6(@types/node@24.10.13)
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@1.7.5)
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))
       '@rsbuild/plugin-type-check':
         specifier: 1.3.4
-        version: 1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.3.4(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 1.2.2
-        version: 1.2.2(@rsbuild/core@1.7.5)
+        version: 1.2.2(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))
       '@rspress/core':
         specifier: 2.0.3
         version: 2.0.3(@types/react@19.2.14)(core-js@3.48.0)
@@ -12125,13 +12125,13 @@ snapshots:
     optionalDependencies:
       core-js: 3.48.0
 
-  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@1.7.5)':
+  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@rsbuild/core': 1.7.5
+      '@rsbuild/core': 2.0.0-beta.3(core-js@3.48.0)
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -12171,9 +12171,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.7.5
 
-  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@1.7.5)':
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))':
     dependencies:
-      '@rsbuild/core': 1.7.5
+      '@rsbuild/core': 2.0.0-beta.3(core-js@3.48.0)
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
@@ -12202,6 +12202,15 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.97.3
 
+  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))':
+    dependencies:
+      '@rsbuild/core': 2.0.0-beta.3(core-js@3.48.0)
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.6
+      reduce-configs: 1.1.1
+      sass-embedded: 1.97.3
+
   '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@1.7.5)':
     dependencies:
       fast-glob: 3.3.3
@@ -12209,19 +12218,6 @@ snapshots:
       yaml: 2.8.2
     optionalDependencies:
       '@rsbuild/core': 1.7.5
-
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
-    dependencies:
-      deepmerge: 4.3.1
-      json5: 2.2.3
-      reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - tslib
-      - typescript
 
   '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
@@ -12239,6 +12235,10 @@ snapshots:
   '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@1.7.5)':
     optionalDependencies:
       '@rsbuild/core': 1.7.5
+
+  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))':
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.3(core-js@3.48.0)
 
   '@rsdoctor/client@1.2.3': {}
 
@@ -18139,15 +18139,15 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(core-js@3.48.0)
 
-  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1):
-    dependencies:
-      tailwindcss: 4.2.1
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
-
   rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))(tailwindcss@3.4.19):
     dependencies:
       tailwindcss: 3.4.19
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.3(core-js@3.48.0)
+
+  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(core-js@3.48.0))(tailwindcss@4.2.1):
+    dependencies:
+      tailwindcss: 4.2.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(core-js@3.48.0)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental element template support with `experimentalEnableElementTemplate` configuration option to optimize component rendering
  * Extended `@lynx-js/react` package exports with `element-template` and `element-template/internal` subpaths
  * Implemented element template asset collection during build transformation

* **Tests**
  * Added comprehensive test suite for element template functionality across multiple build targets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

- add the initial Element Template transform path and wire the ET flag through the rspeedy React plugins and webpack loaders
- collect emitted Element Template assets during bundling, keep main-thread and testing loaders aligned with ET mode, and clear stale ET build info between builds
- add transform, webpack, and regression coverage for ET output generation and template collection behavior
- keep changeset as not required for this step because Element Template support is still a gated, incomplete implementation that needs follow-up PRs before becoming a usable public capability

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
