### PR TITLE
feat(example): add react-lazy-bundle-standalone example

### DIFF
--- a/.changeset/example-react-lazy-bundle-standalone.md
+++ b/.changeset/example-react-lazy-bundle-standalone.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Add a new `examples/react-lazy-bundle-standalone` example demonstrating a split producer/consumer setup for ReactLynx lazy bundles, with two `rspeedy` dev servers (consumer proxies `/producer` to the producer) and a small `node scripts/dev.mjs` runner so the consumer keeps the TTY for the QR code while the producer streams logs in the background. No package release is required.

--- a/.changeset/example-react-lazy-bundle-standalone.md
+++ b/.changeset/example-react-lazy-bundle-standalone.md
@@ -2,4 +2,4 @@
 
 ---
 
-Add a new `examples/react-lazy-bundle-standalone` example demonstrating a split producer/consumer setup for ReactLynx lazy bundles, with two `rspeedy` dev servers (consumer proxies `/producer` to the producer) and a small `node scripts/dev.mjs` runner so the consumer keeps the TTY for the QR code while the producer streams logs in the background. No package release is required.
+Add a new `examples/react-lazy-bundle-standalone` example demonstrating a split producer/consumer setup for ReactLynx lazy bundles, with two `rspeedy` instances (consumer proxies `/producer` to the producer). Provides aggregate `dev`/`build`/`preview` scripts: `build` runs the two configs in parallel via pnpm, while `dev`/`preview` go through `scripts/serve.mjs` so the consumer keeps the TTY for the QR code while the producer's logs stream in the background. No package release is required.

--- a/examples/react-lazy-bundle-standalone/.gitignore
+++ b/examples/react-lazy-bundle-standalone/.gitignore
@@ -1,0 +1,2 @@
+dist-consumer
+dist-producer

--- a/examples/react-lazy-bundle-standalone/demo-ports.js
+++ b/examples/react-lazy-bundle-standalone/demo-ports.js
@@ -1,3 +1,19 @@
+import os from 'node:os';
+
 export const producerDevPort = Number(
   process.env['LYNX_STANDALONE_PRODUCER_PORT'] ?? '43721',
 );
+
+export function detectLanHost() {
+  if (process.env['LYNX_STANDALONE_PRODUCER_HOST']) {
+    return process.env['LYNX_STANDALONE_PRODUCER_HOST'];
+  }
+  for (const ifaces of Object.values(os.networkInterfaces())) {
+    for (const iface of ifaces ?? []) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        return iface.address;
+      }
+    }
+  }
+  return 'localhost';
+}

--- a/examples/react-lazy-bundle-standalone/demo-ports.js
+++ b/examples/react-lazy-bundle-standalone/demo-ports.js
@@ -1,0 +1,3 @@
+export const producerDevPort = Number(
+  process.env['LYNX_STANDALONE_PRODUCER_PORT'] ?? '43721',
+);

--- a/examples/react-lazy-bundle-standalone/lynx.config.consumer.js
+++ b/examples/react-lazy-bundle-standalone/lynx.config.consumer.js
@@ -5,16 +5,18 @@ import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
 import { defineConfig } from '@lynx-js/rspeedy';
 
-import { producerDevPort } from './demo-ports.js';
+import { detectLanHost, producerDevPort } from './demo-ports.js';
 
 const projectRoot = path.dirname(fileURLToPath(import.meta.url));
 const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
