### PR TITLE
fix: web-core touch event cloning

### DIFF
--- a/.changeset/clone-touch-events.md
+++ b/.changeset/clone-touch-events.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Always clone touch event lists when creating cross-thread events so synthetic touch events only carry structured-clone-safe primitive fields.

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -135,6 +135,25 @@ describe('Element APIs', () => {
     expect(lynxEvent.detail).toEqual({ x: 100, y: 200 });
   });
 
+  test('createCrossThreadEvent clone touches for untrusted events', async () => {
+    const { createCrossThreadEvent } = await import(
+      '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'
+    );
+    const touchEvent = new Event('touchstart') as any;
+    touchEvent.touches = [{
+      clientX: 100,
+      clientY: 200,
+      nested: { ignored: true },
+    }];
+    touchEvent.targetTouches = [{ identifier: 1, target: {} }];
+    touchEvent.changedTouches = [{ pageX: 10, preventDefault: () => {} }];
+
+    const lynxEvent = createCrossThreadEvent(touchEvent);
+    expect(lynxEvent.touches).toEqual([{ clientX: 100, clientY: 200 }]);
+    expect(lynxEvent.targetTouches).toEqual([{ identifier: 1 }]);
+    expect(lynxEvent.changedTouches).toEqual([{ pageX: 10 }]);
+  });
+
   test('createCrossThreadEvent sets empty detail if no touches', async () => {
     const { createCrossThreadEvent } = await import(
       '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts
@@ -28,7 +28,6 @@ export function createCrossThreadEvent(
 ): LynxCrossThreadEvent {
   const type = domEvent.type;
   const params: Cloneable = {};
-  const isTrusted = domEvent.isTrusted;
   const otherProperties: CloneableObject = {};
   let detail = domEvent.detail ?? {};
   if (type.match(/^transition/)) {
@@ -49,17 +48,9 @@ export function createCrossThreadEvent(
     const targetTouches = [...touchEvent.targetTouches as unknown as Touch[]];
     const changedTouches = [...touchEvent.changedTouches as unknown as Touch[]];
     Object.assign(otherProperties, {
-      touches: isTrusted ? touch.map(toCloneableObject) : touch,
-      targetTouches: isTrusted
-        ? targetTouches.map(
-          toCloneableObject,
-        )
-        : targetTouches,
-      changedTouches: isTrusted
-        ? changedTouches.map(
-          toCloneableObject,
-        )
-        : changedTouches,
+      touches: touch.map(toCloneableObject),
+      targetTouches: targetTouches.map(toCloneableObject),
+      changedTouches: changedTouches.map(toCloneableObject),
     });
     if (touch[0]) {
       detail = {


### PR DESCRIPTION
Summary:

- Always run `touches`, `targetTouches`, and `changedTouches` through `toCloneableObject` in `createCrossThreadEvent`.
- Add regression coverage for synthetic/untrusted touch events so non-cloneable fields are filtered consistently.
- Add a patch changeset for `@lynx-js/web-core`.

Validation:

- `pnpm dprint check .changeset/clone-touch-events.md packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createCrossThreadEvent.ts packages/web-platform/web-core/tests/element-apis.spec.ts`
- `pnpm build:wasm`
- `pnpm exec tsc --build packages/tools/css-serializer/tsconfig.json packages/web-platform/web-worker-rpc/tsconfig.json packages/web-platform/web-elements/tsconfig.json`
- `pnpm test tests/element-apis.spec.ts` (74 tests)
- `pnpm changeset status --since=upstream/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Touch event lists are now consistently cloned when creating cross-thread events, ensuring only structured-clone-safe primitive fields are included in synthetic touch events.

* **Tests**
  * Added test coverage verifying proper cloning of touch event data during cross-thread event creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2636)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->