### PR TITLE
feat(et): support spread attributes and events

### DIFF
--- a/packages/react/runtime/__test__/element-template/fixtures/background/event/spread-event/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/event/spread-event/index.tsx
@@ -7,8 +7,14 @@ interface SpreadProps {
 interface AppProps {
   spread?: SpreadProps;
   onCatch?: () => void;
+  showChild?: boolean;
+  childSpread?: SpreadProps;
 }
 
-export function App({ spread = {}, onCatch }: AppProps) {
-  return <view catchtap={onCatch} {...spread} />;
+export function App({ spread = {}, onCatch, showChild = false, childSpread = {} }: AppProps) {
+  return (
+    <view catchtap={onCatch} {...spread}>
+      {showChild ? <text {...childSpread}>tap</text> : null}
+    </view>
+  );
 }

--- a/packages/react/runtime/__test__/element-template/fixtures/background/event/spread-event/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/event/spread-event/index.tsx
@@ -1,0 +1,14 @@
+interface SpreadProps {
+  id?: string;
+  className?: string;
+  bindtap?: () => void;
+}
+
+interface AppProps {
+  spread?: SpreadProps;
+  onCatch?: () => void;
+}
+
+export function App({ spread = {}, onCatch }: AppProps) {
+  return <view catchtap={onCatch} {...spread} />;
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/hydrate/background-hydrate/attrs.nullish-values/output.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/hydrate/background-hydrate/attrs.nullish-values/output.txt
@@ -5,7 +5,6 @@ Object {
     0,
     Object {
       "id": null,
-      "title": undefined,
     },
   ],
 }

--- a/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
@@ -70,6 +70,8 @@ interface CompiledSpreadEventModule extends CompiledFixtureModuleExports {
   App: (props: {
     spread?: SpreadFixtureProps;
     onCatch?: () => void;
+    showChild?: boolean;
+    childSpread?: SpreadFixtureProps;
   }) => JSX.Element;
 }
 
@@ -190,9 +192,13 @@ describe('Compiled direct event background updates', () => {
     moduleExports: CompiledSpreadEventModule,
     spread: SpreadFixtureProps | undefined,
     onCatch?: () => void,
+    childOptions?: {
+      showChild?: boolean;
+      childSpread?: SpreadFixtureProps;
+    },
   ): BackgroundElementTemplateInstance {
     envManager.switchToBackground();
-    root.render(createElement(moduleExports.App, { spread, onCatch }));
+    root.render(createElement(moduleExports.App, { spread, onCatch, ...childOptions }));
     return getRenderedHost();
   }
 
@@ -200,11 +206,15 @@ describe('Compiled direct event background updates', () => {
     moduleExports: CompiledSpreadEventModule,
     spread: SpreadFixtureProps | undefined,
     onCatch?: () => void,
+    childOptions?: {
+      showChild?: boolean;
+      childSpread?: SpreadFixtureProps;
+    },
   ): BackgroundElementTemplateInstance {
     const host = getRenderedHost();
 
     envManager.switchToMainThread();
-    root.render(createElement(moduleExports.App, { spread, onCatch }));
+    root.render(createElement(moduleExports.App, { spread, onCatch, ...childOptions }));
     renderPage();
     envManager.switchToBackground();
 
@@ -400,6 +410,42 @@ describe('Compiled direct event background updates', () => {
     envManager.switchToBackground();
     expect(host.attributeSlots).toEqual([`${host.instanceId}:0:`, preparedSpread]);
     expect(getEventHandlerForEventValue(spreadEventValue)).toBe(handleSpreadTap);
+  });
+
+  it('registers and dispatches spread events on inserted compiled subtrees', async () => {
+    const { backgroundModule, mainModule } = await loadCompiledSpreadEventFixture();
+    const handleSpreadTap = vi.fn();
+
+    const host = renderSpreadEventOnBackground(backgroundModule, undefined, undefined, {
+      showChild: false,
+    });
+    hydrateSpreadEventFromMainThread(mainModule, undefined, undefined, { showChild: false });
+    updateEvents = [];
+
+    renderSpreadEventOnBackground(backgroundModule, undefined, undefined, {
+      showChild: true,
+      childSpread: { id: 'inserted', bindtap: handleSpreadTap },
+    });
+    const inserted = getSlotChildAt(0, host);
+    const spreadEventValue = `${inserted.instanceId}:0:bindtap`;
+    const preparedSpread = { id: 'inserted', bindtap: spreadEventValue };
+
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops).toEqual([
+      ...collectRecursiveCreateCommandStream(inserted),
+      ElementTemplateUpdateOps.insertNode,
+      host.instanceId,
+      SLOT_ID,
+      inserted.instanceId,
+      0,
+    ]);
+    envManager.switchToBackground();
+    expect(inserted.attributeSlots).toEqual([preparedSpread]);
+    expect(getEventHandlerForEventValue(spreadEventValue)).toBe(handleSpreadTap);
+
+    publishEvent(spreadEventValue, { type: 'tap', source: 'inserted-spread' });
+
+    expect(handleSpreadTap).toHaveBeenCalledWith({ type: 'tap', source: 'inserted-spread' });
   });
 
   it('registers and dispatches direct events on inserted compiled subtrees', async () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
@@ -49,6 +49,7 @@ const CONDITIONAL_DIRECT_EVENT_FIXTURE = path.resolve(
   __dirname,
   '../../../fixtures/background/event/conditional-direct-event/index.tsx',
 );
+const SPREAD_EVENT_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/event/spread-event/index.tsx');
 const SLOT_ID = 0;
 
 interface CompiledDirectEventModule extends CompiledFixtureModuleExports {
@@ -57,6 +58,19 @@ interface CompiledDirectEventModule extends CompiledFixtureModuleExports {
 
 interface CompiledConditionalDirectEventModule extends CompiledFixtureModuleExports {
   App: (props: { show?: boolean; onTap?: () => void }) => JSX.Element;
+}
+
+interface SpreadFixtureProps {
+  id?: string;
+  className?: string;
+  bindtap?: () => void;
+}
+
+interface CompiledSpreadEventModule extends CompiledFixtureModuleExports {
+  App: (props: {
+    spread?: SpreadFixtureProps;
+    onCatch?: () => void;
+  }) => JSX.Element;
 }
 
 function getRenderedHost(): BackgroundElementTemplateInstance {
@@ -135,6 +149,20 @@ describe('Compiled direct event background updates', () => {
     return { backgroundModule, mainModule };
   }
 
+  async function loadCompiledSpreadEventFixture(): Promise<{
+    backgroundModule: CompiledSpreadEventModule;
+    mainModule: CompiledSpreadEventModule;
+  }> {
+    const mainArtifact = await compileFixtureSource(SPREAD_EVENT_FIXTURE, { target: 'LEPUS' });
+    primeCompiledFixtureTemplates(mainArtifact);
+    const mainModule = await loadCompiledFixtureModule<CompiledSpreadEventModule>(mainArtifact);
+
+    const backgroundArtifact = await compileFixtureSource(SPREAD_EVENT_FIXTURE, { target: 'JS' });
+    const backgroundModule = await loadCompiledFixtureModule<CompiledSpreadEventModule>(backgroundArtifact);
+
+    return { backgroundModule, mainModule };
+  }
+
   function renderDirectEventOnBackground(
     moduleExports: CompiledDirectEventModule,
     onTap?: () => void,
@@ -152,6 +180,31 @@ describe('Compiled direct event background updates', () => {
 
     envManager.switchToMainThread();
     root.render(createElement(moduleExports.App, { onTap }));
+    renderPage();
+    envManager.switchToBackground();
+
+    return host;
+  }
+
+  function renderSpreadEventOnBackground(
+    moduleExports: CompiledSpreadEventModule,
+    spread: SpreadFixtureProps | undefined,
+    onCatch?: () => void,
+  ): BackgroundElementTemplateInstance {
+    envManager.switchToBackground();
+    root.render(createElement(moduleExports.App, { spread, onCatch }));
+    return getRenderedHost();
+  }
+
+  function hydrateSpreadEventFromMainThread(
+    moduleExports: CompiledSpreadEventModule,
+    spread: SpreadFixtureProps | undefined,
+    onCatch?: () => void,
+  ): BackgroundElementTemplateInstance {
+    const host = getRenderedHost();
+
+    envManager.switchToMainThread();
+    root.render(createElement(moduleExports.App, { spread, onCatch }));
     renderPage();
     envManager.switchToBackground();
 
@@ -280,6 +333,73 @@ describe('Compiled direct event background updates', () => {
     expect(firstHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'first' });
     expect(firstHandler).toHaveBeenCalledTimes(1);
     expect(secondHandler).toHaveBeenCalledWith({ type: 'tap', phase: 'second' });
+  });
+
+  it('hydrates compiled spread attrs and dispatches direct plus spread event values independently', async () => {
+    const { backgroundModule, mainModule } = await loadCompiledSpreadEventFixture();
+    const handleSpreadTap = vi.fn();
+    const handleDirectCatch = vi.fn();
+
+    const host = renderSpreadEventOnBackground(
+      backgroundModule,
+      { id: 'cta', className: 'primary', bindtap: handleSpreadTap },
+      handleDirectCatch,
+    );
+    hydrateSpreadEventFromMainThread(
+      mainModule,
+      { id: 'cta', className: 'primary', bindtap: handleSpreadTap },
+      handleDirectCatch,
+    );
+
+    const directEventValue = `${host.instanceId}:0:`;
+    const spreadEventValue = `${host.instanceId}:1:bindtap`;
+    const preparedSpread = { id: 'cta', class: 'primary', bindtap: spreadEventValue };
+    expect(host.attributeSlots).toEqual([directEventValue, preparedSpread]);
+    expect(getEventHandlerForEventValue(directEventValue)).toBe(handleDirectCatch);
+    expect(getEventHandlerForEventValue(spreadEventValue)).toBe(handleSpreadTap);
+
+    publishEvent(directEventValue, { type: 'tap', source: 'direct' });
+    publishEvent(spreadEventValue, { type: 'tap', source: 'spread' });
+
+    expect(handleDirectCatch).toHaveBeenCalledWith({ type: 'tap', source: 'direct' });
+    expect(handleSpreadTap).toHaveBeenCalledWith({ type: 'tap', source: 'spread' });
+  });
+
+  it('updates compiled spread plain attrs through a whole-slot setAttribute patch', async () => {
+    const { backgroundModule, mainModule } = await loadCompiledSpreadEventFixture();
+    const handleSpreadTap = vi.fn();
+    const handleDirectCatch = vi.fn();
+
+    const host = renderSpreadEventOnBackground(
+      backgroundModule,
+      { id: 'cta', className: 'primary', bindtap: handleSpreadTap },
+      handleDirectCatch,
+    );
+    hydrateSpreadEventFromMainThread(
+      mainModule,
+      { id: 'cta', className: 'primary', bindtap: handleSpreadTap },
+      handleDirectCatch,
+    );
+    updateEvents = [];
+
+    renderSpreadEventOnBackground(
+      backgroundModule,
+      { id: 'cta-next', className: 'secondary', bindtap: handleSpreadTap },
+      handleDirectCatch,
+    );
+
+    const spreadEventValue = `${host.instanceId}:1:bindtap`;
+    const preparedSpread = { id: 'cta-next', class: 'secondary', bindtap: spreadEventValue };
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      host.instanceId,
+      1,
+      preparedSpread,
+    ]);
+    envManager.switchToBackground();
+    expect(host.attributeSlots).toEqual([`${host.instanceId}:0:`, preparedSpread]);
+    expect(getEventHandlerForEventValue(spreadEventValue)).toBe(handleSpreadTap);
   });
 
   it('registers and dispatches direct events on inserted compiled subtrees', async () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -18,6 +18,7 @@ import type { SerializedElementTemplate } from '../../../../src/element-template
 import {
   __etAttrPlanMap,
   adaptEventAttrSlot,
+  adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 
@@ -55,6 +56,8 @@ function createHydrationChild(
 
 describe('hydrate', () => {
   beforeEach(() => {
+    globalThis.__MAIN_THREAD__ = false;
+    globalThis.__BACKGROUND__ = true;
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
     clearEtAttrPlanMap();
@@ -926,6 +929,83 @@ describe('hydrate', () => {
     ]);
     expect(root.attributeSlots).toEqual([null]);
     expect(getEventHandlerForEventValue('-9:0:')).toBeUndefined();
+  });
+
+  it('prepares background spread event handlers with the serialized uid before diffing hydrate slots', () => {
+    __etAttrPlanMap.root = [0, adaptSpreadAttrSlot];
+    const root = new BackgroundElementTemplateInstance('root');
+    const handleTap = vi.fn();
+    root.setAttribute('attributeSlots', [{
+      id: 'cta',
+      bindtap: handleTap,
+    }]);
+    const temporaryEventValue = `${root.instanceId}:0:bindtap`;
+    const preparedSpread = { id: 'cta', bindtap: '-10:0:bindtap' };
+    expect(getEventHandlerForEventValue(temporaryEventValue)).toBe(handleTap);
+
+    const stream = hydrate(
+      createHydrationTemplate(-10, 'root', {
+        attributeSlots: [preparedSpread],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([]);
+    expect(root.attributeSlots).toEqual([preparedSpread]);
+    expect(getEventHandlerForEventValue(temporaryEventValue)).toBeUndefined();
+    expect(getEventHandlerForEventValue('-10:0:bindtap')).toBe(handleTap);
+  });
+
+  it('patches a hydrated spread value when main thread serialized null but background has a spread event', () => {
+    __etAttrPlanMap.root = [0, adaptSpreadAttrSlot];
+    const root = new BackgroundElementTemplateInstance('root');
+    const handleTap = vi.fn();
+    root.setAttribute('attributeSlots', [{
+      id: 'cta',
+      bindtap: handleTap,
+    }]);
+    const temporaryEventValue = `${root.instanceId}:0:bindtap`;
+    const preparedSpread = { id: 'cta', bindtap: '-11:0:bindtap' };
+    expect(getEventHandlerForEventValue(temporaryEventValue)).toBe(handleTap);
+
+    const stream = hydrate(
+      createHydrationTemplate(-11, 'root', {
+        attributeSlots: [null],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      -11,
+      0,
+      preparedSpread,
+    ]);
+    expect(root.attributeSlots).toEqual([preparedSpread]);
+    expect(getEventHandlerForEventValue(temporaryEventValue)).toBeUndefined();
+    expect(getEventHandlerForEventValue('-11:0:bindtap')).toBe(handleTap);
+  });
+
+  it('patches null when main thread serialized a spread event value but background clears the spread slot', () => {
+    __etAttrPlanMap.root = [0, adaptSpreadAttrSlot];
+    const root = new BackgroundElementTemplateInstance('root');
+    root.setAttribute('attributeSlots', [false]);
+
+    const stream = hydrate(
+      createHydrationTemplate(-12, 'root', {
+        attributeSlots: [{ bindtap: '-12:0:bindtap' }],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      -12,
+      0,
+      null,
+    ]);
+    expect(root.attributeSlots).toEqual([null]);
+    expect(getEventHandlerForEventValue('-12:0:bindtap')).toBeUndefined();
   });
 
   it('skips sparse background slot indexes when checking trailing slots', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -21,6 +21,7 @@ import { ElementTemplateUpdateOps } from '../../../../src/element-template/proto
 import {
   __etAttrPlanMap,
   adaptEventAttrSlot,
+  adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 
@@ -30,6 +31,8 @@ function createTextNode(text: string): BackgroundElementTemplateInstance {
 
 describe('BackgroundElementTemplateInstance', () => {
   beforeEach(() => {
+    globalThis.__MAIN_THREAD__ = false;
+    globalThis.__BACKGROUND__ = true;
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
     clearEtAttrPlanMap();
@@ -730,6 +733,8 @@ describe('Background raw-text instance', () => {
 
 describe('BackgroundElementTemplateInstance Shadow State', () => {
   beforeEach(() => {
+    globalThis.__MAIN_THREAD__ = false;
+    globalThis.__BACKGROUND__ = true;
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
     clearEtAttrPlanMap();
@@ -916,6 +921,134 @@ describe('BackgroundElementTemplateInstance Shadow State', () => {
     const handler = vi.fn();
     instance.setAttribute('attributeSlots', [handler]);
     const eventValue = `${instance.instanceId}:0:`;
+
+    destroyElementTemplateBackgroundRuntime();
+
+    expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+  });
+
+  it('prepares spread event keys after hydration and registers handlers by event value', () => {
+    __etAttrPlanMap.view = [0, adaptSpreadAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    instance.emitCreate();
+    markElementTemplateHydrated();
+    globalCommitContext.ops = [];
+
+    const handleTap = vi.fn();
+    const handleTouch = vi.fn();
+    instance.setAttribute('attributeSlots', [{
+      id: 'cta',
+      bindtap: handleTap,
+      catchtouchstart: handleTouch,
+    }]);
+
+    const bindtapValue = `${instance.instanceId}:0:bindtap`;
+    const catchTouchValue = `${instance.instanceId}:0:catchtouchstart`;
+    const preparedSpread = {
+      id: 'cta',
+      bindtap: bindtapValue,
+      catchtouchstart: catchTouchValue,
+    };
+    expect(instance.attributeSlots).toEqual([preparedSpread]);
+    expect(getEventHandlerForEventValue(bindtapValue)).toBe(handleTap);
+    expect(getEventHandlerForEventValue(catchTouchValue)).toBe(handleTouch);
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      instance.instanceId,
+      0,
+      preparedSpread,
+    ]);
+  });
+
+  it('updates spread event handlers without patching native when the prepared spread value is unchanged', () => {
+    __etAttrPlanMap.view = [0, adaptSpreadAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    instance.emitCreate();
+    markElementTemplateHydrated();
+
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+    instance.setAttribute('attributeSlots', [{ id: 'cta', bindtap: firstHandler }]);
+    globalCommitContext.ops = [];
+
+    instance.setAttribute('attributeSlots', [{ id: 'cta', bindtap: secondHandler }]);
+
+    const eventValue = `${instance.instanceId}:0:bindtap`;
+    expect(instance.attributeSlots).toEqual([{ id: 'cta', bindtap: eventValue }]);
+    expect(getEventHandlerForEventValue(eventValue)).toBe(secondHandler);
+    expect(globalCommitContext.ops).toEqual([]);
+  });
+
+  it('patches the whole spread slot when event keys change and cleans removed handlers', () => {
+    __etAttrPlanMap.view = [0, adaptSpreadAttrSlot];
+    const instance = new BackgroundElementTemplateInstance('view');
+    instance.emitCreate();
+    markElementTemplateHydrated();
+
+    const handleTap = vi.fn();
+    const handleTouch = vi.fn();
+    instance.setAttribute('attributeSlots', [{ id: 'cta', bindtap: handleTap }]);
+    const removedEventValue = `${instance.instanceId}:0:bindtap`;
+    globalCommitContext.ops = [];
+
+    instance.setAttribute('attributeSlots', [{ id: 'cta', catchtouchstart: handleTouch }]);
+
+    const nextEventValue = `${instance.instanceId}:0:catchtouchstart`;
+    const preparedSpread = { id: 'cta', catchtouchstart: nextEventValue };
+    expect(instance.attributeSlots).toEqual([preparedSpread]);
+    expect(getEventHandlerForEventValue(removedEventValue)).toBeUndefined();
+    expect(getEventHandlerForEventValue(nextEventValue)).toBe(handleTouch);
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      instance.instanceId,
+      0,
+      preparedSpread,
+    ]);
+  });
+
+  it('emits prepared spread values instead of handler functions in create payloads', () => {
+    __etAttrPlanMap.view = [0, adaptSpreadAttrSlot];
+    markElementTemplateHydrated();
+    const instance = new BackgroundElementTemplateInstance('view');
+    const handleTap = vi.fn();
+    instance.setAttribute('attributeSlots', [{ id: 'cta', bindtap: handleTap }]);
+    globalCommitContext.ops = [];
+
+    instance.emitCreate();
+
+    const eventValue = `${instance.instanceId}:0:bindtap`;
+    const preparedSpread = { id: 'cta', bindtap: eventValue };
+    expect(getEventHandlerForEventValue(eventValue)).toBe(handleTap);
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.createTemplate,
+      instance.instanceId,
+      'view',
+      null,
+      [preparedSpread],
+      [],
+    ]);
+  });
+
+  it('clears spread event handlers owned by an instance when it is torn down', () => {
+    __etAttrPlanMap.view = [0, adaptSpreadAttrSlot];
+    markElementTemplateHydrated();
+    const instance = new BackgroundElementTemplateInstance('view');
+    const handleTap = vi.fn();
+    instance.setAttribute('attributeSlots', [{ bindtap: handleTap }]);
+    const eventValue = `${instance.instanceId}:0:bindtap`;
+
+    instance.tearDown();
+
+    expect(getEventHandlerForEventValue(eventValue)).toBeUndefined();
+  });
+
+  it('clears spread event handlers when the background runtime is destroyed', () => {
+    __etAttrPlanMap.view = [0, adaptSpreadAttrSlot];
+    markElementTemplateHydrated();
+    const instance = new BackgroundElementTemplateInstance('view');
+    const handleTap = vi.fn();
+    instance.setAttribute('attributeSlots', [{ bindtap: handleTap }]);
+    const eventValue = `${instance.instanceId}:0:bindtap`;
 
     destroyElementTemplateBackgroundRuntime();
 

--- a/packages/react/runtime/__test__/element-template/runtime/prop-adapters/event.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/prop-adapters/event.test.ts
@@ -60,7 +60,7 @@ describe('ElementTemplate event bridge', () => {
     function onTap(data: unknown) {
       received.push(data);
     }
-    createEventInstance(-8, onTap);
+    createEventInstance(-8, [0, adaptEventAttrSlot], [onTap]);
 
     publishEvent('-8:0:', { type: 'tap', detail: { x: 1 } });
 
@@ -78,7 +78,7 @@ describe('ElementTemplate event bridge', () => {
     const alog = console.alog as unknown as { mock: { calls: unknown[][] }; mockClear(): void };
     alog.mockClear();
     const handler = vi.fn();
-    createEventInstance(-9, handler);
+    createEventInstance(-9, [0, adaptEventAttrSlot], [handler]);
 
     publishEvent('-9:0:', { type: 'tap' });
 

--- a/packages/react/runtime/__test__/element-template/runtime/prop-adapters/event.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/prop-adapters/event.test.ts
@@ -13,15 +13,20 @@ import {
 import {
   __etAttrPlanMap,
   adaptEventAttrSlot,
+  adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 
 describe('ElementTemplate event bridge', () => {
-  function createEventInstance(handleId: number, handler: () => void): BackgroundElementTemplateInstance {
-    __etAttrPlanMap.view = [0, adaptEventAttrSlot];
+  function createEventInstance(
+    handleId: number,
+    attrPlan: typeof __etAttrPlanMap[string],
+    rawSlots: unknown[],
+  ): BackgroundElementTemplateInstance {
+    __etAttrPlanMap.view = attrPlan;
     const instance = new BackgroundElementTemplateInstance('view');
     backgroundElementTemplateInstanceManager.updateId(instance.instanceId, handleId);
-    instance.setAttribute('attributeSlots', [handler]);
+    instance.setAttribute('attributeSlots', rawSlots);
     return instance;
   }
 
@@ -41,7 +46,7 @@ describe('ElementTemplate event bridge', () => {
   it('dispatches publishEvent to the current handler', () => {
     const handler = vi.fn();
     const eventData = { type: 'tap', detail: { x: 1 } };
-    createEventInstance(-1, handler);
+    createEventInstance(-1, [0, adaptEventAttrSlot], [handler]);
 
     publishEvent('-1:0:', eventData);
 
@@ -84,11 +89,37 @@ describe('ElementTemplate event bridge', () => {
   it('dispatches publicComponentEvent through the same handler lookup', () => {
     const handler = vi.fn();
     const eventData = { type: 'tap' };
-    createEventInstance(-2, handler);
+    createEventInstance(-2, [0, adaptEventAttrSlot], [handler]);
 
     publicComponentEvent('component-id', '-2:0:', eventData);
 
     expect(handler).toHaveBeenCalledWith(eventData);
+  });
+
+  it('dispatches spread event values through the same handler lookup', () => {
+    const handler = vi.fn();
+    const eventData = { type: 'tap', spread: true };
+    createEventInstance(-8, [0, adaptSpreadAttrSlot], [{ bindtap: handler }]);
+
+    publishEvent('-8:0:bindtap', eventData);
+
+    expect(handler).toHaveBeenCalledWith(eventData);
+  });
+
+  it('dispatches direct and spread event values from their owning raw slots', () => {
+    const directHandler = vi.fn();
+    const spreadHandler = vi.fn();
+    createEventInstance(
+      -9,
+      [0, adaptEventAttrSlot, 1, adaptSpreadAttrSlot],
+      [directHandler, { bindtap: spreadHandler }],
+    );
+
+    publishEvent('-9:0:', { type: 'tap', direct: true });
+    publishEvent('-9:1:bindtap', { type: 'tap', spread: true });
+
+    expect(directHandler).toHaveBeenCalledWith({ type: 'tap', direct: true });
+    expect(spreadHandler).toHaveBeenCalledWith({ type: 'tap', spread: true });
   });
 
   it('reports handler errors without throwing through native', () => {
@@ -97,9 +128,9 @@ describe('ElementTemplate event bridge', () => {
     const reportError = vi.fn();
     lynx.reportError = reportError;
     try {
-      createEventInstance(-3, () => {
+      createEventInstance(-3, [0, adaptEventAttrSlot], [() => {
         throw error;
-      });
+      }]);
 
       expect(() => publishEvent('-3:0:', { type: 'tap' })).not.toThrow();
       expect(reportError).toHaveBeenCalledWith(error);
@@ -116,11 +147,11 @@ describe('ElementTemplate event bridge', () => {
 
     resetEventStateForRuntime();
     publishEvent('-4:0:', queuedEvent);
-    createEventInstance(-4, queuedHandler);
+    createEventInstance(-4, [0, adaptEventAttrSlot], [queuedHandler]);
     flushPendingEvents();
 
     publishEvent('-5:0:', droppedEvent);
-    createEventInstance(-5, droppedHandler);
+    createEventInstance(-5, [0, adaptEventAttrSlot], [droppedHandler]);
 
     expect(queuedHandler).toHaveBeenCalledWith(queuedEvent);
     expect(droppedHandler).not.toHaveBeenCalled();
@@ -132,7 +163,7 @@ describe('ElementTemplate event bridge', () => {
     publishEvent('-6:0:', { type: 'tap' });
 
     destroyElementTemplateBackgroundRuntime();
-    createEventInstance(-6, handler);
+    createEventInstance(-6, [0, adaptEventAttrSlot], [handler]);
     flushPendingEvents();
 
     expect(handler).not.toHaveBeenCalled();
@@ -144,7 +175,7 @@ describe('ElementTemplate event bridge', () => {
     destroyElementTemplateBackgroundRuntime();
 
     publishEvent('-7:0:', { type: 'tap' });
-    createEventInstance(-7, handler);
+    createEventInstance(-7, [0, adaptEventAttrSlot], [handler]);
     flushPendingEvents();
 
     expect(handler).not.toHaveBeenCalled();

--- a/packages/react/runtime/__test__/element-template/runtime/prop-adapters/spread.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/prop-adapters/spread.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getEventValue } from '../../../../src/element-template/prop-adapters/event-value.js';
+import { prepareSpreadAttrSlot } from '../../../../src/element-template/prop-adapters/spread.js';
+
+describe('ElementTemplate spread prop adapter', () => {
+  it('normalizes host spread keys and emits ordinary event values', () => {
+    const handleTap = vi.fn();
+    const unsupportedWorkletEvent = vi.fn();
+    const unsupportedFunctionProp = vi.fn();
+    const ref = vi.fn();
+
+    const prepared = prepareSpreadAttrSlot(
+      -1,
+      0,
+      {
+        className: 'primary',
+        class: 'final',
+        id: 'cta',
+        name: 'submit',
+        __self: 'debug-self',
+        __source: { fileName: 'app.tsx' },
+        __spread: true,
+        ref,
+        bindtap: handleTap,
+        'main-thread:bindtap': unsupportedWorkletEvent,
+        onReady: unsupportedFunctionProp,
+      },
+    );
+
+    expect(prepared).toEqual({
+      class: 'final',
+      id: 'cta',
+      name: 'submit',
+      bindtap: getEventValue(-1, 0, 'bindtap'),
+    });
+  });
+
+  it('normalizes nullish spread class values to an empty class string', () => {
+    const prepared = prepareSpreadAttrSlot(-2, 0, { className: null });
+
+    expect(prepared).toEqual({ class: '' });
+  });
+
+  it('emits null for removed event props', () => {
+    const prepared = prepareSpreadAttrSlot(-3, 0, {
+      bindtap: null,
+      catchtap: undefined,
+      'capture-bindtap': false,
+    });
+
+    expect(prepared).toEqual({
+      bindtap: null,
+      catchtap: null,
+      'capture-bindtap': null,
+    });
+  });
+
+  it('returns null for removed spread values', () => {
+    expect(prepareSpreadAttrSlot(-4, 0, null)).toBeNull();
+    expect(prepareSpreadAttrSlot(-4, 0, false)).toBeNull();
+  });
+
+  it('ignores non-host spread props', () => {
+    const prepared = prepareSpreadAttrSlot(-5, 0, {
+      ref: vi.fn(),
+      'main-thread:ref': vi.fn(),
+      'main-thread:bindtap': vi.fn(),
+      'main-thread:gesture': {},
+      onReady: vi.fn(),
+      title: 'hello',
+    });
+
+    expect(prepared).toEqual({ title: 'hello' });
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
@@ -10,6 +10,7 @@ import { elementTemplateRegistry } from '../../../../src/element-template/runtim
 import {
   __etAttrPlanMap,
   adaptEventAttrSlot,
+  adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 import {
@@ -120,6 +121,38 @@ describe('renderOpcodesIntoElementTemplate', () => {
       '_et_event',
       null,
       [null, null, null, '-1:3:'],
+      null,
+      -1,
+    );
+    expect(addEvent).not.toHaveBeenCalled();
+  });
+
+  it('prepares spread event values before native create', () => {
+    const rootRef = { kind: 'root-ref' };
+    const handleTap = vi.fn();
+    createElementTemplate.mockReturnValue(rootRef);
+    __etAttrPlanMap._et_spread = [0, adaptSpreadAttrSlot];
+
+    renderOpcodesIntoElementTemplate([
+      __OpBegin,
+      { type: '_et_spread' },
+      __OpAttr,
+      'attributeSlots',
+      [{
+        id: 'cta',
+        className: 'primary',
+        __self: 'debug-self',
+        __source: { fileName: 'app.tsx' },
+        bindtap: handleTap,
+        catchtouchstart: false,
+      }],
+      __OpEnd,
+    ]);
+
+    expect(createElementTemplate).toHaveBeenCalledWith(
+      '_et_spread',
+      null,
+      [{ id: 'cta', class: 'primary', bindtap: '-1:0:bindtap', catchtouchstart: null }],
       null,
       -1,
     );

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.test.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { instantiateCompiledTemplate, setAttributeSlotOnTemplateInstance } from './templateTree.js';
+import type { CompiledTemplateNode } from './templateTree.js';
+
+describe('mock native template tree spread slots', () => {
+  it('expands spread slots in descriptor order', () => {
+    const template = {
+      kind: 'element',
+      type: 'view',
+      attributesArray: [
+        { kind: 'attribute', binding: 'static', key: 'id', value: 'static-id' },
+        { kind: 'spread', binding: 'slot', attrSlotIndex: 0 },
+        { kind: 'attribute', binding: 'slot', key: 'id', attrSlotIndex: 1 },
+      ],
+      children: [],
+    };
+
+    const root = instantiateCompiledTemplate(
+      template,
+      [{ id: 'spread-id', class: 'primary' }, 'slot-id'],
+      [],
+    );
+
+    expect(root.attributes).toEqual({
+      id: 'slot-id',
+      class: 'primary',
+    });
+  });
+
+  it('replaces the whole spread slot when setAttribute updates a template instance', () => {
+    const template = {
+      kind: 'element',
+      type: 'view',
+      attributesArray: [
+        { kind: 'spread', binding: 'slot', attrSlotIndex: 0 },
+      ],
+      children: [],
+    };
+    const initialSpread = { id: 'cta', class: 'primary' };
+    const root = instantiateCompiledTemplate(template, [initialSpread], []);
+    root.__compiledTemplate = template as CompiledTemplateNode['__compiledTemplate'];
+    root.__attributeSlots = [initialSpread];
+
+    setAttributeSlotOnTemplateInstance(root, 0, { id: 'cta-next' });
+
+    expect(root.__attributeSlots).toEqual([{ id: 'cta-next' }]);
+    expect(root.attributes).toEqual({ id: 'cta-next' });
+  });
+});

--- a/packages/react/runtime/src/element-template/internal.ts
+++ b/packages/react/runtime/src/element-template/internal.ts
@@ -54,4 +54,4 @@ export type { Options } from 'preact';
 // export { registerWorkletOnBackground } from '../worklet/hmr.js';
 // export { loadWorkletRuntime } from '@lynx-js/react/worklet-runtime/bindings';
 export { __etSlot } from './runtime/components/slot.js';
-export { __etAttrPlanMap, adaptEventAttrSlot } from './runtime/template/attr-slot-plan.js';
+export { __etAttrPlanMap, adaptEventAttrSlot, adaptSpreadAttrSlot } from './runtime/template/attr-slot-plan.js';

--- a/packages/react/runtime/src/element-template/prop-adapters/event-value.ts
+++ b/packages/react/runtime/src/element-template/prop-adapters/event-value.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export function getEventValue(
+  handleId: number,
+  attrSlotIndex: number,
+  eventKey = '',
+): string {
+  return `${handleId}:${attrSlotIndex}:${eventKey}`;
+}

--- a/packages/react/runtime/src/element-template/prop-adapters/spread.ts
+++ b/packages/react/runtime/src/element-template/prop-adapters/spread.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { getEventValue } from './event-value.js';
+import type { SerializableValue } from '../protocol/types.js';
+
+export interface SpreadAttrAdapterContext {
+  previousPreparedValue?: unknown;
+}
+
+const eventPropKeyRegExp = /^(?:global-bind|bind|catch|capture-bind|capture-catch)[A-Za-z]+$/;
+const namespacedEventKeyRegExp = /^[A-Za-z-]+:(?:global-bind|bind|catch|capture-bind|capture-catch)[A-Za-z]+$/;
+
+function isEventPropKey(key: string): boolean {
+  return eventPropKeyRegExp.test(key);
+}
+
+function isSpreadRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function prepareSpreadAttrSlot(
+  handleId: number,
+  attrSlotIndex: number,
+  value: unknown,
+  _context?: SpreadAttrAdapterContext,
+): SerializableValue | null {
+  if (value === false || !isSpreadRecord(value)) {
+    return null;
+  }
+
+  const prepared: Record<string, SerializableValue> = {};
+
+  for (const key in value) {
+    const spreadValue = value[key];
+    if (key === '__spread' || key === '__self' || key === '__source') {
+      continue;
+    }
+
+    if (key === 'class' || key === 'className') {
+      prepared['class'] = (spreadValue ?? '') as SerializableValue;
+      continue;
+    }
+
+    if (isEventPropKey(key)) {
+      prepared[key] = spreadValue === null || spreadValue === undefined || spreadValue === false
+        ? null
+        : getEventValue(handleId, attrSlotIndex, key);
+      continue;
+    }
+
+    if (
+      spreadValue === undefined
+      || key === 'ref'
+      || key.endsWith(':ref')
+      || key.endsWith(':gesture')
+      || namespacedEventKeyRegExp.test(key)
+      || typeof spreadValue === 'function'
+    ) {
+      continue;
+    }
+
+    prepared[key] = spreadValue as SerializableValue;
+  }
+
+  return prepared;
+}

--- a/packages/react/runtime/src/element-template/runtime/template/attr-slot-plan.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/attr-slot-plan.ts
@@ -2,12 +2,18 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { getEventValue } from '../../prop-adapters/event-value.js';
+import { prepareSpreadAttrSlot } from '../../prop-adapters/spread.js';
+import type { SpreadAttrAdapterContext } from '../../prop-adapters/spread.js';
 import type { SerializableValue } from '../../protocol/types.js';
+
+export interface EtAttrAdapterContext extends SpreadAttrAdapterContext {}
 
 export type EtAttrAdapter = (
   handleId: number,
   attrSlotIndex: number,
   value: unknown,
+  context?: EtAttrAdapterContext,
 ) => SerializableValue | null;
 
 export type EtAttrPlan = (number | EtAttrAdapter)[];
@@ -23,11 +29,21 @@ export function adaptEventAttrSlot(
   handleId: number,
   attrSlotIndex: number,
   value: unknown,
+  _context?: EtAttrAdapterContext,
 ): SerializableValue | null {
   if (value === null || value === undefined || value === false) {
     return null;
   }
-  return `${handleId}:${attrSlotIndex}:`;
+  return getEventValue(handleId, attrSlotIndex);
+}
+
+export function adaptSpreadAttrSlot(
+  handleId: number,
+  attrSlotIndex: number,
+  value: unknown,
+  context?: EtAttrAdapterContext,
+): SerializableValue | null {
+  return prepareSpreadAttrSlot(handleId, attrSlotIndex, value, context);
 }
 
 export function clearEtAttrPlanMap(): void {

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -297,14 +297,23 @@ where
       extractor.into_extracted_template_parts()
     };
 
-    let event_attr_plan_slots = dynamic_attrs
+    #[derive(Clone, Copy)]
+    enum AttrPlanAdapter {
+      Event,
+      Spread,
+    }
+
+    let attr_plan_slots = dynamic_attrs
       .iter()
       .filter_map(|dynamic_attr| match dynamic_attr {
         DynamicAttributePart::Attr {
           attr_name: AttrName::Event,
           slot_index,
           ..
-        } => Some(*slot_index),
+        } => Some((*slot_index, AttrPlanAdapter::Event)),
+        DynamicAttributePart::Spread { slot_index, .. } => {
+          Some((*slot_index, AttrPlanAdapter::Spread))
+        }
         _ => None,
       })
       .collect::<Vec<_>>();
@@ -332,20 +341,27 @@ where
         entry_template_uid: Expr = entry_template_uid.clone(),
     ));
     self.current_template_defs.push(entry_template_uid_def);
-    if !event_attr_plan_slots.is_empty() {
+    if !attr_plan_slots.is_empty() {
       let internal_runtime_id = self.internal_runtime_id.clone();
-      let mut attr_plan_elements = Vec::with_capacity(event_attr_plan_slots.len() * 2);
-      for slot_index in event_attr_plan_slots {
+      let mut attr_plan_elements = Vec::with_capacity(attr_plan_slots.len() * 2);
+      for (slot_index, adapter) in attr_plan_slots {
         attr_plan_elements.push(Some(ExprOrSpread {
           spread: None,
           expr: Box::new(i32_to_expr(&slot_index)),
         }));
-        attr_plan_elements.push(Some(ExprOrSpread {
-          spread: None,
-          expr: Box::new(quote!(
+        let adapter_expr = match adapter {
+          AttrPlanAdapter::Event => quote!(
             "$internal_runtime_id.adaptEventAttrSlot" as Expr,
             internal_runtime_id: Expr = internal_runtime_id.clone(),
-          )),
+          ),
+          AttrPlanAdapter::Spread => quote!(
+            "$internal_runtime_id.adaptSpreadAttrSlot" as Expr,
+            internal_runtime_id: Expr = internal_runtime_id.clone(),
+          ),
+        };
+        attr_plan_elements.push(Some(ExprOrSpread {
+          spread: None,
+          expr: Box::new(adapter_expr),
         }));
       }
 

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_spread_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_spread_attributes.snap
@@ -1,9 +1,10 @@
 ---
 source: packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
+assertion_line: 612
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\n<_et_da39a_test_1 attributeSlots={[\n    props\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\nReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1] = [\n    0,\n    ReactLynxInternal.adaptSpreadAttrSlot\n];\n<_et_da39a_test_1 attributeSlots={[\n    props\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_da39a_test_1",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_keep_code_and_template_attribute_slots_in_sync_for_spread.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_keep_code_and_template_attribute_slots_in_sync_for_spread.snap
@@ -1,9 +1,10 @@
 ---
 source: packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
+assertion_line: 612
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\nReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1] = [\n    2,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_da39a_test_1 attributeSlots={[\n    dynamicId,\n    props,\n    1,\n    viewRef\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_da39a_test_1 = \"_et_da39a_test_1\";\nReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1] = [\n    1,\n    ReactLynxInternal.adaptSpreadAttrSlot,\n    2,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_da39a_test_1 attributeSlots={[\n    dynamicId,\n    props,\n    1,\n    viewRef\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_da39a_test_1",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
@@ -183,7 +183,7 @@ fn should_emit_direct_event_attr_plan_for_lepus_target() {
 }
 
 #[test]
-fn should_not_emit_attr_plan_for_non_event_attrs() {
+fn should_emit_spread_attr_plan_without_ref_adapter() {
   let (code, _) = first_user_template_json_with_code(
     r#"
       <view id={dynamicId} ref={viewRef} {...props} />
@@ -193,10 +193,17 @@ fn should_not_emit_attr_plan_for_non_event_attrs() {
       ..element_template_config()
     },
   );
+  let code = without_whitespace(&code);
 
   assert!(
-    !code.contains("__etAttrPlanMap") && !code.contains("adaptEventAttrSlot"),
-    "only direct event slots should enter the Phase 2 attr plan, got: {code}"
+    code.contains(
+      "ReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1]=[2,ReactLynxInternal.adaptSpreadAttrSlot];"
+    ),
+    "spread slots should register the ET spread attr adapter, got: {code}"
+  );
+  assert!(
+    !code.contains("adaptEventAttrSlot"),
+    "ref and ordinary attrs must not enter the event adapter plan, got: {code}"
   );
 }
 
@@ -416,10 +423,18 @@ fn should_not_consume_hidden_et_slots_for_list_item_platform_attrs() {
 
 #[test]
 fn should_keep_slot_descriptor_order_for_dynamic_attr_spread_event_and_ref() {
-  let template = first_user_template_json(
+  let (code, template) = first_user_template_json_with_code(
     r#"
       <view id={dynamicId} {...props} bindtap={handleTap} ref={viewRef} />
     "#,
+    element_template_config(),
+  );
+  let code = without_whitespace(&code);
+  assert!(
+    code.contains(
+      "ReactLynxInternal.__etAttrPlanMap[_et_da39a_test_1]=[1,ReactLynxInternal.adaptSpreadAttrSlot,2,ReactLynxInternal.adaptEventAttrSlot];"
+    ),
+    "spread and direct event adapters should keep their descriptor slot order, got: {code}"
   );
 
   let attrs = template["attributesArray"]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for spreading props (including event handlers) onto elements with correct mapping and consistent behavior across main/background runtimes and hydration.

* **Bug Fixes**
  * More reliable hydration and update semantics for spread-derived attributes and event handlers, including correct handler registration, teardown, and slot patching on insert/update.

* **Tests**
  * Expanded unit and end-to-end tests covering spread props, event dispatch/routing, background rendering, and compiled fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2630)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds Element Template support for spread attributes in the experimental ET transform/runtime path. Spread attrs now reserve a dedicated attribute slot with a spread adapter, so the main-thread template create path, serialized hydration payload, and background update path can all preserve the same slot ordering while expanding ordinary attrs and event values through the adapter boundary.

## Key Points

- The transform emits spread attr adapter metadata as part of the ET attr plan instead of lowering spread values into ad hoc static attrs.
- The runtime prepares spread slots through `prop-adapters/spread`, keeping event preparation on the existing event adapter path and preserving static/dynamic attr slot ordering.
- Background hydrate/update and native template-tree mocks now cover spread attrs, nullish spread behavior, and spread-provided event handlers, including inserted subtree updates.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
