### PR TITLE
fix(web): list cannot drag-scroll inside x-foldview-slot-ng

### DIFF
--- a/.changeset/tender-carrots-exist.md
+++ b/.changeset/tender-carrots-exist.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: list cannot drag-scroll inside x-foldview-slot-ng
+
+Cause: `touchstart` used `elementsFromPoint(pageX, pageY)` (expects `clientX/clientY`), so hit-testing can miss the real inner scroller (e.g. `x-list` shadow `#content`) when the document is scrolled.
+
+Fix: use `elementsFromPoint(clientX, clientY)` + `event.composedPath()` for Shadow DOM, and keep `previousPageX` updated during `touchmove`.

--- a/packages/web-platform/web-elements/src/elements/XFoldViewNg/XFoldviewNg.ts
+++ b/packages/web-platform/web-elements/src/elements/XFoldViewNg/XFoldviewNg.ts
@@ -8,6 +8,7 @@ import { CommonEventsAndMethods } from '../common/CommonEventsAndMethods.js';
 import { XFoldviewNgEvents } from './XFoldviewNgEvents.js';
 import { scrollContainerDom } from '../common/constants.js';
 import type { XFoldviewSlotNg } from './XFoldviewSlotNg.js';
+
 import { LinearContainer } from '../../compat/index.js';
 
 export const scrollableLength = Symbol('scrollableLength');

--- a/packages/web-platform/web-elements/src/elements/XFoldViewNg/XFoldviewSlotNgTouchEventsHandler.ts
+++ b/packages/web-platform/web-elements/src/elements/XFoldViewNg/XFoldviewSlotNgTouchEventsHandler.ts
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 */
 import type { AttributeReactiveClass } from '../../element-reactive/index.js';
+import { scrollContainerDom } from '../common/constants.js';
 import { isHeaderShowing, type XFoldviewNg } from './XFoldviewNg.js';
 import type { XFoldviewSlotNg } from './XFoldviewSlotNg.js';
 export class XFoldviewSlotNgTouchEventsHandler
@@ -35,6 +36,24 @@ export class XFoldviewSlotNgTouchEventsHandler
     this.#dom.addEventListener('wheel', this.#handleWheel, {
       passive: false,
     });
+  }
+
+  #resolveScrollContainer(element: Element): Element {
+    const maybeScrollContainer = (
+      element as unknown as Record<PropertyKey, unknown>
+    )[scrollContainerDom];
+
+    return maybeScrollContainer instanceof Element
+      ? maybeScrollContainer
+      : element;
+  }
+
+  #collectCandidateElements(elements: Element[]): Element[] {
+    return [
+      ...new Set(
+        elements.map(element => this.#resolveScrollContainer(element)),
+      ),
+    ];
   }
 
   #isScrollContainer(element: Element): boolean {
@@ -101,6 +120,7 @@ export class XFoldviewSlotNgTouchEventsHandler
     }
     this.#handleScrollDelta(deltaY, parentElement);
     this.#previousPageY = pageY;
+    this.#previousPageX = pageX;
   };
 
   #handleWheel = (event: WheelEvent) => {
@@ -121,7 +141,10 @@ export class XFoldviewSlotNgTouchEventsHandler
     const pointElements = document.elementsFromPoint(clientX, clientY).filter(
       e => this.#dom.contains(e),
     );
-    this.#elements = [...new Set([...pathElements, ...pointElements])];
+    this.#elements = this.#collectCandidateElements([
+      ...pathElements,
+      ...pointElements,
+    ]);
     this.#parentScrollTop = parentElement.scrollTop;
     if (this.#elements) {
       for (const element of this.#elements) {
@@ -142,10 +165,24 @@ export class XFoldviewSlotNgTouchEventsHandler
   }
 
   #touchStart = (event: TouchEvent) => {
-    const { pageX, pageY } = event.touches.item(0)!;
-    this.#elements = document.elementsFromPoint(pageX, pageY).filter(e =>
-      this.#dom.contains(e) && e !== this.#dom
+    const touch = event.touches.item(0)!;
+    const { pageX, pageY, clientX, clientY } = touch;
+    // `elementsFromPoint()` doesn't reliably pierce into Shadow DOM; combine with
+    // the composed path so we can pick up internal scroll containers like
+    // `x-list`'s `#content` inside the shadow root.
+    const pathElements = event.composedPath().filter((
+      element,
+    ): element is Element =>
+      element instanceof Element && this.#dom.contains(element)
+      && element !== this.#dom
     );
+    const pointElements = document.elementsFromPoint(clientX, clientY).filter(
+      e => this.#dom.contains(e) && e !== this.#dom,
+    );
+    this.#elements = this.#collectCandidateElements([
+      ...pathElements,
+      ...pointElements,
+    ]);
     this.#previousPageY = pageY;
     this.#previousPageX = pageX;
     this.#parentScrollTop = this.#getParentElement()?.scrollTop ?? 0;

--- a/packages/web-platform/web-elements/src/elements/XList/XList.ts
+++ b/packages/web-platform/web-elements/src/elements/XList/XList.ts
@@ -9,6 +9,7 @@ import { XListEvents } from './XListEvents.js';
 import { XListWaterfall } from './XListWaterfall.js';
 import { CommonEventsAndMethods } from '../common/CommonEventsAndMethods.js';
 import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
