### PR TITLE
ci: migrate to GitHub-hosted runners and actions/cache

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -51,7 +51,7 @@ runs:
     - name: Restore rustup cache
       id: restore
       if: ${{ inputs.save-if == 'true' }}
-      uses: lynx-infra/cache/restore@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: ~/.rustup/toolchains
         key: rustup-cache-v3-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
@@ -69,16 +69,15 @@ runs:
           -c clippy \
           -c rustfmt
     - name: Save rustup cache
-      uses: lynx-infra/cache/save@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+      uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
         path: ~/.rustup/toolchains
         key: rustup-cache-v3-${{ runner.os }}-${{ steps.get-toolchain.outputs.toolchain }}
 
     - name: Cargo cache
-      uses: stormslowly/rust-cache@8269079380bc35105b3ed8b0f1f7c9557c6dec93 # v0.0.2
+      uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
       with:
         prefix-key: "RCache-L-5"
         shared-key: ${{ inputs.key }}
         save-if: ${{ inputs.save-if }}
-        fullmatch-only: "true"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -227,9 +227,6 @@
     // Rspress not compatible
     "@microsoft/api-documenter",
 
-    // Not following SemVer
-    "stormslowly/rust-cache",
-
     // Too many breaking change in 1.5.7. Manually upgrade later.
     "@rspack/test-tools",
 

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   zizmor:
     timeout-minutes: 10
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -103,7 +103,6 @@ jobs:
       runs-on: ubuntu-24.04
       is-web: true
       run: |
-        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-elements run test --reporter='github,dot,junit,html'
@@ -118,7 +117,6 @@ jobs:
       runs-on: ubuntu-24.04
       is-web: true
       run: |
-        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-tests run test --reporter='github,dot,junit,html'

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -81,7 +81,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: >
         pnpm run test
         --testTimeout=50000
@@ -100,7 +100,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       run: |
         ulimit -Sn 655350
@@ -115,7 +115,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       run: |
         ulimit -Sn 655350

