### PR TITLE
chore(react-refresh-webpack-plugin): add missed changeset for peer range bump

### DIFF
--- a/.changeset/react-refresh-peer-bump.md
+++ b/.changeset/react-refresh-peer-bump.md
@@ -2,4 +2,4 @@
 "@lynx-js/react-refresh-webpack-plugin": patch
 ---
 
-Release the `@lynx-js/react-webpack-plugin` peer range bump from #2423 (extending the upper bound to `^0.9.0`). Without this entry the peer-range fix sat on `main` but never reached a published version, so npm-resolved installs continued to pull `@lynx-js/react-webpack-plugin@0.8.0` alongside newer `^0.9.0` consumers and triggered duplicate physical copies of `@lynx-js/template-webpack-plugin` under `node_modules`.
+Widen `@lynx-js/react-webpack-plugin` peer range to include `^0.9.0`.

--- a/.changeset/react-refresh-peer-bump.md
+++ b/.changeset/react-refresh-peer-bump.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-refresh-webpack-plugin": patch
+---
+
+Release the `@lynx-js/react-webpack-plugin` peer range bump from #2423 (extending the upper bound to `^0.9.0`). Without this entry the peer-range fix sat on `main` but never reached a published version, so npm-resolved installs continued to pull `@lynx-js/react-webpack-plugin@0.8.0` alongside newer `^0.9.0` consumers and triggered duplicate physical copies of `@lynx-js/template-webpack-plugin` under `node_modules`.


### PR DESCRIPTION
## Summary

#2423 extended the `@lynx-js/react-webpack-plugin` peer range on `@lynx-js/react-refresh-webpack-plugin` to include `^0.9.0`:

```diff
- "@lynx-js/react-webpack-plugin": "^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0"
+ "@lynx-js/react-webpack-plugin": "^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0"
```

…but the changeset in that PR only bumped `@lynx-js/react`, `@lynx-js/react-webpack-plugin`, and `@lynx-js/react-rsbuild-plugin`. The `react-refresh-webpack-plugin` change has been sitting on `main` without ever triggering a new release.

## Impact

The published `@lynx-js/react-refresh-webpack-plugin@0.3.5` still ships the old (narrow) peer range, so `npm install` consumers continue to pull `@lynx-js/react-webpack-plugin@0.8.0` alongside the newer `^0.9.0` instance their direct deps demand. That parallel install in turn pins `@lynx-js/template-webpack-plugin@0.10.9` at the top of `node_modules` and pushes `0.11.0` into nested copies under different parents — the exact precondition that drives the `Cannot destructure property 'buffer' of '(intermediate value)' as it is undefined` build error.

(`pnpm install` was unaffected because its symlinked layout collapses references regardless.)

## Change

Single changeset file. No source code change is needed — the peer-range fix is already in place on `main`; this entry just makes sure the next release cuts a new `@lynx-js/react-refresh-webpack-plugin` carrying it.

## Test plan

- [x] `pnpm changeset status` now lists `@lynx-js/react-refresh-webpack-plugin` under "Packages to be bumped at patch"
- [ ] CI pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency metadata and peer dependency version ranges for enhanced compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2626)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->