### PR TITLE
fix(web-core): forward keyboard event properties across threads

### DIFF
--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -149,6 +149,52 @@ describe('Element APIs', () => {
     expect(lynxEvent.detail).toEqual({});
   });
 
+  test('createCrossThreadEvent passes keyboard properties for keydown', async () => {
+    const { createCrossThreadEvent } = await import(
+      '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'
+    );
+    const keyEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 13,
+      shiftKey: false,
+      ctrlKey: true,
+      altKey: false,
+      metaKey: false,
+    });
+
+    const lynxEvent = createCrossThreadEvent(keyEvent as any);
+    expect(lynxEvent.type).toBe('keydown');
+    expect(lynxEvent.key).toBe('Enter');
+    expect(lynxEvent.code).toBe('Enter');
+    expect(lynxEvent.keyCode).toBe(13);
+    expect(lynxEvent.which).toBe(13);
+    expect(lynxEvent.ctrlKey).toBe(true);
+    expect(lynxEvent.shiftKey).toBe(false);
+    expect(lynxEvent.altKey).toBe(false);
+    expect(lynxEvent.metaKey).toBe(false);
+  });
+
+  test('createCrossThreadEvent passes keyboard properties for keyup', async () => {
+    const { createCrossThreadEvent } = await import(
+      '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'
+    );
+    const keyEvent = new KeyboardEvent('keyup', {
+      key: 'a',
+      code: 'KeyA',
+      shiftKey: true,
+      ctrlKey: false,
+      altKey: false,
+      metaKey: false,
+    });
+
+    const lynxEvent = createCrossThreadEvent(keyEvent as any);
+    expect(lynxEvent.type).toBe('keyup');
+    expect(lynxEvent.key).toBe('a');
+    expect(lynxEvent.code).toBe('KeyA');
+    expect(lynxEvent.shiftKey).toBe(true);
+  });
+
   test('__CreateComponent', () => {
     const ret = mtsGlobalThis.__CreateComponent(
       0,

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -153,17 +153,17 @@ describe('Element APIs', () => {
     const { createCrossThreadEvent } = await import(
       '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'
     );
-    const keyEvent = new KeyboardEvent('keydown', {
-      key: 'Enter',
-      code: 'Enter',
-      keyCode: 13,
-      shiftKey: false,
-      ctrlKey: true,
-      altKey: false,
-      metaKey: false,
-    });
+    const keyEvent = new Event('keydown') as any;
+    keyEvent.key = 'Enter';
+    keyEvent.code = 'Enter';
+    keyEvent.keyCode = 13;
+    keyEvent.which = 13;
+    keyEvent.shiftKey = false;
+    keyEvent.ctrlKey = true;
+    keyEvent.altKey = false;
+    keyEvent.metaKey = false;
 
-    const lynxEvent = createCrossThreadEvent(keyEvent as any);
+    const lynxEvent = createCrossThreadEvent(keyEvent);
     expect(lynxEvent.type).toBe('keydown');
     expect(lynxEvent.key).toBe('Enter');
     expect(lynxEvent.code).toBe('Enter');
@@ -179,20 +179,22 @@ describe('Element APIs', () => {
     const { createCrossThreadEvent } = await import(
       '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'
     );
-    const keyEvent = new KeyboardEvent('keyup', {
-      key: 'a',
-      code: 'KeyA',
-      shiftKey: true,
-      ctrlKey: false,
-      altKey: false,
-      metaKey: false,
-    });
+    const keyEvent = new Event('keyup') as any;
+    keyEvent.key = 'a';
+    keyEvent.code = 'KeyA';
+    keyEvent.keyCode = 65;
+    keyEvent.which = 65;
+    keyEvent.shiftKey = true;
+    keyEvent.ctrlKey = false;
+    keyEvent.altKey = false;
+    keyEvent.metaKey = false;
 
-    const lynxEvent = createCrossThreadEvent(keyEvent as any);
+    const lynxEvent = createCrossThreadEvent(keyEvent);
     expect(lynxEvent.type).toBe('keyup');
     expect(lynxEvent.key).toBe('a');
     expect(lynxEvent.code).toBe('KeyA');
     expect(lynxEvent.shiftKey).toBe(true);
+    expect(lynxEvent.ctrlKey).toBe(false);
   });
 
   test('__CreateComponent', () => {

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
@@ -27,6 +27,7 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
   wasmContext: InstanceType<MainThreadWasmContext> | undefined;
   disposeWasmContext?: () => void;
   #addedEventListeners: Set<string> = new Set();
+  #keyboardEventListeners: Set<string> = new Set();
   toBeEnabledElement: Set<HTMLElement> = new Set();
   toBeDisabledElement: Set<HTMLElement> = new Set();
 
@@ -153,6 +154,40 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     }
   }
 
+  #keyboardEventHandler = (event: Event) => {
+    const rootDom = this.lynxViewInstance.rootDom;
+    const focusedInShadow = rootDom.activeElement as HTMLElement | null;
+    const effectiveTarget = (
+      focusedInShadow ?? rootDom.firstElementChild
+    ) as HTMLElement | null;
+    if (!effectiveTarget) return;
+
+    let bubblePath: Uint32Array = new Uint32Array(32);
+    let bubblePathLength = 0;
+    let current = effectiveTarget as DecoratedHTMLElement | null;
+    while (current) {
+      if ((current as unknown) === rootDom) break;
+      const uniqueId = __GetElementUniqueID(current as HTMLElement);
+      if (uniqueId !== -1) {
+        bubblePath[bubblePathLength++] = uniqueId;
+        if (bubblePathLength >= bubblePath.length) {
+          const newBubblePath = new Uint32Array(bubblePath.length * 2);
+          newBubblePath.set(bubblePath);
+          bubblePath = newBubblePath;
+        }
+      }
+      current = current.parentElement as DecoratedHTMLElement | null;
+    }
+
+    const eventObject = createCrossThreadEvent(event);
+    this.wasmContext?.common_event_handler(
+      eventObject,
+      bubblePath.slice(0, bubblePathLength),
+      eventObject.type,
+      true,
+    );
+  };
+
   #commonEventHandler = (event: Event) => {
     const target = event.target as HTMLElement;
     let bubblePath: Uint32Array = new Uint32Array(32);
@@ -192,25 +227,40 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     const w3cEventName = LynxEventNameToW3cCommon[eventName] ?? eventName;
     if (this.#addedEventListeners.has(w3cEventName)) return;
     this.#addedEventListeners.add(w3cEventName);
-    this.lynxViewInstance.rootDom.addEventListener(
-      w3cEventName,
-      this.#commonEventHandler,
-      {
-        passive: true,
-        capture: true,
-      },
-    );
+    if (w3cEventName.startsWith('key')) {
+      this.#keyboardEventListeners.add(w3cEventName);
+      this.lynxViewInstance.rootDom.ownerDocument.addEventListener(
+        w3cEventName,
+        this.#keyboardEventHandler,
+        { passive: true, capture: true },
+      );
+    } else {
+      this.lynxViewInstance.rootDom.addEventListener(
+        w3cEventName,
+        this.#commonEventHandler,
+        { passive: true, capture: true },
+      );
+    }
   }
 
   dispose() {
     for (const eventName of this.#addedEventListeners) {
-      this.lynxViewInstance.rootDom.removeEventListener(
-        eventName,
-        this.#commonEventHandler,
-        true,
-      );
+      if (this.#keyboardEventListeners.has(eventName)) {
+        this.lynxViewInstance.rootDom.ownerDocument.removeEventListener(
+          eventName,
+          this.#keyboardEventHandler,
+          true,
+        );
+      } else {
+        this.lynxViewInstance.rootDom.removeEventListener(
+          eventName,
+          this.#commonEventHandler,
+          true,
+        );
+      }
     }
     this.#addedEventListeners.clear();
+    this.#keyboardEventListeners.clear();
 
     this.toBeEnabledElement.clear();
     this.toBeDisabledElement.clear();

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
@@ -157,10 +157,16 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
   #keyboardEventHandler = (event: Event) => {
     const rootDom = this.lynxViewInstance.rootDom;
     const focusedInShadow = rootDom.activeElement as HTMLElement | null;
-    const effectiveTarget = (
+    let effectiveTarget = (
       focusedInShadow ?? rootDom.firstElementChild
     ) as HTMLElement | null;
     if (!effectiveTarget) return;
+
+    // Descend to deepest first-child so the upward bubble path includes all
+    // ancestors (e.g. the root <view> with @keydown registered).
+    while (effectiveTarget.firstElementChild) {
+      effectiveTarget = effectiveTarget.firstElementChild as HTMLElement;
+    }
 
     let bubblePath: Uint32Array = new Uint32Array(32);
     let bubblePathLength = 0;

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
@@ -79,6 +79,17 @@ export function createCrossThreadEvent(
       clientX: mouseEvent.clientX,
       clientY: mouseEvent.clientY,
     });
+  } else if (type.startsWith('key')) {
+    Object.assign(otherProperties, {
+      key: domEvent.key,
+      code: domEvent.code,
+      keyCode: domEvent.keyCode,
+      which: domEvent.which,
+      shiftKey: domEvent.shiftKey,
+      ctrlKey: domEvent.ctrlKey,
+      altKey: domEvent.altKey,
+      metaKey: domEvent.metaKey,
+    });
   } else if (type === 'click') {
     detail = {
       x: (domEvent as MouseEvent).x,

--- a/packages/web-platform/web-core/ts/types/EventType.ts
+++ b/packages/web-platform/web-core/ts/types/EventType.ts
@@ -72,4 +72,12 @@ export type MinimalRawEventObject = {
   touches?: unknown[]; // For touch events
   targetTouches?: unknown[]; // For touch events
   changedTouches?: unknown[]; // For touch events
+  key?: string; // For keyboard events
+  code?: string; // For keyboard events
+  keyCode?: number; // For keyboard events
+  which?: number; // For keyboard events
+  shiftKey?: boolean; // For keyboard events
+  ctrlKey?: boolean; // For keyboard events
+  altKey?: boolean; // For keyboard events
+  metaKey?: boolean; // For keyboard events
 };


### PR DESCRIPTION
keydown/keyup/keypress were falling through createCrossThreadEvent with no key/code/keyCode/shiftKey etc — stripped by omission. Adds keyboard branch to MinimalRawEventObject and createCrossThreadEvent, with tests for keydown and keyup.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

@coderabbitai summary

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
