### PR TITLE
refactor(react): simplify template attribute descriptors

### DIFF
--- a/.changeset/upgrade-tasm-039.md
+++ b/.changeset/upgrade-tasm-039.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react": patch
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Update the @lynx-js/tasm dependency to 0.0.39 and align React template attribute descriptors with it.

--- a/packages/react/runtime/__test__/element-template/fixtures/patch/props-update/case.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/patch/props-update/case.tsx
@@ -11,7 +11,7 @@ export function run() {
         kind: 'element',
         type: 'view',
         attributesArray: [
-          { kind: 'attribute', binding: 'slot', key: 'id', attrSlotIndex: 0 },
+          { kind: 'slot', key: 'id', attrSlotIndex: 0 },
         ],
         children: [],
       },

--- a/packages/react/runtime/__test__/element-template/fixtures/patch/state-update/case.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/patch/state-update/case.tsx
@@ -23,7 +23,7 @@ export async function run() {
           kind: 'element',
           type: 'view',
           attributesArray: [
-            { kind: 'attribute', binding: 'slot', key: 'id', attrSlotIndex: 0 },
+            { kind: 'slot', key: 'id', attrSlotIndex: 0 },
           ],
           children: [],
         },

--- a/packages/react/runtime/__test__/element-template/fixtures/render/child-siblings/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/child-siblings/templates.json.txt
@@ -6,9 +6,8 @@
       "type": "text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "static",
           "key": "text",
-          "binding": "static",
           "value": "Slot Content 1"
         }
       ],
@@ -23,9 +22,8 @@
       "type": "text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "static",
           "key": "text",
-          "binding": "static",
           "value": "Slot Content 2"
         }
       ],
@@ -72,9 +70,8 @@
       "type": "raw-text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "text",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],

--- a/packages/react/runtime/__test__/element-template/fixtures/render/component-slot-content/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/component-slot-content/templates.json.txt
@@ -11,9 +11,8 @@
           "type": "text",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "text",
-              "binding": "static",
               "value": "custom"
             }
           ],
@@ -35,9 +34,8 @@
       "type": "text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "static",
           "key": "text",
-          "binding": "static",
           "value": "child"
         }
       ],
@@ -68,9 +66,8 @@
       "type": "raw-text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "text",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],

--- a/packages/react/runtime/__test__/element-template/fixtures/render/component/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/component/templates.json.txt
@@ -16,9 +16,8 @@
           "type": "text",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "text",
-              "binding": "static",
               "value": "Hello"
             }
           ],
@@ -34,9 +33,8 @@
           "type": "text",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "text",
-              "binding": "static",
               "value": "World"
             }
           ],
@@ -58,9 +56,8 @@
       "type": "raw-text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "text",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],

--- a/packages/react/runtime/__test__/element-template/fixtures/render/mapped-view-children/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/mapped-view-children/templates.json.txt
@@ -6,9 +6,8 @@
       "type": "view",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "id",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],
@@ -52,9 +51,8 @@
       "type": "raw-text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "text",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],

--- a/packages/react/runtime/__test__/element-template/fixtures/render/mixed-children/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/mixed-children/templates.json.txt
@@ -39,9 +39,8 @@
       "type": "raw-text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "text",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],

--- a/packages/react/runtime/__test__/element-template/fixtures/render/multiple-text/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/multiple-text/templates.json.txt
@@ -43,9 +43,8 @@
           "type": "view",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "id",
-              "binding": "static",
               "value": "1"
             }
           ],
@@ -62,9 +61,8 @@
           "type": "view",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "id",
-              "binding": "static",
               "value": "2"
             }
           ],
@@ -81,9 +79,8 @@
           "type": "view",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "id",
-              "binding": "static",
               "value": "3"
             }
           ],
@@ -107,9 +104,8 @@
           "type": "view",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "id",
-              "binding": "static",
               "value": "4"
             }
           ],
@@ -139,9 +135,8 @@
       "type": "raw-text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "text",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],

--- a/packages/react/runtime/__test__/element-template/fixtures/render/nested-templates/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/nested-templates/templates.json.txt
@@ -38,9 +38,8 @@
       "type": "raw-text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "text",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],