+const producerHost = detectLanHost();
 
 export default defineConfig({
   source: {
     entry: './src/index.tsx',
     define: {
       'process.env.LYNX_STANDALONE_PRODUCER_PORT': producerDevPort.toString(),
+      'process.env.LYNX_STANDALONE_PRODUCER_HOST': JSON.stringify(producerHost),
     },
   },
   output: {

--- a/examples/react-lazy-bundle-standalone/lynx.config.consumer.js
+++ b/examples/react-lazy-bundle-standalone/lynx.config.consumer.js
@@ -1,0 +1,50 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+import { producerDevPort } from './demo-ports.js';
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
+
+export default defineConfig({
+  source: {
+    entry: './src/index.tsx',
+    define: {
+      'process.env.LYNX_STANDALONE_PRODUCER_PORT': producerDevPort.toString(),
+    },
+  },
+  output: {
+    distPath: {
+      root: path.join(projectRoot, 'dist-consumer'),
+    },
+  },
+  server: {
+    proxy: {
+      '/producer': {
+        target: `http://127.0.0.1:${producerDevPort}`,
+        pathRewrite: {
+          '^/producer': '',
+        },
+      },
+    },
+  },
+  plugins: [
+    pluginReactLynx(),
+    pluginQRCode({
+      schema(url) {
+        return `${url}?fullscreen=true`;
+      },
+    }),
+  ],
+  environments: {
+    lynx: {
+      performance: {
+        profile: enableBundleAnalysis,
+      },
+    },
+  },
+});

--- a/examples/react-lazy-bundle-standalone/lynx.config.producer.js
+++ b/examples/react-lazy-bundle-standalone/lynx.config.producer.js
@@ -1,0 +1,42 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+import { producerDevPort } from './demo-ports.js';
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
+
+export default defineConfig({
+  source: {
+    entry: {
+      LazyComponent: './src/LazyComponent.tsx',
+      add: './src/utils/add.ts',
+      minus: './src/utils/minus.ts',
+      dynamic: './src/utils/dynamic.ts',
+    },
+  },
+  output: {
+    distPath: {
+      root: path.join(projectRoot, 'dist-producer'),
+    },
+  },
+  server: {
+    port: producerDevPort,
+    strictPort: true,
+  },
+  plugins: [
+    pluginReactLynx({
+      experimental_isLazyBundle: true,
+    }),
+  ],
+  environments: {
+    lynx: {
+      performance: {
+        profile: enableBundleAnalysis,
+      },
+    },
+  },
+});

--- a/examples/react-lazy-bundle-standalone/lynx.config.producer.js
+++ b/examples/react-lazy-bundle-standalone/lynx.config.producer.js
@@ -4,10 +4,11 @@ import { fileURLToPath } from 'node:url';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
 import { defineConfig } from '@lynx-js/rspeedy';
 
-import { producerDevPort } from './demo-ports.js';
+import { detectLanHost, producerDevPort } from './demo-ports.js';
 
 const projectRoot = path.dirname(fileURLToPath(import.meta.url));
 const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
+const producerPublicPath = `http://${detectLanHost()}:${producerDevPort}/`;
 
 export default defineConfig({
   source: {
@@ -19,9 +20,13 @@ export default defineConfig({
     },
   },
   output: {
+    assetPrefix: producerPublicPath,
     distPath: {
       root: path.join(projectRoot, 'dist-producer'),
     },
+  },
+  dev: {
+    assetPrefix: producerPublicPath,
   },
   server: {
     port: producerDevPort,

--- a/examples/react-lazy-bundle-standalone/package.json
+++ b/examples/react-lazy-bundle-standalone/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@lynx-js/example-react-lazy-bundle-standalone",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "node scripts/dev.mjs",
+    "dev:consumer": "rspeedy dev --config lynx.config.consumer.js",
+    "dev:producer": "rspeedy dev --config lynx.config.producer.js"
+  },
+  "dependencies": {
+    "@lynx-js/react": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
+    "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/types": "3.7.0",
+    "@types/react": "^18.3.28"
+  }
+}

--- a/examples/react-lazy-bundle-standalone/package.json
+++ b/examples/react-lazy-bundle-standalone/package.json
@@ -4,10 +4,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rspeedy build",
-    "dev": "node scripts/dev.mjs",
+    "build": "pnpm run --parallel \"/^build:(producer|consumer)$/\"",
+    "build:consumer": "rspeedy build --config lynx.config.consumer.js",
+    "build:producer": "rspeedy build --config lynx.config.producer.js",
+    "dev": "node scripts/serve.mjs dev",
     "dev:consumer": "rspeedy dev --config lynx.config.consumer.js",
-    "dev:producer": "rspeedy dev --config lynx.config.producer.js"
+    "dev:producer": "rspeedy dev --config lynx.config.producer.js",
+    "preview": "node scripts/serve.mjs preview",
+    "preview:consumer": "rspeedy preview --config lynx.config.consumer.js",
+    "preview:producer": "rspeedy preview --config lynx.config.producer.js"
   },
   "dependencies": {
     "@lynx-js/react": "workspace:*"

--- a/examples/react-lazy-bundle-standalone/scripts/dev.mjs
+++ b/examples/react-lazy-bundle-standalone/scripts/dev.mjs
@@ -1,0 +1,38 @@
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+const rspeedy = process.platform === 'win32' ? 'rspeedy.cmd' : 'rspeedy';
+
+const producer = spawn(
+  rspeedy,
+  ['dev', '--config', 'lynx.config.producer.js'],
+  { stdio: ['ignore', 'pipe', 'pipe'] },
+);
+
+const prefix = (stream, label) => {
+  const rl = createInterface({ input: stream });
+  rl.on('line', (line) => {
+    process.stdout.write(`[${label}] ${line}\n`);
+  });
+};
+prefix(producer.stdout, 'producer');
+prefix(producer.stderr, 'producer');
+
+const consumer = spawn(
+  rspeedy,
+  ['dev', '--config', 'lynx.config.consumer.js'],
+  { stdio: 'inherit' },
+);
+
+const shutdown = (code) => {
+  if (typeof code === 'number') process.exitCode = code;
+  if (!producer.killed) producer.kill('SIGTERM');
+  if (!consumer.killed) consumer.kill('SIGTERM');
+};
+
+consumer.on('exit', (code) => shutdown(code ?? 0));
+producer.on('exit', (code) => {
+  if (code !== 0 && code !== null) shutdown(code);
+});
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));

--- a/examples/react-lazy-bundle-standalone/scripts/serve.mjs
+++ b/examples/react-lazy-bundle-standalone/scripts/serve.mjs
@@ -1,11 +1,18 @@
 import { spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 
+const subcommand = process.argv[2];
+if (subcommand !== 'dev' && subcommand !== 'preview') {
+  process.stderr.write(`Usage: node scripts/serve.mjs <dev|preview>\n`);
+  process.exitCode = 1;
+  throw new Error(`unknown subcommand: ${subcommand ?? '(none)'}`);
+}
+
 const rspeedy = process.platform === 'win32' ? 'rspeedy.cmd' : 'rspeedy';
 
 const producer = spawn(
   rspeedy,
-  ['dev', '--config', 'lynx.config.producer.js'],
+  [subcommand, '--config', 'lynx.config.producer.js'],
   { stdio: ['ignore', 'pipe', 'pipe'] },
 );
 
@@ -20,7 +27,7 @@ prefix(producer.stderr, 'producer');
 
 const consumer = spawn(
   rspeedy,
-  ['dev', '--config', 'lynx.config.consumer.js'],
+  [subcommand, '--config', 'lynx.config.consumer.js'],
   { stdio: 'inherit' },
 );
 

--- a/examples/react-lazy-bundle-standalone/src/App.css
+++ b/examples/react-lazy-bundle-standalone/src/App.css
@@ -1,0 +1,38 @@
+:root {
+  background-color: #000;
+  --color-text: #fff;
+}
+
+.Background {
+  position: fixed;
+  background: radial-gradient(
+    71.43% 62.3% at 46.43% 36.43%,
+    rgba(18, 229, 229, 0) 15%,
+    rgba(239, 155, 255, 0.3) 56.35%,
+    #ff6448 100%
+  );
+  box-shadow: 0px 12.93px 28.74px 0px #ffd28db2 inset;
+  border-radius: 50%;
+  width: 200vw;
+  height: 200vw;
+  top: -60vw;
+  left: -14.27vw;
+  transform: rotate(15.25deg);
+}
+
+.App {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+text {
+  color: var(--color-text);
+}
+
+.Suspense {
+  margin-top: 21px;
+}

--- a/examples/react-lazy-bundle-standalone/src/App.tsx
+++ b/examples/react-lazy-bundle-standalone/src/App.tsx
@@ -1,0 +1,53 @@
+import { Suspense, lazy, useEffect } from '@lynx-js/react';
+
+import { createProducerBundleUrl } from './entry-url.js';
+
+import './App.css';
+
+const LazyComponent = lazy(() =>
+  import(createProducerBundleUrl('LazyComponent.lynx.bundle'), {
+    with: {
+      type: 'component',
+    },
+  })
+);
+
+export function App() {
+  useEffect(() => {
+    console.info('Hello, ReactLynx');
+    void import(createProducerBundleUrl('add.lynx.bundle'), {
+      with: {
+        type: 'component',
+      },
+    }).then((res: typeof import('./utils/add.js')) => {
+      console.info('dynamic import add', res.add(1, 2));
+    });
+    void import(createProducerBundleUrl('dynamic.lynx.bundle'), {
+      with: {
+        type: 'component',
+      },
+    }).then((res: typeof import('./utils/dynamic.js')) => {
+      console.info('dynamic import dynamic');
+      void res.dynamicAdd(1, 2).then((res) => {
+        console.info('dynamic add', res);
+      });
+    });
+  }, []);
+
+  return (
+    <view>
+      <view className='Background' />
+      <view className='App'>
+        <view className='Banner'>
+          <text className='Title'>React</text>
+          <text className='Subtitle'>on Lynx</text>
+        </view>
+        <view className='Suspense'>
+          <Suspense fallback={<text>Loading...</text>}>
+            <LazyComponent />
+          </Suspense>
+        </view>
+      </view>
+    </view>
+  );
+}

--- a/examples/react-lazy-bundle-standalone/src/LazyComponent.css
+++ b/examples/react-lazy-bundle-standalone/src/LazyComponent.css
@@ -1,0 +1,4 @@
+.LazyComponent {
+  font-weight: 700;
+  color: yellow;
+}

--- a/examples/react-lazy-bundle-standalone/src/LazyComponent.tsx
+++ b/examples/react-lazy-bundle-standalone/src/LazyComponent.tsx
@@ -1,0 +1,9 @@
+import './LazyComponent.css';
+
+export default function LazyComponent() {
+  return (
+    <view>
+      <text className='LazyComponent'>LazyComponent</text>
+    </view>
+  );
+}

--- a/examples/react-lazy-bundle-standalone/src/entry-url.ts
+++ b/examples/react-lazy-bundle-standalone/src/entry-url.ts
@@ -1,0 +1,3 @@
+export function createProducerBundleUrl(bundleFileName: string): string {
+  return `${__webpack_public_path__}producer/${bundleFileName}`;
+}

--- a/examples/react-lazy-bundle-standalone/src/entry-url.ts
+++ b/examples/react-lazy-bundle-standalone/src/entry-url.ts
@@ -1,6 +1,6 @@
 export function createProducerBundleUrl(bundleFileName: string): string {
   if (process.env.NODE_ENV === 'production') {
-    return `http://localhost:${process.env.LYNX_STANDALONE_PRODUCER_PORT}/${bundleFileName}`;
+    return `http://${process.env.LYNX_STANDALONE_PRODUCER_HOST}:${process.env.LYNX_STANDALONE_PRODUCER_PORT}/${bundleFileName}`;
   }
   return `${__webpack_public_path__}producer/${bundleFileName}`;
 }

--- a/examples/react-lazy-bundle-standalone/src/entry-url.ts
+++ b/examples/react-lazy-bundle-standalone/src/entry-url.ts
@@ -1,3 +1,6 @@
 export function createProducerBundleUrl(bundleFileName: string): string {
+  if (process.env.NODE_ENV === 'production') {
+    return `http://localhost:${process.env.LYNX_STANDALONE_PRODUCER_PORT}/${bundleFileName}`;
+  }
   return `${__webpack_public_path__}producer/${bundleFileName}`;
 }

--- a/examples/react-lazy-bundle-standalone/src/index.tsx
+++ b/examples/react-lazy-bundle-standalone/src/index.tsx
@@ -1,0 +1,22 @@
+import '@lynx-js/preact-devtools';
+import '@lynx-js/react/debug';
+import { root } from '@lynx-js/react';
+
+import { App } from './App.jsx';
+import { createProducerBundleUrl } from './entry-url.js';
+
+void import(createProducerBundleUrl('minus.lynx.bundle'), {
+  with: {
+    type: 'component',
+  },
+}).then((res: typeof import('./utils/minus.js')) => {
+  console.info('dynamic import minus', res.minus(1, 2));
+});
+
+root.render(
+  <App />,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/react-lazy-bundle-standalone/src/rspeedy-env.d.ts
+++ b/examples/react-lazy-bundle-standalone/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/react-lazy-bundle-standalone/src/utils/add.ts
+++ b/examples/react-lazy-bundle-standalone/src/utils/add.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b;
+}

--- a/examples/react-lazy-bundle-standalone/src/utils/dynamic.ts
+++ b/examples/react-lazy-bundle-standalone/src/utils/dynamic.ts
@@ -1,0 +1,4 @@
+export async function dynamicAdd(a: number, b: number) {
+  const { add } = await import('./add.js');
+  return add(a, b);
+}

--- a/examples/react-lazy-bundle-standalone/src/utils/minus.ts
+++ b/examples/react-lazy-bundle-standalone/src/utils/minus.ts
@@ -1,0 +1,3 @@
+export function minus(a: number, b: number) {
+  return a - b;
+}

--- a/examples/react-lazy-bundle-standalone/tsconfig.json
+++ b/examples/react-lazy-bundle-standalone/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+    "noEmit": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedDeclarations": false,
+  },
+  "include": ["src", "lynx.config.js", "test", "vitest.config.ts"],
+  "references": [
+    { "path": "../../packages/react/tsconfig.json" },
+    { "path": "../../packages/rspeedy/core/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-qrcode/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-react/tsconfig.build.json" },
+  ],
+}

--- a/examples/react-lazy-bundle-standalone/tsconfig.json
+++ b/examples/react-lazy-bundle-standalone/tsconfig.json
@@ -9,7 +9,7 @@
     "checkJs": true,
     "isolatedDeclarations": false,
   },
-  "include": ["src", "lynx.config.js", "test", "vitest.config.ts"],
+  "include": ["src", "lynx.config.consumer.js", "lynx.config.producer.js", "demo-ports.js", "test", "vitest.config.ts"],
   "references": [
     { "path": "../../packages/react/tsconfig.json" },
     { "path": "../../packages/rspeedy/core/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,7 +323,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@1.7.5)
+        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -416,6 +416,31 @@ importers:
         version: 7.0.3
 
   examples/react-lazy-bundle:
+    dependencies:
+      '@lynx-js/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+    devDependencies:
+      '@lynx-js/preact-devtools':
+        specifier: ^5.0.1
+        version: 5.0.1
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-qrcode
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      '@lynx-js/types':
+        specifier: 3.7.0
+        version: 3.7.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+
+  examples/react-lazy-bundle-standalone:
     dependencies:
       '@lynx-js/react':
         specifier: workspace:*
@@ -686,7 +711,7 @@ importers:
         version: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
       rsbuild-plugin-i18next-extractor:
         specifier: 0.2.1
-        version: 0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
+        version: 0.2.1(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
 
   packages/lynx/benchx_cli:
     dependencies:
@@ -1397,10 +1422,10 @@ importers:
         version: link:../../web-platform/web-elements
       '@rsbuild/plugin-less':
         specifier: 1.6.0
-        version: 1.6.0(@rsbuild/core@1.7.5)
+        version: 1.6.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@1.7.5)
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -1415,7 +1440,7 @@ importers:
         version: 1.1.1
       rsbuild-plugin-tailwindcss:
         specifier: 0.2.4
-        version: 0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1)
+        version: 0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@4.2.1)
       rslog:
         specifier: ^1.3.2
         version: 1.3.2
@@ -1509,7 +1534,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@1.7.5)
+        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1887,7 +1912,7 @@ importers:
         version: link:../test-tools
       '@rspack/test-tools':
         specifier: catalog:rspack
-        version: 1.5.6(@rspack/core@1.7.9(@swc/helpers@0.5.21))
+        version: 1.5.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.8.1(jsdom@27.4.0)
@@ -2068,7 +2093,7 @@ importers:
         version: 7.58.2(@types/node@24.10.13)
       '@rspack/test-tools':
         specifier: catalog:rspack
-        version: 1.5.6(@rspack/core@1.7.9(@swc/helpers@0.5.21))
+        version: 1.5.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.8.1(jsdom@27.4.0)
@@ -2111,7 +2136,7 @@ importers:
         version: 7.58.2(@types/node@24.10.13)
       '@rspack/test-tools':
         specifier: catalog:rspack
-        version: 1.5.6(@rspack/core@1.7.9(@swc/helpers@0.5.21))
+        version: 1.5.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.8.1(jsdom@27.4.0)
@@ -2123,7 +2148,7 @@ importers:
         version: 1.0.4
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@1.7.9(@swc/helpers@0.5.21))(webpack@5.105.2)
+        version: 7.1.4(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))(webpack@5.105.2)
       webpack:
         specifier: ^5.105.2
         version: 5.105.2
