### PR TITLE
test(template-webpack-plugin): lock initial css order

### DIFF
--- a/.github/lynx-stack.instructions.md
+++ b/.github/lynx-stack.instructions.md
@@ -6,3 +6,10 @@ When updating web element APIs, add targeted Playwright tests in packages/web-pl
 Ensure Playwright browsers are installed (pnpm exec playwright install --with-deps <browser>) before running web-elements tests.
 For x-input type="number" in web-elements, keep inner input type as text, set inputmode="decimal", and filter number input internally without setting input-filter explicitly.
 Add new web-elements UI fixtures under packages/web-platform/web-elements/tests/fixtures and commit matching snapshots in packages/web-platform/web-elements/tests/web-elements.spec.ts-snapshots.
+
+---
+applyTo: "packages/webpack/template-webpack-plugin/**/*"
+---
+
+When changing initial CSS handling in template-webpack-plugin, add or update a code-splitting case that asserts the exact selector order in `tasm.json`, not just that CSS assets exist.
+Prefer a shared-plus-split initial chunk fixture when validating CSS merge order so the expected rule sequence follows the source import order clearly.

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/blue.css
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/blue.css
@@ -1,0 +1,3 @@
+.shared {
+  color: blue;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/common.css
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/common.css
@@ -1,0 +1,3 @@
+.shared {
+  color: green;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/common.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/common.js
@@ -1,0 +1,3 @@
+import './common.css';
+
+export const common = 'common';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/entry-main.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/entry-main.js
@@ -1,0 +1,5 @@
+import './common.js';
+import './feature-b.js';
+import './feature-a.js';
+
+export const entryMain = 'entry-main';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/feature-a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/feature-a.js
@@ -1,0 +1,3 @@
+import './red.css';
+
+export const featureA = 'feature-a';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/feature-b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/feature-b.js
@@ -1,0 +1,3 @@
+import './blue.css';
+
+export const featureB = 'feature-b';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/index.js
@@ -1,0 +1,37 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="vitest/globals" />
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+// entry-main imports common -> feature-b -> feature-a, so the merged .shared
+// rules should keep green -> blue -> red even after splitChunks extraction.
+import './entry-main.js';
+
+it('should preserve source css order across shared and split initial chunks', async () => {
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/main/tasm.json');
+  expect(existsSync(tasmJSONPath)).toBeTruthy();
+
+  const content = await readFile(tasmJSONPath, 'utf-8');
+  const { css } = JSON.parse(content);
+
+  const sharedRules = Object.values(css.cssMap)
+    .flat()
+    .filter((rule) =>
+      rule.type === 'StyleRule' && rule.selectorText?.value === '.shared'
+    );
+  const sharedColors = sharedRules.map((rule) => {
+    const colorDeclaration = rule.style.find(
+      (property) => property.name === 'color',
+    );
+    return colorDeclaration?.value;
+  });
+
+  expect(sharedRules).toHaveLength(3);
+  expect(sharedColors).toEqual(['green', 'blue', 'red']);
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/red.css
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/red.css
@@ -1,0 +1,3 @@
+.shared {
+  color: red;
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/rspack.config.js
@@ -1,0 +1,68 @@
+import { CssExtractRspackPlugin } from '@rspack/core';
+
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../src';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  devtool: false,
+  entry: {
+    main: './code-splitting/initial-css-order/entry-main.js',
+  },
+  mode: 'development',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          CssExtractRspackPlugin.loader,
+          'css-loader',
+        ],
+      },
+    ],
+  },
+  output: {
+    filename: (...args) => {
+      if (args[0].chunk.name === 'main') {
+        return 'rspack.bundle.js';
+      }
+      return '[name].js';
+    },
+  },
+  optimization: {
+    splitChunks: {
+      chunks: function(chunk) {
+        return !chunk.name?.includes('__main-thread');
+      },
+      cacheGroups: {
+        common: {
+          test: /common\.js$/,
+          name: 'common',
+          enforce: true,
+          priority: 3,
+        },
+        featureA: {
+          test: /feature-a\.js$/,
+          name: 'feature-a',
+          enforce: true,
+          priority: 2,
+        },
+        featureB: {
+          test: /feature-b\.js$/,
+          name: 'feature-b',
+          enforce: true,
+          priority: 1,
+        },
+      },
+    },
+  },
+  plugins: [
+    new CssExtractRspackPlugin({}),
+    new LynxEncodePlugin({
+      inlineScripts: /(main|common|feature-a|feature-b)\.js$/,
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      intermediate: '.rspeedy/main',
+    }),
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/test.config.cjs
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/initial-css-order/test.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'rspack.bundle.js',
+  ],
+};


### PR DESCRIPTION
## Summary
- add a `code-splitting/initial-css-order` case for `template-webpack-plugin`
- assert the exact `.shared` selector order in `tasm.json` for shared plus split initial chunks
- document the expectation to verify selector order rather than only CSS asset presence

## Test Plan
- [x] `pnpm --dir packages/webpack/template-webpack-plugin test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test case validating that CSS rule order is preserved during code-splitting operations, ensuring source import order is maintained in the final stylesheet.

* **Chores**
  * Updated build instructions to require CSS order validation tests when modifying initial CSS handling in code-splitting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->