### PR TITLE
fix(autolink): use published codegen version in scaffold

### DIFF
--- a/.changeset/create-extension-dependency-version.md
+++ b/.changeset/create-extension-dependency-version.md
@@ -1,0 +1,5 @@
+---
+"create-lynx-extension": patch
+---
+
+Use published package versions for scaffolded autolink codegen dependencies instead of workspace placeholders.

--- a/.github/autolink-extension.instructions.md
+++ b/.github/autolink-extension.instructions.md
@@ -15,6 +15,13 @@ updating Lynx extensions.
   `@LynxNativeModule`, `@LynxService`, or `LynxNativeModule("...")`.
 - The current create-extension and codegen packages are Native-only. Do not add
   Web Autolink or Web spec output in these packages.
+- Keep `create-lynx-extension` interactive prompts aligned with
+  `create-rspeedy` by using `@clack/prompts` prompt primitives. Extension type
+  selection should be a required multi-select that can produce Native Module,
+  Element, and Service files in one package.
+- Keep generated package dependency versions as workspace placeholders in
+  templates, then replace them from `create-lynx-extension` package metadata at
+  scaffold time so published CLIs emit published versions.
 
 iOS Autolink scanners in the native repo may still recognize existing Lynx lazy
 registration forms for compatibility, but new generated templates should prefer

--- a/packages/lynx/create-lynx-extension/README.md
+++ b/packages/lynx/create-lynx-extension/README.md
@@ -6,6 +6,12 @@ Create Native Autolink Lynx extensions.
 npm create lynx-extension
 ```
 
+The interactive flow lets you choose one or more extension types:
+
+- Native Module
+- Element
+- Service
+
 For non-interactive usage:
 
 ```bash
@@ -19,6 +25,9 @@ npm create lynx-extension -- \
   --service-name ButtonService
 ```
 
+Use `--types all` to generate a package that contains all supported extension
+types.
+
 Generated extensions include `lynx.ext.json`, JS facade sources, Android and
 iOS native examples, an example app skeleton, and a `codegen` script powered by
-`@lynx-js/autolink-codegen`.
+the current published version of `@lynx-js/autolink-codegen`.

--- a/packages/lynx/create-lynx-extension/package.json
+++ b/packages/lynx/create-lynx-extension/package.json
@@ -35,6 +35,12 @@
     "dev": "rslib build --watch",
     "test": "vitest run"
   },
+  "dependencies": {
+    "@clack/prompts": "1.0.1"
+  },
+  "devDependencies": {
+    "@lynx-js/autolink-codegen": "workspace:^"
+  },
   "engines": {
     "node": "^20 || ^22 || ^24"
   }

--- a/packages/lynx/create-lynx-extension/src/cli.ts
+++ b/packages/lynx/create-lynx-extension/src/cli.ts
@@ -5,9 +5,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { stdin as input, stdout as output } from 'node:process';
-import readline from 'node:readline';
 import type { Readable, Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
+
+import { cancel, isCancel, multiselect, text } from '@clack/prompts';
 
 import type { CreateLynxExtensionOptions, ExtensionType } from './index.js';
 import {
@@ -27,11 +28,17 @@ export interface CliOptions {
   help: boolean;
 }
 
+export interface CliPrompts {
+  text: typeof text;
+  multiselect: typeof multiselect;
+}
+
 export interface CliRuntime {
   input: Readable & { isTTY?: boolean };
   output: Writable & { isTTY?: boolean };
   info: (message: string) => void;
   error: (message: string) => void;
+  prompts?: CliPrompts;
 }
 
 const DEFAULT_RUNTIME: CliRuntime = {
@@ -43,6 +50,24 @@ const DEFAULT_RUNTIME: CliRuntime = {
   error(message) {
     console.error(message);
   },
+};
+class CliCancelError extends Error {
+  override name = 'CliCancelError';
+}
+const DEFAULT_PROMPTS: CliPrompts = {
+  text,
+  multiselect,
+};
+const DEFAULT_PROJECT_NAME = 'lynx-extension';
+const EXTENSION_TYPE_LABELS: Record<ExtensionType, string> = {
+  'native-module': 'Native Module',
+  element: 'Element',
+  service: 'Service',
+};
+const EXTENSION_TYPE_HINTS: Record<ExtensionType, string> = {
+  'native-module': 'JS bridge APIs implemented by native code',
+  element: 'native UI element registered through Autolink',
+  service: 'native service implementation registered globally',
 };
 
 /**
@@ -69,8 +94,11 @@ export function parseArgs(argv: string[]): CliOptions {
       continue;
     }
 
-    if (arg === '--types') {
-      options.types = parseExtensionTypes(readValue(argv, index, arg));
+    if (arg === '--types' || arg === '--type') {
+      options.types = [
+        ...(options.types ?? []),
+        ...parseExtensionTypes(readValue(argv, index, arg)),
+      ];
       index += 1;
       continue;
     }
@@ -140,13 +168,23 @@ function printHelp(runtime: CliRuntime): void {
 
 Options:
   --dir, -d <dir>              Target directory.
-  --types <list>               Comma-separated list: native-module,element,service.
+  --type, --types <list>       Comma-separated list or "all".
   --package-name <name>        npm package name.
   --android-package <name>     Android package name for lynx.ext.json.
   --module-name <name>         Native module class name.
   --element-name <name>        Element tag name.
   --service-name <name>        Service class name.
   --help, -h                   Show this help message.
+
+Extension types:
+  native-module                JS bridge APIs implemented by native code.
+  element                      Native UI element registered through Autolink.
+  service                      Native service implementation registered globally.
+
+Examples:
+  create-lynx-extension
+  create-lynx-extension lynx-button --types native-module,element,service
+  create-lynx-extension lynx-kit --types all
 `);
 }
 