@@ -2259,13 +2284,13 @@ importers:
         version: 7.33.6(@types/node@24.10.13)
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@1.7.5)
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@rsbuild/plugin-type-check':
         specifier: 1.3.4
-        version: 1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.3.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 1.2.2
-        version: 1.2.2(@rsbuild/core@1.7.5)
+        version: 1.2.2(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@rspress/core':
         specifier: 2.0.3
         version: 2.0.3(@module-federation/runtime-tools@0.22.0)(@types/react@19.2.14)(core-js@3.48.0)
@@ -13710,13 +13735,13 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@1.7.5)':
+  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@rsbuild/core': 1.7.5
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -13756,9 +13781,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.7.5
 
-  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@1.7.5)':
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
     dependencies:
-      '@rsbuild/core': 1.7.5
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
@@ -13787,6 +13812,15 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.97.3
 
+  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
+    dependencies:
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.6
+      reduce-configs: 1.1.1
+      sass-embedded: 1.97.3
+
   '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@1.7.5)':
     dependencies:
       fast-glob: 3.3.3
@@ -13794,19 +13828,6 @@ snapshots:
       yaml: 2.8.3
     optionalDependencies:
       '@rsbuild/core': 1.7.5
-
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
-    dependencies:
-      deepmerge: 4.3.1
-      json5: 2.2.3
-      reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - tslib
-      - typescript
 
   '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
