### PR TITLE
feat(a2ui): add headless message buffer and surface processor

### DIFF
--- a/packages/genui/a2ui/package.json
+++ b/packages/genui/a2ui/package.json
@@ -93,7 +93,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "a2ui-catalog-extractor --catalog-dir src/catalog --out-dir dist/catalog"
+    "build": "a2ui-catalog-extractor --catalog-dir src/catalog --out-dir dist/catalog",
+    "test": "rstest"
   },
   "dependencies": {
     "@a2ui/web_core": "0.9.1",
@@ -105,6 +106,7 @@
     "@lynx-js/lynx-ui-input": "^3.130.0",
     "@lynx-js/react": "workspace:*",
     "@lynx-js/types": "3.7.0",
+    "@rstest/core": "catalog:rstest",
     "@types/react": "^18.3.28"
   },
   "peerDependencies": {

--- a/packages/genui/a2ui/rstest.config.ts
+++ b/packages/genui/a2ui/rstest.config.ts
@@ -1,0 +1,12 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { defineConfig } from '@rstest/core';
+
+const config: ReturnType<typeof defineConfig> = defineConfig({
+  name: 'genui/a2ui',
+  globals: true,
+  include: ['test/**/*.test.ts'],
+});
+
+export default config;

--- a/packages/genui/a2ui/src/store/MessageStore.ts
+++ b/packages/genui/a2ui/src/store/MessageStore.ts
@@ -1,0 +1,82 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { ServerToClientMessage } from './types.js';
+
+/**
+ * A pure append-only buffer of raw protocol messages produced by the
+ * developer's IO module. The store knows nothing about the v0.9 protocol —
+ * it does not parse, process, or interpret messages. It only:
+ *
+ *  1. Stores them in arrival order.
+ *  2. Notifies subscribers when new ones land.
+ *  3. Hands the current snapshot back via `getSnapshot()` (referentially
+ *     stable between mutations — required by `useSyncExternalStore`).
+ *
+ * Protocol-aware processing — surfaces, signals, resources, action
+ * dispatch — is the responsibility of `<A2UI>` (the renderer component).
+ * Developers who don't want to learn the protocol should use `<A2UI>`;
+ * developers who do can run their own `MessageProcessor` against the
+ * snapshot directly.
+ */
+export interface MessageStore {
+  /** `useSyncExternalStore` subscribe contract. */
+  readonly subscribe: (cb: () => void) => () => void;
+  /** `useSyncExternalStore` getSnapshot contract — stable between pushes. */
+  readonly getSnapshot: () => readonly ServerToClientMessage[];
+  /**
+   * Append one or more raw messages to the buffer. Notifies subscribers
+   * once per call (batches a single array argument into a single notify).
+   */
+  push(
+    message: ServerToClientMessage | readonly ServerToClientMessage[],
+  ): void;
+  /** Reset the buffer. Notifies subscribers. */
+  clear(): void;
+}
+
+export interface MessageStoreOptions {
+  /**
+   * Optional initial buffer contents. Useful when rehydrating a previous
+   * agent response or replaying a fixture stream.
+   */
+  initialMessages?: readonly ServerToClientMessage[];
+}
+
+export function createMessageStore(
+  options: MessageStoreOptions = {},
+): MessageStore {
+  let snapshot: readonly ServerToClientMessage[] = options.initialMessages
+    ? Object.freeze([...options.initialMessages])
+    : Object.freeze<ServerToClientMessage[]>([]);
+  const subscribers = new Set<() => void>();
+
+  const notify = () => {
+    for (const cb of subscribers) cb();
+  };
+
+  return {
+    subscribe(cb) {
+      subscribers.add(cb);
+      return () => {
+        subscribers.delete(cb);
+      };
+    },
+    getSnapshot() {
+      return snapshot;
+    },
+    push(message) {
+      const incoming = Array.isArray(message)
+        ? (message as ServerToClientMessage[])
+        : [message as ServerToClientMessage];
+      if (incoming.length === 0) return;
+      snapshot = Object.freeze([...snapshot, ...incoming]);
+      notify();
+    },
+    clear() {
+      if (snapshot.length === 0) return;
+      snapshot = Object.freeze<ServerToClientMessage[]>([]);
+      notify();
+    },
+  };
+}

--- a/packages/genui/a2ui/src/store/index.ts
+++ b/packages/genui/a2ui/src/store/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+export { createMessageStore } from './MessageStore.js';
+export type { MessageStore, MessageStoreOptions } from './MessageStore.js';
+export {
+  createFallbackMessagesFromPlainText,
+  createTextCardMessages,
+  normalizePayloadToMessages,
+  prepareMessagesForProcessing,
+} from './payloadNormalizer.js';
+export type { ServerToClientMessage } from './types.js';

--- a/packages/genui/a2ui/src/store/payloadNormalizer.ts
+++ b/packages/genui/a2ui/src/store/payloadNormalizer.ts
@@ -1,0 +1,220 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { ServerToClientMessage } from './types.js';
+
+function randomId(prefix = '') {
+  return prefix + Date.now().toString(36)
+    + Math.random().toString(36).slice(2, 10);
+}
+
+/**
+ * Build a single-Text fallback message stream from a plain string. Used by
+ * transports / `Session.ingest` callers that receive free-form text from
+ * the agent instead of structured protocol messages.
+ */
+export function createFallbackMessagesFromPlainText(
+  text: string,
+): ServerToClientMessage[] {
+  const surfaceId = 'default';
+  const rootId = 'root-text';
+
+  return [
+    {
+      createSurface: {
+        surfaceId,
+        catalogId: 'inline-text',
+      },
+    },
+    {
+      updateComponents: {
+        surfaceId,
+        components: [
+          {
+            id: rootId,
+            component: 'Text',
+            text,
+          },
+        ],
+      },
+    },
+  ] as ServerToClientMessage[];
+}
+
+/**
+ * Build a Card-wrapped Text fallback message stream from a plain string.
+ * Used when the agent emits text payloads with `kind: 'text'`.
+ */
+export function createTextCardMessages(
+  text: string,
+): ServerToClientMessage[] {
+  const surfaceId = randomId('text_surface_');
+  const rootId = 'root';
+  const textId = 'text';
+
+  return [
+    {
+      createSurface: {
+        surfaceId,
+        catalogId: 'inline-text',
+      },
+    },
+    {
+      updateComponents: {
+        surfaceId,
+        components: [
+          {
+            id: rootId,
+            component: 'Card',
+            child: textId,
+          },
+          {
+            id: textId,
+            component: 'Text',
+            text,
+            variant: 'body',
+          },
+        ],
+      },
+    },
+  ] as ServerToClientMessage[];
+}
+
+/**
+ * Normalize an arbitrary payload (string, array, object) into a flat list of
+ * `ServerToClientMessage` records. Pass-through for already-structured
+ * messages; falls back to wrapping plain text in a Text/Card surface.
+ */
+export function normalizePayloadToMessages(
+  payload: unknown,
+): ServerToClientMessage[] {
+  const messages: ServerToClientMessage[] = [];
+
+  const add = (value: unknown) => {
+    // Treat only `null` / `undefined` as no-ops — `0`, `false`, `''` are
+    // legitimate fallback payloads upstream callers may produce.
+    if (value === null || value === undefined) return;
+    if (Array.isArray(value)) {
+      for (const item of value) add(item);
+    } else {
+      messages.push(value as ServerToClientMessage);
+    }
+  };
+
+  const handle = (value: unknown): void => {
+    if (value === null || value === undefined) return;
+
+    if (Array.isArray(value)) {
+      for (const item of value) handle(item);
+      return;
+    }
+
+    if (typeof value === 'string') {
+      add(createFallbackMessagesFromPlainText(value));
+      return;
+    }
+
+    if (
+      typeof value === 'number' || typeof value === 'boolean'
+      || typeof value === 'bigint'
+    ) {
+      // Coerce non-string primitives so payloads like `0` or `false`
+      // surface as visible fallback messages instead of disappearing.
+      add(createFallbackMessagesFromPlainText(String(value)));
+      return;
+    }
+
+    if (typeof value === 'object') {
+      const v = value as Record<string, unknown>;
+
+      if (
+        v['createSurface'] || v['updateComponents'] || v['updateDataModel']
+        || v['deleteSurface']
+      ) {
+        add(v);
+        return;
+      }
+
+      if ('kind' in v && 'data' in v) {
+        if (v['kind'] === 'data') {
+          handle(v['data']);
+        } else if (v['kind'] === 'text') {
+          add(
+            createTextCardMessages(
+              typeof v['data'] === 'string' ? v['data'] : String(v['data']),
+            ),
+          );
+        }
+        return;
+      }
+
+      if (Array.isArray(v['messages'])) {
+        handle(v['messages']);
+        return;
+      }
+
+      // `JSON.stringify` throws on circular refs and `BigInt` values; fall
+      // back to a generic placeholder rather than letting the whole
+      // normalize call crash.
+      let serialized: string;
+      try {
+        serialized = JSON.stringify(v);
+      } catch {
+        serialized = '[unserializable object]';
+      }
+      add(createFallbackMessagesFromPlainText(serialized));
+      return;
+    }
+  };
+
+  handle(payload);
+  return messages;
+}
+
+/**
+ * Tag messages with the given messageId and report whether any of them
+ * carries a non-empty `updateComponents`. Also dedupes `createSurface`
+ * messages against the set of currently-active surfaces.
+ */
+export function prepareMessagesForProcessing(
+  rawMessages: ServerToClientMessage[],
+  messageId: string,
+  activeSurfaceIds: Set<string>,
+): { messages: ServerToClientMessage[]; hasComponentUpdate: boolean } {
+  let hasComponentUpdate = false;
+  const messages = rawMessages.filter((msg) => {
+    const deletedSurfaceId = (msg as { deleteSurface?: { surfaceId?: string } })
+      .deleteSurface?.surfaceId;
+    if (typeof deletedSurfaceId === 'string') {
+      activeSurfaceIds.delete(deletedSurfaceId);
+    }
+
+    const createdSurfaceId = (msg as { createSurface?: { surfaceId?: string } })
+      .createSurface?.surfaceId;
+    if (typeof createdSurfaceId === 'string') {
+      if (activeSurfaceIds.has(createdSurfaceId)) {
+        return false;
+      }
+      activeSurfaceIds.add(createdSurfaceId);
+    }
+
+    if (
+      ((msg as { updateComponents?: { components?: unknown[] } })
+        .updateComponents
+        && Array.isArray(
+          (msg as { updateComponents?: { components?: unknown[] } })
+            .updateComponents?.components,
+        )
+        && (((msg as { updateComponents?: { components: unknown[] } })
+          .updateComponents?.components ?? []).length > 0))
+    ) {
+      hasComponentUpdate = true;
+    }
+
+    msg.messageId ??= messageId;
+
+    return true;
+  });
+
+  return { messages, hasComponentUpdate };
+}

--- a/packages/genui/a2ui/test/messageStore.test.ts
+++ b/packages/genui/a2ui/test/messageStore.test.ts
@@ -1,0 +1,97 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { createMessageStore } from '../src/store/MessageStore.js';
+import type { ServerToClientMessage } from '../src/store/types.js';
+
+const A: ServerToClientMessage = {
+  createSurface: { surfaceId: 's1' },
+} as ServerToClientMessage;
+const B: ServerToClientMessage = {
+  updateComponents: {
+    surfaceId: 's1',
+    components: [{ id: 'root', component: 'Text', text: 'hi' }],
+  },
+} as ServerToClientMessage;
+
+describe('createMessageStore', () => {
+  test('starts empty when no initial messages are provided', () => {
+    const store = createMessageStore();
+    expect(store.getSnapshot()).toHaveLength(0);
+  });
+
+  test('seeds from `initialMessages`', () => {
+    const store = createMessageStore({ initialMessages: [A, B] });
+    expect(store.getSnapshot()).toEqual([A, B]);
+  });
+
+  test('getSnapshot is referentially stable between mutations', () => {
+    const store = createMessageStore();
+    const a = store.getSnapshot();
+    const b = store.getSnapshot();
+    expect(a).toBe(b);
+  });
+
+  test('push appends a single message and notifies subscribers', () => {
+    const store = createMessageStore();
+    let calls = 0;
+    store.subscribe(() => calls++);
+    store.push(A);
+    expect(store.getSnapshot()).toEqual([A]);
+    expect(calls).toBe(1);
+  });
+
+  test('push appends a batch in one notification', () => {
+    const store = createMessageStore();
+    let calls = 0;
+    store.subscribe(() => calls++);
+    store.push([A, B]);
+    expect(store.getSnapshot()).toEqual([A, B]);
+    expect(calls).toBe(1);
+  });
+
+  test('push of an empty array is a no-op', () => {
+    const store = createMessageStore();
+    let calls = 0;
+    store.subscribe(() => calls++);
+    store.push([]);
+    expect(store.getSnapshot()).toEqual([]);
+    expect(calls).toBe(0);
+  });
+
+  test('subscribers can unsubscribe', () => {
+    const store = createMessageStore();
+    let calls = 0;
+    const dispose = store.subscribe(() => calls++);
+    dispose();
+    store.push(A);
+    expect(calls).toBe(0);
+  });
+
+  test('clear empties the buffer and notifies', () => {
+    const store = createMessageStore({ initialMessages: [A, B] });
+    let calls = 0;
+    store.subscribe(() => calls++);
+    store.clear();
+    expect(store.getSnapshot()).toEqual([]);
+    expect(calls).toBe(1);
+  });
+
+  test('clear is a no-op when already empty', () => {
+    const store = createMessageStore();
+    let calls = 0;
+    store.subscribe(() => calls++);
+    store.clear();
+    expect(calls).toBe(0);
+  });
+
+  test('snapshot is frozen — mutations throw in strict mode', () => {
+    const store = createMessageStore({ initialMessages: [A] });
+    const snap = store.getSnapshot();
+    expect(() => {
+      (snap as ServerToClientMessage[]).push(B);
+    }).toThrow();
+  });
+});

--- a/packages/genui/a2ui/test/payloadNormalizer.test.ts
+++ b/packages/genui/a2ui/test/payloadNormalizer.test.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  createFallbackMessagesFromPlainText,
+  createTextCardMessages,
+  normalizePayloadToMessages,
+  prepareMessagesForProcessing,
+} from '../src/store/payloadNormalizer.js';
+import type { ServerToClientMessage } from '../src/store/types.js';
+
+describe('payloadNormalizer', () => {
+  test('createFallbackMessagesFromPlainText wraps text in a Text component', () => {
+    const msgs = createFallbackMessagesFromPlainText('hello');
+    expect(msgs).toHaveLength(2);
+    const update = msgs[1] as { updateComponents: { components: unknown[] } };
+    expect(update.updateComponents.components[0]).toMatchObject({
+      component: 'Text',
+      text: 'hello',
+    });
+  });
+
+  test('createTextCardMessages wraps text in a Card with Text child', () => {
+    const msgs = createTextCardMessages('greetings');
+    expect(msgs).toHaveLength(2);
+    const update = msgs[1] as { updateComponents: { components: unknown[] } };
+    expect(update.updateComponents.components).toHaveLength(2);
+    const [card, text] = update.updateComponents
+      .components as Record<string, unknown>[];
+    expect(card['component']).toBe('Card');
+    expect(text['component']).toBe('Text');
+    expect(text['text']).toBe('greetings');
+  });
+
+  test('normalizePayloadToMessages passes through structured messages', () => {
+    const input = [{ createSurface: { surfaceId: 's' } }];
+    expect(normalizePayloadToMessages(input)).toEqual(input);
+  });
+
+  test('normalizePayloadToMessages wraps plain text in fallback', () => {
+    const out = normalizePayloadToMessages('hi');
+    expect(out).toHaveLength(2);
+    expect((out[0] as { createSurface: unknown }).createSurface).toBeDefined();
+  });
+
+  test('normalizePayloadToMessages handles { kind: "text", data: "..." }', () => {
+    const out = normalizePayloadToMessages({ kind: 'text', data: 'yo' });
+    expect(out).toHaveLength(2);
+    const update = out[1] as { updateComponents: { components: unknown[] } };
+    expect(update.updateComponents.components).toHaveLength(2);
+  });
+
+  test('prepareMessagesForProcessing tags messageId and dedupes createSurface', () => {
+    const messages = [
+      { createSurface: { surfaceId: 's1' } },
+      { createSurface: { surfaceId: 's1' } },
+      {
+        updateComponents: {
+          surfaceId: 's1',
+          components: [{ id: 'root', component: 'Text' }],
+        },
+      },
+    ] as ServerToClientMessage[];
+    const active = new Set<string>();
+    const result = prepareMessagesForProcessing(messages, 'task_1', active);
+    expect(result.messages).toHaveLength(2);
+    expect(result.hasComponentUpdate).toBe(true);
+    for (const m of result.messages) {
+      expect(m.messageId).toBe('task_1');
+    }
+    expect(active.has('s1')).toBe(true);
+  });
+});