--- a/packages/react/runtime/__test__/element-template/fixtures/render/opcodes-into-element-template/_shared.ts
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/opcodes-into-element-template/_shared.ts
@@ -31,9 +31,8 @@ const templates = [
       type: 'raw-text',
       attributesArray: [
         {
-          kind: 'attribute',
+          kind: 'slot',
           key: 'text',
-          binding: 'slot',
           attrSlotIndex: 0,
         },
       ],
@@ -47,9 +46,8 @@ const templates = [
       type: 'view',
       attributesArray: [
         {
-          kind: 'attribute',
+          kind: 'slot',
           key: 'id',
-          binding: 'slot',
           attrSlotIndex: 0,
         },
       ],
@@ -88,9 +86,8 @@ const templates = [
       type: 'view',
       attributesArray: [
         {
-          kind: 'attribute',
+          kind: 'slot',
           key: 'title',
-          binding: 'slot',
           attrSlotIndex: 0,
         },
       ],

--- a/packages/react/runtime/__test__/element-template/fixtures/render/react-example/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/react-example/templates.json.txt
@@ -6,15 +6,13 @@
       "type": "image",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "src",
-          "binding": "slot",
           "attrSlotIndex": 0
         },
         {
-          "kind": "attribute",
+          "kind": "static",
           "key": "class",
-          "binding": "static",
           "value": "Logo--react"
         }
       ],
@@ -29,15 +27,13 @@
       "type": "image",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "src",
-          "binding": "slot",
           "attrSlotIndex": 0
         },
         {
-          "kind": "attribute",
+          "kind": "static",
           "key": "class",
-          "binding": "static",
           "value": "Logo--lynx"
         }
       ],
@@ -57,9 +53,8 @@
           "type": "view",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "class",
-              "binding": "static",
               "value": "Background"
             }
           ],
@@ -70,9 +65,8 @@
           "type": "view",
           "attributesArray": [
             {
-              "kind": "attribute",
+              "kind": "static",
               "key": "class",
-              "binding": "static",
               "value": "App"
             }
           ],
@@ -82,9 +76,8 @@
               "type": "view",
               "attributesArray": [
                 {
-                  "kind": "attribute",
+                  "kind": "static",
                   "key": "class",
-                  "binding": "static",
                   "value": "Banner"
                 }
               ],
@@ -94,15 +87,13 @@
                   "type": "view",
                   "attributesArray": [
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "class",
-                      "binding": "static",
                       "value": "Logo"
                     },
                     {
-                      "kind": "attribute",
+                      "kind": "slot",
                       "key": "bindtap",
-                      "binding": "slot",
                       "attrSlotIndex": 0
                     }
                   ],
@@ -119,15 +110,13 @@
                   "type": "text",
                   "attributesArray": [
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "class",
-                      "binding": "static",
                       "value": "Title"
                     },
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "text",
-                      "binding": "static",
                       "value": "React"
                     }
                   ],
@@ -138,15 +127,13 @@
                   "type": "text",
                   "attributesArray": [
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "class",
-                      "binding": "static",
                       "value": "Subtitle"
                     },
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "text",
-                      "binding": "static",
                       "value": "on Lynx"
                     }
                   ],
@@ -159,9 +146,8 @@
               "type": "view",
               "attributesArray": [
                 {
-                  "kind": "attribute",
+                  "kind": "static",
                   "key": "class",
-                  "binding": "static",
                   "value": "Content"
                 }
               ],
@@ -171,15 +157,13 @@
                   "type": "image",
                   "attributesArray": [
                     {
-                      "kind": "attribute",
+                      "kind": "slot",
                       "key": "src",
-                      "binding": "slot",
                       "attrSlotIndex": 1
                     },
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "class",
-                      "binding": "static",
                       "value": "Arrow"
                     }
                   ],
@@ -190,15 +174,13 @@
                   "type": "text",
                   "attributesArray": [
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "class",
-                      "binding": "static",
                       "value": "Description"
                     },
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "text",
-                      "binding": "static",
                       "value": "Tap the logo and have fun!"
                     }
                   ],
@@ -209,9 +191,8 @@
                   "type": "text",
                   "attributesArray": [
                     {
-                      "kind": "attribute",
+                      "kind": "static",
                       "key": "class",
-                      "binding": "static",
                       "value": "Hint"
                     }
                   ],
@@ -221,9 +202,8 @@
                       "type": "raw-text",
                       "attributesArray": [
                         {
-                          "kind": "attribute",
+                          "kind": "static",
                           "key": "text",
-                          "binding": "static",
                           "value": "Edit"
                         }
                       ],
@@ -234,9 +214,8 @@
                       "type": "text",
                       "attributesArray": [
                         {
-                          "kind": "attribute",
+                          "kind": "static",
                           "key": "style",
-                          "binding": "static",
                           "value": "font-style:italic;color:rgba(255, 255, 255, 0.85)"
                         }
                       ],
@@ -253,9 +232,8 @@
                       "type": "raw-text",
                       "attributesArray": [
                         {
-                          "kind": "attribute",
+                          "kind": "static",
                           "key": "text",
-                          "binding": "static",
                           "value": "to see updates!"
                         }
                       ],
