### PR TITLE
feat(react): support element template events

### DIFF
--- a/.changeset/empty-et-event-implementation.md
+++ b/.changeset/empty-et-event-implementation.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+No package release is required because this change continues the unpublished Element Template event implementation behind the experimental runtime path and only updates internal runtime, transform, fixtures, and tests without changing public APIs, package exports, or release-facing defaults.

--- a/packages/react/runtime/__test__/element-template/fixtures/background/event/conditional-direct-event/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/event/conditional-direct-event/index.tsx
@@ -1,0 +1,8 @@
+interface AppProps {
+  show?: boolean;
+  onTap?: () => void;
+}
+
+export function App({ show = true, onTap }: AppProps) {
+  return <view>{show ? <text bindtap={onTap}>tap</text> : null}</view>;
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/background/event/direct-event/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/event/direct-event/index.tsx
@@ -1,0 +1,7 @@
+interface AppProps {
+  onTap?: () => void;
+}
+
+export function App({ onTap }: AppProps) {
+  return <view bindtap={onTap} />;
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/render/react-example/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/react-example/index.js.txt
@@ -1,4 +1,5 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+import * as ReactLynxInternal from "@lynx-js/react/element-template/internal";
 import { useCallback, useEffect, useState } from '@lynx-js/react';
 const arrow = './assets/arrow.png';
 const lynxLogo = './assets/lynx-logo.png';
@@ -6,6 +7,10 @@ const reactLynxLogo = './assets/react-logo.png';
 const _et_7a8c6_test_2 = "_et_7a8c6_test_2";
 const _et_7a8c6_test_3 = "_et_7a8c6_test_3";
 const _et_7a8c6_test_1 = "_et_7a8c6_test_1";
+ReactLynxInternal.__etAttrPlanMap[_et_7a8c6_test_1] = [
+    0,
+    ReactLynxInternal.adaptEventAttrSlot
+];
 export function App() {
     const [alterLogo, setAlterLogo] = useState(false);
     useEffect(()=>{

--- a/packages/react/runtime/__test__/element-template/fixtures/render/react-example/output.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/react-example/output.txt
@@ -2,7 +2,7 @@
   <view class="Background" />
   <view class="App">
     <view class="Banner">
-      <view bindtap="1" class="Logo">
+      <view bindtap="-3:0:" class="Logo">
         <image class="Logo--lynx" src="./assets/lynx-logo.png" />
       </view>
       <text class="Title" text="React" />

--- a/packages/react/runtime/__test__/element-template/fixtures/render/react-example/papi.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/react-example/papi.txt
@@ -24,7 +24,7 @@
     "_et_7a8c6_test_1",
     null,
     [
-      1,
+      "-3:0:",
       "./assets/arrow.png"
     ],
     [

--- a/packages/react/runtime/__test__/element-template/native/index.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/index.test.ts
@@ -111,7 +111,7 @@ describe('element-template native index wiring', () => {
     const callDestroyLifetimeFun = vi.fn();
     const publishEvent = vi.fn();
     const publicComponentEvent = vi.fn();
-    const resetEventHandlersForRuntime = vi.fn();
+    const resetEventStateForRuntime = vi.fn();
 
     vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
       injectCalledByNative,
@@ -149,7 +149,7 @@ describe('element-template native index wiring', () => {
     vi.doMock('../../../src/element-template/prop-adapters/event.js', () => ({
       publishEvent,
       publicComponentEvent,
-      resetEventHandlersForRuntime,
+      resetEventStateForRuntime,
     }));
     vi.doMock('../../../src/element-template/background/instance.js', () => ({
       BackgroundElementTemplateInstance: class BackgroundElementTemplateInstance {
@@ -166,7 +166,7 @@ describe('element-template native index wiring', () => {
     expect(initTimingAPI).toHaveBeenCalledTimes(1);
     expect(initProfileHook).toHaveBeenCalledTimes(1);
     expect(setupLynxEnv).toHaveBeenCalledTimes(1);
-    expect(resetEventHandlersForRuntime).toHaveBeenCalledTimes(1);
+    expect(resetEventStateForRuntime).toHaveBeenCalledTimes(1);
     expect(globalThis.lynxCoreInject.tt.callDestroyLifetimeFun).toBe(callDestroyLifetimeFun);
     expect(globalThis.lynxCoreInject.tt.publishEvent).toBe(publishEvent);
     expect(globalThis.lynxCoreInject.tt.publicComponentEvent).toBe(publicComponentEvent);

--- a/packages/react/runtime/__test__/element-template/native/index.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/index.test.ts
@@ -19,6 +19,7 @@ describe('element-template native index wiring', () => {
     vi.doUnmock('../../../src/element-template/native/patch-listener.js');
     vi.doUnmock('../../../src/element-template/native/mts-destroy.js');
     vi.doUnmock('../../../src/element-template/native/callDestroyLifetimeFun.js');
+    vi.doUnmock('../../../src/element-template/prop-adapters/event.js');
     vi.doUnmock('../../../src/element-template/background/document.js');
     vi.doUnmock('../../../src/element-template/background/hydration-listener.js');
     vi.doUnmock('../../../src/element-template/background/commit-hook.js');
@@ -108,6 +109,9 @@ describe('element-template native index wiring', () => {
     const initTimingAPI = vi.fn();
     const setRoot = vi.fn();
     const callDestroyLifetimeFun = vi.fn();
+    const publishEvent = vi.fn();
+    const publicComponentEvent = vi.fn();
+    const resetEventHandlersForRuntime = vi.fn();
 
     vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
       injectCalledByNative,
@@ -142,6 +146,11 @@ describe('element-template native index wiring', () => {
     vi.doMock('../../../src/element-template/native/callDestroyLifetimeFun.js', () => ({
       callDestroyLifetimeFun,
     }));
+    vi.doMock('../../../src/element-template/prop-adapters/event.js', () => ({
+      publishEvent,
+      publicComponentEvent,
+      resetEventHandlersForRuntime,
+    }));
     vi.doMock('../../../src/element-template/background/instance.js', () => ({
       BackgroundElementTemplateInstance: class BackgroundElementTemplateInstance {
         constructor(public type: string) {}
@@ -157,7 +166,10 @@ describe('element-template native index wiring', () => {
     expect(initTimingAPI).toHaveBeenCalledTimes(1);
     expect(initProfileHook).toHaveBeenCalledTimes(1);
     expect(setupLynxEnv).toHaveBeenCalledTimes(1);
+    expect(resetEventHandlersForRuntime).toHaveBeenCalledTimes(1);
     expect(globalThis.lynxCoreInject.tt.callDestroyLifetimeFun).toBe(callDestroyLifetimeFun);
+    expect(globalThis.lynxCoreInject.tt.publishEvent).toBe(publishEvent);
+    expect(globalThis.lynxCoreInject.tt.publicComponentEvent).toBe(publicComponentEvent);
 
     expect(injectCalledByNative).not.toHaveBeenCalled();
     expect(installElementTemplatePatchListener).not.toHaveBeenCalled();

--- a/packages/react/runtime/__test__/element-template/runtime/background/event-bridge.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/event-bridge.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { destroyElementTemplateBackgroundRuntime } from '../../../../src/element-template/background/destroy.js';
+import {
+  clearEventHandlers,
+  flushPendingEvents,
+  publicComponentEvent,
+  publishEvent,
+  resetEventHandlersForRuntime,
+  setEventHandler,
+} from '../../../../src/element-template/prop-adapters/event.js';
+
+describe('ElementTemplate event bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearEventHandlers();
+  });
+
+  it('dispatches publishEvent to the current handler', () => {
+    const handler = vi.fn();
+    const eventData = { type: 'tap', detail: { x: 1 } };
+    setEventHandler(-1, 0, handler);
+
+    publishEvent('-1:0:', eventData);
+
+    expect(handler).toHaveBeenCalledWith(eventData);
+  });
+
+  it('dispatches publicComponentEvent through the same handler lookup', () => {
+    const handler = vi.fn();
+    const eventData = { type: 'tap' };
+    setEventHandler(-2, 0, handler);
+
+    publicComponentEvent('component-id', '-2:0:', eventData);
+
+    expect(handler).toHaveBeenCalledWith(eventData);
+  });
+
+  it('reports handler errors without throwing through native', () => {
+    const error = new Error('event failed');
+    const oldReportError = lynx.reportError;
+    const reportError = vi.fn();
+    lynx.reportError = reportError;
+    try {
+      setEventHandler(-3, 0, () => {
+        throw error;
+      });
+
+      expect(() => publishEvent('-3:0:', { type: 'tap' })).not.toThrow();
+      expect(reportError).toHaveBeenCalledWith(error);
+    } finally {
+      lynx.reportError = oldReportError;
+    }
+  });
+
+  it('queues missing handlers before hydrate and drops missing handlers after flush', () => {
+    const queuedHandler = vi.fn();
+    const droppedHandler = vi.fn();
+    const queuedEvent = { type: 'tap', phase: 'before-hydrate' };
+    const droppedEvent = { type: 'tap', phase: 'after-hydrate' };
+
+    resetEventHandlersForRuntime();
+    publishEvent('-4:0:', queuedEvent);
+    setEventHandler(-4, 0, queuedHandler);
+    flushPendingEvents();
+
+    publishEvent('-5:0:', droppedEvent);
+    setEventHandler(-5, 0, droppedHandler);
+
+    expect(queuedHandler).toHaveBeenCalledWith(queuedEvent);
+    expect(droppedHandler).not.toHaveBeenCalled();
+  });
+
+  it('clears queued events when the background runtime is destroyed', () => {
+    const handler = vi.fn();
+    resetEventHandlersForRuntime();
+    publishEvent('-6:0:', { type: 'tap' });
+
+    destroyElementTemplateBackgroundRuntime();
+    setEventHandler(-6, 0, handler);
+    flushPendingEvents();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not queue stale native events after the background runtime is destroyed', () => {
+    const handler = vi.fn();
+    resetEventHandlersForRuntime();
+    destroyElementTemplateBackgroundRuntime();
+
+    publishEvent('-7:0:', { type: 'tap' });
+    setEventHandler(-7, 0, handler);
+    flushPendingEvents();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
@@ -1,0 +1,352 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createElement } from 'preact';
+
+import {
+  installElementTemplateCommitHook,
+  resetElementTemplateCommitState,
+} from '../../../../../src/element-template/background/commit-hook.js';
+import {
+  installElementTemplateHydrationListener,
+  resetElementTemplateHydrationListener,
+} from '../../../../../src/element-template/background/hydration-listener.js';
+import {
+  collectElementTemplateSubtreeHandleIds,
+  BackgroundElementTemplateInstance,
+} from '../../../../../src/element-template/background/instance.js';
+import { backgroundElementTemplateInstanceManager } from '../../../../../src/element-template/background/manager.js';
+import { root } from '../../../../../src/element-template/index.js';
+import {
+  clearEventState,
+  getEventHandlerForEventValue,
+  publishEvent,
+} from '../../../../../src/element-template/prop-adapters/event.js';
+import { ElementTemplateLifecycleConstant } from '../../../../../src/element-template/protocol/lifecycle-constant.js';
+import { ElementTemplateUpdateOps } from '../../../../../src/element-template/protocol/opcodes.js';
+import type {
+  ElementTemplateUpdateCommandStream,
+  ElementTemplateUpdateCommitContext,
+} from '../../../../../src/element-template/protocol/types.js';
+import { clearEtAttrPlanMap } from '../../../../../src/element-template/runtime/template/attr-slot-plan.js';
+import { __root } from '../../../../../src/element-template/runtime/page/root-instance.js';
+import { compileFixtureSource } from '../../../test-utils/debug/compiledFixtureCompiler.js';
+import {
+  loadCompiledFixtureModule,
+  type CompiledFixtureModuleExports,
+} from '../../../test-utils/debug/compiledFixtureModule.js';
+import { primeCompiledFixtureTemplates } from '../../../test-utils/debug/compiledFixtureRegistry.js';
+import { ElementTemplateEnvManager } from '../../../test-utils/debug/envManager.js';
+import { serializeBackgroundTree } from '../../../test-utils/debug/serializer.js';
+
+declare const renderPage: () => void;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DIRECT_EVENT_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/event/direct-event/index.tsx');
+const CONDITIONAL_DIRECT_EVENT_FIXTURE = path.resolve(
+  __dirname,
+  '../../../fixtures/background/event/conditional-direct-event/index.tsx',
+);
+const SLOT_ID = 0;
+
+interface CompiledDirectEventModule extends CompiledFixtureModuleExports {
+  App: (props: { onTap?: () => void }) => JSX.Element;
+}
+
+interface CompiledConditionalDirectEventModule extends CompiledFixtureModuleExports {
+  App: (props: { show?: boolean; onTap?: () => void }) => JSX.Element;
+}
+
+function getRenderedHost(): BackgroundElementTemplateInstance {
+  const host = (__root as BackgroundElementTemplateInstance).firstChild;
+  if (!host) {
+    throw new Error('Missing rendered host.');
+  }
+  return host;
+}
+
+function getSlotChildAt(
+  index: number,
+  host = getRenderedHost(),
+): BackgroundElementTemplateInstance {
+  const child = host.elementSlots[SLOT_ID]?.[index];
+  if (!child) {
+    throw new Error(`Missing slot child at ${index}.\n${serializeBackgroundTree(host)}`);
+  }
+  return child;
+}
+
+function collectRecursiveCreateCommandStream(
+  instance: BackgroundElementTemplateInstance,
+): ElementTemplateUpdateCommandStream {
+  const commands: ElementTemplateUpdateCommandStream = [];
+  for (const slotChildren of instance.elementSlots) {
+    for (const child of slotChildren ?? []) {
+      commands.push(...collectRecursiveCreateCommandStream(child));
+    }
+  }
+  commands.push(
+    ElementTemplateUpdateOps.createTemplate,
+    instance.instanceId,
+    instance.type,
+    null,
+    instance.attributeSlots,
+    instance.elementSlots.map(children => (children ?? []).map(child => child.instanceId)),
+  );
+  return commands;
+}
+
+describe('Compiled direct event background updates', () => {
+  const envManager = new ElementTemplateEnvManager();
+  let updateEvents: ElementTemplateUpdateCommitContext[] = [];
+  const onUpdate = (event: { data: unknown }) => {
+    updateEvents.push(event.data as ElementTemplateUpdateCommitContext);
+  };
+
+  async function loadCompiledDirectEventFixture(): Promise<{
+    backgroundModule: CompiledDirectEventModule;
+    mainModule: CompiledDirectEventModule;
+  }> {
+    const mainArtifact = await compileFixtureSource(DIRECT_EVENT_FIXTURE, { target: 'LEPUS' });
+    primeCompiledFixtureTemplates(mainArtifact);
+    const mainModule = await loadCompiledFixtureModule<CompiledDirectEventModule>(mainArtifact);
+
+    const backgroundArtifact = await compileFixtureSource(DIRECT_EVENT_FIXTURE, { target: 'JS' });
+    const backgroundModule = await loadCompiledFixtureModule<CompiledDirectEventModule>(backgroundArtifact);
+
+    return { backgroundModule, mainModule };
+  }
+
+  async function loadCompiledConditionalDirectEventFixture(): Promise<{
+    backgroundModule: CompiledConditionalDirectEventModule;
+    mainModule: CompiledConditionalDirectEventModule;
+  }> {
+    const mainArtifact = await compileFixtureSource(CONDITIONAL_DIRECT_EVENT_FIXTURE, { target: 'LEPUS' });
+    primeCompiledFixtureTemplates(mainArtifact);
+    const mainModule = await loadCompiledFixtureModule<CompiledConditionalDirectEventModule>(mainArtifact);
+
+    const backgroundArtifact = await compileFixtureSource(CONDITIONAL_DIRECT_EVENT_FIXTURE, { target: 'JS' });
+    const backgroundModule = await loadCompiledFixtureModule<CompiledConditionalDirectEventModule>(
+      backgroundArtifact,
+    );
+
+    return { backgroundModule, mainModule };
+  }
+
+  function renderDirectEventOnBackground(
+    moduleExports: CompiledDirectEventModule,
+    onTap?: () => void,
+  ): BackgroundElementTemplateInstance {
+    envManager.switchToBackground();
+    root.render(createElement(moduleExports.App, { onTap }));
+    return getRenderedHost();
+  }
+
+  function hydrateDirectEventFromMainThread(
+    moduleExports: CompiledDirectEventModule,
+    onTap?: () => void,
+  ): BackgroundElementTemplateInstance {
+    const host = getRenderedHost();
+
+    envManager.switchToMainThread();
+    root.render(createElement(moduleExports.App, { onTap }));
+    renderPage();
+    envManager.switchToBackground();
+
+    return host;
+  }
+
+  function renderConditionalDirectEventOnBackground(
+    moduleExports: CompiledConditionalDirectEventModule,
+    show: boolean,
+    onTap?: () => void,
+  ): BackgroundElementTemplateInstance {
+    envManager.switchToBackground();
+    root.render(createElement(moduleExports.App, { show, onTap }));
+    return getRenderedHost();
+  }
+
+  function hydrateConditionalDirectEventFromMainThread(
+    moduleExports: CompiledConditionalDirectEventModule,
+    show: boolean,
+    onTap?: () => void,
+  ): BackgroundElementTemplateInstance {
+    const host = getRenderedHost();
+
+    envManager.switchToMainThread();
+    root.render(createElement(moduleExports.App, { show, onTap }));
+    renderPage();
+    envManager.switchToBackground();
+
+    return host;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetElementTemplateCommitState();
+    clearEtAttrPlanMap();
+    clearEventState();
+    updateEvents = [];
+    envManager.resetEnv('background');
+    envManager.setUseElementTemplate(true);
+    installElementTemplateCommitHook();
+    installElementTemplateHydrationListener();
+
+    envManager.switchToMainThread();
+    lynx.getJSContext().addEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+    envManager.switchToBackground();
+  });
+
+  afterEach(() => {
+    envManager.switchToMainThread();
+    lynx.getJSContext().removeEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+    envManager.switchToBackground();
+    resetElementTemplateHydrationListener();
+    envManager.setUseElementTemplate(false);
+  });
+
+  it('uses the latest background handler without dispatching a native patch when only handler identity changes', async () => {
+    const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+
+    const host = renderDirectEventOnBackground(backgroundModule, firstHandler);
+    hydrateDirectEventFromMainThread(mainModule, firstHandler);
+    updateEvents = [];
+
+    renderDirectEventOnBackground(backgroundModule, secondHandler);
+
+    const eventValue = `${host.instanceId}:0:`;
+    envManager.switchToMainThread();
+    expect(updateEvents).toEqual([]);
+    envManager.switchToBackground();
+    expect(host.attributeSlots).toEqual([eventValue]);
+    expect(getEventHandlerForEventValue(eventValue)).toBe(secondHandler);
+  });
+
+  it('uses ordinary setAttribute patches when direct event handlers are added or removed', async () => {
+    const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
+    const handler = vi.fn();
+
+    const host = renderDirectEventOnBackground(backgroundModule);
+    hydrateDirectEventFromMainThread(mainModule);
+    updateEvents = [];
+
+    renderDirectEventOnBackground(backgroundModule, handler);
+
+    const eventValue = `${host.instanceId}:0:`;
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      host.instanceId,
+      0,
+      eventValue,
+    ]);
+    envManager.switchToBackground();
+    expect(host.attributeSlots).toEqual([eventValue]);
+    expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+
+    updateEvents = [];
+    renderDirectEventOnBackground(backgroundModule);
+
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      host.instanceId,
+      0,
+      null,
+    ]);
+    envManager.switchToBackground();
+    expect(host.attributeSlots).toEqual([null]);
+    expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+  });
+
+  it('dispatches native event values to the latest hydrated direct event handler', async () => {
+    const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+
+    const host = renderDirectEventOnBackground(backgroundModule, firstHandler);
+    hydrateDirectEventFromMainThread(mainModule, firstHandler);
+    const eventValue = `${host.instanceId}:0:`;
+
+    publishEvent(eventValue, { type: 'tap', phase: 'first' });
+
+    renderDirectEventOnBackground(backgroundModule, secondHandler);
+    publishEvent(eventValue, { type: 'tap', phase: 'second' });
+
+    expect(firstHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'first' });
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+    expect(secondHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'second' });
+  });
+
+  it('registers and dispatches direct events on inserted compiled subtrees', async () => {
+    const { backgroundModule, mainModule } = await loadCompiledConditionalDirectEventFixture();
+    const handler = vi.fn();
+
+    const host = renderConditionalDirectEventOnBackground(backgroundModule, false);
+    hydrateConditionalDirectEventFromMainThread(mainModule, false);
+    updateEvents = [];
+
+    renderConditionalDirectEventOnBackground(backgroundModule, true, handler);
+    const inserted = getSlotChildAt(0, host);
+    const eventValue = `${inserted.instanceId}:0:`;
+
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops).toEqual([
+      ...collectRecursiveCreateCommandStream(inserted),
+      ElementTemplateUpdateOps.insertNode,
+      host.instanceId,
+      SLOT_ID,
+      inserted.instanceId,
+      0,
+    ]);
+    envManager.switchToBackground();
+    expect(inserted.attributeSlots).toEqual([eventValue]);
+    expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+
+    publishEvent(eventValue, { type: 'tap', phase: 'inserted' });
+
+    expect(handler).toHaveBeenCalledWith({ type: 'tap', phase: 'inserted' });
+  });
+
+  it('cleans direct event handlers when compiled subtrees are removed', async () => {
+    const { backgroundModule, mainModule } = await loadCompiledConditionalDirectEventFixture();
+    const handler = vi.fn();
+
+    const host = renderConditionalDirectEventOnBackground(backgroundModule, true, handler);
+    hydrateConditionalDirectEventFromMainThread(mainModule, true, handler);
+    const removed = getSlotChildAt(0, host);
+    const removedSubtreeHandleIds = collectElementTemplateSubtreeHandleIds(removed);
+    const eventValue = `${removed.instanceId}:0:`;
+    expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+    updateEvents = [];
+
+    vi.useFakeTimers();
+    try {
+      renderConditionalDirectEventOnBackground(backgroundModule, false);
+
+      envManager.switchToMainThread();
+      expect(updateEvents.at(-1)?.ops).toEqual([
+        ElementTemplateUpdateOps.removeNode,
+        host.instanceId,
+        SLOT_ID,
+        removed.instanceId,
+        removedSubtreeHandleIds,
+      ]);
+      envManager.switchToBackground();
+      expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+
+      vi.advanceTimersByTime(10000);
+
+      expect(backgroundElementTemplateInstanceManager.get(removed.instanceId)).toBeUndefined();
+      expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+      publishEvent(eventValue, { type: 'tap', phase: 'removed' });
+      expect(handler).not.toHaveBeenCalledWith({ type: 'tap', phase: 'removed' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -12,8 +12,17 @@ import {
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
+import {
+  clearEventHandlers,
+  getEventHandlerForEventValue,
+} from '../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateUpdateOps } from '../../../../src/element-template/protocol/opcodes.js';
 import type { SerializedElementTemplate } from '../../../../src/element-template/protocol/types.js';
+import {
+  __etAttrPlanMap,
+  adaptEventAttrSlot,
+  clearEtAttrPlanMap,
+} from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 
 function createHydrationTemplate(
   handleId: number,
@@ -51,6 +60,8 @@ describe('hydrate', () => {
   beforeEach(() => {
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
+    clearEtAttrPlanMap();
+    clearEventHandlers();
     resetElementTemplateCommitState();
     vi.clearAllMocks();
     (globalThis as { __LYNX_REPORT_ERROR_CALLS?: Error[] }).__LYNX_REPORT_ERROR_CALLS = [];
@@ -526,6 +537,41 @@ describe('hydrate', () => {
     expect(child.elementSlots[0]).toEqual([rawText]);
   });
 
+  it('registers event handlers for background-only insertion subtrees during hydrate', () => {
+    __etAttrPlanMap.child = [0, adaptEventAttrSlot];
+    const root = new BackgroundElementTemplateInstance('root');
+    const slot = new BackgroundElementTemplateSlot();
+    slot.setAttribute('id', 0);
+    root.appendChild(slot);
+    const child = new BackgroundElementTemplateInstance('child');
+    const handler = vi.fn();
+    child.setAttribute('attributeSlots', [handler]);
+    slot.appendChild(child);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root', {
+        elementSlots: [[]],
+      }),
+      root,
+    );
+
+    const eventValue = `${child.instanceId}:0:`;
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.createTemplate,
+      child.instanceId,
+      'child',
+      null,
+      [eventValue],
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      0,
+      child.instanceId,
+      0,
+    ]);
+    expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+  });
+
   it('diffs multiple dynamic children slots independently during hydrate', () => {
     const root = new BackgroundElementTemplateInstance('root');
     const slot0 = new BackgroundElementTemplateSlot();
@@ -820,6 +866,69 @@ describe('hydrate', () => {
 
     expect(stream).toEqual([]);
     expect(root.attributeSlots).toEqual([]);
+  });
+
+  it('prepares background event handlers with the serialized uid before diffing hydrate slots', () => {
+    __etAttrPlanMap.root = [0, adaptEventAttrSlot];
+    const root = new BackgroundElementTemplateInstance('root');
+    const handler = vi.fn();
+    root.setAttribute('attributeSlots', [handler]);
+
+    const stream = hydrate(
+      createHydrationTemplate(-7, 'root', {
+        attributeSlots: ['-7:0:'],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([]);
+    expect(root.attributeSlots).toEqual(['-7:0:']);
+    expect(getEventHandlerForEventValue('-7:0:')).toBe(handler);
+  });
+
+  it('patches a hydrated event value when main thread serialized null but background has a handler', () => {
+    __etAttrPlanMap.root = [0, adaptEventAttrSlot];
+    const root = new BackgroundElementTemplateInstance('root');
+    const handler = vi.fn();
+    root.setAttribute('attributeSlots', [handler]);
+
+    const stream = hydrate(
+      createHydrationTemplate(-8, 'root', {
+        attributeSlots: [null],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      -8,
+      0,
+      '-8:0:',
+    ]);
+    expect(root.attributeSlots).toEqual(['-8:0:']);
+    expect(getEventHandlerForEventValue('-8:0:')).toBe(handler);
+  });
+
+  it('patches null when main thread serialized an event value but background clears the handler', () => {
+    __etAttrPlanMap.root = [0, adaptEventAttrSlot];
+    const root = new BackgroundElementTemplateInstance('root');
+    root.setAttribute('attributeSlots', [false]);
+
+    const stream = hydrate(
+      createHydrationTemplate(-9, 'root', {
+        attributeSlots: ['-9:0:'],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      -9,
+      0,
+      null,
+    ]);
+    expect(root.attributeSlots).toEqual([null]);
+    expect(getEventHandlerForEventValue('-9:0:')).toBeUndefined();
   });
 
   it('skips sparse background slot indexes when checking trailing slots', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -12,10 +12,7 @@ import {
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
-import {
-  clearEventHandlers,
-  getEventHandlerForEventValue,
-} from '../../../../src/element-template/prop-adapters/event.js';
+import { clearEventState, getEventHandlerForEventValue } from '../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateUpdateOps } from '../../../../src/element-template/protocol/opcodes.js';
 import type { SerializedElementTemplate } from '../../../../src/element-template/protocol/types.js';
 import {
@@ -61,7 +58,7 @@ describe('hydrate', () => {
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
     clearEtAttrPlanMap();
-    clearEventHandlers();
+    clearEventState();
     resetElementTemplateCommitState();
     vi.clearAllMocks();
     (globalThis as { __LYNX_REPORT_ERROR_CALLS?: Error[] }).__LYNX_REPORT_ERROR_CALLS = [];

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -9,13 +9,23 @@ import {
   markElementTemplateHydrated,
   resetElementTemplateCommitState,
 } from '../../../../src/element-template/background/commit-hook.js';
+import { destroyElementTemplateBackgroundRuntime } from '../../../../src/element-template/background/destroy.js';
 import {
   BackgroundElementTemplateInstance,
   BackgroundElementTemplateSlot,
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
+import {
+  clearEventHandlers,
+  getEventHandlerForEventValue,
+} from '../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateUpdateOps } from '../../../../src/element-template/protocol/opcodes.js';
+import {
+  __etAttrPlanMap,
+  adaptEventAttrSlot,
+  clearEtAttrPlanMap,
+} from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 
 function createTextNode(text: string): BackgroundElementTemplateInstance {
   return new BackgroundElementTemplateInstance(BUILTIN_RAW_TEXT_TEMPLATE_KEY, [text]);
@@ -25,6 +35,8 @@ describe('BackgroundElementTemplateInstance', () => {
   beforeEach(() => {
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
+    clearEtAttrPlanMap();
+    clearEventHandlers();
     resetElementTemplateCommitState();
   });
 
@@ -720,6 +732,14 @@ describe('Background raw-text instance', () => {
 });
 
 describe('BackgroundElementTemplateInstance Shadow State', () => {
+  beforeEach(() => {
+    backgroundElementTemplateInstanceManager.clear();
+    backgroundElementTemplateInstanceManager.nextId = 0;
+    clearEtAttrPlanMap();
+    clearEventHandlers();
+    resetElementTemplateCommitState();
+  });
+
   it('should cache attributeSlots without decoding compiled template attrs', () => {
     const instance = new BackgroundElementTemplateInstance('view');
     const slots = ['logo.png', { id: 'ignored' }] as const;
@@ -737,6 +757,16 @@ describe('BackgroundElementTemplateInstance Shadow State', () => {
     expect(instance.attributeSlots).toEqual(slots);
   });
 
+  it('keeps raw initial planned attribute slots for later native prepare', () => {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view', [true]);
+    instance.instanceId = -10;
+
+    instance.prepareAttributeSlotsForNative();
+
+    expect(instance.attributeSlots).toEqual(['-10:0:']);
+  });
+
   it('emits null when an existing attribute slot is removed after hydration', () => {
     const instance = new BackgroundElementTemplateInstance('view', ['old']);
     instance.emitCreate();
@@ -752,6 +782,147 @@ describe('BackgroundElementTemplateInstance Shadow State', () => {
       0,
       null,
     ]);
+  });
+
+  it('does not patch equivalent null and undefined attribute slots after hydration', () => {
+    const instance = new BackgroundElementTemplateInstance('view', [null]);
+    instance.emitCreate();
+    markElementTemplateHydrated();
+    globalCommitContext.ops = [];
+
+    instance.setAttribute('attributeSlots', [undefined]);
+
+    expect(instance.attributeSlots).toEqual([null]);
+    expect(globalCommitContext.ops).toEqual([]);
+  });
+
+  it('prepares event attribute slots after hydration and registers the handler by event value', () => {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    instance.emitCreate();
+    markElementTemplateHydrated();
+    globalCommitContext.ops = [];
+
+    const handler = vi.fn();
+    instance.setAttribute('attributeSlots', [handler]);
+
+    const eventValue = `${instance.instanceId}:0:`;
+    expect(instance.attributeSlots).toEqual([eventValue]);
+    expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      instance.instanceId,
+      0,
+      eventValue,
+    ]);
+  });
+
+  it('updates the event handler registry without patching native when the event value is unchanged', () => {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    instance.emitCreate();
+    markElementTemplateHydrated();
+
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+    instance.setAttribute('attributeSlots', [firstHandler]);
+    globalCommitContext.ops = [];
+
+    instance.setAttribute('attributeSlots', [secondHandler]);
+
+    const eventValue = `${instance.instanceId}:0:`;
+    expect(instance.attributeSlots).toEqual([eventValue]);
+    expect(getEventHandlerForEventValue(eventValue)).toBe(secondHandler);
+    expect(globalCommitContext.ops).toEqual([]);
+  });
+
+  it('drops a stale handler when an event slot becomes a non-function marker', () => {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    instance.emitCreate();
+    markElementTemplateHydrated();
+
+    const handler = vi.fn();
+    instance.setAttribute('attributeSlots', [handler]);
+    const eventValue = `${instance.instanceId}:0:`;
+    globalCommitContext.ops = [];
+
+    instance.setAttribute('attributeSlots', [true]);
+
+    expect(instance.attributeSlots).toEqual([eventValue]);
+    expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+    expect(globalCommitContext.ops).toEqual([]);
+  });
+
+  it('removes the registered event handler and patches null when the event slot is cleared', () => {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    instance.emitCreate();
+    markElementTemplateHydrated();
+
+    const handler = vi.fn();
+    instance.setAttribute('attributeSlots', [handler]);
+    const eventValue = `${instance.instanceId}:0:`;
+    globalCommitContext.ops = [];
+
+    instance.setAttribute('attributeSlots', [false]);
+
+    expect(instance.attributeSlots).toEqual([null]);
+    expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      instance.instanceId,
+      0,
+      null,
+    ]);
+  });
+
+  it('emits prepared event values instead of handler functions in create payloads', () => {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    markElementTemplateHydrated();
+    const instance = new BackgroundElementTemplateInstance('view');
+    const handler = vi.fn();
+    instance.setAttribute('attributeSlots', [handler]);
+    globalCommitContext.ops = [];
+
+    instance.emitCreate();
+
+    const eventValue = `${instance.instanceId}:0:`;
+    expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.createTemplate,
+      instance.instanceId,
+      'view',
+      null,
+      [eventValue],
+      [],
+    ]);
+  });
+
+  it('clears event handlers owned by an instance when it is torn down', () => {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    markElementTemplateHydrated();
+    const instance = new BackgroundElementTemplateInstance('view');
+    const handler = vi.fn();
+    instance.setAttribute('attributeSlots', [handler]);
+    const eventValue = `${instance.instanceId}:0:`;
+
+    instance.tearDown();
+
+    expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+  });
+
+  it('clears event handlers when the background runtime is destroyed', () => {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    markElementTemplateHydrated();
+    const instance = new BackgroundElementTemplateInstance('view');
+    const handler = vi.fn();
+    instance.setAttribute('attributeSlots', [handler]);
+    const eventValue = `${instance.instanceId}:0:`;
+
+    destroyElementTemplateBackgroundRuntime();
+
+    expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
   });
 });
 

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -16,10 +16,7 @@ import {
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
-import {
-  clearEventHandlers,
-  getEventHandlerForEventValue,
-} from '../../../../src/element-template/prop-adapters/event.js';
+import { clearEventState, getEventHandlerForEventValue } from '../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateUpdateOps } from '../../../../src/element-template/protocol/opcodes.js';
 import {
   __etAttrPlanMap,
@@ -36,7 +33,7 @@ describe('BackgroundElementTemplateInstance', () => {
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
     clearEtAttrPlanMap();
-    clearEventHandlers();
+    clearEventState();
     resetElementTemplateCommitState();
   });
 
@@ -736,7 +733,7 @@ describe('BackgroundElementTemplateInstance Shadow State', () => {
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
     clearEtAttrPlanMap();
-    clearEventHandlers();
+    clearEventState();
     resetElementTemplateCommitState();
   });
 
@@ -796,7 +793,7 @@ describe('BackgroundElementTemplateInstance Shadow State', () => {
     expect(globalCommitContext.ops).toEqual([]);
   });
 
-  it('prepares event attribute slots after hydration and registers the handler by event value', () => {
+  it('prepares event attribute slots after hydration and resolves the handler by event value', () => {
     __etAttrPlanMap.view = [0, adaptEventAttrSlot];
     const instance = new BackgroundElementTemplateInstance('view');
     instance.emitCreate();
@@ -817,7 +814,7 @@ describe('BackgroundElementTemplateInstance Shadow State', () => {
     ]);
   });
 
-  it('updates the event handler registry without patching native when the event value is unchanged', () => {
+  it('uses the latest raw event handler without patching native when the event value is unchanged', () => {
     __etAttrPlanMap.view = [0, adaptEventAttrSlot];
     const instance = new BackgroundElementTemplateInstance('view');
     instance.emitCreate();
@@ -854,7 +851,7 @@ describe('BackgroundElementTemplateInstance Shadow State', () => {
     expect(globalCommitContext.ops).toEqual([]);
   });
 
-  it('removes the registered event handler and patches null when the event slot is cleared', () => {
+  it('removes the raw event handler and patches null when the event slot is cleared', () => {
     __etAttrPlanMap.view = [0, adaptEventAttrSlot];
     const instance = new BackgroundElementTemplateInstance('view');
     instance.emitCreate();

--- a/packages/react/runtime/__test__/element-template/runtime/background/manager.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/manager.test.ts
@@ -57,6 +57,36 @@ describe('BackgroundElementTemplateInstanceManager', () => {
       .toThrow('ElementTemplate instance 99999 is not registered.');
   });
 
+  it('rejects invalid event values', () => {
+    expect(() => backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('1:2:3:4'))
+      .toThrow('Invalid ElementTemplate event value: 1:2:3:4');
+  });
+
+  it('resolves event values for spread attributes', () => {
+    const handler = () => {};
+    const instance = new BackgroundElementTemplateInstance('view', [{
+      bindtap: handler,
+    }]);
+
+    expect(
+      backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(`${instance.instanceId}:0:bindtap`),
+    )
+      .toBe(handler);
+    expect(
+      backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(`${instance.instanceId}:0:missing`),
+    )
+      .toBeUndefined();
+  });
+
+  it('ignores spread event values for non-object attributes', () => {
+    const instance = new BackgroundElementTemplateInstance('view', ['plain']);
+
+    expect(
+      backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(`${instance.instanceId}:0:bindtap`),
+    )
+      .toBeUndefined();
+  });
+
   it('should clear all instances', () => {
     const instance = new BackgroundElementTemplateInstance('view');
     expect(backgroundElementTemplateInstanceManager.get(instance.instanceId)).toBe(instance);

--- a/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
@@ -21,6 +21,7 @@ import { root } from '../../../../../src/element-template/index.js';
 import {
   clearEventHandlers,
   getEventHandlerForEventValue,
+  publishEvent,
 } from '../../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateLifecycleConstant } from '../../../../../src/element-template/protocol/lifecycle-constant.js';
 import { ElementTemplateUpdateOps } from '../../../../../src/element-template/protocol/opcodes.js';
@@ -381,6 +382,25 @@ describe('Compiled background Preact updates', () => {
       envManager.switchToBackground();
       expect(host.attributeSlots).toEqual([null]);
       expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+    });
+
+    it('dispatches native event values to the latest hydrated direct event handler', async () => {
+      const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
+      const firstHandler = vi.fn();
+      const secondHandler = vi.fn();
+
+      const host = renderDirectEventOnBackground(backgroundModule, firstHandler);
+      hydrateDirectEventFromMainThread(mainModule, firstHandler);
+      const eventValue = `${host.instanceId}:0:`;
+
+      publishEvent(eventValue, { type: 'tap', phase: 'first' });
+
+      renderDirectEventOnBackground(backgroundModule, secondHandler);
+      publishEvent(eventValue, { type: 'tap', phase: 'second' });
+
+      expect(firstHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'first' });
+      expect(firstHandler).toHaveBeenCalledTimes(1);
+      expect(secondHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'second' });
     });
   });
 });

--- a/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createElement } from 'preact';
 
 import {
@@ -18,12 +18,17 @@ import {
 } from '../../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../../src/element-template/background/manager.js';
 import { root } from '../../../../../src/element-template/index.js';
+import {
+  clearEventHandlers,
+  getEventHandlerForEventValue,
+} from '../../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateLifecycleConstant } from '../../../../../src/element-template/protocol/lifecycle-constant.js';
 import { ElementTemplateUpdateOps } from '../../../../../src/element-template/protocol/opcodes.js';
 import type {
   ElementTemplateUpdateCommandStream,
   ElementTemplateUpdateCommitContext,
 } from '../../../../../src/element-template/protocol/types.js';
+import { clearEtAttrPlanMap } from '../../../../../src/element-template/runtime/template/attr-slot-plan.js';
 import { __root } from '../../../../../src/element-template/runtime/page/root-instance.js';
 import { compileFixtureSource } from '../../../test-utils/debug/compiledFixtureCompiler.js';
 import {
@@ -40,10 +45,15 @@ declare const renderPage: () => void;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/background/update');
+const DIRECT_EVENT_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/event/direct-event/index.tsx');
 const SLOT_ID = 0;
 
 interface CompiledKeyedListModule extends CompiledFixtureModuleExports {
   App: (props: { items: string[] }) => JSX.Element;
+}
+
+interface CompiledDirectEventModule extends CompiledFixtureModuleExports {
+  App: (props: { onTap?: () => void }) => JSX.Element;
 }
 
 function getRenderedHost(): BackgroundElementTemplateInstance {
@@ -110,6 +120,20 @@ describe('Compiled background Preact updates', () => {
     return { backgroundModule, mainModule };
   }
 
+  async function loadCompiledDirectEventFixture(): Promise<{
+    backgroundModule: CompiledDirectEventModule;
+    mainModule: CompiledDirectEventModule;
+  }> {
+    const mainArtifact = await compileFixtureSource(DIRECT_EVENT_FIXTURE, { target: 'LEPUS' });
+    primeCompiledFixtureTemplates(mainArtifact);
+    const mainModule = await loadCompiledFixtureModule<CompiledDirectEventModule>(mainArtifact);
+
+    const backgroundArtifact = await compileFixtureSource(DIRECT_EVENT_FIXTURE, { target: 'JS' });
+    const backgroundModule = await loadCompiledFixtureModule<CompiledDirectEventModule>(backgroundArtifact);
+
+    return { backgroundModule, mainModule };
+  }
+
   function renderCompiledOnBackground(
     moduleExports: CompiledKeyedListModule,
     items: readonly string[],
@@ -133,9 +157,34 @@ describe('Compiled background Preact updates', () => {
     return host;
   }
 
+  function renderDirectEventOnBackground(
+    moduleExports: CompiledDirectEventModule,
+    onTap?: () => void,
+  ): BackgroundElementTemplateInstance {
+    envManager.switchToBackground();
+    root.render(createElement(moduleExports.App, { onTap }));
+    return getRenderedHost();
+  }
+
+  function hydrateDirectEventFromMainThread(
+    moduleExports: CompiledDirectEventModule,
+    onTap?: () => void,
+  ): BackgroundElementTemplateInstance {
+    const host = getRenderedHost();
+
+    envManager.switchToMainThread();
+    root.render(createElement(moduleExports.App, { onTap }));
+    renderPage();
+    envManager.switchToBackground();
+
+    return host;
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     resetElementTemplateCommitState();
+    clearEtAttrPlanMap();
+    clearEventHandlers();
     updateEvents = [];
     envManager.resetEnv('background');
     envManager.setUseElementTemplate(true);
@@ -274,6 +323,64 @@ describe('Compiled background Preact updates', () => {
           vi.useRealTimers();
         }
       },
+    });
+  });
+
+  describe('direct events', () => {
+    it('updates the background event registry without dispatching a native patch when only handler identity changes', async () => {
+      const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
+      const firstHandler = vi.fn();
+      const secondHandler = vi.fn();
+
+      const host = renderDirectEventOnBackground(backgroundModule, firstHandler);
+      hydrateDirectEventFromMainThread(mainModule, firstHandler);
+      updateEvents = [];
+
+      renderDirectEventOnBackground(backgroundModule, secondHandler);
+
+      const eventValue = `${host.instanceId}:0:`;
+      envManager.switchToMainThread();
+      expect(updateEvents).toEqual([]);
+      envManager.switchToBackground();
+      expect(host.attributeSlots).toEqual([eventValue]);
+      expect(getEventHandlerForEventValue(eventValue)).toBe(secondHandler);
+    });
+
+    it('uses ordinary setAttribute patches when direct event handlers are added or removed', async () => {
+      const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
+      const handler = vi.fn();
+
+      const host = renderDirectEventOnBackground(backgroundModule);
+      hydrateDirectEventFromMainThread(mainModule);
+      updateEvents = [];
+
+      renderDirectEventOnBackground(backgroundModule, handler);
+
+      const eventValue = `${host.instanceId}:0:`;
+      envManager.switchToMainThread();
+      expect(updateEvents.at(-1)?.ops).toEqual([
+        ElementTemplateUpdateOps.setAttribute,
+        host.instanceId,
+        0,
+        eventValue,
+      ]);
+      envManager.switchToBackground();
+      expect(host.attributeSlots).toEqual([eventValue]);
+      expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+
+      updateEvents = [];
+      renderDirectEventOnBackground(backgroundModule);
+
+      envManager.switchToMainThread();
+      expect(updateEvents.at(-1)?.ops).toEqual([
+        ElementTemplateUpdateOps.setAttribute,
+        host.instanceId,
+        0,
+        null,
+      ]);
+      envManager.switchToBackground();
+      expect(host.attributeSlots).toEqual([null]);
+      expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
     });
   });
 });

--- a/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
@@ -18,11 +18,6 @@ import {
 } from '../../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../../src/element-template/background/manager.js';
 import { root } from '../../../../../src/element-template/index.js';
-import {
-  clearEventHandlers,
-  getEventHandlerForEventValue,
-  publishEvent,
-} from '../../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateLifecycleConstant } from '../../../../../src/element-template/protocol/lifecycle-constant.js';
 import { ElementTemplateUpdateOps } from '../../../../../src/element-template/protocol/opcodes.js';
 import type {
@@ -46,23 +41,10 @@ declare const renderPage: () => void;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/background/update');
-const DIRECT_EVENT_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/event/direct-event/index.tsx');
-const CONDITIONAL_DIRECT_EVENT_FIXTURE = path.resolve(
-  __dirname,
-  '../../../fixtures/background/event/conditional-direct-event/index.tsx',
-);
 const SLOT_ID = 0;
 
 interface CompiledKeyedListModule extends CompiledFixtureModuleExports {
   App: (props: { items: string[] }) => JSX.Element;
-}
-
-interface CompiledDirectEventModule extends CompiledFixtureModuleExports {
-  App: (props: { onTap?: () => void }) => JSX.Element;
-}
-
-interface CompiledConditionalDirectEventModule extends CompiledFixtureModuleExports {
-  App: (props: { show?: boolean; onTap?: () => void }) => JSX.Element;
 }
 
 function getRenderedHost(): BackgroundElementTemplateInstance {
@@ -129,36 +111,6 @@ describe('Compiled background Preact updates', () => {
     return { backgroundModule, mainModule };
   }
 
-  async function loadCompiledDirectEventFixture(): Promise<{
-    backgroundModule: CompiledDirectEventModule;
-    mainModule: CompiledDirectEventModule;
-  }> {
-    const mainArtifact = await compileFixtureSource(DIRECT_EVENT_FIXTURE, { target: 'LEPUS' });
-    primeCompiledFixtureTemplates(mainArtifact);
-    const mainModule = await loadCompiledFixtureModule<CompiledDirectEventModule>(mainArtifact);
-
-    const backgroundArtifact = await compileFixtureSource(DIRECT_EVENT_FIXTURE, { target: 'JS' });
-    const backgroundModule = await loadCompiledFixtureModule<CompiledDirectEventModule>(backgroundArtifact);
-
-    return { backgroundModule, mainModule };
-  }
-
-  async function loadCompiledConditionalDirectEventFixture(): Promise<{
-    backgroundModule: CompiledConditionalDirectEventModule;
-    mainModule: CompiledConditionalDirectEventModule;
-  }> {
-    const mainArtifact = await compileFixtureSource(CONDITIONAL_DIRECT_EVENT_FIXTURE, { target: 'LEPUS' });
-    primeCompiledFixtureTemplates(mainArtifact);
-    const mainModule = await loadCompiledFixtureModule<CompiledConditionalDirectEventModule>(mainArtifact);
-
-    const backgroundArtifact = await compileFixtureSource(CONDITIONAL_DIRECT_EVENT_FIXTURE, { target: 'JS' });
-    const backgroundModule = await loadCompiledFixtureModule<CompiledConditionalDirectEventModule>(
-      backgroundArtifact,
-    );
-
-    return { backgroundModule, mainModule };
-  }
-
   function renderCompiledOnBackground(
     moduleExports: CompiledKeyedListModule,
     items: readonly string[],
@@ -182,59 +134,10 @@ describe('Compiled background Preact updates', () => {
     return host;
   }
 
-  function renderDirectEventOnBackground(
-    moduleExports: CompiledDirectEventModule,
-    onTap?: () => void,
-  ): BackgroundElementTemplateInstance {
-    envManager.switchToBackground();
-    root.render(createElement(moduleExports.App, { onTap }));
-    return getRenderedHost();
-  }
-
-  function hydrateDirectEventFromMainThread(
-    moduleExports: CompiledDirectEventModule,
-    onTap?: () => void,
-  ): BackgroundElementTemplateInstance {
-    const host = getRenderedHost();
-
-    envManager.switchToMainThread();
-    root.render(createElement(moduleExports.App, { onTap }));
-    renderPage();
-    envManager.switchToBackground();
-
-    return host;
-  }
-
-  function renderConditionalDirectEventOnBackground(
-    moduleExports: CompiledConditionalDirectEventModule,
-    show: boolean,
-    onTap?: () => void,
-  ): BackgroundElementTemplateInstance {
-    envManager.switchToBackground();
-    root.render(createElement(moduleExports.App, { show, onTap }));
-    return getRenderedHost();
-  }
-
-  function hydrateConditionalDirectEventFromMainThread(
-    moduleExports: CompiledConditionalDirectEventModule,
-    show: boolean,
-    onTap?: () => void,
-  ): BackgroundElementTemplateInstance {
-    const host = getRenderedHost();
-
-    envManager.switchToMainThread();
-    root.render(createElement(moduleExports.App, { show, onTap }));
-    renderPage();
-    envManager.switchToBackground();
-
-    return host;
-  }
-
   beforeEach(() => {
     vi.clearAllMocks();
     resetElementTemplateCommitState();
     clearEtAttrPlanMap();
-    clearEventHandlers();
     updateEvents = [];
     envManager.resetEnv('background');
     envManager.setUseElementTemplate(true);
@@ -373,151 +276,6 @@ describe('Compiled background Preact updates', () => {
           vi.useRealTimers();
         }
       },
-    });
-  });
-
-  describe('direct events', () => {
-    it('updates the background event registry without dispatching a native patch when only handler identity changes', async () => {
-      const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
-      const firstHandler = vi.fn();
-      const secondHandler = vi.fn();
-
-      const host = renderDirectEventOnBackground(backgroundModule, firstHandler);
-      hydrateDirectEventFromMainThread(mainModule, firstHandler);
-      updateEvents = [];
-
-      renderDirectEventOnBackground(backgroundModule, secondHandler);
-
-      const eventValue = `${host.instanceId}:0:`;
-      envManager.switchToMainThread();
-      expect(updateEvents).toEqual([]);
-      envManager.switchToBackground();
-      expect(host.attributeSlots).toEqual([eventValue]);
-      expect(getEventHandlerForEventValue(eventValue)).toBe(secondHandler);
-    });
-
-    it('uses ordinary setAttribute patches when direct event handlers are added or removed', async () => {
-      const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
-      const handler = vi.fn();
-
-      const host = renderDirectEventOnBackground(backgroundModule);
-      hydrateDirectEventFromMainThread(mainModule);
-      updateEvents = [];
-
-      renderDirectEventOnBackground(backgroundModule, handler);
-
-      const eventValue = `${host.instanceId}:0:`;
-      envManager.switchToMainThread();
-      expect(updateEvents.at(-1)?.ops).toEqual([
-        ElementTemplateUpdateOps.setAttribute,
-        host.instanceId,
-        0,
-        eventValue,
-      ]);
-      envManager.switchToBackground();
-      expect(host.attributeSlots).toEqual([eventValue]);
-      expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
-
-      updateEvents = [];
-      renderDirectEventOnBackground(backgroundModule);
-
-      envManager.switchToMainThread();
-      expect(updateEvents.at(-1)?.ops).toEqual([
-        ElementTemplateUpdateOps.setAttribute,
-        host.instanceId,
-        0,
-        null,
-      ]);
-      envManager.switchToBackground();
-      expect(host.attributeSlots).toEqual([null]);
-      expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
-    });
-
-    it('dispatches native event values to the latest hydrated direct event handler', async () => {
-      const { backgroundModule, mainModule } = await loadCompiledDirectEventFixture();
-      const firstHandler = vi.fn();
-      const secondHandler = vi.fn();
-
-      const host = renderDirectEventOnBackground(backgroundModule, firstHandler);
-      hydrateDirectEventFromMainThread(mainModule, firstHandler);
-      const eventValue = `${host.instanceId}:0:`;
-
-      publishEvent(eventValue, { type: 'tap', phase: 'first' });
-
-      renderDirectEventOnBackground(backgroundModule, secondHandler);
-      publishEvent(eventValue, { type: 'tap', phase: 'second' });
-
-      expect(firstHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'first' });
-      expect(firstHandler).toHaveBeenCalledTimes(1);
-      expect(secondHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'second' });
-    });
-
-    it('registers and dispatches direct events on inserted compiled subtrees', async () => {
-      const { backgroundModule, mainModule } = await loadCompiledConditionalDirectEventFixture();
-      const handler = vi.fn();
-
-      const host = renderConditionalDirectEventOnBackground(backgroundModule, false);
-      hydrateConditionalDirectEventFromMainThread(mainModule, false);
-      updateEvents = [];
-
-      renderConditionalDirectEventOnBackground(backgroundModule, true, handler);
-      const inserted = getSlotChildAt(0, host);
-      const eventValue = `${inserted.instanceId}:0:`;
-
-      envManager.switchToMainThread();
-      expect(updateEvents.at(-1)?.ops).toEqual([
-        ...collectRecursiveCreateCommandStream(inserted),
-        ElementTemplateUpdateOps.insertNode,
-        host.instanceId,
-        SLOT_ID,
-        inserted.instanceId,
-        0,
-      ]);
-      envManager.switchToBackground();
-      expect(inserted.attributeSlots).toEqual([eventValue]);
-      expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
-
-      publishEvent(eventValue, { type: 'tap', phase: 'inserted' });
-
-      expect(handler).toHaveBeenCalledWith({ type: 'tap', phase: 'inserted' });
-    });
-
-    it('cleans direct event handlers when compiled subtrees are removed', async () => {
-      const { backgroundModule, mainModule } = await loadCompiledConditionalDirectEventFixture();
-      const handler = vi.fn();
-
-      const host = renderConditionalDirectEventOnBackground(backgroundModule, true, handler);
-      hydrateConditionalDirectEventFromMainThread(mainModule, true, handler);
-      const removed = getSlotChildAt(0, host);
-      const removedSubtreeHandleIds = collectElementTemplateSubtreeHandleIds(removed);
-      const eventValue = `${removed.instanceId}:0:`;
-      expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
-      updateEvents = [];
-
-      vi.useFakeTimers();
-      try {
-        renderConditionalDirectEventOnBackground(backgroundModule, false);
-
-        envManager.switchToMainThread();
-        expect(updateEvents.at(-1)?.ops).toEqual([
-          ElementTemplateUpdateOps.removeNode,
-          host.instanceId,
-          SLOT_ID,
-          removed.instanceId,
-          removedSubtreeHandleIds,
-        ]);
-        envManager.switchToBackground();
-        expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
-
-        vi.advanceTimersByTime(10000);
-
-        expect(backgroundElementTemplateInstanceManager.get(removed.instanceId)).toBeUndefined();
-        expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
-        publishEvent(eventValue, { type: 'tap', phase: 'removed' });
-        expect(handler).not.toHaveBeenCalledWith({ type: 'tap', phase: 'removed' });
-      } finally {
-        vi.useRealTimers();
-      }
     });
   });
 });

--- a/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
@@ -47,6 +47,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const FIXTURES_DIR = path.resolve(__dirname, '../../../fixtures/background/update');
 const DIRECT_EVENT_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/event/direct-event/index.tsx');
+const CONDITIONAL_DIRECT_EVENT_FIXTURE = path.resolve(
+  __dirname,
+  '../../../fixtures/background/event/conditional-direct-event/index.tsx',
+);
 const SLOT_ID = 0;
 
 interface CompiledKeyedListModule extends CompiledFixtureModuleExports {
@@ -55,6 +59,10 @@ interface CompiledKeyedListModule extends CompiledFixtureModuleExports {
 
 interface CompiledDirectEventModule extends CompiledFixtureModuleExports {
   App: (props: { onTap?: () => void }) => JSX.Element;
+}
+
+interface CompiledConditionalDirectEventModule extends CompiledFixtureModuleExports {
+  App: (props: { show?: boolean; onTap?: () => void }) => JSX.Element;
 }
 
 function getRenderedHost(): BackgroundElementTemplateInstance {
@@ -135,6 +143,22 @@ describe('Compiled background Preact updates', () => {
     return { backgroundModule, mainModule };
   }
 
+  async function loadCompiledConditionalDirectEventFixture(): Promise<{
+    backgroundModule: CompiledConditionalDirectEventModule;
+    mainModule: CompiledConditionalDirectEventModule;
+  }> {
+    const mainArtifact = await compileFixtureSource(CONDITIONAL_DIRECT_EVENT_FIXTURE, { target: 'LEPUS' });
+    primeCompiledFixtureTemplates(mainArtifact);
+    const mainModule = await loadCompiledFixtureModule<CompiledConditionalDirectEventModule>(mainArtifact);
+
+    const backgroundArtifact = await compileFixtureSource(CONDITIONAL_DIRECT_EVENT_FIXTURE, { target: 'JS' });
+    const backgroundModule = await loadCompiledFixtureModule<CompiledConditionalDirectEventModule>(
+      backgroundArtifact,
+    );
+
+    return { backgroundModule, mainModule };
+  }
+
   function renderCompiledOnBackground(
     moduleExports: CompiledKeyedListModule,
     items: readonly string[],
@@ -175,6 +199,31 @@ describe('Compiled background Preact updates', () => {
 
     envManager.switchToMainThread();
     root.render(createElement(moduleExports.App, { onTap }));
+    renderPage();
+    envManager.switchToBackground();
+
+    return host;
+  }
+
+  function renderConditionalDirectEventOnBackground(
+    moduleExports: CompiledConditionalDirectEventModule,
+    show: boolean,
+    onTap?: () => void,
+  ): BackgroundElementTemplateInstance {
+    envManager.switchToBackground();
+    root.render(createElement(moduleExports.App, { show, onTap }));
+    return getRenderedHost();
+  }
+
+  function hydrateConditionalDirectEventFromMainThread(
+    moduleExports: CompiledConditionalDirectEventModule,
+    show: boolean,
+    onTap?: () => void,
+  ): BackgroundElementTemplateInstance {
+    const host = getRenderedHost();
+
+    envManager.switchToMainThread();
+    root.render(createElement(moduleExports.App, { show, onTap }));
     renderPage();
     envManager.switchToBackground();
 
@@ -401,6 +450,74 @@ describe('Compiled background Preact updates', () => {
       expect(firstHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'first' });
       expect(firstHandler).toHaveBeenCalledTimes(1);
       expect(secondHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'second' });
+    });
+
+    it('registers and dispatches direct events on inserted compiled subtrees', async () => {
+      const { backgroundModule, mainModule } = await loadCompiledConditionalDirectEventFixture();
+      const handler = vi.fn();
+
+      const host = renderConditionalDirectEventOnBackground(backgroundModule, false);
+      hydrateConditionalDirectEventFromMainThread(mainModule, false);
+      updateEvents = [];
+
+      renderConditionalDirectEventOnBackground(backgroundModule, true, handler);
+      const inserted = getSlotChildAt(0, host);
+      const eventValue = `${inserted.instanceId}:0:`;
+
+      envManager.switchToMainThread();
+      expect(updateEvents.at(-1)?.ops).toEqual([
+        ...collectRecursiveCreateCommandStream(inserted),
+        ElementTemplateUpdateOps.insertNode,
+        host.instanceId,
+        SLOT_ID,
+        inserted.instanceId,
+        0,
+      ]);
+      envManager.switchToBackground();
+      expect(inserted.attributeSlots).toEqual([eventValue]);
+      expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+
+      publishEvent(eventValue, { type: 'tap', phase: 'inserted' });
+
+      expect(handler).toHaveBeenCalledWith({ type: 'tap', phase: 'inserted' });
+    });
+
+    it('cleans direct event handlers when compiled subtrees are removed', async () => {
+      const { backgroundModule, mainModule } = await loadCompiledConditionalDirectEventFixture();
+      const handler = vi.fn();
+
+      const host = renderConditionalDirectEventOnBackground(backgroundModule, true, handler);
+      hydrateConditionalDirectEventFromMainThread(mainModule, true, handler);
+      const removed = getSlotChildAt(0, host);
+      const removedSubtreeHandleIds = collectElementTemplateSubtreeHandleIds(removed);
+      const eventValue = `${removed.instanceId}:0:`;
+      expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+      updateEvents = [];
+
+      vi.useFakeTimers();
+      try {
+        renderConditionalDirectEventOnBackground(backgroundModule, false);
+
+        envManager.switchToMainThread();
+        expect(updateEvents.at(-1)?.ops).toEqual([
+          ElementTemplateUpdateOps.removeNode,
+          host.instanceId,
+          SLOT_ID,
+          removed.instanceId,
+          removedSubtreeHandleIds,
+        ]);
+        envManager.switchToBackground();
+        expect(getEventHandlerForEventValue(eventValue)).toBe(handler);
+
+        vi.advanceTimersByTime(10000);
+
+        expect(backgroundElementTemplateInstanceManager.get(removed.instanceId)).toBeUndefined();
+        expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+        publishEvent(eventValue, { type: 'tap', phase: 'removed' });
+        expect(handler).not.toHaveBeenCalledWith({ type: 'tap', phase: 'removed' });
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
@@ -13,9 +13,9 @@ import {
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { PerformanceTimingFlags, PipelineOrigins } from '../../../../src/element-template/lynx/performance.js';
 import {
-  clearEventHandlers,
+  clearEventState,
   publishEvent,
-  resetEventHandlersForRuntime,
+  resetEventStateForRuntime,
 } from '../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateLifecycleConstant } from '../../../../src/element-template/protocol/lifecycle-constant.js';
 import type { SerializedElementTemplate } from '../../../../src/element-template/protocol/types.js';
@@ -53,7 +53,7 @@ describe('ElementTemplate hydration listener', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearEtAttrPlanMap();
-    clearEventHandlers();
+    clearEventState();
     resetElementTemplateHydrationListener();
     envManager.resetEnv('background');
   });
@@ -223,7 +223,7 @@ describe('ElementTemplate hydration listener', () => {
 
   it('flushes queued direct events after hydrate registers serialized handlers', () => {
     __etAttrPlanMap._et_event = [0, adaptEventAttrSlot];
-    resetEventHandlersForRuntime();
+    resetEventStateForRuntime();
     envManager.switchToBackground();
     installElementTemplateHydrationListener();
 

--- a/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
@@ -12,12 +12,21 @@ import {
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { PerformanceTimingFlags, PipelineOrigins } from '../../../../src/element-template/lynx/performance.js';
+import {
+  clearEventHandlers,
+  publishEvent,
+  resetEventHandlersForRuntime,
+} from '../../../../src/element-template/prop-adapters/event.js';
 import { ElementTemplateLifecycleConstant } from '../../../../src/element-template/protocol/lifecycle-constant.js';
 import type { SerializedElementTemplate } from '../../../../src/element-template/protocol/types.js';
 import { __root } from '../../../../src/element-template/runtime/page/root-instance.js';
+import {
+  __etAttrPlanMap,
+  adaptEventAttrSlot,
+  clearEtAttrPlanMap,
+} from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 import { ElementTemplateEnvManager } from '../../test-utils/debug/envManager.js';
 import { flushCoreContextEvents } from '../../test-utils/mock/mockNativePapi/context.js';
-// removed installMockNativePapi import
 
 import '../../../../src/element-template/native/index.js';
 
@@ -43,6 +52,8 @@ describe('ElementTemplate hydration listener', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearEtAttrPlanMap();
+    clearEventHandlers();
     resetElementTemplateHydrationListener();
     envManager.resetEnv('background');
   });
@@ -208,6 +219,39 @@ describe('ElementTemplate hydration listener', () => {
     envManager.switchToBackground();
     expect(backgroundElementTemplateInstanceManager.get(oldId)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(-1)).toBeUndefined();
+  });
+
+  it('flushes queued direct events after hydrate registers serialized handlers', () => {
+    __etAttrPlanMap._et_event = [0, adaptEventAttrSlot];
+    resetEventHandlersForRuntime();
+    envManager.switchToBackground();
+    installElementTemplateHydrationListener();
+
+    const eventData = { type: 'tap' };
+    const handler = vi.fn();
+    const backgroundRoot = __root as BackgroundElementTemplateInstance;
+    const after = new BackgroundElementTemplateInstance('_et_event');
+    after.setAttribute('attributeSlots', [handler]);
+    backgroundRoot.appendChild(after);
+
+    publishEvent('-1:0:', eventData);
+
+    envManager.switchToMainThread();
+    lynx.getJSContext().dispatchEvent({
+      type: ElementTemplateLifecycleConstant.hydrate,
+      data: [
+        {
+          templateKey: '_et_event',
+          attributeSlots: ['-1:0:'],
+          elementSlots: [],
+          uid: -1,
+        } satisfies SerializedElementTemplate,
+      ],
+    });
+
+    envManager.switchToBackground();
+
+    expect(handler).toHaveBeenCalledWith(eventData);
   });
 
   it('marks hydrate performance timings on background thread', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/prop-adapters/event.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/prop-adapters/event.test.ts
@@ -1,25 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { destroyElementTemplateBackgroundRuntime } from '../../../../src/element-template/background/destroy.js';
+import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import {
-  clearEventHandlers,
+  clearEventState,
   flushPendingEvents,
   publicComponentEvent,
   publishEvent,
-  resetEventHandlersForRuntime,
-  setEventHandler,
+  resetEventStateForRuntime,
 } from '../../../../src/element-template/prop-adapters/event.js';
+import {
+  __etAttrPlanMap,
+  adaptEventAttrSlot,
+  clearEtAttrPlanMap,
+} from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 
 describe('ElementTemplate event bridge', () => {
+  function createEventInstance(handleId: number, handler: () => void): BackgroundElementTemplateInstance {
+    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    backgroundElementTemplateInstanceManager.updateId(instance.instanceId, handleId);
+    instance.setAttribute('attributeSlots', [handler]);
+    return instance;
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
-    clearEventHandlers();
+    backgroundElementTemplateInstanceManager.clear();
+    backgroundElementTemplateInstanceManager.nextId = 0;
+    clearEtAttrPlanMap();
+    clearEventState();
   });
 
   it('dispatches publishEvent to the current handler', () => {
     const handler = vi.fn();
     const eventData = { type: 'tap', detail: { x: 1 } };
-    setEventHandler(-1, 0, handler);
+    createEventInstance(-1, handler);
 
     publishEvent('-1:0:', eventData);
 
@@ -29,7 +46,7 @@ describe('ElementTemplate event bridge', () => {
   it('dispatches publicComponentEvent through the same handler lookup', () => {
     const handler = vi.fn();
     const eventData = { type: 'tap' };
-    setEventHandler(-2, 0, handler);
+    createEventInstance(-2, handler);
 
     publicComponentEvent('component-id', '-2:0:', eventData);
 
@@ -42,7 +59,7 @@ describe('ElementTemplate event bridge', () => {
     const reportError = vi.fn();
     lynx.reportError = reportError;
     try {
-      setEventHandler(-3, 0, () => {
+      createEventInstance(-3, () => {
         throw error;
       });
 
@@ -59,13 +76,13 @@ describe('ElementTemplate event bridge', () => {
     const queuedEvent = { type: 'tap', phase: 'before-hydrate' };
     const droppedEvent = { type: 'tap', phase: 'after-hydrate' };
 
-    resetEventHandlersForRuntime();
+    resetEventStateForRuntime();
     publishEvent('-4:0:', queuedEvent);
-    setEventHandler(-4, 0, queuedHandler);
+    createEventInstance(-4, queuedHandler);
     flushPendingEvents();
 
     publishEvent('-5:0:', droppedEvent);
-    setEventHandler(-5, 0, droppedHandler);
+    createEventInstance(-5, droppedHandler);
 
     expect(queuedHandler).toHaveBeenCalledWith(queuedEvent);
     expect(droppedHandler).not.toHaveBeenCalled();
@@ -73,11 +90,11 @@ describe('ElementTemplate event bridge', () => {
 
   it('clears queued events when the background runtime is destroyed', () => {
     const handler = vi.fn();
-    resetEventHandlersForRuntime();
+    resetEventStateForRuntime();
     publishEvent('-6:0:', { type: 'tap' });
 
     destroyElementTemplateBackgroundRuntime();
-    setEventHandler(-6, 0, handler);
+    createEventInstance(-6, handler);
     flushPendingEvents();
 
     expect(handler).not.toHaveBeenCalled();
@@ -85,11 +102,11 @@ describe('ElementTemplate event bridge', () => {
 
   it('does not queue stale native events after the background runtime is destroyed', () => {
     const handler = vi.fn();
-    resetEventHandlersForRuntime();
+    resetEventStateForRuntime();
     destroyElementTemplateBackgroundRuntime();
 
     publishEvent('-7:0:', { type: 'tap' });
-    setEventHandler(-7, 0, handler);
+    createEventInstance(-7, handler);
     flushPendingEvents();
 
     expect(handler).not.toHaveBeenCalled();

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
@@ -8,6 +8,11 @@ import { renderOpcodesIntoElementTemplate } from '../../../../src/element-templa
 import { resetTemplateId } from '../../../../src/element-template/runtime/template/handle.js';
 import { elementTemplateRegistry } from '../../../../src/element-template/runtime/template/registry.js';
 import {
+  __etAttrPlanMap,
+  adaptEventAttrSlot,
+  clearEtAttrPlanMap,
+} from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
+import {
   __OpAttr,
   __OpBegin,
   __OpEnd,
@@ -17,16 +22,21 @@ import {
 
 describe('renderOpcodesIntoElementTemplate', () => {
   const createElementTemplate = vi.fn();
+  const addEvent = vi.fn();
 
   beforeEach(() => {
     createElementTemplate.mockReset();
+    addEvent.mockReset();
     vi.stubGlobal('__CreateElementTemplate', createElementTemplate);
+    vi.stubGlobal('__AddEvent', addEvent);
     elementTemplateRegistry.clear();
+    clearEtAttrPlanMap();
     resetTemplateId();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    clearEtAttrPlanMap();
   });
 
   it('throws when popping the root frame', () => {
@@ -50,6 +60,70 @@ describe('renderOpcodesIntoElementTemplate', () => {
       -1,
     );
     expect(elementTemplateRegistry.get(-1)).toBe(rootTextRef);
+  });
+
+  it('prepares direct event slots before native create', () => {
+    const rootRef = { kind: 'root-ref' };
+    const handleTap = vi.fn();
+    createElementTemplate.mockReturnValue(rootRef);
+    __etAttrPlanMap._et_event = [
+      0,
+      adaptEventAttrSlot,
+      2,
+      adaptEventAttrSlot,
+    ];
+
+    const result = renderOpcodesIntoElementTemplate([
+      __OpBegin,
+      { type: '_et_event' },
+      __OpAttr,
+      'attributeSlots',
+      [handleTap, 'title', 1],
+      __OpEnd,
+    ]);
+
+    expect(result.rootRefs).toEqual([rootRef]);
+    expect(createElementTemplate).toHaveBeenCalledWith(
+      '_et_event',
+      null,
+      ['-1:0:', 'title', '-1:2:'],
+      null,
+      -1,
+    );
+    expect(addEvent).not.toHaveBeenCalled();
+  });
+
+  it('prepares empty direct event values as null before native create', () => {
+    const rootRef = { kind: 'root-ref' };
+    createElementTemplate.mockReturnValue(rootRef);
+    __etAttrPlanMap._et_event = [
+      0,
+      adaptEventAttrSlot,
+      1,
+      adaptEventAttrSlot,
+      2,
+      adaptEventAttrSlot,
+      3,
+      adaptEventAttrSlot,
+    ];
+
+    renderOpcodesIntoElementTemplate([
+      __OpBegin,
+      { type: '_et_event' },
+      __OpAttr,
+      'attributeSlots',
+      [null, undefined, false, true],
+      __OpEnd,
+    ]);
+
+    expect(createElementTemplate).toHaveBeenCalledWith(
+      '_et_event',
+      null,
+      [null, null, null, '-1:3:'],
+      null,
+      -1,
+    );
+    expect(addEvent).not.toHaveBeenCalled();
   });
 
   it('throws when text is emitted outside of an element slot', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  __etAttrPlanMap,
+  clearEtAttrPlanMap,
+  type EtAttrAdapter,
+} from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
+
+describe('ElementTemplate attr slot plan registry', () => {
+  afterEach(() => {
+    clearEtAttrPlanMap();
+  });
+
+  it('uses undefined as the unregistered template fast path', () => {
+    expect(__etAttrPlanMap._et_without_backend_attrs).toBeUndefined();
+  });
+
+  it('keeps the map object stable when clearing test state', () => {
+    const map = __etAttrPlanMap;
+    const adaptSlot: EtAttrAdapter = (_, __, value) => String(value);
+
+    __etAttrPlanMap._et_card = [0, adaptSlot];
+    clearEtAttrPlanMap();
+
+    expect(__etAttrPlanMap).toBe(map);
+    expect(__etAttrPlanMap._et_card).toBeUndefined();
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/template/element-template-handle.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/template/element-template-handle.test.ts
@@ -8,7 +8,7 @@ import {
   setElementTemplateNativeRef,
 } from '../../../../src/element-template/runtime/template/registry.js';
 import {
-  createElementTemplateWithHandle,
+  createElementTemplateWithReservedHandle,
   destroyElementTemplateId,
   reserveElementTemplateId,
 } from '../../../../src/element-template/runtime/template/handle.js';
@@ -44,8 +44,10 @@ describe('ElementTemplateHandle', () => {
     expect(elementTemplateRegistry.get(id)).toBe(mockNativeRef);
   });
 
-  it('should create an element template with handle id and register the native ref', () => {
-    const nativeRef = createElementTemplateWithHandle(
+  it('should create an element template with a reserved handle id and register the native ref', () => {
+    const id = reserveElementTemplateId();
+    const nativeRef = createElementTemplateWithReservedHandle(
+      id,
       '_et_test',
       null,
       ['text'],
@@ -64,8 +66,8 @@ describe('ElementTemplateHandle', () => {
   });
 
   it('should allocate monotonically decreasing handle ids for template creation', () => {
-    createElementTemplateWithHandle('_et_first', null, null, null);
-    createElementTemplateWithHandle('_et_second', null, null, null);
+    createElementTemplateWithReservedHandle(reserveElementTemplateId(), '_et_first', null, null, null);
+    createElementTemplateWithReservedHandle(reserveElementTemplateId(), '_et_second', null, null, null);
 
     expect(mockCreateElementTemplate.mock.calls[0]?.[4]).toEqual(-1);
     expect(mockCreateElementTemplate.mock.calls[1]?.[4]).toEqual(-2);

--- a/packages/react/runtime/src/element-template/background/attr-slots.ts
+++ b/packages/react/runtime/src/element-template/background/attr-slots.ts
@@ -2,10 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { deleteEventHandler, setEventHandler } from '../prop-adapters/event.js';
-import type { EtEventHandler } from '../prop-adapters/event.js';
 import type { SerializableValue } from '../protocol/types.js';
-import { __etAttrPlanMap, adaptEventAttrSlot } from '../runtime/template/attr-slot-plan.js';
+import { __etAttrPlanMap } from '../runtime/template/attr-slot-plan.js';
 import type { EtAttrAdapter } from '../runtime/template/attr-slot-plan.js';
 
 function normalizeAttributeSlots(rawSlots: readonly unknown[]): SerializableValue[] {
@@ -25,43 +23,22 @@ export function prepareAttributeSlots(
   templateKey: string,
   handleId: number,
   rawSlots: readonly unknown[],
-  registerEvents: boolean,
 ): SerializableValue[] {
   const attrPlan = __etAttrPlanMap[templateKey];
   if (!attrPlan || attrPlan.length === 0) {
     return normalizeAttributeSlots(rawSlots);
   }
 
-  const preparedSlots = normalizeAttributeSlots(rawSlots).slice();
+  const normalizedSlots = normalizeAttributeSlots(rawSlots);
+  const preparedSlots = normalizedSlots === rawSlots
+    ? rawSlots.slice() as SerializableValue[]
+    : normalizedSlots;
   for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
     const attrSlotIndex = attrPlan[planIndex] as number;
     const adapter = attrPlan[planIndex + 1] as EtAttrAdapter;
     const rawValue = rawSlots[attrSlotIndex];
     preparedSlots[attrSlotIndex] = adapter(handleId, attrSlotIndex, rawValue);
-
-    if (registerEvents && adapter === adaptEventAttrSlot) {
-      if (typeof rawValue === 'function') {
-        setEventHandler(handleId, attrSlotIndex, rawValue as EtEventHandler);
-      } else {
-        deleteEventHandler(handleId, attrSlotIndex);
-      }
-    }
   }
 
   return preparedSlots;
-}
-
-export function clearAttributeSlotEventHandlers(templateKey: string, handleId: number): void {
-  const attrPlan = __etAttrPlanMap[templateKey];
-  if (!attrPlan || attrPlan.length === 0) {
-    return;
-  }
-
-  for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
-    const attrSlotIndex = attrPlan[planIndex] as number;
-    const adapter = attrPlan[planIndex + 1] as EtAttrAdapter;
-    if (adapter === adaptEventAttrSlot) {
-      deleteEventHandler(handleId, attrSlotIndex);
-    }
-  }
 }

--- a/packages/react/runtime/src/element-template/background/attr-slots.ts
+++ b/packages/react/runtime/src/element-template/background/attr-slots.ts
@@ -1,0 +1,67 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { deleteEventHandler, setEventHandler } from '../prop-adapters/event.js';
+import type { EtEventHandler } from '../prop-adapters/event.js';
+import type { SerializableValue } from '../protocol/types.js';
+import { __etAttrPlanMap, adaptEventAttrSlot } from '../runtime/template/attr-slot-plan.js';
+import type { EtAttrAdapter } from '../runtime/template/attr-slot-plan.js';
+
+function normalizeAttributeSlots(rawSlots: readonly unknown[]): SerializableValue[] {
+  let normalizedSlots: SerializableValue[] | undefined;
+  for (let slotIndex = 0; slotIndex < rawSlots.length; slotIndex += 1) {
+    const rawSlot = rawSlots[slotIndex];
+    if (rawSlot !== undefined) {
+      continue;
+    }
+    normalizedSlots ??= rawSlots.slice() as SerializableValue[];
+    normalizedSlots[slotIndex] = null;
+  }
+  return normalizedSlots ?? rawSlots as SerializableValue[];
+}
+
+export function prepareAttributeSlots(
+  templateKey: string,
+  handleId: number,
+  rawSlots: readonly unknown[],
+  registerEvents: boolean,
+): SerializableValue[] {
+  const attrPlan = __etAttrPlanMap[templateKey];
+  if (!attrPlan || attrPlan.length === 0) {
+    return normalizeAttributeSlots(rawSlots);
+  }
+
+  const preparedSlots = normalizeAttributeSlots(rawSlots).slice();
+  for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
+    const attrSlotIndex = attrPlan[planIndex] as number;
+    const adapter = attrPlan[planIndex + 1] as EtAttrAdapter;
+    const rawValue = rawSlots[attrSlotIndex];
+    preparedSlots[attrSlotIndex] = adapter(handleId, attrSlotIndex, rawValue);
+
+    if (registerEvents && adapter === adaptEventAttrSlot) {
+      if (typeof rawValue === 'function') {
+        setEventHandler(handleId, attrSlotIndex, rawValue as EtEventHandler);
+      } else {
+        deleteEventHandler(handleId, attrSlotIndex);
+      }
+    }
+  }
+
+  return preparedSlots;
+}
+
+export function clearAttributeSlotEventHandlers(templateKey: string, handleId: number): void {
+  const attrPlan = __etAttrPlanMap[templateKey];
+  if (!attrPlan || attrPlan.length === 0) {
+    return;
+  }
+
+  for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
+    const attrSlotIndex = attrPlan[planIndex] as number;
+    const adapter = attrPlan[planIndex + 1] as EtAttrAdapter;
+    if (adapter === adaptEventAttrSlot) {
+      deleteEventHandler(handleId, attrSlotIndex);
+    }
+  }
+}

--- a/packages/react/runtime/src/element-template/background/destroy.ts
+++ b/packages/react/runtime/src/element-template/background/destroy.ts
@@ -5,6 +5,7 @@
 import { cancelElementTemplateRemovedSubtreeCleanup, resetElementTemplateCommitState } from './commit-hook.js';
 import { resetElementTemplateHydrationListener } from './hydration-listener.js';
 import { backgroundElementTemplateInstanceManager } from './manager.js';
+import { clearEventHandlers } from '../prop-adapters/event.js';
 
 export function destroyElementTemplateBackgroundRuntime(): void {
   resetElementTemplateHydrationListener();
@@ -12,5 +13,6 @@ export function destroyElementTemplateBackgroundRuntime(): void {
   // Destroy is the only place that may discard delayed removed subtrees instead
   // of letting the Snapshot-aligned timer tear them down later.
   cancelElementTemplateRemovedSubtreeCleanup();
+  clearEventHandlers();
   backgroundElementTemplateInstanceManager.clear();
 }

--- a/packages/react/runtime/src/element-template/background/destroy.ts
+++ b/packages/react/runtime/src/element-template/background/destroy.ts
@@ -5,7 +5,7 @@
 import { cancelElementTemplateRemovedSubtreeCleanup, resetElementTemplateCommitState } from './commit-hook.js';
 import { resetElementTemplateHydrationListener } from './hydration-listener.js';
 import { backgroundElementTemplateInstanceManager } from './manager.js';
-import { clearEventHandlers } from '../prop-adapters/event.js';
+import { clearEventState } from '../prop-adapters/event.js';
 
 export function destroyElementTemplateBackgroundRuntime(): void {
   resetElementTemplateHydrationListener();
@@ -13,6 +13,6 @@ export function destroyElementTemplateBackgroundRuntime(): void {
   // Destroy is the only place that may discard delayed removed subtrees instead
   // of letting the Snapshot-aligned timer tear them down later.
   cancelElementTemplateRemovedSubtreeCleanup();
-  clearEventHandlers();
+  clearEventState();
   backgroundElementTemplateInstanceManager.clear();
 }

--- a/packages/react/runtime/src/element-template/background/hydrate.ts
+++ b/packages/react/runtime/src/element-template/background/hydrate.ts
@@ -115,6 +115,7 @@ function hydrateInstance(
   if (!bindHydrationHandleId(instance, handleId, serialized.templateKey)) {
     return;
   }
+  instance.prepareAttributeSlotsForNative();
   hydrateAttributeSlots(handleId, serialized.attributeSlots ?? [], instance.attributeSlots);
 
   if (serialized.templateKey === BUILTIN_RAW_TEXT_TEMPLATE_KEY) {
@@ -261,6 +262,7 @@ function emitCreateSubtree(node: BackgroundElementTemplateInstance): void {
       emitCreateSubtree(child);
     }
   }
+  node.prepareAttributeSlotsForNative();
   node.emitCreate();
 }
 

--- a/packages/react/runtime/src/element-template/background/hydration-listener.ts
+++ b/packages/react/runtime/src/element-template/background/hydration-listener.ts
@@ -16,6 +16,7 @@ import { BackgroundElementTemplateInstance } from './instance.js';
 import { formatElementTemplateUpdateCommands, printElementTemplateTreeToString } from '../debug/alog.js';
 import { profileEnd, profileStart } from '../debug/profile.js';
 import { PerformanceTimingFlags, PipelineOrigins, beginPipeline, markTiming } from '../lynx/performance.js';
+import { flushPendingEvents } from '../prop-adapters/event.js';
 import { ElementTemplateLifecycleConstant } from '../protocol/lifecycle-constant.js';
 import type { SerializedElementTemplate } from '../protocol/types.js';
 import { __root } from '../runtime/page/root-instance.js';
@@ -75,7 +76,9 @@ export function installElementTemplateHydrationListener(): void {
 
     markElementTemplateHydrated();
 
-    if (globalCommitContext.ops.length > 0) {
+    const hasHydrateUpdate = globalCommitContext.ops.length > 0;
+    let didDispatchHydrateUpdate = false;
+    if (hasHydrateUpdate) {
       if (typeof __ALOG__ !== 'undefined' && __ALOG__) {
         console.alog?.(
           '[ReactLynxDebug] ElementTemplate hydrate update commands:\n'
@@ -100,10 +103,14 @@ export function installElementTemplateHydrationListener(): void {
             flowIds: globalCommitContext.flowIds,
           },
         });
+        didDispatchHydrateUpdate = true;
       } finally {
         resetGlobalCommitContext();
         scheduleElementTemplateRemovedSubtreeCleanup(removedSubtrees);
       }
+    }
+    if (!hasHydrateUpdate || didDispatchHydrateUpdate) {
+      flushPendingEvents();
     }
   };
 

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { clearAttributeSlotEventHandlers, prepareAttributeSlots as prepareRawAttributeSlots } from './attr-slots.js';
+import { prepareAttributeSlots as prepareRawAttributeSlots } from './attr-slots.js';
 import { globalCommitContext, markRemovedSubtreeForCurrentCommit } from './commit-context.js';
 import { isElementTemplateHydrated } from './commit-hook.js';
 import { backgroundElementTemplateInstanceManager } from './manager.js';
@@ -81,12 +81,7 @@ export class BackgroundElementTemplateInstance {
     this.nodeType = isBuiltinRawTextTemplateKey(type) ? 3 : 1;
     backgroundElementTemplateInstanceManager.register(this);
     if (initialAttributeSlots) {
-      const preparedSlots = prepareRawAttributeSlots(
-        this.type,
-        this.instanceId,
-        initialAttributeSlots,
-        isElementTemplateHydrated(),
-      );
+      const preparedSlots = prepareRawAttributeSlots(this.type, this.instanceId, initialAttributeSlots);
       this.attributeSlots = preparedSlots;
       if (preparedSlots !== initialAttributeSlots) {
         this.rawAttributeSlots = initialAttributeSlots;
@@ -289,9 +284,12 @@ export class BackgroundElementTemplateInstance {
 
     // Remove from manager
     if (this.instanceId) {
-      clearAttributeSlotEventHandlers(this.type, this.instanceId);
       backgroundElementTemplateInstanceManager.values.delete(this.instanceId);
     }
+  }
+
+  getRawAttributeSlot(attrSlotIndex: number): unknown {
+    return this.rawAttributeSlots?.[attrSlotIndex] ?? this.attributeSlots[attrSlotIndex];
   }
 
   markCreateEmittedForHydration(): void {
@@ -308,7 +306,6 @@ export class BackgroundElementTemplateInstance {
       this.type,
       this.instanceId,
       this.rawAttributeSlots,
-      true,
     );
   }
 
@@ -323,7 +320,6 @@ export class BackgroundElementTemplateInstance {
         this.type,
         this.instanceId,
         value,
-        isHydrated,
       );
       this.rawAttributeSlots = nextSlots === value ? undefined : value;
       const maxLength = Math.max(previousSlots.length, nextSlots.length);

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { clearAttributeSlotEventHandlers, prepareAttributeSlots as prepareRawAttributeSlots } from './attr-slots.js';
 import { globalCommitContext, markRemovedSubtreeForCurrentCommit } from './commit-context.js';
 import { isElementTemplateHydrated } from './commit-hook.js';
 import { backgroundElementTemplateInstanceManager } from './manager.js';
@@ -29,12 +30,6 @@ function stringifyRawTextValue(value: SerializableValue | undefined): string {
   return '';
 }
 
-function normalizeAttributeSlots(
-  slots: readonly (SerializableValue | undefined)[],
-): SerializableValue[] {
-  return slots.map((slot) => normalizeAttributeSlotValue(slot));
-}
-
 function syncElementSlotChildren(
   parent: BackgroundElementTemplateInstance | null,
   slotId: number,
@@ -57,8 +52,9 @@ export class BackgroundElementTemplateInstance {
   public previousSibling: BackgroundElementTemplateInstance | null = null;
 
   // Shadow State for Hydration
-  public attributeSlots: SerializableValue[] = [];
+  public attributeSlots: SerializableValue[];
   public elementSlots: BackgroundElementTemplateInstance[][] = [];
+  private rawAttributeSlots: readonly unknown[] | undefined;
   private hasEmittedCreate = false;
 
   get parentNode(): BackgroundElementTemplateInstance | null {
@@ -83,8 +79,21 @@ export class BackgroundElementTemplateInstance {
   ) {
     this.type = type;
     this.nodeType = isBuiltinRawTextTemplateKey(type) ? 3 : 1;
-    this.attributeSlots = initialAttributeSlots ? normalizeAttributeSlots(initialAttributeSlots) : [];
     backgroundElementTemplateInstanceManager.register(this);
+    if (initialAttributeSlots) {
+      const preparedSlots = prepareRawAttributeSlots(
+        this.type,
+        this.instanceId,
+        initialAttributeSlots,
+        isElementTemplateHydrated(),
+      );
+      this.attributeSlots = preparedSlots;
+      if (preparedSlots !== initialAttributeSlots) {
+        this.rawAttributeSlots = initialAttributeSlots;
+      }
+    } else {
+      this.attributeSlots = [];
+    }
   }
 
   emitCreate(): void {
@@ -101,7 +110,7 @@ export class BackgroundElementTemplateInstance {
       this.instanceId,
       this.type,
       null,
-      normalizeAttributeSlots(this.attributeSlots),
+      this.attributeSlots,
       this.elementSlots.map((children) => children.map((child) => child.instanceId)),
     );
     this.hasEmittedCreate = true;
@@ -275,10 +284,12 @@ export class BackgroundElementTemplateInstance {
     this.nextSibling = null;
 
     this.attributeSlots = [];
+    this.rawAttributeSlots = undefined;
     this.elementSlots = [];
 
     // Remove from manager
     if (this.instanceId) {
+      clearAttributeSlotEventHandlers(this.type, this.instanceId);
       backgroundElementTemplateInstanceManager.values.delete(this.instanceId);
     }
   }
@@ -289,12 +300,32 @@ export class BackgroundElementTemplateInstance {
     this.hasEmittedCreate = true;
   }
 
+  prepareAttributeSlotsForNative(): void {
+    if (!this.rawAttributeSlots) {
+      return;
+    }
+    this.attributeSlots = prepareRawAttributeSlots(
+      this.type,
+      this.instanceId,
+      this.rawAttributeSlots,
+      true,
+    );
+  }
+
   setAttribute(key: string, value: unknown): void {
     if (isBuiltinRawTextTemplateKey(this.type) && (key === '0' || key === 'data')) {
       this.text = String(value);
     } else if (key === 'attributeSlots' && Array.isArray(value)) {
       const previousSlots = this.attributeSlots;
-      const nextSlots = normalizeAttributeSlots(value as Array<SerializableValue | undefined>);
+      const isHydrated = isElementTemplateHydrated();
+      const canEmitPatch = isHydrated && !this.isPendingCreate();
+      const nextSlots = prepareRawAttributeSlots(
+        this.type,
+        this.instanceId,
+        value,
+        isHydrated,
+      );
+      this.rawAttributeSlots = nextSlots === value ? undefined : value;
       const maxLength = Math.max(previousSlots.length, nextSlots.length);
       this.attributeSlots = nextSlots;
       for (let slotIndex = 0; slotIndex < maxLength; slotIndex += 1) {
@@ -303,14 +334,14 @@ export class BackgroundElementTemplateInstance {
         if (isDirectOrDeepEqual(previousValue, nextValue)) {
           continue;
         }
-        if (!this.canEmitPatch()) {
+        if (!canEmitPatch) {
           continue;
         }
         pushOp(
           ElementTemplateUpdateOps.setAttribute,
           this.instanceId,
           slotIndex,
-          normalizeAttributeSlotValue(nextValue),
+          nextValue ?? null,
         );
       }
     } else if (key === 'id' && this instanceof BackgroundElementTemplateSlot) {
@@ -336,6 +367,7 @@ export class BackgroundElementTemplateInstance {
     if (this.attributeSlots[0] === text) {
       return;
     }
+    this.rawAttributeSlots = undefined;
     this.attributeSlots = [text];
     if (!this.canEmitPatch()) {
       return;
@@ -409,8 +441,4 @@ function collectChildren(slot: BackgroundElementTemplateSlot): BackgroundElement
     child = child.nextSibling;
   }
   return res;
-}
-
-function normalizeAttributeSlotValue(value: SerializableValue | undefined): SerializableValue | null {
-  return value === undefined ? null : value;
 }

--- a/packages/react/runtime/src/element-template/background/manager.ts
+++ b/packages/react/runtime/src/element-template/background/manager.ts
@@ -10,6 +10,7 @@ export const backgroundElementTemplateInstanceManager: {
   register(instance: BackgroundElementTemplateInstance): void;
   updateId(oldId: number, newId: number): void;
   get(id: number): BackgroundElementTemplateInstance | undefined;
+  getRawAttributeValueByEventValue(eventValue: string): unknown;
   clear(): void;
 } = {
   nextId: 0,
@@ -49,6 +50,28 @@ export const backgroundElementTemplateInstanceManager: {
 
   get(id: number): BackgroundElementTemplateInstance | undefined {
     return this.values.get(id);
+  },
+
+  getRawAttributeValueByEventValue(eventValue: string): unknown {
+    const parts = eventValue?.split(':');
+    if (!parts || (parts.length !== 2 && parts.length !== 3)) {
+      throw new Error('Invalid ElementTemplate event value: ' + eventValue);
+    }
+
+    const instance = this.values.get(Number(parts[0]));
+    if (!instance) {
+      return null;
+    }
+
+    const value = instance.getRawAttributeSlot(Number(parts[1]));
+    const spreadKey = parts[2];
+    if (!spreadKey) {
+      return value;
+    }
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      return undefined;
+    }
+    return (value as Record<string, unknown>)[spreadKey];
   },
 
   clear(): void {

--- a/packages/react/runtime/src/element-template/index.ts
+++ b/packages/react/runtime/src/element-template/index.ts
@@ -84,4 +84,3 @@ export {
 };
 
 export * from './client/root.js';
-export { __etSlot } from './runtime/components/slot.js';

--- a/packages/react/runtime/src/element-template/internal.ts
+++ b/packages/react/runtime/src/element-template/internal.ts
@@ -54,3 +54,4 @@ export type { Options } from 'preact';
 // export { registerWorkletOnBackground } from '../worklet/hmr.js';
 // export { loadWorkletRuntime } from '@lynx-js/react/worklet-runtime/bindings';
 export { __etSlot } from './runtime/components/slot.js';
+export { __etAttrPlanMap, adaptEventAttrSlot } from './runtime/template/attr-slot-plan.js';

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -14,7 +14,7 @@ import { BackgroundElementTemplateInstance } from '../background/instance.js';
 import { initProfileHook } from '../debug/profile.js';
 import { setupLynxEnv } from '../lynx/env.js';
 import { initTimingAPI } from '../lynx/performance.js';
-import { publicComponentEvent, publishEvent, resetEventHandlersForRuntime } from '../prop-adapters/event.js';
+import { publicComponentEvent, publishEvent, resetEventStateForRuntime } from '../prop-adapters/event.js';
 import { setRoot } from '../runtime/page/root-instance.js';
 
 function init(): void {
@@ -33,7 +33,7 @@ function init(): void {
     setRoot(new BackgroundElementTemplateInstance('root'));
     setupBackgroundElementTemplateDocument();
     installElementTemplateHydrationListener();
-    resetEventHandlersForRuntime();
+    resetEventStateForRuntime();
     lynxCoreInject.tt.callDestroyLifetimeFun = callDestroyLifetimeFun;
     lynxCoreInject.tt.publishEvent = publishEvent;
     lynxCoreInject.tt.publicComponentEvent = publicComponentEvent;

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -14,6 +14,7 @@ import { BackgroundElementTemplateInstance } from '../background/instance.js';
 import { initProfileHook } from '../debug/profile.js';
 import { setupLynxEnv } from '../lynx/env.js';
 import { initTimingAPI } from '../lynx/performance.js';
+import { publicComponentEvent, publishEvent, resetEventHandlersForRuntime } from '../prop-adapters/event.js';
 import { setRoot } from '../runtime/page/root-instance.js';
 
 function init(): void {
@@ -32,7 +33,10 @@ function init(): void {
     setRoot(new BackgroundElementTemplateInstance('root'));
     setupBackgroundElementTemplateDocument();
     installElementTemplateHydrationListener();
+    resetEventHandlersForRuntime();
     lynxCoreInject.tt.callDestroyLifetimeFun = callDestroyLifetimeFun;
+    lynxCoreInject.tt.publishEvent = publishEvent;
+    lynxCoreInject.tt.publicComponentEvent = publicComponentEvent;
     installElementTemplateCommitHook();
     if (process.env['NODE_ENV'] !== 'test') {
       initTimingAPI();

--- a/packages/react/runtime/src/element-template/prop-adapters/event.ts
+++ b/packages/react/runtime/src/element-template/prop-adapters/event.ts
@@ -2,51 +2,40 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { backgroundElementTemplateInstanceManager } from '../background/manager.js';
+
 export type EtEventHandler = (...args: unknown[]) => unknown;
 
-const eventHandlerByEventValue = new Map<string, EtEventHandler>();
 const pendingEvents: Array<[eventValue: string, data: unknown]> = [];
 let queuePendingEvents = false;
 
 function dispatchEvent(eventValue: string, data: unknown): boolean {
-  const handler = eventHandlerByEventValue.get(eventValue);
-  if (!handler) {
+  const handler = backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(eventValue);
+  if (typeof handler !== 'function') {
     return false;
   }
 
   try {
-    handler(data);
+    (handler as EtEventHandler)(data);
   } catch (error) {
     lynx.reportError(error as Error);
   }
   return true;
 }
 
-export function setEventHandler(
-  handleId: number,
-  attrSlotIndex: number,
-  handler: EtEventHandler,
-): void {
-  eventHandlerByEventValue.set(`${handleId}:${attrSlotIndex}:`, handler);
-}
-
-export function deleteEventHandler(handleId: number, attrSlotIndex: number): void {
-  eventHandlerByEventValue.delete(`${handleId}:${attrSlotIndex}:`);
-}
-
-export function clearEventHandlers(): void {
-  eventHandlerByEventValue.clear();
+export function clearEventState(): void {
   pendingEvents.length = 0;
   queuePendingEvents = false;
 }
 
-export function resetEventHandlersForRuntime(): void {
-  clearEventHandlers();
+export function resetEventStateForRuntime(): void {
+  clearEventState();
   queuePendingEvents = true;
 }
 
 export function getEventHandlerForEventValue(eventValue: string): EtEventHandler | undefined {
-  return eventHandlerByEventValue.get(eventValue);
+  const handler = backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(eventValue);
+  return typeof handler === 'function' ? (handler as EtEventHandler) : undefined;
 }
 
 export function publishEvent(eventValue: string, data: unknown): void {

--- a/packages/react/runtime/src/element-template/prop-adapters/event.ts
+++ b/packages/react/runtime/src/element-template/prop-adapters/event.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export type EtEventHandler = (...args: unknown[]) => unknown;
+
+const eventHandlerByEventValue = new Map<string, EtEventHandler>();
+
+export function setEventHandler(
+  handleId: number,
+  attrSlotIndex: number,
+  handler: EtEventHandler,
+): void {
+  eventHandlerByEventValue.set(`${handleId}:${attrSlotIndex}:`, handler);
+}
+
+export function deleteEventHandler(handleId: number, attrSlotIndex: number): void {
+  eventHandlerByEventValue.delete(`${handleId}:${attrSlotIndex}:`);
+}
+
+export function clearEventHandlers(): void {
+  eventHandlerByEventValue.clear();
+}
+
+export function getEventHandlerForEventValue(eventValue: string): EtEventHandler | undefined {
+  return eventHandlerByEventValue.get(eventValue);
+}

--- a/packages/react/runtime/src/element-template/prop-adapters/event.ts
+++ b/packages/react/runtime/src/element-template/prop-adapters/event.ts
@@ -5,6 +5,22 @@
 export type EtEventHandler = (...args: unknown[]) => unknown;
 
 const eventHandlerByEventValue = new Map<string, EtEventHandler>();
+const pendingEvents: Array<[eventValue: string, data: unknown]> = [];
+let queuePendingEvents = false;
+
+function dispatchEvent(eventValue: string, data: unknown): boolean {
+  const handler = eventHandlerByEventValue.get(eventValue);
+  if (!handler) {
+    return false;
+  }
+
+  try {
+    handler(data);
+  } catch (error) {
+    lynx.reportError(error as Error);
+  }
+  return true;
+}
 
 export function setEventHandler(
   handleId: number,
@@ -20,8 +36,43 @@ export function deleteEventHandler(handleId: number, attrSlotIndex: number): voi
 
 export function clearEventHandlers(): void {
   eventHandlerByEventValue.clear();
+  pendingEvents.length = 0;
+  queuePendingEvents = false;
+}
+
+export function resetEventHandlersForRuntime(): void {
+  clearEventHandlers();
+  queuePendingEvents = true;
 }
 
 export function getEventHandlerForEventValue(eventValue: string): EtEventHandler | undefined {
   return eventHandlerByEventValue.get(eventValue);
+}
+
+export function publishEvent(eventValue: string, data: unknown): void {
+  if (dispatchEvent(eventValue, data)) {
+    return;
+  }
+  if (queuePendingEvents) {
+    pendingEvents.push([eventValue, data]);
+  }
+}
+
+export function publicComponentEvent(
+  _componentId: string,
+  eventValue: string,
+  data: unknown,
+): void {
+  publishEvent(eventValue, data);
+}
+
+export function flushPendingEvents(): void {
+  queuePendingEvents = false;
+  if (pendingEvents.length === 0) {
+    return;
+  }
+  const events = pendingEvents.splice(0);
+  for (const [eventValue, data] of events) {
+    dispatchEvent(eventValue, data);
+  }
 }

--- a/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
@@ -4,7 +4,13 @@
 
 import { __OpAttr, __OpBegin, __OpEnd, __OpSlot, __OpText } from './render-to-opcodes.js';
 import type { SerializableValue } from '../../protocol/types.js';
-import { createElementTemplateWithHandle } from '../template/handle.js';
+import { __etAttrPlanMap } from '../template/attr-slot-plan.js';
+import type { EtAttrAdapter } from '../template/attr-slot-plan.js';
+import {
+  createElementTemplateWithHandle,
+  createElementTemplateWithReservedHandle,
+  reserveElementTemplateId,
+} from '../template/handle.js';
 
 const BUILTIN_RAW_TEXT_TEMPLATE_KEY = '_et_builtin_raw_text';
 
@@ -89,12 +95,35 @@ export function renderOpcodesIntoElementTemplate(
         const parentTemplateKey = templateKeyStack[stackTop];
         const parentActiveElementSlot = activeElementSlotStack[stackTop];
 
-        const elementRef = createElementTemplateWithHandle(
-          concreteTemplateKey,
-          null,
-          attributeSlots ?? null,
-          elementSlots ?? null,
-        );
+        const attrPlan = __etAttrPlanMap[concreteTemplateKey];
+        let elementRef: ElementRef;
+        if (attrPlan === undefined) {
+          elementRef = createElementTemplateWithHandle(
+            concreteTemplateKey,
+            null,
+            attributeSlots ?? null,
+            elementSlots ?? null,
+          );
+        } else {
+          const handleId = reserveElementTemplateId();
+          const preparedAttributeSlots = attributeSlots?.slice() ?? [];
+          for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
+            const attrSlotIndex = attrPlan[planIndex] as number;
+            const adapter = attrPlan[planIndex + 1] as EtAttrAdapter;
+            preparedAttributeSlots[attrSlotIndex] = adapter(
+              handleId,
+              attrSlotIndex,
+              preparedAttributeSlots[attrSlotIndex],
+            );
+          }
+          elementRef = createElementTemplateWithReservedHandle(
+            handleId,
+            concreteTemplateKey,
+            null,
+            preparedAttributeSlots,
+            elementSlots ?? null,
+          );
+        }
         appendChildToParent(parentTemplateKey, parentActiveElementSlot, rootRefs, elementRef);
 
         i += 1;

--- a/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
@@ -6,11 +6,7 @@ import { __OpAttr, __OpBegin, __OpEnd, __OpSlot, __OpText } from './render-to-op
 import type { SerializableValue } from '../../protocol/types.js';
 import { __etAttrPlanMap } from '../template/attr-slot-plan.js';
 import type { EtAttrAdapter } from '../template/attr-slot-plan.js';
-import {
-  createElementTemplateWithHandle,
-  createElementTemplateWithReservedHandle,
-  reserveElementTemplateId,
-} from '../template/handle.js';
+import { createElementTemplateWithReservedHandle, reserveElementTemplateId } from '../template/handle.js';
 
 const BUILTIN_RAW_TEXT_TEMPLATE_KEY = '_et_builtin_raw_text';
 
@@ -96,16 +92,17 @@ export function renderOpcodesIntoElementTemplate(
         const parentActiveElementSlot = activeElementSlotStack[stackTop];
 
         const attrPlan = __etAttrPlanMap[concreteTemplateKey];
+        const handleId = reserveElementTemplateId();
         let elementRef: ElementRef;
         if (attrPlan === undefined) {
-          elementRef = createElementTemplateWithHandle(
+          elementRef = createElementTemplateWithReservedHandle(
+            handleId,
             concreteTemplateKey,
             null,
             attributeSlots ?? null,
             elementSlots ?? null,
           );
         } else {
-          const handleId = reserveElementTemplateId();
           const preparedAttributeSlots = attributeSlots?.slice() ?? [];
           for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
             const attrSlotIndex = attrPlan[planIndex] as number;
@@ -148,7 +145,9 @@ export function renderOpcodesIntoElementTemplate(
       }
       case __OpText: {
         const text = opcodes[i + 1] as string;
-        const textRef = createElementTemplateWithHandle(
+        const handleId = reserveElementTemplateId();
+        const textRef = createElementTemplateWithReservedHandle(
+          handleId,
           BUILTIN_RAW_TEXT_TEMPLATE_KEY,
           null,
           [String(text)],

--- a/packages/react/runtime/src/element-template/runtime/template/attr-slot-plan.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/attr-slot-plan.ts
@@ -1,0 +1,28 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { SerializableValue } from '../../protocol/types.js';
+
+export type EtAttrAdapter = (
+  handleId: number,
+  attrSlotIndex: number,
+  value: unknown,
+) => SerializableValue | null;
+
+export type EtAttrPlan = Array<number | EtAttrAdapter>;
+
+export type EtAttrPlanMap = Record<
+  string,
+  EtAttrPlan | undefined
+>;
+
+export const __etAttrPlanMap = Object.create(null) as EtAttrPlanMap;
+
+export function clearEtAttrPlanMap(): void {
+  // The compiled output assigns into the exported side table directly, so the
+  // object identity must stay stable when tests or teardown clear state.
+  for (const templateKey in __etAttrPlanMap) {
+    delete __etAttrPlanMap[templateKey];
+  }
+}

--- a/packages/react/runtime/src/element-template/runtime/template/attr-slot-plan.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/attr-slot-plan.ts
@@ -10,7 +10,7 @@ export type EtAttrAdapter = (
   value: unknown,
 ) => SerializableValue | null;
 
-export type EtAttrPlan = Array<number | EtAttrAdapter>;
+export type EtAttrPlan = (number | EtAttrAdapter)[];
 
 export type EtAttrPlanMap = Record<
   string,
@@ -18,6 +18,17 @@ export type EtAttrPlanMap = Record<
 >;
 
 export const __etAttrPlanMap = Object.create(null) as EtAttrPlanMap;
+
+export function adaptEventAttrSlot(
+  handleId: number,
+  attrSlotIndex: number,
+  value: unknown,
+): SerializableValue | null {
+  if (value === null || value === undefined || value === false) {
+    return null;
+  }
+  return `${handleId}:${attrSlotIndex}:`;
+}
 
 export function clearEtAttrPlanMap(): void {
   // The compiled output assigns into the exported side table directly, so the

--- a/packages/react/runtime/src/element-template/runtime/template/handle.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/handle.ts
@@ -19,7 +19,23 @@ export function createElementTemplateWithHandle(
   attributeSlots: SerializableValue[] | null | undefined,
   elementSlots: ElementRef[][] | null | undefined,
 ): ElementRef {
-  const handleId = nextId--;
+  const handleId = reserveElementTemplateId();
+  return createElementTemplateWithReservedHandle(
+    handleId,
+    templateKey,
+    bundleUrl,
+    attributeSlots,
+    elementSlots,
+  );
+}
+
+export function createElementTemplateWithReservedHandle(
+  handleId: number,
+  templateKey: string,
+  bundleUrl: string | null | undefined,
+  attributeSlots: SerializableValue[] | null | undefined,
+  elementSlots: ElementRef[][] | null | undefined,
+): ElementRef {
   const nativeRef = __CreateElementTemplate(
     templateKey,
     bundleUrl,

--- a/packages/react/runtime/src/element-template/runtime/template/handle.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/handle.ts
@@ -13,22 +13,6 @@ export function reserveElementTemplateId(): number {
   return id;
 }
 
-export function createElementTemplateWithHandle(
-  templateKey: string,
-  bundleUrl: string | null | undefined,
-  attributeSlots: SerializableValue[] | null | undefined,
-  elementSlots: ElementRef[][] | null | undefined,
-): ElementRef {
-  const handleId = reserveElementTemplateId();
-  return createElementTemplateWithReservedHandle(
-    handleId,
-    templateKey,
-    bundleUrl,
-    attributeSlots,
-    elementSlots,
-  );
-}
-
 export function createElementTemplateWithReservedHandle(
   handleId: number,
   templateKey: string,

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -27,7 +27,8 @@ mod template_definition;
 mod template_slot;
 
 pub use self::asset::ElementTemplateAsset;
-use self::extractor::{ElementTemplateExtractor, ExtractedTemplateParts};
+use self::attr_name::AttrName;
+use self::extractor::{DynamicAttributePart, ElementTemplateExtractor, ExtractedTemplateParts};
 use self::lowering::LoweredRuntimeJsx;
 use self::template_slot::ET_SLOT_PLACEHOLDER_TAG;
 
@@ -54,6 +55,45 @@ fn lazy_runtime_id(init: impl FnOnce() -> Expr + 'static) -> Lazy<Expr, RuntimeI
   Lazy::new(Box::new(init))
 }
 
+fn require_runtime_id(runtime_pkg: String) -> Lazy<Expr, RuntimeIdInitializer> {
+  lazy_runtime_id(move || {
+    Expr::Call(CallExpr {
+      ctxt: SyntaxContext::default(),
+      span: DUMMY_SP,
+      callee: Callee::Expr(Box::new(Expr::Ident(
+        IdentName::new("require".into(), DUMMY_SP).into(),
+      ))),
+      args: vec![ExprOrSpread {
+        spread: None,
+        expr: Box::new(Expr::Lit(Lit::Str(Str {
+          span: DUMMY_SP,
+          value: runtime_pkg.into(),
+          raw: None,
+        }))),
+      }],
+      type_args: None,
+    })
+  })
+}
+
+fn internal_runtime_pkg(runtime_pkg: &str) -> String {
+  const INTERNAL_SUFFIXES: &[&str] = &[
+    "/internal",
+    "/internal.ts",
+    "/internal.js",
+    "/internal.mjs",
+    "/internal.cjs",
+  ];
+  if INTERNAL_SUFFIXES
+    .iter()
+    .any(|suffix| runtime_pkg.ends_with(suffix))
+  {
+    runtime_pkg.to_string()
+  } else {
+    format!("{runtime_pkg}/internal")
+  }
+}
+
 /// @internal
 #[derive(Deserialize, PartialEq, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -75,6 +115,8 @@ impl Default for JSXTransformerConfig {
   fn default() -> Self {
     Self {
       preserve_jsx: false,
+      // Keep the authored runtime package stable. rspeedy aliases
+      // `@lynx-js/react` to the ET entry when Element Template is enabled.
       runtime_pkg: "@lynx-js/react".into(),
       jsx_import_source: Some("@lynx-js/react".into()),
       filename: Default::default(),
@@ -93,6 +135,7 @@ where
   filename_hash: String,
   pub content_hash: String,
   runtime_id: Lazy<Expr, RuntimeIdInitializer>,
+  internal_runtime_id: Lazy<Expr, RuntimeIdInitializer>,
   pub element_templates: Option<Rc<RefCell<Vec<ElementTemplateAsset>>>>,
   template_counter: u32,
   current_template_defs: Vec<ModuleItem>,
@@ -131,28 +174,20 @@ where
       content_hash: "test".into(),
       runtime_id: match mode {
         TransformMode::Development => {
-          let runtime_pkg = format!("{}/internal", cfg.runtime_pkg);
-          lazy_runtime_id(move || {
-            Expr::Call(CallExpr {
-              ctxt: SyntaxContext::default(),
-              span: DUMMY_SP,
-              callee: Callee::Expr(Box::new(Expr::Ident(
-                IdentName::new("require".into(), DUMMY_SP).into(),
-              ))),
-              args: vec![ExprOrSpread {
-                spread: None,
-                expr: Box::new(Expr::Lit(Lit::Str(Str {
-                  span: DUMMY_SP,
-                  value: runtime_pkg.into(),
-                  raw: None,
-                }))),
-              }],
-              type_args: None,
-            })
-          })
+          let runtime_pkg = cfg.runtime_pkg.clone();
+          require_runtime_id(runtime_pkg)
         }
         TransformMode::Production | TransformMode::Test => {
           lazy_runtime_id(|| Expr::Ident(private_ident!("ReactLynx")))
+        }
+      },
+      internal_runtime_id: match mode {
+        TransformMode::Development => {
+          let runtime_pkg = internal_runtime_pkg(&cfg.runtime_pkg);
+          require_runtime_id(runtime_pkg)
+        }
+        TransformMode::Production | TransformMode::Test => {
+          lazy_runtime_id(|| Expr::Ident(private_ident!("ReactLynxInternal")))
         }
       },
       element_templates,
@@ -262,6 +297,18 @@ where
       extractor.into_extracted_template_parts()
     };
 
+    let event_attr_plan_slots = dynamic_attrs
+      .iter()
+      .filter_map(|dynamic_attr| match dynamic_attr {
+        DynamicAttributePart::Attr {
+          attr_name: AttrName::Event,
+          slot_index,
+          ..
+        } => Some(*slot_index),
+        _ => None,
+      })
+      .collect::<Vec<_>>();
+
     let LoweredRuntimeJsx {
       attrs: rendered_attrs,
       children: rendered_children,
@@ -285,6 +332,36 @@ where
         entry_template_uid: Expr = entry_template_uid.clone(),
     ));
     self.current_template_defs.push(entry_template_uid_def);
+    if !event_attr_plan_slots.is_empty() {
+      let internal_runtime_id = self.internal_runtime_id.clone();
+      let mut attr_plan_elements = Vec::with_capacity(event_attr_plan_slots.len() * 2);
+      for slot_index in event_attr_plan_slots {
+        attr_plan_elements.push(Some(ExprOrSpread {
+          spread: None,
+          expr: Box::new(i32_to_expr(&slot_index)),
+        }));
+        attr_plan_elements.push(Some(ExprOrSpread {
+          spread: None,
+          expr: Box::new(quote!(
+            "$internal_runtime_id.adaptEventAttrSlot" as Expr,
+            internal_runtime_id: Expr = internal_runtime_id.clone(),
+          )),
+        }));
+      }
+
+      let attr_plan_expr = Expr::Array(ArrayLit {
+        span: DUMMY_SP,
+        elems: attr_plan_elements,
+      });
+      let attr_plan_def = ModuleItem::Stmt(quote!(
+          r#"$internal_runtime_id.__etAttrPlanMap[$template_ident] = $attr_plan_expr"#
+              as Stmt,
+          internal_runtime_id: Expr = internal_runtime_id.clone(),
+          template_ident: Expr = Expr::Ident(template_ident.clone()),
+          attr_plan_expr: Expr = attr_plan_expr,
+      ));
+      self.current_template_defs.push(attr_plan_def);
+    }
 
     let mut dynamic_attr_slot_cursor: usize = 0;
     let mut element_slot_index: i32 = 0;
@@ -378,6 +455,26 @@ where
         })),
       );
     }
+    if let Some(Expr::Ident(internal_runtime_id)) = Lazy::get(&self.internal_runtime_id) {
+      prepend_stmt(
+        &mut n.body,
+        ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+          span: DUMMY_SP,
+          specifiers: vec![ImportSpecifier::Namespace(ImportStarAsSpecifier {
+            span: DUMMY_SP,
+            local: internal_runtime_id.clone(),
+          })],
+          src: Box::new(Str {
+            span: DUMMY_SP,
+            raw: None,
+            value: internal_runtime_pkg(&self.cfg.runtime_pkg).into(),
+          }),
+          type_only: Default::default(),
+          with: Default::default(),
+          phase: ImportPhase::Evaluation,
+        })),
+      );
+    }
 
     if self.used_slot {
       prepend_stmt(
@@ -397,7 +494,7 @@ where
           src: Box::new(Str {
             span: DUMMY_SP,
             raw: None,
-            value: self.cfg.runtime_pkg.clone().into(),
+            value: internal_runtime_pkg(&self.cfg.runtime_pkg).into(),
           }),
           type_only: Default::default(),
           with: Default::default(),

--- a/packages/react/transform/crates/swc_plugin_element_template/lowering.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lowering.rs
@@ -24,7 +24,7 @@ where
   pub(super) fn lower_runtime_jsx(
     &mut self,
     target: TransformTarget,
-    runtime_id: Expr,
+    _runtime_id: Expr,
     key: Option<JSXAttrValue>,
     dynamic_attrs: Vec<DynamicAttributePart>,
     dynamic_children: Vec<DynamicElementPart>,
@@ -55,15 +55,7 @@ where
               value
             }
           } else if let AttrName::Ref = attr_name {
-            if target == TransformTarget::LEPUS {
-              quote!("1" as Expr)
-            } else {
-              quote!(
-                "$runtime_id.transformRef($value)" as Expr,
-                runtime_id: Expr = runtime_id.clone(),
-                value: Expr = value,
-              )
-            }
+            value
           } else {
             value
           };

--- a/packages/react/transform/crates/swc_plugin_element_template/napi.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/napi.rs
@@ -62,6 +62,8 @@ impl Default for JSXTransformerConfig {
   fn default() -> Self {
     Self {
       preserve_jsx: false,
+      // Keep the authored runtime package stable. rspeedy aliases
+      // `@lynx-js/react` to the ET entry when Element Template is enabled.
       runtime_pkg: "@lynx-js/react".into(),
       jsx_import_source: Some("@lynx-js/react".into()),
       filename: Default::default(),

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_js.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1 attributeSlots={[\n    handleTap,\n    handleTouch\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\nReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1] = [\n    0,\n    ReactLynxInternal.adaptEventAttrSlot,\n    1,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_da39a_test_1 attributeSlots={[\n    handleTap,\n    handleTouch\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_da39a_test_1",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_lepus.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1 attributeSlots={[\n    1,\n    1\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\nReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1] = [\n    0,\n    ReactLynxInternal.adaptEventAttrSlot,\n    1,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_da39a_test_1 attributeSlots={[\n    1,\n    1\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_da39a_test_1",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_js.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import { __etSlot as __etSlot } from \"@lynx-js/react\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_2 = \"_et_da39a_test_2\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1>{__etSlot(0, items)}{__etSlot(1, items.map((item)=><_et_da39a_test_2>{__etSlot(0, item)}</_et_da39a_test_2>))}</_et_da39a_test_1>;\n",
+  "code": "import { __etSlot as __etSlot } from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_2 = \"_et_da39a_test_2\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1>{__etSlot(0, items)}{__etSlot(1, items.map((item)=><_et_da39a_test_2>{__etSlot(0, item)}</_et_da39a_test_2>))}</_et_da39a_test_1>;\n",
   "templates": [
     {
       "template_id": "_et_da39a_test_2",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_js.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1 attributeSlots={[\n    ReactLynx.transformRef(viewRef)\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1 attributeSlots={[\n    viewRef\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_da39a_test_1",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_lepus.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1 attributeSlots={[\n    1\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1 attributeSlots={[\n    viewRef\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_da39a_test_1",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_keep_code_and_template_attribute_slots_in_sync_for_spread.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_keep_code_and_template_attribute_slots_in_sync_for_spread.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1 attributeSlots={[\n    dynamicId,\n    props,\n    1,\n    1\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\nReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1] = [\n    2,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_da39a_test_1 attributeSlots={[\n    dynamicId,\n    props,\n    1,\n    viewRef\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_da39a_test_1",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
@@ -644,7 +644,7 @@ fn should_not_emit_element_template_map_in_element_template_mode() {
 }
 
 #[test]
-fn should_use_configured_runtime_package_in_development_mode() {
+fn should_not_use_snapshot_ref_transform_in_element_template_mode() {
   let (code, _, _) = transform_to_code_templates_and_diagnostics_with_mode(
     r#"<view ref={viewRef} />"#,
     JSXTransformerConfig {
@@ -655,7 +655,8 @@ fn should_use_configured_runtime_package_in_development_mode() {
     TransformMode::Development,
   );
 
-  assert!(code.contains(r#"require("@custom/react/internal").transformRef(viewRef)"#));
+  assert!(code.contains("viewRef"));
+  assert!(!code.contains("transformRef"));
   assert!(!code.contains("@lynx-js/react/internal"));
 }
 

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
@@ -129,6 +129,78 @@ fn without_whitespace(value: &str) -> String {
 }
 
 #[test]
+fn should_emit_direct_event_attr_plan_for_js_target() {
+  let (code, _) = first_user_template_json_with_code(
+    r#"
+      <view bindtap={handleTap} catchtouchstart={handleTouch} />
+    "#,
+    JSXTransformerConfig {
+      target: swc_plugins_shared::target::TransformTarget::JS,
+      ..element_template_config()
+    },
+  );
+  let code = without_whitespace(&code);
+
+  assert!(
+    code.contains(
+      "ReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1]=[0,ReactLynxInternal.adaptEventAttrSlot,1,ReactLynxInternal.adaptEventAttrSlot];"
+    ),
+    "direct event slots should register a sparse ET attr plan, got: {code}"
+  );
+  assert!(
+    code.contains("attributeSlots={[handleTap,handleTouch]}"),
+    "JS target should keep raw handlers in attributeSlots before runtime preparation, got: {code}"
+  );
+  assert!(
+    !code.contains("__etEventSlots"),
+    "event slot metadata must not be passed through Preact props, got: {code}"
+  );
+}
+
+#[test]
+fn should_emit_direct_event_attr_plan_for_lepus_target() {
+  let (code, _) = first_user_template_json_with_code(
+    r#"
+      <view bindtap={handleTap} catchtouchstart={handleTouch} />
+    "#,
+    JSXTransformerConfig {
+      target: swc_plugins_shared::target::TransformTarget::LEPUS,
+      ..element_template_config()
+    },
+  );
+  let code = without_whitespace(&code);
+
+  assert!(
+    code.contains(
+      "ReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1]=[0,ReactLynxInternal.adaptEventAttrSlot,1,ReactLynxInternal.adaptEventAttrSlot];"
+    ),
+    "direct event slots should register a sparse ET attr plan, got: {code}"
+  );
+  assert!(
+    code.contains("attributeSlots={[1,1]}"),
+    "LEPUS target should keep event markers in attributeSlots before runtime preparation, got: {code}"
+  );
+}
+
+#[test]
+fn should_not_emit_attr_plan_for_non_event_attrs() {
+  let (code, _) = first_user_template_json_with_code(
+    r#"
+      <view id={dynamicId} ref={viewRef} {...props} />
+    "#,
+    JSXTransformerConfig {
+      target: swc_plugins_shared::target::TransformTarget::JS,
+      ..element_template_config()
+    },
+  );
+
+  assert!(
+    !code.contains("__etAttrPlanMap") && !code.contains("adaptEventAttrSlot"),
+    "only direct event slots should enter the Phase 2 attr plan, got: {code}"
+  );
+}
+
+#[test]
 fn should_not_inject_root_css_scope_attrs_for_element_template() {
   let (code, template) = first_user_template_json_with_code(
     r#"

--- a/packages/webpack/react-webpack-plugin/test/background-loader.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/background-loader.test.ts
@@ -75,7 +75,9 @@ describe('background loader', () => {
     expect(result.code).not.toContain(
       '"@lynx-js/react/element-template/jsx-runtime"',
     );
-    expect(result.code).toContain('"@lynx-js/react/element-template"');
+    expect(result.code).toMatch(
+      /"@lynx-js\/react\/element-template(?:\/internal)?"/,
+    );
     expect(result.code).not.toContain('"@lynx-js/react/internal"');
   });
 });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental Element Template direct-event support: queued delivery, controlled flush on hydration, and reliable background↔main-thread event synchronization.
  * Improved attribute-slot preparation and normalization for more consistent hydration and native template creation.

* **Tests**
  * Broad test coverage added for event registration/dispatch, queued delivery/flush semantics, hydration edge cases, compiled templates, and teardown behavior.

* **Chores**
  * Marked as no package release required (internal/experimental).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds the Element Template event implementation across transform output, runtime attribute-slot handling, background hydration/update behavior, and native bridge wiring. It keeps the work behind the existing experimental Element Template path while making direct event attributes flow through the ET runtime instead of being treated as ordinary static attributes.

## Key Points

- Adds an ET attr-plan side table so transformed templates can identify event attribute slots without changing the serialized template shape for non-event attrs.
- Prepares event attribute slots before main-thread create and background hydrate/update paths, including uid-based event values and handler registration.
- Wires ET native event dispatch through the runtime bridge and covers direct-event subtree migration behavior.
- Organizes event-focused runtime coverage and compiled fixtures, and includes an empty changeset because this remains unpublished experimental ET internals.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added (or not required).

## Verification

- `git diff --check github/main..stack/element-template`
- `pnpm --dir packages/react/runtime run test:et`
- `cargo test --test element_template --test element_template_contract`