### PR TITLE
chore: Adjust Playwright CI retries

### DIFF
--- a/packages/web-platform/playwright-fixtures/src/playwright.common.ts
+++ b/packages/web-platform/playwright-fixtures/src/playwright.common.ts
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 import { type defineConfig, devices } from '@playwright/test';
-import os from 'node:os';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,20 +14,6 @@ process.env['LIBGL_ALWAYS_SOFTWARE'] = 'true'; // https://github.com/microsoft/p
 process.env['GALLIUM_HUD_SCALE'] = '1';
 const isCI = !!process.env['CI'];
 const port = process.env['PORT'] ?? 3080;
-const workerLimit = Math.floor(((cpuCount, envCPULimit) => {
-  if (isCI) {
-    if (envCPULimit) {
-      return envCPULimit / 2;
-    } else {
-      if (cpuCount <= 32) {
-        return 8;
-      } else {
-        return 8 + (cpuCount - 32) / 6;
-      }
-    }
-  }
-  return cpuCount / 2;
-})(os.cpus().length, parseFloat(process.env['cpu_limit'] ?? '0')));
 
 /**
  * Read environment variables from file.
@@ -45,11 +30,11 @@ export const playwrightConfigCommon: Parameters<typeof defineConfig>[0] = {
   testMatch: '**/tests/*',
   /* Run tests in files in parallel */
   fullyParallel: true,
-  workers: isCI ? workerLimit : undefined,
+  workers: undefined,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!isCI,
   /* Retry on CI only */
-  retries: isCI ? 4 : 0,
+  retries: isCI ? 20 : 0,
   // maxFailures: 16,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',


### PR DESCRIPTION
## Summary

- Remove the custom Playwright worker limit calculation so Playwright can choose the worker count itself.
- Increase CI retries from 4 to 20.

## Validation

- Not run per request to submit the PR directly. Earlier formatting/check commands could not complete because the sandbox could not resolve npm registry packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Playwright test worker configuration to use default settings across all environments instead of dynamic allocation.
  * Increased CI test retry attempts from 4 to 20 to improve overall test reliability and reduce flaky test failures in continuous integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2639)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->