### PR TITLE
feat(autolink): add native extension tooling

### DIFF
--- a/.changeset/native-autolink-codegen.md
+++ b/.changeset/native-autolink-codegen.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/autolink-codegen": minor
+"create-lynx-extension": minor
+---
+
+Add Native Autolink codegen and create-extension packages.

--- a/.github/autolink-extension.instructions.md
+++ b/.github/autolink-extension.instructions.md
@@ -1,0 +1,21 @@
+# Native Autolink Extension Instructions
+
+Use the current Native Autolink package names and marker names when creating or
+updating Lynx extensions.
+
+- The codegen package is `@lynx-js/autolink-codegen`.
+- The codegen binary is `lynx-autolink-codegen`.
+- Create new extensions with `create-lynx-extension`.
+- Android extension APIs use only the Autolink names:
+  `LynxAutolinkElement`, `LynxAutolinkNativeModule`, and
+  `LynxAutolinkService`.
+- iOS extension APIs should use `@LynxAutolinkUI`,
+  `@LynxAutolinkNativeModule`, and `@LynxAutolinkService`.
+- Do not generate or document RFC-draft marker names such as `@LynxElement`,
+  `@LynxNativeModule`, `@LynxService`, or `LynxNativeModule("...")`.
+- The current create-extension and codegen packages are Native-only. Do not add
+  Web Autolink or Web spec output in these packages.
+
+iOS Autolink scanners in the native repo may still recognize existing Lynx lazy
+registration forms for compatibility, but new generated templates should prefer
+the Autolink marker names above.

--- a/packages/lynx/autolink-codegen/CHANGELOG.md
+++ b/packages/lynx/autolink-codegen/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @lynx-js/autolink-codegen
+
+## 0.0.0
+
+### Patch Changes
+
+- Initial Native Autolink codegen package.

--- a/packages/lynx/autolink-codegen/README.md
+++ b/packages/lynx/autolink-codegen/README.md
@@ -1,0 +1,30 @@
+# @lynx-js/autolink-codegen
+
+Native Autolink code generator for Lynx extensions.
+
+It scans `types/**/*.d.ts` for native module declarations annotated with
+`/** @lynxmodule */`, reads `lynx.ext.json`, and generates:
+
+- `generated/<ModuleName>.ts`
+- Android `<ModuleName>Spec.java`
+- iOS `<ModuleName>Spec.h` and `<ModuleName>Spec.m`
+
+Run it from an extension package:
+
+```bash
+npx @lynx-js/autolink-codegen
+```
+
+The installed binary name is `lynx-autolink-codegen`, so generated extensions
+can use:
+
+```json
+{
+  "scripts": {
+    "codegen": "lynx-autolink-codegen"
+  }
+}
+```
+
+The first version intentionally supports only Native Autolink. Web Autolink and
+Web spec generation are outside this package.

--- a/packages/lynx/autolink-codegen/package.json
+++ b/packages/lynx/autolink-codegen/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@lynx-js/autolink-codegen",
+  "version": "0.0.0",
+  "description": "Native Autolink code generator for Lynx extensions",
+  "keywords": [
+    "Lynx",
+    "Autolink",
+    "codegen"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/lynx/autolink-codegen"
+  },
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "lynx-autolink-codegen": "./dist/cli.js"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "build": "rslib build",
+    "dev": "rslib build --watch",
+    "test": "vitest run"
+  },
+  "engines": {
+    "node": "^20 || ^22 || ^24"
+  }
+}

--- a/packages/lynx/autolink-codegen/rslib.config.ts
+++ b/packages/lynx/autolink-codegen/rslib.config.ts
@@ -1,0 +1,20 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { RslibConfig } from '@rslib/core';
+import { defineConfig } from '@rslib/core';
+
+const config: RslibConfig = defineConfig({
+  lib: [
+    { format: 'esm', syntax: 'es2022', dts: { bundle: true, tsgo: true } },
+  ],
+  source: {
+    entry: {
+      index: './src/index.ts',
+      cli: './src/cli.ts',
+    },
+    tsconfigPath: './tsconfig.build.json',
+  },
+});
+
+export default config;

