### PR TITLE
fix(autolink): detect create extension npm bin symlinks

### DIFF
--- a/.changeset/fix-create-extension-bin-entrypoint.md
+++ b/.changeset/fix-create-extension-bin-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"create-lynx-extension": patch
+---
+
+Fix npm bin symlink entrypoint detection for the create extension CLI.

--- a/packages/lynx/create-lynx-extension/src/cli.ts
+++ b/packages/lynx/create-lynx-extension/src/cli.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import fs from 'node:fs';
 import path from 'node:path';
 import { stdin as input, stdout as output } from 'node:process';
 import readline from 'node:readline';
@@ -277,9 +278,23 @@ export function reportCliError(
   process.exitCode = 1;
 }
 
-function isCliEntrypoint(): boolean {
-  return process.argv[1] !== undefined
-    && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+export function isCliEntrypoint(
+  entrypoint: string | undefined = process.argv[1],
+  moduleUrl: string = import.meta.url,
+): boolean {
+  return entrypoint !== undefined
+    && normalizeEntrypointPath(entrypoint)
+      === normalizeEntrypointPath(fileURLToPath(moduleUrl));
+}
+
+function normalizeEntrypointPath(filePath: string): string {
+  const resolvedPath = path.resolve(filePath);
+
+  try {
+    return fs.realpathSync(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
 }
 
 /* v8 ignore next 5 */

--- a/packages/lynx/create-lynx-extension/test/cli.test.ts
+++ b/packages/lynx/create-lynx-extension/test/cli.test.ts
@@ -5,11 +5,17 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
+import { pathToFileURL } from 'node:url';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { CliRuntime } from '../src/cli.js';
-import { main, parseArgs, reportCliError } from '../src/cli.js';
+import {
+  isCliEntrypoint,
+  main,
+  parseArgs,
+  reportCliError,
+} from '../src/cli.js';
 
 const tempDirs: string[] = [];
 
@@ -135,6 +141,32 @@ describe('create-lynx-extension CLI', () => {
     reportCliError('string failure', runtime);
     expect(runtime.error).toHaveBeenCalledWith('string failure');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('recognizes npm bin symlinks as executable entrypoints', () => {
+    const binPath = path.join('node_modules', '.bin', 'create-lynx-extension');
+    const cliPath = path.join(
+      'node_modules',
+      'create-lynx-extension',
+      'dist',
+      'cli.js',
+    );
+    const resolvedCliPath = path.resolve(cliPath);
+
+    vi.spyOn(fs, 'realpathSync').mockImplementation(
+      ((filePath) => {
+        const resolvedPath = path.resolve(String(filePath));
+
+        if (resolvedPath === path.resolve(binPath)) {
+          return resolvedCliPath;
+        }
+
+        return resolvedPath;
+      }) as typeof fs.realpathSync,
+    );
+
+    expect(isCliEntrypoint(binPath, pathToFileURL(resolvedCliPath).href))
+      .toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fix `create-lynx-extension` so the published CLI runs when invoked through npm-created bin symlinks such as `npm create lynx-extension-canary` or `npm exec create-lynx-extension`.

## Root Cause

The executable guard compared `path.resolve(process.argv[1])` directly with `fileURLToPath(import.meta.url)`. npm invokes package bins through `node_modules/.bin/*` symlinks, so the comparison failed and `main()` was never called. The process exited successfully without printing help, prompting, or creating files.

## Changes

- Normalize the CLI entrypoint and module path through `fs.realpathSync` before comparing them.
- Export the entrypoint helper for focused test coverage.
- Add a regression test for npm bin symlink execution.

## Validation

- `pnpm --filter create-lynx-extension test`
- `pnpm --filter create-lynx-extension build`
- `pnpm biome check packages/lynx/create-lynx-extension/src/cli.ts packages/lynx/create-lynx-extension/test/cli.test.ts`
- `pnpm dprint fmt packages/lynx/create-lynx-extension/src/cli.ts packages/lynx/create-lynx-extension/test/cli.test.ts`
- Local `npm exec --package /Users/bytedance/Code/lynx-stack/packages/lynx/create-lynx-extension create-lynx-extension -- --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI entrypoint detection to correctly handle npm `.bin` symlinks and consistently normalize paths for reliable executable detection.

* **Tests**
  * Added test coverage to verify npm `.bin` symlink entrypoint detection for the CLI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2623)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->