### PR TITLE
feat: Support frame element on web

### DIFF
--- a/.changeset/frame-web-core.md
+++ b/.changeset/frame-web-core.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Add web support for the `<frame>` element by mapping it to `<lynx-view>`.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -261,6 +261,71 @@ test.describe('reactlynx3 tests', () => {
       await expect(height).toHaveText('5678');
     });
 
+    test('api-frame-element-map', async ({ page }, { title }) => {
+      await goto(page, title);
+      await expect(page.locator('#target')).toHaveJSProperty(
+        'tagName',
+        'LYNX-VIEW',
+      );
+    });
+
+    test('api-frame-src', async ({ page }, { title }) => {
+      await goto(page, title);
+      await expect(page.locator('#frame-ready')).toHaveText('frame:ready');
+    });
+
+    test('api-frame-data', async ({ page }, { title }) => {
+      await goto(page, title);
+      await expect(page.locator('#frame-data')).toHaveText('data:from-data');
+    });
+
+    test('api-frame-data-update', async ({ page }, { title }) => {
+      await goto(page, title);
+      await expect(page.locator('#frame-data')).toHaveText('data:before');
+      await page.locator('#update-frame-data').click();
+      await expect(page.locator('#frame-data')).toHaveText('data:after');
+    });
+
+    test('api-frame-global-props', async ({ page }, { title }) => {
+      await goto(page, title);
+      await expect(page.locator('#frame-global-props')).toHaveText(
+        'global:from-global-props',
+      );
+    });
+
+    test('api-frame-bindload', async ({ page }, { title }) => {
+      await goto(page, title);
+      await expect(page.locator('#frame-load-status')).toHaveText('0');
+      await expect(page.locator('#frame-load-message')).toHaveText('success');
+      await expect(page.locator('#frame-load-url')).toContainText(
+        '/dist/api-frame-inner.web.bundle',
+      );
+    });
+
+    test('api-frame-auto-height', async ({ page }, { title }) => {
+      await goto(page, title);
+      await expect(page.locator('#target')).toHaveAttribute(
+        'auto-height',
+        'true',
+      );
+      await expect(page.locator('#target')).not.toHaveAttribute(
+        'height',
+        'auto',
+      );
+    });
+
+    test('api-frame-auto-width', async ({ page }, { title }) => {
+      await goto(page, title);
+      await expect(page.locator('#target')).toHaveAttribute(
+        'auto-width',
+        'true',
+      );
+      await expect(page.locator('#target')).not.toHaveAttribute(
+        'width',
+        'auto',
+      );
+    });
+
     test('basic-bindtap-simultaneous', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-auto-height/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-auto-height/index.jsx
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+function App() {
+  return (
+    <view>
+      <frame
+        id='target'
+        auto-height={true}
+        src='/dist/api-frame-inner.web.bundle'
+        style={{ width: '300px' }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-auto-width/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-auto-width/index.jsx
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+function App() {
+  return (
+    <view>
+      <frame
+        id='target'
+        auto-width={true}
+        src='/dist/api-frame-inner.web.bundle'
+        style={{ height: '120px' }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-bindload/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-bindload/index.jsx
@@ -1,0 +1,27 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+
+function App() {
+  const [detail, setDetail] = useState({
+    statusCode: -1,
+    statusMessage: '',
+    url: '',
+  });
+
+  return (
+    <view>
+      <frame
+        src='/dist/api-frame-inner.web.bundle'
+        bindload={event => setDetail(event.detail)}
+        style={{ width: '300px', height: '120px' }}
+      />
+      <text id='frame-load-status'>{detail.statusCode}</text>
+      <text id='frame-load-message'>{detail.statusMessage}</text>
+      <text id='frame-load-url'>{detail.url}</text>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-data-update/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-data-update/index.jsx
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+
+function App() {
+  const [label, setLabel] = useState('before');
+
+  return (
+    <view>
+      <frame
+        src='/dist/api-frame-inner.web.bundle'
+        data={{ label }}
+        style={{ width: '300px', height: '120px' }}
+      />
+      <view id='update-frame-data' bindtap={() => setLabel('after')}>
+        <text>update</text>
+      </view>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-data/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-data/index.jsx
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+function App() {
+  return (
+    <view>
+      <frame
+        src='/dist/api-frame-inner.web.bundle'
+        data={{ label: 'from-data' }}
+        style={{ width: '300px', height: '120px' }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-element-map/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-element-map/index.jsx
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+function App() {
+  return (
+    <view>
+      <frame
+        id='target'
+        src='/dist/api-frame-inner.web.bundle'
+        style={{ width: '300px', height: '120px' }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-global-props/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-global-props/index.jsx
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+function App() {
+  return (
+    <view>
+      <frame
+        src='/dist/api-frame-inner.web.bundle'
+        global-props={{ message: 'from-global-props' }}
+        style={{ width: '300px', height: '120px' }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-inner/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-inner/index.jsx
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useInitData } from '@lynx-js/react';
+
+function App() {
+  const initData = useInitData();
+  const globalProps = lynx.__globalProps;
+
+  return (
+    <view>
+      <text id='frame-ready'>frame:ready</text>
+      <text id='frame-data'>data:{initData.label}</text>
+      <text id='frame-global-props'>global:{globalProps.message}</text>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-src/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-frame-src/index.jsx
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+
+function App() {
+  return (
+    <view>
+      <frame
+        id='target'
+        src='/dist/api-frame-inner.web.bundle'
+        style={{ width: '300px', height: '120px' }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core/src/constants.rs
+++ b/packages/web-platform/web-core/src/constants.rs
@@ -32,6 +32,7 @@ lazy_static::lazy_static! {
     ("list", "x-list"),
     ("page", "div"),
     ("svg", "x-svg"),
+    ("frame", "lynx-view"),
   ]);
 
   pub static ref HTML_TAG_TO_LYNX_TAG_MAP: FnvHashMap<&'static str, &'static str> = FnvHashMap::from_iter(LYNX_TAG_TO_HTML_TAG_MAP

--- a/packages/web-platform/web-core/src/template/template_sections/style_info/style_info_decoder.rs
+++ b/packages/web-platform/web-core/src/template/template_sections/style_info/style_info_decoder.rs
@@ -704,6 +704,44 @@ mod test {
   }
 
   #[test]
+  fn test_frame_type_selector() {
+    let raw_style_info = RawStyleInfo {
+      css_id_to_style_sheet: FnvHashMap::from_iter(vec![(
+        0,
+        StyleSheet {
+          imports: vec![],
+          rules: vec![Rule {
+            nested_rules: vec![],
+            rule_type: RuleType::Declaration,
+            prelude: RulePrelude {
+              selector_list: vec![Selector {
+                simple_selectors: vec![OneSimpleSelector {
+                  selector_type: OneSimpleSelectorType::TypeSelector,
+                  value: "frame".to_string(),
+                }],
+              }],
+            },
+            declaration_block: DeclarationBlock {
+              declarations: vec![ParsedDeclaration {
+                property_id: CSSPropertyEnum::Height.into(),
+                is_important: false,
+                value_token_list: vec![ValueToken {
+                  token_type: crate::css_tokenizer::token_types::DIMENSION_TOKEN,
+                  value: "200px".to_string(),
+                }],
+              }],
+            },
+          }],
+        },
+      )]),
+      style_content_str_size_hint: 0,
+    };
+    let result = generate_string_buf(raw_style_info, true, None);
+    let expected = "lynx-view:not([l-e-name]){height:200px;}";
+    assert_eq!(result.style_content, expected);
+  }
+
+  #[test]
   fn test_multiple_selectors() {
     let raw_style_info = RawStyleInfo {
       css_id_to_style_sheet: FnvHashMap::from_iter(vec![(

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
@@ -70,8 +70,10 @@ export class LynxViewElement extends HTMLElement {
   static tag = 'lynx-view' as const;
   static observedAttributeAsProperties = [
     'url',
+    'src',
     'global-props',
     'init-data',
+    'data',
     'browser-config',
     'transform-vw',
     'transform-vh',
@@ -203,9 +205,19 @@ export class LynxViewElement extends HTMLElement {
   get url(): string | undefined {
     return this.#url;
   }
-  set url(val: string) {
+  set url(val: string | undefined) {
+    if (this.#url === val) {
+      return;
+    }
     this.#url = val;
     this.#render();
+  }
+
+  get src(): string | undefined {
+    return this.url;
+  }
+  set src(val: string | undefined) {
+    this.url = val;
   }
 
   #globalProps: Cloneable = {};
@@ -218,11 +230,16 @@ export class LynxViewElement extends HTMLElement {
     return this.#globalProps;
   }
   set globalProps(val: string | Cloneable) {
-    if (typeof val === 'string') {
-      this.#globalProps = JSON.parse(val);
-    } else {
-      this.#globalProps = val;
-    }
+    const nextGlobalProps = typeof val === 'string' ? JSON.parse(val) : val;
+    this.#globalProps = nextGlobalProps;
+    this.#instance?.updateGlobalProps(nextGlobalProps);
+  }
+
+  get ['global-props'](): Cloneable {
+    return this.globalProps;
+  }
+  set ['global-props'](val: string | Cloneable) {
+    this.globalProps = val;
   }
 
   #initData: Cloneable = {};
@@ -235,11 +252,22 @@ export class LynxViewElement extends HTMLElement {
     return this.#initData;
   }
   set initData(val: string | Cloneable) {
-    if (typeof val === 'string') {
-      this.#initData = JSON.parse(val);
-    } else {
-      this.#initData = val;
-    }
+    const nextInitData = typeof val === 'string' ? JSON.parse(val) : val;
+    this.updateData(nextInitData);
+  }
+
+  get ['init-data'](): Cloneable {
+    return this.initData;
+  }
+  set ['init-data'](val: string | Cloneable) {
+    this.initData = val;
+  }
+
+  get data(): Cloneable {
+    return this.initData;
+  }
+  set data(val: string | Cloneable) {
+    this.initData = val;
   }
 
   #initI18nResources: InitI18nResources = [];
@@ -320,6 +348,7 @@ export class LynxViewElement extends HTMLElement {
     processorName?: string,
     callback?: () => void,
   ) {
+    this.#initData = data;
     this.#instance?.updateData(data, processorName).then(() => {
       callback?.();
     });
@@ -331,7 +360,6 @@ export class LynxViewElement extends HTMLElement {
    * update the `__globalProps`
    */
   updateGlobalProps(data: Cloneable) {
-    this.#instance?.updateGlobalProps(data);
     this.globalProps = data;
   }
 
@@ -371,20 +399,26 @@ export class LynxViewElement extends HTMLElement {
   /**
    * @private
    */
-  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+  attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ) {
     if (oldValue !== newValue) {
       switch (name) {
         case 'url':
-          this.#url = newValue;
+        case 'src':
+          this.url = newValue ?? undefined;
           break;
         case 'global-props':
-          this.#globalProps = JSON.parse(newValue);
+          this.globalProps = newValue ? JSON.parse(newValue) : {};
           break;
         case 'browser-config':
-          this.browserConfig = JSON.parse(newValue);
+          this.browserConfig = newValue ? JSON.parse(newValue) : undefined;
           break;
         case 'init-data':
-          this.#initData = JSON.parse(newValue);
+        case 'data':
+          this.initData = newValue ? JSON.parse(newValue) : {};
           break;
         case 'transform-vw':
           this.transformVW = newValue !== 'false' && newValue !== null;
@@ -446,7 +480,7 @@ export class LynxViewElement extends HTMLElement {
    * @private
    */
   async #render() {
-    if (!this.#rendering && this.#connected) {
+    if (!this.#rendering && this.#connected && this.#url) {
       this.#rendering = true;
       if (!this.shadowRoot) {
         this.attachShadow({ mode: 'open' });
@@ -524,6 +558,13 @@ export class LynxViewElement extends HTMLElement {
    * @private
    */
   connectedCallback() {
+    this.#upgradeProperty('url');
+    this.#upgradeProperty('src');
+    this.#upgradeProperty('globalProps');
+    this.#upgradeProperty('global-props');
+    this.#upgradeProperty('initData');
+    this.#upgradeProperty('init-data');
+    this.#upgradeProperty('data');
     this.#upgradeProperty('browserConfig');
     this.#upgradeProperty('transformVW');
     this.#upgradeProperty('transformVH');

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createElementAPI.ts
@@ -59,6 +59,21 @@ const {
   set_inline_styles_in_key_value_vec,
 } = wasmInstance;
 
+function dispatchLynxViewLoadEvent(host: HTMLElement & { url?: string }) {
+  host.dispatchEvent(
+    new CustomEvent('load', {
+      detail: {
+        statusCode: 0,
+        statusMessage: 'success',
+        url: host.url ?? '',
+      },
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    }),
+  );
+}
+
 export function createElementAPI(
   rootDom: ShadowRoot,
   mtsBinding: WASMJSBinding,
@@ -171,6 +186,17 @@ export function createElementAPI(
     },
     __CreateImage(parentComponentUniqueId) {
       const dom = document.createElement('x-image') as DecoratedHTMLElement;
+      dom[uniqueIdSymbol] = wasmContext.create_element_common(
+        parentComponentUniqueId,
+        dom,
+        new WeakRef(dom),
+      );
+      return dom;
+    },
+    __CreateFrame(parentComponentUniqueId) {
+      const dom = document.createElement(
+        LYNX_TAG_TO_HTML_TAG_MAP['frame']!,
+      ) as DecoratedHTMLElement;
       dom[uniqueIdSymbol] = wasmContext.create_element_common(
         parentComponentUniqueId,
         dom,
@@ -610,6 +636,9 @@ export function createElementAPI(
         backgroundThread.markTiming('ui_operation_flush_start', pipelineId);
         rootDom.appendChild(page);
         (rootDom.host as HTMLElement).style.display = 'flex';
+        dispatchLynxViewLoadEvent(
+          rootDom.host as HTMLElement & { url?: string },
+        );
         backgroundThread.markTiming('ui_operation_flush_end', pipelineId);
         backgroundThread.markTiming('layout_end', pipelineId);
         backgroundThread.markTiming('dispatch_end', pipelineId);

--- a/packages/web-platform/web-core/ts/constants.ts
+++ b/packages/web-platform/web-core/ts/constants.ts
@@ -87,6 +87,7 @@ export const LYNX_TAG_TO_HTML_TAG_MAP: Record<string, string> =
       'input': 'x-input',
       'x-input-ng': 'x-input',
       'svg': 'x-svg',
+      'frame': 'lynx-view',
     }),
   );
 

--- a/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
@@ -20,6 +20,7 @@ import type {
   AppendElementPAPI,
   CreateComponentPAPI,
   CreateElementPAPI,
+  CreateFramePAPI,
   CreateImagePAPI,
   CreateListPAPI,
   CreatePagePAPI,
@@ -303,6 +304,15 @@ export function createElementAPI(
         );
         return { [uniqueIdSymbol]: id } as unknown as DecoratedHTMLElement;
       }) as CreateImagePAPI,
+      __CreateFrame: ((parentComponentUniqueId: number) => {
+        const htmlTag = LYNX_TAG_TO_HTML_TAG_MAP['frame']!;
+        const id = wasmContext.create_element(htmlTag, parentComponentUniqueId);
+        const el = { [uniqueIdSymbol]: id };
+        if (!config.enableCSSSelector) {
+          wasmContext.set_attribute(id, lynxUniqueIdAttribute, id.toString());
+        }
+        return el as unknown as DecoratedHTMLElement;
+      }) as CreateFramePAPI,
       __CreateRawText: ((text: string) => {
         const id = wasmContext.create_element('raw-text');
         wasmContext.set_attribute(id, 'text', text);

--- a/packages/web-platform/web-core/ts/types/IElementPAPI.ts
+++ b/packages/web-platform/web-core/ts/types/IElementPAPI.ts
@@ -225,6 +225,8 @@ export type CreateRawTextPAPI = (text: string) => HTMLElement;
 
 export type CreateImagePAPI = CreateViewPAPI;
 
+export type CreateFramePAPI = CreateViewPAPI;
+
 export type CreateScrollViewPAPI = CreateViewPAPI;
 
 export type CreateWrapperElementPAPI = CreateViewPAPI;
@@ -393,6 +395,7 @@ export interface ElementPAPIs {
   __CreateText: CreateTextPAPI;
   __CreateRawText: CreateRawTextPAPI;
   __CreateImage: CreateImagePAPI;
+  __CreateFrame: CreateFramePAPI;
   __CreateScrollView: CreateScrollViewPAPI;
   __CreateWrapperElement: CreateWrapperElementPAPI;
   __CreateComponent: CreateComponentPAPI;


### PR DESCRIPTION
## Summary

- Add `<frame>` creation support in web-core PAPI and the React snapshot transform.
- Map `frame` to `lynx-view` in both TypeScript and Rust tag maps, including style selector decoding.
- Wire frame-facing `src`, `data`, `global-props`, `auto-height`, `auto-width`, and `bindload` behavior through `LynxView`.
- Add focused Playwright e2e coverage for each frame API behavior.

## Validation

- `cargo test -p swc_plugin_snapshot basic_full_static`
- `cargo test -p web-core test_type_selector`
- `pnpm turbo build`
- `pnpm exec playwright test tests/reactlynx.spec.ts --grep api-frame --project=chromium`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `<frame>` element on the web platform, enabling dynamic content loading from external bundles.
  * Frame element supports data passing, auto-sizing properties, and global props configuration.
  * Added `bindload` event for tracking frame load status with status code and message information.
  * Frame content updates now propagate when data changes dynamically.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2604)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->