### PR TITLE
fix(web-core-e2e): run build commands serially instead of in parallel

### DIFF
--- a/packages/web-platform/web-core-e2e/scripts/generate-build-command.js
+++ b/packages/web-platform/web-core-e2e/scripts/generate-build-command.js
@@ -16,30 +16,24 @@ const command = configFiles
     (lynxConfigFilePath) => `npx rspeedy build --config=${lynxConfigFilePath}`,
   );
 
-if (command.length) {
-  const promises = [];
-  for (let i = 0; i < command.length; i++) {
-    promises.push(
-      new Promise((resolve, reject) => {
-        const child = spawn(command[i], [], {
-          stdio: 'inherit',
-          cwd: path.join(import.meta.dirname, '..'),
-          shell: true,
-          env: {
-            ...process.env,
-          },
-        });
+for (const cmd of command) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(cmd, [], {
+      stdio: 'inherit',
+      cwd: path.join(import.meta.dirname, '..'),
+      shell: true,
+      env: {
+        ...process.env,
+      },
+    });
 
-        child.on('exit', (code) => {
-          if (code !== 0) {
-            console.error(`Command failed with exit code ${code}`);
-            reject(code);
-          } else {
-            resolve();
-          }
-        });
-      }),
-    );
-  }
-  await Promise.all(promises);
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        console.error(`Command failed with exit code ${code}`);
+        reject(code);
+      } else {
+        resolve();
+      }
+    });
+  });
 }

--- a/packages/web-platform/web-core-e2e/scripts/generate-build-command.js
+++ b/packages/web-platform/web-core-e2e/scripts/generate-build-command.js
@@ -27,6 +27,11 @@ for (const cmd of command) {
       },
     });
 
+    child.on('error', (error) => {
+      console.error(`Failed to start process: ${error.message}`);
+      reject(error);
+    });
+
     child.on('exit', (code) => {
       if (code !== 0) {
         console.error(`Command failed with exit code ${code}`);


### PR DESCRIPTION
## Summary

- The `generate-build-command.js` script previously launched all `rspeedy build` processes concurrently via `Promise.all()`, which could cause resource contention under memory-constrained CI environments.
- Replaced the parallel execution pattern with a sequential `for...of` loop that `await`s each spawned process before starting the next.

## Test plan

- [ ] Run `node ./scripts/generate-build-command.js` in `packages/web-platform/web-core-e2e` and confirm each build completes before the next one starts.
- [ ] Verify the existing CI build job (`build:csr`) passes end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build command execution updated to run generated build commands sequentially instead of parallel batching.
  * Improved child-process error handling: startup errors are now detected, logged, and surface as failures rather than only relying on exit codes—so build failures are reported more promptly and reliably.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2614)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->