### PR TITLE
feat(a2ui): pluggable defineCatalog API + extractor bin shim fix

### DIFF
--- a/packages/genui/a2ui-catalog-extractor/src/cli.ts
+++ b/packages/genui/a2ui-catalog-extractor/src/cli.ts
@@ -163,11 +163,19 @@ function readValue(args: string[], index: number, option: string): string {
   return value;
 }
 
+function isEntryScript(): boolean {
+  if (!process.argv[1]) return false;
+  const entryUrl = pathToFileURL(process.argv[1]).href;
+  if (import.meta.url === entryUrl) return true;
+  // The published bin shim does `import '../dist/cli.js'`. In that case the
+  // entry script is the bin shim, not this module — but we should still run.
+  return /[/\\]bin[/\\]a2ui-catalog-extractor\.[mc]?js$/.test(
+    process.argv[1],
+  );
+}
+
 try {
-  if (
-    process.argv[1]
-    && import.meta.url === pathToFileURL(process.argv[1]).href
-  ) {
+  if (isEntryScript()) {
     process.exitCode = await runCli(process.argv.slice(2));
   }
 } catch (error) {

--- a/packages/genui/a2ui/src/catalog/Button/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Button/index.tsx
@@ -1,8 +1,8 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { A2UIRender } from '../../core/A2UIRender.jsx';
-import type { GenericComponentProps } from '../../core/types.js';
+import { A2UIRenderer } from '../../react/A2UIRenderer.jsx';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/Button.css';
 
@@ -40,7 +40,7 @@ export function Button(
   return (
     <view className='button' bindtap={handleClick}>
       {childResource
-        ? <A2UIRender resource={childResource} />
+        ? <A2UIRenderer resource={childResource} />
         : <text>Button</text>}
     </view>
   );

--- a/packages/genui/a2ui/src/catalog/Card/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Card/index.tsx
@@ -1,8 +1,8 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { NodeRenderer } from '../../core/A2UIRender.jsx';
-import type { GenericComponentProps } from '../../core/types.js';
+import { NodeRenderer } from '../../react/A2UIRenderer.jsx';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/Card.css';
 

--- a/packages/genui/a2ui/src/catalog/CheckBox/index.tsx
+++ b/packages/genui/a2ui/src/catalog/CheckBox/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { GenericComponentProps } from '../../core/types.js';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/CheckBox.css';
 

--- a/packages/genui/a2ui/src/catalog/Column/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Column/index.tsx
@@ -1,8 +1,8 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { NodeRenderer } from '../../core/A2UIRender.jsx';
-import type { GenericComponentProps } from '../../core/types.js';
+import { NodeRenderer } from '../../react/A2UIRenderer.jsx';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/Column.css';
 

--- a/packages/genui/a2ui/src/catalog/Divider/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Divider/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { GenericComponentProps } from '../../core/types.js';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/Divider.css';
 

--- a/packages/genui/a2ui/src/catalog/Image/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Image/index.tsx
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { useEffect, useState } from '@lynx-js/react';
 
-import type { GenericComponentProps } from '../../core/types.js';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/Image.css';
 

--- a/packages/genui/a2ui/src/catalog/List/index.tsx
+++ b/packages/genui/a2ui/src/catalog/List/index.tsx
@@ -3,9 +3,9 @@
 // LICENSE file in the root directory of this source tree.
 import type * as v0_9 from '@a2ui/web_core/v0_9';
 
-import { NodeRenderer } from '../../core/A2UIRender.jsx';
-import type { GenericComponentProps } from '../../core/types.js';
-import { useDataBinding } from '../../core/useDataBinding.js';
+import { NodeRenderer } from '../../react/A2UIRenderer.jsx';
+import { useDataBinding } from '../../react/useDataBinding.js';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/List.css';
 

--- a/packages/genui/a2ui/src/catalog/README.md
+++ b/packages/genui/a2ui/src/catalog/README.md
@@ -1,0 +1,133 @@
+# Catalog composition
+
+`defineCatalog` builds the runtime catalog the renderer uses. Composition
+is per-component so bundlers can tree-shake what you don't reference.
+
+## The minimum a renderer needs
+
+If you only need to render, names alone are enough. Pass bare components —
+the protocol name comes from `displayName ?? component.name`:
+
+```tsx
+import { defineCatalog, Text, Button } from '@lynx-js/a2ui-reactlynx';
+
+const catalog = defineCatalog([Text, Button]);
+```
+
+Bundlers tree-shake unused components — pulling `Text` does not drag in
+`Button`, `Card`, etc.
+
+## Adding schemas for the agent handshake
+
+If you want `serializeCatalog(...)` to emit JSON Schema for each component
+(so the agent knows what props to send), pair each component with the JSON
+the extractor emitted at `dist/catalog/<Name>/catalog.json`:
+
+```tsx
+import { Text } from '@lynx-js/a2ui-reactlynx/catalog/Text';
+import textManifest from '@lynx-js/a2ui-reactlynx/catalog/Text/catalog.json'
+  with { type: 'json' };
+
+const catalog = defineCatalog([[Text, textManifest]]);
+agentChannel.handshake({ catalog: serializeCatalog(catalog) });
+```
+
+The protocol name lives in the JSON as the top-level key, so the runtime
+never duplicates it.
+
+## "I really want every built-in" — the paste-able recipe
+
+```tsx
+import {
+  defineCatalog,
+  Button,
+  Card,
+  CheckBox,
+  Column,
+  Divider,
+  Image,
+  List,
+  RadioGroup,
+  Row,
+  Text,
+} from '@lynx-js/a2ui-reactlynx';
+import buttonManifest from '@lynx-js/a2ui-reactlynx/catalog/Button/catalog.json' with {
+  type: 'json',
+};
+import cardManifest from '@lynx-js/a2ui-reactlynx/catalog/Card/catalog.json' with {
+  type: 'json',
+};
+import checkBoxManifest from '@lynx-js/a2ui-reactlynx/catalog/CheckBox/catalog.json' with {
+  type: 'json',
+};
+import columnManifest from '@lynx-js/a2ui-reactlynx/catalog/Column/catalog.json' with {
+  type: 'json',
+};
+import dividerManifest from '@lynx-js/a2ui-reactlynx/catalog/Divider/catalog.json' with {
+  type: 'json',
+};
+import imageManifest from '@lynx-js/a2ui-reactlynx/catalog/Image/catalog.json' with {
+  type: 'json',
+};
+import listManifest from '@lynx-js/a2ui-reactlynx/catalog/List/catalog.json' with {
+  type: 'json',
+};
+import radioGroupManifest from '@lynx-js/a2ui-reactlynx/catalog/RadioGroup/catalog.json' with {
+  type: 'json',
+};
+import rowManifest from '@lynx-js/a2ui-reactlynx/catalog/Row/catalog.json' with {
+  type: 'json',
+};
+import textManifest from '@lynx-js/a2ui-reactlynx/catalog/Text/catalog.json' with {
+  type: 'json',
+};
+
+export const allBuiltins = defineCatalog([
+  [Text, textManifest],
+  [Image, imageManifest],
+  [Row, rowManifest],
+  [Column, columnManifest],
+  [List, listManifest],
+  [Card, cardManifest],
+  [Button, buttonManifest],
+  [Divider, dividerManifest],
+  [CheckBox, checkBoxManifest],
+  [RadioGroup, radioGroupManifest],
+]);
+```
+
+Drop the `manifest` import + tuple form for any component whose schema you
+don't need to ship to the agent.
+
+## Custom components
+
+A component is anything that takes a single props object and returns a
+ReactNode. The function's name (or `displayName`) is the protocol name the
+agent will use:
+
+```tsx
+function MyChart(props: { data: number[] }) { ... }
+
+const catalog = defineCatalog([Text, Button, MyChart]);
+// Agent sends `{ component: 'MyChart', data: [...] }` → renders MyChart.
+```
+
+If you want schema introspection for a custom component, generate the
+manifest with `@lynx-js/a2ui-catalog-extractor` against your interface and
+pair it the same way:
+
+```tsx
+defineCatalog([[MyChart, myChartManifest]]);
+```
+
+## API surface
+
+- `defineCatalog(inputs)` — builds the runtime catalog. Inputs can mix bare
+  components, `[component, manifest]` tuples, and already-resolved entries
+  (e.g. from `mergeCatalogs`).
+- `mergeCatalogs(...catalogs)` — last-write-wins on duplicate names.
+- `serializeCatalog(catalog)` — emits the JSON manifest for the agent
+  handshake. Components without an attached schema serialize to `{ name }`
+  only.
+- `resolveCatalog(catalog)` — name → component map (used internally by the
+  renderer; exposed for advanced cases).

--- a/packages/genui/a2ui/src/catalog/RadioGroup/index.tsx
+++ b/packages/genui/a2ui/src/catalog/RadioGroup/index.tsx
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { Radio, RadioGroupRoot, RadioIndicator } from '@lynx-js/lynx-ui';
 
-import type { GenericComponentProps } from '../../core/types.js';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/RadioGroup.css';
 

--- a/packages/genui/a2ui/src/catalog/Row/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Row/index.tsx
@@ -1,8 +1,8 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { NodeRenderer } from '../../core/A2UIRender.jsx';
-import type { GenericComponentProps } from '../../core/types.js';
+import { NodeRenderer } from '../../react/A2UIRenderer.jsx';
+import type { GenericComponentProps } from '../../store/types.js';
 
 import '../../../styles/catalog/Row.css';
 

--- a/packages/genui/a2ui/src/catalog/Text/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Text/index.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { GenericComponentProps } from '../../core/types.js';
+import type { GenericComponentProps } from '../../store/types.js';
 import '../../../styles/catalog/Text.css';
 
 /**

--- a/packages/genui/a2ui/src/catalog/defineCatalog.ts
+++ b/packages/genui/a2ui/src/catalog/defineCatalog.ts
@@ -1,0 +1,185 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { ComponentType } from '@lynx-js/react';
+
+import type { GenericComponentProps } from '../core/types.js';
+
+/**
+ * JSON Schema fragment describing a component's props. Produced at build time
+ * by `@lynx-js/a2ui-catalog-extractor` from the component's TypeScript
+ * interface marked with `@a2uiCatalog <Name>`. Optional at runtime — entries
+ * that ship without a schema serialize to just `{ name }`.
+ */
+export type CatalogSchema = Record<string, unknown>;
+
+/**
+ * The shape produced by the extractor as `dist/catalog/<Name>/catalog.json`.
+ * The single top-level key is the component's protocol name; the value is
+ * its schema. Importing the JSON gives you both, in one declaration.
+ */
+export type CatalogManifest = Record<string, CatalogSchema>;
+
+/**
+ * Loose component type — entries receive runtime-shaped props from the
+ * protocol stream, so we don't enforce per-component prop typing here.
+ */
+export type CatalogComponent = ComponentType<GenericComponentProps>;
+
+/**
+ * What the developer passes into `defineCatalog`. Three forms:
+ *
+ *  - **Bare component** — name is read from `displayName ?? name`. Useful
+ *    for renderer-only consumers who don't need to announce schemas to the
+ *    agent.
+ *  - **`[component, manifest]` tuple** — name and schema are read from the
+ *    manifest. Use this when you want `serializeCatalog(...)` to include a
+ *    schema for this component in the agent handshake.
+ *  - **`ResolvedCatalogEntry`** — pass-through for already-resolved entries
+ *    (e.g. the output of `mergeCatalogs(...)` or another `defineCatalog`).
+ */
+export type CatalogInput =
+  | CatalogComponent
+  | readonly [CatalogComponent, CatalogManifest]
+  | ResolvedCatalogEntry;
+
+/**
+ * A resolved catalog entry. Internal representation; consumers don't usually
+ * construct these directly — they pass `CatalogInput`s to `defineCatalog`.
+ */
+export interface ResolvedCatalogEntry {
+  name: string;
+  component: CatalogComponent;
+  schema?: CatalogSchema;
+}
+
+export type Catalog = readonly ResolvedCatalogEntry[];
+
+/** The serialized payload sent to the agent during channel handshake. */
+export interface SerializedCatalog {
+  version: '0.9';
+  components: Array<{ name: string; schema?: CatalogSchema }>;
+}
+
+function isResolvedEntry(input: CatalogInput): input is ResolvedCatalogEntry {
+  return typeof input === 'object'
+    && input !== null
+    && !Array.isArray(input)
+    && 'component' in input
+    && 'name' in input;
+}
+
+function isTuple(
+  input: CatalogInput,
+): input is readonly [CatalogComponent, CatalogManifest] {
+  return Array.isArray(input);
+}
+
+function deriveBareName(component: CatalogComponent): string {
+  const name = (component as { displayName?: string }).displayName
+    ?? (component as { name?: string }).name;
+  if (!name) {
+    throw new Error(
+      '[a2ui] Cannot add a component to the catalog: no displayName or '
+        + 'function name. This typically happens when the bundler '
+        + 'minifies function names. Set `Foo.displayName = "Foo"` after '
+        + 'the component declaration (the string literal survives '
+        + 'minification), or pair it with its `catalog.json` manifest as '
+        + '`[Foo, fooManifest]`.',
+    );
+  }
+  return name;
+}
+
+function resolveInput(input: CatalogInput): ResolvedCatalogEntry {
+  if (isResolvedEntry(input)) return input;
+  if (isTuple(input)) {
+    const [component, manifest] = input;
+    const keys = Object.keys(manifest);
+    if (keys.length === 0) {
+      throw new Error(
+        '[a2ui] Empty manifest passed to defineCatalog; expected '
+          + '`{ <ComponentName>: schema }`.',
+      );
+    }
+    const name = keys[0]!;
+    const entry: ResolvedCatalogEntry = { name, component };
+    const schema = manifest[name];
+    if (schema !== undefined) entry.schema = schema;
+    return entry;
+  }
+  return { name: deriveBareName(input), component: input };
+}
+
+/**
+ * Build a catalog from a list of components and/or `[component, manifest]`
+ * pairs. The protocol name comes from the manifest key (tuple form) or
+ * from `displayName ?? name` (bare component form). Duplicate names are
+ * rejected.
+ *
+ * @example
+ * import { Text, Button } from '@lynx-js/a2ui-reactlynx';
+ * import textManifest from '@lynx-js/a2ui-reactlynx/catalog/Text/catalog.json'
+ *   with { type: 'json' };
+ *
+ * const catalog = defineCatalog([
+ *   [Text, textManifest],   // renderer + handshake metadata
+ *   Button,                  // renderer-only
+ * ]);
+ */
+export function defineCatalog(inputs: readonly CatalogInput[]): Catalog {
+  const entries: ResolvedCatalogEntry[] = [];
+  const seen = new Set<string>();
+  for (const input of inputs) {
+    const entry = resolveInput(input);
+    if (seen.has(entry.name)) {
+      throw new Error(
+        `[a2ui] Duplicate component name in catalog: "${entry.name}". `
+          + `Use mergeCatalogs() if you intend to override.`,
+      );
+    }
+    seen.add(entry.name);
+    entries.push(entry);
+  }
+  return entries;
+}
+
+/**
+ * Merge multiple catalogs. Last write wins on duplicate names — useful when
+ * a page-level catalog overrides a brand-level one which overrides built-ins.
+ */
+export function mergeCatalogs(...catalogs: Catalog[]): Catalog {
+  const map = new Map<string, ResolvedCatalogEntry>();
+  for (const cat of catalogs) {
+    for (const entry of cat) map.set(entry.name, entry);
+  }
+  return Array.from(map.values());
+}
+
+/**
+ * Build a name → component lookup map from a catalog. The renderer uses
+ * this to resolve `{ component: 'Text', ... }` from the protocol stream.
+ */
+export function resolveCatalog(
+  catalog: Catalog,
+): ReadonlyMap<string, CatalogComponent> {
+  const map = new Map<string, CatalogComponent>();
+  for (const entry of catalog) map.set(entry.name, entry.component);
+  return map;
+}
+
+/**
+ * Produce the JSON manifest the client should announce to the agent during
+ * channel handshake. Entries without an attached schema serialize to
+ * `{ name }` only — useful for letting the agent at least know what's
+ * renderable.
+ */
+export function serializeCatalog(catalog: Catalog): SerializedCatalog {
+  const components: Array<{ name: string; schema?: CatalogSchema }> = [];
+  for (const entry of catalog) {
+    const out: { name: string; schema?: CatalogSchema } = { name: entry.name };
+    if (entry.schema !== undefined) out.schema = entry.schema;
+    components.push(out);
+  }
+  return { version: '0.9', components };
+}

--- a/packages/genui/a2ui/src/catalog/defineCatalog.ts
+++ b/packages/genui/a2ui/src/catalog/defineCatalog.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import type { ComponentType } from '@lynx-js/react';
 
-import type { GenericComponentProps } from '../core/types.js';
+import type { GenericComponentProps } from '../store/types.js';
 
 /**
  * JSON Schema fragment describing a component's props. Produced at build time

--- a/packages/genui/a2ui/src/catalog/index.ts
+++ b/packages/genui/a2ui/src/catalog/index.ts
@@ -1,4 +1,23 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+export {
+  defineCatalog,
+  mergeCatalogs,
+  resolveCatalog,
+  serializeCatalog,
+} from './defineCatalog.js';
+export type {
+  Catalog,
+  CatalogComponent,
+  CatalogInput,
+  CatalogManifest,
+  CatalogSchema,
+  ResolvedCatalogEntry,
+  SerializedCatalog,
+} from './defineCatalog.js';
+
+// Existing global-registry exports — kept for back-compat with the
+// current `core/A2UIRender` path. The new `defineCatalog` API above is
+// the pluggable, side-effect-free alternative.
 export * from './all.js';

--- a/packages/genui/a2ui/src/react/A2UIRenderer.tsx
+++ b/packages/genui/a2ui/src/react/A2UIRenderer.tsx
@@ -1,0 +1,12 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+// Compatibility re-export. The headless renderer refactor exposes the
+// renderer under `src/react/`; this barrel keeps the new import path
+// stable while the implementation still lives under `core/`. The
+// renamed export (`A2UIRenderer`) matches the post-refactor symbol so
+// catalog components can adopt the new path now.
+export {
+  A2UIRender as A2UIRenderer,
+  NodeRenderer,
+} from '../core/A2UIRender.jsx';

--- a/packages/genui/a2ui/src/react/useDataBinding.ts
+++ b/packages/genui/a2ui/src/react/useDataBinding.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+// Compatibility re-export. See `react/A2UIRenderer.tsx` for context.
+export * from '../core/useDataBinding.js';

--- a/packages/genui/a2ui/src/store/types.ts
+++ b/packages/genui/a2ui/src/store/types.ts
@@ -1,0 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+// Compatibility re-export. The headless renderer refactor moves these
+// types to `src/store/`; this barrel keeps the new import path stable
+// while the implementation still lives under `core/`.
+export * from '../core/types.js';


### PR DESCRIPTION
## Summary

- Adds a runtime `defineCatalog` API that lets renderer consumers compose per-instance catalogs without depending on the global `componentRegistry` side-effect path. Bundlers tree-shake unused built-ins because the import surface is per-component.
- Adds `mergeCatalogs`, `serializeCatalog`, and `resolveCatalog` so app shells can layer brand/page-level catalogs and emit the agent-handshake JSON (with optional per-component schemas) directly.
- Harden the extractor CLI's bin-entry detection so `bin/a2ui-catalog-extractor.{m,c,}js` is recognized alongside direct ESM execution.

This PR is **additive** — `export * from './all.js'` is preserved in `catalog/index.ts`, so existing consumers of the global registry are unaffected.

Companion to the broader headless-renderer refactor in [#2536](https://github.com/lynx-family/lynx-stack/pull/2536); this slice can land independently because nothing in `core/` or `chat/` depends on it.

## Test plan

- [ ] `pnpm -F @lynx-js/a2ui-reactlynx build` — extractor still emits `dist/catalog/<Name>/catalog.json` for all 10 built-ins.
- [ ] `pnpm -F @lynx-js/a2ui-catalog-extractor test` — 6/6 extractor tests pass.
- [ ] `pnpm -F @lynx-js/a2ui-reactlynx exec tsc --noEmit` — clean (pre-existing `lynx-ui-input` error in `chat/Conversation.tsx` is unrelated).
- [ ] Spot-check `defineCatalog([Text])` produces `[{ name: 'Text', component: Text }]`.
- [ ] Spot-check `defineCatalog([[Text, textManifest]])` reads the name from the manifest key (survives minification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a catalog system for composing, merging, resolving, and serializing UI component collections.

* **Documentation**
  * Added a comprehensive catalog README with usage, schema guidance, recipes, and public API notes.

* **Refactor**
  * Stabilized React renderer and data-binding import paths via compatibility re-exports.

* **Chores**
  * Updated internal component imports to the new renderer/store paths; component APIs and behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->