--- a/packages/lynx/autolink-codegen/src/cli.ts
+++ b/packages/lynx/autolink-codegen/src/cli.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+
+import type { CodegenOptions } from './index.js';
+import { runCodegen } from './index.js';
+
+interface CliOptions {
+  root?: string;
+  help: boolean;
+}
+
+/**
+ * Parses command-line arguments for the autolink codegen CLI.
+ */
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { help: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === '--root' || arg === '-r') {
+      const value = argv[index + 1];
+
+      if (value === undefined || value.startsWith('-')) {
+        throw new Error(`${arg} requires a value`);
+      }
+
+      options.root = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown option "${arg ?? ''}"`);
+  }
+
+  return options;
+}
+
+/**
+ * Prints usage information for the autolink codegen CLI.
+ */
+function printHelp(): void {
+  console.info(`Usage: lynx-autolink-codegen [--root <dir>]
+
+Generate Native Autolink JS, Android, and iOS specs from types/**/*.d.ts.
+
+Options:
+  --root, -r <dir>  Extension package root. Defaults to the current directory.
+  --help, -h        Show this help message.
+`);
+}
+
+/**
+ * Runs code generation from parsed CLI options.
+ */
+function main(): void {
+  const cliOptions = parseArgs(process.argv.slice(2));
+
+  if (cliOptions.help) {
+    printHelp();
+    return;
+  }
+
+  const options: CodegenOptions = {};
+
+  if (cliOptions.root !== undefined) {
+    options.root = path.resolve(cliOptions.root);
+  }
+
+  const files = runCodegen(options);
+
+  for (const file of files) {
+    console.info(`generated ${file.path}`);
+  }
+}
+
+try {
+  main();
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packages/lynx/autolink-codegen/src/index.ts
+++ b/packages/lynx/autolink-codegen/src/index.ts
@@ -1,0 +1,718 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface CodegenOptions {
+  root?: string;
+}
+
+export interface GeneratedFile {
+  path: string;
+  content: string;
+}
+
+export type NativeModuleTypeName = 'void' | 'string' | 'number' | 'boolean';
+
+export interface NativeModuleType {
+  name: NativeModuleTypeName;
+  nullable: boolean;
+}
+
+export interface NativeModuleParam {
+  name: string;
+  type: NativeModuleType;
+}
+
+export interface NativeModuleMethod {
+  name: string;
+  params: NativeModuleParam[];
+  returnType: NativeModuleType;
+}
+
+export interface NativeModuleSpec {
+  name: string;
+  methods: NativeModuleMethod[];
+}
+
+interface LynxExtJson {
+  platforms: {
+    android: {
+      packageName: string;
+      sourceDir: string;
+    };
+    ios: {
+      sourceDir: string;
+    };
+  };
+}
+
+const MODULE_DECLARATION_PATTERN =
+  /\/\*\*[\s\S]*?@lynxmodule[\s\S]*?\*\/\s*export\s+declare\s+class\s+([A-Za-z_$][\w$]*)\s*\{([\s\S]*?)\}/g;
+const IDENTIFIER_PATTERN = /^[A-Z_$][\w$]*$/i;
+
+/**
+ * Parses native module declarations marked with `@lynxmodule` from a TypeScript declaration source.
+ */
+export function parseNativeModules(
+  source: string,
+  filename = '<inline>',
+): NativeModuleSpec[] {
+  const modules: NativeModuleSpec[] = [];
+  const seen = new Set<string>();
+
+  for (const match of source.matchAll(MODULE_DECLARATION_PATTERN)) {
+    const moduleName = match[1];
+    const body = match[2];
+
+    if (moduleName === undefined || body === undefined) {
+      continue;
+    }
+
+    if (seen.has(moduleName)) {
+      throw new Error(`Duplicate native module "${moduleName}" in ${filename}`);
+    }
+    seen.add(moduleName);
+
+    modules.push({
+      name: moduleName,
+      methods: parseMethods(body, filename, moduleName),
+    });
+  }
+
+  return modules;
+}
+
+/**
+ * Builds the generated JS facade, Android spec, and iOS spec file contents for an extension package.
+ */
+export function generate(options: CodegenOptions = {}): GeneratedFile[] {
+  const root = path.resolve(options.root ?? process.cwd());
+  const manifest = readManifest(root);
+  const modules = readNativeModuleSpecs(root);
+  const seenModules = new Set<string>();
+  const files: GeneratedFile[] = [];
+
+  for (const module of modules) {
+    if (seenModules.has(module.name)) {
+      throw new Error(`Duplicate native module "${module.name}" across types`);
+    }
+    seenModules.add(module.name);
+
+    files.push({
+      path: path.posix.join('generated', `${module.name}.ts`),
+      content: generateJsFacade(module),
+    });
+    files.push({
+      path: path.posix.join(
+        manifest.platforms.android.sourceDir,
+        'src',
+        'main',
+        'java',
+        ...manifest.platforms.android.packageName.split('.'),
+        'generated',
+        `${module.name}Spec.java`,
+      ),
+      content: generateAndroidSpec(
+        module,
+        manifest.platforms.android.packageName,
+      ),
+    });
+    files.push({
+      path: path.posix.join(
+        manifest.platforms.ios.sourceDir,
+        'src',
+        'generated',
+        `${module.name}Spec.h`,
+      ),
+      content: generateIosHeader(module),
+    });
+    files.push({
+      path: path.posix.join(
+        manifest.platforms.ios.sourceDir,
+        'src',
+        'generated',
+        `${module.name}Spec.m`,
+      ),
+      content: generateIosImplementation(module),
+    });
+  }
+
+  return files;
+}
+
+/**
+ * Writes generated files to disk and returns the generated file descriptors.
+ */
+export function runCodegen(options: CodegenOptions = {}): GeneratedFile[] {
+  const root = path.resolve(options.root ?? process.cwd());
+  const files = generate({ root });
+
+  for (const file of files) {
+    const target = resolveInside(root, file.path, 'package root');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, file.content);
+  }
+
+  return files;
+}
+
+/**
+ * Parses method signatures from a native module declaration body.
+ */
+function parseMethods(
+  body: string,
+  filename: string,
+  moduleName: string,
+): NativeModuleMethod[] {
+  const methods: NativeModuleMethod[] = [];
+  const seen = new Set<string>();
+
+  for (const trimmed of splitMethodDeclarations(body, filename, moduleName)) {
+    const openParen = trimmed.indexOf('(');
+    const closeParen = trimmed.lastIndexOf(')');
+    const returnColon = closeParen === -1
+      ? -1
+      : trimmed.indexOf(':', closeParen);
+
+    if (
+      openParen <= 0 || closeParen <= openParen || returnColon <= closeParen
+    ) {
+      throw new Error(
+        `Invalid method declaration in ${filename}: ${moduleName}.${trimmed}`,
+      );
+    }
+
+    const methodName = trimmed.slice(0, openParen).trim();
+    const paramsSource = trimmed.slice(openParen + 1, closeParen);
+    const returnSource = trimmed.slice(returnColon + 1).trim();
+
+    if (!IDENTIFIER_PATTERN.test(methodName)) {
+      throw new Error(
+        `Invalid method name "${methodName}" in ${filename}: ${moduleName}`,
+      );
+    }
+
+    if (seen.has(methodName)) {
+      throw new Error(
+        `Duplicate method "${moduleName}.${methodName}" in ${filename}`,
+      );
+    }
+    seen.add(methodName);
+
+    methods.push({
+      name: methodName,
+      params: parseParams(paramsSource, filename, moduleName, methodName),
+      returnType: parseType(
+        returnSource.trim(),
+        filename,
+        `${moduleName}.${methodName} return`,
+      ),
+    });
+  }
+
+  return methods;
+}
+
+/**
+ * Splits a module body into method declarations while accepting semicolon and newline separators.
+ */
+function splitMethodDeclarations(
+  body: string,
+  filename: string,
+  moduleName: string,
+): string[] {
+  const declarations: string[] = [];
+  let buffer = '';
+
+  for (const line of body.split(/\r?\n/)) {
+    const parts = line.split(';');
+
+    for (let index = 0; index < parts.length; index += 1) {
+      const part = parts[index]?.trim();
+
+      if (part !== undefined && part.length > 0) {
+        buffer = `${buffer} ${part}`.trim();
+      }
+
+      if (
+        buffer.length > 0
+        && (index < parts.length - 1 || isCompleteMethodDeclaration(buffer))
+      ) {
+        declarations.push(buffer);
+        buffer = '';
+      }
+    }
+  }
+
+  if (buffer.length > 0) {
+    throw new Error(
+      `Invalid method declaration in ${filename}: ${moduleName}.${buffer}`,
+    );
+  }
+
+  return declarations;
+}
+
+/**
+ * Checks whether a buffered method declaration has balanced parentheses and a return type.
+ */
+function isCompleteMethodDeclaration(source: string): boolean {
+  if (source.length === 0) {
+    return false;
+  }
+
+  let parenDepth = 0;
+
+  for (const character of source) {
+    if (character === '(') {
+      parenDepth += 1;
+      continue;
+    }
+
+    if (character === ')') {
+      parenDepth -= 1;
+
+      if (parenDepth < 0) {
+        return false;
+      }
+    }
+  }
+
+  if (parenDepth !== 0) {
+    return false;
+  }
+
+  const openParen = source.indexOf('(');
+  const closeParen = source.lastIndexOf(')');
+  const returnColon = closeParen === -1
+    ? -1
+    : source.indexOf(':', closeParen);
+
+  return openParen > 0 && closeParen > openParen && returnColon > closeParen;
+}
+
+/**
+ * Parses and validates native module method parameters.
+ */
+function parseParams(
+  source: string,
+  filename: string,
+  moduleName: string,
+  methodName: string,
+): NativeModuleParam[] {
+  const trimmed = source.trim();
+
+  if (trimmed.length === 0) {
+    return [];
+  }
+
+  return trimmed.split(',').map((paramSource): NativeModuleParam => {
+    const normalizedParam = paramSource.trim();
+    const colon = normalizedParam.indexOf(':');
+
+    if (colon <= 0 || colon === normalizedParam.length - 1) {
+      throw new Error(
+        `Invalid parameter declaration in ${filename}: ${moduleName}.${methodName}(${paramSource})`,
+      );
+    }
+
+    const rawName = normalizedParam.slice(0, colon).trim();
+    const optional = rawName.endsWith('?');
+    const name = optional ? rawName.slice(0, -1).trim() : rawName;
+    const typeSource = normalizedParam.slice(colon + 1).trim();
+
+    if (!IDENTIFIER_PATTERN.test(name)) {
+      throw new Error(
+        `Invalid parameter name "${rawName}" in ${filename}: ${moduleName}.${methodName}`,
+      );
+    }
+
+    if (optional) {
+      throw new Error(
+        `Optional parameter "${moduleName}.${methodName}.${name}" is not supported by Native Autolink codegen v1`,
+      );
+    }
+
+    return {
+      name,
+      type: parseType(
+        typeSource,
+        filename,
+        `${moduleName}.${methodName}.${name}`,
+      ),
+    };
+  });
+}
+
+/**
+ * Resolves a generated path and rejects paths that escape the package root.
+ */
+function resolveInside(root: string, filePath: string, label: string): string {
+  const resolvedRoot = path.resolve(root);
+  const target = path.resolve(resolvedRoot, filePath);
+  const relativePath = path.relative(resolvedRoot, target);
+
+  if (
+    relativePath === '..' || relativePath.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error(`Generated path escapes ${label}: ${filePath}`);
+  }
+
+  return target;
+}
+
+/**
+ * Parses a supported Native Autolink type, including nullable unions.
+ */
+function parseType(
+  source: string,
+  filename: string,
+  context: string,
+): NativeModuleType {
+  const parts = source.split('|').map((part) => part.trim()).filter(Boolean);
+  const nullable = parts.includes('null');
+  const nonNullParts = parts.filter((part) => part !== 'null');
+
+  if (nonNullParts.length !== 1) {
+    throw unsupportedType(source, filename, context);
+  }
+
+  const name = nonNullParts[0];
+
+  if (
+    name === undefined
+    || (
+      name !== 'void'
+      && name !== 'string'
+      && name !== 'number'
+      && name !== 'boolean'
+    )
+  ) {
+    throw unsupportedType(source, filename, context);
+  }
+
+  if (nullable && name === 'void') {
+    throw unsupportedType(source, filename, context);
+  }
+
+  return { name, nullable };
+}
+
+/**
+ * Creates a consistent unsupported-type error for parser and generator validation.
+ */
+function unsupportedType(
+  source: string,
+  filename: string,
+  context: string,
+): Error {
+  return new Error(
+    `Unsupported type "${source}" for ${context} in ${filename}. Native Autolink codegen v1 supports void, string, number, boolean, and unions with null.`,
+  );
+}
+
+/**
+ * Reads all native module specs declared under the package `types` directory.
+ */
+function readNativeModuleSpecs(root: string): NativeModuleSpec[] {
+  const typesDir = path.join(root, 'types');
+
+  if (!fs.existsSync(typesDir)) {
+    return [];
+  }
+
+  const modules: NativeModuleSpec[] = [];
+
+  for (const file of walkFiles(typesDir)) {
+    if (!file.endsWith('.d.ts')) {
+      continue;
+    }
+
+    const source = fs.readFileSync(file, 'utf8');
+    modules.push(...parseNativeModules(source, path.relative(root, file)));
+  }
+
+  return modules;
+}
+
+/**
+ * Recursively lists files in deterministic order.
+ */
+function walkFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(entryPath));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
+}
+
+/**
+ * Reads and normalizes the Native Autolink extension manifest.
+ */
+function readManifest(root: string): LynxExtJson {
+  const manifestPath = path.join(root, 'lynx.ext.json');
+
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(
+      `Missing lynx.ext.json in ${root}. Native Autolink codegen must run from an extension package root.`,
+    );
+  }
+
+  const json = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as unknown;
+  const platforms = readObject(json, 'platforms', manifestPath);
+  const android = readObject(platforms, 'android', manifestPath);
+  const ios = readObject(platforms, 'ios', manifestPath);
+  const packageName = readRequiredString(
+    android,
+    'packageName',
+    manifestPath,
+    'platforms.android.packageName',
+  );
+
+  return {
+    platforms: {
+      android: {
+        packageName,
+        sourceDir: readOptionalString(android, 'sourceDir') ?? 'android',
+      },
+      ios: {
+        sourceDir: readOptionalString(ios, 'sourceDir') ?? 'ios',
+      },
+    },
+  };
+}
+
+/**
+ * Reads a required object property from `lynx.ext.json`.
+ */
+function readObject(
+  value: unknown,
+  key: string,
+  manifestPath: string,
+): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${manifestPath} must be a JSON object`);
+  }
+
+  const child = value[key];
+
+  if (!isRecord(child)) {
+    throw new Error(`${manifestPath} must define object "${key}"`);
+  }
+
+  return child;
+}
+
+/**
+ * Reads a required non-empty string from `lynx.ext.json`.
+ */
+function readRequiredString(
+  value: Record<string, unknown>,
+  key: string,
+  manifestPath: string,
+  displayPath: string,
+): string {
+  const child = value[key];
+
+  if (typeof child !== 'string' || child.trim().length === 0) {
+    throw new Error(`${manifestPath} must define string "${displayPath}"`);
+  }
+
+  return child;
+}
+
+/**
+ * Reads an optional non-empty string from `lynx.ext.json`.
+ */
+function readOptionalString(
+  value: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const child = value[key];
+
+  if (typeof child === 'string' && child.trim().length > 0) {
+    return child;
+  }
+
+  return undefined;
+}
+
+/**
+ * Narrows unknown JSON values to plain object records.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Generates the TypeScript facade for one native module.
+ */
+function generateJsFacade(module: NativeModuleSpec): string {
+  const methods = module.methods.map((method) =>
+    `  ${method.name}(${
+      method.params.map((param) => `${param.name}: ${toTsType(param.type)}`)
+        .join(
+          ', ',
+        )
+    }): ${toTsType(method.returnType)};`
+  ).join('\n');
+
+  return `// Generated by @lynx-js/autolink-codegen. Do not edit.
+
+declare const NativeModules: {
+  ${module.name}: {
+${methods}
+  };
+};
+
+export const ${module.name}: typeof NativeModules.${module.name} = NativeModules.${module.name};
+export default ${module.name};
+`;
+}
+
+/**
+ * Generates the Android abstract native module spec for one native module.
+ */
+function generateAndroidSpec(
+  module: NativeModuleSpec,
+  packageName: string,
+): string {
+  const methods = module.methods.map((method) =>
+    `  @LynxMethod\n  public abstract ${
+      toJavaType(method.returnType)
+    } ${method.name}(${
+      method.params.map((param) => `${toJavaType(param.type)} ${param.name}`)
+        .join(', ')
+    });`
+  ).join('\n\n');
+
+  return `// Generated by @lynx-js/autolink-codegen. Do not edit.
+package ${packageName}.generated;
+
+import androidx.annotation.Nullable;
+import com.lynx.tasm.behavior.LynxContext;
+import com.lynx.tasm.behavior.LynxContextModule;
+import com.lynx.tasm.behavior.LynxMethod;
+
+public abstract class ${module.name}Spec extends LynxContextModule {
+  public ${module.name}Spec(LynxContext context) {
+    super(context);
+  }
+
+${methods}
+}
+`;
+}
+
+/**
+ * Generates the iOS protocol header for one native module.
+ */
+function generateIosHeader(module: NativeModuleSpec): string {
+  const methods = module.methods.map((method) =>
+    `- (${toObjCReturnType(method.returnType)})${method.name}${
+      method.params.length === 0 ? '' : toObjCParams(method.params)
+    };`
+  ).join('\n');
+
+  return `// Generated by @lynx-js/autolink-codegen. Do not edit.
+#import <Foundation/Foundation.h>
+#import <Lynx/LynxModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ${module.name}Spec <LynxModule>
+
+${methods}
+
+@end
+
+NS_ASSUME_NONNULL_END
+`;
+}
+
+/**
+ * Generates the iOS implementation shim for one native module spec.
+ */
+function generateIosImplementation(module: NativeModuleSpec): string {
+  return `// Generated by @lynx-js/autolink-codegen. Do not edit.
+#import "${module.name}Spec.h"
+`;
+}
+
+/**
+ * Converts a parsed native module type to TypeScript syntax.
+ */
+function toTsType(type: NativeModuleType): string {
+  const base = type.name === 'void' ? 'void' : type.name;
+  return type.nullable ? `${base} | null` : base;
+}
+
+/**
+ * Converts a parsed native module type to Java syntax.
+ */
+function toJavaType(type: NativeModuleType): string {
+  switch (type.name) {
+    case 'void':
+      return 'void';
+    case 'string':
+      return type.nullable ? '@Nullable String' : 'String';
+    case 'number':
+      return type.nullable ? '@Nullable Double' : 'double';
+    case 'boolean':
+      return type.nullable ? '@Nullable Boolean' : 'boolean';
+  }
+}
+
+/**
+ * Converts a parsed native module type to an Objective-C return type.
+ */
+function toObjCReturnType(type: NativeModuleType): string {
+  switch (type.name) {
+    case 'void':
+      return 'void';
+    case 'string':
+      return type.nullable ? 'nullable NSString *' : 'NSString *';
+    case 'number':
+      return type.nullable ? 'nullable NSNumber *' : 'double';
+    case 'boolean':
+      return type.nullable ? 'nullable NSNumber *' : 'BOOL';
+  }
+}
+
+/**
+ * Converts a parsed native module type to an Objective-C parameter type.
+ */
+function toObjCParamType(type: NativeModuleType): string {
+  switch (type.name) {
+    case 'void':
+      throw new Error('void parameters are not supported');
+    case 'string':
+      return type.nullable ? 'nullable NSString *' : 'NSString *';
+    case 'number':
+      return type.nullable ? 'nullable NSNumber *' : 'double';
+    case 'boolean':
+      return type.nullable ? 'nullable NSNumber *' : 'BOOL';
+  }
+}
+
+/**
+ * Converts parsed parameters into an Objective-C selector suffix.
+ */
+function toObjCParams(params: NativeModuleParam[]): string {
+  return params.map((param, index) => {
+    const prefix = index === 0 ? ':' : ` ${param.name}:`;
+    return `${prefix}(${toObjCParamType(param.type)})${param.name}`;
+  }).join('');
+}

