### PR TITLE
fix(react): silence invalid worklet warnings

### DIFF
--- a/.changeset/remove-invalid-mtf-warn.md
+++ b/.changeset/remove-invalid-mtf-warn.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Stop warning when `runWorklet` receives an invalid or missing main-thread function object. Invalid worklet contexts are still ignored, but nullish handler values no longer produce noisy `MainThreadFunction: Invalid function object` console output.

--- a/packages/react/runtime/__test__/worklet-runtime/workletRuntime.test.js
+++ b/packages/react/runtime/__test__/worklet-runtime/workletRuntime.test.js
@@ -303,14 +303,14 @@ describe('Worklet', () => {
 
   it('should not throw when invalid worklet ctx', () => {
     initWorklet();
+    consoleMock.mockClear();
+
     globalThis.runWorklet({});
-    expect(consoleMock).lastCalledWith('MainThreadFunction: Invalid function object: {}');
     globalThis.runWorklet(undefined);
-    expect(consoleMock).lastCalledWith('MainThreadFunction: Invalid function object: undefined');
     globalThis.runWorklet(null);
-    expect(consoleMock).lastCalledWith('MainThreadFunction: Invalid function object: null');
     globalThis.runWorklet(1);
-    expect(consoleMock).lastCalledWith('MainThreadFunction: Invalid function object: 1');
+
+    expect(consoleMock).not.toHaveBeenCalled();
   });
 
   it('should not throw when depth of argument exceeds limit', () => {

--- a/packages/react/runtime/src/worklet-runtime/workletRuntime.ts
+++ b/packages/react/runtime/src/worklet-runtime/workletRuntime.ts
@@ -55,7 +55,6 @@ function registerWorklet(_type: string, id: string, worklet: (...args: unknown[]
  */
 function runWorklet(ctx: Worklet, params: ClosureValueType[], options?: RunWorkletOptions): unknown {
   if (!validateWorklet(ctx)) {
-    console.warn('MainThreadFunction: Invalid function object: ' + JSON.stringify(ctx));
     return;
   }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Removed the "Invalid function object" console warning that appeared when worklet runtime encountered invalid, null, or undefined handler functions. Invalid worklet contexts continue to be properly rejected; only the diagnostic message has been eliminated to reduce unnecessary console output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

- `runWorklet` can receive invalid or missing main-thread function objects when optional/nullish handlers flow through the worklet event path.
- Those values are still ignored by returning early, but the runtime no longer emits the noisy `MainThreadFunction: Invalid function object` warning.

## Key Points

- The invalid ctx guard keeps the same control flow: values without `_wkltId` or `_lepusWorkletHash` return without executing a worklet.
- The console side effect and its `JSON.stringify(ctx)` work were removed from that early-return path.
- The focused runtime test now asserts invalid ctx values do not throw and do not warn.

For example, an event value shaped like `{ _workletType: "main-thread" }` is still treated as non-executable worklet ctx, but it is ignored silently instead of surfacing a developer-console warning.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