@@ -13824,6 +13845,10 @@ snapshots:
   '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@1.7.5)':
     optionalDependencies:
       '@rsbuild/core': 1.7.5
+
+  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 
   '@rsdoctor/client@1.5.6': {}
 
@@ -14211,6 +14236,45 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
       '@rspack/core': 1.7.9(@swc/helpers@0.5.21)
+      cross-env: 10.1.0
+      csv-to-markdown-table: 1.6.3
+      deepmerge: 4.3.1
+      filenamify: 4.3.0
+      fs-extra: 11.3.3
+      glob: 11.1.0
+      graceful-fs: 4.2.11
+      iconv-lite: 0.6.3
+      jest-diff: 29.7.0
+      jest-snapshot: 29.7.0
+      jsdom: 26.1.0
+      loader-utils: 2.0.4
+      memfs: 4.38.2
+      path-serializer: 0.5.1
+      pretty-format: 29.7.0
+      rimraf: 5.0.10
+      source-map: 0.7.6
+      terser-webpack-plugin: 5.3.16(webpack@5.99.9)
+      wast-loader: 1.14.1
+      webpack: 5.99.9
+      webpack-merge: 6.0.1
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - bufferutil
+      - canvas
+      - esbuild
+      - supports-color
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+
+  '@rspack/test-tools@1.5.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))':
+    dependencies:
+      '@babel/generator': 7.28.3
+      '@babel/parser': 7.28.4
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
+      '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21)
       cross-env: 10.1.0
       csv-to-markdown-table: 1.6.3
       deepmerge: 4.3.1