--- a/packages/lynx/autolink-codegen/test/codegen.test.ts
+++ b/packages/lynx/autolink-codegen/test/codegen.test.ts
@@ -1,0 +1,276 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { generate, parseNativeModules, runCodegen } from '../src/index.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe('@lynx-js/autolink-codegen', () => {
+  it('parses @lynxmodule declarations from d.ts sources', () => {
+    const modules = parseNativeModules(
+      `/** @lynxmodule */
+export declare class StorageModule {
+  setValue(key: string, value: string): void;
+  getValue(key: string): string | null;
+  hasValue(key: string): boolean;
+  score(): number;
+}
+`,
+      'types/index.d.ts',
+    );
+
+    expect(modules).toEqual([
+      {
+        name: 'StorageModule',
+        methods: [
+          {
+            name: 'setValue',
+            params: [
+              { name: 'key', type: { name: 'string', nullable: false } },
+              { name: 'value', type: { name: 'string', nullable: false } },
+            ],
+            returnType: { name: 'void', nullable: false },
+          },
+          {
+            name: 'getValue',
+            params: [
+              { name: 'key', type: { name: 'string', nullable: false } },
+            ],
+            returnType: { name: 'string', nullable: true },
+          },
+          {
+            name: 'hasValue',
+            params: [
+              { name: 'key', type: { name: 'string', nullable: false } },
+            ],
+            returnType: { name: 'boolean', nullable: false },
+          },
+          {
+            name: 'score',
+            params: [],
+            returnType: { name: 'number', nullable: false },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('parses native module declarations without semicolons', () => {
+    const modules = parseNativeModules(
+      `/** @lynxmodule */
+export declare class StorageModule {
+  setValue(key: string, value: string): void
+  getValue(key: string): string | null
+}
+`,
+      'types/index.d.ts',
+    );
+
+    expect(modules[0]?.methods.map((method) => method.name)).toEqual([
+      'setValue',
+      'getValue',
+    ]);
+  });
+
+  it('generates JS, Android, and iOS specs', () => {
+    const root = createFixture({
+      manifest: {
+        platforms: {
+          android: {
+            packageName: 'com.example.storage',
+          },
+          ios: {},
+        },
+      },
+      types: `/** @lynxmodule */
+export declare class StorageModule {
+  setValue(key: string, value: string): void;
+  getValue(key: string): string | null;
+}
+`,
+    });
+
+    const files = generate({ root });
+
+    expect(files.map((file) => file.path)).toEqual([
+      'generated/StorageModule.ts',
+      'android/src/main/java/com/example/storage/generated/StorageModuleSpec.java',
+      'ios/src/generated/StorageModuleSpec.h',
+      'ios/src/generated/StorageModuleSpec.m',
+    ]);
+    expect(files[0]?.content).toContain('NativeModules.StorageModule');
+    expect(files[1]?.content).toContain(
+      'package com.example.storage.generated;',
+    );
+    expect(files[1]?.content).toContain('public abstract void setValue');
+    expect(files[2]?.content).toContain('@protocol StorageModuleSpec');
+    expect(files[2]?.content).toContain(
+      '- (nullable NSString *)getValue:(NSString *)key;',
+    );
+  });
+
+  it('writes generated files from a temp extension package', () => {
+    const root = createFixture({
+      manifest: {
+        platforms: {
+          android: {
+            packageName: 'com.example.storage',
+            sourceDir: 'android',
+          },
+          ios: {
+            sourceDir: 'ios',
+          },
+        },
+      },
+      types: `/** @lynxmodule */
+export declare class StorageModule {
+  clear(): void;
+}
+`,
+    });
+
+    const files = runCodegen({ root });
+
+    expect(files).toHaveLength(4);
+    expect(
+      fs.readFileSync(path.join(root, 'generated/StorageModule.ts'), 'utf8'),
+    ).toContain('export const StorageModule');
+    expect(
+      fs.existsSync(
+        path.join(
+          root,
+          'android/src/main/java/com/example/storage/generated/StorageModuleSpec.java',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects generated paths that escape the package root', () => {
+    const root = createFixture({
+      manifest: {
+        platforms: {
+          android: {
+            packageName: 'com.example.storage',
+            sourceDir: '../outside',
+          },
+          ios: {
+            sourceDir: 'ios',
+          },
+        },
+      },
+      types: `/** @lynxmodule */
+export declare class StorageModule {
+  clear(): void;
+}
+`,
+    });
+    const outside = path.resolve(root, '../outside');
+
+    expect(() => runCodegen({ root })).toThrow(
+      /Generated path escapes package root/,
+    );
+    expect(fs.existsSync(outside)).toBe(false);
+  });
+
+  it('fails clearly when lynx.ext.json is missing', () => {
+    const root = createTempDir();
+    fs.mkdirSync(path.join(root, 'types'), { recursive: true });
+
+    expect(() => generate({ root })).toThrow(/Missing lynx\.ext\.json/);
+  });
+
+  it('fails clearly when android packageName is missing', () => {
+    const root = createFixture({
+      manifest: {
+        platforms: {
+          android: {},
+          ios: {},
+        },
+      },
+      types: '',
+    });
+
+    expect(() => generate({ root })).toThrow(
+      /platforms\.android\.packageName/,
+    );
+  });
+
+  it('fails clearly for unsupported native module types', () => {
+    expect(() =>
+      parseNativeModules(
+        `/** @lynxmodule */
+export declare class BadModule {
+  setValue(value: string[]): void;
+}
+`,
+        'types/index.d.ts',
+      )
+    ).toThrow(/Unsupported type "string\[\]"/);
+  });
+
+  it('fails clearly for duplicate module names across files', () => {
+    const root = createTempDir();
+    writeJson(path.join(root, 'lynx.ext.json'), {
+      platforms: {
+        android: { packageName: 'com.example.dupe' },
+        ios: {},
+      },
+    });
+    fs.mkdirSync(path.join(root, 'types/a'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'types/b'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'types/a/index.d.ts'),
+      `/** @lynxmodule */
+export declare class DupeModule {
+  a(): void;
+}
+`,
+    );
+    fs.writeFileSync(
+      path.join(root, 'types/b/index.d.ts'),
+      `/** @lynxmodule */
+export declare class DupeModule {
+  b(): void;
+}
+`,
+    );
+
+    expect(() => generate({ root })).toThrow(
+      /Duplicate native module "DupeModule"/,
+    );
+  });
+});
+
+function createFixture(options: {
+  manifest: unknown;
+  types: string;
+}): string {
+  const root = createTempDir();
+  writeJson(path.join(root, 'lynx.ext.json'), options.manifest);
+  fs.mkdirSync(path.join(root, 'types'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'types/index.d.ts'), options.types);
+  return root;
+}
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lynx-autolink-codegen-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeJson(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}

--- a/packages/lynx/autolink-codegen/tsconfig.build.json
+++ b/packages/lynx/autolink-codegen/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "lib": ["es2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2022",
+    "types": ["node"],
+  },
+  "include": ["src"],
+}

--- a/packages/lynx/autolink-codegen/tsconfig.json
+++ b/packages/lynx/autolink-codegen/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" },
+  ],
+}

--- a/packages/lynx/autolink-codegen/tsconfig.test.json
+++ b/packages/lynx/autolink-codegen/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "test"]
+}

--- a/packages/lynx/autolink-codegen/turbo.json
+++ b/packages/lynx/autolink-codegen/turbo.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["build"]
+    }
+  }
+}

