### PR TITLE
fix(web): ensure x-list scrolltolower observer sentinel is detectable

### DIFF
--- a/.changeset/wild-wolves-love.md
+++ b/.changeset/wild-wolves-love.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: list `bindscrolltolower` may not trigger because the lower threshold
+sentinel had no effective size or offset, causing the bottom
+`IntersectionObserver` to miss the list boundary

--- a/packages/web-platform/web-core-e2e/server-tests/__snapshots__/server-e2e.test.ts.snap
+++ b/packages/web-platform/web-core-e2e/server-tests/__snapshots__/server-e2e.test.ts.snap
@@ -73,6 +73,7 @@ exports[`executeTemplate should run lepusCode.root from basic-element-list-basic
                 <div
                   class="observer placeholder-dom"
                   id="upper-threshold-observer"
+                  part="upper-threshold-sentinel"
                 ></div>
               </div>
               <slot part="slot"></slot>
@@ -83,6 +84,7 @@ exports[`executeTemplate should run lepusCode.root from basic-element-list-basic
                 <div
                   class="observer placeholder-dom"
                   id="lower-threshold-observer"
+                  part="lower-threshold-sentinel"
                 ></div>
               </div></div></template></x-list
       ></x-view></div></template

--- a/packages/web-platform/web-elements/src/elements/XList/x-list.css
+++ b/packages/web-platform/web-elements/src/elements/XList/x-list.css
@@ -157,6 +157,37 @@ x-list[x-enable-scrolltoloweredge-event]::part(lower-threshold-observer) {
   display: flex;
 }
 
+x-list[x-enable-scrolltoupper-event]::part(upper-threshold-sentinel),
+x-list[x-enable-scrolltoupperedge-event]::part(upper-threshold-sentinel),
+x-list[x-enable-scrolltolower-event]::part(lower-threshold-sentinel),
+x-list[x-enable-scrolltoloweredge-event]::part(lower-threshold-sentinel) {
+  flex: 0 0 1px;
+}
+
+x-list[x-enable-scrolltoupper-event]::part(upper-threshold-sentinel),
+x-list[x-enable-scrolltoupperedge-event]::part(upper-threshold-sentinel) {
+  margin-bottom: -1px;
+}
+
+x-list[x-enable-scrolltolower-event]::part(lower-threshold-sentinel),
+x-list[x-enable-scrolltoloweredge-event]::part(lower-threshold-sentinel) {
+  margin-top: -1px;
+  transform: translateY(1px);
+}
+
+x-list[scroll-orientation="horizontal"][x-enable-scrolltoupper-event]::part(upper-threshold-sentinel),
+x-list[scroll-orientation="horizontal"][x-enable-scrolltoupperedge-event]::part(upper-threshold-sentinel) {
+  margin-bottom: 0;
+  margin-right: -1px;
+}
+
+x-list[scroll-orientation="horizontal"][x-enable-scrolltolower-event]::part(lower-threshold-sentinel),
+x-list[scroll-orientation="horizontal"][x-enable-scrolltoloweredge-event]::part(lower-threshold-sentinel) {
+  margin-top: 0;
+  margin-left: -1px;
+  transform: translateX(1px);
+}
+
 x-list::part(lower-threshold-observer) {
   flex-direction: column-reverse;
 }

--- a/packages/web-platform/web-elements/src/elements/htmlTemplates.ts
+++ b/packages/web-platform/web-elements/src/elements/htmlTemplates.ts
@@ -148,6 +148,7 @@ export const templateXList = `<style>
     <div
       class="observer placeholder-dom"
       id="upper-threshold-observer"
+      part="upper-threshold-sentinel"
     ></div>
   </div>
   <slot part="slot"></slot>
@@ -158,6 +159,7 @@ export const templateXList = `<style>
     <div
       class="observer placeholder-dom"
       id="lower-threshold-observer"
+      part="lower-threshold-sentinel"
     ></div>
   </div>
 </div>`;

--- a/packages/web-platform/web-elements/src/template.rs
+++ b/packages/web-platform/web-elements/src/template.rs
@@ -155,6 +155,7 @@ pub const TEMPLATE_X_LIST: &str = r#"<style>
     <div
       class="observer placeholder-dom"
       id="upper-threshold-observer"
+      part="upper-threshold-sentinel"
     ></div>
   </div>
   <slot part="slot"></slot>
@@ -165,6 +166,7 @@ pub const TEMPLATE_X_LIST: &str = r#"<style>
     <div
       class="observer placeholder-dom"
       id="lower-threshold-observer"
+      part="lower-threshold-sentinel"
     ></div>
   </div>
 </div>"#;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where scroll-to-lower events did not trigger at the bottom of lists.
  * Improved sentinel sizing and placement for scroll boundaries so scroll events fire reliably (including horizontal scrolling scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
