### PR TITLE
fix(web): xmarkdown create img incorrectly

### DIFF
--- a/.changeset/neat-beds-film.md
+++ b/.changeset/neat-beds-film.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+fix: xmarkdown create img incorrectly

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
@@ -1065,6 +1065,7 @@ export class XMarkdownAttributes {
       root.innerHTML = sanitizeHtml(
         preprocessInlineView(renderMarkdown(parser, visible)),
       );
+      this.#injectInlineViews(root);
     }
 
     this.#appendTypewriterCursor(root);

--- a/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-inlineview.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-markdown/typewriter-inlineview.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>typewriter-inlineview</title>
+    <meta content="width=device-width,initial-scale=1.0" name="viewport">
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page">
+      <x-markdown id="markdown" style="width: 300px">
+        <x-view
+          id="badge"
+          slot="badge"
+          style="display: inline-block; width: 10px; height: 10px; background: rgb(255, 0, 0)"
+        ></x-view>
+      </x-markdown>
+    </x-view>
+    <script>
+    window._typewriterInlineViewState = null;
+
+      const collectState = () => {
+        const el = document.getElementById('markdown');
+        const root = el?.shadowRoot?.querySelector('#markdown-root');
+        return {
+          inlineViewCount:
+            root?.querySelectorAll('.md-inline-view').length ?? 0,
+          inlineImageCount:
+            root?.querySelectorAll('img[data-inlineview]').length ?? 0,
+        };
+      };
+
+      const waitForInlineViewRender = async () => {
+        const deadline = Date.now() + 5000;
+        while (Date.now() < deadline) {
+          const state = collectState();
+          if (state.inlineViewCount > 0 || state.inlineImageCount > 0) {
+            return state;
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+        return collectState();
+      };
+
+      window.addEventListener('load', async () => {
+        await customElements.whenDefined('x-markdown');
+        const el = document.getElementById('markdown');
+        const content = 'inline view here ![](inlineview://badge) next';
+
+        el.setAttribute('content', content);
+        el.setAttribute('initial-animation-step', String(content.length));
+        el.setAttribute('animation-paused', 'true');
+        el.setAttribute('animation-type', 'typewriter');
+
+        window._typewriterInlineViewState =
+          await waitForInlineViewRender();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/x-markdown.spec.ts
+++ b/packages/web-platform/web-elements/tests/x-markdown.spec.ts
@@ -637,6 +637,19 @@ test.describe('x-markdown', () => {
     expect(projected).toBe(true);
   });
 
+  test('should not create img for inline view in typewriter mode', async ({ page }) => {
+    await goto(page, 'x-markdown/typewriter-inlineview');
+    await page.waitForFunction(() =>
+      (window as any)._typewriterInlineViewState !== null
+    );
+    const state = await page.evaluate(() =>
+      (window as any)._typewriterInlineViewState
+    );
+
+    expect(state.inlineViewCount).toBe(1);
+    expect(state.inlineImageCount).toBe(0);
+  });
+
   test('should apply class styles to inline view', async ({ page }) => {
     await goto(page, 'x-markdown/inlineview-class');
     await page.waitForFunction(() => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed x-markdown component to correctly render inline-view images and badges during typewriter animation mode, ensuring they appear as expected when content is animated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