--- a/packages/lynx/autolink-codegen/vitest.config.ts
+++ b/packages/lynx/autolink-codegen/vitest.config.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'lynx/autolink-codegen',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/lynx/create-lynx-extension/CHANGELOG.md
+++ b/packages/lynx/create-lynx-extension/CHANGELOG.md
@@ -1,0 +1,7 @@
+# create-lynx-extension
+
+## 0.0.0
+
+### Patch Changes
+
+- Initial Native Autolink extension scaffolding package.

--- a/packages/lynx/create-lynx-extension/README.md
+++ b/packages/lynx/create-lynx-extension/README.md
@@ -1,0 +1,24 @@
+# create-lynx-extension
+
+Create Native Autolink Lynx extensions.
+
+```bash
+npm create lynx-extension
+```
+
+For non-interactive usage:
+
+```bash
+npm create lynx-extension -- \
+  --dir ./lynx-button \
+  --types native-module,element,service \
+  --package-name @example/lynx-button \
+  --android-package com.example.button \
+  --module-name ButtonModule \
+  --element-name x-button \
+  --service-name ButtonService
+```
+
+Generated extensions include `lynx.ext.json`, JS facade sources, Android and
+iOS native examples, an example app skeleton, and a `codegen` script powered by
+`@lynx-js/autolink-codegen`.

--- a/packages/lynx/create-lynx-extension/package.json
+++ b/packages/lynx/create-lynx-extension/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "create-lynx-extension",
+  "version": "0.0.0",
+  "description": "Create Native Autolink Lynx extensions",
+  "keywords": [
+    "Lynx",
+    "Autolink",
+    "create"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/lynx/create-lynx-extension"
+  },
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "create-lynx-extension": "./dist/cli.js"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "build": "rslib build",
+    "dev": "rslib build --watch",
+    "test": "vitest run"
+  },
+  "engines": {
+    "node": "^20 || ^22 || ^24"
+  }
+}

