### PR TITLE
chore: add Playwright CI ulimit

### DIFF
--- a/.github/lynx-stack.instructions.md
+++ b/.github/lynx-stack.instructions.md
@@ -13,3 +13,9 @@ applyTo: "packages/webpack/template-webpack-plugin/**/*"
 
 When changing initial CSS handling in template-webpack-plugin, add or update a code-splitting case that asserts the exact selector order in `tasm.json`, not just that CSS assets exist.
 Prefer a shared-plus-split initial chunk fixture when validating CSS merge order so the expected rule sequence follows the source import order clearly.
+
+---
+applyTo: ".github/workflows/**/*"
+---
+
+For Playwright-related CI jobs, add ulimit -Sn 655350 directly in each job's run block before invoking Playwright commands.

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -103,6 +103,7 @@ jobs:
       runs-on: lynx-custom-container
       is-web: true
       run: |
+        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-elements run test --reporter='github,dot,junit,html'
@@ -117,6 +118,7 @@ jobs:
       runs-on: lynx-custom-container
       is-web: true
       run: |
+        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-tests run test --reporter='github,dot,junit,html'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
       runs-on: lynx-custom-container
       is-web: true
       run: |
+        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         pnpm --filter @lynx-js/web-core-e2e run lh || echo "Lighthouse failed"
   playwright-web-elements:
@@ -98,6 +99,7 @@ jobs:
       codecov-flags: "e2e"
       web-report-path: "packages/web-platform/web-elements/playwright-report"
       run: |
+        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-elements run test --reporter='github,dot,junit,html' --shard=${{ matrix.shard }}/2
@@ -154,6 +156,7 @@ jobs:
         if [ "${{ matrix.render }}" = "SSR" ]; then
           export ENABLE_SSR=true
         fi
+        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-core-e2e run test --reporter='github,dot,junit,html' --shard=${{ matrix.shard }}/2


### PR DESCRIPTION
## Summary

- Add `ulimit -Sn 655350` directly in each Playwright-related CI `run` block before invoking test commands.
- Cover the PR test workflow's Lighthouse, web-elements, and web-core-e2e jobs, plus the deploy-main web coverage jobs.
- Add workflow guidance so future Playwright CI jobs keep the limit colocated with their concrete test command.

## Validation

- Parsed the relevant workflow YAML files with Ruby.
- Ran `git diff --check`.
- Attempted `pnpm dprint check .github/workflows/workflow-test.yml .github/lynx-stack.instructions.md`, but the local checkout does not currently have the `dprint` binary installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by increasing file-descriptor limits in web test and coverage jobs to reduce flaky test failures.

* **Documentation**
  * Added guidance for testing initial CSS handling and code-splitting behavior, and updated CI guidance for Playwright job resource configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->