@@ -16036,6 +16100,20 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.7.9(@swc/helpers@0.5.21)
+      webpack: 5.105.2
+
+  css-loader@7.1.4(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))(webpack@5.105.2):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.5.6)
+      postcss-modules-scope: 3.2.0(postcss@8.5.6)
+      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      postcss-value-parser: 4.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21)
       webpack: 5.105.2
 
   css-minimizer-webpack-plugin@7.0.2(lightningcss@1.31.1)(webpack@5.105.2):
@@ -20119,10 +20197,10 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260212.1
       typescript: 5.9.3
 
-  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
+  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
-      '@rsbuild/core': 1.7.5
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
       '@rspack/lite-tapable': 1.1.0
       i18next-cli: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
@@ -20142,15 +20220,15 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 
-  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1):
-    dependencies:
-      tailwindcss: 4.2.1
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
-
   rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@3.4.19):
     dependencies:
       tailwindcss: 3.4.19
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+
+  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@4.2.1):
+    dependencies:
+      tailwindcss: 4.2.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,7 +323,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.1.0(@rsbuild/core@1.7.5)
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -711,7 +711,7 @@ importers:
         version: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
       rsbuild-plugin-i18next-extractor:
         specifier: 0.2.1
-        version: 0.2.1(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
+        version: 0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
 
   packages/lynx/benchx_cli:
     dependencies:
@@ -1422,10 +1422,10 @@ importers:
         version: link:../../web-platform/web-elements
       '@rsbuild/plugin-less':
         specifier: 1.6.0
-        version: 1.6.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.6.0(@rsbuild/core@1.7.5)
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.5.0(@rsbuild/core@1.7.5)
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -1440,7 +1440,7 @@ importers:
         version: 1.1.1
       rsbuild-plugin-tailwindcss:
         specifier: 0.2.4
-        version: 0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@4.2.1)
+        version: 0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1)
       rslog:
         specifier: ^1.3.2
         version: 1.3.2