--- a/packages/lynx/create-lynx-extension/rslib.config.ts
+++ b/packages/lynx/create-lynx-extension/rslib.config.ts
@@ -1,0 +1,20 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { RslibConfig } from '@rslib/core';
+import { defineConfig } from '@rslib/core';
+
+const config: RslibConfig = defineConfig({
+  lib: [
+    { format: 'esm', syntax: 'es2022', dts: { bundle: true, tsgo: true } },
+  ],
+  source: {
+    entry: {
+      index: './src/index.ts',
+      cli: './src/cli.ts',
+    },
+    tsconfigPath: './tsconfig.build.json',
+  },
+});
+
+export default config;

--- a/packages/lynx/create-lynx-extension/src/cli.ts
+++ b/packages/lynx/create-lynx-extension/src/cli.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { stdin as input, stdout as output } from 'node:process';
+import readline from 'node:readline';
+
+import type { CreateLynxExtensionOptions, ExtensionType } from './index.js';
+import {
+  EXTENSION_TYPES,
+  createLynxExtension,
+  parseExtensionTypes,
+} from './index.js';
+
+interface CliOptions {
+  dir?: string;
+  types?: ExtensionType[];
+  packageName?: string;
+  androidPackage?: string;
+  moduleName?: string;
+  elementName?: string;
+  serviceName?: string;
+  help: boolean;
+}
+
+/**
+ * Parses command-line arguments for the extension scaffold CLI.
+ */
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { help: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === undefined) {
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === '--dir' || arg === '-d') {
+      options.dir = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--types') {
+      options.types = parseExtensionTypes(readValue(argv, index, arg));
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--package-name') {
+      options.packageName = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--android-package') {
+      options.androidPackage = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--module-name') {
+      options.moduleName = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--element-name') {
+      options.elementName = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--service-name') {
+      options.serviceName = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      throw new Error(`Unknown option "${arg}"`);
+    }
+
+    if (options.dir !== undefined) {
+      throw new Error(`Unexpected positional argument "${arg}"`);
+    }
+
+    options.dir = arg;
+  }
+
+  return options;
+}
+
+/**
+ * Reads the value that follows a CLI option and rejects missing flag-like values.
+ */
+function readValue(argv: string[], index: number, option: string): string {
+  const value = argv[index + 1];
+
+  if (value === undefined || value.startsWith('-')) {
+    throw new Error(`${option} requires a value`);
+  }
+
+  return value;
+}
+
+/**
+ * Prints usage information for the extension scaffold CLI.
+ */
+function printHelp(): void {
+  console.info(`Usage: create-lynx-extension [dir] [options]
+
+Options:
+  --dir, -d <dir>              Target directory.
+  --types <list>               Comma-separated list: native-module,element,service.
+  --package-name <name>        npm package name.
+  --android-package <name>     Android package name for lynx.ext.json.
+  --module-name <name>         Native module class name.
+  --element-name <name>        Element tag name.
+  --service-name <name>        Service class name.
+  --help, -h                   Show this help message.
+`);
+}
+
+/**
+ * Prompts for required scaffold options when the CLI is attached to a TTY.
+ */
+async function fillInteractiveOptions(
+  options: CliOptions,
+): Promise<CliOptions> {
+  const next: CliOptions = { ...options };
+  const needsPrompt = next.dir === undefined
+    || next.types === undefined
+    || next.types.length === 0;
+
+  if (!needsPrompt) {
+    return next;
+  }
+
+  if (!input.isTTY || !output.isTTY) {
+    throw new Error(
+      'Missing required options: --dir and --types are required in non-interactive mode',
+    );
+  }
+
+  const rl = readline.createInterface({ input, output });
+
+  try {
+    if (next.dir === undefined) {
+      const answer = await ask(rl, 'Target directory: ');
+      next.dir = answer.trim();
+    }
+
+    if (next.types === undefined || next.types.length === 0) {
+      const answer = await ask(
+        rl,
+        `Extension types (${EXTENSION_TYPES.join(', ')}): `,
+      );
+      next.types = parseExtensionTypes(answer.trim());
+    }
+
+    return next;
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Wraps readline questions in a promise for async CLI flow.
+ */
+function ask(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, resolve);
+  });
+}
+
+/**
+ * Runs the scaffold command from parsed and interactive CLI options.
+ */
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv.slice(2));
+
+  if (parsed.help) {
+    printHelp();
+    return;
+  }
+
+  const options = await fillInteractiveOptions(parsed);
+
+  if (options.dir === undefined || options.dir.trim().length === 0) {
+    throw new Error('Target directory is required');
+  }
+
+  if (options.types === undefined || options.types.length === 0) {
+    throw new Error('At least one extension type is required');
+  }
+
+  const createOptions: CreateLynxExtensionOptions = {
+    dir: path.resolve(options.dir),
+    types: options.types,
+  };
+
+  if (options.packageName !== undefined) {
+    createOptions.packageName = options.packageName;
+  }
+  if (options.androidPackage !== undefined) {
+    createOptions.androidPackage = options.androidPackage;
+  }
+  if (options.moduleName !== undefined) {
+    createOptions.moduleName = options.moduleName;
+  }
+  if (options.elementName !== undefined) {
+    createOptions.elementName = options.elementName;
+  }
+  if (options.serviceName !== undefined) {
+    createOptions.serviceName = options.serviceName;
+  }
+
+  const files = createLynxExtension(createOptions);
+
+  console.info(`Created ${files.length} files in ${createOptions.dir}`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/lynx/create-lynx-extension/src/index.ts
+++ b/packages/lynx/create-lynx-extension/src/index.ts
@@ -1,0 +1,738 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type ExtensionType = 'native-module' | 'element' | 'service';
+
+export interface CreateLynxExtensionOptions {
+  dir: string;
+  types: ExtensionType[];
+  packageName?: string;
+  androidPackage?: string;
+  moduleName?: string;
+  elementName?: string;
+  serviceName?: string;
+}
+
+export interface CreatedFile {
+  path: string;
+  content: string;
+}
+
+interface TemplateContext {
+  packageName: string;
+  androidPackage: string;
+  androidPackagePath: string;
+  moduleName: string;
+  elementName: string;
+  elementClassName: string;
+  serviceName: string;
+  serviceProtocolName: string;
+  types: Set<ExtensionType>;
+}
+
+export const EXTENSION_TYPES: readonly ExtensionType[] = [
+  'native-module',
+  'element',
+  'service',
+] as const;
+
+/**
+ * Creates a Native Autolink extension scaffold on disk.
+ */
+export function createLynxExtension(
+  options: CreateLynxExtensionOptions,
+): CreatedFile[] {
+  const targetDir = path.resolve(options.dir);
+
+  if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+    throw new Error(`Target directory is not empty: ${targetDir}`);
+  }
+
+  const types = new Set(options.types);
+
+  if (types.size === 0) {
+    throw new Error('At least one extension type must be selected');
+  }
+
+  for (const type of types) {
+    if (!isExtensionType(type)) {
+      throw new Error(`Unsupported extension type: ${String(type)}`);
+    }
+  }
+
+  const context = createContext(options, types);
+  const files = createFiles(context);
+
+  for (const file of files) {
+    const absolutePath = resolveInside(targetDir, file.path);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, file.content);
+  }
+
+  return files;
+}
+
+/**
+ * Parses a comma-separated extension type list from CLI input.
+ */
+export function parseExtensionTypes(source: string): ExtensionType[] {
+  const types = source.split(',').map((type) => type.trim()).filter(Boolean);
+
+  if (types.length === 0) {
+    return [];
+  }
+
+  return types.map((type) => {
+    if (!isExtensionType(type)) {
+      throw new Error(
+        `Unsupported extension type "${type}". Expected one of: ${
+          EXTENSION_TYPES.join(
+            ', ',
+          )
+        }`,
+      );
+    }
+
+    return type;
+  });
+}
+
+/**
+ * Derives template names and platform identifiers from scaffold options.
+ */
+function createContext(
+  options: CreateLynxExtensionOptions,
+  types: Set<ExtensionType>,
+): TemplateContext {
+  const directoryName = path.basename(path.resolve(options.dir));
+  const packageName = options.packageName
+    ?? normalizePackageName(directoryName);
+  const baseName = packageName.split('/').at(-1) ?? packageName;
+  const prefix = toPascalCase(baseName);
+  const moduleName = options.moduleName ?? `${prefix}Module`;
+  const elementName = options.elementName ?? `x-${toKebabCase(prefix)}`;
+  const serviceName = options.serviceName ?? `${prefix}Service`;
+  const elementPrefix = toPascalCase(elementName.replace(/^x-/, ''));
+  const androidPackage = options.androidPackage
+    ?? `com.example.${toJavaPackageSegment(prefix)}`;
+
+  return {
+    packageName,
+    androidPackage,
+    androidPackagePath: androidPackage.replaceAll('.', '/'),
+    moduleName,
+    elementName,
+    elementClassName: `${elementPrefix}Element`,
+    serviceName,
+    serviceProtocolName: `${serviceName}Protocol`,
+    types,
+  };
+}
+
+/**
+ * Creates the complete in-memory file list for the selected extension types.
+ */
+function createFiles(context: TemplateContext): CreatedFile[] {
+  const files: CreatedFile[] = [
+    { path: 'package.json', content: packageJson(context) },
+    { path: 'lynx.ext.json', content: manifestJson(context) },
+    { path: 'README.md', content: readme(context) },
+    { path: 'tsconfig.json', content: tsconfigJson() },
+    { path: 'src/index.ts', content: sourceIndex(context) },
+    { path: 'types/index.d.ts', content: typesDeclaration(context) },
+    { path: 'android/build.gradle.kts', content: androidBuildGradle(context) },
+    {
+      path: 'android/src/main/AndroidManifest.xml',
+      content: androidManifest(),
+    },
+    { path: 'ios/build.podspec', content: iosPodspec(context) },
+    { path: 'example/package.json', content: examplePackageJson(context) },
+    { path: 'example/lynx.config.ts', content: exampleLynxConfig() },
+    { path: 'example/src/index.tsx', content: exampleEntry() },
+    { path: 'example/src/App.tsx', content: exampleApp(context) },
+  ];
+
+  if (context.types.has('native-module')) {
+    files.push(
+      {
+        path:
+          `android/src/main/java/${context.androidPackagePath}/${context.moduleName}.java`,
+        content: androidNativeModule(context),
+      },
+      {
+        path: `ios/src/${context.moduleName}.h`,
+        content: iosNativeModuleHeader(context),
+      },
+      {
+        path: `ios/src/${context.moduleName}.m`,
+        content: iosNativeModuleImplementation(context),
+      },
+    );
+  }
+
+  if (context.types.has('element')) {
+    files.push(
+      {
+        path:
+          `android/src/main/java/${context.androidPackagePath}/${context.elementClassName}.java`,
+        content: androidElement(context),
+      },
+      {
+        path: `ios/src/${context.elementClassName}.h`,
+        content: iosElementHeader(context),
+      },
+      {
+        path: `ios/src/${context.elementClassName}.m`,
+        content: iosElementImplementation(context),
+      },
+    );
+  }
+
+  if (context.types.has('service')) {
+    files.push(
+      {
+        path:
+          `android/src/main/java/${context.androidPackagePath}/${context.serviceName}.java`,
+        content: androidService(context),
+      },
+      {
+        path: `ios/src/${context.serviceName}.h`,
+        content: iosServiceHeader(context),
+      },
+      {
+        path: `ios/src/${context.serviceName}.m`,
+        content: iosServiceImplementation(context),
+      },
+    );
+  }
+
+  return files;
+}
+
+/**
+ * Resolves a generated path and rejects paths that escape the scaffold target directory.
+ */
+function resolveInside(targetDir: string, filePath: string): string {
+  const resolvedTargetDir = path.resolve(targetDir);
+  const absolutePath = path.resolve(resolvedTargetDir, filePath);
+  const relativePath = path.relative(resolvedTargetDir, absolutePath);
+
+  if (
+    relativePath === '..' || relativePath.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error(`Generated path escapes target directory: ${filePath}`);
+  }
+
+  return absolutePath;
+}
+
+/**
+ * Generates the extension package manifest.
+ */
+function packageJson(context: TemplateContext): string {
+  return json({
+    name: context.packageName,
+    version: '0.0.1',
+    description: 'A Native Autolink Lynx extension',
+    license: 'Apache-2.0',
+    type: 'module',
+    main: './src/index.ts',
+    types: './types/index.d.ts',
+    files: [
+      'android',
+      'generated',
+      'ios',
+      'src',
+      'types',
+      'lynx.ext.json',
+      'README.md',
+    ],
+    scripts: {
+      codegen: 'lynx-autolink-codegen',
+    },
+    devDependencies: {
+      '@lynx-js/autolink-codegen': '^0.0.0',
+    },
+  });
+}
+
+/**
+ * Generates the Native Autolink manifest.
+ */
+function manifestJson(context: TemplateContext): string {
+  return json({
+    platforms: {
+      android: {
+        packageName: context.androidPackage,
+        sourceDir: 'android',
+      },
+      ios: {
+        sourceDir: 'ios',
+        podspecPath: 'ios/build.podspec',
+      },
+    },
+  });
+}
+
+/**
+ * Generates the scaffold README.
+ */
+function readme(context: TemplateContext): string {
+  return `# ${context.packageName}
+
+Native Autolink Lynx extension.
+
+## Development
+
+\`\`\`bash
+npm install
+npm run codegen
+\`\`\`
+
+The generated native specs are written to \`generated/\`, \`android/\`, and
+\`ios/\`. The package is discovered by Lynx Autolink through \`lynx.ext.json\`.
+`;
+}
+
+/**
+ * Generates the TypeScript configuration for a scaffolded extension.
+ */
+function tsconfigJson(): string {
+  return json({
+    compilerOptions: {
+      declaration: true,
+      emitDeclarationOnly: true,
+      module: 'ESNext',
+      moduleResolution: 'Bundler',
+      outDir: 'dist',
+      strict: true,
+      target: 'ES2022',
+    },
+    include: ['src', 'types', 'generated'],
+  });
+}
+
+/**
+ * Generates the package entry point.
+ */
+function sourceIndex(context: TemplateContext): string {
+  if (!context.types.has('native-module')) {
+    return `// Native Autolink package entry.
+`;
+  }
+
+  return `export { ${context.moduleName} } from '../generated/${context.moduleName}';
+`;
+}
+
+/**
+ * Generates the initial native module type declarations.
+ */
+function typesDeclaration(context: TemplateContext): string {
+  if (!context.types.has('native-module')) {
+    return `// Add native module declarations here and run npm run codegen.
+`;
+  }
+
+  return `/** @lynxmodule */
+export declare class ${context.moduleName} {
+  setValue(key: string, value: string): void;
+  getValue(key: string): string | null;
+  clear(): void;
+}
+`;
+}
+
+/**
+ * Generates the Android library Gradle build file.
+ */
+function androidBuildGradle(context: TemplateContext): string {
+  return `plugins {
+  id("com.android.library")
+}
+
+android {
+  namespace = "${context.androidPackage}"
+  compileSdk = 35
+
+  defaultConfig {
+    minSdk = 23
+  }
+}
+
+dependencies {
+  implementation("org.lynxsdk.lynx:lynx:0.0.1-alpha.1")
+  implementation("org.lynxsdk.lynx:service-api:0.0.1-alpha.1")
+  annotationProcessor("org.lynxsdk.lynx:lynx-processor:0.0.1-alpha.1")
+}
+`;
+}
+
+/**
+ * Generates the Android library manifest.
+ */
+function androidManifest(): string {
+  return `<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application />
+</manifest>
+`;
+}
+
+/**
+ * Generates the Android native module example implementation.
+ */
+function androidNativeModule(context: TemplateContext): string {
+  return `package ${context.androidPackage};
+
+import androidx.annotation.Nullable;
+import com.lynx.tasm.behavior.LynxContext;
+import com.lynx.tasm.behavior.LynxMethod;
+import com.lynx.tasm.behavior.annotation.LynxAutolinkNativeModule;
+import ${context.androidPackage}.generated.${context.moduleName}Spec;
+
+@LynxAutolinkNativeModule(name = "${context.moduleName}")
+public class ${context.moduleName} extends ${context.moduleName}Spec {
+  public ${context.moduleName}(LynxContext context) {
+    super(context);
+  }
+
+  @Override
+  @LynxMethod
+  public void setValue(String key, String value) {
+  }
+
+  @Override
+  @LynxMethod
+  @Nullable
+  public String getValue(String key) {
+    return null;
+  }
+
+  @Override
+  @LynxMethod
+  public void clear() {
+  }
+}
+`;
+}
+
+/**
+ * Generates the Android element example implementation.
+ */
+function androidElement(context: TemplateContext): string {
+  return `package ${context.androidPackage};
+
+import android.content.Context;
+import android.widget.TextView;
+import com.lynx.tasm.behavior.LynxContext;
+import com.lynx.tasm.behavior.ui.LynxUI;
+import com.lynx.tasm.behavior.annotation.LynxAutolinkElement;
+
+@LynxAutolinkElement(name = "${context.elementName}")
+public class ${context.elementClassName} extends LynxUI<TextView> {
+  public ${context.elementClassName}(LynxContext context) {
+    super(context);
+  }
+
+  @Override
+  protected TextView createView(Context context) {
+    TextView view = new TextView(context);
+    view.setText("${context.elementName}");
+    return view;
+  }
+}
+`;
+}
+
+/**
+ * Generates the Android service example implementation.
+ */
+function androidService(context: TemplateContext): string {
+  return `package ${context.androidPackage};
+
+import com.lynx.tasm.service.LynxService;
+import com.lynx.tasm.service.annotation.LynxAutolinkService;
+
+@LynxAutolinkService
+public class ${context.serviceName} implements LynxService {
+  public String name() {
+    return "${context.serviceName}";
+  }
+}
+`;
+}
+
+/**
+ * Generates the iOS CocoaPods podspec.
+ */
+function iosPodspec(context: TemplateContext): string {
+  return `Pod::Spec.new do |s|
+  s.name = '${podspecName(context.packageName)}'
+  s.version = '0.0.1'
+  s.summary = 'Native Autolink Lynx extension'
+  s.license = { :type => 'Apache-2.0' }
+  s.author = 'Lynx'
+  s.source = { :path => '..' }
+  s.source_files = 'src/**/*.{h,m,mm}'
+  s.dependency 'Lynx'
+end
+`;
+}
+
+/**
+ * Generates the iOS native module header.
+ */
+function iosNativeModuleHeader(context: TemplateContext): string {
+  return `#import <Foundation/Foundation.h>
+#import <Lynx/LynxModule.h>
+#import "generated/${context.moduleName}Spec.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@LynxAutolinkNativeModule("${context.moduleName}")
+@interface ${context.moduleName} : NSObject <${context.moduleName}Spec>
+
+@end
+
+NS_ASSUME_NONNULL_END
+`;
+}
+
+/**
+ * Generates the iOS native module implementation.
+ */
+function iosNativeModuleImplementation(context: TemplateContext): string {
+  return `#import "${context.moduleName}.h"
+
+@implementation ${context.moduleName}
+
+- (void)setValue:(NSString *)key value:(NSString *)value {
+}
+
+- (nullable NSString *)getValue:(NSString *)key {
+  return nil;
+}
+
+- (void)clear {
+}
+
+@end
+`;
+}
+
+/**
+ * Generates the iOS element header.
+ */
+function iosElementHeader(context: TemplateContext): string {
+  return `#import <UIKit/UIKit.h>
+#import <Lynx/LynxUI.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@LynxAutolinkUI("${context.elementName}")
+@interface ${context.elementClassName} : LynxUI<UILabel *>
+
+@end
+
+NS_ASSUME_NONNULL_END
+`;
+}
+
+/**
+ * Generates the iOS element implementation.
+ */
+function iosElementImplementation(context: TemplateContext): string {
+  return `#import "${context.elementClassName}.h"
+
+@implementation ${context.elementClassName}
+
+- (UILabel *)createView {
+  UILabel *label = [[UILabel alloc] init];
+  label.text = @"${context.elementName}";
+  return label;
+}
+
+@end
+`;
+}
+
+/**
+ * Generates the iOS service header.
+ */
+function iosServiceHeader(context: TemplateContext): string {
+  return `#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ${context.serviceProtocolName} <NSObject>
+
+- (NSString *)name;
+
+@end
+
+@LynxAutolinkService(${context.serviceName}, ${context.serviceProtocolName})
+@interface ${context.serviceName} : NSObject <${context.serviceProtocolName}>
+
+@end
+
+NS_ASSUME_NONNULL_END
+`;
+}
+
+/**
+ * Generates the iOS service implementation.
+ */
+function iosServiceImplementation(context: TemplateContext): string {
+  return `#import "${context.serviceName}.h"
+
+@implementation ${context.serviceName}
+
+- (NSString *)name {
+  return @"${context.serviceName}";
+}
+
+@end
+`;
+}
+
+/**
+ * Generates the example app package manifest.
+ */
+function examplePackageJson(context: TemplateContext): string {
+  return json({
+    name: `${context.packageName}-example`,
+    private: true,
+    type: 'module',
+    dependencies: {
+      [context.packageName]: 'file:..',
+      '@lynx-js/react': '^0.111.0',
+      '@lynx-js/react-rsbuild-plugin': '^0.11.0',
+      '@lynx-js/rspeedy': '^0.11.0',
+    },
+    devDependencies: {
+      typescript: '^5.9.3',
+    },
+    scripts: {
+      dev: 'rspeedy dev',
+      build: 'rspeedy build',
+    },
+  });
+}
+
+/**
+ * Generates the example app Lynx config.
+ */
+function exampleLynxConfig(): string {
+  return `import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+export default defineConfig({
+  plugins: [pluginReactLynx()],
+});
+`;
+}
+
+/**
+ * Generates the example app entry point.
+ */
+function exampleEntry(): string {
+  return `import { root } from '@lynx-js/react';
+
+import { App } from './App.js';
+
+root.render(<App />);
+`;
+}
+
+/**
+ * Generates the example app component for the selected extension types.
+ */
+function exampleApp(context: TemplateContext): string {
+  const moduleButton = context.types.has('native-module')
+    ? `<text bindtap={() => ${context.moduleName}.setValue('key', 'value')}>
+        Native module
+      </text>`
+    : '';
+  const element = context.types.has('element')
+    ? `<${context.elementName} />`
+    : '';
+  const importSource = context.types.has('native-module')
+    ? `import { ${context.moduleName} } from '${context.packageName}';
+
+`
+    : '';
+
+  return `${importSource}export function App() {
+  return (
+    <view>
+      <text>${context.packageName}</text>
+      ${moduleButton}
+      ${element}
+    </view>
+  );
+}
+`;
+}
+
+/**
+ * Normalizes a directory or package basename into an npm package name.
+ */
+function normalizePackageName(name: string): string {
+  return name.toLowerCase().replaceAll(/[^a-z0-9_-]/g, '-');
+}
+
+/**
+ * Converts a name into PascalCase for generated class names.
+ */
+function toPascalCase(name: string): string {
+  const words = name.split(/[^A-Z0-9]+/i).filter(Boolean);
+  const result = words.map((word) =>
+    `${word.charAt(0).toUpperCase()}${word.slice(1)}`
+  ).join('');
+
+  return result.length > 0 ? result : 'LynxExtension';
+}
+
+/**
+ * Converts a name into kebab-case for element tags and package segments.
+ */
+function toKebabCase(name: string): string {
+  return name
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replaceAll(/[^A-Z0-9]+/gi, '-')
+    .replaceAll(/^-|-$/g, '')
+    .toLowerCase();
+}
+
+/**
+ * Converts a name into a safe Java package segment.
+ */
+function toJavaPackageSegment(name: string): string {
+  const segment = toKebabCase(name).replaceAll('-', '');
+  return segment.length > 0 ? segment : 'extension';
+}
+
+/**
+ * Converts an npm package name into a podspec name.
+ */
+function podspecName(packageName: string): string {
+  return packageName.replace(/^@/, '').replaceAll('/', '-');
+}
+
+/**
+ * Checks whether a string is a supported extension type.
+ */
+function isExtensionType(type: string): type is ExtensionType {
+  return (EXTENSION_TYPES as readonly string[]).includes(type);
+}
+
+/**
+ * Serializes scaffold JSON files with a trailing newline.
+ */
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}

