### PR TITLE
chore: reject H1/H2/H3 heading in changeset

### DIFF
--- a/.github/changeset-ci.instructions.md
+++ b/.github/changeset-ci.instructions.md
@@ -3,3 +3,5 @@ applyTo: ".github/workflows/test.yml"
 ---
 
 When validating changesets in CI, use `pnpm changeset status --since=origin/main --output <file>` and consume the JSON in a script for stable checks (for example, blocking `major` bumps) instead of parsing CLI text output.
+
+When validating changeset Markdown files in CI, run `node .github/scripts/check-no-heading-changeset.cjs .changeset-status.json` so the script resolves files from `changeset status` output, and fail the job if any listed changeset file contains H1 (`#`), H2 (`##`) or H3 (`###`) headings.

--- a/.github/scripts/check-no-heading-changeset.cjs
+++ b/.github/scripts/check-no-heading-changeset.cjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const HEADING_RE = /^\s{0,3}#{1,3}\s+\S/;
+
+function parseChangesetIds(statusFile) {
+  const data = JSON.parse(readFileSync(statusFile, 'utf8'));
+  const changesets = Array.isArray(data.changesets) ? data.changesets : [];
+  return changesets
+    .map((changeset) => changeset?.id)
+    .filter((id) => typeof id === 'string' && id.length > 0);
+}
+
+function findHeadingViolationsFromStatusFile(statusFile, changesetDir) {
+  const ids = parseChangesetIds(statusFile);
+  const violations = [];
+
+  for (const id of ids) {
+    const file = `${id}.md`;
+    const fullPath = join(changesetDir, file);
+    const lines = readFileSync(fullPath, 'utf8').split(/\r?\n/);
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (!HEADING_RE.test(line)) {
+        continue;
+      }
+      violations.push({
+        file,
+        line: index + 1,
+        heading: line.trim(),
+      });
+    }
+  }
+
+  return violations;
+}
+
+function main() {
+  const statusFile = process.argv[2] || '.changeset-status.json';
+  const changesetDir = process.argv[3] || '.changeset';
+  const violations = findHeadingViolationsFromStatusFile(
+    statusFile,
+    changesetDir,
+  );
+
+  if (violations.length === 0) {
+    process.stdout.write('No H1/H2/H3 headings found in changeset files.\n');
+    return;
+  }
+
+  process.stderr.write(
+    'H1/H2/H3 headings are not allowed in changeset files.\n',
+  );
+  for (const violation of violations) {
+    process.stderr.write(
+      `- ${violation.file}:${violation.line} -> ${violation.heading}\n`,
+    );
+  }
+
+  throw new Error('H1/H2/H3 headings found in changeset files.');
+}
+
+module.exports = {
+  findHeadingViolationsFromStatusFile,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/.github/scripts/check-no-heading-changeset.cjs
+++ b/.github/scripts/check-no-heading-changeset.cjs
@@ -6,6 +6,7 @@
 const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
 
+const FENCE_RE = /^\s{0,3}(?:```|~~~)/;
 const HEADING_RE = /^\s{0,3}#{1,3}\s+\S/;
 
 function parseChangesetIds(statusFile) {
@@ -24,10 +25,16 @@ function findHeadingViolationsFromStatusFile(statusFile, changesetDir) {
     const file = `${id}.md`;
     const fullPath = join(changesetDir, file);
     const lines = readFileSync(fullPath, 'utf8').split(/\r?\n/);
+    let inFence = false;
 
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index];
-      if (!HEADING_RE.test(line)) {
+      if (FENCE_RE.test(line)) {
+        inFence = !inFence;
+        continue;
+      }
+
+      if (inFence || !HEADING_RE.test(line)) {
         continue;
       }
       violations.push({

--- a/.github/scripts/check-no-heading-changeset.test.cjs
+++ b/.github/scripts/check-no-heading-changeset.test.cjs
@@ -119,3 +119,18 @@ test('reports H3 heading in changeset file', () => {
     },
   );
 });
+
+test('ignores headings inside fenced code blocks', () => {
+  withChangesetStatus(
+    {
+      'valid.md':
+        '---\n\'pkg\': patch\n---\n\n```md\n# Allowed In Code\n```\n\n~~~js\n## Also Allowed In Code\n~~~\n',
+    },
+    ({ statusFile, changesetDir }) => {
+      assert.deepEqual(
+        findHeadingViolationsFromStatusFile(statusFile, changesetDir),
+        [],
+      );
+    },
+  );
+});

