### PR TITLE
feat: refine A2UI unsupported handling

### DIFF
--- a/.changeset/soft-lemons-burn.md
+++ b/.changeset/soft-lemons-burn.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/a2ui-reactlynx": patch
+---
+
+Refine A2UI unsupported handling to use a single `renderUnsupported` entry and unify the default unsupported notice for component and syntax cases.

--- a/packages/genui/a2ui-playground/lynx-src/a2ui/index.css
+++ b/packages/genui/a2ui-playground/lynx-src/a2ui/index.css
@@ -105,6 +105,8 @@
   --a2ui-color-text-subtle: var(--content-muted-2);
   --a2ui-color-primary-content-muted: var(--primary-content-faded);
   --a2ui-color-overlay: var(--neutral-film);
+
+  --a2ui-button-border-radius: 2rem;
 }
 
 page {

--- a/packages/genui/a2ui-playground/src/mock/basic/fridge-search.json
+++ b/packages/genui/a2ui-playground/src/mock/basic/fridge-search.json
@@ -20,7 +20,7 @@
           "id": "header",
           "component": "Text",
           "variant": "h3",
-          "text": "< Refrigerators"
+          "text": "Refrigerators"
         },
         {
           "id": "statusBar",

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -67,6 +67,7 @@ export function DemosPage(props: {
   );
   const [error, setError] = useState('');
   const [jsonEdited, setJsonEdited] = useState(false);
+  const [previewRenderKey, setPreviewRenderKey] = useState(0);
   const [previewInput, setPreviewInput] = useState<PreviewInput | null>(() =>
     initialScenario
       ? {
@@ -174,6 +175,7 @@ export function DemosPage(props: {
       actionMocks: currentScenario?.actionMocks,
       demoId: isKnownDemo ? currentScenario?.id : undefined,
     });
+    setPreviewRenderKey((value) => value + 1);
   }, [currentScenario, customJson, jsonEdited]);
 
   const handleFillExample = useCallback(() => {
@@ -305,6 +307,7 @@ export function DemosPage(props: {
         previewSource={previewSource}
       >
         <PreviewViewport
+          key={previewRenderKey}
           emptyTitle='Select a demo to preview'
           emptySubTitle='Lynx rendering will appear here'
         />

--- a/packages/genui/a2ui-playground/src/pages/OpenUIDemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/OpenUIDemosPage.tsx
@@ -31,6 +31,7 @@ export function OpenUIDemosPage(_props: { protocol: Protocol }) {
   );
   const [customRawText, setCustomRawText] = useState('');
   const [error, setError] = useState('');
+  const [previewRenderKey, setPreviewRenderKey] = useState(0);
   const [previewInput, setPreviewInput] = useState<PreviewInput | null>(() => {
     const initialScenario = OPENUI_SCENARIOS[0];
     return initialScenario ? { rawText: initialScenario.raw } : null;
@@ -88,6 +89,7 @@ export function OpenUIDemosPage(_props: { protocol: Protocol }) {
     }
     setError('');
     setPreviewInput({ rawText: customRawText });
+    setPreviewRenderKey((value) => value + 1);
   }, [customRawText]);
 
   return (
@@ -206,6 +208,7 @@ export function OpenUIDemosPage(_props: { protocol: Protocol }) {
         previewSource={previewSource}
       >
         <PreviewViewport
+          key={previewRenderKey}
           emptyTitle='Select a scenario to preview'
           emptySubTitle='Lynx rendering will appear here'
         />

--- a/packages/genui/a2ui/src/catalog/Icon/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Icon/index.tsx
@@ -23,7 +23,7 @@ export function Icon(
   props: IconProps,
 ): import('@lynx-js/react').ReactNode {
   const { id, name, size = 'md', color = 'inherit' } = props;
-  const iconName = toMaterialName(name as string);
+  const iconName = typeof name === 'string' ? toMaterialName(name) : '';
 
   return (
     <text

--- a/packages/genui/a2ui/src/catalog/Image/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Image/index.tsx
@@ -59,6 +59,7 @@ export function Image(
       className={`a2ui-image image-variant-${
         props.variant ?? 'mediumFeature'
       } ${typeof props.weight === 'number' ? 'image-weighted' : ''}`}
+      auto-size={true}
       src={hasError ? fallbackImage : src as string}
       mode={mode}
       binderror={() => setHasError(true)}

--- a/packages/genui/a2ui/src/react/A2UI.tsx
+++ b/packages/genui/a2ui/src/react/A2UI.tsx
@@ -15,6 +15,7 @@ import type { ReactNode } from '@lynx-js/react';
 
 import { A2UIProvider } from './A2UIProvider.jsx';
 import { A2UIRenderer } from './A2UIRenderer.jsx';
+import type { UnsupportedInfo } from './A2UIRenderer.jsx';
 import type { Catalog, CatalogInput } from '../catalog/defineCatalog.js';
 import { defineCatalog } from '../catalog/defineCatalog.js';
 import { MessageProcessor } from '../store/MessageProcessor.js';
@@ -78,6 +79,8 @@ export interface A2UIProps {
   renderFallback?: () => ReactNode;
   /** Render when the active resource fails. */
   renderError?: (err: unknown) => ReactNode;
+  /** Render when unsupported data syntax or an unsupported component is encountered. */
+  renderUnsupported?: (info: UnsupportedInfo) => ReactNode;
 }
 
 interface InternalSession {
@@ -117,6 +120,7 @@ function A2UIImpl(props: A2UIProps): import('@lynx-js/react').ReactNode {
     renderEmpty,
     renderFallback,
     renderError,
+    renderUnsupported,
     className,
   } = props;
 
@@ -261,6 +265,7 @@ function A2UIImpl(props: A2UIProps): import('@lynx-js/react').ReactNode {
   if (wrapSurface) rendererProps.wrapSurface = wrapSurface;
   if (renderFallback) rendererProps.renderFallback = renderFallback;
   if (renderError) rendererProps.renderError = renderError;
+  if (renderUnsupported) rendererProps.renderUnsupported = renderUnsupported;
 
   return (
     <A2UIProvider processor={session.processor} catalog={catalog}>

--- a/packages/genui/a2ui/src/react/A2UIRenderer.tsx
+++ b/packages/genui/a2ui/src/react/A2UIRenderer.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from '@lynx-js/react';
 
 import { useAction } from './useAction.js';
 import { useCatalog } from './useCatalog.js';
-import { useResolvedProps } from './useDataBinding.js';
+import { splitUnsupportedProps, useResolvedProps } from './useDataBinding.js';
 import type { ComponentInstance, Resource, Surface } from '../store/types.js';
 
 const noop = () => {
@@ -21,6 +21,13 @@ const emptySnapshot = {
 const returnEmptySnapshot = () => emptySnapshot;
 const warnedTags = new Set<string>();
 
+export interface UnsupportedInfo {
+  id: string;
+  tag: string;
+  kind: 'component' | 'syntax';
+  fields?: string[];
+}
+
 function DefaultLoading(props: { id: string }) {
   const content = `loading ${props.id}...`;
   return (
@@ -29,7 +36,7 @@ function DefaultLoading(props: { id: string }) {
         width: '100%',
         minHeight: '20px',
         padding: '10px',
-        backgroundColor: '#f5f5f5',
+        backgroundColor: 'var(--a2ui-color-surface-muted)',
         borderRadius: '6px',
       }}
     >
@@ -38,36 +45,84 @@ function DefaultLoading(props: { id: string }) {
   );
 }
 
+function DefaultUnsupportedNotice(props: UnsupportedInfo) {
+  return (
+    <view
+      style={{
+        width: '100%',
+        minHeight: '20px',
+        marginBottom: '8px',
+        padding: '6px',
+        borderRadius: '6px',
+        border: '1px dashed var(--a2ui-color-border)',
+        backgroundColor: 'var(--a2ui-color-surface-muted)',
+        color: 'var(--a2ui-color-text-muted)',
+      }}
+    >
+      <text style={{ color: 'inherit', fontSize: '10px', lineHeight: '12px' }}>
+        Unsupported {props.kind} in {props.id}
+      </text>
+    </view>
+  );
+}
+
 function buildNodeRecursive(
   component: ComponentInstance,
   surface: Surface,
   catalog: ReadonlyMap<string, (props: Record<string, unknown>) => ReactNode>,
-  resolvedProps?: Record<string, unknown>,
+  renderUnsupported:
+    | ((info: UnsupportedInfo) => ReactNode)
+    | undefined,
+  props?: Record<string, unknown>,
   setValue?: (key: string, value: unknown) => void,
   sendAction?: (action: Record<string, unknown>) => void,
 ): ReactNode {
   const tag = component.component;
   const Component = catalog.get(tag);
-  if (!Component) return null;
-
+  const renderUnsupportedNotice = (info: UnsupportedInfo) => {
+    if (typeof renderUnsupported === 'function') {
+      return renderUnsupported(info);
+    }
+    return <DefaultUnsupportedNotice {...info} />;
+  };
+  if (!Component) {
+    return renderUnsupportedNotice({
+      id: component.id ?? '',
+      tag,
+      kind: 'component',
+    });
+  }
+  const { unsupportedFields, displayProps } = splitUnsupportedProps(props);
   return (
-    <Component
-      key={component.id}
-      {
-        // Spread first so any data-binding key that collides with internal
-        // plumbing (`surface`, `setValue`, `sendAction`, `id`,
-        // `dataContextPath`) is overwritten by the explicit props below
-        // rather than silently shadowing them.
-        ...resolvedProps
-      }
-      id={component.id ?? ''}
-      surface={surface}
-      setValue={setValue}
-      sendAction={(a: Record<string, unknown>) => {
-        void sendAction?.(a);
-      }}
-      dataContextPath={component.dataContextPath}
-    />
+    <>
+      {unsupportedFields.length > 0
+        ? (
+          renderUnsupportedNotice({
+            id: component.id ?? '',
+            tag,
+            kind: 'syntax',
+            fields: unsupportedFields,
+          })
+        )
+        : null}
+      <Component
+        key={component.id}
+        {
+          // Spread first so any data-binding key that collides with internal
+          // plumbing (`surface`, `setValue`, `sendAction`, `id`,
+          // `dataContextPath`) is overwritten by the explicit props below
+          // rather than silently shadowing them.
+          ...displayProps
+        }
+        id={component.id ?? ''}
+        surface={surface}
+        setValue={setValue}
+        sendAction={(a: Record<string, unknown>) => {
+          void sendAction?.(a);
+        }}
+        dataContextPath={component.dataContextPath}
+      />
+    </>
   );
 }
 
@@ -77,6 +132,7 @@ export interface A2UIRendererProps {
   className?: string;
   renderFallback?: () => ReactNode;
   renderError?: (e: unknown) => ReactNode;
+  renderUnsupported?: (info: UnsupportedInfo) => ReactNode;
   /**
    * Wrap each top-level surface so consumers can apply an outer theme
    * shell, wrapper className, or additional styles. The default does not
@@ -94,6 +150,7 @@ function A2UIRendererImpl(
 ): import('@lynx-js/react').ReactNode {
   const {
     resource,
+    renderUnsupported,
     wrapSurface,
     renderFallback,
     renderError,
@@ -141,6 +198,8 @@ function A2UIRendererImpl(
     if (wrapSurface) childProps.wrapSurface = wrapSurface;
     if (renderFallback) childProps.renderFallback = renderFallback;
     if (renderError) childProps.renderError = renderError;
+    if (renderUnsupported) childProps.renderUnsupported = renderUnsupported;
+
     const inner = (
       <view id={`surface-${surfaceId}`} className={surfaceClassName}>
         <A2UIRenderer {...childProps} />
@@ -150,7 +209,13 @@ function A2UIRendererImpl(
   }
 
   if (type === 'surfaceUpdate' && component) {
-    return <NodeRenderer component={component} surface={surface} />;
+    return (
+      <NodeRenderer
+        component={component}
+        surface={surface}
+        renderUnsupported={renderUnsupported}
+      />
+    );
   }
 
   if (type === 'deleteSurface') {
@@ -166,9 +231,16 @@ function NodeRendererImpl(
   props: {
     component: ComponentInstance;
     surface: Surface;
+    renderUnsupported?:
+      | ((info: UnsupportedInfo) => ReactNode)
+      | undefined;
   },
 ): import('@lynx-js/react').ReactNode {
-  const { component: initialComponent, surface } = props;
+  const {
+    component: initialComponent,
+    surface,
+    renderUnsupported,
+  } = props;
   const catalog = useCatalog();
 
   const resource = surface.resources.get(initialComponent.id!);
@@ -216,21 +288,20 @@ function NodeRendererImpl(
   const { sendAction } = useAction(actionProps);
 
   return (
-    <>
-      {buildNodeRecursive(
-        effectiveComponent,
-        surface,
-        catalog as ReadonlyMap<
-          string,
-          (props: Record<string, unknown>) => ReactNode
-        >,
-        resolvedProps,
-        setValue,
-        (a: Record<string, unknown>) => {
-          void sendAction(a as unknown as Parameters<typeof sendAction>[0]);
-        },
-      )}
-    </>
+    buildNodeRecursive(
+      effectiveComponent,
+      surface,
+      catalog as ReadonlyMap<
+        string,
+        (props: Record<string, unknown>) => ReactNode
+      >,
+      renderUnsupported,
+      resolvedProps,
+      setValue,
+      (a: Record<string, unknown>) => {
+        void sendAction(a as unknown as Parameters<typeof sendAction>[0]);
+      },
+    )
   );
 }
 

--- a/packages/genui/a2ui/src/react/useDataBinding.ts
+++ b/packages/genui/a2ui/src/react/useDataBinding.ts
@@ -17,6 +17,7 @@ const noop = () => {
   /* no-op subscribe disposer */
 };
 const noopSubscribe = (): () => void => noop;
+const UNSUPPORTED_PROP = Symbol('a2ui.unsupported');
 
 function subscribeToSignal<T>(
   signal: Signal<T> | undefined,
@@ -109,7 +110,45 @@ function isDataBinding(prop: unknown): boolean {
   );
 }
 
-function resolveProperties(
+function isCallExpression(prop: unknown): boolean {
+  return Boolean(
+    prop
+      && typeof prop === 'object'
+      && 'call' in prop
+      && 'args' in prop
+      && 'returnType' in prop,
+  );
+}
+
+export function splitUnsupportedProps(
+  properties: Record<string, unknown> | undefined,
+): {
+  unsupportedFields: string[];
+  displayProps: Record<string, unknown> | undefined;
+} {
+  const unsupportedFields: string[] = [];
+  if (!properties) {
+    return { unsupportedFields, displayProps: properties };
+  }
+
+  const nextProps: Record<string, unknown> = {};
+  let changed = false;
+  for (const [key, value] of Object.entries(properties)) {
+    if (value === UNSUPPORTED_PROP) {
+      unsupportedFields.push(key);
+      changed = true;
+      continue;
+    }
+    nextProps[key] = value;
+  }
+
+  return {
+    unsupportedFields,
+    displayProps: changed ? nextProps : properties,
+  };
+}
+
+export function resolveProperties(
   properties: Record<string, unknown>,
   surface: Surface | undefined,
   dataContextPath?: string,
@@ -132,6 +171,8 @@ function resolveProperties(
       } else {
         result[key] = undefined;
       }
+    } else if (isCallExpression(prop)) {
+      result[key] = UNSUPPORTED_PROP;
     } else if (
       typeof prop === 'string'
       || typeof prop === 'number'

--- a/packages/genui/a2ui/styles/catalog/CheckBox.css
+++ b/packages/genui/a2ui/styles/catalog/CheckBox.css
@@ -6,8 +6,6 @@
   align-items: center;
   justify-content: flex-start;
   gap: 12px;
-  width: 100%;
-  min-width: 0;
 }
 
 .checkbox-input {
@@ -18,13 +16,12 @@
   height: 20px;
   border-radius: 4px;
   border: 1.5px solid var(--a2ui-color-border);
-  background-color: var(--a2ui-color-background);
-  color: var(--a2ui-color-on-primary);
+  background-color: var(--a2ui-color-surface);
+  color: var(--a2ui-color-on-surface);
   flex-shrink: 0;
 }
 
 .checkbox-input-checked {
-  background-color: var(--a2ui-color-primary);
   border-color: var(--a2ui-color-primary);
 }
 

--- a/packages/genui/a2ui/styles/catalog/Image.css
+++ b/packages/genui/a2ui/styles/catalog/Image.css
@@ -1,46 +1,9 @@
 @import "../theme.css";
 
-.image-variant-icon {
-  width: 24px;
-  height: 24px;
-  border-radius: 0;
-}
-
-.image-variant-avatar {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-}
-
-.image-variant-smallFeature {
-  width: 120px;
-  height: 80px;
-  max-width: var(--a2ui-image-small-feature-size, 120px);
-  border-radius: 8px;
-}
-
-.image-variant-mediumFeature {
-  width: 240px;
-  height: 160px;
-  border-radius: 8px;
-}
-
-.image-variant-largeFeature {
-  width: 100%;
-  height: 180px;
-  border-radius: 12px;
-  max-height: var(--a2ui-image-large-feature-size, 400px);
-}
-
-.image-variant-header {
-  width: 100%;
-  height: 200px;
-  border-radius: 12px;
-}
-
 .a2ui-image {
   flex-shrink: 0;
   overflow: hidden;
+  border-radius: var(--a2ui-image-radius, 12px);
 }
 
 .image-weighted {
@@ -51,4 +14,34 @@
 .column-weighted-item .a2ui-image {
   width: 100%;
   box-sizing: border-box;
+}
+
+.image-variant-icon {
+  width: var(--a2ui-image-avatar-size, 24px);
+  height: var(--a2ui-image-avatar-size, 24px);
+  border-radius: 0;
+}
+
+.image-variant-avatar {
+  width: var(--a2ui-image-avatar-size, 40px);
+  height: var(--a2ui-image-avatar-size, 40px);
+  border-radius: 50%;
+}
+
+.image-variant-header {
+  width: 100%;
+  height: var(--a2ui-image-header-size, 200px);
+  border-radius: 12px;
+}
+
+.image-variant-smallFeature {
+  max-width: var(--a2ui-image-small-feature-size, 120px);
+}
+
+.image-variant-mediumFeature {
+  max-width: var(--a2ui-image-medium-feature-size, 240px);
+}
+
+.image-variant-largeFeature {
+  max-height: var(--a2ui-image-large-feature-size, 400px);
 }

--- a/packages/genui/a2ui/test/useDataBinding.test.ts
+++ b/packages/genui/a2ui/test/useDataBinding.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { resolveProperties } from '../src/react/useDataBinding.js';
+import { SignalStore } from '../src/store/SignalStore.js';
+import type { Surface } from '../src/store/types.js';
+
+function createSurface(): Surface {
+  return {
+    surfaceId: 'surface-1',
+    components: new Map(),
+    resources: new Map(),
+    store: new SignalStore(),
+  };
+}
+
+describe('resolveProperties', () => {
+  test('resolves path bindings and keeps primitive values', () => {
+    const surface = createSurface();
+    surface.store.update('/weather/tempLow', 12);
+
+    const resolved = resolveProperties(
+      {
+        title: 'hello',
+        visible: true,
+        tempLow: { path: 'weather/tempLow' },
+      },
+      surface,
+    );
+
+    expect(resolved).toEqual({
+      title: 'hello',
+      visible: true,
+      tempLow: 12,
+    });
+  });
+
+  test('returns Unsupported Data Syntax for call expressions', () => {
+    const surface = createSurface();
+
+    const resolved = resolveProperties(
+      {
+        text: {
+          call: 'formatString',
+          args: {
+            value: '${/tempLow}°',
+          },
+          returnType: 'string',
+        },
+      },
+      surface,
+    );
+
+    expect(typeof resolved['text']).toBe('symbol');
+  });
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional callback for custom handling of unsupported components and syntax; unified default unsupported notice.

* **Bug Fixes**
  * Fixed preview remounting when rendering custom input.
  * Improved icon handling for edge cases.
  * Images now support auto-sizing.
  * Updated sample demo header text.

* **Style**
  * Checkbox and image styling updated to use design tokens.
  * Button border-radius configurable via theme tokens.

* **Tests**
  * Added tests for data-binding and property resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2644)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
