### PR TITLE
fix(template-webpack-plugin): make getLynxTemplatePluginHooks a cross-module singleton

### DIFF
--- a/.changeset/template-plugin-hooks-singleton.md
+++ b/.changeset/template-plugin-hooks-singleton.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Fix `LynxTemplatePlugin.getLynxTemplatePluginHooks` returning per-module-instance hooks when this package is loaded from multiple physical paths under `node_modules` (e.g. npm hoist conflicts that nest two copies). Hooks storage is now keyed by `Symbol.for(...)` on the `compilation` itself, so any copy of the plugin resolves to the same hooks for a given compilation. This eliminates the "`Cannot destructure property 'buffer' of '(intermediate value)' as it is undefined`" build error that occurred when `LynxEncodePlugin` registered taps via one module instance while `LynxTemplatePlugin` awaited `hooks.encode.promise(...)` on another.

--- a/.changeset/template-plugin-hooks-singleton.md
+++ b/.changeset/template-plugin-hooks-singleton.md
@@ -2,4 +2,4 @@
 "@lynx-js/template-webpack-plugin": patch
 ---
 
-Fix `LynxTemplatePlugin.getLynxTemplatePluginHooks` returning per-module-instance hooks when this package is loaded from multiple physical paths under `node_modules` (e.g. npm hoist conflicts that nest two copies). Hooks storage is now keyed by `Symbol.for(...)` on the `compilation` itself, so any copy of the plugin resolves to the same hooks for a given compilation. This eliminates the "`Cannot destructure property 'buffer' of '(intermediate value)' as it is undefined`" build error that occurred when `LynxEncodePlugin` registered taps via one module instance while `LynxTemplatePlugin` awaited `hooks.encode.promise(...)` on another.
+Make `LynxTemplatePlugin.getLynxTemplatePluginHooks` a cross-module singleton so duplicate copies of this package (e.g. from npm hoist conflicts) share the same hooks per compilation.

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -56,7 +56,15 @@ export interface EncodeOptions {
   [k: string]: unknown;
 }
 
-const LynxTemplatePluginHooksMap = new WeakMap<Compilation, TemplateHooks>();
+// Stash hooks on the Compilation itself, keyed by a `Symbol.for` so that multiple
+// module instances of this package (e.g. when a non-pnpm install nests two copies
+// in node_modules and ESM treats them as distinct modules) all read/write the same
+// hooks for a given compilation. A module-scoped WeakMap would have one copy per
+// module instance, causing taps registered through one copy to be invisible to
+// `encode.promise()` invoked through another.
+const LYNX_TEMPLATE_HOOKS_KEY: unique symbol = Symbol.for(
+  '@lynx-js/template-webpack-plugin/hooks',
+) as never;
 
 /**
  * To allow other plugins to alter the Template, this plugin executes
@@ -352,13 +360,14 @@ export class LynxTemplatePlugin {
    * Returns all public hooks of the Lynx template webpack plugin for the given compilation
    */
   static getLynxTemplatePluginHooks(compilation: Compilation): TemplateHooks {
-    let hooks = LynxTemplatePluginHooksMap.get(compilation);
+    const stash = compilation as unknown as {
+      [LYNX_TEMPLATE_HOOKS_KEY]?: TemplateHooks;
+    };
+    let hooks = stash[LYNX_TEMPLATE_HOOKS_KEY];
     // Setup the hooks only once
     if (hooks === undefined) {
-      LynxTemplatePluginHooksMap.set(
-        compilation,
-        hooks = createLynxTemplatePluginHooks(),
-      );
+      hooks = createLynxTemplatePluginHooks();
+      stash[LYNX_TEMPLATE_HOOKS_KEY] = hooks;
     }
     return hooks;
   }

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -56,12 +56,8 @@ export interface EncodeOptions {
   [k: string]: unknown;
 }
 
-// Stash hooks on the Compilation itself, keyed by a `Symbol.for` so that multiple
-// module instances of this package (e.g. when a non-pnpm install nests two copies
-// in node_modules and ESM treats them as distinct modules) all read/write the same
-// hooks for a given compilation. A module-scoped WeakMap would have one copy per
-// module instance, causing taps registered through one copy to be invisible to
-// `encode.promise()` invoked through another.
+// Use `Symbol.for` so duplicate copies of this module (e.g. from an npm hoist
+// conflict that nests two copies under node_modules) share the same hooks slot.
 const LYNX_TEMPLATE_HOOKS_KEY: unique symbol = Symbol.for(
   '@lynx-js/template-webpack-plugin/hooks',
 ) as never;

