### PR TITLE
fix(web): XMarkdown slot created should not have prefix

### DIFF
--- a/.changeset/breezy-sloths-move.md
+++ b/.changeset/breezy-sloths-move.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: XMarkdown slot created should not have prefix

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
@@ -1288,7 +1288,7 @@ export class XMarkdownAttributes {
           const container = document.createElement('span');
           container.className = 'md-inline-view';
           const slot = document.createElement('slot');
-          slot.name = `md-inline-view-${id}`;
+          slot.name = id;
           container.appendChild(slot);
           img.replaceWith(container);
         }

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview-class.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview-class.html
@@ -20,7 +20,7 @@
       <x-markdown id="markdown" style="width: 300px">
         <x-view
           id="content-view"
-          slot="md-inline-view-content-view"
+          slot="content-view"
           class="content"
         ></x-view>
       </x-markdown>

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/inlineview.html
@@ -12,7 +12,7 @@
       <x-markdown id="markdown" style="width: 300px">
         <x-view
           id="badge"
-          slot="md-inline-view-badge"
+          slot="badge"
           style="display: inline-block; width: 10px; height: 10px; background: rgb(255, 0, 0)"
         ></x-view>
       </x-markdown>


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * XMarkdown inline view slots no longer include the `md-inline-view-` prefix. Slots are now directly assigned using their identifier for improved clarity and simplified slot targeting when populating inline view content within markdown documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
