### PR TITLE
fix(react): avoid retaining transformed worklet ctx

### DIFF
--- a/.changeset/weak-worklet-context.md
+++ b/.changeset/weak-worklet-context.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react": patch
+---
+
+Avoid retaining transformed nested worklet contexts through a strong `.ctx` reference.
+
+Nested worklets transformed by the worklet runtime now store the original worklet context through `ctxRef` instead of a strong `ctx` property, preventing cached transformed worklet functions from keeping list-item worklet contexts alive. Hydration still falls back to the legacy `.ctx` shape for compatibility.

--- a/.changeset/weak-worklet-context.md
+++ b/.changeset/weak-worklet-context.md
@@ -2,6 +2,6 @@
 "@lynx-js/react": patch
 ---
 
-Avoid retaining transformed nested worklet contexts through a strong `.ctx` reference.
+Avoid retaining transformed nested worklet contexts after worklet transformation.
 
-Nested worklets transformed by the worklet runtime now store the original worklet context through `ctxRef` instead of a strong `ctx` property, preventing cached transformed worklet functions from keeping list-item worklet contexts alive. Hydration still falls back to the legacy `.ctx` shape for compatibility.
+Nested worklets transformed by the worklet runtime now keep their context recovery metadata through a weak reference, preventing cached transformed worklet functions from keeping list-item worklet contexts alive.

--- a/packages/react/runtime/__test__/worklet-runtime/runOnBackground.test.js
+++ b/packages/react/runtime/__test__/worklet-runtime/runOnBackground.test.js
@@ -17,6 +17,57 @@ afterEach(() => {
 });
 
 describe('runOnBackground', () => {
+  it('should not keep transformed worklet ctx through a strong ctx property', () => {
+    const childCtx = {
+      _wkltId: 'child',
+    };
+    const parentCtx = {
+      _wkltId: 'parent',
+      child: childCtx,
+    };
+
+    globalThis.registerWorklet('main-thread', 'parent', function() {
+      return this.child;
+    });
+    globalThis.registerWorklet('main-thread', 'child', function() {});
+
+    const childWorklet = globalThis.runWorklet(parentCtx, []);
+    expect(childWorklet).toHaveProperty('ctxRef');
+    expect(childWorklet).not.toHaveProperty('ctx');
+    expect(childWorklet.ctxRef.deref()).toBe(childCtx);
+  });
+
+  it('should hydrate nested worklet ctx from a weak ctx ref', () => {
+    const firstScreenChildCtx = {
+      _wkltId: 'child',
+      _jsFn: {
+        '_jsFn1': { '_isFirstScreen': true },
+      },
+    };
+    const firstScreenWorklet = {
+      _wkltId: 'parent',
+      child: Object.assign(function() {}, {
+        ctxRef: new WeakRef(firstScreenChildCtx),
+      }),
+    };
+    const worklet = {
+      _wkltId: 'parent',
+      child: {
+        _wkltId: 'child',
+        _jsFn: {
+          '_jsFn1': { '_jsFnId': 1 },
+        },
+      },
+      _execId: 8,
+    };
+
+    globalThis.lynxWorkletImpl._hydrateCtx(worklet, firstScreenWorklet);
+
+    expect(firstScreenChildCtx._jsFn._jsFn1._isFirstScreen).toBe(false);
+    expect(firstScreenChildCtx._jsFn._jsFn1._jsFnId).toBe(1);
+    expect(firstScreenChildCtx._jsFn._jsFn1._execId).toBe(8);
+  });
+
   it('should delay and run task', () => {
     const firstScreenWorklet = {
       _wkltId: 'ctx1',

--- a/packages/react/runtime/src/worklet-runtime/bindings/types.ts
+++ b/packages/react/runtime/src/worklet-runtime/bindings/types.ts
@@ -34,7 +34,9 @@ export type ClosureValueType =
   | Worklet
   | WorkletRef<unknown>
   | Element
-  | (((...args: unknown[]) => unknown) & { ctx?: ClosureValueType })
+  | (((...args: unknown[]) => unknown) & {
+    ctxRef?: WeakRef<object>;
+  })
   | ClosureValueType_
   | ClosureValueType[];
 

--- a/packages/react/runtime/src/worklet-runtime/hydrate.ts
+++ b/packages/react/runtime/src/worklet-runtime/hydrate.ts
@@ -52,7 +52,7 @@ function hydrateCtxImpl(
       );
     } else {
       const firstScreenValue = typeof firstScreenCtxObj[key] === 'function'
-        ? (firstScreenCtxObj[key] as { ctx: ClosureValueType }).ctx
+        ? (firstScreenCtxObj[key] as { ctxRef?: WeakRef<object> }).ctxRef?.deref() as ClosureValueType
         : firstScreenCtxObj[key];
       hydrateCtxImpl(ctxObj[key], firstScreenValue, execId);
     }

--- a/packages/react/runtime/src/worklet-runtime/workletRuntime.ts
+++ b/packages/react/runtime/src/worklet-runtime/workletRuntime.ts
@@ -182,7 +182,7 @@ const transformWorkletInner = (
       // This would result in the value of `workletCache` referencing its key.
       obj[key] = lynxWorkletImpl._workletMap[(subObj as Worklet)._wkltId]!
         .bind({ ...subObj });
-      obj[key].ctx = subObj;
+      obj[key].ctxRef = new WeakRef(subObj as object);
       continue;
     }
     const isJsFn = '_jsFnId' in subObj;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management for nested worklets: transformed nested worklets now use weak references so original list-item contexts are not retained, reducing memory footprint.

* **Tests**
  * Added tests confirming nested worklet contexts use weak references and that hydration correctly converts first-screen entries into hydrated function metadata.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2591)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Transforming a nested worklet already binds the callable to a shallow copy of the nested worklet context, but the transformed function also kept the original context through strong internal metadata.
- That strong back-reference can make a cached transformed worklet function retain the original list-item worklet context after the item is clicked, because the `workletCache` value points back to the context it was meant to avoid retaining.
- This PR switches that internal metadata to a `WeakRef`, so hydration can recover a still-live first-screen context without extending the lifetime of list-item worklet contexts.

## Key Points

- The root cause is the extra strong context edge added after nested worklet transformation:

  ```ts
  obj[key] = registeredWorklet.bind({ ...subObj });
  obj[key].ctx = subObj;
  ```

  The bound function no longer needs the original object for execution, but that metadata kept the original object alive through any cache that retained the transformed function.

- The transformed function now stores the original nested worklet context through weak metadata:

  ```ts
  obj[key].ctxRef = new WeakRef(subObj);
  ```

  This preserves first-screen context recovery while avoiding a cache value that strongly retains the original context.

- Hydration consumes the weak metadata from transformed first-screen functions:

  ```ts
  const firstScreenValue = fn.ctxRef?.deref();
  ```

  This does not change public ReactLynx APIs, serialized native payloads, or the worklet registration contract.

- The new runtime test covers the retain-cycle-sensitive shape directly: a transformed nested worklet function should expose weak context metadata, should not expose the old strong context metadata, and the weak reference should point to the original nested worklet context while it is still reachable.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
