### PR TITLE
chore: add openui repository metadata

### DIFF
--- a/packages/genui/openui/package.json
+++ b/packages/genui/openui/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@lynx-js/openui-reactlynx",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/genui/openui"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Adds the missing `repository` metadata to `packages/genui/openui/package.json`, matching the format used by other packages in the monorepo.

## Impact

Consumers and package metadata tooling can resolve the package back to the Lynx Stack repository and package directory.

## Validation

- `node -e "JSON.parse(require('node:fs').readFileSync('packages/genui/openui/package.json','utf8')); console.log('package.json OK')"`
- `git diff --check HEAD^ HEAD -- packages/genui/openui/package.json`
- `node_modules/.bin/dprint check packages/genui/openui/package.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository metadata.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2616)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->