@@ -270,9 +248,8 @@
               "type": "view",
               "attributesArray": [
                 {
-                  "kind": "attribute",
+                  "kind": "static",
                   "key": "style",
-                  "binding": "static",
                   "value": "flex:1"
                 }
               ],
@@ -291,9 +268,8 @@
       "type": "raw-text",
       "attributesArray": [
         {
-          "kind": "attribute",
+          "kind": "slot",
           "key": "text",
-          "binding": "slot",
           "attrSlotIndex": 0
         }
       ],

--- a/packages/react/runtime/__test__/element-template/runtime/patch/update-fixture-helper.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/update-fixture-helper.test.tsx
@@ -14,7 +14,7 @@ describe('patch update fixture helper', () => {
           kind: 'element',
           type: 'view',
           attributesArray: [
-            { kind: 'attribute', binding: 'slot', key: 'id', attrSlotIndex: 0 },
+            { kind: 'slot', key: 'id', attrSlotIndex: 0 },
           ],
           children: [],
         },

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-main-thread.contract.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-main-thread.contract.test.ts
@@ -41,7 +41,7 @@ describe('renderMainThread contract', () => {
           kind: 'element',
           type: 'view',
           attributesArray: [
-            { kind: 'attribute', key: 'id', binding: 'slot', attrSlotIndex: 0 },
+            { kind: 'slot', key: 'id', attrSlotIndex: 0 },
           ],
           children: [
             { kind: 'elementSlot', type: 'slot', elementSlotIndex: 0 },

--- a/packages/react/runtime/__test__/element-template/test-utils/debug/registry.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/debug/registry.ts
@@ -13,9 +13,8 @@ const builtinRawTextTemplate = {
     type: 'raw-text',
     attributesArray: [
       {
-        kind: 'attribute',
+        kind: 'slot',
         key: 'text',
-        binding: 'slot',
         attrSlotIndex: 0,
       },
     ],

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.ts
@@ -20,13 +20,10 @@ export interface CompiledTemplateNode {
   __options?: Record<string, unknown>;
 }
 
-interface CompiledAttributeDescriptor {
-  kind: 'attribute' | 'spread';
-  binding: 'static' | 'slot';
-  key?: string;
-  value?: unknown;
-  attrSlotIndex?: number;
-}
+type CompiledAttributeDescriptor =
+  | { kind: 'static'; key: string; value: unknown }
+  | { kind: 'slot'; key: string; attrSlotIndex: number }
+  | { kind: 'spread'; attrSlotIndex: number };
 
 interface CompiledElementNode {
   kind: 'element';
@@ -62,24 +59,20 @@ function applyCompiledAttributes(
   const attributes: Record<string, unknown> = {};
 
   for (const descriptor of node.attributesArray ?? []) {
-    if (descriptor.kind === 'attribute') {
-      if (descriptor.binding === 'static') {
-        if (descriptor.key) {
-          attributes[descriptor.key] = descriptor.value;
-        }
-        continue;
-      }
+    if (descriptor.kind === 'static') {
+      attributes[descriptor.key] = descriptor.value;
+      continue;
+    }
 
-      if (descriptor.key) {
-        const slotValue = attributeSlots?.[descriptor.attrSlotIndex ?? -1];
-        if (slotValue !== null && slotValue !== undefined) {
-          attributes[descriptor.key] = slotValue;
-        }
+    if (descriptor.kind === 'slot') {
+      const slotValue = attributeSlots?.[descriptor.attrSlotIndex];
+      if (slotValue !== null && slotValue !== undefined) {
+        attributes[descriptor.key] = slotValue;
       }
       continue;
     }
 
-    const spreadValue = attributeSlots?.[descriptor.attrSlotIndex ?? -1];
+    const spreadValue = attributeSlots?.[descriptor.attrSlotIndex];
     if (isRecord(spreadValue)) {
       Object.assign(attributes, spreadValue);
     }
@@ -296,18 +289,19 @@ function decodeDynamicAttrsForNode(
   const attrs: Record<string, unknown> = {};
 
   for (const descriptor of compiledTemplate.attributesArray ?? []) {
-    if (descriptor.binding !== 'slot') {
-      continue;
-    }
-
-    const slotValue = attributeSlots[descriptor.attrSlotIndex ?? -1];
-    if (descriptor.kind === 'attribute') {
-      if (descriptor.key && slotValue !== null && slotValue !== undefined) {
+    if (descriptor.kind === 'slot') {
+      const slotValue = attributeSlots[descriptor.attrSlotIndex];
+      if (slotValue !== null && slotValue !== undefined) {
         attrs[descriptor.key] = slotValue;
       }
       continue;
     }
 
+    if (descriptor.kind !== 'spread') {
+      continue;
+    }
+
+    const slotValue = attributeSlots[descriptor.attrSlotIndex];
     if (!isRecord(slotValue)) {
       continue;
     }

--- a/packages/react/transform/crates/swc_plugin_element_template/asset.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/asset.rs
@@ -28,9 +28,8 @@ where
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0,
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/template_definition.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/template_definition.rs
@@ -91,7 +91,7 @@ where
 
   fn element_template_static_attribute_descriptor(&self, key: &str, value: Expr) -> Expr {
     quote!(
-      r#"{ kind: "attribute", key: $key, binding: "static", value: $value }"# as Expr,
+      r#"{ kind: "static", key: $key, value: $value }"# as Expr,
       key: Expr = self.element_template_string_expr(key),
       value: Expr = value,
     )
@@ -99,7 +99,7 @@ where
 
   fn element_template_attribute_slot_descriptor(&self, key: &str, attr_slot_index: i32) -> Expr {
     quote!(
-      r#"{ kind: "attribute", key: $key, binding: "slot", attrSlotIndex: $attr_slot_index }"# as Expr,
+      r#"{ kind: "slot", key: $key, attrSlotIndex: $attr_slot_index }"# as Expr,
       key: Expr = self.element_template_string_expr(key),
       attr_slot_index: Expr = i32_to_expr(&attr_slot_index),
     )
@@ -107,7 +107,7 @@ where
 
   fn element_template_spread_slot_descriptor(&self, attr_slot_index: i32) -> Expr {
     quote!(
-      r#"{ kind: "spread", binding: "slot", attrSlotIndex: $attr_slot_index }"# as Expr,
+      r#"{ kind: "spread", attrSlotIndex: $attr_slot_index }"# as Expr,
       attr_slot_index: Expr = i32_to_expr(&attr_slot_index),
     )
   }

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_generate_attribute_slots_for_dynamic_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_generate_attribute_slots_for_dynamic_attributes.snap
@@ -12,15 +12,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "class",
-            "binding": "static",
             "value": "static"
           },
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "id",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           }
         ],
@@ -30,15 +28,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "slot",
                 "key": "data-value",
-                "binding": "slot",
                 "attrSlotIndex": 1.0
               },
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Dynamic Value"
               }
             ],
@@ -54,9 +50,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "raw-text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "Static"
                   }
                 ],
@@ -74,9 +69,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_background_conditional_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_background_conditional_attributes.snap
@@ -12,15 +12,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "data-a",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           },
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "b",
-            "binding": "slot",
             "attrSlotIndex": 1.0
           }
         ],
@@ -34,9 +32,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_boolean_and_number_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_boolean_and_number_attributes.snap
@@ -12,21 +12,18 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "disabled",
-            "binding": "static",
             "value": true
           },
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "opacity",
-            "binding": "static",
             "value": 0.5
           },
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "lines",
-            "binding": "static",
             "value": 2.0
           }
         ],
@@ -36,9 +33,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Attribute Types Test"
               }
             ],
