### PR TITLE
ci: add package repository metadata check

### DIFF
--- a/.github/package-metadata.instructions.md
+++ b/.github/package-metadata.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "{package.json,packages/**/package.json,pnpm-workspace.yaml,.meta-updater/main.mjs,.github/workflows/*.yml}"
+---
+
+Use `@pnpm/meta-updater` for workspace package metadata consistency checks. Keep repository metadata generation in `.meta-updater/main.mjs`, and wire CI checks through `meta-updater --test` instead of duplicating workspace package discovery in custom scripts.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
         run: |
           pnpm dprint check
           pnpm biome check
+      - name: Package Metadata Check
+        run: pnpm --package=@pnpm/meta-updater@2.0.6 dlx meta-updater --test
       - name: API Check
         run: pnpm turbo api-extractor
       - name: Changeset Check

--- a/.meta-updater/main.mjs
+++ b/.meta-updater/main.mjs
@@ -1,0 +1,56 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+
+import { sortPackageJson } from 'sort-package-json';
+
+const REPOSITORY_TYPE = 'git';
+const REPOSITORY_URL = 'https://github.com/lynx-family/lynx-stack.git';
+
+const toPosixPath = (filePath) => filePath.split(path.sep).join('/');
+
+const resolvePackageDir = (dirOrOptions) => {
+  if (typeof dirOrOptions === 'string') return dirOrOptions;
+  if (!dirOrOptions || typeof dirOrOptions !== 'object') return null;
+
+  if (typeof dirOrOptions.dir === 'string') return dirOrOptions.dir;
+
+  if (typeof dirOrOptions.resolvedPath === 'string') {
+    return path.dirname(dirOrOptions.resolvedPath);
+  }
+
+  if (typeof dirOrOptions.filePath === 'string') {
+    return path.dirname(dirOrOptions.filePath);
+  }
+
+  return null;
+};
+
+const createRepository = (dirOrOptions, workspaceDir) => {
+  const packageDir = resolvePackageDir(dirOrOptions);
+  const directory = packageDir == null
+    ? ''
+    : toPosixPath(path.relative(workspaceDir, packageDir));
+
+  return {
+    type: REPOSITORY_TYPE,
+    url: REPOSITORY_URL,
+    ...(directory ? { directory } : {}),
+  };
+};
+
+export default function createLynxStackMetaUpdateOptions(workspaceDir) {
+  return {
+    'package.json': (manifest, options) => {
+      if (manifest?.private === true || manifest?.repository != null) {
+        return sortPackageJson(manifest);
+      }
+
+      return sortPackageJson({
+        ...manifest,
+        repository: createRepository(options, workspaceDir),
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds a `.meta-updater/main.mjs` configuration for workspace `package.json` metadata and wires a package metadata check into CI.

The updater uses `sort-package-json` for stable manifest ordering and fills `repository` metadata for non-private workspace packages that do not already define it. Existing `repository` values are preserved for now, so this PR only enforces presence of the field rather than normalizing historical URL/directory differences.

## Problem Avoided

This is meant to prevent the same issue fixed in #2616: a new non-private workspace package, `packages/genui/openui`, was added without `repository` metadata. That leaves published package metadata without a reliable link back to the GitHub repository and package directory, which makes npm/GitHub package navigation and metadata tooling worse.

Now that #2616 has landed, this PR only contains the metadata checker and CI wiring.

## Validation

- `pnpm --package=@pnpm/meta-updater@2.0.6 dlx meta-updater --test`
- `node_modules/.bin/dprint check .meta-updater/main.mjs .github/workflows/test.yml .github/package-metadata.instructions.md`
- `node_modules/.bin/eslint .meta-updater/main.mjs .github/workflows/test.yml .github/package-metadata.instructions.md --flag v10_config_lookup_from_file --no-warn-ignored`
- direct import smoke test for `.meta-updater/main.mjs` behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package metadata validation checks to the continuous integration pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2617)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->