### PR TITLE
feat: set `bundle-url` on lazy bundle border elements

### DIFF
--- a/.changeset/orange-crabs-win.md
+++ b/.changeset/orange-crabs-win.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Set `bundle-url` on lazy bundle border elements.

--- a/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
@@ -182,6 +182,64 @@ describe('insertBefore', () => {
     `);
   });
 
+  it('sets bundle-url when ensuring a child from a different entry', async function() {
+    const lazyEntryName = 'https://example.com/lazy/template.js';
+    const lazySnapshot = createSnapshot(
+      'cross-entry-child-for-bundle-url',
+      () => [__CreateView(0)],
+      null,
+      [],
+      undefined,
+      lazyEntryName,
+      null,
+      true,
+    );
+    const parent = new SnapshotInstance(snapshot1);
+    const child = new SnapshotInstance(lazySnapshot);
+
+    parent.insertBefore(child);
+    parent.ensureElements();
+
+    expect(parent.__element_root.props['bundle-url']).toBeUndefined();
+    expect(child.__element_root.props['bundle-url']).toBe(lazyEntryName);
+  });
+
+  it('does not set bundle-url when ensuring a child from the same entry', async function() {
+    const lazyEntryName = 'https://example.com/lazy/template.js';
+    const parentSnapshot = createSnapshot(
+      'same-entry-parent-for-bundle-url',
+      () => {
+        const el = __CreateView(0);
+        const slot = __CreateWrapperElement(0);
+        __AppendElement(el, slot);
+        return [el, slot];
+      },
+      null,
+      [[DynamicPartType.Slot, 1]],
+      undefined,
+      lazyEntryName,
+      null,
+      true,
+    );
+    const childSnapshot = createSnapshot(
+      'same-entry-child-for-bundle-url',
+      () => [__CreateView(0)],
+      null,
+      [],
+      undefined,
+      lazyEntryName,
+      null,
+      true,
+    );
+    const parent = new SnapshotInstance(parentSnapshot);
+    const child = new SnapshotInstance(childSnapshot);
+
+    parent.insertBefore(child);
+    parent.ensureElements();
+
+    expect(child.__element_root.props['bundle-url']).toBeUndefined();
+  });
+
   it('insert in the middle', async function() {
     const bsi1 = new BackgroundSnapshotInstance(snapshot1);
     const bsi2 = new BackgroundSnapshotInstance(snapshot2);

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -134,6 +134,17 @@ export class SnapshotInstance {
       }
     }
 
+    if (
+      entryName !== DEFAULT_ENTRY_NAME && entryName !== undefined && this.parentNode
+      && entryName !== this.parentNode.__snapshot_def.entryName
+    ) {
+      __SetAttribute(
+        this.__element_root!,
+        'bundle-url',
+        this.__snapshot_def.entryName,
+      );
+    }
+
     __pendingListUpdates.runWithoutUpdates(() => {
       const values = this.__values;
       if (values) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

It will help user to know the lazy bundle border:

<img width="989" height="347" alt="image" src="https://github.com/user-attachments/assets/e1aa4c3f-7f66-47b3-bf34-212db8387577" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lazy bundle border elements now correctly receive the bundle-URL attribute when crossing snapshot entry boundaries, while properly excluding it for elements within the same entry. This patch improves the handling and coordination of lazy-loaded modules, enhancing inter-entry communication and runtime behavior consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes lazy bundle Suspense wrappers so they receive the correct `bundle-url` from the lazy bundle source instead of relying on the host bundle entry. It also keeps the source through `loadLazyBundle(...).then(...)` chains and avoids leaking lazy bundle metadata into unrelated lazy components.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