@@ -54,9 +50,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_complex_text_structure.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_complex_text_structure.snap
@@ -22,9 +22,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "raw-text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "Hello"
                   }
                 ],
@@ -35,9 +34,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "World"
                   }
                 ],
@@ -48,9 +46,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "raw-text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "!"
                   }
                 ],
@@ -68,9 +65,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "raw-text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "First"
                   }
                 ],
@@ -81,9 +77,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "Second"
                   }
                 ],
@@ -94,9 +89,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "raw-text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "Third"
                   }
                 ],
@@ -114,9 +108,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_dataset_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_dataset_attributes.snap
@@ -12,21 +12,18 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "data-id",
-            "binding": "static",
             "value": "123"
           },
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "data-name",
-            "binding": "static",
             "value": "test"
           },
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "data-long-name",
-            "binding": "static",
             "value": "long-value"
           }
         ],
@@ -36,9 +33,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Dataset Test"
               }
             ],
@@ -54,9 +50,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_deeply_nested_user_components.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_deeply_nested_user_components.snap
@@ -12,9 +12,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "text",
-            "binding": "static",
             "value": "Deep Slot"
           }
         ],
@@ -43,9 +42,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_dynamic_class_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_dynamic_class_attributes.snap
@@ -12,15 +12,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "class",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           },
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "class",
-            "binding": "static",
             "value": "static-class"
           }
         ],
