### PR TITLE
feat(a2ui-playground): rename demos and resize panels

### DIFF
--- a/packages/genui/a2ui-playground/AGENTS.md
+++ b/packages/genui/a2ui-playground/AGENTS.md
@@ -22,7 +22,7 @@ the Lynx app and passes that `initData` to it.
 
 Web build has two entrypoints (see `rsbuild.config.ts`):
 
-- `src/entry.tsx`: the main control panel (tabs: Examples / Components / Chat)
+- `src/entry.tsx`: the main control panel (tabs: Create / Examples / Components)
 - `src/render.tsx`: a dedicated page (`/render.html`) that hosts a `<lynx-view>`
 
 `/render.html` is the important glue:

--- a/packages/genui/a2ui-playground/AGENTS.md
+++ b/packages/genui/a2ui-playground/AGENTS.md
@@ -22,7 +22,7 @@ the Lynx app and passes that `initData` to it.
 
 Web build has two entrypoints (see `rsbuild.config.ts`):
 
-- `src/entry.tsx`: the main control panel (tabs: Demos / Components / Chat)
+- `src/entry.tsx`: the main control panel (tabs: Examples / Components / Chat)
 - `src/render.tsx`: a dedicated page (`/render.html`) that hosts a `<lynx-view>`
 
 `/render.html` is the important glue:

--- a/packages/genui/a2ui-playground/src/App.tsx
+++ b/packages/genui/a2ui-playground/src/App.tsx
@@ -10,10 +10,10 @@ import { DemosPage } from './pages/DemosPage.js';
 import type { ProtocolVersion } from './utils/protocol.js';
 import { DEFAULT_PROTOCOL } from './utils/protocol.js';
 
-type Tab = 'chat' | 'examples' | 'components';
+type Tab = 'create' | 'examples' | 'components';
 
 const TABS: { id: Tab; label: string }[] = [
-  { id: 'chat', label: 'AI Chat' },
+  { id: 'create', label: 'Create' },
   { id: 'examples', label: 'Examples' },
   { id: 'components', label: 'Components' },
 ];
@@ -29,10 +29,13 @@ function parseHash(hash: string): Route {
   if (parts[0] === 'examples' || parts[0] === 'demos') {
     return { tab: 'examples' };
   }
+  if (parts[0] === 'create' || parts[0] === 'chat') {
+    return { tab: 'create' };
+  }
   if (parts[0] === 'components') {
     return { tab: 'components', componentName: parts[1] };
   }
-  return { tab: 'chat' };
+  return { tab: 'create' };
 }
 
 type Theme = 'light' | 'dark';
@@ -83,7 +86,7 @@ export function App() {
           />
         );
       default:
-        return <AIChatPage key='chat' protocol={protocol} />;
+        return <AIChatPage key='create' protocol={protocol} />;
     }
   })();
 

--- a/packages/genui/a2ui-playground/src/App.tsx
+++ b/packages/genui/a2ui-playground/src/App.tsx
@@ -10,11 +10,11 @@ import { DemosPage } from './pages/DemosPage.js';
 import type { ProtocolVersion } from './utils/protocol.js';
 import { DEFAULT_PROTOCOL } from './utils/protocol.js';
 
-type Tab = 'chat' | 'demos' | 'components';
+type Tab = 'chat' | 'examples' | 'components';
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'chat', label: 'AI Chat' },
-  { id: 'demos', label: 'Demos' },
+  { id: 'examples', label: 'Examples' },
   { id: 'components', label: 'Components' },
 ];
 
