### PR TITLE
feat(chunk-loading): bypass Promise.all for single sync-then chunk loads

### DIFF
--- a/.changeset/sync-then-chunk-load.md
+++ b/.changeset/sync-then-chunk-load.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/chunk-loading-webpack-plugin": patch
+---
+
+Override `__webpack_require__.e` so a single sync-then chunk load (the
+typical lazy bundle case) bypasses `Promise.all`. This preserves the
+sync-then chain end-to-end so preact's `lazy(loader)` can resolve at
+first render instead of always falling back to the Suspense fallback.
+Multi-promise loads still take the `Promise.all` path unchanged.

--- a/.changeset/sync-then-chunk-load.md
+++ b/.changeset/sync-then-chunk-load.md
@@ -3,7 +3,5 @@
 ---
 
 Override `__webpack_require__.e` so a single sync-then chunk load (the
-typical lazy bundle case) bypasses `Promise.all`. This preserves the
-sync-then chain end-to-end so preact's `lazy(loader)` can resolve at
-first render instead of always falling back to the Suspense fallback.
-Multi-promise loads still take the `Promise.all` path unchanged.
+typical lazy bundle case) bypasses `Promise.all`. It will make first screen
+in main thread can load lazy bundle synchronously when using dynamic import.

--- a/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
@@ -69,6 +69,11 @@ export default function() {
         },
         [],
       );
+      // Skip the Promise.all wrap for the common one-chunk case so a
+      // sync-resolved loader (e.g. cached lazy bundle) keeps its sync `.then`
+      // and preact's `lazy()` can resolve at first render. webpack callers
+      // (`__webpack_require__.bind(__webpack_require__, moduleId)`) ignore the
+      // resolved value, so returning a single value instead of `[value]` is safe.
       if (promises.length === 1) return promises[0];
       return Promise.all(promises);
     };

--- a/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
@@ -62,10 +62,13 @@ export default function() {
     };
 
     $RuntimeGlobals_ensureChunk$ = function(chunkId) {
-      var promises = [];
-      Object.keys($RuntimeGlobals_ensureChunkHandlers$).forEach(function(key) {
-        $RuntimeGlobals_ensureChunkHandlers$[key](chunkId, promises);
-      });
+      var promises = Object.keys($RuntimeGlobals_ensureChunkHandlers$).reduce(
+        function(promises, key) {
+          $RuntimeGlobals_ensureChunkHandlers$[key](chunkId, promises);
+          return promises;
+        },
+        [],
+      );
       if (promises.length === 1) return promises[0];
       return Promise.all(promises);
     };

--- a/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
@@ -60,6 +60,15 @@ export default function() {
         }
       }
     };