@@ -1534,7 +1534,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.1.0(@rsbuild/core@1.7.5)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1912,7 +1912,7 @@ importers:
         version: link:../test-tools
       '@rspack/test-tools':
         specifier: catalog:rspack
-        version: 1.5.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))
+        version: 1.5.6(@rspack/core@1.7.9(@swc/helpers@0.5.21))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.8.1(jsdom@27.4.0)
@@ -2093,7 +2093,7 @@ importers:
         version: 7.58.2(@types/node@24.10.13)
       '@rspack/test-tools':
         specifier: catalog:rspack
-        version: 1.5.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))
+        version: 1.5.6(@rspack/core@1.7.9(@swc/helpers@0.5.21))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.8.1(jsdom@27.4.0)
@@ -2136,7 +2136,7 @@ importers:
         version: 7.58.2(@types/node@24.10.13)
       '@rspack/test-tools':
         specifier: catalog:rspack
-        version: 1.5.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))
+        version: 1.5.6(@rspack/core@1.7.9(@swc/helpers@0.5.21))
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.8.1(jsdom@27.4.0)
@@ -2148,7 +2148,7 @@ importers:
         version: 1.0.4
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))(webpack@5.105.2)
+        version: 7.1.4(@rspack/core@1.7.9(@swc/helpers@0.5.21))(webpack@5.105.2)
       webpack:
         specifier: ^5.105.2
         version: 5.105.2
