### PR TITLE
chore: Stabilize playwright flaky assertions

### DIFF
--- a/.github/playwright-flaky.instructions.md
+++ b/.github/playwright-flaky.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/**/tests/**/*.{ts,tsx}"
+---
+
+For Playwright tests that assert async browser behavior, prefer locator assertions, `expect.poll`, or `page.waitForFunction` that waits for the exact rendered/event state under test instead of fixed `wait(ms)` followed by a one-shot `innerText`, `count`, or array assertion. Keep the original behavior assertion intact: wait for the same text, CSS value, event count, worker count, or parsed event payload that the test is meant to prove.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -34,13 +34,11 @@ const diffScreenShot = async (
 };
 
 const expectHasText = async (page: Page, text: string) => {
-  const hasText = (await page.getByText(text).count()) === 1;
-  await expect(hasText).toBe(true);
+  await expect(page.getByText(text)).toHaveCount(1);
 };
 
 const expectNoText = async (page: Page, text: string) => {
-  const hasText = (await page.getByText(text).count()) === 1;
-  await expect(hasText).toBe(false);
+  await expect(page.getByText(text)).toHaveCount(0);
 };
 
 const goto = async (
@@ -3191,9 +3189,9 @@ test.describe('reactlynx3 tests', () => {
           await goto(page, title);
           await wait(100);
           await page.locator('.focus').click({ force: true });
-          await wait(100);
-          const result = await page.locator('.result').first().innerText();
-          expect(result).toBe('bindfocus');
+          await expect(page.locator('.result').first()).toHaveText(
+            'bindfocus',
+          );
         },
       );
       // input/focus test-case end

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -856,7 +856,11 @@ test.describe('web-elements test suite', () => {
     }, { title }) => {
       await gotoWebComponentPage(page, title);
       await wait(500);
-      expect(page.locator('x-foldview-slot-ng')).toHaveCSS('top', '200px');
+      await expect.poll(() =>
+        page.locator('x-foldview-slot-ng').evaluate((slot) =>
+          (slot as HTMLElement).style.top
+        )
+      ).toBe('200px');
     });
     test('x-foldview-ng/size-parent-grow-children-specific', async ({
       page,

--- a/packages/web-platform/web-elements/tests/x-markdown.spec.ts
+++ b/packages/web-platform/web-elements/tests/x-markdown.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@lynx-js/playwright-fixtures';
 import type { Page } from '@playwright/test';
 
+const markdownInitialRenderTimeout = 5_000;
+const markdownRenderTimeout = 15_000;
+
 const goto = async (page: Page, fixtureName: string) => {
   await page.goto(`tests/fixtures/${fixtureName}.html`, { waitUntil: 'load' });
   await page.evaluate(() => document.fonts.ready);
@@ -17,6 +20,64 @@ const getShadowCount = async (page: Page, selector: string) =>
     const element = document.querySelector('x-markdown');
     return element?.shadowRoot?.querySelectorAll(value).length ?? 0;
   }, selector);
+
+const hasEmptyMarkdownRoot = async (page: Page) =>
+  page.locator('x-markdown').evaluate((element) => {
+    const root = element.shadowRoot?.querySelector('#markdown-root');
+    return Boolean(
+      element.getAttribute('content') && root
+        && root.childElementCount === 0
+        && root.textContent === '',
+    );
+  }).catch(() => false);
+
+const reloadWhenMarkdownRootIsEmpty = async (
+  page: Page,
+  error: unknown,
+) => {
+  // The dev server can serve xmarkdown-deps while lazy compilation is still
+  // warming; reload once only when the markdown root never rendered content.
+  if (!(await hasEmptyMarkdownRoot(page))) {
+    throw error;
+  }
+  await page.reload({ waitUntil: 'load' });
+  await page.evaluate(() => document.fonts.ready);
+};
+
+const expectMarkdownText = async (
+  page: Page,
+  selector: string,
+  text: string,
+) => {
+  const locator = page.locator('x-markdown').locator(selector);
+  try {
+    await expect(locator).toHaveText(text, {
+      timeout: markdownInitialRenderTimeout,
+    });
+  } catch (error) {
+    await reloadWhenMarkdownRootIsEmpty(page, error);
+    await expect(locator).toHaveText(text, { timeout: markdownRenderTimeout });
+  }
+};
+
+const expectMarkdownAttribute = async (
+  page: Page,
+  selector: string,
+  name: string,
+  value: string,
+) => {
+  const locator = page.locator('x-markdown').locator(selector);
+  try {
+    await expect(locator).toHaveAttribute(name, value, {
+      timeout: markdownInitialRenderTimeout,
+    });
+  } catch (error) {
+    await reloadWhenMarkdownRootIsEmpty(page, error);
+    await expect(locator).toHaveAttribute(name, value, {
+      timeout: markdownRenderTimeout,
+    });
+  }
+};
 
 const appendContent = async (page: Page, suffix: string) => {
   await page.evaluate((value) => {
@@ -94,7 +155,7 @@ test.describe('x-markdown', () => {
     await goto(page, 'x-markdown/basic');
     const markdown = page.locator('x-markdown');
 
-    await expect(markdown.locator('h1')).toHaveText('Title');
+    await expectMarkdownText(page, 'h1', 'Title');
     await expect(markdown.locator('strong')).toHaveText('bold');
     await expect(markdown.locator('em')).toHaveText('italic');
     await expect(markdown.locator('li')).toHaveCount(2);
@@ -104,12 +165,9 @@ test.describe('x-markdown', () => {
   test('should apply markdown-style updates', async ({ page }) => {
     await goto(page, 'x-markdown/style');
     const markdown = page.locator('x-markdown');
-    await page.waitForFunction(() => {
-      const element = document.querySelector('x-markdown');
-      return element?.shadowRoot?.querySelector('a')?.textContent === 'link';
-    });
 
     const link = markdown.locator('a');
+    await expectMarkdownText(page, 'a', 'link');
     await expect(link).toHaveCSS('color', 'rgb(255, 0, 0)');
     await expect(link).toHaveCSS('line-height', '24px');
 
@@ -134,6 +192,7 @@ test.describe('x-markdown', () => {
     const markdown = page.locator('x-markdown');
 
     const link = markdown.locator('a');
+    await expectMarkdownText(page, 'a', 'link');
     const propertyValue = await markdown.evaluate((el: any) => {
       el['markdown-style'] = { link: { color: '00ff00' } };
       return el.markdownStyle;
@@ -149,10 +208,9 @@ test.describe('x-markdown', () => {
 
   test('should render image', async ({ page }) => {
     await goto(page, 'x-markdown/image');
-    const markdown = page.locator('x-markdown');
-
-    const image = markdown.locator('img');
-    await expect(image).toHaveAttribute(
+    await expectMarkdownAttribute(
+      page,
+      'img',
       'src',
       '/tests/fixtures/resources/firefox-logo.png',
     );
@@ -608,6 +666,12 @@ test.describe('x-markdown', () => {
 
   test('should getImages return image sources', async ({ page }) => {
     await goto(page, 'x-markdown/image');
+    await expectMarkdownAttribute(
+      page,
+      'img',
+      'src',
+      '/tests/fixtures/resources/firefox-logo.png',
+    );
     const images = await page.evaluate(() => {
       const el = document.querySelector('x-markdown') as any;
       return el.getImages();

--- a/packages/web-platform/web-tests/tests/react.spec.ts
+++ b/packages/web-platform/web-tests/tests/react.spec.ts
@@ -34,13 +34,11 @@ const diffScreenShot = async (
 };
 
 const expectHasText = async (page: Page, text: string) => {
-  const hasText = (await page.getByText(text).count()) === 1;
-  await expect(hasText).toBe(true);
+  await expect(page.getByText(text)).toHaveCount(1);
 };
 
 const expectNoText = async (page: Page, text: string) => {
-  const hasText = (await page.getByText(text).count()) === 1;
-  await expect(hasText).toBe(false);
+  await expect(page.getByText(text)).toHaveCount(0);
 };
 
 const goto = async (


### PR DESCRIPTION
## Summary

- Stabilize Playwright assertions that were racing async rendering/event updates by using locator auto-waiting and `expect.poll`.
- Add x-markdown render helpers that retry once only when the markdown shadow root stays empty during lazy `xmarkdown-deps` warmup, while preserving the original text/style/image/API assertions.
- Add a small `.github` instruction for future Playwright flaky fixes to keep behavior assertions intact.

## Root Cause

Some Playwright tests used one-shot `count()`/`innerText()` checks or an un-awaited assertion, so they could observe the page before async browser work completed. The x-markdown tests also saw transient empty shadow roots when the lazy markdown dependency bundle was still warming under parallel Playwright workers.

## Validation

- `pnpm turbo build`
- `pnpm dprint fmt packages/web-platform/web-elements/tests/web-elements.spec.ts packages/web-platform/web-elements/tests/x-markdown.spec.ts packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts packages/web-platform/web-tests/tests/react.spec.ts .github/playwright-flaky.instructions.md`
- `pnpm --dir packages/web-platform/web-elements exec playwright test tests/web-elements.spec.ts:853 tests/x-markdown.spec.ts:128 tests/x-markdown.spec.ts:139 tests/x-markdown.spec.ts:164 --reporter=line --retries=0 --repeat-each=3` (36/36 passed)
- `pnpm --dir packages/web-platform/web-elements exec playwright test tests/x-markdown.spec.ts:209 tests/x-markdown.spec.ts:667 --reporter=line --retries=0 --repeat-each=5` (30/30 passed)
- `pnpm --dir packages/web-platform/web-core-e2e exec playwright test tests/reactlynx.spec.ts --grep "basic-setsate-with-cb|basic-element-x-input-focus" --reporter=line --retries=0 --repeat-each=3` (15 passed, 3 skipped)
- `pnpm --dir packages/web-platform/web-tests exec playwright test tests/react.spec.ts --grep "basic-setsate-with-cb" --reporter=line --retries=0 --repeat-each=3` (9/9 passed)
- `pnpm --dir packages/web-platform/web-elements exec playwright test --reporter=line --retries=0 --max-failures=20` (1 failed: existing `x-refresh-view/pull` screenshot color-state mismatch, 139 skipped, 886 passed)

I left `x-refresh-view/pull` unchanged because the fixture intentionally changes the content background from pink to chartreuse when the footer intersects the refresh root; clipping or relaxing the snapshot would remove that behavior signal instead of making the test more reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to improve reliability by replacing fixed timing waits with proper asynchronous assertions
  * Updated test helpers to use Playwright's robust matching methods
  * Improved handling of dynamic async behaviors and lazy-loaded components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2637)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->