--- a/packages/webpack/template-webpack-plugin/test/fixtures/template-plugin-second-instance.ts
+++ b/packages/webpack/template-webpack-plugin/test/fixtures/template-plugin-second-instance.ts
@@ -1,0 +1,49 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Mimics a second physical copy of `@lynx-js/template-webpack-plugin` that
+// would land at a separate node_modules path under npm hoist conflicts. It
+// re-implements `getLynxTemplatePluginHooks` end-to-end so that *this* module
+// instance has its own `createHooks` and its own module-level state — any
+// successful cross-instance sharing must therefore happen through whatever
+// shared slot the real implementation uses on `compilation`, not through
+// accidental code identity.
+import {
+  AsyncSeriesBailHook,
+  AsyncSeriesWaterfallHook,
+  SyncWaterfallHook,
+} from '@rspack/lite-tapable';
+
+const LYNX_TEMPLATE_HOOKS_KEY = Symbol.for(
+  '@lynx-js/template-webpack-plugin/hooks',
+);
+
+interface MinimalHooks {
+  asyncChunkName: SyncWaterfallHook<unknown>;
+  beforeEncode: AsyncSeriesWaterfallHook<unknown>;
+  encode: AsyncSeriesBailHook<unknown, unknown>;
+  beforeEmit: AsyncSeriesWaterfallHook<unknown>;
+  afterEmit: AsyncSeriesWaterfallHook<unknown>;
+}
+
+function createHooks(): MinimalHooks {
+  return {
+    asyncChunkName: new SyncWaterfallHook(['pluginArgs']),
+    beforeEncode: new AsyncSeriesWaterfallHook(['pluginArgs']),
+    encode: new AsyncSeriesBailHook(['pluginArgs']),
+    beforeEmit: new AsyncSeriesWaterfallHook(['pluginArgs']),
+    afterEmit: new AsyncSeriesWaterfallHook(['pluginArgs']),
+  };
+}
+
+export function getHooksFromSecondInstance(
+  compilation: Record<symbol, unknown>,
+): MinimalHooks {
+  let hooks = compilation[LYNX_TEMPLATE_HOOKS_KEY] as MinimalHooks | undefined;
+  if (hooks === undefined) {
+    hooks = createHooks();
+    compilation[LYNX_TEMPLATE_HOOKS_KEY] = hooks;
+  }
+  return hooks;
+}

--- a/packages/webpack/template-webpack-plugin/test/get-hooks-singleton.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/get-hooks-singleton.test.ts
@@ -4,10 +4,9 @@
 import { describe, expect, test } from '@rstest/core';
 
 import { LynxTemplatePlugin } from '../src/index.js';