@@ -2284,13 +2284,13 @@ importers:
         version: 7.33.6(@types/node@24.10.13)
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.5.0(@rsbuild/core@1.7.5)
       '@rsbuild/plugin-type-check':
         specifier: 1.3.4
-        version: 1.3.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.2.2(@rsbuild/core@1.7.5)
       '@rspress/core':
         specifier: 2.0.3
         version: 2.0.3(@module-federation/runtime-tools@0.22.0)(@types/react@19.2.14)(core-js@3.48.0)
@@ -13735,13 +13735,13 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
+  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@1.7.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+      '@rsbuild/core': 1.7.5
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -13781,9 +13781,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.7.5
 
-  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@1.7.5)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+      '@rsbuild/core': 1.7.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
@@ -13812,15 +13812,6 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.97.3
 
-  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
-    dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.6
-      reduce-configs: 1.1.1
-      sass-embedded: 1.97.3
-
   '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@1.7.5)':
     dependencies:
       fast-glob: 3.3.3
@@ -13828,6 +13819,19 @@ snapshots:
       yaml: 2.8.3
     optionalDependencies:
       '@rsbuild/core': 1.7.5
+
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
+    dependencies:
+      deepmerge: 4.3.1
+      json5: 2.2.3
+      reduce-configs: 1.1.1
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
+    optionalDependencies:
+      '@rsbuild/core': 1.7.5
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - tslib
+      - typescript
 
   '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
@@ -13845,10 +13849,6 @@ snapshots:
   '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@1.7.5)':
     optionalDependencies:
       '@rsbuild/core': 1.7.5
-
-  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 
   '@rsdoctor/client@1.5.6': {}
 
@@ -14236,45 +14236,6 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
       '@rspack/core': 1.7.9(@swc/helpers@0.5.21)