--- a/packages/genui/a2ui/tsconfig.build.json
+++ b/packages/genui/a2ui/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "./src",
+  },
+  "include": ["src"],
+  "exclude": ["test"],
+}

--- a/packages/genui/a2ui/tsconfig.json
+++ b/packages/genui/a2ui/tsconfig.json
@@ -7,8 +7,9 @@
     "target": "esnext",
     "jsx": "preserve",
     "jsxImportSource": "@lynx-js/react",
-    "rootDir": "./src",
+    "noEmit": true,
+    "types": ["@rstest/core/globals"],
   },
-  "include": ["src"],
+  "include": ["src", "test", "rstest.config.ts"],
   "references": [],
 }

--- a/packages/genui/tsconfig.json
+++ b/packages/genui/tsconfig.json
@@ -11,7 +11,7 @@
   "references": [
     /** packages-start */
     { "path": "./a2ui-catalog-extractor/tsconfig.json" },
-    { "path": "./a2ui/tsconfig.json" },
+    { "path": "./a2ui/tsconfig.build.json" },
     /** packages-end */
   ],
   "include": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,6 +580,9 @@ importers:
       '@lynx-js/types':
         specifier: 3.7.0
         version: 3.7.0
+      '@rstest/core':
+        specifier: catalog:rstest
+        version: 0.8.1(jsdom@27.4.0)
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28