--- a/packages/lynx/create-lynx-extension/test/create.test.ts
+++ b/packages/lynx/create-lynx-extension/test/create.test.ts
@@ -1,0 +1,180 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createLynxExtension, parseExtensionTypes } from '../src/index.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe('create-lynx-extension', () => {
+  it('parses non-interactive extension type flags', () => {
+    expect(parseExtensionTypes('native-module,element,service')).toEqual([
+      'native-module',
+      'element',
+      'service',
+    ]);
+    expect(() => parseExtensionTypes('web')).toThrow(
+      /Unsupported extension type/,
+    );
+  });
+
+  it('creates a mixed Native Autolink extension', () => {
+    const dir = createTempDir('mixed');
+    const files = createLynxExtension({
+      dir,
+      types: ['native-module', 'element', 'service'],
+      packageName: '@example/lynx-button',
+      androidPackage: 'com.example.button',
+      moduleName: 'ButtonModule',
+      elementName: 'x-button',
+      serviceName: 'ButtonService',
+    });
+
+    expect(files.map((file) => file.path)).toEqual(
+      expect.arrayContaining([
+        'package.json',
+        'lynx.ext.json',
+        'types/index.d.ts',
+        'src/index.ts',
+        'android/src/main/java/com/example/button/ButtonModule.java',
+        'android/src/main/java/com/example/button/ButtonElement.java',
+        'android/src/main/java/com/example/button/ButtonService.java',
+        'ios/src/ButtonModule.h',
+        'ios/src/ButtonElement.h',
+        'ios/src/ButtonElement.m',
+        'ios/src/ButtonService.h',
+        'ios/src/ButtonService.m',
+        'example/src/App.tsx',
+      ]),
+    );
+
+    expect(read(dir, 'package.json')).toContain(
+      '"codegen": "lynx-autolink-codegen"',
+    );
+    expect(read(dir, 'package.json')).toContain(
+      '"@lynx-js/autolink-codegen": "^0.0.0"',
+    );
+    expect(read(dir, 'lynx.ext.json')).toContain(
+      '"packageName": "com.example.button"',
+    );
+    expect(read(dir, 'types/index.d.ts')).toContain('/** @lynxmodule */');
+    expect(read(dir, 'types/index.d.ts')).toContain(
+      'setValue(key: string, value: string): void;',
+    );
+    expect(
+      read(dir, 'android/src/main/java/com/example/button/ButtonModule.java'),
+    ).toContain('@LynxAutolinkNativeModule(name = "ButtonModule")');
+    expect(
+      read(dir, 'android/src/main/java/com/example/button/ButtonElement.java'),
+    ).toContain('@LynxAutolinkElement(name = "x-button")');
+    expect(
+      read(dir, 'android/src/main/java/com/example/button/ButtonService.java'),
+    ).toContain('@LynxAutolinkService');
+    expect(read(dir, 'ios/src/ButtonModule.h')).toContain(
+      '@LynxAutolinkNativeModule("ButtonModule")',
+    );
+    expect(read(dir, 'ios/src/ButtonElement.h')).toContain(
+      '@LynxAutolinkUI("x-button")',
+    );
+    expect(read(dir, 'ios/src/ButtonService.h')).toContain(
+      '@LynxAutolinkService(ButtonService, ButtonServiceProtocol)',
+    );
+  });
+
+  it('creates Native Module only projects without element or service files', () => {
+    const dir = createTempDir('module');
+    const files = createLynxExtension({
+      dir,
+      types: ['native-module'],
+      packageName: 'storage-extension',
+      androidPackage: 'com.example.storage',
+      moduleName: 'StorageModule',
+    });
+
+    expect(files.map((file) => file.path)).toContain(
+      'android/src/main/java/com/example/storage/StorageModule.java',
+    );
+    expect(files.map((file) => file.path)).not.toContain(
+      'android/src/main/java/com/example/storage/StorageElement.java',
+    );
+    expect(read(dir, 'src/index.ts')).toContain(
+      'export { StorageModule } from \'../generated/StorageModule\';',
+    );
+  });
+
+  it('creates Element and Service projects with Autolink markers', () => {
+    const dir = createTempDir('view');
+    const files = createLynxExtension({
+      dir,
+      types: ['element', 'service'],
+      packageName: 'view-extension',
+      androidPackage: 'com.example.view',
+      elementName: 'x-view',
+      serviceName: 'ViewService',
+    });
+
+    expect(files.map((file) => file.path)).toEqual(
+      expect.arrayContaining([
+        'ios/src/ViewElement.h',
+        'ios/src/ViewService.h',
+      ]),
+    );
+    expect(read(dir, 'types/index.d.ts')).toContain(
+      'Add native module declarations',
+    );
+    expect(read(dir, 'src/index.ts')).toContain(
+      'Native Autolink package entry',
+    );
+    expect(read(dir, 'android/src/main/java/com/example/view/ViewElement.java'))
+      .toContain('@LynxAutolinkElement(name = "x-view")');
+    expect(read(dir, 'ios/src/ViewService.h')).toContain(
+      '@LynxAutolinkService(ViewService, ViewServiceProtocol)',
+    );
+    expect(read(dir, 'example/src/App.tsx')).not.toContain('import {');
+  });
+
+  it('rejects generated paths that escape the target directory', () => {
+    const dir = createTempDir('escape');
+
+    expect(() =>
+      createLynxExtension({
+        dir,
+        types: ['native-module'],
+        packageName: 'escape-extension',
+        androidPackage: 'com.example.escape',
+        moduleName: '../../../../../../../../EscapeModule',
+      })
+    ).toThrow(/Generated path escapes target directory/);
+  });
+
+  it('refuses to overwrite a non-empty directory', () => {
+    const dir = createTempDir('nonempty');
+    fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+
+    expect(() => createLynxExtension({ dir, types: ['native-module'] }))
+      .toThrow(/not empty/);
+  });
+});
+
+function createTempDir(name: string): string {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'lynx-extension-'));
+  const dir = path.join(parent, name);
+  fs.mkdirSync(dir, { recursive: true });
+  tempDirs.push(parent);
+  return dir;
+}
+
+function read(root: string, file: string): string {
+  return fs.readFileSync(path.join(root, file), 'utf8');
+}

