### PR TITLE
[codex] add pnpm lockfile dedupe check

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "*.rs": [
       "cargo fmt --"
     ],
-    "package.json": "sort-package-json"
+    "package.json": "sort-package-json",
+    "pnpm-lock.yaml": "pnpm dedupe --check"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
## Summary

- Add a `lint-staged` task for `pnpm-lock.yaml`.
- Run `pnpm dedupe --check` when the lockfile is staged so duplicate resolutions are caught before commit.

## Validation

- `node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync('package.json', 'utf8')); if (pkg['lint-staged']?.['pnpm-lock.yaml'] !== 'pnpm dedupe --check') throw new Error('missing command'); console.log(pkg['lint-staged']['pnpm-lock.yaml']);"`
- `pnpm dprint fmt package.json`
- `pnpm dedupe --check`
