### PR TITLE
build(i18n): upgrade i18next extractor plugin

### DIFF
--- a/.github/i18n.instructions.md
+++ b/.github/i18n.instructions.md
@@ -3,3 +3,4 @@ applyTo: "packages/i18n/**"
 ---
 
 Treat mini-apps under `tests/fixtures/**` as build fixtures rather than production source. When they are used only as integration-test inputs, prefer keeping them out of root ESLint coverage instead of forcing them to satisfy the full package source lint rules.
+When upgrading `rsbuild-plugin-i18next-extractor`, keep the lockfile peer resolution aligned with the repository Rsbuild catalog unless intentionally validating a newer Rsbuild major; newer extractor releases can otherwise cause unrelated pnpm peer snapshot churn.

--- a/packages/i18n/i18next-translation-dedupe/package.json
+++ b/packages/i18n/i18next-translation-dedupe/package.json
@@ -41,7 +41,7 @@
     "@lynx-js/types": "3.7.0",
     "i18next": "26.0.6",
     "i18next-cli": "1.54.2",
-    "rsbuild-plugin-i18next-extractor": "0.2.0"
+    "rsbuild-plugin-i18next-extractor": "0.2.1"
   },
   "peerDependencies": {
     "rsbuild-plugin-i18next-extractor": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,8 +614,8 @@ importers:
         specifier: 1.54.2
         version: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
       rsbuild-plugin-i18next-extractor:
-        specifier: 0.2.0
-        version: 0.2.0(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
+        specifier: 0.2.1
+        version: 0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
 
   packages/lynx/benchx_cli:
     dependencies:
@@ -9818,11 +9818,11 @@ packages:
       typescript:
         optional: true
 
-  rsbuild-plugin-i18next-extractor@0.2.0:
-    resolution: {integrity: sha512-GtHV/x2EKUCckWX11N5PBOjTyD3zCfPIxLxBWJ/5opcYprawFMw4k44ezyyArKFiYygsrxJymur7wYmtt7Y1OA==}
+  rsbuild-plugin-i18next-extractor@0.2.1:
+    resolution: {integrity: sha512-3mlQ+SWyMS09PEXB/GeNjKV4bQ4d3505MoO+raPmP0VYiw+qOGc4mjVJyrF05MmKRQskK66qjTSt5netgk0rSg==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@rsbuild/core': ^1.0.0
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
       i18next-cli: ^1.33.5
 
   rsbuild-plugin-publint@0.3.4:
@@ -20046,7 +20046,7 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260212.1
       typescript: 5.9.3
 
-  rsbuild-plugin-i18next-extractor@0.2.0(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
+  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
       '@rsbuild/core': 1.7.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10892,6 +10892,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:


### PR DESCRIPTION
## Summary

- Upgrade `rsbuild-plugin-i18next-extractor` from `0.2.0` to `0.2.1` for `@lynx-js/i18next-translation-dedupe`.
- Run `pnpm dedupe --lockfile-only` and keep the lockfile peer resolution aligned with the repository Rsbuild catalog (`@rsbuild/core@1.7.5`) to avoid unrelated pnpm peer snapshot churn.
- Add an i18n contributor note for future extractor upgrades.

## Reference

This picks up the upstream extractor change from https://github.com/rstackjs/rsbuild-plugin-i18next-extractor/pull/8.

## Validation

- `pnpm dedupe --lockfile-only`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm dprint fmt --allow-no-files -- pnpm-lock.yaml`
- `pnpm run test --project i18n/i18next-translation-dedupe`
- `pnpm turbo build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing dependency upgrades and peer resolution alignment.

* **Chores**
  * Updated development dependency to version 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->