--- a/packages/lynx/create-lynx-extension/tsconfig.build.json
+++ b/packages/lynx/create-lynx-extension/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "lib": ["es2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2022",
+    "types": ["node"],
+  },
+  "include": ["src"],
+}

--- a/packages/lynx/create-lynx-extension/tsconfig.json
+++ b/packages/lynx/create-lynx-extension/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.test.json" },
+  ],
+}

--- a/packages/lynx/create-lynx-extension/tsconfig.test.json
+++ b/packages/lynx/create-lynx-extension/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "test"]
+}

--- a/packages/lynx/create-lynx-extension/turbo.json
+++ b/packages/lynx/create-lynx-extension/turbo.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["build"]
+    }
+  }
+}

--- a/packages/lynx/create-lynx-extension/vitest.config.ts
+++ b/packages/lynx/create-lynx-extension/vitest.config.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'lynx/create-lynx-extension',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/lynx/tsconfig.json
+++ b/packages/lynx/tsconfig.json
@@ -4,6 +4,8 @@
   },
   "references": [
     /** packages-start */
+    { "path": "./autolink-codegen/tsconfig.build.json" },
+    { "path": "./create-lynx-extension/tsconfig.build.json" },
     { "path": "./gesture-runtime/tsconfig.build.json" },
     /** packages-end */
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,11 +716,15 @@ importers:
         specifier: 0.2.1
         version: 0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
 
+  packages/lynx/autolink-codegen: {}
+
   packages/lynx/benchx_cli:
     dependencies:
       zx:
         specifier: ^8.8.5
         version: 8.8.5
+
+  packages/lynx/create-lynx-extension: {}
 
   packages/lynx/gesture-runtime:
     devDependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -82,7 +82,7 @@ export default defineConfig({
       'packages/use-sync-external-store/vitest.config.ts',
       'packages/web-platform/*/vitest.config.ts',
       'packages/webpack/*/vitest.config.ts',
-      'packages/lynx/gesture-runtime/vitest.config.ts',
+      'packages/lynx/*/vitest.config.ts',
       'packages/motion/vitest.config.ts',
     ],
   },


### PR DESCRIPTION
## Summary

- add `@lynx-js/autolink-codegen` for Native-only JS, Android, and iOS spec generation
- add `create-lynx-extension` scaffolding for Native Module, Element, and Service extensions
- use the `lynx-autolink-codegen` CLI name in package metadata, generated templates, docs, and tests
- wire the new Lynx packages into TS references, Vitest projects, lockfile, instructions, and changesets

## Validation

- `pnpm --filter @lynx-js/autolink-codegen test`
- `pnpm --filter create-lynx-extension test`
- `pnpm --filter @lynx-js/autolink-codegen build`
- `pnpm --filter create-lynx-extension build`
- `pnpm dprint check`
- `pnpm biome check`
- targeted `pnpm eslint --cache --fix --no-warn-ignored --flag v10_config_lookup_from_file packages/lynx/autolink-codegen packages/lynx/create-lynx-extension`
- CLI smoke test: create a temp extension and run autolink codegen against it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added @lynx-js/autolink-codegen CLI for generating native Android/iOS bindings from types
  * Added create-lynx-extension CLI for scaffolding native Lynx extension projects with example app and scripts
* **Documentation**
  * Added README and usage guides for both packages plus contributor instructions for native autolink extensions
* **Tests**
  * Added test suites validating parsing, generation, and safety checks across platforms
* **Chores**
  * Test runner updated to include new package test configs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->