### PR TITLE
fix(plugin-react): respect hmr flag for refresh

### DIFF
--- a/.changeset/fix-plugin-react-hmr-refresh.md
+++ b/.changeset/fix-plugin-react-hmr-refresh.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Respect `dev.hmr: false` when installing React Refresh integrations so disabled HMR no longer injects the refresh loader or plugin.

--- a/packages/rspeedy/plugin-react/src/refresh.ts
+++ b/packages/rspeedy/plugin-react/src/refresh.ts
@@ -18,13 +18,13 @@ import { LAYERS } from '@lynx-js/react-webpack-plugin'
 const PLUGIN_NAME_REACT_REFRESH = 'lynx:react:refresh'
 
 export function applyRefresh(api: RsbuildPluginAPI): void {
-  api.modifyWebpackChain?.(async (chain, { CHAIN_ID, isProd }) => {
-    if (!isProd) {
+  api.modifyWebpackChain?.(async (chain, { CHAIN_ID, environment, isProd }) => {
+    if (!isProd && environment.config.dev?.hmr !== false) {
       await applyRefreshRules(api, chain, CHAIN_ID, ReactRefreshWebpackPlugin)
     }
   })
-  api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID }) => {
-    if (!isProd) {
+  api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID, environment }) => {
+    if (!isProd && environment.config.dev?.hmr !== false) {
       // biome-ignore lint/correctness/useHookAtTopLevel: not react hooks
       const { resolve } = api.useExposed<
         { resolve: (request: string) => Promise<string> }

--- a/packages/rspeedy/plugin-react/test/refresh.test.ts
+++ b/packages/rspeedy/plugin-react/test/refresh.test.ts
@@ -47,4 +47,45 @@ describe('pluginReactLynx with react-refresh', () => {
     ).toBe(true)
     expect(rspackConfig).toHaveLoader(ReactRefreshRspackPlugin.loader)
   })
+
+  test('does not inject refresh loader and plugin when hmr is disabled', async () => {
+    const { pluginReactLynx } = await import('../src/index.js')
+    const { ReactRefreshRspackPlugin } = await import(
+      '@lynx-js/react-refresh-webpack-plugin'
+    )
+
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        dev: {
+          hmr: false,
+        },
+        tools: {
+          rspack: {
+            output: {
+              chunkFormat: 'commonjs',
+            },
+            resolve: {
+              extensionAlias: {
+                '.js': ['.ts', '.js'],
+              },
+            },
+          },
+        },
+        plugins: [
+          pluginReactLynx(),
+          pluginStubRspeedyAPI(),
+        ],
+      },
+    })
+
+    const [rspackConfig] = await rsbuild.initConfigs()
+
+    expect(rspackConfig?.mode).toBe('development')
+    expect(
+      rspackConfig?.plugins?.some(plugin =>
+        plugin instanceof ReactRefreshRspackPlugin
+      ),
+    ).toBe(false)
+    expect(rspackConfig).not.toHaveLoader(ReactRefreshRspackPlugin.loader)
+  })
 })


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * React Refresh integration now correctly respects the `dev.hmr: false` configuration, ensuring the React Refresh loader is not injected when HMR is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

- `dev.hmr: false` already prevented the React refresh runtime entry from being prepended, but the React Refresh webpack integration was still installed in development builds.
- This change makes the refresh loader and plugin follow the same HMR gate, so disabling HMR fully disables React Refresh integration.

## Key Points

- Guards both webpack and bundler chain refresh setup with `environment.config.dev?.hmr !== false`.
- Adds coverage for the disabled-HMR case to ensure the refresh plugin and loader are not injected.
- Keeps the existing development refresh behavior unchanged when HMR is enabled or omitted.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