@@ -183,38 +221,45 @@ async function fillInteractiveOptions(
     );
   }
 
-  const rl = readline.createInterface({
-    input: runtime.input,
-    output: runtime.output,
-  });
+  const prompts = getPrompts(runtime);
 
-  try {
-    if (next.dir === undefined) {
-      const answer = await ask(rl, 'Target directory: ');
-      next.dir = answer.trim();
-    }
+  next.dir ??= checkCancel<string>(
+    await prompts.text({
+      input: runtime.input,
+      output: runtime.output,
+      message: 'Project name or path',
+      placeholder: DEFAULT_PROJECT_NAME,
+      defaultValue: DEFAULT_PROJECT_NAME,
+      validate(value) {
+        if (value?.trim().length === 0) {
+          return 'Project name is required';
+        }
+        return undefined;
+      },
+    }),
+    runtime,
+  ).trim();
 
-    if (next.types === undefined || next.types.length === 0) {
-      const answer = await ask(
-        rl,
-        `Extension types (${EXTENSION_TYPES.join(', ')}): `,
-      );
-      next.types = parseExtensionTypes(answer.trim());
-    }
-
-    return next;
-  } finally {
-    rl.close();
+  if (next.types === undefined || next.types.length === 0) {
+    next.types = checkCancel<ExtensionType[]>(
+      await prompts.multiselect<ExtensionType>({
+        input: runtime.input,
+        output: runtime.output,
+        message:
+          'Select extension types (Use <space> to select, <enter> to continue)',
+        options: EXTENSION_TYPES.map((type) => ({
+          value: type,
+          label: EXTENSION_TYPE_LABELS[type],
+          hint: EXTENSION_TYPE_HINTS[type],
+        })),
+        initialValues: [...EXTENSION_TYPES],
+        required: true,
+      }),
+      runtime,
+    );
   }
-}
 