@@ -26,7 +26,9 @@ interface Route {
 function parseHash(hash: string): Route {
   const cleaned = hash.replace(/^#\/?/u, '');
   const parts = cleaned.split('/');
-  if (parts[0] === 'demos') return { tab: 'demos' };
+  if (parts[0] === 'examples' || parts[0] === 'demos') {
+    return { tab: 'examples' };
+  }
   if (parts[0] === 'components') {
     return { tab: 'components', componentName: parts[1] };
   }
@@ -70,8 +72,8 @@ export function App() {
 
   const page = (() => {
     switch (route.tab) {
-      case 'demos':
-        return <DemosPage key='demos' protocol={protocol} />;
+      case 'examples':
+        return <DemosPage key='examples' protocol={protocol} />;
       case 'components':
         return (
           <ComponentsPage

--- a/packages/genui/a2ui-playground/src/componentCatalog.ts
+++ b/packages/genui/a2ui-playground/src/componentCatalog.ts
@@ -35,13 +35,13 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
     props: [
       {
         name: 'text',
-        type: 'TextValue',
-        description: 'Content to display',
+        type: 'string | { path: string }',
+        description: 'Literal text or path binding',
       },
       {
-        name: 'usageHint',
+        name: 'variant',
         type: 'string',
-        description: 'Text style variant: h1, h2, h3, body, caption',
+        description: 'Text style variant: h1, h2, h3, h4, h5, caption, body',
         default: 'body',
       },
     ],
@@ -67,7 +67,12 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
       {
         name: 'action',
         type: 'object',
-        description: 'Action to trigger on press',
+        description: 'v0.9 event action to trigger on press',
+      },
+      {
+        name: 'variant',
+        type: 'string',
+        description: 'Button style variant: primary, borderless',
       },
     ],
     usage: {
@@ -82,33 +87,33 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
   {
     name: 'Image',
     category: 'Display',
-    description: 'Displays an image from a URL with optional dimensions.',
+    description: 'Displays an image from a URL or data binding.',
     props: [
-      { name: 'src', type: 'string', description: 'Image URL' },
       {
-        name: 'alt',
+        name: 'url',
+        type: 'string | { path: string }',
+        description: 'Image URL or path binding',
+      },
+      {
+        name: 'fit',
         type: 'string',
-        description: 'Alternative text for accessibility',
+        description: 'Object fit: contain, cover, fill, none, scale-down',
       },
       {
-        name: 'width',
-        type: 'number',
-        description: 'Image width in logical pixels',
-      },
-      {
-        name: 'height',
-        type: 'number',
-        description: 'Image height in logical pixels',
+        name: 'variant',
+        type: 'string',
+        description:
+          'Image style variant: icon, avatar, smallFeature, mediumFeature, largeFeature, header',
+        default: 'mediumFeature',
       },
     ],
     usage: {
       '0.9': {
-        id: 'hero-image',
+        id: 'lynx-image',
         component: 'Image',
-        src: 'https://example.com/hero.png',
-        alt: 'Hero banner',
-        width: 320,
-        height: 180,
+        url: 'https://picsum.photos/seed/a2ui-image-preview/320/180',
+        fit: 'cover',
+        variant: 'mediumFeature',
       },
     },
   },
@@ -118,48 +123,35 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
     description: 'A visual separator line used to divide content sections.',
     props: [
       {
-        name: 'direction',
+        name: 'axis',
         type: 'string',
         description: 'Divider orientation: horizontal, vertical',
         default: 'horizontal',
-      },
-      {
-        name: 'color',
-        type: 'string',
-        description: 'Divider line color as a CSS color value',
       },
     ],
     usage: {
       '0.9': {
         id: 'section-divider',
         component: 'Divider',
-        direction: 'horizontal',
-        color: '#E0E0E0',
+        axis: 'horizontal',
       },
     },
   },
   {
     name: 'Card',
     category: 'Layout',
-    description: 'A container with visual elevation or outline styling.',
+    description: 'A container that renders one child component inside a card.',
     props: [
       {
         name: 'child',
         type: 'string',
         description: 'ID of the child component rendered inside the card',
       },
-      {
-        name: 'usageHint',
-        type: 'string',
-        description: 'Card style: elevated, outlined, filled',
-        default: 'elevated',
-      },
     ],
     usage: {
       '0.9': {
         id: 'info-card',
         component: 'Card',
-        usageHint: 'elevated',
         child: 'info-card-content',
       },
     },
@@ -176,13 +168,13 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
         description: 'Child components arranged horizontally',
       },
       {
-        name: 'alignment',
+        name: 'align',
         type: 'string',
         description: 'Vertical alignment: start, center, end, stretch',
-        default: 'center',
+        default: 'stretch',
       },
       {
-        name: 'distribution',
+        name: 'justify',
         type: 'string',
         description:
           'Horizontal distribution: start, center, end, spaceBetween, spaceAround, spaceEvenly',
@@ -193,8 +185,8 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
       '0.9': {
         id: 'action-row',
         component: 'Row',
-        alignment: 'center',
-        distribution: 'spaceBetween',
+        align: 'center',
+        justify: 'spaceBetween',
         children: ['left-item', 'right-item'],
       },
     },
@@ -211,17 +203,25 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
         description: 'Child components arranged vertically',
       },
       {
-        name: 'usageHint',
+        name: 'align',
         type: 'string',
-        description: 'Column role: root-column, group',
-        default: 'group',
+        description: 'Horizontal alignment: start, center, end, stretch',
+        default: 'stretch',
+      },
+      {
+        name: 'justify',
+        type: 'string',
+        description:
+          'Vertical distribution: start, center, end, spaceBetween, spaceAround, spaceEvenly',
+        default: 'start',
       },
     ],
     usage: {
       '0.9': {
         id: 'main-column',
         component: 'Column',
-        usageHint: 'root-column',
+        align: 'start',
+        justify: 'start',
         children: ['header', 'body', 'footer'],
       },
     },
@@ -238,22 +238,24 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
         description: 'Child components or template for list items',
       },
       {
-        name: 'template',
-        type: 'object',
-        description: 'Template for dynamic item rendering with data binding',
+        name: 'direction',
+        type: 'string',
+        description: 'Scroll direction: horizontal, vertical',
+        default: 'vertical',
+      },
+      {
+        name: 'align',
+        type: 'string',
+        description: 'Item alignment: start, center, end, stretch',
       },
     ],
     usage: {
       '0.9': {
         id: 'item-list',
         component: 'List',
+        direction: 'vertical',
+        align: 'stretch',
         children: ['item-1', 'item-2', 'item-3'],
-        template: {
-          dataSource: '/items',
-          component: 'Text',
-          variant: 'body',
-          text: { path: '/items/$/name' },
-        },
       },
     },
   },
@@ -264,19 +266,15 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
     props: [
       {
         name: 'label',
-        type: 'string',
-        description: 'Label text displayed next to the checkbox',
+        type: 'string | { path: string }',
+        description:
+          'Label text or path binding displayed next to the checkbox',
       },
       {
-        name: 'checked',
-        type: 'boolean',
-        description: 'Whether the checkbox is checked',
+        name: 'value',
+        type: 'boolean | { path: string }',
+        description: 'Whether the checkbox is checked, or a path binding',
         default: 'false',
-      },
-      {
-        name: 'action',
-        type: 'object',
-        description: 'Action triggered when the checkbox is toggled',
       },
     ],
     usage: {
@@ -284,8 +282,7 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
         id: 'agree-checkbox',
         component: 'CheckBox',
         label: 'I agree to the terms',
-        checked: false,
-        action: { event: { name: 'toggle_agree' } },
+        value: false,
       },
     },
   },
