### PR TITLE
feat(react): clean up removed element template subtrees

### DIFF
--- a/.changeset/empty-et-removed-subtree-cleanup.md
+++ b/.changeset/empty-et-removed-subtree-cleanup.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+No package release is required because this change only updates the unpublished Element Template runtime path and its internal tests, without changing public APIs, package exports, or release-facing defaults.

--- a/packages/react/runtime/__test__/element-template/fixtures/background/update/compiled-keyed-list/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/update/compiled-keyed-list/index.tsx
@@ -1,0 +1,15 @@
+interface AppProps {
+  items?: string[];
+}
+
+function Item({ id }: { id: string }) {
+  return <view id={id} />;
+}
+
+export function App({ items = [] }: AppProps) {
+  return (
+    <view>
+      {items.map(item => <Item key={item} id={item} />)}
+    </view>
+  );
+}

--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-context.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-context.test.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  GlobalCommitContext,
+  markRemovedSubtreeForCurrentCommit,
+  resetGlobalCommitContext,
+  takeRemovedSubtreesForCurrentCommit,
+} from '../../../../src/element-template/background/commit-context.js';
+import {
+  BackgroundElementTemplateInstance,
+  BackgroundElementTemplateSlot,
+  BUILTIN_RAW_TEXT_TEMPLATE_KEY,
+  collectElementTemplateSubtreeHandleIds,
+} from '../../../../src/element-template/background/instance.js';
+import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
+
+describe('ElementTemplate commit context', () => {
+  beforeEach(() => {
+    backgroundElementTemplateInstanceManager.clear();
+    backgroundElementTemplateInstanceManager.nextId = 0;
+    resetGlobalCommitContext();
+  });
+
+  it('keeps removed subtree roots outside the update payload', () => {
+    const root = new BackgroundElementTemplateInstance('view');
+
+    markRemovedSubtreeForCurrentCommit(root);
+    markRemovedSubtreeForCurrentCommit(root);
+
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([root]);
+    expect({
+      ops: GlobalCommitContext.ops,
+      flushOptions: GlobalCommitContext.flushOptions,
+      flowIds: GlobalCommitContext.flowIds,
+    }).not.toHaveProperty('removedSubtrees');
+  });
+
+  it('takes removed subtree roots from the current commit once', () => {
+    const root = new BackgroundElementTemplateInstance('view');
+    markRemovedSubtreeForCurrentCommit(root);
+
+    expect(takeRemovedSubtreesForCurrentCommit()).toEqual([root]);
+    expect(takeRemovedSubtreesForCurrentCommit()).toEqual([]);
+  });
+
+  it('clears non-payload state when the global commit context resets', () => {
+    const root = new BackgroundElementTemplateInstance('view');
+    markRemovedSubtreeForCurrentCommit(root);
+
+    resetGlobalCommitContext();
+
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+  });
+
+  it('collects only handles that are registered in the main-thread registry', () => {
+    const root = new BackgroundElementTemplateInstance('root');
+    const slot = new BackgroundElementTemplateSlot();
+    slot.setAttribute('id', 0);
+    root.appendChild(slot);
+    const child = new BackgroundElementTemplateInstance('child');
+    const childSlot = new BackgroundElementTemplateSlot();
+    childSlot.setAttribute('id', 0);
+    child.appendChild(childSlot);
+    const rawText = new BackgroundElementTemplateInstance(BUILTIN_RAW_TEXT_TEMPLATE_KEY, ['text']);
+    childSlot.appendChild(rawText);
+    slot.appendChild(child);
+
+    expect(collectElementTemplateSubtreeHandleIds(root)).toEqual([
+      root.instanceId,
+      child.instanceId,
+      rawText.instanceId,
+    ]);
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
@@ -12,7 +12,12 @@ import {
   installElementTemplateHydrationListener,
   resetElementTemplateHydrationListener,
 } from '../../../../src/element-template/background/hydration-listener.js';
-import { GlobalCommitContext } from '../../../../src/element-template/background/commit-context.js';
+import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
+import {
+  GlobalCommitContext,
+  markRemovedSubtreeForCurrentCommit,
+} from '../../../../src/element-template/background/commit-context.js';
 import { ElementTemplateUpdateOps } from '../../../../src/element-template/protocol/opcodes.js';
 import { ElementTemplateLifecycleConstant } from '../../../../src/element-template/protocol/lifecycle-constant.js';
 import { PipelineOrigins } from '../../../../src/element-template/lynx/performance.js';
@@ -39,6 +44,8 @@ describe('ElementTemplate commit hook', () => {
 
   beforeEach(() => {
     resetElementTemplateCommitState();
+    backgroundElementTemplateInstanceManager.clear();
+    backgroundElementTemplateInstanceManager.nextId = 0;
     updateEvents = [];
     envManager.resetEnv('background');
     installElementTemplateCommitHook();
@@ -151,6 +158,52 @@ describe('ElementTemplate commit hook', () => {
 
     expect(formatSpy).not.toHaveBeenCalled();
     expect(alog.mock.calls).toHaveLength(0);
+  });
+
+  it('schedules delayed cleanup from the current commit non-payload state', () => {
+    vi.useFakeTimers();
+    try {
+      markElementTemplateHydrated();
+      const root = new BackgroundElementTemplateInstance('root');
+      markRemovedSubtreeForCurrentCommit(root);
+      GlobalCommitContext.ops = createRawTextOps(1, 'flush');
+
+      options.__c?.({} as unknown as object, []);
+      expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+      vi.advanceTimersByTime(9999);
+      expect(backgroundElementTemplateInstanceManager.get(root.instanceId)).toBe(root);
+
+      vi.advanceTimersByTime(1);
+
+      expect(backgroundElementTemplateInstanceManager.get(root.instanceId)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resets commit state when update dispatch throws', () => {
+    vi.useFakeTimers();
+    const dispatchError = new Error('update dispatch failed');
+    const dispatchSpy = vi.spyOn(lynx.getCoreContext(), 'dispatchEvent').mockImplementationOnce(() => {
+      throw dispatchError;
+    });
+
+    try {
+      markElementTemplateHydrated();
+      const root = new BackgroundElementTemplateInstance('root');
+      markRemovedSubtreeForCurrentCommit(root);
+      GlobalCommitContext.ops = createRawTextOps(1, 'flush');
+
+      expect(() => options.__c?.({} as unknown as object, [])).toThrow(dispatchError);
+      expect(GlobalCommitContext.ops).toEqual([]);
+      expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+
+      vi.advanceTimersByTime(10000);
+      expect(backgroundElementTemplateInstanceManager.get(root.instanceId)).toBeUndefined();
+    } finally {
+      dispatchSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it('is idempotent', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -427,6 +427,7 @@ describe('BackgroundElementTemplateInstance', () => {
         0,
         child.instanceId,
       ]);
+      expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([child]);
     });
 
     it('supports silent removal from a slot container', () => {
@@ -442,6 +443,7 @@ describe('BackgroundElementTemplateInstance', () => {
 
       expect(parent.elementSlots[0]).toEqual([]);
       expect(GlobalCommitContext.ops).toEqual([]);
+      expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
     });
 
     it('clears cached elementSlots when removing a slot child', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
@@ -1,0 +1,254 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { createElement } from 'preact';
+
+import {
+  installElementTemplateCommitHook,
+  resetElementTemplateCommitState,
+} from '../../../../../src/element-template/background/commit-hook.js';
+import {
+  installElementTemplateHydrationListener,
+  resetElementTemplateHydrationListener,
+} from '../../../../../src/element-template/background/hydration-listener.js';
+import { BackgroundElementTemplateInstance } from '../../../../../src/element-template/background/instance.js';
+import { backgroundElementTemplateInstanceManager } from '../../../../../src/element-template/background/manager.js';
+import { root } from '../../../../../src/element-template/index.js';
+import { ElementTemplateLifecycleConstant } from '../../../../../src/element-template/protocol/lifecycle-constant.js';
+import { ElementTemplateUpdateOps } from '../../../../../src/element-template/protocol/opcodes.js';
+import type { ElementTemplateUpdateCommitContext } from '../../../../../src/element-template/protocol/types.js';
+import { __root } from '../../../../../src/element-template/runtime/page/root-instance.js';
+import { compileFixtureSource } from '../../../test-utils/debug/compiledFixtureCompiler.js';
+import {
+  loadCompiledFixtureModule,
+  type CompiledFixtureModuleExports,
+} from '../../../test-utils/debug/compiledFixtureModule.js';
+import { primeCompiledFixtureTemplates } from '../../../test-utils/debug/compiledFixtureRegistry.js';
+import { ElementTemplateEnvManager } from '../../../test-utils/debug/envManager.js';
+import { runFixtureTests } from '../../../test-utils/debug/fixtureRunner.js';
+import { serializeBackgroundTree } from '../../../test-utils/debug/serializer.js';
+
+declare const renderPage: () => void;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/background/update');
+const SLOT_ID = 0;
+
+interface CompiledKeyedListModule extends CompiledFixtureModuleExports {
+  App: (props: { items: string[] }) => JSX.Element;
+}
+
+function getRenderedHost(): BackgroundElementTemplateInstance {
+  const host = (__root as BackgroundElementTemplateInstance).firstChild;
+  if (!host) {
+    throw new Error('Missing rendered host.');
+  }
+  return host;
+}
+
+function getSlotChildren(host = getRenderedHost()): BackgroundElementTemplateInstance[] {
+  return host.elementSlots[SLOT_ID] ?? [];
+}
+
+function getSlotChildAt(
+  index: number,
+  host = getRenderedHost(),
+): BackgroundElementTemplateInstance {
+  const child = getSlotChildren(host)[index];
+  if (!child) {
+    throw new Error(`Missing slot child at ${index}.\n${serializeBackgroundTree(host)}`);
+  }
+  return child;
+}
+
+describe('Compiled background Preact updates', () => {
+  const envManager = new ElementTemplateEnvManager();
+  let updateEvents: ElementTemplateUpdateCommitContext[] = [];
+  const onUpdate = (event: { data: unknown }) => {
+    updateEvents.push(event.data as ElementTemplateUpdateCommitContext);
+  };
+
+  async function loadCompiledFixture(sourcePath: string): Promise<{
+    backgroundModule: CompiledKeyedListModule;
+    mainModule: CompiledKeyedListModule;
+  }> {
+    const mainArtifact = await compileFixtureSource(sourcePath, { target: 'LEPUS' });
+    primeCompiledFixtureTemplates(mainArtifact);
+    const mainModule = await loadCompiledFixtureModule<CompiledKeyedListModule>(mainArtifact);
+
+    const backgroundArtifact = await compileFixtureSource(sourcePath, { target: 'JS' });
+    const backgroundModule = await loadCompiledFixtureModule<CompiledKeyedListModule>(backgroundArtifact);
+
+    return { backgroundModule, mainModule };
+  }
+
+  function renderCompiledOnBackground(
+    moduleExports: CompiledKeyedListModule,
+    items: readonly string[],
+  ): BackgroundElementTemplateInstance {
+    envManager.switchToBackground();
+    root.render(createElement(moduleExports.App, { items: [...items] }));
+    return getRenderedHost();
+  }
+
+  function hydrateFromMainThread(
+    moduleExports: CompiledKeyedListModule,
+    items: readonly string[],
+  ): BackgroundElementTemplateInstance {
+    const host = getRenderedHost();
+
+    envManager.switchToMainThread();
+    root.render(createElement(moduleExports.App, { items: [...items] }));
+    renderPage();
+    envManager.switchToBackground();
+
+    return host;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetElementTemplateCommitState();
+    updateEvents = [];
+    envManager.resetEnv('background');
+    envManager.setUseElementTemplate(true);
+    installElementTemplateCommitHook();
+    installElementTemplateHydrationListener();
+
+    envManager.switchToMainThread();
+    lynx.getJSContext().addEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+    envManager.switchToBackground();
+  });
+
+  afterEach(() => {
+    envManager.switchToMainThread();
+    lynx.getJSContext().removeEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+    envManager.switchToBackground();
+    resetElementTemplateHydrationListener();
+    envManager.setUseElementTemplate(false);
+  });
+
+  describe('keyed moves', () => {
+    runFixtureTests({
+      fixturesRoot: FIXTURES_DIR,
+      async run({ fixtureDir }) {
+        const sourcePath = path.join(fixtureDir, 'index.tsx');
+        const { backgroundModule, mainModule } = await loadCompiledFixture(sourcePath);
+
+        const host = renderCompiledOnBackground(backgroundModule, ['a', 'b', 'c']);
+        hydrateFromMainThread(mainModule, ['a', 'b', 'c']);
+        const first = getSlotChildAt(0, host);
+        const second = getSlotChildAt(1, host);
+        const moved = getSlotChildAt(2, host);
+        updateEvents = [];
+
+        renderCompiledOnBackground(backgroundModule, ['c', 'a', 'b']);
+
+        envManager.switchToMainThread();
+        expect(updateEvents.at(-1)?.ops).toEqual([
+          ElementTemplateUpdateOps.insertNode,
+          host.instanceId,
+          SLOT_ID,
+          moved.instanceId,
+          first.instanceId,
+        ]);
+        envManager.switchToBackground();
+        expect(getSlotChildren(host)).toEqual([moved, first, second]);
+      },
+    });
+  });
+
+  describe('removals', () => {
+    runFixtureTests({
+      fixturesRoot: FIXTURES_DIR,
+      async run({ fixtureDir }) {
+        const sourcePath = path.join(fixtureDir, 'index.tsx');
+        const { backgroundModule, mainModule } = await loadCompiledFixture(sourcePath);
+        const host = renderCompiledOnBackground(backgroundModule, ['keep', 'remove']);
+        hydrateFromMainThread(mainModule, ['keep', 'remove']);
+        const removed = getSlotChildAt(1, host);
+        updateEvents = [];
+
+        vi.useFakeTimers();
+        try {
+          renderCompiledOnBackground(backgroundModule, ['keep']);
+
+          envManager.switchToMainThread();
+          expect(updateEvents.at(-1)?.ops).toEqual([
+            ElementTemplateUpdateOps.removeNode,
+            host.instanceId,
+            SLOT_ID,
+            removed.instanceId,
+          ]);
+          envManager.switchToBackground();
+          expect(backgroundElementTemplateInstanceManager.get(removed.instanceId)).toBe(removed);
+
+          vi.advanceTimersByTime(9999);
+          expect(backgroundElementTemplateInstanceManager.get(removed.instanceId)).toBe(removed);
+
+          vi.advanceTimersByTime(1);
+          expect(backgroundElementTemplateInstanceManager.get(removed.instanceId)).toBeUndefined();
+        } finally {
+          vi.useRealTimers();
+        }
+      },
+    });
+  });
+
+  describe('remove and re-add', () => {
+    runFixtureTests({
+      fixturesRoot: FIXTURES_DIR,
+      async run({ fixtureDir }) {
+        const sourcePath = path.join(fixtureDir, 'index.tsx');
+        const { backgroundModule, mainModule } = await loadCompiledFixture(sourcePath);
+        const host = renderCompiledOnBackground(backgroundModule, ['keep', 'again']);
+        hydrateFromMainThread(mainModule, ['keep', 'again']);
+        const keep = getSlotChildAt(0, host);
+        const removed = getSlotChildAt(1, host);
+        updateEvents = [];
+
+        vi.useFakeTimers();
+        try {
+          renderCompiledOnBackground(backgroundModule, ['keep']);
+          envManager.switchToMainThread();
+          expect(updateEvents.at(-1)?.ops).toEqual([
+            ElementTemplateUpdateOps.removeNode,
+            host.instanceId,
+            SLOT_ID,
+            removed.instanceId,
+          ]);
+          envManager.switchToBackground();
+
+          updateEvents = [];
+          renderCompiledOnBackground(backgroundModule, ['keep', 'again']);
+          const current = getSlotChildAt(1, host);
+          expect(current).not.toBe(removed);
+          envManager.switchToMainThread();
+          expect(updateEvents.at(-1)?.ops).toEqual([
+            ElementTemplateUpdateOps.createTemplate,
+            current.instanceId,
+            current.type,
+            null,
+            current.attributeSlots,
+            current.elementSlots.map(children => children.map(child => child.instanceId)),
+            ElementTemplateUpdateOps.insertNode,
+            host.instanceId,
+            SLOT_ID,
+            current.instanceId,
+            0,
+          ]);
+          envManager.switchToBackground();
+
+          vi.advanceTimersByTime(10000);
+
+          expect(backgroundElementTemplateInstanceManager.get(current.instanceId)).toBe(current);
+          expect(backgroundElementTemplateInstanceManager.get(removed.instanceId)).toBeUndefined();
+          expect(getSlotChildren(host)).toEqual([keep, current]);
+        } finally {
+          vi.useRealTimers();
+        }
+      },
+    });
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as elementTemplateAlog from '../../../../src/element-template/debug/alog.js';
+import { GlobalCommitContext } from '../../../../src/element-template/background/commit-context.js';
 import {
   installElementTemplateHydrationListener,
   resetElementTemplateHydrationListener,
 } from '../../../../src/element-template/background/hydration-listener.js';
-import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import {
+  BackgroundElementTemplateInstance,
+  BackgroundElementTemplateSlot,
+} from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { PerformanceTimingFlags, PipelineOrigins } from '../../../../src/element-template/lynx/performance.js';
 import { ElementTemplateLifecycleConstant } from '../../../../src/element-template/protocol/lifecycle-constant.js';
@@ -78,6 +82,85 @@ describe('ElementTemplate hydration listener', () => {
     expect(backgroundElementTemplateInstanceManager.get(oldId)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(-1)).toBe(after);
     expect(backgroundElementTemplateInstanceManager.get(-2)).toBeUndefined();
+  });
+
+  it('schedules delayed cleanup for removed subtrees produced during hydration', () => {
+    vi.useFakeTimers();
+    try {
+      envManager.switchToBackground();
+      installElementTemplateHydrationListener();
+
+      const backgroundRoot = __root as BackgroundElementTemplateInstance;
+      const host = new BackgroundElementTemplateInstance('_et_test');
+      const slot = new BackgroundElementTemplateSlot();
+      slot.setAttribute('id', 0);
+      host.appendChild(slot);
+      backgroundRoot.appendChild(host);
+      const stale = new BackgroundElementTemplateInstance('_et_stale');
+
+      envManager.switchToMainThread();
+      lynx.getJSContext().dispatchEvent({
+        type: ElementTemplateLifecycleConstant.hydrate,
+        data: [
+          {
+            ...createSerializedTemplate(host.instanceId, '_et_test'),
+            elementSlots: [[createSerializedTemplate(stale.instanceId, '_et_stale')]],
+          },
+        ],
+      });
+
+      envManager.switchToBackground();
+      vi.advanceTimersByTime(9999);
+      expect(backgroundElementTemplateInstanceManager.get(stale.instanceId)).toBe(stale);
+
+      vi.advanceTimersByTime(1);
+      expect(backgroundElementTemplateInstanceManager.get(stale.instanceId)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resets commit state when hydrate update dispatch throws', () => {
+    vi.useFakeTimers();
+    const dispatchError = new Error('hydrate update dispatch failed');
+    let dispatchSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    try {
+      envManager.switchToBackground();
+      installElementTemplateHydrationListener();
+      dispatchSpy = vi.spyOn(lynx.getCoreContext(), 'dispatchEvent').mockImplementationOnce(() => {
+        throw dispatchError;
+      });
+
+      const backgroundRoot = __root as BackgroundElementTemplateInstance;
+      const host = new BackgroundElementTemplateInstance('_et_test');
+      const slot = new BackgroundElementTemplateSlot();
+      slot.setAttribute('id', 0);
+      host.appendChild(slot);
+      backgroundRoot.appendChild(host);
+      const stale = new BackgroundElementTemplateInstance('_et_stale');
+
+      envManager.switchToMainThread();
+      lynx.getJSContext().dispatchEvent({
+        type: ElementTemplateLifecycleConstant.hydrate,
+        data: [
+          {
+            ...createSerializedTemplate(host.instanceId, '_et_test'),
+            elementSlots: [[createSerializedTemplate(stale.instanceId, '_et_stale')]],
+          },
+        ],
+      });
+
+      expect(() => envManager.switchToBackground()).toThrow(dispatchError);
+      expect(GlobalCommitContext.ops).toEqual([]);
+      expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+
+      vi.advanceTimersByTime(10000);
+      expect(backgroundElementTemplateInstanceManager.get(stale.instanceId)).toBeUndefined();
+    } finally {
+      dispatchSpy?.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it('does nothing when events are flushed on main thread', () => {

--- a/packages/react/runtime/src/element-template/background/commit-context.ts
+++ b/packages/react/runtime/src/element-template/background/commit-context.ts
@@ -1,15 +1,45 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import type { BackgroundElementTemplateInstance } from './instance.js';
 import type { ElementTemplateUpdateCommitContext } from '../protocol/types.js';
 
-export const GlobalCommitContext: ElementTemplateUpdateCommitContext = {
+interface ElementTemplateCommitNonPayloadState {
+  // Background-only JS objects must not be included in the cross-thread update
+  // payload. They ride alongside the payload until dispatch schedules cleanup.
+  removedSubtrees: BackgroundElementTemplateInstance[];
+}
+
+type ElementTemplateGlobalCommitContext = ElementTemplateUpdateCommitContext & {
+  nonPayload: ElementTemplateCommitNonPayloadState;
+};
+
+export const GlobalCommitContext: ElementTemplateGlobalCommitContext = {
   ops: [],
   flushOptions: {},
+  nonPayload: {
+    removedSubtrees: [],
+  },
 };
 
 export function resetGlobalCommitContext(): void {
   GlobalCommitContext.ops = [];
   GlobalCommitContext.flushOptions = {};
   delete GlobalCommitContext.flowIds;
+  GlobalCommitContext.nonPayload.removedSubtrees = [];
+}
+
+export function markRemovedSubtreeForCurrentCommit(
+  root: BackgroundElementTemplateInstance,
+): void {
+  const { removedSubtrees } = GlobalCommitContext.nonPayload;
+  if (!removedSubtrees.includes(root)) {
+    removedSubtrees.push(root);
+  }
+}
+
+export function takeRemovedSubtreesForCurrentCommit(): BackgroundElementTemplateInstance[] {
+  const removedSubtrees = GlobalCommitContext.nonPayload.removedSubtrees;
+  GlobalCommitContext.nonPayload.removedSubtrees = [];
+  return removedSubtrees;
 }

--- a/packages/react/runtime/src/element-template/background/commit-hook.ts
+++ b/packages/react/runtime/src/element-template/background/commit-hook.ts
@@ -4,7 +4,12 @@
 
 import { options } from 'preact';
 
-import { GlobalCommitContext, resetGlobalCommitContext } from './commit-context.js';
+import {
+  GlobalCommitContext,
+  resetGlobalCommitContext,
+  takeRemovedSubtreesForCurrentCommit,
+} from './commit-context.js';
+import type { BackgroundElementTemplateInstance } from './instance.js';
 import { COMMIT } from '../../shared/render-constants.js';
 import { hook } from '../../utils.js';
 import { formatElementTemplateUpdateCommands } from '../debug/alog.js';
@@ -26,6 +31,19 @@ export function isElementTemplateHydrated(): boolean {
 export function resetElementTemplateCommitState(): void {
   hasHydrated = false;
   resetGlobalCommitContext();
+}
+
+export function scheduleElementTemplateRemovedSubtreeCleanup(
+  removedSubtrees: BackgroundElementTemplateInstance[],
+): void {
+  if (removedSubtrees.length === 0) {
+    return;
+  }
+  setTimeout(() => {
+    for (const root of removedSubtrees) {
+      root.tearDown();
+    }
+  }, 10000);
 }
 
 export function installElementTemplateCommitHook(): void {
@@ -69,15 +87,23 @@ export function installElementTemplateCommitHook(): void {
         );
       }
 
-      lynx.getCoreContext().dispatchEvent({
-        type: ElementTemplateLifecycleConstant.update,
-        data: {
-          ops: GlobalCommitContext.ops,
-          flushOptions: GlobalCommitContext.flushOptions,
-          flowIds: GlobalCommitContext.flowIds,
-        },
-      });
-      resetGlobalCommitContext();
+      const removedSubtrees = takeRemovedSubtreesForCurrentCommit();
+      try {
+        lynx.getCoreContext().dispatchEvent({
+          type: ElementTemplateLifecycleConstant.update,
+          data: {
+            ops: GlobalCommitContext.ops,
+            flushOptions: GlobalCommitContext.flushOptions,
+            flowIds: GlobalCommitContext.flowIds,
+          },
+        });
+      } finally {
+        resetGlobalCommitContext();
+        // Match Snapshot's cleanup boundary: start the delayed teardown only
+        // after the bridge dispatch attempt, so background JS objects are not
+        // torn down before main-thread detach observes the same commit.
+        scheduleElementTemplateRemovedSubtreeCleanup(removedSubtrees);
+      }
     }
 
     originalCommit?.(vnode, commitQueue);

--- a/packages/react/runtime/src/element-template/background/hydrate.ts
+++ b/packages/react/runtime/src/element-template/background/hydrate.ts
@@ -456,6 +456,7 @@ function bindHydrationHandleId(
 ): boolean {
   try {
     backgroundElementTemplateInstanceManager.updateId(instance.instanceId, handleId);
+    instance.markCreateEmittedForHydration();
     return true;
   } catch (error) {
     if (__DEV__) {

--- a/packages/react/runtime/src/element-template/background/hydration-listener.ts
+++ b/packages/react/runtime/src/element-template/background/hydration-listener.ts
@@ -1,8 +1,16 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { GlobalCommitContext, resetGlobalCommitContext } from './commit-context.js';
-import { markElementTemplateHydrated, resetElementTemplateCommitState } from './commit-hook.js';
+import {
+  GlobalCommitContext,
+  resetGlobalCommitContext,
+  takeRemovedSubtreesForCurrentCommit,
+} from './commit-context.js';
+import {
+  markElementTemplateHydrated,
+  resetElementTemplateCommitState,
+  scheduleElementTemplateRemovedSubtreeCleanup,
+} from './commit-hook.js';
 import { hydrateIntoContext } from './hydrate.js';
 import { BackgroundElementTemplateInstance } from './instance.js';
 import { formatElementTemplateUpdateCommands, printElementTemplateTreeToString } from '../debug/alog.js';
@@ -81,15 +89,20 @@ export function installElementTemplateHydrationListener(): void {
             ),
         );
       }
-      lynx.getCoreContext().dispatchEvent({
-        type: ElementTemplateLifecycleConstant.update,
-        data: {
-          ops: GlobalCommitContext.ops,
-          flushOptions: GlobalCommitContext.flushOptions,
-          flowIds: GlobalCommitContext.flowIds,
-        },
-      });
-      resetGlobalCommitContext();
+      const removedSubtrees = takeRemovedSubtreesForCurrentCommit();
+      try {
+        lynx.getCoreContext().dispatchEvent({
+          type: ElementTemplateLifecycleConstant.update,
+          data: {
+            ops: GlobalCommitContext.ops,
+            flushOptions: GlobalCommitContext.flushOptions,
+            flowIds: GlobalCommitContext.flowIds,
+          },
+        });
+      } finally {
+        resetGlobalCommitContext();
+        scheduleElementTemplateRemovedSubtreeCleanup(removedSubtrees);
+      }
     }
   };
 

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { GlobalCommitContext } from './commit-context.js';
+import { GlobalCommitContext, markRemovedSubtreeForCurrentCommit } from './commit-context.js';
 import { isElementTemplateHydrated } from './commit-hook.js';
 import { backgroundElementTemplateInstanceManager } from './manager.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
@@ -248,6 +248,9 @@ export class BackgroundElementTemplateInstance {
           slotId,
           child.instanceId,
         );
+        // The removed JS object graph may outlive the detach until GC, so keep
+        // it pending and tear it down on the Snapshot-aligned delayed boundary.
+        markRemovedSubtreeForCurrentCommit(child);
       }
       return;
     }
@@ -281,6 +284,12 @@ export class BackgroundElementTemplateInstance {
     if (this.instanceId) {
       backgroundElementTemplateInstanceManager.values.delete(this.instanceId);
     }
+  }
+
+  markCreateEmittedForHydration(): void {
+    // Hydration binds this object to a template that already exists on the main
+    // thread; future updates must treat it as created without emitting create.
+    this.hasEmittedCreate = true;
   }
 
   setAttribute(key: string, value: unknown): void {
@@ -354,6 +363,28 @@ export class BackgroundElementTemplateSlot extends BackgroundElementTemplateInst
 
   constructor() {
     super('slot');
+  }
+}
+
+export function collectElementTemplateSubtreeHandleIds(
+  root: BackgroundElementTemplateInstance,
+): number[] {
+  const handles: number[] = [];
+  collectElementTemplateSubtreeHandleIdsImpl(root, handles);
+  return handles;
+}
+
+function collectElementTemplateSubtreeHandleIdsImpl(
+  instance: BackgroundElementTemplateInstance,
+  handles: number[],
+): void {
+  if (!(instance instanceof BackgroundElementTemplateSlot) && instance.instanceId !== 0) {
+    handles.push(instance.instanceId);
+  }
+  let child = instance.firstChild;
+  while (child) {
+    collectElementTemplateSubtreeHandleIdsImpl(child, handles);
+    child = child.nextSibling;
   }
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delayed teardown for removed Element Template subtrees with commit-aligned tracking and automatic cleanup scheduling.
  * Hydration now marks instances as emitted to avoid duplicate create events and collects subtree IDs for safer updates.

* **Tests**
  * Added end-to-end and unit tests covering removal tracking, delayed cleanup, hydration failure paths, and keyed-list update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

Element Template currently emits remove patches from the background thread but keeps the removed background subtree registered until something else tears it down. This change adds the first cleanup phase for that lifecycle: removed background roots are tracked beside the current commit payload, then torn down after the Snapshot-aligned delayed commit boundary.

The cleanup state is deliberately kept out of the cross-thread update payload. `GlobalCommitContext` now has payload fields for `ops`, `flushOptions`, and `flowIds`, plus a background-only non-payload area for removed subtree roots.

## Key Points

- Non-silent slot removal now records the removed background root for delayed teardown, while silent detach used for move/reparent remains outside cleanup.
- Both background update commits and hydration update dispatches schedule delayed cleanup after the remove patch has been dispatched.
- Hydration-bound instances are marked as already created so keyed moves after hydration emit move-equivalent insert updates instead of being swallowed by pending-create guards.
- This phase intentionally does not support canceling a removal or reconstructing the same pending removed instance; delete-then-add uses a new background instance, and the old cleanup timer must not remove it.
- The slice includes an empty changeset because Element Template is not publicly released yet and this does not change public APIs, package exports, or release-facing defaults.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
