### PR TITLE
feat(qrcode):  support get entry from api exposed from rspeedy.env.entries

### DIFF
--- a/.changeset/wet-humans-teach.md
+++ b/.changeset/wet-humans-teach.md
@@ -1,0 +1,6 @@
+---
+'@lynx-js/qrcode-rsbuild-plugin': patch
+'@lynx-js/rspeedy': patch
+---
+
+feat(qrcode): support get entry from api exposed from rspeedy.env.entries

--- a/packages/rspeedy/core/etc/rspeedy.api.md
+++ b/packages/rspeedy/core/etc/rspeedy.api.md
@@ -13,6 +13,7 @@ import { logger } from '@rsbuild/core';
 import type { PerformanceConfig } from '@rsbuild/core';
 import type { ProxyConfig } from '@rsbuild/core';
 import type { RsbuildConfig } from '@rsbuild/core';
+import type { RsbuildEntry } from '@rsbuild/core';
 import type { RsbuildInstance } from '@rsbuild/core';
 import { RsbuildPlugin } from '@rsbuild/core';
 import { RsbuildPluginAPI } from '@rsbuild/core';
@@ -195,6 +196,7 @@ export interface EntryDescription {
 export interface ExposedAPI {
     config: Config;
     debug: (message: string | (() => string)) => void;
+    entries?: RsbuildEntry;
     exit: (code?: number) => Promise<void> | void;
     logger: typeof logger;
     version: string;

--- a/packages/rspeedy/core/src/api.ts
+++ b/packages/rspeedy/core/src/api.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import type { logger } from '@rsbuild/core'
+import type { RsbuildEntry } from '@rsbuild/core'
 
 import type { Config } from './config/index.js'
 
@@ -52,4 +53,9 @@ export interface ExposedAPI {
    * The version of Rspeedy.
    */
   version: string
+
+  /**
+   * Used for plugin qrcode get entry points from self-defined environments rather than default lynx environment.
+   */
+  entries?: RsbuildEntry
 }

--- a/packages/rspeedy/core/turbo.json
+++ b/packages/rspeedy/core/turbo.json
@@ -6,6 +6,7 @@
   "tasks": {
     "build": {
       "dependsOn": [
+        "//#build",
         "^build"
       ],
       "env": [

--- a/packages/rspeedy/plugin-qrcode/src/index.ts
+++ b/packages/rspeedy/plugin-qrcode/src/index.ts
@@ -8,7 +8,13 @@
  * A rsbuild plugin that print the template.js url using QRCode.
  */
 
-import type { EnvironmentContext, RsbuildPlugin } from '@rsbuild/core'
+import type {
+  EnvironmentContext,
+  RsbuildEntry,
+  RsbuildPlugin,
+} from '@rsbuild/core'
+
+import type { ExposedAPI } from '@lynx-js/rspeedy'
 
 import { registerConsoleShortcuts } from './shortcuts.js'
 
@@ -102,7 +108,7 @@ export function pluginQRCode(
     pre: ['lynx:rsbuild:api'],
     setup(api) {
       api.onAfterStartProdServer(async ({ environments, port }) => {
-        await main(environments['lynx'], port)
+        await main(getEntries(environments), port)
       })
 
       let printedQRCode = false
@@ -122,27 +128,35 @@ export function pluginQRCode(
 
         printedQRCode = true
 
-        await main(environments['lynx'], api.context.devServer.port)
+        await main(getEntries(environments), api.context.devServer.port)
       })
 
+      function getEntries(
+        environments: Record<string, EnvironmentContext> | undefined,
+      ) {
+        // biome-ignore lint/correctness/useHookAtTopLevel: not react hooks
+        return api.useExposed<ExposedAPI>(Symbol.for('rspeedy.env.entries'))
+          ?.entries ?? environments?.['lynx']?.entry
+      }
+
       async function main(
-        environmentContext: EnvironmentContext | undefined,
+        entries: RsbuildEntry | undefined,
         port: number,
       ) {
-        if (!environmentContext) {
-          // Not lynx environment, skip print QRCode
+        if (!entries) {
+          // No entry points, skip print QRCode
           return
         }
 
-        const entries = Object.keys(environmentContext.entry)
+        const entriesArray = Object.keys(entries)
 
-        if (entries.length === 0) {
+        if (entriesArray.length === 0) {
           return
         }
 
         const unregister = await registerConsoleShortcuts(
           {
-            entries,
+            entries: entriesArray,
             api,
             port,
             schema,

--- a/packages/rspeedy/plugin-qrcode/test/index.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/index.test.ts
@@ -7,7 +7,11 @@ import { fileURLToPath } from 'node:url'
 
 import { isCancel } from '@clack/prompts'
 import { createRsbuild, logger } from '@rsbuild/core'
-import type { RsbuildInstance, RsbuildPlugin } from '@rsbuild/core'
+import type {
+  RsbuildEntry,
+  RsbuildInstance,
+  RsbuildPlugin,
+} from '@rsbuild/core'
 import { beforeEach, describe, expect, onTestFinished, test, vi } from 'vitest'
 
 import type { Config, ExposedAPI } from '@lynx-js/rspeedy'
@@ -27,6 +31,13 @@ const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
       logger,
       version: '1.0.0',
     })
+  },
+})
+
+const pluginStubEnvEntries = (entries: RsbuildEntry): RsbuildPlugin => ({
+  name: 'lynx:rsbuild:env-entries',
+  setup(api) {
+    api.expose(Symbol.for('rspeedy.env.entries'), { entries })
   },
 })
 
@@ -327,6 +338,55 @@ describe('Plugins - Terminal', () => {
             },
             plugins: [
               pluginStubRspeedyAPI(),
+              pluginQRCode(),
+            ],
+          },
+        },
+      )
+
+      await using server = await usingDevServer(rsbuild)
+
+      await server.waitDevCompileDone()
+
+      expect(renderUnicodeCompact).toBeCalledTimes(1)
+    })
+
+    test('print qrcode with exposed custom environment entries', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      const { selectKey, isCancel } = await import('@clack/prompts')
+      vi.mocked(selectKey).mockResolvedValue('foo')
+      vi.mocked(isCancel).mockReturnValueOnce(false)
+      const { renderUnicodeCompact } = await import('uqr')
+      vi.mocked(renderUnicodeCompact).mockReturnValueOnce('<data>')
+
+      const entry = join(
+        dirname(fileURLToPath(import.meta.url)),
+        'fixtures',
+        'hello-world',
+      )
+
+      const rsbuild = await createRsbuild(
+        {
+          rsbuildConfig: {
+            dev: {
+              assetPrefix: 'http://example.com/foo/',
+            },
+            environments: {
+              custom: {},
+            },
+            server: {
+              port: getRandomNumberInRange(3000, 60000),
+            },
+            source: {
+              entry: {
+                main: entry,
+              },
+            },
+            plugins: [
+              pluginStubRspeedyAPI(),
+              pluginStubEnvEntries({
+                main: entry,
+              }),
               pluginQRCode(),
             ],
           },

--- a/packages/rspeedy/plugin-qrcode/test/preview.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/preview.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { createRsbuild, logger } from '@rsbuild/core'
+import type { RsbuildEntry } from '@rsbuild/core'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import type { Config, ExposedAPI, RsbuildPlugin } from '@lynx-js/rspeedy'
@@ -24,6 +25,13 @@ const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
       logger,
       version: '1.0.0',
     })
+  },
+})
+
+const pluginStubEnvEntries = (entries: RsbuildEntry): RsbuildPlugin => ({
+  name: 'lynx:rsbuild:env-entries',
+  setup(api) {
+    api.expose(Symbol.for('rspeedy.env.entries'), { entries })
   },
 })
 