-      cross-env: 10.1.0
-      csv-to-markdown-table: 1.6.3
-      deepmerge: 4.3.1
-      filenamify: 4.3.0
-      fs-extra: 11.3.3
-      glob: 11.1.0
-      graceful-fs: 4.2.11
-      iconv-lite: 0.6.3
-      jest-diff: 29.7.0
-      jest-snapshot: 29.7.0
-      jsdom: 26.1.0
-      loader-utils: 2.0.4
-      memfs: 4.38.2
-      path-serializer: 0.5.1
-      pretty-format: 29.7.0
-      rimraf: 5.0.10
-      source-map: 0.7.6
-      terser-webpack-plugin: 5.3.16(webpack@5.99.9)
-      wast-loader: 1.14.1
-      webpack: 5.99.9
-      webpack-merge: 6.0.1
-      webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - bufferutil
-      - canvas
-      - esbuild
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-
-  '@rspack/test-tools@1.5.6(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))':
-    dependencies:
-      '@babel/generator': 7.28.3
-      '@babel/parser': 7.28.4
-      '@babel/traverse': 7.28.4
-      '@babel/types': 7.28.4
-      '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21)
       cross-env: 10.1.0
       csv-to-markdown-table: 1.6.3
       deepmerge: 4.3.1
@@ -16100,20 +16061,6 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.7.9(@swc/helpers@0.5.21)
-      webpack: 5.105.2
-
-  css-loader@7.1.4(@rspack/core@2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21))(webpack@5.105.2):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.5.6)
-      postcss-modules-scope: 3.2.0(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.4
-    optionalDependencies:
-      '@rspack/core': 2.0.0-beta.0(@module-federation/runtime-tools@0.22.0)(@swc/helpers@0.5.21)
       webpack: 5.105.2
 
   css-minimizer-webpack-plugin@7.0.2(lightningcss@1.31.1)(webpack@5.105.2):
@@ -20197,10 +20144,10 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260212.1
       typescript: 5.9.3
 
-  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
+  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+      '@rsbuild/core': 1.7.5
       '@rspack/lite-tapable': 1.1.0
       i18next-cli: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
@@ -20220,15 +20167,15 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 
+  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1):
+    dependencies:
+      tailwindcss: 4.2.1
+    optionalDependencies:
+      '@rsbuild/core': 1.7.5
+
   rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@3.4.19):
     dependencies:
       tailwindcss: 3.4.19
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
-
-  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@4.2.1):
-    dependencies:
-      tailwindcss: 4.2.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 


### PR DESCRIPTION
## Summary
- New `examples/react-lazy-bundle-standalone` showing a split producer/consumer ReactLynx lazy-bundle setup with two `rspeedy` instances. The consumer proxies `/producer` to the producer (`lynx.config.consumer.js`).
- Aggregate `dev` / `build` / `preview` scripts so the example can be driven with a single command. `build` parallelizes the two configs via pnpm regex script matching; `dev` and `preview` go through `scripts/serve.mjs` so the consumer keeps the TTY (needed for the QR code) while the producer's logs stream in the background with a `[producer]` prefix.
- Producer config has no QR plugin, so backgrounding it is fine; consumer keeps the interactive TTY.

## Test plan
- [ ] `pnpm install` at repo root resolves the workspace cleanly.
- [ ] `pnpm --filter @lynx-js/example-react-lazy-bundle-standalone dev` boots both servers; QR code renders from the consumer; producer logs appear with `[producer]` prefix.
- [ ] `pnpm --filter @lynx-js/example-react-lazy-bundle-standalone build` produces both `dist-producer` and `dist-consumer` outputs.
- [ ] `pnpm --filter @lynx-js/example-react-lazy-bundle-standalone preview` serves the production builds and the consumer QR still renders.
- [ ] Ctrl+C from `dev` / `preview` shuts down both child processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone example demonstrating split producer/consumer lazy bundles with a lazy React component, dynamic module imports, and runtime logs when bundles load.
* **Chores**
  * Added orchestration scripts for dev/build/preview, LAN host/port detection, producer asset proxying, and coordinated producer/consumer process management.
* **Style**
  * New dark theme, centered layout, and highlighted lazy-component styling.
* **Documentation**
  * Added a changeset documenting the example (no package release required).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->