### PR TITLE
fix(web): line-height of markdown-style should be added

### DIFF
--- a/.changeset/tiny-pianos-enter.md
+++ b/.changeset/tiny-pianos-enter.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: line-height of markdown-style should be added `px`

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
@@ -380,7 +380,6 @@ const preprocessInlineView = (html: string) =>
 
 const unitlessCssProperties = new Set([
   'font-weight',
-  'line-height',
   'opacity',
   'z-index',
   'flex',

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/style.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/style.html
@@ -36,6 +36,7 @@
         },
         link: {
           color: 'ff0000',
+          lineHeight: 24,
         },
         inlineCode: {
           color: '0000ff',

--- a/packages/web-platform/web-elements/tests/x-markdown.spec.ts
+++ b/packages/web-platform/web-elements/tests/x-markdown.spec.ts
@@ -104,9 +104,14 @@ test.describe('x-markdown', () => {
   test('should apply markdown-style updates', async ({ page }) => {
     await goto(page, 'x-markdown/style');
     const markdown = page.locator('x-markdown');
+    await page.waitForFunction(() => {
+      const element = document.querySelector('x-markdown');
+      return element?.shadowRoot?.querySelector('a')?.textContent === 'link';
+    });
 
     const link = markdown.locator('a');
     await expect(link).toHaveCSS('color', 'rgb(255, 0, 0)');
+    await expect(link).toHaveCSS('line-height', '24px');
 
     const inlineCode = markdown.locator('code').first();
     await expect(inlineCode).toHaveCSS('color', 'rgb(0, 0, 255)');


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `line-height` values in markdown-style formatting to include explicit `px` unit suffix.

* **Tests**
  * Updated test assertions to verify correct `line-height` CSS property rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
