### PR TITLE
feat(react): align element template hydrate cleanup

### DIFF
--- a/packages/react/runtime/__test__/element-template/fixtures/background/update/compiled-keyed-subtree-list/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/update/compiled-keyed-subtree-list/index.tsx
@@ -1,0 +1,19 @@
+interface AppProps {
+  items?: string[];
+}
+
+function Item({ id }: { id: string }) {
+  return (
+    <view id={id}>
+      <text>{id}</text>
+    </view>
+  );
+}
+
+export function App({ items = [] }: AppProps) {
+  return (
+    <view>
+      {items.map(item => <Item key={item} id={item} />)}
+    </view>
+  );
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/hydrate/background-hydrate/_shared.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/hydrate/background-hydrate/_shared.tsx
@@ -515,40 +515,6 @@ export function runCaseByName(name: string): unknown {
 }
 
 {
-  defineCase('children.skips-duplicate-create-emission', () => {
-    backgroundElementTemplateInstanceManager.clear();
-    backgroundElementTemplateInstanceManager.nextId = 0;
-
-    const rootInstance = new BackgroundElementTemplateInstance('root');
-    const slot0 = new BackgroundElementTemplateSlot();
-    slot0.setAttribute('id', 0);
-    rootInstance.appendChild(slot0);
-    const child = new BackgroundElementTemplateInstance('child');
-    slot0.appendChild(child);
-
-    const before = createHydrationTemplate(-1, 'root', { elementSlots: [[]] });
-
-    const created = new Set<number>();
-    resetGlobalCommitContext();
-    hydrateIntoContext(before, rootInstance, created);
-    const first = GlobalCommitContext.ops;
-    resetGlobalCommitContext();
-    const firstIncludes = first[0] === ElementTemplateUpdateOps.createTemplate;
-
-    resetGlobalCommitContext();
-    hydrateIntoContext(before, rootInstance, created);
-    const second = GlobalCommitContext.ops;
-    resetGlobalCommitContext();
-    const secondIncludes = second[0] === ElementTemplateUpdateOps.createTemplate;
-
-    return {
-      firstIncludes,
-      secondIncludes,
-    };
-  });
-}
-
-{
   defineCase('children.missing-attrs-element', () => {
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;

--- a/packages/react/runtime/__test__/element-template/fixtures/hydrate/background-hydrate/children.skips-duplicate-create-emission/case.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/hydrate/background-hydrate/children.skips-duplicate-create-emission/case.tsx
@@ -1,5 +1,0 @@
-import { runCaseByName } from '../_shared.js';
-
-export function run() {
-  return runCaseByName('children.skips-duplicate-create-emission');
-}

--- a/packages/react/runtime/__test__/element-template/fixtures/hydrate/background-hydrate/children.skips-duplicate-create-emission/output.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/hydrate/background-hydrate/children.skips-duplicate-create-emission/output.txt
@@ -1,4 +1,0 @@
-Object {
-  "firstIncludes": true,
-  "secondIncludes": false,
-}

--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -19,24 +19,29 @@ function createHydrationTemplate(
   handleId: number,
   templateKey: string,
   options: {
-    attributeSlots?: unknown[];
-    elementSlots?: SerializedElementTemplate[][];
+    attributeSlots?: unknown[] | null;
+    elementSlots?: SerializedElementTemplate[][] | null;
   } = {},
 ): SerializedElementTemplate {
-  return {
+  const serialized: SerializedElementTemplate = {
     templateKey,
-    attributeSlots: (options.attributeSlots ?? []) as SerializedElementTemplate['attributeSlots'],
-    elementSlots: (options.elementSlots ?? []) as SerializedElementTemplate['elementSlots'],
     uid: handleId,
   };
+  if ('attributeSlots' in options) {
+    serialized.attributeSlots = options.attributeSlots as SerializedElementTemplate['attributeSlots'];
+  }
+  if ('elementSlots' in options) {
+    serialized.elementSlots = options.elementSlots as SerializedElementTemplate['elementSlots'];
+  }
+  return serialized;
 }
 
 function createHydrationChild(
   handleId: number,
   templateKey: string,
   options: {
-    attributeSlots?: unknown[];
-    elementSlots?: SerializedElementTemplate[][];
+    attributeSlots?: unknown[] | null;
+    elementSlots?: SerializedElementTemplate[][] | null;
   } = {},
 ): SerializedElementTemplate {
   return createHydrationTemplate(handleId, templateKey, options);
@@ -155,6 +160,77 @@ describe('hydrate', () => {
     expect(root.elementSlots[0]).toEqual([]);
   });
 
+  it('includes nested serialized subtree handles from sparse slots when hydrate removes a stale child', () => {
+    const root = new BackgroundElementTemplateInstance('root');
+    const slot = new BackgroundElementTemplateSlot();
+    slot.setAttribute('id', 0);
+    root.appendChild(slot);
+
+    const stale = createHydrationChild(101, 'stale', {
+      elementSlots: [
+        undefined as unknown as SerializedElementTemplate[],
+        [createHydrationChild(102, 'nested', {
+          elementSlots: [[
+            createHydrationChild(103, BUILTIN_RAW_TEXT_TEMPLATE_KEY, {
+              attributeSlots: ['stale text'],
+            }),
+          ]],
+        })],
+      ],
+    });
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root', {
+        elementSlots: [[stale]],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      0,
+      101,
+      [101, 102, 103],
+    ]);
+    expect(root.elementSlots[0]).toEqual([]);
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+    expect(backgroundElementTemplateInstanceManager.get(101)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(102)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(103)).toBeUndefined();
+  });
+
+  it('keeps existing background stale instances on the pending cleanup path during hydrate remove', () => {
+    const root = new BackgroundElementTemplateInstance('root');
+    const slot = new BackgroundElementTemplateSlot();
+    slot.setAttribute('id', 0);
+    root.appendChild(slot);
+
+    const stale = new BackgroundElementTemplateInstance('stale');
+    const keep = new BackgroundElementTemplateInstance('keep');
+    slot.appendChild(keep);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root', {
+        elementSlots: [[
+          createHydrationChild(stale.instanceId, 'stale'),
+          createHydrationChild(keep.instanceId, 'keep'),
+        ]],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      0,
+      stale.instanceId,
+      [stale.instanceId],
+    ]);
+    expect(root.elementSlots[0]).toEqual([keep]);
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([stale]);
+  });
+
   it('moves serialized children to match the background slot order', () => {
     const root = new BackgroundElementTemplateInstance('root');
     const slot = new BackgroundElementTemplateSlot();
@@ -187,6 +263,225 @@ describe('hydrate', () => {
       c.instanceId,
     ]);
     expect(root.elementSlots[0]).toEqual([b, a, c]);
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+  });
+
+  it('treats a source-before-target cross-slot hydrate candidate as remove and recreate', () => {
+    const root = new BackgroundElementTemplateInstance('root');
+    const slot0 = new BackgroundElementTemplateSlot();
+    slot0.setAttribute('id', 0);
+    root.appendChild(slot0);
+    const slot1 = new BackgroundElementTemplateSlot();
+    slot1.setAttribute('id', 1);
+    root.appendChild(slot1);
+
+    const moved = new BackgroundElementTemplateInstance('moved', ['after']);
+    const localId = moved.instanceId;
+    const mainThreadId = -2;
+    slot1.appendChild(moved);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root', {
+        elementSlots: [
+          [createHydrationChild(mainThreadId, 'moved', { attributeSlots: ['before'] })],
+          [],
+        ],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      0,
+      mainThreadId,
+      [mainThreadId],
+      ElementTemplateUpdateOps.createTemplate,
+      localId,
+      'moved',
+      null,
+      ['after'],
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      1,
+      localId,
+      0,
+    ]);
+    expect(root.elementSlots[0]).toEqual([]);
+    expect(root.elementSlots[1]).toEqual([moved]);
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+    expect(backgroundElementTemplateInstanceManager.get(mainThreadId)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(localId)).toBe(moved);
+  });
+
+  it('does not pull cross-slot hydrate recreate candidates back into a non-empty source slot', () => {
+    const root = new BackgroundElementTemplateInstance('root');
+    const slot0 = new BackgroundElementTemplateSlot();
+    slot0.setAttribute('id', 0);
+    root.appendChild(slot0);
+    const slot1 = new BackgroundElementTemplateSlot();
+    slot1.setAttribute('id', 1);
+    root.appendChild(slot1);
+
+    const keep = new BackgroundElementTemplateInstance('keep');
+    const moved = new BackgroundElementTemplateInstance('moved', ['after']);
+    slot0.appendChild(keep);
+    slot1.appendChild(moved);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root', {
+        elementSlots: [
+          [
+            createHydrationChild(-2, 'moved', { attributeSlots: ['before'] }),
+            createHydrationChild(keep.instanceId, 'keep'),
+          ],
+          [],
+        ],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      0,
+      -2,
+      [-2],
+      ElementTemplateUpdateOps.createTemplate,
+      moved.instanceId,
+      'moved',
+      null,
+      ['after'],
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      1,
+      moved.instanceId,
+      0,
+    ]);
+    expect(root.elementSlots[0]).toEqual([keep]);
+    expect(root.elementSlots[1]).toEqual([moved]);
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+    expect(backgroundElementTemplateInstanceManager.get(-2)).toBeUndefined();
+  });
+
+  it('treats a target-before-source cross-slot hydrate candidate as recreate then remove', () => {
+    const root = new BackgroundElementTemplateInstance('root');
+    const slot0 = new BackgroundElementTemplateSlot();
+    slot0.setAttribute('id', 0);
+    root.appendChild(slot0);
+    const slot1 = new BackgroundElementTemplateSlot();
+    slot1.setAttribute('id', 1);
+    root.appendChild(slot1);
+
+    const moved = new BackgroundElementTemplateInstance('moved', ['after']);
+    const localId = moved.instanceId;
+    const mainThreadId = -3;
+    slot0.appendChild(moved);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root', {
+        elementSlots: [
+          [],
+          [createHydrationChild(mainThreadId, 'moved', { attributeSlots: ['before'] })],
+        ],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.createTemplate,
+      localId,
+      'moved',
+      null,
+      ['after'],
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      0,
+      localId,
+      0,
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      1,
+      mainThreadId,
+      [mainThreadId],
+    ]);
+    expect(root.elementSlots[0]).toEqual([moved]);
+    expect(root.elementSlots[1]).toEqual([]);
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+    expect(backgroundElementTemplateInstanceManager.get(mainThreadId)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(localId)).toBe(moved);
+  });
+
+  it('recreates repeated cross-slot hydrate candidates in their target slot order', () => {
+    const root = new BackgroundElementTemplateInstance('root');
+    const slot0 = new BackgroundElementTemplateSlot();
+    slot0.setAttribute('id', 0);
+    root.appendChild(slot0);
+    const slot1 = new BackgroundElementTemplateSlot();
+    slot1.setAttribute('id', 1);
+    root.appendChild(slot1);
+
+    const first = new BackgroundElementTemplateInstance('item');
+    const second = new BackgroundElementTemplateInstance('item');
+    const firstLocalId = first.instanceId;
+    const secondLocalId = second.instanceId;
+    slot1.appendChild(first);
+    slot1.appendChild(second);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root', {
+        elementSlots: [[
+          createHydrationChild(-2, 'item'),
+          createHydrationChild(-3, 'item'),
+        ], []],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      0,
+      -2,
+      [-2],
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      0,
+      -3,
+      [-3],
+      ElementTemplateUpdateOps.createTemplate,
+      firstLocalId,
+      'item',
+      null,
+      [],
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      1,
+      firstLocalId,
+      0,
+      ElementTemplateUpdateOps.createTemplate,
+      secondLocalId,
+      'item',
+      null,
+      [],
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      1,
+      secondLocalId,
+      0,
+    ]);
+    expect(root.elementSlots[0]).toEqual([]);
+    expect(root.elementSlots[1]).toEqual([first, second]);
+    expect(GlobalCommitContext.nonPayload.removedSubtrees).toEqual([]);
+    expect(backgroundElementTemplateInstanceManager.get(-2)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(-3)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(firstLocalId)).toBe(first);
+    expect(backgroundElementTemplateInstanceManager.get(secondLocalId)).toBe(second);
   });
 
   it('recreates background children when serialized root has no child slots', () => {
@@ -357,7 +652,7 @@ describe('hydrate', () => {
     ]);
   });
 