@@ -30,9 +28,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Dynamic Class Test"
               }
             ],
@@ -48,9 +45,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_js.snap
@@ -12,15 +12,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "bindtap",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           },
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "catchtouchstart",
-            "binding": "slot",
             "attrSlotIndex": 1.0
           }
         ],
@@ -30,9 +28,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Event Test"
               }
             ],
@@ -48,9 +45,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_lepus.snap
@@ -12,15 +12,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "bindtap",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           },
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "catchtouchstart",
-            "binding": "slot",
             "attrSlotIndex": 1.0
           }
         ],
@@ -30,9 +28,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Event Test"
               }
             ],
@@ -48,9 +45,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_id_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_id_attributes.snap
@@ -12,9 +12,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "id",
-            "binding": "static",
             "value": "static-id"
           }
         ],
@@ -24,15 +23,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "slot",
                 "key": "id",
-                "binding": "slot",
                 "attrSlotIndex": 0.0
               },
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "ID Test"
               }
             ],
@@ -48,9 +45,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_inline_styles.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_inline_styles.snap
@@ -12,9 +12,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "style",
-            "binding": "static",
             "value": "color: red; width: 100px;"
           }
         ],
@@ -24,15 +23,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "style",
-                "binding": "static",
                 "value": "font-size:16px;font-weight:bold"
               },
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Static Style"
               }
             ],
@@ -43,9 +40,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "view",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "slot",
                 "key": "style",
-                "binding": "slot",
                 "attrSlotIndex": 0.0
               }
             ],
@@ -55,9 +51,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "raw-text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "Dynamic Style"
                   }
                 ],
@@ -75,9 +70,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_js.snap
@@ -32,9 +32,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "view",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "id",
-                "binding": "static",
                 "value": "1"
               }
             ],
@@ -51,9 +50,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "view",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "id",
-                "binding": "static",
                 "value": "2"
               }
             ],
@@ -75,9 +73,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_lepus.snap
@@ -32,9 +32,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "view",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "id",
-                "binding": "static",
                 "value": "1"
               }
             ],
@@ -51,9 +50,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "view",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "id",
-                "binding": "static",
                 "value": "2"
               }
             ],
@@ -75,9 +73,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_mixed_content.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_mixed_content.snap
@@ -17,9 +17,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Start"
               }
             ],
@@ -40,9 +39,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "raw-text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "Middle"
                   }
                 ],
@@ -55,9 +53,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "End"
               }
             ],
@@ -73,9 +70,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_nested_structure_and_dynamic_content.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_nested_structure_and_dynamic_content.snap
@@ -27,9 +27,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "text",
-            "binding": "static",
             "value": "Copyright"
           }
         ],
@@ -43,9 +42,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "class",
-            "binding": "static",
             "value": "wrapper"
           }
         ],
@@ -55,9 +53,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "view",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "class",
-                "binding": "static",
                 "value": "header"
               }
             ],
@@ -67,9 +64,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "Header"
                   }
                 ],
@@ -82,9 +78,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "view",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "class",
-                "binding": "static",
                 "value": "content"
               }
             ],
@@ -101,9 +96,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "view",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "class",
-                "binding": "static",
                 "value": "footer"
               }
             ],
@@ -113,9 +107,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
                 "type": "text",
                 "attributesArray": [
                   {
-                    "kind": "attribute",
+                    "kind": "static",
                     "key": "text",
-                    "binding": "static",
                     "value": "Footer"
                   }
                 ],
@@ -138,9 +131,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_js.snap
@@ -12,9 +12,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "ref",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           }
         ],
@@ -24,9 +23,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Ref Test"
               }
             ],
@@ -42,9 +40,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_lepus.snap
@@ -12,9 +12,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "ref",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           }
         ],
@@ -24,9 +23,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Ref Test"
               }
             ],
@@ -42,9 +40,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_sibling_user_components.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_sibling_user_components.snap
@@ -12,9 +12,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "text",
-            "binding": "static",
             "value": "Slot Content 1"
           }
         ],
@@ -28,9 +27,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "text",
-            "binding": "static",
             "value": "Slot Content 2"
           }
         ],
@@ -59,9 +57,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_spread_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_spread_attributes.snap
@@ -13,13 +13,11 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "attributesArray": [
           {
             "kind": "spread",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           },
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "data-extra",
-            "binding": "static",
             "value": "value"
           }
         ],
@@ -29,9 +27,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Spread Test"
               }
             ],
@@ -47,9 +44,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_user_component.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_user_component.snap
@@ -12,9 +12,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "text",
-            "binding": "static",
             "value": "hello"
           }
         ],