@@ -296,32 +293,29 @@ export const COMPONENT_CATALOG: ComponentDoc[] = [
       'A group of mutually exclusive radio options with selection support.',
     props: [
       {
-        name: 'options',
-        type: 'array',
-        description: 'List of radio options with label and value',
+        name: 'items',
+        type: 'string[] | { path: string }',
+        description: 'List of radio option labels, or a path binding',
       },
       {
-        name: 'selected',
-        type: 'string',
+        name: 'value',
+        type: 'string | { path: string }',
         description: 'Value of the currently selected option',
       },
       {
-        name: 'action',
-        type: 'object',
-        description: 'Action triggered when the selection changes',
+        name: 'usageHint',
+        type: 'string',
+        description: 'Visual style hint: default, card, row',
+        default: 'default',
       },
     ],
     usage: {
       '0.9': {
         id: 'size-picker',
         component: 'RadioGroup',
-        options: [
-          { label: 'Small', value: 'sm' },
-          { label: 'Medium', value: 'md' },
-          { label: 'Large', value: 'lg' },
-        ],
-        selected: 'md',
-        action: { event: { name: 'select_size' } },
+        items: ['Small', 'Medium', 'Large'],
+        value: 'Medium',
+        usageHint: 'card',
       },
     },
   },

--- a/packages/genui/a2ui-playground/src/hooks/useResizablePanels.ts
+++ b/packages/genui/a2ui-playground/src/hooks/useResizablePanels.ts
@@ -1,0 +1,195 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type {
+  CSSProperties,
+  PointerEvent as ReactPointerEvent,
+  RefObject,
+} from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseResizablePanelsOptions {
+  breakpoint: number;
+  disabled?: boolean;
+  initialPrimarySize: number;
+  initialSecondarySize: number;
+  desktopPrimaryMinSize: number;
+  desktopSecondaryMinSize: number;
+  compactPrimaryMinSize: number;
+  compactSecondaryMinSize: number;
+  desktopOffsetSelector?: string;
+  compactOffsetSelector?: string;
+}
+
+interface UseResizablePanelsResult {
+  containerRef: RefObject<HTMLDivElement | null>;
+  isCompactLayout: boolean;
+  isResizing: boolean;
+  primaryPanelStyle: CSSProperties | undefined;
+  secondaryPanelStyle: CSSProperties | undefined;
+  handleResizeStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), Math.max(min, max));
+}
+
+function readElementSize(
+  root: HTMLDivElement,
+  selector: string | undefined,
+  axis: 'width' | 'height',
+): number {
+  if (!selector) {
+    return 0;
+  }
+  const element = root.querySelector(selector);
+  if (!element) {
+    return 0;
+  }
+  const rect = element.getBoundingClientRect();
+  return axis === 'width' ? rect.width : rect.height;
+}
+
+export function useResizablePanels(
+  options: UseResizablePanelsOptions,
+): UseResizablePanelsResult {
+  const {
+    breakpoint,
+    compactOffsetSelector,
+    compactPrimaryMinSize,
+    compactSecondaryMinSize,
+    desktopOffsetSelector,
+    desktopPrimaryMinSize,
+    desktopSecondaryMinSize,
+    disabled = false,
+    initialPrimarySize,
+    initialSecondarySize,
+  } = options;
+
+  const [secondarySize, setSecondarySize] = useState(initialSecondarySize);
+  const [primarySize, setPrimarySize] = useState(initialPrimarySize);
+  const [isResizing, setIsResizing] = useState(false);
+  const [isCompactLayout, setIsCompactLayout] = useState(
+    () => window.innerWidth <= breakpoint,
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const stopResizeRef = useRef<((updateState?: boolean) => void) | null>(null);
+
+  useEffect(() => {
+    const updateLayoutMode = () => {
+      setIsCompactLayout(window.innerWidth <= breakpoint);
+    };
+    updateLayoutMode();
+    window.addEventListener('resize', updateLayoutMode);
+    return () => window.removeEventListener('resize', updateLayoutMode);
+  }, [breakpoint]);
+
+  useEffect(() => {
+    if (disabled) {
+      stopResizeRef.current?.(false);
+    }
+  }, [disabled]);
+
+  useEffect(() => {
+    return () => {
+      stopResizeRef.current?.(false);
+    };
+  }, []);
+
+  const handleResizeStart = useCallback((
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) => {
+    if (disabled || !containerRef.current) {
+      return;
+    }
+
+    event.preventDefault();
+    stopResizeRef.current?.();
+
+    const container = containerRef.current;
+    const compact = window.innerWidth <= breakpoint;
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startSecondarySize = secondarySize;
+    const startPrimarySize = primarySize;
+
+    setIsResizing(true);
+    document.body.dataset.panelResize = compact ? 'vertical' : 'horizontal';
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const containerRect = container.getBoundingClientRect();
+
+      if (compact) {
+        const offset = readElementSize(
+          container,
+          compactOffsetSelector,
+          'height',
+        );
+        const maxPrimarySize = containerRect.height
+          - offset
+          - compactSecondaryMinSize;
+        setPrimarySize(
+          clamp(
+            startPrimarySize + moveEvent.clientY - startY,
+            compactPrimaryMinSize,
+            maxPrimarySize,
+          ),
+        );
+        return;
+      }
+
+      const offset = readElementSize(container, desktopOffsetSelector, 'width');
+      const maxSecondarySize = containerRect.width
+        - offset
+        - desktopPrimaryMinSize;
+      setSecondarySize(
+        clamp(
+          startSecondarySize + startX - moveEvent.clientX,
+          desktopSecondaryMinSize,
+          maxSecondarySize,
+        ),
+      );
+    };
+
+    const stopResize = (updateState = true) => {
+      if (updateState) {
+        setIsResizing(false);
+      }
+      delete document.body.dataset.panelResize;
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerStop);
+      window.removeEventListener('pointercancel', handlePointerStop);
+      stopResizeRef.current = null;
+    };
+    const handlePointerStop = () => stopResize();
+
+    stopResizeRef.current = stopResize;
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerStop);
+    window.addEventListener('pointercancel', handlePointerStop);
+  }, [
+    breakpoint,
+    compactOffsetSelector,
+    compactPrimaryMinSize,
+    compactSecondaryMinSize,
+    desktopOffsetSelector,
+    desktopPrimaryMinSize,
+    desktopSecondaryMinSize,
+    disabled,
+    primarySize,
+    secondarySize,
+  ]);
+
+  return {
+    containerRef,
+    handleResizeStart,
+    isCompactLayout,
+    isResizing,
+    primaryPanelStyle: isCompactLayout && !disabled
+      ? { height: `${primarySize}px` }
+      : undefined,
+    secondaryPanelStyle: !isCompactLayout && !disabled
+      ? { width: `${secondarySize}px` }
+      : undefined,
+  };
+}

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { useResizablePanels } from '../hooks/useResizablePanels.js';
 import type { ProtocolVersion } from '../utils/protocol.js';
 
 interface ChatMessage {
@@ -29,12 +30,34 @@ const MOCK_AI_RESPONSE: ChatMessage = {
   ),
 };
 