+import { getHooksFromSecondInstance } from './fixtures/template-plugin-second-instance.js';
 
 describe('LynxTemplatePlugin.getLynxTemplatePluginHooks - cross-module singleton', () => {
-  const SHARED_KEY = Symbol.for('@lynx-js/template-webpack-plugin/hooks');
-
   test('returns the same hooks for the same compilation across calls', () => {
     const compilation = {} as never;
     const a = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
@@ -23,19 +22,25 @@ describe('LynxTemplatePlugin.getLynxTemplatePluginHooks - cross-module singleton
     expect(a).not.toBe(b);
   });
 
-  // A second physical copy of this module would have its own module-level
-  // storage; the shared `Symbol.for` slot on the compilation is what makes
-  // them converge on the same hooks.
-  test('hooks are reachable through the shared Symbol.for slot', () => {
+  test('real instance writes first, second physical copy reads the same hooks', () => {
     const compilation = {} as Record<symbol, unknown>;
-    const hooksFromRealInstance = LynxTemplatePlugin
+    const hooksReal = LynxTemplatePlugin
       .getLynxTemplatePluginHooks(compilation as never);
-    expect(compilation[SHARED_KEY]).toBe(hooksFromRealInstance);
+    const hooksSecond = getHooksFromSecondInstance(compilation);
+    expect(hooksSecond).toBe(hooksReal);
   });
 
-  test('a tap registered through one instance fires when encode.promise is awaited through another', async () => {
+  test('second physical copy writes first, real instance reads the same hooks', () => {
     const compilation = {} as Record<symbol, unknown>;
-    const hooksA = LynxTemplatePlugin
+    const hooksSecond = getHooksFromSecondInstance(compilation);
+    const hooksReal = LynxTemplatePlugin
+      .getLynxTemplatePluginHooks(compilation as never);
+    expect(hooksReal).toBe(hooksSecond);
+  });
+
+  test('a tap registered through one copy fires when encode.promise is awaited through the other', async () => {
+    const compilation = {} as Record<symbol, unknown>;
+    const hooksReal = LynxTemplatePlugin
       .getLynxTemplatePluginHooks(compilation as never);
 
     const sentinel = {
@@ -43,16 +48,16 @@ describe('LynxTemplatePlugin.getLynxTemplatePluginHooks - cross-module singleton
       debugInfo: '',
       cssDiagnostics: '',
     };
-    hooksA.encode.tapPromise(
-      { name: 'tap-from-instance-A', stage: 0 },
+    hooksReal.encode.tapPromise(
+      { name: 'tap-from-real-instance', stage: 0 },
       async () => sentinel,
     );
 
-    const hooksB = compilation[SHARED_KEY] as typeof hooksA;
-    expect(hooksB).toBe(hooksA);
-
-    const result = await hooksB.encode.promise({
-      encodeOptions: {} as never,
+    const hooksSecond = getHooksFromSecondInstance(compilation);
+    const result = await (hooksSecond.encode as unknown as {
+      promise: (args: unknown) => Promise<unknown>;
+    }).promise({
+      encodeOptions: {},
       intermediate: '.rspeedy',
     });
     expect(result).toBe(sentinel);

--- a/packages/webpack/template-webpack-plugin/test/get-hooks-singleton.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/get-hooks-singleton.test.ts
@@ -5,18 +5,6 @@ import { describe, expect, test } from '@rstest/core';
 
 import { LynxTemplatePlugin } from '../src/index.js';
 
-// When two copies of `@lynx-js/template-webpack-plugin` end up at distinct
-// physical paths under `node_modules` (npm hoist conflict, file:/link:
-// nesting, etc.), Node's ESM loader treats them as two module instances.
-// A module-scoped `WeakMap` stash would then double up: taps registered
-// through one copy of `LynxTemplatePlugin` are invisible to
-// `hooks.encode.promise()` invoked through the other copy, and the bail
-// hook resolves with `undefined` — which downstream code destructures.
-//
-// The fix routes storage through a `Symbol.for(...)` key stashed on the
-// `compilation` itself. The same key resolves to the same symbol across
-// all module instances in the realm, so any copy of the plugin sees the
-// same hooks for a given compilation. These tests assert that contract.
 describe('LynxTemplatePlugin.getLynxTemplatePluginHooks - cross-module singleton', () => {
   const SHARED_KEY = Symbol.for('@lynx-js/template-webpack-plugin/hooks');
 
@@ -35,23 +23,17 @@ describe('LynxTemplatePlugin.getLynxTemplatePluginHooks - cross-module singleton
     expect(a).not.toBe(b);
   });
 
-  test('hooks created by one module instance are visible to another via Symbol.for key', () => {
-    // Simulate a second module instance of `@lynx-js/template-webpack-plugin`
-    // (as would happen when npm puts two copies at different physical paths
-    // under node_modules). The second instance would have its own module-level
-    // storage; the only reliable cross-instance shared state is `Symbol.for`.
+  // A second physical copy of this module would have its own module-level
+  // storage; the shared `Symbol.for` slot on the compilation is what makes
+  // them converge on the same hooks.
+  test('hooks are reachable through the shared Symbol.for slot', () => {
     const compilation = {} as Record<symbol, unknown>;
     const hooksFromRealInstance = LynxTemplatePlugin
       .getLynxTemplatePluginHooks(compilation as never);
-
-    // A second module instance, given the same compilation, should resolve
-    // the same hooks via the well-known Symbol.for slot.
-    const hooksFromSecondInstance = compilation[SHARED_KEY];
-    expect(hooksFromSecondInstance).toBe(hooksFromRealInstance);
+    expect(compilation[SHARED_KEY]).toBe(hooksFromRealInstance);
   });
 
-  test('a tap registered through any instance is observed when encode.promise is awaited through another', async () => {
-    // Build a fresh compilation. First "instance" registers a tap on encode.
+  test('a tap registered through one instance fires when encode.promise is awaited through another', async () => {
     const compilation = {} as Record<symbol, unknown>;
     const hooksA = LynxTemplatePlugin
       .getLynxTemplatePluginHooks(compilation as never);
@@ -66,15 +48,10 @@ describe('LynxTemplatePlugin.getLynxTemplatePluginHooks - cross-module singleton
       async () => sentinel,
     );
 
-    // Second "instance" resolves hooks from the same compilation. Because
-    // storage is keyed by `Symbol.for` on the compilation, both instances see
-    // the identical hooks — the tap from A is reachable from B.
     const hooksB = compilation[SHARED_KEY] as typeof hooksA;
     expect(hooksB).toBe(hooksA);
 
     const result = await hooksB.encode.promise({
-      // The bail handler returns immediately on the sentinel, so the runtime
-      // shape of these arguments is irrelevant.
       encodeOptions: {} as never,
       intermediate: '.rspeedy',
     });

--- a/packages/webpack/template-webpack-plugin/test/get-hooks-singleton.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/get-hooks-singleton.test.ts
@@ -1,0 +1,83 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { LynxTemplatePlugin } from '../src/index.js';
+
+// When two copies of `@lynx-js/template-webpack-plugin` end up at distinct
+// physical paths under `node_modules` (npm hoist conflict, file:/link:
+// nesting, etc.), Node's ESM loader treats them as two module instances.
+// A module-scoped `WeakMap` stash would then double up: taps registered
+// through one copy of `LynxTemplatePlugin` are invisible to
+// `hooks.encode.promise()` invoked through the other copy, and the bail
+// hook resolves with `undefined` — which downstream code destructures.
+//
+// The fix routes storage through a `Symbol.for(...)` key stashed on the
+// `compilation` itself. The same key resolves to the same symbol across
+// all module instances in the realm, so any copy of the plugin sees the
+// same hooks for a given compilation. These tests assert that contract.
+describe('LynxTemplatePlugin.getLynxTemplatePluginHooks - cross-module singleton', () => {
+  const SHARED_KEY = Symbol.for('@lynx-js/template-webpack-plugin/hooks');
+
+  test('returns the same hooks for the same compilation across calls', () => {
+    const compilation = {} as never;
+    const a = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+    const b = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+    expect(b).toBe(a);
+  });
+
+  test('returns distinct hooks for distinct compilations', () => {
+    const compilationA = {} as never;
+    const compilationB = {} as never;
+    const a = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilationA);
+    const b = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilationB);
+    expect(a).not.toBe(b);
+  });
+
+  test('hooks created by one module instance are visible to another via Symbol.for key', () => {
+    // Simulate a second module instance of `@lynx-js/template-webpack-plugin`
+    // (as would happen when npm puts two copies at different physical paths
+    // under node_modules). The second instance would have its own module-level
+    // storage; the only reliable cross-instance shared state is `Symbol.for`.
+    const compilation = {} as Record<symbol, unknown>;
+    const hooksFromRealInstance = LynxTemplatePlugin
+      .getLynxTemplatePluginHooks(compilation as never);
+
+    // A second module instance, given the same compilation, should resolve
+    // the same hooks via the well-known Symbol.for slot.
+    const hooksFromSecondInstance = compilation[SHARED_KEY];
+    expect(hooksFromSecondInstance).toBe(hooksFromRealInstance);
+  });
+
+  test('a tap registered through any instance is observed when encode.promise is awaited through another', async () => {
+    // Build a fresh compilation. First "instance" registers a tap on encode.
+    const compilation = {} as Record<symbol, unknown>;
+    const hooksA = LynxTemplatePlugin
+      .getLynxTemplatePluginHooks(compilation as never);
+
+    const sentinel = {
+      buffer: Buffer.from('ok'),
+      debugInfo: '',
+      cssDiagnostics: '',
+    };
+    hooksA.encode.tapPromise(
+      { name: 'tap-from-instance-A', stage: 0 },
+      async () => sentinel,
+    );
+
+    // Second "instance" resolves hooks from the same compilation. Because
+    // storage is keyed by `Symbol.for` on the compilation, both instances see
+    // the identical hooks — the tap from A is reachable from B.
+    const hooksB = compilation[SHARED_KEY] as typeof hooksA;
+    expect(hooksB).toBe(hooksA);
+
+    const result = await hooksB.encode.promise({
+      // The bail handler returns immediately on the sentinel, so the runtime
+      // shape of these arguments is irrelevant.
+      encodeOptions: {} as never,
+      intermediate: '.rspeedy',
+    });
+    expect(result).toBe(sentinel);
+  });
+});


### PR DESCRIPTION
## Summary

When two physical copies of `@lynx-js/template-webpack-plugin` land at distinct paths under `node_modules` (e.g. npm hoist conflict that keeps an older version pinned at top of `node_modules` via a peer-dep range, while nested copies of the current version live under different parents), Node's ESM loader treats them as **separate module instances**. The module-scoped `LynxTemplatePluginHooksMap` WeakMap then doubles up: taps registered through one copy of `LynxEncodePlugin` are invisible to `hooks.encode.promise(...)` invoked through another copy of `LynxTemplatePlugin`. The bail hook resolves with `undefined`, surfacing as:

```
× Cannot destructure property 'buffer' of '(intermediate value)' as it is undefined.
```

pnpm-managed installs are unaffected because pnpm's symlinked layout collapses multiple references to a single realpath. But the source code shouldn't rely on the package manager's deduplication for correctness — `npm install` and `yarn install` flat layouts are common, and any third-party wrapper around `@lynx-js/template-webpack-plugin` that adds itself as an extra nested consumer can trigger the dual-instance condition even on the OSS chain.

## Fix

Route hooks storage through a `Symbol.for(...)` key stashed on the `compilation` itself:

```ts
const LYNX_TEMPLATE_HOOKS_KEY = Symbol.for('@lynx-js/template-webpack-plugin/hooks');

static getLynxTemplatePluginHooks(compilation) {
  const stash = compilation as unknown as { [LYNX_TEMPLATE_HOOKS_KEY]?: TemplateHooks };
  let hooks = stash[LYNX_TEMPLATE_HOOKS_KEY];
  if (hooks === undefined) {
    hooks = createLynxTemplatePluginHooks();
    stash[LYNX_TEMPLATE_HOOKS_KEY] = hooks;
  }
  return hooks;
}
```

- `Symbol.for(key)` returns the same symbol across all module instances in a realm — any copy of the plugin loaded by Node resolves the same key.
- Storage lives on the `compilation` (of which there is exactly one), so the keyed slot is naturally per-compilation.

## Test plan

- [x] `pnpm --filter @lynx-js/template-webpack-plugin test` — all 348 tests pass locally, including 4 new cases in `test/get-hooks-singleton.test.ts`:
  - returns the same hooks for repeated calls on the same compilation
  - returns distinct hooks for distinct compilations
  - hooks created by one module instance are visible to a simulated second instance via the shared `Symbol.for` key
  - a `tap` registered through one instance is reached when `encode.promise(...)` is awaited through another
- [ ] CI pass (this PR)
- [ ] Manual smoke: the failing project reproduces only on internally-wrapped chains where a second consumer of `@lynx-js/template-webpack-plugin@x` lands at a distinct physical path; OSS `create-rspeedy@latest` scaffolds did not surface the bug under any of pnpm/npm/yarn/bun. The fix is intended to be defensive — once merged, any future wrapper layer that creates a dual-instance condition will no longer be load-bearing for correctness.

## Notes

Draft to gather CI feedback. Happy to add an integration-style test that boots two physically-distinct copies via a synthetic monorepo if the maintainers want stronger coverage than the symbol-key contract test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where npm hoisting conflicts prevented duplicate plugin instances from sharing hooks, ensuring consistent behavior across all copies during compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2624)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->