### PR TITLE
fix(web): genStyleInfo should also preserve CSS variable fallback values

### DIFF
--- a/.changeset/hungry-spoons-like.md
+++ b/.changeset/hungry-spoons-like.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+fix: genStyleInfo should also preserve CSS variable fallback values when encoding web-core stylesheets so declarations like `var(--token, rgba(...))` are emitted with their fallback intact.

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -989,6 +989,14 @@ test.describe('reactlynx3 tests', () => {
       });
       expect(computedStyle.backgroundColor).toBe('rgb(255, 192, 203)');
     });
+    test('basic-css-var-fallback-color', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      await expect(page.locator('#target')).toHaveCSS(
+        'color',
+        'rgba(22, 24, 35, 0.6)',
+      );
+    });
     test('basic-color-not-inherit', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);

--- a/packages/web-platform/web-tests/tests/react/basic-css-var-fallback-color/index.css
+++ b/packages/web-platform/web-tests/tests/react/basic-css-var-fallback-color/index.css
@@ -1,0 +1,3 @@
+#target {
+  color: var(--Text-TextQuaternary, rgba(22, 24, 35, 0.6));
+}

--- a/packages/web-platform/web-tests/tests/react/basic-css-var-fallback-color/index.jsx
+++ b/packages/web-platform/web-tests/tests/react/basic-css-var-fallback-color/index.jsx
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+import './index.css';
+
+function App() {
+  return <text id='target'>fallback</text>;
+}
+
+root.render(<App></App>);

--- a/packages/webpack/template-webpack-plugin/src/web/genStyleInfo.ts
+++ b/packages/webpack/template-webpack-plugin/src/web/genStyleInfo.ts
@@ -6,6 +6,23 @@ import * as CSS from '@lynx-js/css-serializer';
 
 import type { CSSRule, OneInfo, StyleInfo } from './StyleInfo.js';
 
+function restoreCSSVarValue(declaration: CSS.Declaration): string {
+  return declaration.value.replaceAll(
+    /\{\{(--[^}]+)\}\}/g,
+    (_, varName: string) => {
+      const isCSSVarDecl = 'type' in declaration
+        && declaration.type === 'css_var';
+
+      if (!isCSSVarDecl) {
+        return `var(${varName})`;
+      }
+
+      const fallback = declaration.defaultValueMap?.[varName];
+      return fallback ? `var(${varName}, ${fallback})` : `var(${varName})`;
+    },
+  );
+}
+
 export function genStyleInfo(
   cssMap: Record<string, CSS.LynxStyleNode[]>,
 ): StyleInfo {
@@ -113,7 +130,7 @@ export function genStyleInfo(
             declaration,
           ) => [
             declaration.name,
-            declaration.value.replaceAll(/\{\{--([^}]+)\}\}/g, 'var(--$1)'),
+            restoreCSSVarValue(declaration),
           ]);
 
           decl.push(...(Object.entries(node.variables)));


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * CSS variable fallback values in web-core stylesheets are now correctly preserved during encoding. CSS constructs like `var(--token, rgba(...))` will now maintain their fallback values intact when custom properties are not defined.

* **Tests**
  * Added test case to verify CSS variable fallback color rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