+const DESKTOP_PREVIEW_MIN_WIDTH = 320;
+const DESKTOP_CHAT_MIN_WIDTH = 360;
+const COMPACT_CHAT_MIN_HEIGHT = 280;
+const COMPACT_PREVIEW_MIN_HEIGHT = 320;
+const RESIZE_BREAKPOINT = 980;
+
 export function AIChatPage(
   _props: { protocol: ProtocolVersion },
 ) {
   const [messages, setMessages] = useState<ChatMessage[]>([WELCOME_MESSAGE]);
   const [inputValue, setInputValue] = useState<string>('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const {
+    containerRef: pageRef,
+    handleResizeStart: handlePanelResizeStart,
+    isCompactLayout,
+    isResizing: isPanelResizing,
+    primaryPanelStyle: chatPanelStyle,
+    secondaryPanelStyle: previewPanelStyle,
+  } = useResizablePanels({
+    breakpoint: RESIZE_BREAKPOINT,
+    compactPrimaryMinSize: COMPACT_CHAT_MIN_HEIGHT,
+    compactSecondaryMinSize: COMPACT_PREVIEW_MIN_HEIGHT,
+    desktopPrimaryMinSize: DESKTOP_CHAT_MIN_WIDTH,
+    desktopSecondaryMinSize: DESKTOP_PREVIEW_MIN_WIDTH,
+    initialPrimarySize: 400,
+    initialSecondarySize: 420,
+  });
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -67,10 +90,16 @@ export function AIChatPage(
   );
 
   return (
-    <div className='chatPage'>
-      <div className='chatPanel'>
+    <div
+      ref={pageRef}
+      className={isPanelResizing ? 'chatPage resizing' : 'chatPage'}
+    >
+      <div className='chatPanel' style={chatPanelStyle}>
         <div className='chatHeader'>
-          <h2 className='chatHeaderTitle'>AI Chat</h2>
+          <div className='chatHeaderTitleRow'>
+            <h2 className='chatHeaderTitle'>Create</h2>
+            <span className='constructionBadge'>Under construction</span>
+          </div>
           <p className='chatHeaderSub'>Describe the UI you want to build</p>
         </div>
 
@@ -107,7 +136,18 @@ export function AIChatPage(
         </div>
       </div>
 
-      <div className='previewPanel'>
+      <div
+        className={isPanelResizing
+          ? 'panelResizeHandle active'
+          : 'panelResizeHandle'}
+        role='separator'
+        aria-orientation={isCompactLayout ? 'horizontal' : 'vertical'}
+        aria-label='Resize Create and preview panels'
+        title='Drag to resize'
+        onPointerDown={handlePanelResizeStart}
+      />
+
+      <div className='previewPanel' style={previewPanelStyle}>
         <div className='previewPanelHeader'>
           <span className='previewPanelTitle'>Lynx Preview</span>
         </div>

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -21,7 +21,8 @@ const MOCK_AI_RESPONSE: ChatMessage = {
   content: (
     <>
       AI generation is not yet connected. In the meantime, check out the{' '}
-      <a href='#/demos' style={{ textDecoration: 'underline' }}>Demos</a>{' '}
+      <a href='#/examples' style={{ textDecoration: 'underline' }}>Examples</a>
+      {' '}
       tab to see pre-recorded A2UI scenarios with simulated streaming — you can
       even adjust the playback speed.
     </>

--- a/packages/genui/a2ui-playground/src/pages/ComponentsPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/ComponentsPage.tsx
@@ -1,16 +1,75 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { useMemo } from 'react';
+import { json } from '@codemirror/lang-json';
+import CodeMirror from '@uiw/react-codemirror';
+import { useEffect, useMemo, useState } from 'react';
 
 import { CATEGORIES, COMPONENT_CATALOG } from '../componentCatalog.js';
 import type { ComponentDoc } from '../componentCatalog.js';
+import { copyToClipboard } from '../utils/clipboard.js';
+import { DEFAULT_DEMO_URL } from '../utils/demoUrl.js';
 import type { ProtocolVersion } from '../utils/protocol.js';
+import { buildRenderUrl } from '../utils/renderUrl.js';
+
+const jsonExtensions = [json()];
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value ?? {}, null, 2);
+}
+
+function createComponentPreviewMessages(
+  comp: ComponentDoc,
+  usage: unknown,
+): unknown[] {
+  return [
+    {
+      createSurface: {
+        surfaceId: 'default',
+        catalogId: `component-${comp.name.toLowerCase()}`,
+      },
+      updateComponents: {
+        surfaceId: 'default',
+        components: [usage],
+      },
+    },
+  ];
+}
 
 function ComponentDetail(
   props: { comp: ComponentDoc; protocol: ProtocolVersion },
 ) {
   const { comp, protocol } = props;
+  const [usageJson, setUsageJson] = useState(() =>
+    formatJson(comp.usage[protocol])
+  );
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setUsageJson(formatJson(comp.usage[protocol]));
+  }, [comp, protocol]);
+
+  const parsedUsage = useMemo(() => {
+    try {
+      return { error: '', value: JSON.parse(usageJson) as unknown };
+    } catch (e) {
+      return { error: `Invalid JSON: ${String(e)}`, value: null };
+    }
+  }, [usageJson]);
+
+  const previewUrl = useMemo(() => {
+    if (parsedUsage.error) return '';
+    const baseUrl = window.location.href.replace(/#.*$/u, '');
+    return buildRenderUrl(
+      {
+        protocol,
+        demoUrl: DEFAULT_DEMO_URL,
+        messages: createComponentPreviewMessages(comp, parsedUsage.value),
+      },
+      baseUrl,
+    );
+  }, [comp, parsedUsage, protocol]);
+
   return (
     <div className='compContent'>
       <div className='compBreadcrumb'>
@@ -23,11 +82,6 @@ function ComponentDetail(
       <p className='compDesc'>{comp.description}</p>
 
       <div className='compCategoryBadge'>{comp.category}</div>
-
-      <h3 className='compSubheading'>Usage</h3>
-      <pre className='compCodeBlock'>
-        {JSON.stringify(comp.usage[protocol], null, 2)}
-      </pre>
 
       <h3 className='compSubheading'>Props</h3>
       <table className='compTable'>
@@ -50,6 +104,58 @@ function ComponentDetail(
           ))}
         </tbody>
       </table>
+
+      <div className='compSectionHeader'>
+        <h3 className='compSubheading'>Usage</h3>
+        <button
+          className='compCopyBtn'
+          type='button'
+          title={copied ? 'Copied' : 'Copy JSON'}
+          onClick={() => {
+            void copyToClipboard(usageJson).then((ok) => {
+              if (!ok) return;
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1200);
+            });
+          }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <CodeMirror
+        className='compUsageEditor'
+        value={usageJson}
+        extensions={jsonExtensions}
+        onChange={setUsageJson}
+        theme='dark'
+        basicSetup={{
+          lineNumbers: true,
+          foldGutter: true,
+          bracketMatching: true,
+          closeBrackets: true,
+          autocompletion: true,
+        }}
+      />
+      {parsedUsage.error
+        ? <div className='compUsageError'>{parsedUsage.error}</div>
+        : null}
+
+      <h3 className='compSubheading'>Preview</h3>
+      <div className='compPreview'>
+        {previewUrl
+          ? (
+            <iframe
+              className='compPreviewIframe'
+              title={`${comp.name} preview`}
+              src={previewUrl}
+            />
+          )
+          : (
+            <div className='compPreviewInvalid'>
+              Fix the Usage JSON to update the preview.
+            </div>
+          )}
+      </div>
     </div>
   );
 }

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { json } from '@codemirror/lang-json';
 import CodeMirror from '@uiw/react-codemirror';
+import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { MobilePreview } from '../components/MobilePreview.js';
@@ -75,8 +76,18 @@ const ALL_SCENARIOS: Scenario[] = [
   ...DYNAMIC_PRESETS,
 ];
 
+const DESKTOP_PREVIEW_MIN_WIDTH = 320;
+const DESKTOP_CODE_MIN_WIDTH = 360;
+const COMPACT_CODE_MIN_HEIGHT = 220;
+const COMPACT_PREVIEW_MIN_HEIGHT = 320;
+const RESIZE_BREAKPOINT = 980;
+
 function formatJson(value: unknown): string {
   return JSON.stringify(value ?? [], null, 2);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), Math.max(min, max));
 }
 
 export function DemosPage(props: { protocol: ProtocolVersion }) {
@@ -102,11 +113,27 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
   );
   const [fullscreen, setFullscreen] = useState(false);
   const [liveComponents, setLiveComponents] = useState<string[]>([]);
