### PR TITLE
fix(web-core): conditionally include `Card` and `Component` only when `cardType !== 'react'`.

### DIFF
--- a/.changeset/curvy-shrimps-stay.md
+++ b/.changeset/curvy-shrimps-stay.md
@@ -2,6 +2,4 @@
 "@lynx-js/web-core": patch
 ---
 
-fix: conditionally pass Card and Component params based on cardType in background thread sandbox
-
-When `cardType` is `"react"`, the `Card` and `Component` sandbox parameters are omitted from `createChunkLoading` since ReactLynx bundles do not declare these in their function signature. Passing them unconditionally caused a parameter position shift, resulting in `lynx` being `undefined` and a `loadCard failed TypeError: Cannot read properties of undefined (reading 'performance')` crash.
+Conditionally pass Card and Component params based on cardType in background thread.

--- a/.changeset/curvy-shrimps-stay.md
+++ b/.changeset/curvy-shrimps-stay.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: conditionally pass Card and Component params based on cardType in background thread sandbox
+
+When `cardType` is `"react"`, the `Card` and `Component` sandbox parameters are omitted from `createChunkLoading` since ReactLynx bundles do not declare these in their function signature. Passing them unconditionally caused a parameter position shift, resulting in `lynx` being `undefined` and a `loadCard failed TypeError: Cannot read properties of undefined (reading 'performance')` crash.

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createChunkLoading.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createChunkLoading.ts
@@ -8,7 +8,10 @@ import type {
   BundleInitReturnObj,
 } from '../../../types/index.js';
 
-export function createChunkLoading(entryTemplateUrl: string): {
+export function createChunkLoading(
+  entryTemplateUrl: string,
+  cardType: string,
+): {
   readScript: NativeApp['readScript'];
   loadScript: NativeApp['loadScript'];
   loadScriptAsync: NativeApp['loadScriptAsync'];
@@ -59,18 +62,18 @@ export function createChunkLoading(entryTemplateUrl: string): {
   const createBundleInitReturnObj = (
     jsContent: string,
   ): BundleInitReturnObj => {
-    const foo = new Function(
+    const paramNames: string[] = [
       'postMessage',
       'module',
       'exports',
       'lynxCoreInject',
-      'Card',
+      ...(cardType !== 'react' ? ['Card'] : []),
       'setTimeout',
       'setInterval',
       'clearInterval',
       'clearTimeout',
       'NativeModules',
-      'Component',
+      ...(cardType !== 'react' ? ['Component'] : []),
       'ReactLynx',
       'nativeAppId',
       'Behavior',
@@ -98,24 +101,27 @@ export function createChunkLoading(entryTemplateUrl: string): {
       // Lynx API
       'requestAnimationFrame',
       'cancelAnimationFrame',
+    ];
+    const foo = new Function(
+      ...paramNames,
       jsContent,
     ) as BTSChunkEntry;
     return {
       init(lynxCoreInject) {
         const module = { exports: {} };
         const tt = lynxCoreInject.tt as any;
-        foo(
+        const args: unknown[] = [
           undefined,
           module,
           module.exports,
           lynxCoreInject,
-          tt.Card.bind(tt),
+          ...(cardType !== 'react' ? [tt.Card.bind(tt)] : []),
           tt.setTimeout,
           tt.setInterval,
           tt.clearInterval,
           tt.clearTimeout,
           tt.NativeModules,
-          tt.Component.bind(tt),
+          ...(cardType !== 'react' ? [tt.Component.bind(tt)] : []),
           tt.ReactLynx,
           tt.nativeAppId,
           tt.Behavior,
@@ -142,7 +148,8 @@ export function createChunkLoading(entryTemplateUrl: string): {
           tt.global,
           tt.requestAnimationFrame,
           tt.cancelAnimationFrame,
-        );
+        ];
+        (foo as Function).apply(undefined, args);
         return module.exports;
       },
     };

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createNativeApp.ts
@@ -48,6 +48,7 @@ export async function createNativeApp(
   timingSystem: TimingSystem,
   nativeModulesMap: NativeModulesMap,
   entryTemplateUrl: string,
+  cardType: string,
 ): Promise<NativeApp> {
   const performanceApis = createPerformanceApis(
     timingSystem,
@@ -69,7 +70,7 @@ export async function createNativeApp(
   );
   const reportError = mainThreadRpc.createCall(reportErrorEndpoint);
   const { templateCache, loadScript, loadScriptAsync, readScript } =
-    createChunkLoading(entryTemplateUrl);
+    createChunkLoading(entryTemplateUrl, cardType);
 
   mainThreadRpc.registerHandler(
     updateBTSChunkEndpoint,

--- a/packages/web-platform/web-core/ts/client/background/background-apis/startBackgroundThread.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/startBackgroundThread.ts
@@ -33,6 +33,7 @@ export function startBackgroundThread(
     timingSystem,
     nativeModulesMap,
     entryTemplateUrl,
+    cardType,
   );
   const lynxCore = import(
     /* webpackChunkName: "lynx-core-chunk" */


### PR DESCRIPTION
Conditionally include `Card` and `Component` only when `cardType !== 'react'`.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved parameter handling for Card and Component initialization in the background thread based on card type, ensuring proper conditional parameter passing during runtime setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2610)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