@@ -43,9 +42,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_isolate_arrays_with_element_slot_placeholder.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_isolate_arrays_with_element_slot_placeholder.snap
@@ -22,9 +22,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Static"
               }
             ],
@@ -45,9 +44,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_keep_code_and_template_attribute_slots_in_sync_for_spread.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_keep_code_and_template_attribute_slots_in_sync_for_spread.snap
@@ -12,26 +12,22 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "id",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           },
           {
             "kind": "spread",
-            "binding": "slot",
             "attrSlotIndex": 1.0
           },
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "bindtap",
-            "binding": "slot",
             "attrSlotIndex": 2.0
           },
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "ref",
-            "binding": "slot",
             "attrSlotIndex": 3.0
           }
         ],
@@ -41,9 +37,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Spread Sync"
               }
             ],
@@ -59,9 +54,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_output_element_template_simple_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_output_element_template_simple_lepus.snap
@@ -12,9 +12,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "class",
-            "binding": "static",
             "value": "container"
           }
         ],
@@ -24,9 +23,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Hello"
               }
             ],
@@ -42,9 +40,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_output_template_with_static_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_output_template_with_static_attributes.snap
@@ -12,21 +12,18 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "class",
-            "binding": "static",
             "value": "container"
           },
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "id",
-            "binding": "static",
             "value": "main"
           },
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "style",
-            "binding": "static",
             "value": "color: red;"
           }
         ],
@@ -36,9 +33,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Hello"
               }
             ],
@@ -54,9 +50,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_verify_template_structure_complex.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_verify_template_structure_complex.snap
@@ -12,15 +12,13 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "view",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "static",
             "key": "class",
-            "binding": "static",
             "value": "container"
           },
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "id",
-            "binding": "slot",
             "attrSlotIndex": 0.0
           }
         ],
@@ -30,9 +28,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Static"
               }
             ],
@@ -43,9 +40,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "image",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "slot",
                 "key": "src",
-                "binding": "slot",
                 "attrSlotIndex": 1.0
               }
             ],
@@ -61,9 +57,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_verify_text_attribute_and_child_text_slots.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_verify_text_attribute_and_child_text_slots.snap
@@ -17,9 +17,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "static",
                 "key": "text",
-                "binding": "static",
                 "value": "Explicit Text Attribute"
               }
             ],
@@ -30,9 +29,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
             "type": "text",
             "attributesArray": [
               {
-                "kind": "attribute",
+                "kind": "slot",
                 "key": "text",
-                "binding": "slot",
                 "attrSlotIndex": 0.0
               }
             ],
@@ -60,9 +58,8 @@ expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_sn
         "type": "raw-text",
         "attributesArray": [
           {
-            "kind": "attribute",
+            "kind": "slot",
             "key": "text",
-            "binding": "slot",
             "attrSlotIndex": 0
           }
         ],

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
@@ -360,18 +360,18 @@ fn should_keep_static_attribute_values_out_of_et_attribute_slots() {
       .unwrap_or_else(|| panic!("missing attribute descriptor for {key}: {attrs:?}"))
   };
 
-  assert_eq!(attr_by_key("disabled")["binding"], "static");
+  assert_eq!(attr_by_key("disabled")["kind"], "static");
   assert_eq!(attr_by_key("disabled")["value"].as_bool(), Some(true));
-  assert_eq!(attr_by_key("id")["binding"], "static");
+  assert_eq!(attr_by_key("id")["kind"], "static");
   assert_eq!(attr_by_key("id")["value"].as_f64(), Some(1.0));
-  assert_eq!(attr_by_key("data-count")["binding"], "static");
+  assert_eq!(attr_by_key("data-count")["kind"], "static");
   assert_eq!(attr_by_key("data-count")["value"].as_f64(), Some(2.0));
-  assert_eq!(attr_by_key("data-overflow")["binding"], "slot");
+  assert_eq!(attr_by_key("data-overflow")["kind"], "slot");
   assert_eq!(
     attr_by_key("data-overflow")["attrSlotIndex"].as_f64(),
     Some(0.0)
   );
