### PR TITLE
fix(plugin-react): disable css minify when scope removal is off

### DIFF
--- a/.changeset/quiet-bugs-roll.md
+++ b/.changeset/quiet-bugs-roll.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Force CSS minification off when `enableRemoveCSSScope` is set to `false`, overriding the default CSS minify configuration in ReactLynx builds.

--- a/.github/plugin-react-css-minify.instructions.md
+++ b/.github/plugin-react-css-minify.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "packages/rspeedy/plugin-react/**"
+---
+
+When `enableRemoveCSSScope` is explicitly set to `false`, force CSS minification off by overriding `output.minify.css` to `false` after the default Rspeedy minify config has been applied. Do not rely on the core default CSS minify behavior here, because `pluginMinify` still enables CSS minification by default for the general case.
+
+Keep the behavior scoped to ReactLynx/plugin-react integration. If you change the CSS minify flow, add or update regression tests in `packages/rspeedy/plugin-react/test/css.test.ts` for both `enableRemoveCSSScope: false` and `enableRemoveCSSScope: true` so the override only applies to the false case.

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -499,5 +499,24 @@ export function pluginReactLynx(
         )
       },
     },
+    {
+      name: 'lynx:react:css-minify-guard',
+      enforce: 'post',
+      setup(api) {
+        if (resolvedOptions.enableRemoveCSSScope !== false) {
+          return
+        }
+
+        api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+          return mergeRsbuildConfig(config, {
+            output: {
+              minify: {
+                css: false,
+              },
+            },
+          })
+        })
+      },
+    },
   ]
 }

--- a/packages/rspeedy/plugin-react/test/css.test.ts
+++ b/packages/rspeedy/plugin-react/test/css.test.ts
@@ -623,6 +623,29 @@ describe('Plugins - CSS', () => {
           minimizer && minimizer !== '...'
           && minimizer.constructor.name === 'CssMinimizerPlugin'
         ),
+      ).toBeUndefined()
+    })
+
+    test('with enableRemoveCSSScope: true', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      const rspeedy = await createRspeedy({
+        rspeedyConfig: {
+          plugins: [
+            pluginReactLynx({
+              enableRemoveCSSScope: true,
+            }),
+            pluginStubRspeedyAPI(),
+          ],
+        },
+      })
+
+      const [config] = await rspeedy.initConfigs()
+
+      expect(
+        config?.optimization?.minimizer?.find(minimizer =>
+          minimizer && minimizer !== '...'
+          && minimizer.constructor.name === 'CssMinimizerPlugin'
+        ),
       ).toBeDefined()
     })
   })

--- a/packages/web-platform/web-core-e2e/server-tests/__snapshots__/server-e2e.test.ts.snap
+++ b/packages/web-platform/web-core-e2e/server-tests/__snapshots__/server-e2e.test.ts.snap
@@ -1483,15 +1483,15 @@ exports[`executeTemplate should run lepusCode.root from config-css-remove-scope-
       }
       .basic:where([l-css-id="1865610"]):not([l-e-name]),
       .basic:where([l-css-id="3"]):not([l-e-name]) {
-        background-color: green;
         height: 100px;
         width: 100px;
+        background-color: green;
       }
       .basic:where([l-css-id="2"]):not([l-e-name]),
       .basic:where([l-css-id="1853379"]):not([l-e-name]) {
-        background-color: red;
         height: 100px;
         width: 100px;
+        background-color: red;
       }
     </style>
     <div part="page" lynx-default-overflow-visible="true">


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures CSS minification is disabled in ReactLynx builds when the corresponding option is explicitly set to false.

* **Documentation**
  * Clarified integration guidance for configuring CSS minification in ReactLynx builds.

* **Tests**
  * Added regression tests verifying CSS minification behavior for both enabled and disabled configuration states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2641)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
