### PR TITLE
ci: pin pnpm 10 for publish smoke tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,6 +189,9 @@ jobs:
     with:
       runs-on: lynx-ubuntu-24.04-medium
       run: |
+        # Generated smoke-test projects do not carry a packageManager pin, so
+        # keep this stage on pnpm 10 even when Corepack's registry default moves.
+        corepack prepare pnpm@10.29.3 --activate
         pnpm dlx @pnpm/registry-mock@4 prepare
         pnpm dlx @pnpm/registry-mock@4 &
         printf '\n//localhost:4873/:_authToken="this-is-a-fake-token"\n' >> ~/.npmrc


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI testing workflow to ensure consistent package manager versioning during smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

- The publish smoke test creates temporary `create-rspeedy` projects outside the repository root, so those projects do not inherit the root `packageManager` pin.
- Fresh Corepack environments can therefore resolve `pnpm@latest` for the generated projects; with pnpm 11 this turns ignored build scripts into a hard install failure.
- This change pins Corepack to pnpm 10 only at the start of the `test-publish` smoke-test stage, keeping the CI regression path aligned with the repository's current pnpm major without changing `create-rspeedy` templates.

## Key Points

- The pin is scoped to `.github/workflows/test.yml`'s `test-publish` run block, before the local registry and generated app checks are executed.
- The generated projects remain unchanged, so real template output is still validated by the smoke test.
- No package release changes are needed because this only adjusts CI runner setup for a workflow-only regression.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
