### PR TITLE
fix(react): retain offscreen worklet ctx refs

### DIFF
--- a/.changeset/retain-offscreen-worklet-ctx.md
+++ b/.changeset/retain-offscreen-worklet-ctx.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Retain main-thread worklet context references before offscreen snapshot elements are materialized, so event, ref, gesture, and spread callbacks stay alive until the DOM update path can attach them.

--- a/packages/react/runtime/__test__/snapshot/workletLifecycle.test.ts
+++ b/packages/react/runtime/__test__/snapshot/workletLifecycle.test.ts
@@ -1,0 +1,133 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { updateGesture } from '../../src/snapshot/snapshot/gesture';
+import { updateSpread } from '../../src/snapshot/snapshot/spread';
+import { updateWorkletEvent } from '../../src/snapshot/snapshot/workletEvent';
+import { updateWorkletRef } from '../../src/snapshot/snapshot/workletRef';
+
+function createSnapshot(value: unknown) {
+  return {
+    __id: 1,
+    __values: [value],
+    type: 'TestSnapshot',
+  } as any;
+}
+
+describe('worklet lifecycle without elements', () => {
+  let addRef: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    addRef = vi.fn();
+    globalThis.lynxWorkletImpl = {
+      _jsFunctionLifecycleManager: {
+        addRef,
+      },
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete globalThis.lynxWorkletImpl;
+  });
+
+  it('retains main-thread event worklet ctx before elements are materialized', () => {
+    const worklet = {
+      _execId: 1,
+      _wkltId: 'event',
+    };
+
+    updateWorkletEvent(createSnapshot(worklet), 0, undefined as any, 0, 'main-thread', 'bindEvent', 'tap');
+
+    expect(addRef).toHaveBeenCalledTimes(1);
+    expect(addRef).toHaveBeenCalledWith(1, worklet);
+  });
+
+  it('retains main-thread ref worklet ctx before elements are materialized', () => {
+    const worklet = {
+      _execId: 2,
+      _wkltId: 'ref',
+    };
+
+    updateWorkletRef(createSnapshot(worklet), 0, undefined, 0, 'main-thread');
+
+    expect(addRef).toHaveBeenCalledTimes(1);
+    expect(addRef).toHaveBeenCalledWith(2, worklet);
+  });
+
+  it('retains main-thread gesture callbacks before elements are materialized', () => {
+    const callback = {
+      _execId: 3,
+      _wkltId: 'gesture',
+    };
+    const gesture = {
+      __isSerialized: true,
+      callbacks: {
+        onUpdate: callback,
+      },
+      id: 1,
+      type: 0,
+    };
+
+    updateGesture(createSnapshot(gesture), 0, undefined, 0, 'main-thread');
+
+    expect(addRef).toHaveBeenCalledTimes(1);
+    expect(addRef).toHaveBeenCalledWith(3, callback);
+  });
+
+  it('retains main-thread spread worklet ctx before elements are materialized', () => {
+    const eventWorklet = {
+      _execId: 4,
+      _wkltId: 'spread-event',
+    };
+    const refWorklet = {
+      _execId: 5,
+      _wkltId: 'spread-ref',
+    };
+    const gestureCallback = {
+      _execId: 6,
+      _wkltId: 'spread-gesture',
+    };
+    const gesture = {
+      __isSerialized: true,
+      callbacks: {
+        onUpdate: gestureCallback,
+      },
+      id: 1,
+      type: 0,
+    };
+
+    updateSpread(
+      createSnapshot({
+        'main-thread:bindtap': eventWorklet,
+        'main-thread:gesture': gesture,
+        'main-thread:ref': refWorklet,
+      }),
+      0,
+      {},
+      0,
+    );
+
+    expect(addRef.mock.calls).toEqual([
+      [4, eventWorklet],
+      [6, gestureCallback],
+      [5, refWorklet],
+    ]);
+  });
+
+  it('does not retain unchanged spread worklet ctx again before elements are materialized', () => {
+    const eventWorklet = {
+      _execId: 7,
+      _wkltId: 'spread-event',
+    };
+    const spread = {
+      'main-thread:bindtap': eventWorklet,
+    };
+
+    updateSpread(createSnapshot(spread), 0, spread, 0);
+
+    expect(addRef).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/runtime/__test__/worklet-runtime/jsFunctionLifecycle.test.js
+++ b/packages/react/runtime/__test__/worklet-runtime/jsFunctionLifecycle.test.js
@@ -69,4 +69,21 @@ describe('jsFunctionLifecycle', () => {
       }
     `);
   });
+
+  it('should skip duplicated addRef() for the same object', () => {
+    const manager = new JsFunctionLifecycleManager();
+    const target = {};
+    manager.addRef(3, target);
+    manager.addRef(3, target);
+    manager.removeRef(3);
+    manager.fire();
+    expect(events[0]).toMatchInlineSnapshot(`
+      {
+        "data": [
+          3,
+        ],
+        "type": "Lynx.Worklet.releaseBackgroundWorkletCtx",
+      }
+    `);
+  });
 });

--- a/packages/react/runtime/__test__/worklet-runtime/observers.test.js
+++ b/packages/react/runtime/__test__/worklet-runtime/observers.test.js
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { onWorkletCtxUpdate } from '../../src/worklet-runtime/bindings/observers';
+import { onWorkletCtxUpdate, retainWorkletCtx } from '../../src/worklet-runtime/bindings/observers';
 import { initWorklet } from '../../src/worklet-runtime/workletRuntime';
 
 beforeEach(() => {
@@ -24,13 +24,10 @@ describe('MTFObservers', () => {
       addRef,
     };
 
-    onWorkletCtxUpdate(
+    retainWorkletCtx(
       {
         _wkltId: 'ctx1',
       },
-      undefined,
-      false,
-      'element',
     );
 
     expect(addRef).not.toHaveBeenCalled();
@@ -46,8 +43,27 @@ describe('MTFObservers', () => {
       _execId: 8,
     };
 
-    onWorkletCtxUpdate(mtf, undefined, false, 'element');
+    retainWorkletCtx(mtf);
 
     expect(addRef).toHaveBeenCalledWith(8, mtf);
+  });
+
+  it('should not add lifecycle refs during element updates', () => {
+    const addRef = vi.fn();
+    globalThis.lynxWorkletImpl._jsFunctionLifecycleManager = {
+      addRef,
+    };
+
+    onWorkletCtxUpdate(
+      {
+        _wkltId: 'ctx1',
+        _execId: 8,
+      },
+      undefined,
+      false,
+      'element',
+    );
+
+    expect(addRef).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/runtime/src/snapshot/gesture/processGesture.ts
+++ b/packages/react/runtime/src/snapshot/gesture/processGesture.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { onWorkletCtxUpdate } from '@lynx-js/react/worklet-runtime/bindings';
+import { onWorkletCtxUpdate, retainWorkletCtx } from '@lynx-js/react/worklet-runtime/bindings';
 
 import { GestureTypeInner } from './types.js';
 import type { BaseGesture, ComposedGesture, GestureConfig, GestureKind } from './types.js';
@@ -105,6 +105,20 @@ function consumeOldBaseGesture(
   return fallbackOldBaseGesture;
 }
 
+export function retainGestureWorkletCtx(gesture: GestureKind | undefined): void {
+  const retainedBaseGestures: BaseGesture[] = [];
+  appendUniqueSerializedBaseGestures(gesture, retainedBaseGestures, new Set());
+
+  for (const baseGesture of retainedBaseGestures) {
+    for (const key of Object.keys(baseGesture.callbacks)) {
+      const callback = baseGesture.callbacks[key];
+      if (callback) {
+        retainWorkletCtx(callback);
+      }
+    }
+  }
+}
+
 function removeGestureDetector(dom: FiberElement, id: number): void {
   // Keep compatibility with old runtimes where remove API is not exposed.
   if (typeof __RemoveGestureDetector === 'function') {
@@ -169,9 +183,13 @@ export function processGesture(
   isFirstScreen: boolean,
   gestureOptions?: {
     domSet: boolean;
+    retainCallbacks?: boolean;
   },
 ): void {
   const domSet = gestureOptions?.domSet === true;
+  if (gestureOptions?.retainCallbacks !== false) {
+    retainGestureWorkletCtx(gesture);
+  }
   if (!gesture || !isSerializedGesture(gesture)) {
     const { oldBaseGesturesById } = collectOldGestureInfo(oldGesture);
     for (const oldBaseGesture of oldBaseGesturesById.values()) {

--- a/packages/react/runtime/src/snapshot/snapshot/gesture.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/gesture.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { processGesture } from '../gesture/processGesture.js';
+import { processGesture, retainGestureWorkletCtx } from '../gesture/processGesture.js';
 import type { GestureKind } from '../gesture/types.js';
 import { isMainThreadHydrating } from '../lifecycle/patch/isMainThreadHydrating.js';
 import type { SnapshotInstance } from '../snapshot/snapshot.js';
@@ -13,12 +13,19 @@ export function updateGesture(
   elementIndex: number,
   workletType: string,
 ): void {
+  const value = snapshot.__values![expIndex] as GestureKind;
+  if (workletType === 'main-thread') {
+    retainGestureWorkletCtx(value);
+  }
+
   if (!snapshot.__elements) {
     return;
   }
-  const value = snapshot.__values![expIndex] as GestureKind;
 
   if (workletType === 'main-thread') {
-    processGesture(snapshot.__elements[elementIndex]!, value, oldValue as GestureKind, isMainThreadHydrating);
+    processGesture(snapshot.__elements[elementIndex]!, value, oldValue as GestureKind, isMainThreadHydrating, {
+      domSet: false,
+      retainCallbacks: false,
+    });
   }
 }

--- a/packages/react/runtime/src/snapshot/snapshot/spread.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/spread.ts
@@ -9,6 +9,7 @@
  * optimized attribute updates at compile time, avoiding runtime object spreads.
  */
 
+import { retainWorkletCtx } from '@lynx-js/react/worklet-runtime/bindings';
 import type { Element, Worklet, WorkletRefImpl } from '@lynx-js/react/worklet-runtime/bindings';
 
 import type { BackgroundSnapshotInstance } from './backgroundSnapshot.js';
@@ -19,6 +20,8 @@ import { transformRef, updateRef } from './ref.js';
 import { updateWorkletEvent } from './workletEvent.js';
 import { updateWorkletRef } from './workletRef.js';
 import { isDirectOrDeepEqual, isEmptyObject, pick } from '../../utils.js';
+import { retainGestureWorkletCtx } from '../gesture/processGesture.js';
+import type { GestureKind } from '../gesture/types.js';
 import { ListUpdateInfoRecording } from '../list/listUpdateInfo.js';
 import { __pendingListUpdates } from '../list/pendingListUpdates.js';
 import type { SnapshotInstance } from '../snapshot/snapshot.js';
@@ -39,6 +42,31 @@ const noFlattenAttributes = /* @__PURE__ */ new Set<string>([
   'exposure-scene',
   'exposure-id',
 ]);
+
+function retainSpreadWorkletCtx(newValue: Record<string, unknown>, oldValue: Record<string, unknown>): void {
+  let match: RegExpMatchArray | null = null;
+  for (const key in newValue) {
+    const value = newValue[key];
+    if (value === oldValue[key]) {
+      continue;
+    }
+
+    if (key.endsWith(':ref')) {
+      if (key.slice(0, -4) === 'main-thread' && value && (value as Worklet)._wkltId) {
+        retainWorkletCtx(value as Worklet);
+      }
+    } else if (key.endsWith(':gesture')) {
+      if (key.slice(0, -8) === 'main-thread') {
+        retainGestureWorkletCtx(value as GestureKind);
+      }
+    } else if (
+      (match = eventRegExp.exec(key)) && match[2] === 'main-thread' && value !== null && value !== undefined
+      && typeof value === 'object'
+    ) {
+      retainWorkletCtx(value as Worklet);
+    }
+  }
+}
 
 function updateSpread(
   snapshot: SnapshotInstance,
@@ -84,6 +112,7 @@ function updateSpread(
   }
 
   if (!snapshot.__elements) {
+    retainSpreadWorkletCtx(newValue, oldValue);
     return;
   }
 

--- a/packages/react/runtime/src/snapshot/snapshot/workletEvent.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/workletEvent.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { onWorkletCtxUpdate } from '@lynx-js/react/worklet-runtime/bindings';
+import { onWorkletCtxUpdate, retainWorkletCtx } from '@lynx-js/react/worklet-runtime/bindings';
 import type { Worklet } from '@lynx-js/react/worklet-runtime/bindings';
 
 import { describeInvalidValue } from '../debug/describeInvalidValue.js';
@@ -41,16 +41,24 @@ function updateWorkletEvent(
   eventType: string,
   eventName: string,
 ): void {
-  if (!snapshot.__elements) {
-    return;
-  }
   const rawValue = snapshot.__values![expIndex];
   if (__DEV__ && rawValue !== null && rawValue !== undefined && typeof rawValue !== 'object') {
+    if (!snapshot.__elements) {
+      return;
+    }
     reportInvalidWorkletValue(snapshot, elementIndex, workletType, eventType, eventName, rawValue);
     return;
   }
   const value = (rawValue ?? {}) as Worklet;
   value._workletType = workletType;
+
+  if (workletType === 'main-thread') {
+    retainWorkletCtx(value);
+  }
+
+  if (!snapshot.__elements) {
+    return;
+  }
 
   if (workletType === 'main-thread') {
     onWorkletCtxUpdate(value, oldValue, isMainThreadHydrating, snapshot.__elements[elementIndex]!);

--- a/packages/react/runtime/src/snapshot/snapshot/workletRef.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/workletRef.ts
@@ -2,7 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { onWorkletCtxUpdate, runWorkletCtx, updateWorkletRef as update } from '@lynx-js/react/worklet-runtime/bindings';
+import {
+  onWorkletCtxUpdate,
+  retainWorkletCtx,
+  runWorkletCtx,
+  updateWorkletRef as update,
+} from '@lynx-js/react/worklet-runtime/bindings';
 import type { Element, Worklet, WorkletRefImpl } from '@lynx-js/react/worklet-runtime/bindings';
 
 import { isMainThreadHydrating } from '../lifecycle/patch/isMainThreadHydrating.js';
@@ -45,8 +50,13 @@ export function updateWorkletRef(
   expIndex: number,
   oldValue: WorkletRefImpl<Element> | Worklet | null | undefined,
   elementIndex: number,
-  _workletType: string,
+  workletType: string,
 ): void {
+  const value = snapshot.__values![expIndex] as (WorkletRefImpl<Element> | Worklet | undefined);
+  if (workletType === 'main-thread' && value && (value as Worklet)._wkltId) {
+    retainWorkletCtx(value as Worklet);
+  }
+
   if (!snapshot.__elements) {
     return;
   }
@@ -56,7 +66,6 @@ export function updateWorkletRef(
     snapshot.__worklet_ref_set?.delete(oldValue);
   }
 
-  const value = snapshot.__values![expIndex] as (WorkletRefImpl<Element> | Worklet | undefined);
   if (value === null || value === undefined) {
     // do nothing
   } else if (value._wvid) {

--- a/packages/react/runtime/src/worklet-runtime/bindings/observers.ts
+++ b/packages/react/runtime/src/worklet-runtime/bindings/observers.ts
@@ -18,15 +18,18 @@ export function onWorkletCtxUpdate(
   isFirstScreen: boolean,
   element: ElementNode,
 ): void {
-  if (worklet._execId !== undefined) {
-    globalThis.lynxWorkletImpl?._jsFunctionLifecycleManager?.addRef(worklet._execId, worklet);
-  }
   if (isFirstScreen && oldWorklet) {
     globalThis.lynxWorkletImpl?._hydrateCtx(worklet, oldWorklet);
   }
   // For old version dynamic component compatibility.
   if (isFirstScreen) {
     globalThis.lynxWorkletImpl?._eventDelayImpl.runDelayedWorklet(worklet, element);
+  }
+}
+
+export function retainWorkletCtx(worklet: Worklet): void {
+  if (worklet._execId !== undefined) {
+    globalThis.lynxWorkletImpl?._jsFunctionLifecycleManager?.addRef(worklet._execId, worklet);
   }
 }
 

--- a/packages/react/runtime/src/worklet-runtime/jsFunctionLifecycle.ts
+++ b/packages/react/runtime/src/worklet-runtime/jsFunctionLifecycle.ts
@@ -14,6 +14,7 @@ import { isSdkVersionGt } from './utils/version.js';
 class JsFunctionLifecycleManager {
   private execIdRefCount = new Map<number, number>();
   private execIdSetToFire = new Set<number>();
+  private retainedObjects = new WeakSet<object>();
   private willFire = false;
   private registry?: FinalizationRegistry<number> = undefined;
 
@@ -22,6 +23,10 @@ class JsFunctionLifecycleManager {
   }
 
   addRef(execId: number, objToRef: object): void {
+    if (this.retainedObjects.has(objToRef)) {
+      return;
+    }
+    this.retainedObjects.add(objToRef);
     this.execIdRefCount.set(
       execId,
       (this.execIdRefCount.get(execId) ?? 0) + 1,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worklet callback retention to keep event, ref, gesture, and spread handlers alive on the main thread before snapshot elements are materialized, ensuring proper attachment during DOM updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2592)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

Main-thread worklets used by events, refs, gestures, and spread props can be recorded on snapshot values before the snapshot has concrete `__elements`. This happens for offscreen list items and similar deferred materialization paths.

Previously, lifecycle retaining was coupled to `onWorkletCtxUpdate()`, which only runs when an element is available. That meant an offscreen main-thread worklet ctx could miss the lifecycle `addRef` step before the later DOM attach/update path, so the background worklet ctx was allowed to be released too early.

This PR separates lifecycle retaining from element update side effects. Snapshot update paths now retain main-thread worklet ctx values as soon as they observe them, while `onWorkletCtxUpdate()` remains responsible only for hydration and delayed-worklet behavior that actually needs an element.

## Key Points

- Root cause: lifecycle `addRef` was behind the `snapshot.__elements` guard through `onWorkletCtxUpdate()`. Offscreen snapshots skipped that path until materialization, which was too late for retaining the background ctx reference.
- Fix: introduce a minimal `retainWorkletCtx(worklet)` helper and call it from event, ref, gesture, and spread update paths before returning for missing `__elements`.
- Gesture handling retains callback worklets when the snapshot value updates, then suppresses a second retain when `processGesture()` later performs the real DOM update for the same value.
- `JsFunctionLifecycleManager` now deduplicates repeated `addRef()` calls for the same object identity, so repeated `componentAtIndex` access cannot inflate the ref count for the exact same retained object.

## Runtime Contract

The lifecycle retain step is now independent from element-specific update work:

```ts
// Retain can happen before native elements are materialized.
if (workletType === 'main-thread') {
  retainWorkletCtx(worklet);
}

// Element-side hydration, delayed execution, and DOM binding still require elements.
if (snapshot.__elements) {
  onWorkletCtxUpdate(worklet, oldWorklet, isMainThreadHydrating, element);
}
```

For gestures, the retained unit is each serialized base gesture callback. The DOM update path keeps using `processGesture()` for detector setup, but passes `retainCallbacks: false` when the callbacks have already been retained by the snapshot update path.

This does not change the serialized worklet shape, native gesture detector contract, transform output, or public component API. Missing `_execId` remains a no-op for lifecycle retaining, and legacy first-screen hydration / delayed-worklet behavior stays in `onWorkletCtxUpdate()`.

## Compatibility / Boundaries

- The dedupe is object-identity based: retaining the same object twice is ignored, while distinct objects that share an `execId` still contribute separate lifecycle references.
- The fix is limited to main-thread worklet lifecycle retention for event, ref, gesture, and spread paths. It does not introduce debug logging, dump fields, or example-page changes.
- Existing compatibility branches for old main-thread ref values and old gesture cleanup APIs are preserved.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