+
+    $RuntimeGlobals_ensureChunk$ = function(chunkId) {
+      var promises = [];
+      Object.keys($RuntimeGlobals_ensureChunkHandlers$).forEach(function(key) {
+        $RuntimeGlobals_ensureChunkHandlers$[key](chunkId, promises);
+      });
+      if (promises.length === 1) return promises[0];
+      return Promise.all(promises);
+    };
   }
   if (typeof installChunk !== 'undefined') {
     $RuntimeGlobals_externalInstallChunk$ = installChunk;

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/dynamic.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/dynamic.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/index.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/index.js
@@ -1,0 +1,77 @@
+/// <reference types="@rspack/test-tools/rstest" />
+
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(__filename);
+
+const SYNC_MARKER = Symbol.for('test.syncThen');
+
+function makeSyncThenPromise(value) {
+  const p = Promise.resolve(value);
+  const syncThen = function(onF) {
+    if (!onF) return p;
+    var ret;
+    try {
+      ret = onF(value);
+    } catch (e) {
+      return Promise.reject(e);
+    }
+    return makeSyncThenPromise(ret);
+  };
+  syncThen[SYNC_MARKER] = true;
+  p.then = syncThen;
+  return p;
+}
+
+globalThis.lynx = {
+  loadLazyBundle: rstest.fn(function loadLazyBundle(request) {
+    return makeSyncThenPromise(
+      require(path.join(__dirname, `${request}.rspack.bundle.cjs`)),
+    );
+  }),
+  requireModuleAsync: rstest.fn(function requireModuleAsync(_url, cb) {
+    cb(null, {});
+  }),
+};
+
+it('preserves the inner sync-then promise when only one handler pushes one promise', () => {
+  const chunkId = Object.keys(__webpack_require__.lynx_aci)[0];
+  expect(chunkId).toBeTruthy();
+
+  const out = __webpack_require__.e(chunkId);
+  expect(out.then[SYNC_MARKER]).toBe(true);
+
+  let observed;
+  out.then((v) => {
+    observed = v;
+  });
+  expect(observed).toBeDefined();
+});
+
+it('falls back to Promise.all (native then) when more than one promise is pushed', async () => {
+  const savedRequire = __webpack_require__.f.require;
+  __webpack_require__.f.require = () => {
+    /* swap out f.require so the chunk loader doesn't add its own promise */
+  };
+  __webpack_require__.f.extraA = (_id, list) => list.push(Promise.resolve('a'));
+  __webpack_require__.f.extraB = (_id, list) => list.push(Promise.resolve('b'));
+  try {
+    const out = __webpack_require__.e('any-chunk');
+    expect(out.then[SYNC_MARKER]).toBeUndefined();
+    const values = await out;
+    expect(values).toBeInstanceOf(Array);
+    expect(values).toContain('a');
+    expect(values).toContain('b');
+  } finally {
+    __webpack_require__.f.require = savedRequire;
+    delete __webpack_require__.f.extraA;
+    delete __webpack_require__.f.extraB;
+  }
+});
+
+it('chunk loading still works end to end', async () => {
+  await import(/* webpackChunkName: 'dynamic' */ './dynamic.js');
+  expect(__webpack_require__.lynx_aci).toHaveProperty('dynamic');
+  expect(lynx.loadLazyBundle).toBeCalled();
+});

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/rspack.config.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/rspack.config.js
@@ -2,7 +2,7 @@ import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
 
 import { ChunkLoadingWebpackPlugin } from '../../../../lib/index.js';
 
-/** @type {import('webpack').Configuration} */
+/** @type {import('@rspack/core').Configuration} */
 export default {
   mode: 'development',
   output: {
@@ -13,7 +13,7 @@ export default {
   plugins: [
     new ChunkLoadingWebpackPlugin(),
     /**
-     * @param {import('webpack').Compiler} compiler
+     * @param {import('@rspack/core').Compiler} compiler
      */
     compiler => {
       const { RuntimeModule } = compiler.webpack;

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/rspack.config.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/rspack.config.js
@@ -38,13 +38,15 @@ export default {
          * @override
          */
         generate() {
-          const chunk = this.chunk;
+          const chunk =
+            /** @type {import('@rspack/core').Chunk} */ (this.chunk);
 
           return `// lynx async chunks
     ${RuntimeGlobals.lynxAsyncChunkIds} = ${
             JSON.stringify(
               Object.fromEntries(
                 Array.from(chunk.getAllAsyncChunks()).map(
+                  /** @param {import('@rspack/core').Chunk} c */
                   c => [c.id, c.name],
                 ),
               ),

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/rspack.config.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/rspack.config.js
@@ -1,0 +1,57 @@
+import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
+
+import { ChunkLoadingWebpackPlugin } from '../../../../lib/index.js';
+
+/** @type {import('webpack').Configuration} */
+export default {
+  mode: 'development',
+  output: {
+    chunkLoading: 'lynx',
+    chunkFormat: 'commonjs',
+    chunkFilename: '[id].rspack.bundle.cjs',
+  },
+  plugins: [
+    new ChunkLoadingWebpackPlugin(),
+    /**
+     * @param {import('webpack').Compiler} compiler
+     */
+    compiler => {
+      const { RuntimeModule } = compiler.webpack;
+
+      compiler.hooks.compilation.tap('test', compilation => {
+        compilation.hooks.runtimeRequirementInTree.for(
+          RuntimeGlobals.lynxAsyncChunkIds,
+        ).tap('test', (chunk) => {
+          compilation.addRuntimeModule(
+            chunk,
+            new LynxAsyncChunksRuntimeModule(),
+          );
+        });
+      });
+
+      class LynxAsyncChunksRuntimeModule extends RuntimeModule {
+        constructor() {
+          super('Lynx async chunks', RuntimeModule.STAGE_ATTACH);
+        }
+
+        /**
+         * @override
+         */
+        generate() {
+          const chunk = this.chunk;
+
+          return `// lynx async chunks
+    ${RuntimeGlobals.lynxAsyncChunkIds} = ${
+            JSON.stringify(
+              Object.fromEntries(
+                Array.from(chunk.getAllAsyncChunks()).map(
+                  c => [c.id, c.name],
+                ),
+              ),
+            )
+          }`;
+        }
+      }
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

`__webpack_require__.e` always wrapped chunk handlers' promises in `Promise.all`, which collapses any sync-then promise back into a native one. preact's `lazy(loader)` therefore always saw a pending \`prom\` at first render and fell through to the Suspense fallback — even when the underlying \`lynx.loadLazyBundle\` resolved synchronously (cached / \`fetchBundle.wait()\`).

Override \`e\` from the Lynx chunk-loading runtime so that when exactly one handler pushes exactly one promise (the typical lazy-bundle shape — one JS chunk, no separate CSS chunk, no shared splits), we return that promise directly. The sync-then contract survives all the way to preact and the lazy component renders on the first pass.

Length 0 and length > 1 fall through to the original \`Promise.all\` path; behavior for those is unchanged.

## Test plan

- [x] Existing \`@lynx-js/chunk-loading-webpack-plugin\` tests still pass (40/40)
- [x] Existing \`@lynx-js/react-runtime\` tests still pass
- [x] Built \`examples/react-lazy-bundle\` and confirmed the runtime now emits \`r.e=function(e){var t=[];return(...,1===t.length)?t[0]:Promise.all(t)}\` instead of always-Promise.all
- [ ] Manual: lazy bundle renders without Suspense fallback flash on cached load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Single-chunk dynamic imports now take a fast synchronous path so lazy-loaded components resolve immediately in common cases; multi-chunk behavior remains unchanged.

* **Tests**
  * Added tests covering single-vs-multi-chunk promise behavior and end-to-end dynamic import scenarios.

* **Chores**
  * Bumped chunk-loading plugin to a patch release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2597)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->