-/**
- * Wraps readline questions in a promise for async CLI flow.
- */
-function ask(rl: readline.Interface, question: string): Promise<string> {
-  return new Promise((resolve) => {
-    rl.question(question, resolve);
-  });
+  return next;
 }
 
 /**
@@ -264,7 +309,12 @@ export async function main(
 
   const files = createLynxExtension(createOptions);
 
-  runtime.info(`Created ${files.length} files in ${createOptions.dir}`);
+  runtime.info(formatSuccessMessage({
+    dir: createOptions.dir,
+    filesCount: files.length,
+    packageManager: detectPackageManager(),
+    types: options.types,
+  }));
 }
 
 /**
@@ -274,6 +324,10 @@ export function reportCliError(
   error: unknown,
   runtime: CliRuntime = DEFAULT_RUNTIME,
 ): void {
+  if (error instanceof CliCancelError) {
+    return;
+  }
+
   runtime.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
 }
@@ -295,6 +349,84 @@ function normalizeEntrypointPath(filePath: string): string {
   } catch {
     return resolvedPath;
   }
+}
+
+function getPrompts(runtime: CliRuntime): CliPrompts {
+  return runtime.prompts ?? DEFAULT_PROMPTS;
+}
+
+function checkCancel<T>(value: T | symbol, runtime: CliRuntime): T {
+  if (isCancel(value)) {
+    cancel('Operation cancelled.', {
+      input: runtime.input,
+      output: runtime.output,
+    });
+    throw new CliCancelError();
+  }
+
+  return value;
+}
+
+function formatSuccessMessage({
+  dir,
+  filesCount,
+  packageManager,
+  types,
+}: {
+  dir: string;
+  filesCount: number;
+  packageManager: PackageManager;
+  types: ExtensionType[];
+}): string {
+  // Display extension types in the canonical order from EXTENSION_TYPES.
+  const selectedTypes = EXTENSION_TYPES.filter((type) => types.includes(type));
+  const typeSummary = selectedTypes
+    .map((type) => `  - ${EXTENSION_TYPE_LABELS[type]}`)
+    .join('\n');
+  const nextSteps = [
+    `1. cd ${formatTargetDir(dir)}`,
+    `2. ${packageManager} install`,
+  ];
+
+  if (selectedTypes.includes('native-module')) {
+    nextSteps.push(`3. ${packageManager} run codegen`);
+  }
+
+  return `Created ${filesCount} files in ${dir}
+
+Extension types:
+${typeSummary}
+
+Next steps:
+${nextSteps.map((step) => `  ${step}`).join('\n')}`;
+}
+
+type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn';
+
+function detectPackageManager(
+  userAgent: string | undefined = process.env['npm_config_user_agent'],
+): PackageManager {
+  const name = userAgent?.split(' ')[0]?.split('/')[0];
+
+  if (name === 'bun' || name === 'pnpm' || name === 'yarn') {
+    return name;
+  }
+
+  return 'npm';
+}
+
+function formatTargetDir(targetDir: string): string {
+  const relativePath = path.relative(process.cwd(), targetDir);
+
+  if (relativePath.length === 0) {
+    return '.';
+  }
+
+  if (!relativePath.startsWith('..') && !path.isAbsolute(relativePath)) {
+    return relativePath;
+  }
+
+  return targetDir;
 }
 
 /* v8 ignore next 5 */

