### PR TITLE
fix(web): markdown should pre-set slot

### DIFF
--- a/.changeset/rich-teams-melt.md
+++ b/.changeset/rich-teams-melt.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: x-markdown inline view injection no longer queries light DOM children when the content attribute changes. Consumers must now pre-set `slot="{id}"` on the child element they want to project into `inlineview://{id}`.

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
@@ -1285,23 +1285,12 @@ export class XMarkdownAttributes {
         const inlineId = img.getAttribute('data-inlineview');
         if (inlineId) {
           const id = inlineId;
-          const view = this.#dom.querySelector(`#${CSS.escape(id)}`);
-          if (view) {
-            const container = document.createElement('span');
-            container.className = 'md-inline-view';
-            const vAlign = (view as HTMLElement).getAttribute('vertical-align')
-              || (view as HTMLElement).style.verticalAlign
-              || '';
-            if (vAlign) {
-              (container.style as any).verticalAlign = vAlign;
-            }
-            const slot = document.createElement('slot');
-            const slotName = `md-inline-view-${id}`;
-            slot.name = slotName;
-            (view as HTMLElement).slot = slotName;
-            container.appendChild(slot);
-            img.replaceWith(container);
-          }
+          const container = document.createElement('span');
+          container.className = 'md-inline-view';
+          const slot = document.createElement('slot');
+          slot.name = `md-inline-view-${id}`;
+          container.appendChild(slot);
+          img.replaceWith(container);
         }
       }
     } catch {

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview-class.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview-class.html
@@ -18,7 +18,11 @@
     <script src="/main.js" defer></script>
     <x-view class="page">
       <x-markdown id="markdown" style="width: 300px">
-        <x-view id="content-view" class="content"></x-view>
+        <x-view
+          id="content-view"
+          slot="md-inline-view-content-view"
+          class="content"
+        ></x-view>
       </x-markdown>
     </x-view>
     <script>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview.html
@@ -12,7 +12,7 @@
       <x-markdown id="markdown" style="width: 300px">
         <x-view
           id="badge"
-          vertical-align="middle"
+          slot="md-inline-view-badge"
           style="display: inline-block; width: 10px; height: 10px; background: rgb(255, 0, 0)"
         ></x-view>
       </x-markdown>

--- a/packages/web-platform/web-elements/tests/x-markdown.spec.ts
+++ b/packages/web-platform/web-elements/tests/x-markdown.spec.ts
@@ -617,22 +617,24 @@ test.describe('x-markdown', () => {
     ]);
   });
 
-  test('should inject inline view and keep vertical-align', async ({ page }) => {
+  test('should inject inline view via pre-set slot', async ({ page }) => {
     await goto(page, 'x-markdown/inlineview');
     await page.waitForFunction(() => {
       const el = document.querySelector('x-markdown');
       const root = el && (el as any).shadowRoot;
       return !!root && !!root.querySelector('.md-inline-view');
     });
-    const va = await page.evaluate(() => {
+    const projected = await page.evaluate(() => {
       const el = document.querySelector('x-markdown')!;
       const root = el.shadowRoot as ShadowRoot;
-      const inline = root.querySelector('.md-inline-view') as
-        | HTMLElement
-        | null;
-      return inline ? getComputedStyle(inline).verticalAlign : '';
+      const slot = root.querySelector(
+        '.md-inline-view slot',
+      ) as HTMLSlotElement | null;
+      return slot?.assignedElements().some((node) =>
+        (node as HTMLElement).id === 'badge'
+      ) ?? false;
     });
-    expect(va).toBe('middle');
+    expect(projected).toBe(true);
   });
 
   test('should apply class styles to inline view', async ({ page }) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed inline view injection in x-markdown: when content changes, the component no longer queries light DOM children. Inline view elements now use slot-based projection and require a `slot` attribute to be set upfront.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