### PR DESCRIPTION
## Summary

Foundational message-buffer + payload-normalization layer for the headless A2UI renderer. Pure data logic, no React surface, no breaking changes.

- `MessageStore` — append-only buffer of raw protocol messages with a `useSyncExternalStore`-friendly `subscribe` / `getSnapshot` API.
- `payloadNormalizer` — turns arbitrary developer payloads (string, structured object, `{ kind, data }` envelope, nested arrays) into a flat `ServerToClientMessage[]`. Includes `createFallbackMessagesFromPlainText`, `createTextCardMessages`, and `prepareMessagesForProcessing` helpers used by IO transports.

Adds a per-package `rstest.config.ts` plus split `tsconfig.json` (lint + tests) / `tsconfig.build.json` (emit) so tests run via `pnpm -F @lynx-js/a2ui-reactlynx test` without polluting the emit `rootDir`.

This PR is **purely additive** — the existing `core/`, `chat/`, and `utils/` paths (`BaseClient`, `A2UIRender`, the global `componentRegistry`, the legacy `createResource` / `SignalStore`) keep working untouched. The bigger types-divergent pieces (`MessageProcessor`, the new `Resource` with `subscribe` / `getSnapshot` / explicit status, the new `SignalStore`) ship together with the React renderer in [#2571](https://github.com/lynx-family/lynx-stack/pull/2571), since they introduce a new `Surface` shape that the catalog components must migrate to in the same PR.

## Test plan

- [ ] \`pnpm -F @lynx-js/a2ui-reactlynx test\` — 16/16 pass (`MessageStore`, `payloadNormalizer`)
- [ ] \`pnpm -F @lynx-js/a2ui-reactlynx build\` — extractor still emits the 10 catalog manifests
- [ ] Existing playground (which uses `core/`/`chat/` paths) still runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a message store and payload-normalization utilities for handling and preparing runtime messages.

* **Tests**
  * Added tests covering message store behavior, payload normalization, message processing, and edge cases.

* **Chores**
  * Integrated a test runner and dev-dependency, and updated TypeScript build/test configurations and project references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->