--- a/packages/lynx/create-lynx-extension/src/index.ts
+++ b/packages/lynx/create-lynx-extension/src/index.ts
@@ -15,6 +15,7 @@ export interface CreateLynxExtensionOptions {
   moduleName?: string;
   elementName?: string;
   serviceName?: string;
+  dependencyVersions?: Record<string, string>;
 }
 
 export interface CreatedFile {
@@ -31,7 +32,15 @@ interface TemplateContext {
   elementClassName: string;
   serviceName: string;
   serviceProtocolName: string;
+  dependencyVersions: Record<string, string>;
   types: Set<ExtensionType>;
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
 }
 
 export const EXTENSION_TYPES: readonly ExtensionType[] = [
@@ -45,6 +54,12 @@ const PACKAGE_ROOT = path.resolve(
   '..',
 );
 const TEMPLATE_FILE_SUFFIX = '.tmpl';
+const PACKAGE_JSON_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const satisfies ReadonlyArray<keyof PackageJson>;
 
 /**
  * Creates a Native Autolink extension scaffold on disk.
@@ -94,7 +109,15 @@ export function createLynxExtension(
  * Parses a comma-separated extension type list from CLI input.
  */
 export function parseExtensionTypes(source: string): ExtensionType[] {
-  const types = source.split(',').map((type) => type.trim()).filter(Boolean);
+  const normalizedSource = source.trim().toLowerCase();
+
+  if (normalizedSource === 'all') {
+    return [...EXTENSION_TYPES];
+  }
+
+  const types = normalizedSource.split(',').map((type) => type.trim()).filter(
+    Boolean,
+  );
 
   if (types.length === 0) {
     return [];
@@ -143,6 +166,8 @@ function createContext(
     elementClassName: `${elementPrefix}Element`,
     serviceName,
     serviceProtocolName: `${serviceName}Protocol`,
+    dependencyVersions: options.dependencyVersions
+      ?? readDefaultDependencyVersions(),
     types,
   };
 }
@@ -183,15 +208,90 @@ function createFilesFromTemplateGroup(
   return listTemplateFiles(root).map((absolutePath) => {
     const relativePath = toPosixPath(path.relative(root, absolutePath));
     const renderedPath = renderTemplate(relativePath, replacements);
+    const filePath = stripTemplateFileSuffix(renderedPath);
+    const content = renderTemplate(
+      fs.readFileSync(absolutePath, 'utf8'),
+      replacements,
+    );
 
     return {
-      path: stripTemplateFileSuffix(renderedPath),
-      content: renderTemplate(
-        fs.readFileSync(absolutePath, 'utf8'),
-        replacements,
-      ),
+      path: filePath,
+      content: filePath.endsWith('package.json')
+        ? replacePackageDependencyVersions(
+          content,
+          context.dependencyVersions,
+          filePath,
+        )
+        : content,
     };
   });
+}
+
+/**
+ * Reads dependency versions carried by the published scaffold package metadata.
+ *
+ * This intentionally uses the target dependency's published version rewritten
+ * from workspace protocol during packing, not create-lynx-extension's own
+ * package version.
+ */
+function readDefaultDependencyVersions(): Record<string, string> {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8'),
+  ) as PackageJson;
+
+  return packageJson.devDependencies ?? {};
+}
+
+/**
+ * Replaces workspace template dependency versions with the scaffold package's current version table.
+ */
+function replacePackageDependencyVersions(
+  source: string,
+  dependencyVersions: Record<string, string>,
+  filePath: string,
+): string {
+  let packageJson: PackageJson;
+
+  try {
+    packageJson = JSON.parse(source) as PackageJson;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid package.json template after rendering: ${filePath}: ${message}`,
+    );
+  }
+
+  const missingVersionPackages = new Set<string>();
+
+  for (const field of PACKAGE_JSON_DEPENDENCY_FIELDS) {
+    const dependencies = packageJson[field];
+
+    if (dependencies === undefined) {
+      continue;
+    }
+
+    for (const [name, version] of Object.entries(dependencies)) {
+      if (version.startsWith('workspace:')) {
+        const replacement = dependencyVersions[name];
+
+        if (replacement === undefined) {
+          missingVersionPackages.add(name);
+        } else {
+          dependencies[name] = replacement;
+        }
+      }
+    }
+  }
+
+  if (missingVersionPackages.size > 0) {
+    throw new Error(
+      `Template package.json "${filePath}" contains workspace dependencies without version mappings: ${
+        Array.from(missingVersionPackages).join(', ')
+      }. Add these packages to create-lynx-extension's devDependencies.`,
+    );
+  }
+
+  return `${JSON.stringify(packageJson, null, 2)}\n`;
 }
 
 /**

--- a/packages/lynx/create-lynx-extension/template-common/package.json
+++ b/packages/lynx/create-lynx-extension/template-common/package.json
@@ -19,6 +19,6 @@
     "codegen": "lynx-autolink-codegen"
   },
   "devDependencies": {
-    "@lynx-js/autolink-codegen": "^0.0.0"
+    "@lynx-js/autolink-codegen": "workspace:*"
   }
 }

--- a/packages/lynx/create-lynx-extension/test/cli.test.ts
+++ b/packages/lynx/create-lynx-extension/test/cli.test.ts
@@ -9,7 +9,7 @@ import { pathToFileURL } from 'node:url';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { CliRuntime } from '../src/cli.js';
+import type { CliPrompts, CliRuntime } from '../src/cli.js';
 import {
   isCliEntrypoint,
   main,
@@ -34,7 +34,9 @@ describe('create-lynx-extension CLI', () => {
       parseArgs([
         'demo-extension',
         '--types',
-        'native-module,element,service',
+        'native-module,element',
+        '--type',
+        'service',
         '--package-name',
         '@example/demo-extension',
         '--android-package',
@@ -101,7 +103,15 @@ describe('create-lynx-extension CLI', () => {
     ], runtime);
 
     expect(runtime.info).toHaveBeenCalledWith(
-      `Created 19 files in ${path.resolve(dir)}`,
+      expect.stringContaining(`Created 19 files in ${path.resolve(dir)}`),
+    );
+    expect(runtime.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Extension types:\n  - Native Module\n  - Element',
+      ),
+    );
+    expect(runtime.info).toHaveBeenCalledWith(
+      expect.stringContaining('Next steps:'),
     );
     expect(read(dir, 'package.json')).toContain(
       '"name": "@example/cli-extension"',
@@ -113,17 +123,116 @@ describe('create-lynx-extension CLI', () => {
     );
   });
 
+  it('creates an all-in-one scaffold from the shorthand type flag', async () => {
+    const dir = createTempPath('all-extension');
+    const runtime = createRuntime();
+
+    await main([
+      '--dir',
+      dir,
+      '--types',
+      'all',
+      '--package-name',
+      '@example/all-extension',
+      '--android-package',
+      'com.example.all',
+    ], runtime);
+
+    expect(runtime.info).toHaveBeenCalledWith(
+      expect.stringContaining('  - Native Module\n  - Element\n  - Service'),
+    );
+    expect(
+      read(
+        dir,
+        'android/src/main/java/com/example/all/AllExtensionModule.java',
+      ),
+    )
+      .toContain('@LynxAutolinkNativeModule(name = "AllExtensionModule")');
+    expect(
+      read(
+        dir,
+        'android/src/main/java/com/example/all/AllExtensionElement.java',
+      ),
+    )
+      .toContain('@LynxAutolinkElement(name = "x-all-extension")');
+    expect(
+      read(
+        dir,
+        'android/src/main/java/com/example/all/AllExtensionService.java',
+      ),
+    )
+      .toContain('@LynxAutolinkService');
+  });
+
   it('fails in non-interactive mode when required options are missing', async () => {
     await expect(main([], createRuntime())).rejects.toThrow(
       /Missing required options in non-interactive mode: --dir, --types/,
     );
   });
 
+  it('prompts with project text and extension type multiselect controls', async () => {
+    const dir = createTempPath('interactive-extension');
+    const textPrompt = vi.fn().mockResolvedValue(dir);
+    const multiselectPrompt = vi.fn().mockResolvedValue([
+      'native-module',
+      'element',
+      'service',
+    ]);
+    const runtime = createRuntime({
+      isTTY: true,
+      prompts: {
+        text: textPrompt as CliPrompts['text'],
+        multiselect: multiselectPrompt as CliPrompts['multiselect'],
+      },
+    });
+
+    await main([], runtime);
+
+    expect(textPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultValue: 'lynx-extension',
+        message: 'Project name or path',
+        placeholder: 'lynx-extension',
+      }),
+    );
+    expect(multiselectPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValues: ['native-module', 'element', 'service'],
+        required: true,
+      }),
+    );
+    const multiselectOptions = multiselectPrompt.mock.calls[0]?.[0] as
+      | { message?: string }
+      | undefined;
+    expect(multiselectOptions?.message).toContain('Select extension types');
+    expect(multiselectPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          expect.objectContaining({
+            label: 'Native Module',
+            value: 'native-module',
+          }),
+          expect.objectContaining({ label: 'Element', value: 'element' }),
+          expect.objectContaining({ label: 'Service', value: 'service' }),
+        ],
+      }),
+    );
+    expect(read(dir, 'ios/src/InteractiveExtensionService.h')).toContain(
+      '@protocol InteractiveExtensionServiceProtocol',
+    );
+  });
+
   it('rejects empty interactive type answers', async () => {
     const dir = createTempPath('interactive-extension');
-    const runtime = createRuntime({ isTTY: true });
-    const input = runtime.input as PassThrough;
-    input.end('\n');
+    const runtime = createRuntime({
+      isTTY: true,
+      prompts: {
+        text: vi.fn().mockResolvedValue(dir) as CliPrompts['text'],
+        multiselect: vi.fn().mockResolvedValue([]) as CliPrompts[
+          'multiselect'
+        ],
+      },
+    });
 
     await expect(main(['--dir', dir], runtime)).rejects.toThrow(
       /At least one extension type is required/,
@@ -170,7 +279,9 @@ describe('create-lynx-extension CLI', () => {
   });
 });
 
-function createRuntime(options: { isTTY?: boolean } = {}): CliRuntime {
+function createRuntime(
+  options: { isTTY?: boolean; prompts?: CliPrompts } = {},
+): CliRuntime {
   const input = new PassThrough() as PassThrough & { isTTY?: boolean };
   const output = new PassThrough() as PassThrough & { isTTY?: boolean };
   input.isTTY = options.isTTY ?? false;
@@ -181,6 +292,7 @@ function createRuntime(options: { isTTY?: boolean } = {}): CliRuntime {
     output,
     info: vi.fn(),
     error: vi.fn(),
+    ...(options.prompts === undefined ? {} : { prompts: options.prompts }),
   };
 }
 

--- a/packages/lynx/create-lynx-extension/test/create.test.ts
+++ b/packages/lynx/create-lynx-extension/test/create.test.ts
@@ -24,6 +24,11 @@ describe('create-lynx-extension', () => {
       'element',
       'service',
     ]);
+    expect(parseExtensionTypes('ALL')).toEqual([
+      'native-module',
+      'element',
+      'service',
+    ]);
     expect(() => parseExtensionTypes('web')).toThrow(
       /Unsupported extension type/,
     );
@@ -39,6 +44,9 @@ describe('create-lynx-extension', () => {
       moduleName: 'ButtonModule',
       elementName: 'x-button',
       serviceName: 'ButtonService',
+      dependencyVersions: {
+        '@lynx-js/autolink-codegen': '^0.123.0',
+      },
     });
 
     expect(files.map((file) => file.path)).toEqual(
@@ -63,8 +71,12 @@ describe('create-lynx-extension', () => {
       '"codegen": "lynx-autolink-codegen"',
     );
     expect(read(dir, 'package.json')).toContain(
+      '"@lynx-js/autolink-codegen": "^0.123.0"',
+    );
+    expect(read(dir, 'package.json')).not.toContain(
       '"@lynx-js/autolink-codegen": "^0.0.0"',
     );
+    expect(read(dir, 'package.json')).not.toContain('workspace:');
     expect(read(dir, 'lynx.ext.json')).toContain(
       '"packageName": "com.example.button"',
     );
@@ -173,6 +185,37 @@ describe('create-lynx-extension', () => {
       '@LynxAutolinkService(ViewService, ViewServiceProtocol)',
     );
     expect(read(dir, 'example/src/App.tsx')).not.toContain('import {');
+  });
+
+  it('fails when package templates contain unmapped workspace dependencies', () => {
+    const dir = createTempDir('missing-version');
+
+    expect(() =>
+      createLynxExtension({
+        dir,
+        types: ['native-module'],
+        dependencyVersions: {},
+      })
+    ).toThrow(
+      /workspace dependencies without version mappings: @lynx-js\/autolink-codegen/,
+    );
+  });
+
+  it('adds package template context when rendered package JSON is invalid', () => {
+    const dir = createTempDir('invalid-json');
+
+    expect(() =>
+      createLynxExtension({
+        dir,
+        types: ['native-module'],
+        packageName: 'bad"name',
+        dependencyVersions: {
+          '@lynx-js/autolink-codegen': '^0.123.0',
+        },
+      })
+    ).toThrow(
+      /Invalid package\.json template after rendering: .*package\.json/,
+    );
   });
 
   it('rejects generated paths that escape the target directory', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,7 +742,15 @@ importers:
         specifier: ^8.8.5
         version: 8.8.5
 
-  packages/lynx/create-lynx-extension: {}
+  packages/lynx/create-lynx-extension:
+    dependencies:
+      '@clack/prompts':
+        specifier: 1.0.1
+        version: 1.0.1
+    devDependencies:
+      '@lynx-js/autolink-codegen':
+        specifier: workspace:^
+        version: link:../autolink-codegen
 
   packages/lynx/gesture-runtime:
     devDependencies:


### PR DESCRIPTION
## Summary

- Align `create-lynx-extension` prompts with the `create-rspeedy` flow using `create-rstack` controls.
- Support all-in-one extension scaffolds with native module, element, and service selections.
- Replace scaffolded `@lynx-js/autolink-codegen` workspace placeholders from published package metadata instead of hard-coding `^0.0.0`.
- Add tests, documentation, authoring instructions, and a changeset.

## Validation

- `pnpm dprint check .changeset/create-extension-dependency-version.md .github/autolink-extension.instructions.md packages/lynx/create-lynx-extension/README.md packages/lynx/create-lynx-extension/package.json packages/lynx/create-lynx-extension/template-common/package.json packages/lynx/create-lynx-extension/src/cli.ts packages/lynx/create-lynx-extension/src/index.ts packages/lynx/create-lynx-extension/test/cli.test.ts packages/lynx/create-lynx-extension/test/create.test.ts pnpm-lock.yaml`
- `pnpm --filter create-lynx-extension test`
- `pnpm --filter create-lynx-extension build`
- `pnpm exec tsc --build packages/lynx/create-lynx-extension/tsconfig.json --pretty false`
- `pnpm eslint packages/lynx/create-lynx-extension/src/cli.ts packages/lynx/create-lynx-extension/src/index.ts packages/lynx/create-lynx-extension/test/cli.test.ts packages/lynx/create-lynx-extension/test/create.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced interactive prompts with improved UI for selecting extension types (Native Module, Element, Service).
  * Added `--type` as shorthand alias for `--types` option.
  * Added `--types all` to generate all extension types in a single package.
  * Improved success messages with next steps and automatic package manager detection.

* **Documentation**
  * Updated CLI documentation with clearer interactive workflow descriptions and expanded examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2628)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->