### PR TITLE
Security: Potential XSS in MobilePreview iframe

### DIFF
--- a/packages/genui/a2ui-playground/src/components/MobilePreview.tsx
+++ b/packages/genui/a2ui-playground/src/components/MobilePreview.tsx
@@ -5,7 +5,7 @@ export function MobilePreview(props: { src: string }) {
   return (
     <div className='phoneWrap'>
       <div className='phoneFrame'>
-        <iframe className='phoneIframe' title='preview' src={props.src} />
+        <iframe className='phoneIframe' title='preview' src={props.src} sandbox='allow-scripts' />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Security: Potential XSS in MobilePreview iframe

## Problem

**Severity**: `High` | **File**: `packages/genui/a2ui-playground/src/components/MobilePreview.tsx:L8`

The MobilePreview component renders an iframe with a src prop that could be controlled by external input without sanitization or sandboxing.

## Solution

Add sandbox attribute to iframe (e.g., sandbox='allow-scripts') and validate/normalize the src URL to prevent XSS attacks. Consider using srcdoc for additional isolation.

## Changes

- `packages/genui/a2ui-playground/src/components/MobilePreview.tsx` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile preview security by implementing stricter access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->