+  const [previewPanelWidth, setPreviewPanelWidth] = useState(420);
+  const [codePanelHeight, setCodePanelHeight] = useState(320);
+  const [isPanelResizing, setIsPanelResizing] = useState(false);
+  const [isCompactLayout, setIsCompactLayout] = useState(
+    () => window.innerWidth <= RESIZE_BREAKPOINT,
+  );
+  const pageRef = useRef<HTMLDivElement>(null);
   const liveTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   const baseUrl = window.location.href.replace(/#.*$/, '');
   const rspeedyDevUrl = useRspeedyDevUrl();
   const lynxUrlSeqRef = useRef(0);
+
+  useEffect(() => {
+    const updateLayoutMode = () => {
+      setIsCompactLayout(window.innerWidth <= RESIZE_BREAKPOINT);
+    };
+    updateLayoutMode();
+    window.addEventListener('resize', updateLayoutMode);
+    return () => window.removeEventListener('resize', updateLayoutMode);
+  }, []);
 
   // For QR codes, replace localhost/127.0.0.1 with the LAN IP so phones can reach it.
   const networkBaseUrl = useMemo(() => {
@@ -315,8 +342,83 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
     setJsonEdited(false);
   }, []);
 
+  const handlePanelResizeStart = useCallback((
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) => {
+    if (fullscreen || !pageRef.current) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const pageEl = pageRef.current;
+    const compact = window.innerWidth <= RESIZE_BREAKPOINT;
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startPreviewWidth = previewPanelWidth;
+    const startCodeHeight = codePanelHeight;
+
+    setIsPanelResizing(true);
+    document.body.dataset.panelResize = compact ? 'vertical' : 'horizontal';
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const pageRect = pageEl.getBoundingClientRect();
+
+      if (compact) {
+        const sidebarHeight = pageEl.querySelector('.sidebar')
+          ?.getBoundingClientRect().height ?? 0;
+        const maxCodeHeight = pageRect.height
+          - sidebarHeight
+          - COMPACT_PREVIEW_MIN_HEIGHT;
+        setCodePanelHeight(
+          clamp(
+            startCodeHeight + moveEvent.clientY - startY,
+            COMPACT_CODE_MIN_HEIGHT,
+            maxCodeHeight,
+          ),
+        );
+        return;
+      }
+
+      const sidebarWidth = pageEl.querySelector('.sidebar')
+        ?.getBoundingClientRect().width ?? 0;
+      const maxPreviewWidth = pageRect.width
+        - sidebarWidth
+        - DESKTOP_CODE_MIN_WIDTH;
+      setPreviewPanelWidth(
+        clamp(
+          startPreviewWidth + startX - moveEvent.clientX,
+          DESKTOP_PREVIEW_MIN_WIDTH,
+          maxPreviewWidth,
+        ),
+      );
+    };
+
+    const stopResize = () => {
+      setIsPanelResizing(false);
+      delete document.body.dataset.panelResize;
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', stopResize);
+      window.removeEventListener('pointercancel', stopResize);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', stopResize);
+    window.addEventListener('pointercancel', stopResize);
+  }, [codePanelHeight, fullscreen, previewPanelWidth]);
+
+  const codePanelStyle = isCompactLayout && !fullscreen
+    ? { height: `${codePanelHeight}px` }
+    : undefined;
+  const previewPanelStyle = !isCompactLayout && !fullscreen
+    ? { width: `${previewPanelWidth}px` }
+    : undefined;
+
   return (
-    <div className='demosPage'>
+    <div
+      ref={pageRef}
+      className={isPanelResizing ? 'demosPage resizing' : 'demosPage'}
+    >
       {/* Sidebar */}
       <aside className='sidebar'>
         <div className='sidebarSection'>
@@ -339,7 +441,7 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
       </aside>
 
       {/* Code Panel */}
-      <div className='codePanel'>
+      <div className='codePanel' style={codePanelStyle}>
         <div className='codePanelToolbar'>
           <div className='codePanelTitle'>
             A2UI Messages
@@ -392,11 +494,27 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
         {error ? <div className='codeError'>{error}</div> : null}
       </div>
 
+      {fullscreen
+        ? null
+        : (
+          <div
+            className={isPanelResizing
+              ? 'panelResizeHandle active'
+              : 'panelResizeHandle'}
+            role='separator'
+            aria-orientation={isCompactLayout ? 'horizontal' : 'vertical'}
+            aria-label='Resize JSON and preview panels'
+            title='Drag to resize'
+            onPointerDown={handlePanelResizeStart}
+          />
+        )}
+
       {/* Preview Panel */}
       <div
         className={fullscreen
           ? 'previewPanel previewPanelFullscreen'
           : 'previewPanel'}
+        style={previewPanelStyle}
       >
         <div className='previewPanelHeader'>
           <span className='previewPanelTitle'>Lynx Preview</span>

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -120,6 +120,7 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
     () => window.innerWidth <= RESIZE_BREAKPOINT,
   );
   const pageRef = useRef<HTMLDivElement>(null);
+  const resizeStopRef = useRef<((updateState?: boolean) => void) | null>(null);
   const liveTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   const baseUrl = window.location.href.replace(/#.*$/, '');
@@ -133,6 +134,12 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
     updateLayoutMode();
     window.addEventListener('resize', updateLayoutMode);
     return () => window.removeEventListener('resize', updateLayoutMode);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      resizeStopRef.current?.(false);
+    };
   }, []);
 
   // For QR codes, replace localhost/127.0.0.1 with the LAN IP so phones can reach it.