-  it('creates missing slots and stringifies raw-text placeholder values', () => {
+  it('removes serialized-only raw-text children without creating background instances', () => {
     const root = new BackgroundElementTemplateInstance('root');
 
     const stream = hydrate(
@@ -370,13 +665,10 @@ describe('hydrate', () => {
       root,
     );
 
-    const slot = root.firstChild as BackgroundElementTemplateSlot | null;
-    const rawTrue = backgroundElementTemplateInstanceManager.get(-2);
-    const rawEmpty = backgroundElementTemplateInstanceManager.get(-3);
-    expect(slot).toBeInstanceOf(BackgroundElementTemplateSlot);
-    expect(slot?.partId).toBe(0);
-    expect(rawTrue?.text).toBe('true');
-    expect(rawEmpty?.text).toBe('');
+    expect(root.firstChild).toBeNull();
+    expect(root.elementSlots[0]).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(-2)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(-3)).toBeUndefined();
     expect(stream).toEqual([
       4,
       root.instanceId,
@@ -391,25 +683,30 @@ describe('hydrate', () => {
     ]);
   });
 
-  it('creates non-raw placeholders with copied attribute slots and bound handles', () => {
+  it('removes serialized-only children without copying them into the background manager', () => {
     const root = new BackgroundElementTemplateInstance('root');
 
-    hydrate(
+    const stream = hydrate(
       createHydrationTemplate(root.instanceId, 'root', {
         elementSlots: [[createHydrationChild(-2, 'child', { attributeSlots: ['payload'] })]],
       }),
       root,
     );
 
-    const placeholder = backgroundElementTemplateInstanceManager.get(-2);
-    expect(placeholder?.type).toBe('child');
-    expect(placeholder?.attributeSlots).toEqual(['payload']);
+    expect(backgroundElementTemplateInstanceManager.get(-2)).toBeUndefined();
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      0,
+      -2,
+      [-2],
+    ]);
   });
 
   it('does not hydrate runtime options from the serialized identity field', () => {
     const root = new BackgroundElementTemplateInstance('root');
 
-    hydrate(
+    const stream = hydrate(
       createHydrationTemplate(root.instanceId, 'root', {
         elementSlots: [[
           createHydrationChild(-2, 'child'),
@@ -418,28 +715,15 @@ describe('hydrate', () => {
       root,
     );
 
-    const placeholder = backgroundElementTemplateInstanceManager.get(-2);
     expect(root.options).toBeUndefined();
-    expect(placeholder?.options).toBeUndefined();
-  });
-
-  it('ignores invalid non-template payloads inside element slots defensively', () => {
-    const root = new BackgroundElementTemplateInstance('root');
-    const invalidChild = {
-      kind: 'element',
-      tag: 'view',
-      attributes: {},
-      children: [],
-    } as unknown as SerializedElementTemplate;
-
-    const stream = hydrate(
-      createHydrationTemplate(root.instanceId, 'root', {
-        elementSlots: [[invalidChild]],
-      }),
-      root,
-    );
-
-    expect(stream).toEqual([]);
+    expect(backgroundElementTemplateInstanceManager.get(-2)).toBeUndefined();
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.removeNode,
+      root.instanceId,
+      0,
+      -2,
+      [-2],
+    ]);
   });
 
   it('reports non-Error failures when rebinding handle ids', () => {
@@ -478,22 +762,50 @@ describe('hydrate', () => {
     expect(stream).toEqual([]);
   });
 
-  it('treats null serialized attributeSlots and elementSlots as empty', () => {
+  it('treats omitted serialized slots as empty arrays', () => {
+    const root = new BackgroundElementTemplateInstance('root', ['background-root']);
+    const slot = new BackgroundElementTemplateSlot();
+    slot.setAttribute('id', 0);
+    root.appendChild(slot);
+    const child = new BackgroundElementTemplateInstance('child');
+    slot.appendChild(child);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root'),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      root.instanceId,
+      0,
+      'background-root',
+      ElementTemplateUpdateOps.createTemplate,
+      child.instanceId,
+      'child',
+      null,
+      [],
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      0,
+      child.instanceId,
+      0,
+    ]);
+  });
+
+  it('treats null serialized slots as empty arrays', () => {
     const root = new BackgroundElementTemplateInstance('root');
 
     const stream = hydrate(
-      {
-        templateKey: 'root',
+      createHydrationTemplate(root.instanceId, 'root', {
         attributeSlots: null,
         elementSlots: null,
-        uid: root.instanceId,
-      } as unknown as SerializedElementTemplate,
+      }),
       root,
     );
 
     expect(stream).toEqual([]);
-    expect(root.attributeSlots).toEqual([]);
-    expect(root.elementSlots).toEqual([]);
   });
 
   it('does not patch serialized null when the background attribute slot is missing', () => {
@@ -531,92 +843,6 @@ describe('hydrate', () => {
     expect(root.elementSlots[0]).toBeUndefined();
     expect(root.elementSlots[1]).toBeUndefined();
     expect(root.elementSlots[2]).toEqual([]);
-  });
-
-  it('fails fast in dev for nested serialized children without handle ids', () => {
-    const oldReportError = lynx.reportError;
-    const reportError = vi.fn();
-    lynx.reportError = reportError;
-    const root = new BackgroundElementTemplateInstance('root');
-
-    const stream = hydrate(
-      createHydrationTemplate(root.instanceId, 'root', {
-        elementSlots: [[
-          {
-            templateKey: 'child',
-            attributeSlots: [],
-            elementSlots: [],
-          } as SerializedElementTemplate,
-        ]],
-      }),
-      root,
-    );
-
-    expect(stream).toEqual([]);
-    expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain(
-      'invalid nested uid undefined for \'child\'',
-    );
-    lynx.reportError = oldReportError;
-    (globalThis as { __LYNX_REPORT_ERROR_CALLS?: Error[] }).__LYNX_REPORT_ERROR_CALLS = [];
-  });
-
-  it('fails fast in dev for missing top-level handle ids', () => {
-    const oldReportError = lynx.reportError;
-    const reportError = vi.fn();
-    lynx.reportError = reportError;
-    const root = new BackgroundElementTemplateInstance('root');
-
-    const stream = hydrate(
-      {
-        templateKey: 'root',
-        attributeSlots: [],
-        elementSlots: [],
-      } as SerializedElementTemplate,
-      root,
-    );
-
-    expect(stream).toEqual([]);
-    expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain(
-      'missing uid for \'root\'',
-    );
-    lynx.reportError = oldReportError;
-    (globalThis as { __LYNX_REPORT_ERROR_CALLS?: Error[] }).__LYNX_REPORT_ERROR_CALLS = [];
-  });
-
-  it('fails fast in dev for nested move candidates without handle ids', () => {
-    const oldReportError = lynx.reportError;
-    const reportError = vi.fn();
-    lynx.reportError = reportError;
-
-    const root = new BackgroundElementTemplateInstance('root');
-    const slot = new BackgroundElementTemplateSlot();
-    slot.setAttribute('id', 0);
-    root.appendChild(slot);
-    const childB = new BackgroundElementTemplateInstance('b');
-    const childA = new BackgroundElementTemplateInstance('a');
-    slot.appendChild(childB);
-    slot.appendChild(childA);
-
-    hydrate(
-      createHydrationTemplate(root.instanceId, 'root', {
-        elementSlots: [[
-          {
-            templateKey: 'a',
-            attributeSlots: [],
-            elementSlots: [],
-          } as SerializedElementTemplate,
-          createHydrationChild(childB.instanceId, 'b'),
-        ]],
-      }),
-      root,
-    );
-
-    expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain(
-      'invalid nested uid undefined for \'a\'',
-    );
-    expect(root.elementSlots[0]).toEqual([childB, childA]);
-    lynx.reportError = oldReportError;
-    (globalThis as { __LYNX_REPORT_ERROR_CALLS?: Error[] }).__LYNX_REPORT_ERROR_CALLS = [];
   });
 
   it('emits create recursively for inserted nested children', () => {
@@ -659,68 +885,5 @@ describe('hydrate', () => {
       child.instanceId,
       0,
     ]);
-  });
-
-  it('keeps placeholder children when nested remove handles are missing in prod mode', () => {
-    const root = new BackgroundElementTemplateInstance('root');
-    const slot = new BackgroundElementTemplateSlot();
-    slot.setAttribute('id', 0);
-    root.appendChild(slot);
-
-    const originalDev = globalThis.__DEV__;
-    globalThis.__DEV__ = false;
-    try {
-      const stream = hydrate(
-        createHydrationTemplate(root.instanceId, 'root', {
-          elementSlots: [[
-            {
-              templateKey: 'child',
-              attributeSlots: [],
-              elementSlots: [],
-            } as SerializedElementTemplate,
-          ]],
-        }),
-        root,
-      );
-
-      expect(stream).toEqual([]);
-      expect(root.elementSlots[0]?.map(child => child.type)).toEqual(['child']);
-    } finally {
-      globalThis.__DEV__ = originalDev;
-    }
-  });
-
-  it('keeps placeholder ordering when nested move handles are missing in prod mode', () => {
-    const root = new BackgroundElementTemplateInstance('root');
-    const slot = new BackgroundElementTemplateSlot();
-    slot.setAttribute('id', 0);
-    root.appendChild(slot);
-    const childB = new BackgroundElementTemplateInstance('b');
-    const childA = new BackgroundElementTemplateInstance('a');
-    slot.appendChild(childB);
-    slot.appendChild(childA);
-
-    const originalDev = globalThis.__DEV__;
-    globalThis.__DEV__ = false;
-    try {
-      const stream = hydrate(
-        createHydrationTemplate(root.instanceId, 'root', {
-          elementSlots: [[
-            {
-              templateKey: 'a',
-              attributeSlots: [],
-              elementSlots: [],
-            } as SerializedElementTemplate,
-            createHydrationChild(childB.instanceId, 'b'),
-          ]],
-        }),
-        root,
-      );
-
-      expect(stream).toEqual([]);
-      expect(root.elementSlots[0]?.map(child => child.type)).toEqual(['a', 'b']);
-    } finally {
-      globalThis.__DEV__ = originalDev;
-    }
   });
 });

--- a/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
@@ -12,12 +12,18 @@ import {
   installElementTemplateHydrationListener,
   resetElementTemplateHydrationListener,
 } from '../../../../../src/element-template/background/hydration-listener.js';
-import { BackgroundElementTemplateInstance } from '../../../../../src/element-template/background/instance.js';
+import {
+  collectElementTemplateSubtreeHandleIds,
+  BackgroundElementTemplateInstance,
+} from '../../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../../src/element-template/background/manager.js';
 import { root } from '../../../../../src/element-template/index.js';
 import { ElementTemplateLifecycleConstant } from '../../../../../src/element-template/protocol/lifecycle-constant.js';
 import { ElementTemplateUpdateOps } from '../../../../../src/element-template/protocol/opcodes.js';
-import type { ElementTemplateUpdateCommitContext } from '../../../../../src/element-template/protocol/types.js';
+import type {
+  ElementTemplateUpdateCommandStream,
+  ElementTemplateUpdateCommitContext,
+} from '../../../../../src/element-template/protocol/types.js';
 import { __root } from '../../../../../src/element-template/runtime/page/root-instance.js';
 import { compileFixtureSource } from '../../../test-utils/debug/compiledFixtureCompiler.js';
 import {
@@ -61,6 +67,26 @@ function getSlotChildAt(
     throw new Error(`Missing slot child at ${index}.\n${serializeBackgroundTree(host)}`);
   }
   return child;
+}
+
+function collectRecursiveCreateCommandStream(
+  instance: BackgroundElementTemplateInstance,
+): ElementTemplateUpdateCommandStream {
+  const commands: ElementTemplateUpdateCommandStream = [];
+  for (const slotChildren of instance.elementSlots) {
+    for (const child of slotChildren ?? []) {
+      commands.push(...collectRecursiveCreateCommandStream(child));
+    }
+  }
+  commands.push(
+    ElementTemplateUpdateOps.createTemplate,
+    instance.instanceId,
+    instance.type,
+    null,
+    instance.attributeSlots,
+    instance.elementSlots.map(children => (children ?? []).map(child => child.instanceId)),
+  );
+  return commands;
 }
 
 describe('Compiled background Preact updates', () => {
@@ -168,6 +194,7 @@ describe('Compiled background Preact updates', () => {
         const host = renderCompiledOnBackground(backgroundModule, ['keep', 'remove']);
         hydrateFromMainThread(mainModule, ['keep', 'remove']);
         const removed = getSlotChildAt(1, host);
+        const removedSubtreeHandleIds = collectElementTemplateSubtreeHandleIds(removed);
         updateEvents = [];
 
         vi.useFakeTimers();
@@ -180,7 +207,7 @@ describe('Compiled background Preact updates', () => {
             host.instanceId,
             SLOT_ID,
             removed.instanceId,
-            [removed.instanceId],
+            removedSubtreeHandleIds,
           ]);
           envManager.switchToBackground();
           expect(backgroundElementTemplateInstanceManager.get(removed.instanceId)).toBe(removed);
@@ -207,6 +234,7 @@ describe('Compiled background Preact updates', () => {
         hydrateFromMainThread(mainModule, ['keep', 'again']);
         const keep = getSlotChildAt(0, host);
         const removed = getSlotChildAt(1, host);
+        const removedSubtreeHandleIds = collectElementTemplateSubtreeHandleIds(removed);
         updateEvents = [];
 
         vi.useFakeTimers();
@@ -218,7 +246,7 @@ describe('Compiled background Preact updates', () => {
             host.instanceId,
             SLOT_ID,
             removed.instanceId,
-            [removed.instanceId],
+            removedSubtreeHandleIds,
           ]);
           envManager.switchToBackground();
 
@@ -228,12 +256,7 @@ describe('Compiled background Preact updates', () => {
           expect(current).not.toBe(removed);
           envManager.switchToMainThread();
           expect(updateEvents.at(-1)?.ops).toEqual([
-            ElementTemplateUpdateOps.createTemplate,
-            current.instanceId,
-            current.type,
-            null,
-            current.attributeSlots,
-            current.elementSlots.map(children => children.map(child => child.instanceId)),
+            ...collectRecursiveCreateCommandStream(current),
             ElementTemplateUpdateOps.insertNode,
             host.instanceId,
             SLOT_ID,

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.ts
@@ -270,8 +270,8 @@ type SerializableValueForMock =
 interface SerializedElementTemplateForMock {
   templateKey: string;
   bundleUrl?: string;
-  attributeSlots: SerializableValueForMock[];
-  elementSlots: SerializedElementTemplateForMock[][];
+  attributeSlots?: SerializableValueForMock[] | null;
+  elementSlots?: SerializedElementTemplateForMock[][] | null;
   uid: number | string;
 }
 

--- a/packages/react/runtime/src/element-template/background/hydrate.ts
+++ b/packages/react/runtime/src/element-template/background/hydrate.ts
@@ -2,12 +2,9 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { GlobalCommitContext, resetGlobalCommitContext } from './commit-context.js';
-import {
-  BUILTIN_RAW_TEXT_TEMPLATE_KEY,
-  BackgroundElementTemplateInstance,
-  BackgroundElementTemplateSlot,
-} from './instance.js';
+import { GlobalCommitContext, markRemovedSubtreeForCurrentCommit, resetGlobalCommitContext } from './commit-context.js';
+import { BUILTIN_RAW_TEXT_TEMPLATE_KEY } from './instance.js';
+import type { BackgroundElementTemplateInstance } from './instance.js';
 import { backgroundElementTemplateInstanceManager } from './manager.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
@@ -17,256 +14,243 @@ import type {
   SerializedElementTemplate,
 } from '../protocol/types.js';
 
-function isRawTextTemplateKey(type: string): boolean {
-  return type === BUILTIN_RAW_TEXT_TEMPLATE_KEY;
-}
-
 export function hydrate(
-  before: SerializedElementTemplate,
-  after: BackgroundElementTemplateInstance,
+  serialized: SerializedElementTemplate,
+  instance: BackgroundElementTemplateInstance,
 ): ElementTemplateUpdateCommandStream {
   resetGlobalCommitContext();
-  hydrateIntoContext(before, after);
+  hydrateIntoContext(serialized, instance);
   return GlobalCommitContext.ops;
 }
 
 export function hydrateIntoContext(
-  before: SerializedElementTemplate,
-  after: BackgroundElementTemplateInstance,
-  created?: Set<number>,
+  serialized: SerializedElementTemplate,
+  instance: BackgroundElementTemplateInstance,
 ): void {
-  hydrateImpl(before, after, created ?? new Set<number>());
+  hydrateInstance(serialized, instance);
 }
 
-interface DiffResult<K> {
-  $$diff: true;
-  i: Record<number, K>;
-  r: number[];
-  m: Record<number, number>;
+interface HydrateChildListDiff {
+  hasChanges: boolean;
+  // Background child at a new slot index that has no matching serialized child.
+  insertions: Record<number, BackgroundElementTemplateInstance>;
+  insertionCount: number;
+  // Serialized child indexes that no longer exist in the background slot.
+  removals: number[];
+  // Serialized child old index -> same-slot reorder target.
+  moves: Record<number, { toIndex: number; instance: BackgroundElementTemplateInstance }>;
 }
 
-function diffArrayAction<T, K>(
-  before: T[],
-  diffResult: DiffResult<K>,
-  onInsert: (node: K, target: T | undefined) => T,
-  onRemove: (node: T) => void,
-  onMove: (node: T, target: T | undefined) => void,
-): T[] {
-  const deleteSet = new Set(diffResult.r);
-  const { i: insertMap, m: placementMap } = diffResult;
-  const moveTempMap = new Map<number, T>();
-  let old: T | undefined;
-  let k = 0;
-  old = before[k];
-  const result: T[] = [];
-  let i = 0;
-  let j = 0;
-  let remain = Object.keys(insertMap).length;
-  while (old || remain > 0) {
-    let keep = false;
-    if (old && deleteSet.has(j)) {
-      onRemove(old);
-    } else if (old && placementMap[j] !== undefined) {
-      moveTempMap.set(placementMap[j]!, old);
-      remain += 1;
-    } else {
-      let newNode = old;
-      if (moveTempMap.has(i)) {
-        newNode = moveTempMap.get(i)!;
-        keep = true;
-        onMove(newNode, old);
-        remain -= 1;
-      } else if (insertMap[i] !== undefined) {
-        newNode = onInsert(insertMap[i]!, old);
-        keep = true;
-        remain -= 1;
+function hydrateMatchingChildrenAndDiffSlot(
+  serializedChildren: SerializedElementTemplate[],
+  backgroundChildren: BackgroundElementTemplateInstance[],
+): HydrateChildListDiff {
+  let lastPlacedIndex = 0;
+  const result: HydrateChildListDiff = {
+    hasChanges: false,
+    insertions: {},
+    insertionCount: 0,
+    removals: [],
+    moves: {},
+  };
+  const serializedByTemplateKey: Record<string, [SerializedElementTemplate, number][]> = {};
+  const serializedCursorByTemplateKey: Record<string, number> = {};
+
+  for (let i = 0; i < serializedChildren.length; i += 1) {
+    const node = serializedChildren[i]!;
+    (serializedByTemplateKey[node.templateKey] ??= []).push([node, i]);
+  }
+
+  for (let i = 0; i < backgroundChildren.length; i += 1) {
+    const backgroundChild = backgroundChildren[i]!;
+    const serializedCandidates = serializedByTemplateKey[backgroundChild.type];
+    const candidateCursor = serializedCursorByTemplateKey[backgroundChild.type] ?? 0;
+    const matchedSerialized = serializedCandidates?.[candidateCursor];
+
+    if (matchedSerialized) {
+      serializedCursorByTemplateKey[backgroundChild.type] = candidateCursor + 1;
+      const oldIndex = matchedSerialized[1];
+      hydrateInstance(matchedSerialized[0], backgroundChild);
+      if (oldIndex < lastPlacedIndex) {
+        result.moves[oldIndex] = { toIndex: i, instance: backgroundChild };
+        result.hasChanges = true;
+      } else {
+        lastPlacedIndex = oldIndex;
       }
-
-      result.push(newNode!);
-      i += 1;
+    } else {
+      result.insertions[i] = backgroundChild;
+      result.insertionCount += 1;
+      result.hasChanges = true;
     }
-    if (old && !keep) {
-      old = before[++k];
-      j += 1;
+  }
+
+  for (const key in serializedByTemplateKey) {
+    const candidates = serializedByTemplateKey[key]!;
+    const candidateCursor = serializedCursorByTemplateKey[key] ?? 0;
+    for (let i = candidateCursor; i < candidates.length; i += 1) {
+      result.removals.push(candidates[i]![1]);
+      result.hasChanges = true;
     }
   }
 
   return result;
 }
 
-function hydrateImpl(
-  before: SerializedElementTemplate,
-  after: BackgroundElementTemplateInstance,
-  created: Set<number>,
+function hydrateInstance(
+  serialized: SerializedElementTemplate,
+  instance: BackgroundElementTemplateInstance,
 ): void {
-  if (before.templateKey !== after.type && __DEV__) {
-    lynx.reportError(
-      new Error(
-        `ElementTemplate hydrate key mismatch: main='${before.templateKey}' background='${after.type}'.`,
-      ),
-    );
-    return;
-  }
-
-  const handleId = getSerializedHandleId(before);
-  if (handleId == null) {
+  if (serialized.templateKey !== instance.type) {
     if (__DEV__) {
       lynx.reportError(
-        new Error(`ElementTemplate hydrate missing uid for '${before.templateKey}'.`),
+        new Error(
+          `ElementTemplate hydrate key mismatch: main='${serialized.templateKey}' background='${instance.type}'.`,
+        ),
       );
     }
     return;
   }
 
-  if (!bindHydrationHandleId(after, handleId, before.templateKey)) {
+  const handleId = serialized.uid as number;
+  if (!bindHydrationHandleId(instance, handleId, serialized.templateKey)) {
     return;
   }
-  syncAttributeSlots(handleId, getSerializedAttributeSlots(before), after.attributeSlots);
+  hydrateAttributeSlots(handleId, serialized.attributeSlots ?? [], instance.attributeSlots);
 
-  if (isRawTextTemplateKey(before.templateKey)) {
+  if (serialized.templateKey === BUILTIN_RAW_TEXT_TEMPLATE_KEY) {
     return;
   }
 
-  const beforeElementSlots = getSerializedElementSlots(before);
-  const slotIds = new Set<number>();
-  for (let slotId = 0; slotId < beforeElementSlots.length; slotId += 1) {
-    if (!beforeElementSlots[slotId]) {
+  const serializedElementSlots = serialized.elementSlots ?? [];
+  // Snapshot hydrates dynamic children through slot-filtered lists. Keeping ET
+  // scoped the same way means a cross-slot candidate is a source remove plus a
+  // target create/insert, while same-slot reorder can still stay move-like.
+  const slotCount = Math.max(serializedElementSlots.length, instance.elementSlots.length);
+  for (let slotId = 0; slotId < slotCount; slotId += 1) {
+    const serializedSlot = serializedElementSlots[slotId];
+    const backgroundSlot = instance.elementSlots[slotId];
+    if (!serializedSlot && !backgroundSlot) {
       continue;
     }
-    slotIds.add(slotId);
-  }
-
-  for (const slotId of slotIds) {
-    syncSlotChildren(after, slotId, getSerializedTemplateChildren(beforeElementSlots[slotId]), created);
-  }
-
-  for (let slotId = 0; slotId < after.elementSlots.length; slotId += 1) {
-    if (!after.elementSlots[slotId]) {
-      continue;
-    }
-    if (slotIds.has(slotId)) {
-      continue;
-    }
-    syncSlotChildren(after, slotId, [], created);
+    hydrateElementSlot(instance, slotId, serializedSlot ?? []);
   }
 }
 
-function syncSlotChildren(
+function hydrateElementSlot(
   parent: BackgroundElementTemplateInstance,
   slotId: number,
-  beforeChildren: SerializedElementTemplate[],
-  created: Set<number>,
+  serializedChildren: SerializedElementTemplate[],
 ): void {
-  if (__DEV__ && !validateTemplateChildrenHandles(parent, slotId, beforeChildren)) {
+  const backgroundChildren = parent.elementSlots[slotId] ?? [];
+  if (backgroundChildren.length === 0) {
+    for (const serialized of serializedChildren) {
+      emitSerializedSubtreeRemove(parent, slotId, serialized);
+    }
     return;
   }
 
-  const slot = ensureSlot(parent, slotId);
+  const listDiff = hydrateMatchingChildrenAndDiffSlot(serializedChildren, backgroundChildren);
 
-  const afterChildren = parent.elementSlots[slotId]!;
-
-  const beforeMap: Record<string, Array<[SerializedElementTemplate, number]>> = {};
-  for (let i = 0; i < beforeChildren.length; i += 1) {
-    const node = beforeChildren[i]!;
-    const key = getSerializedInstanceKey(node);
-    (beforeMap[key] ??= []).push([node, i]);
+  if (!listDiff.hasChanges) {
+    return;
   }
 
-  const diffResult: DiffResult<BackgroundElementTemplateInstance> = {
-    $$diff: true,
-    i: {},
-    r: [],
-    m: {},
-  };
-
-  let lastPlacedIndex = 0;
-  for (let i = 0; i < afterChildren.length; i += 1) {
-    const afterNode = afterChildren[i]!;
-    const key = getBackgroundInstanceKey(afterNode);
-    const beforeNodes = beforeMap[key];
-    let beforeNode: [SerializedElementTemplate, number] | undefined;
-
-    if (beforeNodes && beforeNodes.length) {
-      beforeNode = beforeNodes.shift();
-    }
-
-    if (beforeNode) {
-      const [beforeInstance, oldIndex] = beforeNode;
-      hydrateImpl(beforeInstance, afterNode, created);
-      if (oldIndex < lastPlacedIndex) {
-        diffResult.m[oldIndex] = i;
-      } else {
-        lastPlacedIndex = oldIndex;
-      }
+  // Hydrate emits patches directly here. Replaying against serialized order
+  // keeps insert targets in the main-thread slot without reshaping background.
+  const removalIndexes = new Set(listDiff.removals);
+  const { insertions, moves } = listDiff;
+  const pendingMoves = new Map<number, BackgroundElementTemplateInstance>();
+  let serializedCursor = 0;
+  let currentSerializedChild = serializedChildren[serializedCursor];
+  let newIndex = 0;
+  let oldIndex = 0;
+  // Insertions are known before replay starts. Moves are counted only when their
+  // old serialized position is reached, so the cursor can keep emitting patches
+  // even after all serialized children have been consumed.
+  let pendingInsertOrMovePatchCount = listDiff.insertionCount;
+  while (currentSerializedChild || pendingInsertOrMovePatchCount > 0) {
+    let keepCurrentSerializedChild = false;
+    if (currentSerializedChild && removalIndexes.has(oldIndex)) {
+      emitSerializedSubtreeRemove(parent, slotId, currentSerializedChild);
+    } else if (currentSerializedChild && moves[oldIndex] !== undefined) {
+      const move = moves[oldIndex]!;
+      pendingMoves.set(move.toIndex, move.instance);
+      pendingInsertOrMovePatchCount += 1;
     } else {
-      diffResult.i[i] = afterNode;
+      const beforeChildId = currentSerializedChild ? currentSerializedChild.uid as number : 0;
+      const movedChild = pendingMoves.get(newIndex);
+      if (movedChild) {
+        keepCurrentSerializedChild = true;
+        GlobalCommitContext.ops.push(
+          ElementTemplateUpdateOps.insertNode,
+          parent.instanceId,
+          slotId,
+          movedChild.instanceId,
+          beforeChildId,
+        );
+        pendingInsertOrMovePatchCount -= 1;
+      } else if (insertions[newIndex] !== undefined) {
+        const insertedChild = insertions[newIndex]!;
+        keepCurrentSerializedChild = true;
+        emitCreateSubtree(insertedChild);
+        GlobalCommitContext.ops.push(
+          ElementTemplateUpdateOps.insertNode,
+          parent.instanceId,
+          slotId,
+          insertedChild.instanceId,
+          beforeChildId,
+        );
+        pendingInsertOrMovePatchCount -= 1;
+      }
+
+      newIndex += 1;
+    }
+    if (currentSerializedChild && !keepCurrentSerializedChild) {
+      currentSerializedChild = serializedChildren[++serializedCursor];
+      oldIndex += 1;
     }
   }
-
-  for (const key in beforeMap) {
-    for (const [, index] of beforeMap[key]!) {
-      diffResult.r.push(index);
-    }
-  }
-
-  if (isEmptyDiffResult(diffResult)) {
-    return;
-  }
-
-  const mainOrder: BackgroundElementTemplateInstance[] = [];
-  for (const serialized of beforeChildren) {
-    const handleId = getSerializedHandleId(serialized);
-    const reused = handleId == null
-      ? undefined
-      : backgroundElementTemplateInstanceManager.get(handleId);
-    mainOrder.push(reused ?? createPlaceholder(serialized));
-  }
-
-  replaceChildren(slot, mainOrder);
-
-  diffArrayAction(
-    beforeChildren,
-    diffResult,
-    (node, target) => {
-      const beforeHandleId = getSerializedHandleId(target);
-      const beforeChild = beforeHandleId == null
-        ? null
-        : backgroundElementTemplateInstanceManager.get(beforeHandleId)!;
-      emitCreateRecursive(node, created);
-      slot.insertBefore(node, beforeChild);
-      return (target ?? node) as unknown as SerializedElementTemplate;
-    },
-    (node) => {
-      const childId = getSerializedHandleId(node);
-      if (childId == null) {
-        return;
-      }
-      const child = backgroundElementTemplateInstanceManager.get(childId);
-      if (child && child.parent === slot) {
-        slot.removeChild(child);
-      }
-    },
-    (node, target) => {
-      const childId = getSerializedHandleId(node);
-      if (childId == null) {
-        return;
-      }
-      const child = backgroundElementTemplateInstanceManager.get(childId);
-      const beforeHandleId = getSerializedHandleId(target);
-      const beforeChild = beforeHandleId == null
-        ? null
-        : backgroundElementTemplateInstanceManager.get(beforeHandleId)!;
-      if (child && child.parent === slot) {
-        slot.insertBefore(child, beforeChild);
-      }
-    },
-  );
 }
 
-function emitCreateRecursive(node: BackgroundElementTemplateInstance, created: Set<number>): void {
-  if (created.has(node.instanceId)) {
-    return;
+function emitSerializedSubtreeRemove(
+  parent: BackgroundElementTemplateInstance,
+  slotId: number,
+  serialized: SerializedElementTemplate,
+): void {
+  const childId = serialized.uid as number;
+  const existing = backgroundElementTemplateInstanceManager.get(childId);
+  // The removed child may no longer have a live background instance in this
+  // slot, so serialized data is the source of truth for registry cleanup.
+  const removedSubtreeHandleIds: number[] = [];
+  collectSerializedSubtreeHandleIdsInto(serialized, removedSubtreeHandleIds);
+  GlobalCommitContext.ops.push(
+    ElementTemplateUpdateOps.removeNode,
+    parent.instanceId,
+    slotId,
+    childId,
+    removedSubtreeHandleIds,
+  );
+  if (existing && !existing.parent) {
+    markRemovedSubtreeForCurrentCommit(existing);
   }
+}
+
+function collectSerializedSubtreeHandleIdsInto(
+  serialized: SerializedElementTemplate,
+  handles: number[],
+): void {
+  handles.push(serialized.uid as number);
+  for (const slotChildren of serialized.elementSlots ?? []) {
+    if (!slotChildren) {
+      continue;
+    }
+    for (const child of slotChildren) {
+      collectSerializedSubtreeHandleIdsInto(child, handles);
+    }
+  }
+}
+
+function emitCreateSubtree(node: BackgroundElementTemplateInstance): void {
   for (const slotChildren of node.elementSlots) {
     /* v8 ignore start */
     if (!slotChildren) {
@@ -274,179 +258,10 @@ function emitCreateRecursive(node: BackgroundElementTemplateInstance, created: S
     }
     /* v8 ignore stop */
     for (const child of slotChildren) {
-      emitCreateRecursive(child, created);
+      emitCreateSubtree(child);
     }
   }
-  created.add(node.instanceId);
   node.emitCreate();
-}
-
-function ensureSlot(
-  parent: BackgroundElementTemplateInstance,
-  slotId: number,
-): BackgroundElementTemplateSlot {
-  parent.elementSlots[slotId] ??= [];
-  let child = parent.firstChild;
-  while (child) {
-    if (child instanceof BackgroundElementTemplateSlot && child.partId === slotId) {
-      return child;
-    }
-    child = child.nextSibling;
-  }
-
-  const slot = new BackgroundElementTemplateSlot();
-  slot.setAttribute('id', slotId);
-  parent.appendChild(slot);
-  return slot;
-}
-
-function replaceChildren(
-  parent: BackgroundElementTemplateInstance,
-  children: BackgroundElementTemplateInstance[],
-): void {
-  let child = parent.firstChild;
-  while (child) {
-    const next = child.nextSibling;
-    child.parent = null;
-    child.nextSibling = null;
-    child.previousSibling = null;
-    child = next;
-  }
-
-  parent.firstChild = null;
-  parent.lastChild = null;
-
-  let prev: BackgroundElementTemplateInstance | null = null;
-  for (const c of children) {
-    c.parent = parent;
-    c.previousSibling = prev;
-    c.nextSibling = null;
-    if (prev) {
-      prev.nextSibling = c;
-    } else {
-      parent.firstChild = c;
-    }
-    prev = c;
-    parent.lastChild = c;
-  }
-
-  if (parent instanceof BackgroundElementTemplateSlot) {
-    const host = parent.parent;
-    if (host && parent.partId >= 0) {
-      host.elementSlots[parent.partId] = [...children];
-    }
-  }
-}
-
-function createPlaceholder(serialized: SerializedElementTemplate): BackgroundElementTemplateInstance {
-  const handleId = getSerializedHandleId(serialized);
-  const type = serialized.templateKey;
-  let node: BackgroundElementTemplateInstance;
-  if (isRawTextTemplateKey(type)) {
-    const text = getSerializedRawText(serialized);
-    node = new BackgroundElementTemplateInstance(
-      BUILTIN_RAW_TEXT_TEMPLATE_KEY,
-      [text],
-    );
-  } else {
-    node = new BackgroundElementTemplateInstance(type);
-    node.attributeSlots = [...getSerializedAttributeSlots(serialized)];
-  }
-  if (handleId != null) {
-    bindHydrationHandleId(node, handleId, serialized.templateKey);
-  }
-  return node;
-}
-
-function isEmptyDiffResult(result: DiffResult<unknown>): boolean {
-  return Object.keys(result.i).length === 0
-    && result.r.length === 0
-    && Object.keys(result.m).length === 0;
-}
-
-function getSerializedInstanceKey(instance: SerializedElementTemplate): string {
-  return instance.templateKey;
-}
-
-function getBackgroundInstanceKey(instance: BackgroundElementTemplateInstance): string {
-  return instance.type;
-}
-
-function getSerializedTemplateChildren(
-  value: SerializedElementTemplate[] | undefined,
-): SerializedElementTemplate[] {
-  /* v8 ignore next 3 */
-  if (!value) {
-    return [];
-  }
-  const children: SerializedElementTemplate[] = [];
-  for (const node of value as unknown[]) {
-    if (
-      typeof node === 'object'
-      && node !== null
-      && typeof (node as { templateKey?: unknown }).templateKey === 'string'
-    ) {
-      children.push(node as SerializedElementTemplate);
-    }
-  }
-  return children;
-}
-
-function getSerializedAttributeSlots(
-  value: SerializedElementTemplate | undefined,
-): SerializableValue[] {
-  return Array.isArray(value?.attributeSlots) ? value.attributeSlots : [];
-}
-
-function getSerializedElementSlots(
-  value: SerializedElementTemplate | undefined,
-): SerializedElementTemplate[][] {
-  return Array.isArray(value?.elementSlots) ? value.elementSlots : [];
-}
-
-function getSerializedHandleId(
-  value: SerializedElementTemplate | undefined,
-): number | undefined {
-  const uid = value?.uid;
-  return typeof uid === 'number' ? uid : undefined;
-}
-
-function isValidHandleId(handleId: number | undefined): handleId is number {
-  return Number.isInteger(handleId) && handleId !== 0;
-}
-
-function validateTemplateChildrenHandles(
-  parent: BackgroundElementTemplateInstance,
-  slotId: number,
-  beforeChildren: SerializedElementTemplate[],
-): boolean {
-  for (const child of beforeChildren) {
-    const handleId = getSerializedHandleId(child);
-    if (isValidHandleId(handleId)) {
-      continue;
-    }
-    lynx.reportError(
-      new Error(
-        `ElementTemplate hydrate received invalid nested uid ${String(child.uid)} for `
-          + `'${child.templateKey}' in slot ${slotId} of '${parent.type}'.`,
-      ),
-    );
-    return false;
-  }
-  return true;
-}
-
-function getSerializedRawText(
-  value: SerializedElementTemplate,
-): string {
-  const text = value.attributeSlots[0];
-  if (typeof text === 'string') {
-    return text;
-  }
-  if (typeof text === 'number' || typeof text === 'boolean') {
-    return String(text);
-  }
-  return '';
 }
 
 function bindHydrationHandleId(
@@ -469,7 +284,7 @@ function bindHydrationHandleId(
   }
 }
 
-function syncAttributeSlots(
+function hydrateAttributeSlots(
   handleId: number,
   beforeSlots: SerializableValue[],
   afterSlots: SerializableValue[],
@@ -489,11 +304,7 @@ function syncAttributeSlots(
       ElementTemplateUpdateOps.setAttribute,
       handleId,
       slotIndex,
-      normalizeAttributeSlotValue(afterValue),
+      afterValue ?? null,
     );
   }
-}
-
-function normalizeAttributeSlotValue(value: SerializableValue | undefined): SerializableValue | null {
-  return value === undefined ? null : value;
 }

--- a/packages/react/runtime/src/element-template/protocol/types.ts
+++ b/packages/react/runtime/src/element-template/protocol/types.ts
@@ -17,8 +17,8 @@ export type RuntimeOptions = Record<string, SerializableValue>;
 export interface SerializedElementTemplate {
   templateKey: string;
   bundleUrl?: string;
-  attributeSlots: SerializableValue[];
-  elementSlots: SerializedElementTemplate[][];
+  attributeSlots?: SerializableValue[] | null;
+  elementSlots?: SerializedElementTemplate[][] | null;
   uid: number | string;
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a keyed-subtree fixture exercising keyed list rendering.
  * Strengthened hydration tests to validate deeper removal/cleanup semantics and updated expected outputs; removed one legacy hydration case and its expected output.
  * Adjusted test mocks/types to accept optional/null attribute and element slots.

* **Refactor**
  * Reworked background hydration to emit consolidated update ops (insert/remove/move/attribute) and simplified related APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

Element Template hydrate previously mixed main-thread serialized children with background instances through a temporary reconciliation path. That made stale-child removal harder to reason about: serialized-only nodes could require placeholder background instances, same-slot moves and true deletes were easy to conflate, and cross-slot candidates could accidentally look like reusable nodes even though Snapshot hydrates dynamic children through slot-scoped lists.

This PR rewrites hydrate child reconciliation around slot-filtered diffs. Hydrate now binds matching same-slot children, emits remove patches directly for stale serialized children, emits create/insert for background-only children, and keeps move-like behavior limited to reorder within the same element slot.

## Key Points

- Hydrate now computes a per-slot diff between `SerializedElementTemplate[]` and `BackgroundElementTemplateInstance[]`. This keeps the source of truth explicit: serialized data represents what exists on the main thread, while background instances represent what the current render wants.
- Serialized-only stale subtrees are removed without constructing temporary `BackgroundElementTemplateInstance` placeholders. Their registry cleanup handles are collected from the serialized payload itself, including nested sparse slots.
- Existing stale background instances still go through the pending cleanup path, so live background state keeps the same delayed teardown semantics as the rest of removed-subtree cleanup.
- Same-slot reorder remains a move-equivalent `insertNode`; cross-slot same-type candidates are treated as source remove plus target create/insert, matching Snapshot's slot-filtered hydrate boundary.
- The compiled keyed-subtree fixture covers the real Preact render/update path with ordinary JSX so hydrate/update cleanup is not only proven through manually assembled slot data.

## Runtime Contract

Hydrate continues to emit the existing ET remove command shape:

```ts
[
  ElementTemplateUpdateOps.removeNode,
  targetHandleId,
  elementSlotIndex,
  childHandleId,
  removedSubtreeHandleIds,
]
```

The important contract is where `removedSubtreeHandleIds` comes from:

- For serialized-only stale children, hydrate derives the subtree handles from `SerializedElementTemplate` and does not create background instances just to clean main-thread registry entries.
- For stale children that still have background instances, hydrate emits the remove patch and marks those instances for the normal pending background cleanup lifecycle.
- Move/reorder does not populate removal handles or pending cleanup state unless the source slot actually loses a serialized child.

This PR does not add removed-instance reconstruct/reinsert support, and it does not implement ref/worklet/event/list side-table cleanup.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
