### PR TITLE
fix(react): correct list update indices after insertBefore

### DIFF
--- a/.changeset/tangy-worlds-battle.md
+++ b/.changeset/tangy-worlds-battle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix list update indices when existing items are updated after inserting siblings before them.

--- a/packages/react/runtime/__test__/snapshot/list.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/list.test.jsx
@@ -400,6 +400,44 @@ describe(`list "update-list-info"`, () => {
         ],
       }
     `);
+
+    __pendingListUpdates.clearAttachedLists();
+
+    const d4 = new SnapshotInstance(s3);
+    const d5 = new SnapshotInstance(s3);
+
+    b1.insertBefore(d4, d2);
+    b1.insertBefore(d5, d2);
+    d2.setAttribute(0, { 'item-key': 2 });
+
+    expect(__pendingListUpdates.values).toMatchInlineSnapshot(`
+      {
+        "-4": [
+          {
+            "insertAction": [
+              {
+                "position": 1,
+                "type": "__snapshot_a94a8_test_20",
+              },
+              {
+                "position": 2,
+                "type": "__snapshot_a94a8_test_20",
+              },
+            ],
+            "removeAction": [],
+            "updateAction": [
+              {
+                "flush": false,
+                "from": 3,
+                "item-key": 2,
+                "to": 3,
+                "type": "__snapshot_a94a8_test_20",
+              },
+            ],
+          },
+        ],
+      }
+    `);
   });
 });
 

--- a/packages/react/runtime/src/snapshot/list/listUpdateInfo.ts
+++ b/packages/react/runtime/src/snapshot/list/listUpdateInfo.ts
@@ -163,11 +163,12 @@ export class ListUpdateInfoRecording implements ListUpdateInfo {
     let j = 0;
     for (let i = 0; i < this.oldChildNodes.length; i++, j++) {
       const child = this.oldChildNodes[i]!;
+      const insertedBefore = insertBefore.get(child)?.length ?? 0;
       if (platformInfoUpdate.has(child)) {
         updates.push({
           ...platformInfoUpdate.get(child),
-          from: +j,
-          to: +j,
+          from: +j + insertedBefore,
+          to: +j + insertedBefore,
           // no flush
           flush: false,
           type: child.type,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed list item update indices when inserting sibling elements before existing items in the list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
