### PR TITLE
chore: add web-core bindwheel e2e coverage

### DIFF
--- a/.github/lynx-stack.instructions.md
+++ b/.github/lynx-stack.instructions.md
@@ -19,3 +19,10 @@ applyTo: ".github/workflows/**/*"
 ---
 
 For Playwright-related CI jobs, add ulimit -Sn 655350 directly in each job's run block before invoking Playwright commands.
+
+---
+applyTo: "packages/web-platform/web-core-e2e/**/*"
+---
+
+For ReactLynx Playwright coverage in web-core-e2e, add fixtures under `tests/reactlynx/<test-title>/index.jsx` and use the same `<test-title>` string in `tests/reactlynx.spec.ts`.
+Skip WebKit for tests that depend on `page.mouse.wheel`, since the existing suites treat WebKit wheel support as unavailable.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -1039,6 +1039,24 @@ test.describe('reactlynx3 tests', () => {
         ); // green
       },
     );
+    test(
+      'basic-bindwheel-view',
+      async ({ page, browserName }, { title }) => {
+        test.skip(
+          browserName === 'webkit',
+          'mouse wheel unsupported on webkit',
+        );
+        await goto(page, title);
+        await wait(300);
+        await page.locator('#target').hover();
+        await page.mouse.wheel(0, 100);
+        await expect(page.locator('#result')).toHaveText('wheel');
+        await expect(page.locator('#indicator')).toHaveCSS(
+          'background-color',
+          'rgb(0, 128, 0)',
+        );
+      },
+    );
 
     test('basic-page-event', async ({ page }, { title }) => {
       await goto(page, title);
@@ -4746,6 +4764,24 @@ test.describe('reactlynx3 tests', () => {
           await wait(1000);
           expect(scrolled).toBeTruthy();
           expect(scrollend).toBeTruthy();
+        },
+      );
+      test(
+        'basic-element-list-bindwheel',
+        async ({ page, browserName }, { title }) => {
+          test.skip(
+            browserName === 'webkit',
+            'mouse wheel unsupported on webkit',
+          );
+          await goto(page, title);
+          await wait(300);
+          await page.locator('#target').hover();
+          await page.mouse.wheel(0, 100);
+          await expect(page.locator('#result')).toHaveText('wheel');
+          await expect(page.locator('#indicator')).toHaveCSS(
+            'background-color',
+            'rgb(0, 128, 0)',
+          );
         },
       );
       test(

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-bindwheel-view/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-bindwheel-view/index.jsx
@@ -1,0 +1,35 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+
+function App() {
+  const [eventType, setEventType] = useState('');
+
+  const handleWheel = (e) => {
+    if (e.type === 'wheel') {
+      setEventType(e.type);
+    }
+  };
+
+  return (
+    <view style={{ display: 'flex', flexDirection: 'column' }}>
+      <view
+        id='target'
+        style={{ width: '160px', height: '160px', backgroundColor: 'pink' }}
+        bindwheel={handleWheel}
+      />
+      <text id='result'>{eventType}</text>
+      <view
+        id='indicator'
+        style={{
+          width: '100px',
+          height: '100px',
+          backgroundColor: eventType === 'wheel' ? 'green' : 'pink',
+        }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-list-bindwheel/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-list-bindwheel/index.jsx
@@ -1,0 +1,46 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+
+function App() {
+  const [eventType, setEventType] = useState('');
+
+  const handleWheel = (e) => {
+    if (e.type === 'wheel') {
+      setEventType(e.type);
+    }
+  };
+
+  return (
+    <view style={{ display: 'flex', flexDirection: 'column' }}>
+      <list
+        id='target'
+        list-type='single'
+        style={{ width: '240px', height: '240px', backgroundColor: 'yellow' }}
+        bindwheel={handleWheel}
+      >
+        {Array.from({ length: 8 }, (_, index) => (
+          <list-item
+            key={index}
+            item-key={`${index}`}
+            style={{ width: '100%', height: '100px', backgroundColor: 'white' }}
+          >
+            <text>{index}</text>
+          </list-item>
+        ))}
+      </list>
+      <text id='result'>{eventType}</text>
+      <view
+        id='indicator'
+        style={{
+          width: '100px',
+          height: '100px',
+          backgroundColor: eventType === 'wheel' ? 'green' : 'pink',
+        }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);


### PR DESCRIPTION
## Summary
- Add ReactLynx web-core-e2e coverage for `bindwheel` on `view`.
- Add ReactLynx web-core-e2e coverage for `bindwheel` on `list`.
- Document the web-core-e2e fixture/title pattern and WebKit wheel skip note.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm dprint fmt packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts packages/web-platform/web-core-e2e/tests/reactlynx/basic-bindwheel-view/index.jsx packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-list-bindwheel/index.jsx .github/lynx-stack.instructions.md`
- `pnpm turbo build` failed first with a rustc SIGSEGV in `swc_plugin_reactlynx`; reran with `RUST_MIN_STACK=16777216 pnpm turbo build` and it passed.
- `pnpm --filter @lynx-js/web-core-e2e test --grep "basic-bindwheel-view|basic-element-list-bindwheel" --project chromium`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added testing structure guidelines for ReactLynx Playwright tests with fixture organization standards.

* **Tests**
  * Added test cases for mouse wheel event handling verification on supported browsers.
  * Implemented tests to validate wheel event binding functionality across list and view components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2596)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->