+import { scrollContainerDom } from '../common/constants.js';
 import { templateXList } from '../htmlTemplates.js';
 
 @Component<typeof XList>(
@@ -52,6 +53,10 @@ export class XList extends HTMLElement {
 
   override get scrollWidth() {
     return this.#getListContainer().scrollWidth;
+  }
+
+  get [scrollContainerDom]() {
+    return this.#getListContainer();
   }
 
   get __scrollTop() {

--- a/packages/web-platform/web-elements/tests/fixtures/x-foldview-ng/swipe-with-x-list.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-foldview-ng/swipe-with-x-list.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation">
+    <link href="/main.css" rel="stylesheet">
+    <style>
+    x-view {
+      width: 100%;
+    }
+
+    x-list {
+      width: 100%;
+      height: 100%;
+    }
+
+    .item {
+      height: 100px;
+      border-width: 2px;
+      border-color: green;
+      background-color: hsl(calc(20 * var(--item-index)), 100%, 70%);
+    }
+    </style>
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <!-- Make the document scrollable so `pageX/pageY` differs from `clientX/clientY`. -->
+    <div style="height: 800px; background: #f5f5f5">spacer</div>
+
+    <div style="width: 100vw; display: flex; flex-direction: row">
+      <x-foldview-ng
+        id="foldview"
+        style="width: 80%; height: 400px; background-color: wheat; display: flex; flex-direction: column"
+      >
+        <x-foldview-header-ng
+          style="position: absolute; width: 100%; height: 200px"
+        >
+          <div style="background-color: aqua; width: 100%; height: 300px"></div>
+        </x-foldview-header-ng>
+        <x-foldview-slot-ng style="width: 100%; height: 400px">
+          <x-list id="inner-list" enable-scroll="true">
+            <list-item class="item" style="--item-index: 0" item-key="0"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 1" item-key="1"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 2" item-key="2"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 3" item-key="3"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 4" item-key="4"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 5" item-key="5"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 6" item-key="6"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 7" item-key="7"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 8" item-key="8"><x-view
+              ></x-view></list-item>
+            <list-item class="item" style="--item-index: 9" item-key="9"><x-view
+              ></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 10"
+              item-key="10"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 11"
+              item-key="11"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 12"
+              item-key="12"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 13"
+              item-key="13"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 14"
+              item-key="14"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 15"
+              item-key="15"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 16"
+              item-key="16"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 17"
+              item-key="17"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 18"
+              item-key="18"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 19"
+              item-key="19"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 20"
+              item-key="20"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 21"
+              item-key="21"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 22"
+              item-key="22"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 23"
+              item-key="23"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 24"
+              item-key="24"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 25"
+              item-key="25"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 26"
+              item-key="26"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 27"
+              item-key="27"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 28"
+              item-key="28"
+            ><x-view></x-view></list-item>
+            <list-item
+              class="item"
+              style="--item-index: 29"
+              item-key="29"
+            ><x-view></x-view></list-item>
+          </x-list>
+        </x-foldview-slot-ng>
+      </x-foldview-ng>
+    </div>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -1051,6 +1051,59 @@ test.describe('web-elements test suite', () => {
       });
       expect(scrollLeft).toBeGreaterThan(100);
     });
+
+    test('x-foldview-ng/swipe-with-x-list', async ({
+      page,
+      browserName,
+      context,
+    }, { title }) => {
+      test.skip(browserName !== 'chromium', 'using chromium only cdp methods');
+      const cdpSession = await context.newCDPSession(page);
+      await gotoWebComponentPage(page, title);
+
+      const foldview = page.locator('#foldview');
+      const xlist = page.locator('#inner-list');
+
+      // Ensure the document is scrolled: legacy code used `pageX/pageY` with
+      // `elementsFromPoint()`, which expects `clientX/clientY`, causing misses.
+      await page.evaluate(() => window.scrollTo(0, 600));
+      await wait(50);
+
+      await xlist.evaluate((dom: HTMLElement) => {
+        dom.scrollTop = 0;
+      });
+
+      const listInitial = await xlist.evaluate((dom: HTMLElement) =>
+        dom.scrollTop
+      );
+
+      const box = await foldview.boundingBox();
+      expect(box, 'foldview should be visible').toBeTruthy();
+      const x = (box!.x + box!.width / 2) | 0;
+      const y = (box!.y + box!.height / 2) | 0;
+
+      // Scroll the foldview header fully away first, then the swipe should
+      // continue to inner scroll container (x-list). This is the part that
+      // regressed when `touchstart` picked elements via the wrong coordinates.
+      await foldview.evaluate((dom: HTMLElement) => {
+        dom.scrollTop = dom.scrollHeight;
+      });
+      await wait(150);
+
+      await swipe(cdpSession, {
+        x,
+        y,
+        xDistance: 0,
+        yDistance: -200,
+        speed: 300,
+      });
+      await wait(250);
+
+      expect(
+        await xlist.evaluate((dom: HTMLElement) => dom.scrollTop),
+        'swipe-continues-to-inner-list-scroll',
+      ).toBeGreaterThan(listInitial);
+    });
     test('x-foldview-ng/event-offset-granularity', async ({
       page,
       browserName,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed drag-scroll (swipe) inside x-foldview-slot-ng so inner scrollable lists continue scrolling correctly when the page is scrolled and when Shadow DOM is present.

* **Tests**
  * Added an end-to-end swipe test and supporting fixture that reproduces document scroll offsets to validate nested swipe/scroll behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