@@ -231,7 +239,56 @@ describe('Preview', () => {
     expect(exit).not.toBeCalled()
   })
 
-  test('preview without entry', async () => {
+  test('preview with exposed custom environment entries', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const { renderUnicodeCompact } = await import('uqr')
+
+    const { selectKey, isCancel } = await import('@clack/prompts')
+    vi.mocked(selectKey).mockResolvedValue('foo')
+    vi.mocked(isCancel).mockReturnValue(true)
+
+    vi.mocked(renderUnicodeCompact).mockReturnValueOnce('<data>')
+
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        source: {
+          entry: {
+            main: './fixtures/hello-world/index.js',
+          },
+        },
+        plugins: [
+          pluginStubRspeedyAPI(),
+          pluginStubEnvEntries({
+            main: './fixtures/hello-world/index.js',
+          }),
+          pluginQRCode(),
+        ],
+        environments: {
+          custom: {},
+        },
+        dev: {
+          assetPrefix: 'http://example.com/',
+        },
+        server: {
+          port: getRandomNumberInRange(3000, 60000),
+        },
+      },
+    })
+
+    const { server } = await rsbuild.preview({ checkDistDir: false })
+
+    expect(renderUnicodeCompact).toBeCalled()
+    expect(renderUnicodeCompact).toBeCalledWith(
+      'http://example.com/main.lynx.bundle',
+    )
+
+    await server.close()
+    await vi.waitFor(() => {
+      expect(exit).toBeCalledTimes(1)
+    })
+  })
+
+  test('preview with empty exposed entries', async () => {
     vi.stubEnv('NODE_ENV', 'development')
     const { renderUnicodeCompact } = await import('uqr')
 
@@ -245,10 +302,14 @@ describe('Preview', () => {
       rsbuildConfig: {
         plugins: [
           pluginStubRspeedyAPI(),
+          pluginStubEnvEntries({}),
           pluginQRCode(),
         ],
-        source: {
-          entry: {},
+        environments: {
+          custom: {},
+        },
+        dev: {
+          assetPrefix: 'http://example.com/',
         },
         server: {
           port: getRandomNumberInRange(3000, 50000),


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QR code plugin can now read entry configuration from an exposed runtime API, enabling flexible entry-point resolution alongside existing environment config.

* **Tests**
  * Added unit and preview tests covering populated and empty exposed-entry scenarios to validate QR rendering and lifecycle behavior.

* **Documentation**
  * Public API docs updated to include the new optional entries field on the exposed runtime API.

* **Chores**
  * Added release metadata and build task ordering update for patch publications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