--- a/.github/scripts/check-no-heading-changeset.test.cjs
+++ b/.github/scripts/check-no-heading-changeset.test.cjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+const assert = require('node:assert/strict');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const test = require('node:test');
+
+const { findHeadingViolationsFromStatusFile } = require(
+  './check-no-heading-changeset.cjs',
+);
+
+function withChangesetStatus(files, run) {
+  const dir = mkdtempSync(join(tmpdir(), 'changeset-heading-check-'));
+  const changesetDir = join(dir, '.changeset');
+  const statusFile = join(dir, '.changeset-status.json');
+  mkdirSync(changesetDir, { recursive: true });
+
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(changesetDir, name), content, 'utf8');
+  }
+
+  writeFileSync(
+    statusFile,
+    JSON.stringify(
+      {
+        changesets: Object.keys(files).map((name) => ({
+          id: name.replace(/\.md$/, ''),
+          summary: '',
+          releases: [],
+        })),
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  try {
+    run({ statusFile, changesetDir });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('passes when changeset files do not contain H1/H2 headings', () => {
+  withChangesetStatus(
+    {
+      'valid.md': '---\n\'pkg\': patch\n---\n\nnormal paragraph\n',
+    },
+    ({ statusFile, changesetDir }) => {
+      assert.deepEqual(
+        findHeadingViolationsFromStatusFile(statusFile, changesetDir),
+        [],
+      );
+    },
+  );
+});
+
+test('reports H1 heading in changeset file', () => {
+  withChangesetStatus(
+    {
+      'invalid.md': '---\n\'pkg\': patch\n---\n\n# Not Allowed\n',
+    },
+    ({ statusFile, changesetDir }) => {
+      assert.deepEqual(
+        findHeadingViolationsFromStatusFile(statusFile, changesetDir),
+        [
+          {
+            file: 'invalid.md',
+            line: 5,
+            heading: '# Not Allowed',
+          },
+        ],
+      );
+    },
+  );
+});
+
+test('reports H2 heading in changeset file', () => {
+  withChangesetStatus(
+    {
+      'invalid.md': '---\n\'pkg\': patch\n---\n\n## Not Allowed\n',
+    },
+    ({ statusFile, changesetDir }) => {
+      assert.deepEqual(
+        findHeadingViolationsFromStatusFile(statusFile, changesetDir),
+        [
+          {
+            file: 'invalid.md',
+            line: 5,
+            heading: '## Not Allowed',
+          },
+        ],
+      );
+    },
+  );
+});
+
+test('reports H3 heading in changeset file', () => {
+  withChangesetStatus(
+    {
+      'invalid.md': '---\n\'pkg\': patch\n---\n\n### Not Allowed\n',
+    },
+    ({ statusFile, changesetDir }) => {
+      assert.deepEqual(
+        findHeadingViolationsFromStatusFile(statusFile, changesetDir),
+        [
+          {
+            file: 'invalid.md',
+            line: 5,
+            heading: '### Not Allowed',
+          },
+        ],
+      );
+    },
+  );
+});

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,8 @@ jobs:
         run: pnpm changeset status --since=origin/main --output .changeset-status.json
       - name: Major Bump Check
         run: node .github/scripts/check-no-major-changeset.cjs .changeset-status.json
+      - name: Changeset Heading Check
+        run: node .github/scripts/check-no-heading-changeset.cjs .changeset-status.json
 
   eslint:
     needs: build

--- a/packages/web-platform/web-core/CHANGELOG.md
+++ b/packages/web-platform/web-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   This mechanism enables seamless cross-element event communication without requiring a formal DOM tree relationship, allowing decoupled elements to observe and respond to standard events occurring anywhere within the component tree.
 
-  ### Usage
+  #### Usage
 
   Global bindings allow an observer element to react to events triggered on another target element.
 
@@ -70,18 +70,18 @@
 
 - **This is a breaking change** ([#2322](https://github.com/lynx-family/lynx-stack/pull/2322))
 
-  ## Architectural Upgrade: `web-core-wasm` replaces `web-core`
+  #### Architectural Upgrade: `web-core-wasm` replaces `web-core`
 
   This release marks a major architectural upgrade for the web platform. The experimental, WASM-powered engine formerly known as `web-core-wasm` has been fully stabilized and merged into the main branch, completely replacing the previous pure JS/TS based `web-core` implementation. This consolidation massively improves execution performance and aligns the API boundaries of the Web platform directly with other native Lynx implementations.
 
-  ### 🎉 Added Features
+  ##### 🎉 Added Features
 
   - **Core API Enhancements**: Successfully exposed and supported `__QuerySelector` and `__InvokeUIMethod` methods.
   - **Security & CSP Compliance**: Added a `nonce` attribute to the iframe's `srcdoc` script execution, strengthening Content Security Policy (CSP) compliance.
   - **`<lynx-view>` Parameter Enhancements**:
     - Added the `browser-config` attribute and property to `<lynx-view>`. Development environments can now supply a `BrowserConfig` object (e.g., configuring `pixelRatio`, `pixelWidth`, `pixelHeight`) allowing the `systemInfo` payload to be dynamically configured at the instance level.
 
-  ### 🔄 Changed Features
+  ##### 🔄 Changed Features
 
   - **Legacy JSON Backwards Compatibility**: Delivered comprehensive fixes and optimizations to deeply support legacy JSON output templates:
     - Added support for lazy loading execution mode (`lazy usage`).
@@ -120,7 +120,7 @@
   - **Dependency & Boot Sequence Improvements**: Re-architected module loading pathways. Promoted `wasm-feature-detect` directly to a core dependency, and hardened the web worker count initialization assertions.
   - **Initialization Optimizations**: Converted `SERVER_IN_SHADOW_CSS` initialization bounds to use compilation-time constant expressions for better optimization.
 
-  ### 🗑️ Deleted Features & Structural Deprecations
+  ##### 🗑️ Deleted Features & Structural Deprecations
 
   - **`<lynx-view>` Parameter Removals**:
     - Removed the `thread-strategy` property and attribute. Historically, this permitted consumers to toggle between `'multi-thread'` and `'all-on-ui'` modes depending on how they wanted the background logic to be executed. The WASM-driven architecture enforces a consolidated concurrency model, deprecating this `<lynx-view>` attribute entirely.
@@ -154,7 +154,7 @@
   - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/container-type
   - https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_queries
 
-  ### how it works?
+  #### how it works?
 
   For the following code
 

--- a/packages/web-platform/web-elements/CHANGELOG.md
+++ b/packages/web-platform/web-elements/CHANGELOG.md
@@ -80,14 +80,14 @@
 
 - chore: migrate all @lynx-js/web-elements-\* packages into one ([#2057](https://github.com/lynx-family/lynx-stack/pull/2057))
 
-  ### Before
+  #### Before
 
   ```js
   import '@lynx-js/web-elements-template';
   import '@lynx-js/web-elements-compat/LinearContainer';
   ```
 
-  ### After
+  #### After
 
   ```js
   import '@lynx-js/web-elements/html-templates';
@@ -710,17 +710,17 @@
 - 3547621: feat(web): use `<lynx-wrapper/>` to replace `<div style="display:content"/>`
 - bed4f24: feat(web): implement <x-list> with list-type="single"
 
-  ## 1. RFC
+  #### 1. RFC
 
   https://github.com/lynx-wg/lynx-stack/issues/106
 
-  ## 2. Implementation differences with RFC
+  #### 2. Implementation differences with RFC
 
-  ### paging-enabled
+  ##### paging-enabled
 
   deprecated, no need to implement
 
-  ### layoutcomplete
+  ##### layoutcomplete
 
   Triggered only after the first screen because using contentvisibilityautostatechange.
 
@@ -729,28 +729,28 @@
   > This is because content is the parent container of list-item, and content is always visible before list-item.
   > We cannot obtain the timing of all the successfully visible list-items on the screen, so 100ms is used to delay this behavior.
 
-  ### event-scrolltoedge
+  ##### event-scrolltoedge
 
   split bindscrolltoupperedge and bindscrooltolowerdge.
 
-  ### event-scrolltoupper/lower
+  ##### event-scrolltoupper/lower
 
   Can be used with upper/lower-threshold-item-count.
 
   Attention, when the number of x-list children changes, scrolltoupper/lower will be re-triggered (if the new node is on the screen).
 
-  ### getVisibleCells, layoutcomplete
+  ##### getVisibleCells, layoutcomplete
 
   The returned cells may be an empty array, because there is a high probability that the contentvisibilityautostatechange event of list-item will not be captured when the first screen is displayed.
 
-  ## 3. Tests not implemented
+  #### 3. Tests not implemented
 
-  ### HTML Tests
+  ##### HTML Tests
 
   1. event-layoutcomplete skipped webkit, firefox due to contentvisibilityautostatechange not propagate
   2. get-visible-cells skipped webkit, firefox due to contentvisibilityautostatechange not propagate
 
-  ### React Tests
+  ##### React Tests
 
   1. lynx.createQuery not supported.
 
@@ -815,7 +815,7 @@
 - 8c6eeb9: fix(web): rename x-swiper-itrm to swiper-item
 - 1fe49a2: feat(web): add custom element x-audio-tt
 
-  ## The behavior is different from the native x-audio-tt:
+  #### The behavior is different from the native x-audio-tt:
 
   - When src changes, resources will not be loaded immediately. Resources will only be loaded when the play and prepare methods are triggered.
 
@@ -824,13 +824,13 @@
 
   - The code returned by the binderror event does not include -4
 
-  ## Unimplemented properties:
+  #### Unimplemented properties:
 
   - autoplay
   - playertype
   - experimental-ios-async-prepare
 
-  ## Unimplemented methods:
+  #### Unimplemented methods:
 
   - requestFocus
   - releaseFocus


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now includes a validation step that detects top-level markdown headings in changeset files.

* **Tests**
  * Added tests covering heading detection and ignoring headings inside fenced code blocks.

* **Chores**
  * Updated CI workflow to run the new validation.
  * Reformatted changelog files by adjusting markdown heading levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
