### PR TITLE
test: use @rstest/core/globals for test runner type globals

### DIFF
--- a/.changeset/rstest-globals-type-ref.md
+++ b/.changeset/rstest-globals-type-ref.md
@@ -1,0 +1,7 @@
+---
+
+---
+
+No package release is required. Switch test case files from the unresolvable
+`@rspack/test-tools/rstest` triple-slash type reference to `@rstest/core/globals`,
+which is the correct entry exported by the installed `@rstest/core` package.

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting-with-setupListTransformer/index.js
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting-with-setupListTransformer/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { add } from './lib-common.js';
 

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting/index.js
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { add } from './lib-common.js';
 

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/not-splitting/index.js
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/not-splitting/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { add } from './lib-common.js';
 

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/not-cache-events/lazy-bundle/index.js
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/not-cache-events/lazy-bundle/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import('./lazy-component.js');
 

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/development/index.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/development/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import { createRequire } from 'node:module';

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/index.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/ensure-chunk-shortcut/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { createRequire } from 'node:module';
 import path from 'node:path';

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/production/index.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/production/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import { createRequire } from 'node:module';

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/runtime-globals/index.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/runtime-globals/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { createRequire } from 'node:module';
 import path from 'node:path';

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/css/development/index.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/css/development/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import { createRequire } from 'node:module';

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/css/initial/index.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/css/initial/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import './foo.css';
 

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/chunk-loading/cache/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/chunk-loading/cache/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import { createRequire } from 'node:module';

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/runtime-globals/lynx-chunk-entries-production/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/runtime-globals/lynx-chunk-entries-production/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
 

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/runtime-globals/lynx-chunk-entries/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/runtime-globals/lynx-chunk-entries/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
 

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/source-map/basic/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/source-map/basic/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 // @ts-check
 
 import fs from 'node:fs/promises';

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/component/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/component/index.js
@@ -1,3 +1,3 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 expect(Component).toBe(undefined);

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/default-entry/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/default-entry/index.js
@@ -1,3 +1,3 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 expect(globDynamicComponentEntry).toBe('__Card__');

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/empty-entry/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/empty-entry/index.js
@@ -1,3 +1,3 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 expect(globDynamicComponentEntry).toBe('__Card__');

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/entry/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/entry/index.js
@@ -1,3 +1,3 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 expect(globDynamicComponentEntry).toBe('__FOO__');

--- a/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/inject-vars/index.js
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/test/cases/variables/inject-vars/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 expect(typeof Component).toBe('undefined');
 try {

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-before-encode/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-before-encode/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-filename/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-filename/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-production/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-production/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-auto/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-auto/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-custom/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info-public-path-custom/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/debug-info/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/filename-flat/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/filename-flat/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/filename-hash-8/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/filename-hash-8/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/filename-hash/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/filename-hash/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/lazy-bundle/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/lazy-bundle/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/lepus-chunk/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/lepus-chunk/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/mode-none/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/mode-none/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/production/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/production/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/assets/source-map/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/assets/source-map/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 

--- a/packages/webpack/template-webpack-plugin/test/cases/bundle-splitting/async-chunk/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/bundle-splitting/async-chunk/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/bundle-splitting/with-style/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/bundle-splitting/with-style/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/async-chunk/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/async-chunk/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/context/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/context/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/a.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/b.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/c.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/c.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/d.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/d.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/e.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/e.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/webpack-chunk-name/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/webpack-chunk-name/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/with-style/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/with-style/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/defaults/compile-options/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/defaults/compile-options/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/defaults/config/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/defaults/config/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/after-emit/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/after-emit/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/before-emit-filename-hash/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/before-emit-filename-hash/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/before-emit-filename/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/before-emit-filename/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/before-emit/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/before-emit/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode-css/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode-css/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';

--- a/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/hooks/before-encode/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-fn/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-fn/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-object/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-object/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-partial/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-regex/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-regex/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/index.js
@@ -3,7 +3,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/a.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/b.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/c.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/c.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/d.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/d.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/e.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/main-thread/mpa/e.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunk/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunk/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import(
   /* webpackChunkName: 'dynamic' */

--- a/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks/index.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import(
   /* webpackChunkName: 'dynamic' */

--- a/packages/webpack/template-webpack-plugin/test/cases/web/all-in-one/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/all-in-one/b.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/web/default-export/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/default-export/b.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/web/element-template/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/element-template/b.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';

--- a/packages/webpack/template-webpack-plugin/test/cases/web/page-config/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/web/page-config/b.js
@@ -1,4 +1,4 @@
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
 
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';


### PR DESCRIPTION
## Summary

The triple-slash `/// <reference types="@rspack/test-tools/rstest" />` in our webpack-plugin test cases is unresolvable — `@rspack/test-tools@1.5.6` does not list `./rstest` under its package `exports`, so `tsc` fails to find the type file and reports `it`, `expect`, `rstest`, etc. as undefined globals.

This PR switches every affected test case across `runtime-wrapper-webpack-plugin`, `cache-events-webpack-plugin`, `chunk-loading-webpack-plugin`, and `template-webpack-plugin` to the supported `@rstest/core/globals` entry, which the installed `@rstest/core@0.8.1` ships and which the rest of the repo (e.g. `packages/testing-library/examples/basic/src/rspeedy-env.d.ts`) already uses.

Each of the 69 file changes is a single-line swap:

```diff
-/// <reference types="@rspack/test-tools/rstest" />
+/// <reference types="@rstest/core/globals" />
```

This is a tooling-only fix; nothing in the published packages is affected, so the changeset is empty (no release).

## Test plan

- [ ] `pnpm --filter @lynx-js/runtime-wrapper-webpack-plugin exec tsc -p tsconfig.json` — clean
- [ ] `pnpm --filter @lynx-js/cache-events-webpack-plugin exec tsc -p tsconfig.json` — clean
- [ ] `pnpm --filter @lynx-js/template-webpack-plugin exec tsc -p tsconfig.json` — clean
- [ ] `pnpm --filter @lynx-js/chunk-loading-webpack-plugin exec tsc -p tsconfig.json` — confirms only pre-existing errors (Compiler type mismatch, `__webpack_require__`, CSS module decl) remain; the `Cannot find type definition file for '@rspack/test-tools/rstest'` / `Cannot find name 'it'/'expect'/'rstest'` cascade is gone
- [ ] `pnpm --filter @lynx-js/chunk-loading-webpack-plugin test` still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

- Updated type references in test files across multiple webpack plugins (cache-events, chunk-loading, runtime-wrapper, and template plugins) to align with testing framework standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2605)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->