### PR TITLE
fix(react): clear removed snapshot prop refs

### DIFF
--- a/.changeset/clear-snapshot-prop-refs.md
+++ b/.changeset/clear-snapshot-prop-refs.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Clear transient snapshot child props when removed snapshot subtrees are detached, preventing compiled `$*` child references from retaining deleted list holder or list item subtrees after removal.

--- a/packages/react/runtime/__test__/snapshot/renderToOpcodes.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/renderToOpcodes.test.jsx
@@ -121,7 +121,7 @@ describe('renderToString', () => {
     expect(vnode.childNodes).toEqual([]);
   });
 
-  it('should only clear compiler transient child props', () => {
+  it('should clear all named child props', () => {
     const child = createElement('text', null, 'Hello');
     const vnode = createElement('view', { $0: child, $foo: child });
 
@@ -129,7 +129,7 @@ describe('renderToString', () => {
     vnode.removeChild(child);
 
     expect(vnode.props.$0).toBeUndefined();
-    expect(vnode.props.$foo).toBe(child);
+    expect(vnode.props.$foo).toBeUndefined();
   });
 
   it('should tolerate cycles in transient prop arrays when clearing removed children', () => {

--- a/packages/react/runtime/__test__/snapshot/renderToOpcodes.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/renderToOpcodes.test.jsx
@@ -94,6 +94,59 @@ describe('renderToString', () => {
     `);
   });
 
+  it('should clear transient named child props when the child is removed', () => {
+    const child = createElement('text', null, 'Hello');
+    const vnode = createElement('view', { $0: child });
+
+    renderToString(vnode, new SnapshotInstance('root'));
+
+    expect(vnode.props.$0).toBe(child);
+    vnode.removeChild(child);
+
+    expect(vnode.props.$0).toBeUndefined();
+    expect('$0' in vnode.props).toBe(false);
+    expect(vnode.childNodes).toEqual([]);
+  });
+
+  it('should clear removed children from nested transient prop arrays', () => {
+    const child = createElement('text', null, 'Hello');
+    const vnode = createElement('view', { $0: [[child]] });
+
+    renderToString(vnode, new SnapshotInstance('root'));
+
+    expect(vnode.props.$0[0][0]).toBe(child);
+    vnode.removeChild(child);
+
+    expect(vnode.props.$0).toEqual([[undefined]]);
+    expect(vnode.childNodes).toEqual([]);
+  });
+
+  it('should only clear compiler transient child props', () => {
+    const child = createElement('text', null, 'Hello');
+    const vnode = createElement('view', { $0: child, $foo: child });
+
+    renderToString(vnode, new SnapshotInstance('root'));
+    vnode.removeChild(child);
+
+    expect(vnode.props.$0).toBeUndefined();
+    expect(vnode.props.$foo).toBe(child);
+  });
+
+  it('should tolerate cycles in transient prop arrays when clearing removed children', () => {
+    const child = createElement('text', null, 'Hello');
+    const vnode = createElement('view', { $0: child });
+
+    renderToString(vnode, new SnapshotInstance('root'));
+    const children = [child];
+    children.push(children);
+    vnode.props.$0 = children;
+    vnode.removeChild(child);
+
+    expect(vnode.props.$0[0]).toBeUndefined();
+    expect(vnode.props.$0[1]).toBe(children);
+    expect(vnode.childNodes).toEqual([]);
+  });
+
   it('should render Component depth 1', () => {
     function App() {
       const [a, setA] = useState(111);
@@ -1287,32 +1340,13 @@ describe('renderOpcodesInto', () => {
 
     const [vnodeA, vnodeB, vnodeC, vnodeC2, vnodeD] = scratch.__firstChild.props.$0;
 
-    expect(vnodeA).not.toHaveProperty('__elements');
-    expect(vnodeA).not.toHaveProperty('__element_root');
+    expect(vnodeA).toBeUndefined();
     expect(vnodeB).toHaveProperty('__elements');
     expect(vnodeB).toHaveProperty('__element_root');
     expect(vnodeC).toHaveProperty('__elements');
     expect(vnodeC).toHaveProperty('__element_root');
-    expect(vnodeD).not.toHaveProperty('__elements');
-    expect(vnodeD).not.toHaveProperty('__element_root');
-
-    {
-      const componentVNodeC = vnodeC2.props.$0;
-      expect(componentVNodeC.type).toBe(Fragment);
-      expect(componentVNodeC.props.children).toHaveLength(4);
-      // FIXME(hzy): there is still a cycle reference
-      expect(componentVNodeC.__c.__v).toBe(componentVNodeC);
-      componentVNodeC.props.children.forEach((vnode) => {
-        expect(vnode).not.toHaveProperty('__elements');
-        expect(vnode).not.toHaveProperty('__element_root');
-      });
-    }
-
-    expect(vnodeD.props.$0).toHaveLength(4);
-    vnodeD.props.$0.forEach((vnode) => {
-      expect(vnode).not.toHaveProperty('__elements');
-      expect(vnode).not.toHaveProperty('__element_root');
-    });
+    expect(vnodeC2).toBeUndefined();
+    expect(vnodeD).toBeUndefined();
   });
 });
 

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -41,6 +41,62 @@ export const snapshotInstanceManager: {
   },
 };
 
+function isRemovedSnapshot(
+  value: unknown,
+  removedSnapshots: WeakSet<object>,
+): boolean {
+  return (typeof value === 'object' || typeof value === 'function') && value !== null
+    && removedSnapshots.has(value);
+}
+
+function clearRemovedSnapshotsFromArray(
+  values: unknown[],
+  removedSnapshots: WeakSet<object>,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (seen.has(values)) {
+    return false;
+  }
+  seen.add(values);
+
+  let changed = false;
+  values.forEach((value, index) => {
+    if (isRemovedSnapshot(value, removedSnapshots)) {
+      values[index] = undefined;
+      changed = true;
+    } else if (Array.isArray(value) && clearRemovedSnapshotsFromArray(value, removedSnapshots, seen)) {
+      changed = true;
+    }
+  });
+  return changed;
+}
+
+function clearTransientChildPropRefs(owner: SnapshotInstance, removedChild: SnapshotInstance): void {
+  const props = (owner as unknown as { props?: Record<string, unknown> }).props;
+  if (!props) {
+    return;
+  }
+
+  const removedSnapshots = new WeakSet<object>();
+  traverseSnapshotInstance(removedChild, snapshot => {
+    removedSnapshots.add(snapshot);
+  });
+
+  for (const key of Object.keys(props)) {
+    // The compiler stores named children in transient `$N` props. Once a child
+    // subtree is removed, those staging refs must not keep the old snapshots alive.
+    if (!/^\$\d+$/.test(key)) {
+      continue;
+    }
+    const value = props[key];
+    if (isRemovedSnapshot(value, removedSnapshots)) {
+      delete props[key];
+    } else if (Array.isArray(value)) {
+      clearRemovedSnapshotsFromArray(value, removedSnapshots);
+    }
+  }
+}
+
 export let snapshotCreatorMap: Record<string, (uniqId: string) => string> = {};
 
 if (__DEV__ && __JS__) {
@@ -425,6 +481,7 @@ export class SnapshotInstance {
 
   removeChild(child: SnapshotInstance): void {
     const __snapshot_def = this.__snapshot_def;
+    clearTransientChildPropRefs(this, child);
     if (__snapshot_def.isListHolder) {
       if (__pendingListUpdates.values) {
         (__pendingListUpdates.values[this.__id] ??= new ListUpdateInfoRecording(
@@ -434,6 +491,7 @@ export class SnapshotInstance {
 
       this.__removeChild(child);
       traverseSnapshotInstance(child, v => {
+        clearTransientChildPropRefs(v, v);
         snapshotInstanceManager.values.delete(v.__id);
       });
       // mark this child as deleted
@@ -453,6 +511,7 @@ export class SnapshotInstance {
         snapshotDestroyList(v);
       }
 
+      clearTransientChildPropRefs(v, v);
       v.__parent = null;
       v.__previousSibling = null;
       v.__nextSibling = null;

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -71,21 +71,24 @@ function clearRemovedSnapshotsFromArray(
   return changed;
 }
 
-function clearTransientChildPropRefs(owner: SnapshotInstance, removedChild: SnapshotInstance): void {
+function collectRemovedSnapshots(removedChild: SnapshotInstance): WeakSet<object> {
+  const removedSnapshots = new WeakSet<object>();
+  traverseSnapshotInstance(removedChild, snapshot => {
+    removedSnapshots.add(snapshot);
+  });
+  return removedSnapshots;
+}
+
+function clearTransientChildPropRefs(owner: SnapshotInstance, removedSnapshots: WeakSet<object>): void {
   const props = (owner as unknown as { props?: Record<string, unknown> }).props;
   if (!props) {
     return;
   }
 
-  const removedSnapshots = new WeakSet<object>();
-  traverseSnapshotInstance(removedChild, snapshot => {
-    removedSnapshots.add(snapshot);
-  });
-
   for (const key of Object.keys(props)) {
-    // The compiler stores named children in transient `$N` props. Once a child
-    // subtree is removed, those staging refs must not keep the old snapshots alive.
-    if (!/^\$\d+$/.test(key)) {
+    // Named child props are transient staging refs. Once a child subtree is
+    // removed, they must not keep the old snapshots alive.
+    if (!key.startsWith('$')) {
       continue;
     }
     const value = props[key];
@@ -481,7 +484,8 @@ export class SnapshotInstance {
 
   removeChild(child: SnapshotInstance): void {
     const __snapshot_def = this.__snapshot_def;
-    clearTransientChildPropRefs(this, child);
+    const removedSnapshots = collectRemovedSnapshots(child);
+    clearTransientChildPropRefs(this, removedSnapshots);
     if (__snapshot_def.isListHolder) {
       if (__pendingListUpdates.values) {
         (__pendingListUpdates.values[this.__id] ??= new ListUpdateInfoRecording(
@@ -491,7 +495,7 @@ export class SnapshotInstance {
 
       this.__removeChild(child);
       traverseSnapshotInstance(child, v => {
-        clearTransientChildPropRefs(v, v);
+        clearTransientChildPropRefs(v, removedSnapshots);
         snapshotInstanceManager.values.delete(v.__id);
       });
       // mark this child as deleted
@@ -511,7 +515,7 @@ export class SnapshotInstance {
         snapshotDestroyList(v);
       }
 
-      clearTransientChildPropRefs(v, v);
+      clearTransientChildPropRefs(v, removedSnapshots);
       v.__parent = null;
       v.__previousSibling = null;
       v.__nextSibling = null;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared transient snapshot child property references when snapshot subtrees are removed, preventing deleted items from being retained.

* **Tests**
  * Added tests covering cleanup behavior for removed children, including nested arrays and cyclic reference scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2590)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

This fixes a main-thread snapshot retention path where removed child subtrees could still be strongly referenced by compiler-generated transient child props. Snapshot JSX uses `$*` props as staging references for named children; when `SnapshotInstance.removeChild()` detached a child, the structural tree and native elements were cleaned up, but those `$*` props could still point at the removed snapshot subtree.

The practical failure mode is that a deleted list holder or list item subtree can remain reachable from the root props chain after it is removed. That keeps old snapshot instances alive even though they are no longer part of the rendered tree.

## Key points

- Clear transient `$*` owner props during removal. Direct refs such as `{ $0: removedChild }` are deleted from `props`, so the owner no longer keeps a hard reference to the removed subtree after `removeChild()`.
- Handle compiled array child shapes recursively. When a transient prop stores children as arrays, only removed snapshot entries are cleared, including nested arrays:

  ```js
  // before removal
  owner.props.$0 = [keptChild, [removedChild]];

  // after removeChild(removedChild)
  owner.props.$0 = [keptChild, [undefined]];
  ```

- Clean transient props inside the removed subtree as it is torn down. This breaks references held by the deleted subtree itself, including component/list structures that had their own compiled child staging props.

## Runtime Contract

This only affects compiler-owned transient child props whose keys start with `$`. Normal user props, public runtime APIs, serialized snapshot shape, native patch operations, and list update protocols are unchanged.

The cleanup is tied to `SnapshotInstance.removeChild()`: removed snapshot instances and descendants are collected into a removal set, then `$*` prop values are cleared if they directly reference any removed snapshot or contain one inside an array. Existing array identity is preserved, and non-removed entries keep their current identity and order.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