@@ -394,17 +401,22 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
       );
     };
 
-    const stopResize = () => {
-      setIsPanelResizing(false);
+    const stopResize = (updateState = true) => {
+      if (updateState) {
+        setIsPanelResizing(false);
+      }
       delete document.body.dataset.panelResize;
       window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', stopResize);
-      window.removeEventListener('pointercancel', stopResize);
+      window.removeEventListener('pointerup', handlePointerStop);
+      window.removeEventListener('pointercancel', handlePointerStop);
+      resizeStopRef.current = null;
     };
+    const handlePointerStop = () => stopResize();
 
+    resizeStopRef.current = stopResize;
     window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', stopResize);
-    window.addEventListener('pointercancel', stopResize);
+    window.addEventListener('pointerup', handlePointerStop);
+    window.addEventListener('pointercancel', handlePointerStop);
   }, [codePanelHeight, fullscreen, previewPanelWidth]);
 
   const codePanelStyle = isCompactLayout && !fullscreen

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 import { json } from '@codemirror/lang-json';
 import CodeMirror from '@uiw/react-codemirror';
-import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { MobilePreview } from '../components/MobilePreview.js';
@@ -13,6 +12,7 @@ import {
   STATIC_DEMOS,
   componentsByMessage,
 } from '../demos.js';
+import { useResizablePanels } from '../hooks/useResizablePanels.js';
 import { DEFAULT_DEMO_URL } from '../utils/demoUrl.js';
 import type { ProtocolVersion } from '../utils/protocol.js';
 import { buildRenderUrl } from '../utils/renderUrl.js';
@@ -86,10 +86,6 @@ function formatJson(value: unknown): string {
   return JSON.stringify(value ?? [], null, 2);
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), Math.max(min, max));
-}
-
 export function DemosPage(props: { protocol: ProtocolVersion }) {
   const { protocol } = props;
 
@@ -113,34 +109,30 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
   );
   const [fullscreen, setFullscreen] = useState(false);
   const [liveComponents, setLiveComponents] = useState<string[]>([]);