--- a/.github/workflows/nodejs-dependencies.yml
+++ b/.github/workflows/nodejs-dependencies.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   sherif:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/pull-request-content-check.yml
+++ b/.github/workflows/pull-request-content-check.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate-pr-title:
     name: Validate PR title
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       # https://github.com/amannn/action-semantic-pull-request

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -35,7 +35,7 @@ jobs:
           - path: ./packages/rspeedy/core
             name: rspeedy
             key: RELATIVE_CI_PROJECT_RSPEEDY_CORE_KEY
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     name: Upload ${{ matrix.project.name }}
     env:
       RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY: ${{ secrets.RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,9 +25,9 @@ jobs:
     strategy:
       matrix:
         runs-on:
-          - label: lynx-ubuntu-24.04-xlarge
+          - label: ubuntu-24.04
             name: Ubuntu
-          # - label: lynx-windows-2022-large
+          # - label: windows-2022
           #   name: Windows
     timeout-minutes: 30
     permissions:
@@ -61,7 +61,7 @@ jobs:
           files: target/nextest/ci/test-report.junit.xml
 
   rustfmt:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -77,7 +77,7 @@ jobs:
         run: cargo fmt --check
 
   clippy:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         runs-on:
-          - label: ubuntu-24.04
+          - label: ubuntu-24.04-32core
             name: Ubuntu
           # - label: windows-2022
           #   name: Windows

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         runs-on:
-          - label: ubuntu-24.04-32core
+          - label: ubuntu-24.04
             name: Ubuntu
           # - label: windows-2022
           #   name: Windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-bundle-analysis.yml
   code-style-check:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions: {}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: pnpm eslint . --flag v10_config_lookup_from_file
 
   lighthouse:
@@ -77,7 +77,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       run: |
         ulimit -Sn 655350
@@ -94,7 +94,7 @@ jobs:
         shard: [1, 2]
     name: Playwright Web Elements Test (${{ matrix.shard }}/2)
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       codecov-flags: "e2e"
       web-report-path: "packages/web-platform/web-elements/playwright-report"
@@ -120,7 +120,7 @@ jobs:
   #       #   - thread: MULTI_THREAD
   #       #     render: SSR
   #   with:
-  #     runs-on: lynx-custom-container
+  #     runs-on: ubuntu-24.04
   #     is-web: true
   #     web-report-name: "playwright-${{ matrix.thread }}-${{ matrix.render }}-shard${{ matrix.shard }}"
   #     codecov-flags: "e2e"
@@ -147,7 +147,7 @@ jobs:
         render: [CSR]
         shard: [1, 2]
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       web-report-name: "playwright-${{ matrix.render }}-shard${{ matrix.shard }}"
       web-report-path: "packages/web-platform/web-core-e2e/playwright-report"
@@ -166,7 +166,7 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
 
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: |
         pnpm turbo api-extractor -- --local
         if test "$(git diff -- './packages/**/*.api.md' --name-only | wc -l)" -gt 0 ; then
@@ -190,7 +190,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: |
         # Generated smoke-test projects do not carry a packageManager pin, so
         # keep this stage on pnpm 10 even when Corepack's registry default moves.
@@ -233,7 +233,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: >
         pnpm
         --filter @lynx-js/react-runtime
@@ -259,7 +259,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: pnpm -r run test:type
   test-rstest:
     needs: build
@@ -267,7 +267,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: >
         pnpm exec rstest run
         -c rstest.config.ts
@@ -281,7 +281,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     name: Kitten Lynx Android Emulator Test
     with:
-      runs-on: lynx-ubuntu-22.04-physical-medium
+      runs-on: ubuntu-22.04
       run: |
         # 4. Start Emulator
         echo "Starting emulator..."
@@ -332,7 +332,7 @@ jobs:
         pnpm --filter @lynx-js/kitten-lynx-test-infra run test --coverage --reporter=github-actions --reporter=dot --reporter=junit --outputFile=test-report.junit.xml --coverage.reporter='json' --coverage.reporter='text' --testTimeout=50000 --no-cache --logHeapUsage --silent
 
   test-typos:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     steps:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
       - uses: crate-ci/typos@57b11c6b7e54c402ccd9cda953f1072ec4f78e33 # v1.43.5
@@ -346,9 +346,9 @@ jobs:
       matrix:
         runs-on:
           - name: Ubuntu
-            label: lynx-ubuntu-24.04-medium
+            label: ubuntu-24.04
           - name: Windows
-            label: lynx-windows-2022-large
+            label: windows-2022
     name: Vitest (${{ matrix.runs-on.name }})
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -320,22 +320,9 @@ jobs:
           script: |
             wget -q https://github.com/lynx-family/lynx/releases/download/3.6.0/LynxExplorer-noasan-release.apk -O LynxExplorer.apk
             adb install -r LynxExplorer.apk
-            if ! adb shell pm list packages | grep -q com.lynx.explorer; then
-              echo "Error: com.lynx.explorer is not installed!"
-              exit 1
-            fi
+            adb shell pm list packages | grep -q com.lynx.explorer
             adb shell monkey -p com.lynx.explorer -c android.intent.category.LAUNCHER 1
-            MAX_RETRIES=10
-            RETRY_COUNT=0
-            while ! adb shell pidof com.lynx.explorer > /dev/null; do
-              if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
-                echo "Error: com.lynx.explorer failed to start!"
-                exit 1
-              fi
-              echo "Waiting... ($RETRY_COUNT/$MAX_RETRIES)"
-              sleep 2
-              RETRY_COUNT=$((RETRY_COUNT+1))
-            done
+            bash -c 'for i in $(seq 1 20); do adb shell pidof com.lynx.explorer >/dev/null && exit 0; sleep 2; done; echo "com.lynx.explorer failed to start" >&2; exit 1'
             pnpm --filter @lynx-js/kitten-lynx-test-infra run test --coverage --reporter=github-actions --reporter=dot --reporter=junit --outputFile=test-report.junit.xml --coverage.reporter='json' --coverage.reporter='text' --testTimeout=50000 --no-cache --logHeapUsage --silent
 
   test-typos:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,6 @@ jobs:
       runs-on: ubuntu-24.04
       is-web: true
       run: |
-        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         pnpm --filter @lynx-js/web-core-e2e run lh || echo "Lighthouse failed"
   playwright-web-elements:
@@ -99,7 +98,6 @@ jobs:
       codecov-flags: "e2e"
       web-report-path: "packages/web-platform/web-elements/playwright-report"
       run: |
-        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-elements run test --reporter='github,dot,junit,html' --shard=${{ matrix.shard }}/2
@@ -156,7 +154,6 @@ jobs:
         if [ "${{ matrix.render }}" = "SSR" ]; then
           export ENABLE_SSR=true
         fi
-        ulimit -Sn 655350
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-core-e2e run test --reporter='github,dot,junit,html' --shard=${{ matrix.shard }}/2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,60 +276,70 @@ jobs:
         --hookTimeout=50000
   kitten-lynx-android-emulator:
     needs: build
-    uses: ./.github/workflows/workflow-test.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     name: Kitten Lynx Android Emulator Test
-    with:
-      runs-on: ubuntu-22.04
-      run: |
-        # 4. Start Emulator
-        echo "Starting emulator..."
-        ${ANDROID_HOME}/emulator/emulator -avd Nexus_5_API_28 -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect &
-
-        # 5. Wait for boot
-        echo "Waiting for emulator to boot..."
-        adb wait-for-device
-        BOOT_TIMEOUT=60
-        BOOT_ELAPSED=0
-        while [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" != "1" ]; do
-            if [ $BOOT_ELAPSED -ge $BOOT_TIMEOUT ]; then
-              echo "Error: Emulator failed to boot within ${BOOT_TIMEOUT} seconds!"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    permissions: {}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "22"
+          package-manager-cache: false
+      - name: TurboCache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .turbo
+          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: Install
+        run: |
+          npm install -g corepack@latest
+          corepack enable
+          pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm turbo build --summarize
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run tests on Android emulator
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          api-level: 28
+          target: default
+          arch: x86_64
+          profile: Nexus 5
+          force-avd-creation: false
+          emulator-options: -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect
+          disable-animations: true
+          script: |
+            wget -q https://github.com/lynx-family/lynx/releases/download/3.6.0/LynxExplorer-noasan-release.apk -O LynxExplorer.apk
+            adb install -r LynxExplorer.apk
+            if ! adb shell pm list packages | grep -q com.lynx.explorer; then
+              echo "Error: com.lynx.explorer is not installed!"
               exit 1
             fi
-            sleep 2
-            BOOT_ELAPSED=$((BOOT_ELAPSED+2))
-        done
-        echo "Emulator is ready."
-
-        # 6. Install Lynx Explorer
-        wget -q https://github.com/lynx-family/lynx/releases/download/3.6.0/LynxExplorer-noasan-release.apk -O LynxExplorer.apk
-        adb install -r LynxExplorer.apk
-
-        # 7. Start Lynx Explorer and verify
-        echo "Starting Lynx Explorer..."
-        if ! adb shell pm list packages | grep -q com.lynx.explorer; then
-          echo "Error: com.lynx.explorer is not installed!"
-          exit 1
-        fi
-        adb shell monkey -p com.lynx.explorer -c android.intent.category.LAUNCHER 1
-
-        echo "Waiting for Lynx Explorer to start..."
-        MAX_RETRIES=10
-        RETRY_COUNT=0
-        while ! adb shell pidof com.lynx.explorer > /dev/null; do
-          if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
-            echo "Error: com.lynx.explorer failed to start!"
-            exit 1
-          fi
-          echo "Waiting... ($RETRY_COUNT/$MAX_RETRIES)"
-          sleep 2
-          RETRY_COUNT=$((RETRY_COUNT+1))
-        done
-        echo "Lynx Explorer is running."
-
-        # 8. Run the tests
-        pnpm --filter @lynx-js/kitten-lynx-test-infra run test --coverage --reporter=github-actions --reporter=dot --reporter=junit --outputFile=test-report.junit.xml --coverage.reporter='json' --coverage.reporter='text' --testTimeout=50000 --no-cache --logHeapUsage --silent
+            adb shell monkey -p com.lynx.explorer -c android.intent.category.LAUNCHER 1
+            MAX_RETRIES=10
+            RETRY_COUNT=0
+            while ! adb shell pidof com.lynx.explorer > /dev/null; do
+              if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+                echo "Error: com.lynx.explorer failed to start!"
+                exit 1
+              fi
+              echo "Waiting... ($RETRY_COUNT/$MAX_RETRIES)"
+              sleep 2
+              RETRY_COUNT=$((RETRY_COUNT+1))
+            done
+            pnpm --filter @lynx-js/kitten-lynx-test-infra run test --coverage --reporter=github-actions --reporter=dot --reporter=junit --outputFile=test-report.junit.xml --coverage.reporter='json' --coverage.reporter='text' --testTimeout=50000 --no-cache --logHeapUsage --silent
 
   test-typos:
     runs-on: ubuntu-24.04
@@ -360,7 +370,7 @@ jobs:
         --reporter=dot
         --reporter=junit
         --outputFile=test-report.junit.xml
-        --expect.poll.timeout=5000
+        --expect.poll.timeout=10000
         --testTimeout=50000
         --hookTimeout=50000
         --coverage

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -14,7 +14,7 @@ jobs:
     # Error: Event merge_group is not supported by CodSpeed
     # Error: unknown variant `merge_group`, expected one of `push`, `pull_request`, `workflow_dispatch`, `schedule`, `local` at line 1 column 13
     if: github.event_name != 'merge_group'
-    runs-on: ubuntu-24.04-32core
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -14,7 +14,7 @@ jobs:
     # Error: Event merge_group is not supported by CodSpeed
     # Error: unknown variant `merge_group`, expected one of `push`, `pull_request`, `workflow_dispatch`, `schedule`, `local` at line 1 column 13
     if: github.event_name != 'merge_group'
-    runs-on: lynx-ubuntu-24.04-xlarge
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -25,7 +25,7 @@ jobs:
           package-manager-cache: false
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -14,7 +14,7 @@ jobs:
     # Error: Event merge_group is not supported by CodSpeed
     # Error: unknown variant `merge_group`, expected one of `push`, `pull_request`, `workflow_dispatch`, `schedule`, `local` at line 1 column 13
     if: github.event_name != 'merge_group'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-32core
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   get-merge-base:
     permissions: {}
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
       # We have 2 cases:
@@ -71,9 +71,9 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - label: lynx-ubuntu-24.04-xlarge
+          - label: ubuntu-24.04
             name: Ubuntu
-          - label: lynx-windows-2022-large
+          - label: windows-2022
             name: Windows
     timeout-minutes: 30
     needs: get-merge-base
@@ -92,7 +92,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.sha }}

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - label: ubuntu-24.04-32core
+          - label: ubuntu-24.04
             name: Ubuntu
           - label: windows-2022
             name: Windows

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - label: ubuntu-24.04
+          - label: ubuntu-24.04-32core
             name: Ubuntu
           - label: windows-2022
             name: Windows

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -10,7 +10,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   build:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -39,7 +39,7 @@ jobs:
           node-version: "24"
           package-manager-cache: false
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -47,6 +47,10 @@ jobs:
       env:
         CI: 1
         TURBO_TELEMETRY_DISABLED: 1
+        # Firefox refuses to launch unless $HOME is owned by the current user;
+        # the runner mounts /github/home which is owned by the host runner user.
+        # See: https://playwright.dev/docs/ci#running-as-root
+        HOME: /root
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -47,10 +47,6 @@ jobs:
       env:
         CI: 1
         TURBO_TELEMETRY_DISABLED: 1
-        # Firefox refuses to launch unless $HOME is owned by the current user;
-        # the runner mounts /github/home which is owned by the host runner user.
-        # See: https://playwright.dev/docs/ci#running-as-root
-        HOME: /root
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -95,6 +91,12 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          # Firefox refuses to launch when $HOME isn't owned by the current
+          # user. GitHub Actions hard-codes HOME=/github/home for container
+          # jobs (mounted from the host runner user's tmp dir), so override
+          # it at step scope only when we're inside the Playwright container.
+          # See https://playwright.dev/docs/ci#running-as-root
+          HOME: ${{ inputs.is-web && '/root' || '/home/runner' }}
         run: ${{ inputs.run }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -39,7 +39,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   check:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ${{ inputs.runs-on }}
     permissions: {}
     container:
@@ -53,6 +53,17 @@ jobs:
           # Codecov requires fetch-depth: 0
           fetch-depth: 0
           persist-credentials: false
+      # actions/cache derives its internal version hash from the available
+      # compression tool (zstd vs gzip). The build job saves with zstd on the
+      # host; the Playwright container image is missing zstd, so without this
+      # step `is-web` jobs fall back to gzip and miss the cache.
+      - name: Install zstd for cache compatibility
+        if: ${{ inputs.is-web }}
+        shell: bash
+        run: |
+          if ! command -v zstd >/dev/null 2>&1; then
+            apt-get update && apt-get install -y --no-install-recommends zstd
+          fi
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -58,7 +58,7 @@ jobs:
           node-version: "22"
           package-manager-cache: false
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build:
     permissions: {}
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -20,7 +20,7 @@ jobs:
           node-version: "24"
           package-manager-cache: false
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}

--- a/packages/web-platform/playwright-fixtures/src/playwright.common.ts
+++ b/packages/web-platform/playwright-fixtures/src/playwright.common.ts
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 import { type defineConfig, devices } from '@playwright/test';
-import os from 'node:os';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,20 +14,6 @@ process.env['LIBGL_ALWAYS_SOFTWARE'] = 'true'; // https://github.com/microsoft/p
 process.env['GALLIUM_HUD_SCALE'] = '1';
 const isCI = !!process.env['CI'];
 const port = process.env['PORT'] ?? 3080;
-const workerLimit = Math.floor(((cpuCount, envCPULimit) => {
-  if (isCI) {
-    if (envCPULimit) {
-      return envCPULimit / 2;
-    } else {
-      if (cpuCount <= 32) {
-        return 8;
-      } else {
-        return 8 + (cpuCount - 32) / 6;
-      }
-    }
-  }
-  return cpuCount / 2;
-})(os.cpus().length, parseFloat(process.env['cpu_limit'] ?? '0')));
 
 /**
  * Read environment variables from file.
@@ -45,7 +30,7 @@ export const playwrightConfigCommon: Parameters<typeof defineConfig>[0] = {
   testMatch: '**/tests/*',
   /* Run tests in files in parallel */
   fullyParallel: true,
-  workers: isCI ? workerLimit : undefined,
+  workers: isCI ? 1 : undefined,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!isCI,
   /* Retry on CI only */


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched many CI jobs to GitHub-hosted Ubuntu runners (ubuntu-24.04/22.04/ubuntu-24.04-32core) instead of custom infra.
  * Standardized caching by replacing custom cache actions with the official actions/cache (pinned) and updated Rust toolchain caching.
  * Removed some pre-test ulimit steps and adjusted runner labels/matrices; increased select CI timeouts and test poll timeouts.
  * Reworked Android emulator job for reliability and added zstd install in Playwright runs.
  * Updated Renovate config to remove a prior ignore entry.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2593)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

