### PR TITLE
fix(web-core): add ^build to turbo build deps

### DIFF
--- a/packages/web-platform/web-core/turbo.json
+++ b/packages/web-platform/web-core/turbo.json
@@ -8,7 +8,7 @@
       "outputs": ["binary/**"]
     },
     "build": {
-      "dependsOn": ["build:wasm"],
+      "dependsOn": ["^build", "build:wasm"],
       "inputs": ["src/**", "ts/**", "css/**", "*.ts"],
       "outputs": ["dist/**"]
     }


### PR DESCRIPTION
## Summary

`packages/web-platform/web-core`'s turbo `build` task only depended on its local `build:wasm`, missing `^build`. This caused turbo to start `web-core`'s TypeScript build before its workspace deps (`@lynx-js/web-elements`, `@lynx-js/web-worker-rpc`, `@lynx-js/css-serializer`, ...) had finished building, producing partial `dist/` output and intermittent CI failures (e.g. `repl` failing to resolve modules from `web-core/dist`).

Adding `^build` makes turbo wait for upstream workspace builds, matching the convention used by every other package in the repo.

This was extracted from #2584 where the same fix unblocked Build (Ubuntu).

## Test plan

- [x] Verified Build (Ubuntu) passes with this change applied on top of #2584
- [ ] Build (Ubuntu) passes on this PR
- [ ] Build (Windows) passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build task configuration to improve build process sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->