-  assert_eq!(attr_by_key("class")["binding"], "slot");
+  assert_eq!(attr_by_key("class")["kind"], "slot");
   assert_eq!(attr_by_key("class")["attrSlotIndex"].as_f64(), Some(1.0));
   let code = without_whitespace(&code);
   assert!(
@@ -403,9 +403,9 @@ fn should_not_consume_hidden_et_slots_for_list_item_platform_attrs() {
     .find(|attr| attr["key"] == "recyclable")
     .expect("recyclable descriptor");
 
-  assert_eq!(item_key["binding"], "slot");
+  assert_eq!(item_key["kind"], "slot");
   assert_eq!(item_key["attrSlotIndex"].as_f64(), Some(0.0));
-  assert_eq!(recyclable["binding"], "static");
+  assert_eq!(recyclable["kind"], "static");
   assert_eq!(recyclable["value"].as_bool(), Some(true));
   let code = without_whitespace(&code);
   assert!(
@@ -427,23 +427,19 @@ fn should_keep_slot_descriptor_order_for_dynamic_attr_spread_event_and_ref() {
     .expect("attributesArray");
   assert_eq!(attrs.len(), 4);
 
-  assert_eq!(attrs[0]["kind"], "attribute");
+  assert_eq!(attrs[0]["kind"], "slot");
   assert_eq!(attrs[0]["key"], "id");
-  assert_eq!(attrs[0]["binding"], "slot");
   assert_eq!(attrs[0]["attrSlotIndex"].as_f64(), Some(0.0));
 
   assert_eq!(attrs[1]["kind"], "spread");
-  assert_eq!(attrs[1]["binding"], "slot");
   assert_eq!(attrs[1]["attrSlotIndex"].as_f64(), Some(1.0));
 
-  assert_eq!(attrs[2]["kind"], "attribute");
+  assert_eq!(attrs[2]["kind"], "slot");
   assert_eq!(attrs[2]["key"], "bindtap");
-  assert_eq!(attrs[2]["binding"], "slot");
   assert_eq!(attrs[2]["attrSlotIndex"].as_f64(), Some(2.0));
 
-  assert_eq!(attrs[3]["kind"], "attribute");
+  assert_eq!(attrs[3]["kind"], "slot");
   assert_eq!(attrs[3]["key"], "ref");
-  assert_eq!(attrs[3]["binding"], "slot");
   assert_eq!(attrs[3]["attrSlotIndex"].as_f64(), Some(3.0));
 }
 
@@ -460,14 +456,12 @@ fn should_keep_worklet_attr_descriptor_keys_for_namespaced_attrs() {
     .expect("attributesArray");
   assert_eq!(attrs.len(), 2);
 
-  assert_eq!(attrs[0]["kind"], "attribute");
+  assert_eq!(attrs[0]["kind"], "slot");
   assert_eq!(attrs[0]["key"], "main-thread:bindtap");
-  assert_eq!(attrs[0]["binding"], "slot");
   assert_eq!(attrs[0]["attrSlotIndex"].as_f64(), Some(0.0));
 
-  assert_eq!(attrs[1]["kind"], "attribute");
+  assert_eq!(attrs[1]["kind"], "slot");
   assert_eq!(attrs[1]["key"], "main-thread:ref");
-  assert_eq!(attrs[1]["binding"], "slot");
   assert_eq!(attrs[1]["attrSlotIndex"].as_f64(), Some(1.0));
 }
 
@@ -484,14 +478,12 @@ fn should_treat_unknown_namespaced_attrs_as_regular_attrs() {
     .expect("attributesArray");
   assert_eq!(attrs.len(), 2);
 
-  assert_eq!(attrs[0]["kind"], "attribute");
+  assert_eq!(attrs[0]["kind"], "slot");
   assert_eq!(attrs[0]["key"], "custom:flag");
-  assert_eq!(attrs[0]["binding"], "slot");
   assert_eq!(attrs[0]["attrSlotIndex"].as_f64(), Some(0.0));
 
-  assert_eq!(attrs[1]["kind"], "attribute");
+  assert_eq!(attrs[1]["kind"], "static");
   assert_eq!(attrs[1]["key"], "custom:static");
-  assert_eq!(attrs[1]["binding"], "static");
   assert_eq!(attrs[1]["value"].as_f64(), Some(1.0));
 }
 
@@ -508,9 +500,8 @@ fn should_skip_lynx_part_id_without_reserving_attr_slot() {
     .expect("attributesArray");
   assert_eq!(attrs.len(), 1);
 
-  assert_eq!(attrs[0]["kind"], "attribute");
+  assert_eq!(attrs[0]["kind"], "slot");
   assert_eq!(attrs[0]["key"], "id");
-  assert_eq!(attrs[0]["binding"], "slot");
   assert_eq!(attrs[0]["attrSlotIndex"].as_f64(), Some(0.0));
 }
 
@@ -586,7 +577,7 @@ fn should_preserve_user_wrapper_elements_as_template_nodes() {
     .as_array()
     .expect("wrapper attributesArray");
   assert_eq!(wrapper_attrs[0]["key"], "id");
-  assert_eq!(wrapper_attrs[0]["binding"], "static");
+  assert_eq!(wrapper_attrs[0]["kind"], "static");
   assert_eq!(wrapper_attrs[0]["value"], "user-wrapper");
 
   assert_eq!(children[1]["kind"], "elementSlot");

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@lynx-js/css-serializer": "workspace:*",
     "@lynx-js/runtime-wrapper-webpack-plugin": "workspace:*",
-    "@lynx-js/tasm": "0.0.35"
+    "@lynx-js/tasm": "0.0.39"
   },
   "devDependencies": {
     "@lynx-js/react": "workspace:*",

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/rspack.config.js
@@ -47,9 +47,8 @@ export default {
                       {
                         "attributesArray": [
                           {
-                            "binding": "static",
                             "key": "text",
-                            "kind": "attribute",
+                            "kind": "static",
                             "value": "Hello, ",
                           },
                         ],
@@ -70,9 +69,8 @@ export default {
                     "attributesArray": [
                       {
                         "attrSlotIndex": 0,
-                        "binding": "slot",
                         "key": "text",
-                        "kind": "attribute",
+                        "kind": "slot",
                       },
                     ],
                     "children": [],

--- a/packages/webpack/template-webpack-plugin/package.json
+++ b/packages/webpack/template-webpack-plugin/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.29",
     "@lynx-js/css-serializer": "workspace:*",
-    "@lynx-js/tasm": "0.0.35",
+    "@lynx-js/tasm": "0.0.39",
     "@lynx-js/web-core": "workspace:*",
     "@lynx-js/webpack-runtime-globals": "workspace:^",
     "@rspack/lite-tapable": "1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1216,8 +1216,8 @@ importers:
         specifier: workspace:*
         version: link:../../webpack/runtime-wrapper-webpack-plugin
       '@lynx-js/tasm':
-        specifier: 0.0.35
-        version: 0.0.35
+        specifier: 0.0.39
+        version: 0.0.39
     devDependencies:
       '@lynx-js/react':
         specifier: workspace:*
@@ -2143,8 +2143,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/css-serializer
       '@lynx-js/tasm':
-        specifier: 0.0.35
-        version: 0.0.35
+        specifier: 0.0.39
+        version: 0.0.39
       '@lynx-js/web-core':
         specifier: workspace:*
         version: link:../../web-platform/web-core
@@ -3912,8 +3912,8 @@ packages:
     peerDependencies:
       '@lynx-js/react': '>=0.114.4'
 
-  '@lynx-js/tasm@0.0.35':
-    resolution: {integrity: sha512-8c2Nh6JbAdOzIvAwOgbUZGV7mNJ917y40xzGKHOjyv8Rxhjw0FTv+f+FJGpW3VXl9DUzUGM9GNoDOrL678Kt8A==}
+  '@lynx-js/tasm@0.0.39':
+    resolution: {integrity: sha512-FNIV6Cc2K0wCKOHVMfpr3M6kpIZqHHNI02GpVl+h0ClyyK44jxEO+lf58gLFD5E3o0hJ1cp3H2OBIxSUJGkPDw==}
     hasBin: true
 
   '@lynx-js/trace-processor@0.0.1':
@@ -13133,7 +13133,7 @@ snapshots:
       - react
       - react-dom
 
-  '@lynx-js/tasm@0.0.35': {}
+  '@lynx-js/tasm@0.0.39': {}
 
   '@lynx-js/trace-processor@0.0.1':
     dependencies:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated @lynx-js/tasm to v0.0.39 across relevant packages; published patch updates for @lynx-js/react, @lynx-js/template-webpack-plugin, and @lynx-js/lynx-bundle-rslib-config.
* **Tests**
  * Aligned compiled template attribute descriptor format to use static/slot/spread across tooling and test fixtures; updated snapshots and contract tests accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2643)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR makes `kind` the single discriminator for template attribute descriptors (`static`, `slot`, or `spread`) and removes the separate `binding` field. It also updates the TASM encoder dependency used by the template bundling packages to `@lynx-js/tasm@0.0.39`.

## Key Points

- The transform now emits static descriptors with `kind: "static"`, dynamic attribute slots with `kind: "slot"`, and spread slots with `kind: "spread"`.
- Runtime/native test mocks and debug fixtures consume the same descriptor shape, so producer and consumer assertions stay aligned.
- Transform snapshots, runtime fixtures, and the webpack element-template fixture were regenerated for the new descriptor shape.
- The changeset includes `@lynx-js/react` for the React transform output change, plus `@lynx-js/template-webpack-plugin` and `@lynx-js/lynx-bundle-rslib-config` for the `@lynx-js/tasm@0.0.39` dependency update.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).