Removes the workflow dependency on the `lynx-infra` self-hosted runner pool and on `lynx-infra/cache` (a fork of `actions/cache`), so CI runs entirely on GitHub-official infrastructure.

### Runner migration

| Old (self-hosted)                    | New (GitHub-hosted) |
| ------------------------------------ | ------------------- |
| `lynx-ubuntu-24.04-medium`           | `ubuntu-24.04`      |
| `lynx-ubuntu-24.04-xlarge`           | `ubuntu-24.04`      |
| `lynx-windows-2022-large`            | `windows-2022`      |
| `lynx-ubuntu-22.04-physical-medium`  | `ubuntu-22.04`      |
| `lynx-custom-container`              | `ubuntu-24.04` (Playwright container still pinned via `jobs.<id>.container.image`) |

### Cache migration

All five `lynx-infra/cache@5c6160a…` references swapped for `actions/cache@0400d5f6… # v4.2.4`. The action is API-compatible, so `path` / `key` / `restore-keys` / `fail-on-cache-miss` are untouched and cache continuity is preserved by key.

### Files touched

12 files under `.github/workflows/` — runner labels and cache `uses:` only. No logic changes.

## Things reviewers should know

- **Android emulator job** (`kitten-lynx-android-emulator` in `test.yml`): previously ran on `lynx-ubuntu-22.04-physical-medium` for hardware acceleration. GitHub's `ubuntu-22.04` hosted runner supports nested virtualization / KVM, but if the emulator boot fails in CI, the fallback is to keep this single job on `ubuntu-22.04` paired with `reactivecircus/android-emulator-runner@v2`.
- **Cache continuity**: the first build on the new runners will be a cold cache for `turbo-v4-${{ runner.os }}-…` keys; subsequent runs should hit normally since `runner.os` values (`Linux` / `Windows`) are unchanged from the previous labels.
- **Workflows already on official runners** (`copilot-setup-steps.yml`, `stale.yml`, several `deploy-main.yml` jobs) were not modified.

## Checklist

- [x] Tests updated (or not required) — CI-config-only change.
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required) — infra-only change, no package changes.