-  const [previewPanelWidth, setPreviewPanelWidth] = useState(420);
-  const [codePanelHeight, setCodePanelHeight] = useState(320);
-  const [isPanelResizing, setIsPanelResizing] = useState(false);
-  const [isCompactLayout, setIsCompactLayout] = useState(
-    () => window.innerWidth <= RESIZE_BREAKPOINT,
-  );
-  const pageRef = useRef<HTMLDivElement>(null);
-  const resizeStopRef = useRef<((updateState?: boolean) => void) | null>(null);
   const liveTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const {
+    containerRef: pageRef,
+    handleResizeStart: handlePanelResizeStart,
+    isCompactLayout,
+    isResizing: isPanelResizing,
+    primaryPanelStyle: codePanelStyle,
+    secondaryPanelStyle: previewPanelStyle,
+  } = useResizablePanels({
+    breakpoint: RESIZE_BREAKPOINT,
+    compactOffsetSelector: '.sidebar',
+    compactPrimaryMinSize: COMPACT_CODE_MIN_HEIGHT,
+    compactSecondaryMinSize: COMPACT_PREVIEW_MIN_HEIGHT,
+    desktopOffsetSelector: '.sidebar',
+    desktopPrimaryMinSize: DESKTOP_CODE_MIN_WIDTH,
+    desktopSecondaryMinSize: DESKTOP_PREVIEW_MIN_WIDTH,
+    disabled: fullscreen,
+    initialPrimarySize: 320,
+    initialSecondarySize: 420,
+  });
 
   const baseUrl = window.location.href.replace(/#.*$/, '');
   const rspeedyDevUrl = useRspeedyDevUrl();
   const lynxUrlSeqRef = useRef(0);
-
-  useEffect(() => {
-    const updateLayoutMode = () => {
-      setIsCompactLayout(window.innerWidth <= RESIZE_BREAKPOINT);
-    };
-    updateLayoutMode();
-    window.addEventListener('resize', updateLayoutMode);
-    return () => window.removeEventListener('resize', updateLayoutMode);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      resizeStopRef.current?.(false);
-    };
-  }, []);
 
   // For QR codes, replace localhost/127.0.0.1 with the LAN IP so phones can reach it.
   const networkBaseUrl = useMemo(() => {
@@ -348,83 +340,6 @@ export function DemosPage(props: { protocol: ProtocolVersion }) {
     setError('');
     setJsonEdited(false);
   }, []);
-
-  const handlePanelResizeStart = useCallback((
-    event: ReactPointerEvent<HTMLDivElement>,
-  ) => {
-    if (fullscreen || !pageRef.current) {
-      return;
-    }
-
-    event.preventDefault();
-
-    const pageEl = pageRef.current;
-    const compact = window.innerWidth <= RESIZE_BREAKPOINT;
-    const startX = event.clientX;
-    const startY = event.clientY;
-    const startPreviewWidth = previewPanelWidth;
-    const startCodeHeight = codePanelHeight;
-
-    setIsPanelResizing(true);
-    document.body.dataset.panelResize = compact ? 'vertical' : 'horizontal';
-
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      const pageRect = pageEl.getBoundingClientRect();
-
-      if (compact) {
-        const sidebarHeight = pageEl.querySelector('.sidebar')
-          ?.getBoundingClientRect().height ?? 0;
-        const maxCodeHeight = pageRect.height
-          - sidebarHeight
-          - COMPACT_PREVIEW_MIN_HEIGHT;
-        setCodePanelHeight(
-          clamp(
-            startCodeHeight + moveEvent.clientY - startY,
-            COMPACT_CODE_MIN_HEIGHT,
-            maxCodeHeight,
-          ),
-        );
-        return;
-      }
-
-      const sidebarWidth = pageEl.querySelector('.sidebar')
-        ?.getBoundingClientRect().width ?? 0;
-      const maxPreviewWidth = pageRect.width
-        - sidebarWidth
-        - DESKTOP_CODE_MIN_WIDTH;
-      setPreviewPanelWidth(
-        clamp(
-          startPreviewWidth + startX - moveEvent.clientX,
-          DESKTOP_PREVIEW_MIN_WIDTH,
-          maxPreviewWidth,
-        ),
-      );
-    };
-
-    const stopResize = (updateState = true) => {
-      if (updateState) {
-        setIsPanelResizing(false);
-      }
-      delete document.body.dataset.panelResize;
-      window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', handlePointerStop);
-      window.removeEventListener('pointercancel', handlePointerStop);
-      resizeStopRef.current = null;
-    };
-    const handlePointerStop = () => stopResize();
-
-    resizeStopRef.current = stopResize;
-    window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', handlePointerStop);
-    window.addEventListener('pointercancel', handlePointerStop);
-  }, [codePanelHeight, fullscreen, previewPanelWidth]);
-
-  const codePanelStyle = isCompactLayout && !fullscreen
-    ? { height: `${codePanelHeight}px` }
-    : undefined;
-  const previewPanelStyle = !isCompactLayout && !fullscreen
-    ? { width: `${previewPanelWidth}px` }
-    : undefined;
 
   return (
     <div

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -13,6 +13,7 @@ import {
   componentsByMessage,
 } from '../demos.js';
 import { useResizablePanels } from '../hooks/useResizablePanels.js';
+import { copyToClipboard } from '../utils/clipboard.js';
 import { DEFAULT_DEMO_URL } from '../utils/demoUrl.js';
 import type { ProtocolVersion } from '../utils/protocol.js';
 import { buildRenderUrl } from '../utils/renderUrl.js';
@@ -33,17 +34,6 @@ function formatUrlForDisplay(url: string): string {
   const head = url.slice(0, 44);
   const tail = url.slice(-24);
   return `${head}…${tail}`;
-}
-
-async function copyToClipboard(text: string): Promise<boolean> {
-  try {
-    const clipboard = window.navigator?.clipboard;
-    if (!clipboard) return false;
-    await clipboard.writeText(text);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function useRspeedyDevUrl(): string {

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -1202,13 +1202,17 @@ a {
 }
 
 /* ═══════════════════════════════════════════
-   AI Chat Page
+   Create Page
    ═══════════════════════════════════════════ */
 
 .chatPage {
   display: flex;
   flex: 1;
   overflow: hidden;
+}
+
+.chatPage.resizing {
+  user-select: none;
 }
 
 .chatPanel {
@@ -1225,16 +1229,38 @@ a {
   flex-shrink: 0;
 }
 
+.chatHeaderTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
 .chatHeaderTitle {
   font-size: 15px;
   font-weight: 600;
-  margin: 0 0 2px;
+  margin: 0;
+}
+
+.constructionBadge {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  border: 1px solid var(--geist-border);
+  border-radius: 999px;
+  background: var(--geist-surface);
+  color: var(--geist-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .chatHeaderSub {
   font-size: 12px;
   color: var(--geist-secondary);
-  margin: 0;
+  margin: 2px 0 0;
 }
 
 .chatMessages {
@@ -1399,5 +1425,6 @@ a {
 
   .chatPanel {
     min-height: 400px;
+    flex: 0 0 auto;
   }
 }

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -1095,6 +1095,95 @@ a {
   margin-bottom: 24px;
 }
 
+.compSectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.compSectionHeader .compSubheading {
+  margin: 0;
+}
+
+.compCopyBtn {
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--geist-border);
+  border-radius: var(--geist-radius-sm);
+  background: var(--geist-background);
+  color: var(--geist-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--geist-transition);
+}
+
+.compCopyBtn:hover {
+  color: var(--geist-foreground);
+  border-color: var(--geist-border-hover);
+}
+
+.compUsageEditor {
+  margin-bottom: 24px;
+  border: 1px solid var(--geist-border);
+  border-radius: var(--geist-radius-md);
+  overflow: hidden;
+}
+
+.compUsageEditor .cm-editor {
+  height: auto;
+  max-height: 520px;
+  font-family: var(--geist-mono);
+  font-size: 13px;
+  background: var(--geist-code-bg);
+}
+
+.compUsageEditor .cm-scroller {
+  max-height: 520px;
+  overflow: auto;
+}
+
+.compUsageError {
+  margin: -16px 0 24px;
+  padding: 8px 12px;
+  border: 1px solid var(--geist-error);
+  border-radius: var(--geist-radius-sm);
+  background: var(--geist-error-light);
+  color: var(--geist-error);
+  font-family: var(--geist-mono);
+  font-size: 12px;
+}
+
+.compPreview {
+  width: 100%;
+  height: 360px;
+  margin-bottom: 24px;
+  border: 1px solid var(--geist-border);
+  border-radius: var(--geist-radius-md);
+  background: var(--geist-surface);
+  overflow: hidden;
+}
+
+.compPreviewIframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: var(--geist-background);
+}
+
+.compPreviewInvalid {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  color: var(--geist-secondary);
+  font-size: 13px;
+  text-align: center;
+}
+
 /* ── Category Grid (All Components view) ── */
 .compCategorySection {
   margin-bottom: 32px;

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -70,6 +70,22 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+body[data-panel-resize="horizontal"],
+body[data-panel-resize="horizontal"] * {
+  cursor: col-resize !important;
+  user-select: none;
+}
+
+body[data-panel-resize="vertical"],
+body[data-panel-resize="vertical"] * {
+  cursor: row-resize !important;
+  user-select: none;
+}
+
+body[data-panel-resize] iframe {
+  pointer-events: none;
+}
+
 #root {
   height: 100%;
 }
@@ -666,13 +682,17 @@ a {
 }
 
 /* ═══════════════════════════════════════════
-   Demos Page
+   Examples Page
    ═══════════════════════════════════════════ */
 
 .demosPage {
   display: flex;
   flex: 1;
   overflow: hidden;
+}
+
+.demosPage.resizing {
+  user-select: none;
 }
 
 /* ── Sidebar ── */
@@ -783,6 +803,47 @@ a {
   min-width: 0;
   display: flex;
   flex-direction: column;
+}
+
+.panelResizeHandle {
+  position: relative;
+  width: 8px;
+  flex-shrink: 0;
+  cursor: col-resize;
+  background: var(--geist-background);
+  border-left: 1px solid var(--geist-border);
+  border-right: 1px solid var(--geist-border);
+  touch-action: none;
+  transition: background var(--geist-transition);
+}
+
+.panelResizeHandle::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2px;
+  height: 40px;
+  border-radius: 999px;
+  background: var(--geist-border-hover);
+  opacity: 0.35;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity var(--geist-transition),
+    height var(--geist-transition),
+    background var(--geist-transition);
+}
+
+.panelResizeHandle:hover,
+.panelResizeHandle.active {
+  background: var(--geist-surface);
+}
+
+.panelResizeHandle:hover::before,
+.panelResizeHandle.active::before {
+  height: 56px;
+  opacity: 0.9;
+  background: var(--geist-foreground);
 }
 
 .codePanelToolbar {
@@ -1284,6 +1345,28 @@ a {
 
   .codePanel {
     min-height: 280px;
+    flex: 0 0 auto;
+  }
+
+  .panelResizeHandle {
+    width: 100%;
+    height: 8px;
+    cursor: row-resize;
+    border-left: none;
+    border-right: none;
+    border-top: 1px solid var(--geist-border);
+    border-bottom: 1px solid var(--geist-border);
+  }
+
+  .panelResizeHandle::before {
+    width: 48px;
+    height: 2px;
+  }
+
+  .panelResizeHandle:hover::before,
+  .panelResizeHandle.active::before {
+    width: 64px;
+    height: 2px;
   }
 
   .previewPanel {

--- a/packages/genui/a2ui-playground/src/utils/clipboard.ts
+++ b/packages/genui/a2ui-playground/src/utils/clipboard.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    const clipboard = window.navigator?.clipboard;
+    if (!clipboard) return false;
+    await clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resizable panels across layouts with improved drag handle and accessibility.
  * Interactive JSON editor for component usage with live iframe preview and "Copy JSON" action.
  * Clipboard helper for reliable copy operations.

* **Chores**
  * Renamed "Demos" tab to "Examples"; default landing tab changed to "Create" (Chat removed as primary).

* **Documentation**
  * Updated in-app docs to reflect new tab labels and revised component prop examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
