### PR TITLE
fix(react): dispose list item snapshots on destroy

### DIFF
--- a/.changeset/list-snapshot-dispose.md
+++ b/.changeset/list-snapshot-dispose.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Dispose list item snapshots when their owning list is destroyed, preventing retained snapshot references after list cleanup.

--- a/packages/react/runtime/src/snapshot/list/list.ts
+++ b/packages/react/runtime/src/snapshot/list/list.ts
@@ -8,6 +8,7 @@ import { applyRefQueue } from '../snapshot/workletRef.js';
 
 export const gSignMap: Record<number, Map<number, SnapshotInstance>> = {};
 export const gRecycleMap: Record<number, Map<string, Map<number, SnapshotInstance>>> = {};
+export const gListAllItems: Record<number, Set<SnapshotInstance>> = {};
 const gParentWeakMap: WeakMap<SnapshotInstance, unknown> = new WeakMap();
 const resolvedPromise = /* @__PURE__ */ Promise.resolve();
 
@@ -18,6 +19,13 @@ export function clearListGlobal(): void {
   for (const key in gRecycleMap) {
     delete gRecycleMap[key];
   }
+  for (const key in gListAllItems) {
+    delete gListAllItems[key];
+  }
+}
+
+export function trackListItem(listID: number, childCtx: SnapshotInstance): void {
+  (gListAllItems[listID] ??= new Set()).add(childCtx);
 }
 
 export function componentAtIndexFactory(
@@ -62,6 +70,7 @@ export function componentAtIndexFactory(
     /* v8 ignore end */
 
     const platformInfo = childCtx.__listItemPlatformInfo ?? {};
+    trackListItem(listID, childCtx);
 
     // The lifecycle of this `__extraProps.isReady`:
     // 0 -> Promise<number> -> 1
@@ -142,6 +151,7 @@ export function componentAtIndexFactory(
         return sign;
       } else {
         const newCtx = childCtx.takeElements();
+        trackListItem(listID, newCtx);
         signMap.set(sign, newCtx);
       }
     }
@@ -149,6 +159,7 @@ export function componentAtIndexFactory(
     if (recycleSignMap && recycleSignMap.size > 0) {
       const [first] = recycleSignMap;
       const [sign, oldCtx] = first!;
+      trackListItem(listID, oldCtx);
       recycleSignMap.delete(sign);
       hydrateFunction(oldCtx, childCtx);
       oldCtx.unRenderElements();

--- a/packages/react/runtime/src/snapshot/snapshot/list.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/list.ts
@@ -2,11 +2,22 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { componentAtIndexFactory, enqueueComponentFactory, gRecycleMap, gSignMap } from '../list/list.js';
+import { componentAtIndexFactory, enqueueComponentFactory, gListAllItems, gRecycleMap, gSignMap } from '../list/list.js';
 import { hydrate } from '../renderToOpcodes/hydrate.js';
 import type { SnapshotInstance } from '../snapshot/snapshot.js';
 
 const destroyLifetimeHandlerMap = new Map<number, () => void>();
+
+function disposeSnapshotSetValues(set: Set<SnapshotInstance> | undefined): void {
+  const seen = new Set<SnapshotInstance>();
+  set?.forEach((value) => {
+    if (seen.has(value)) {
+      return;
+    }
+    seen.add(value);
+    value.disposeDetached();
+  });
+}
 
 export function snapshotCreateList(
   pageId: number,
@@ -15,6 +26,7 @@ export function snapshotCreateList(
 ): FiberElement {
   const signMap = new Map<number, SnapshotInstance>();
   const recycleMap = new Map<string, Map<number, SnapshotInstance>>();
+  const listAllItems = new Set<SnapshotInstance>();
   const [componentAtIndex, componentAtIndexes] = componentAtIndexFactory([], hydrate);
   const list = __CreateList(
     pageId,
@@ -36,6 +48,7 @@ export function snapshotCreateList(
 
   gSignMap[listID] = signMap;
   gRecycleMap[listID] = recycleMap;
+  gListAllItems[listID] = listAllItems;
   return list;
 }
 
@@ -45,6 +58,7 @@ export function snapshotDestroyList(si: SnapshotInstance): void {
   const listID = __GetElementUniqueID(list);
 
   __UpdateListCallbacks(list, () => -1, () => {}, () => {});
+  disposeSnapshotSetValues(gListAllItems[listID]);
 
   if (typeof lynx !== 'undefined' && typeof lynx.getNative === 'function') {
     const cb = destroyLifetimeHandlerMap.get(listID);
@@ -54,6 +68,7 @@ export function snapshotDestroyList(si: SnapshotInstance): void {
     }
   }
 
+  delete gListAllItems[listID];
   delete gSignMap[listID];
   delete gRecycleMap[listID];
 }

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -259,6 +259,23 @@ export class SnapshotInstance {
     });
   }
 
+  disposeDetached(): void {
+    traverseSnapshotInstance(this, v => {
+      if (v.__snapshot_def.isListHolder) {
+        snapshotDestroyList(v);
+      }
+
+      v.__parent = null;
+      v.__previousSibling = null;
+      v.__nextSibling = null;
+      v.__firstChild = null;
+      v.__lastChild = null;
+      delete v.__elements;
+      delete v.__element_root;
+      snapshotInstanceManager.values.delete(v.__id);
+    });
+  }
+
   // onCreate?: () => void;
   // onAttach?: () => void;
   // onDetach?: () => void;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Stability**
  * Improved list-item tracking and snapshot cleanup to avoid retained references and reduce memory leaks.
* **Bug Fixes**
  * Ensures list-related snapshot instances are properly disposed when lists are destroyed.
* **Chores**
  * Added a changeset entry documenting the snapshot disposal fix for the React runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2622)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
