### PR TITLE
feat(react): expose ET data processors

### DIFF
--- a/packages/react/runtime/__test__/core/lynx-data-processors.test.ts
+++ b/packages/react/runtime/__test__/core/lynx-data-processors.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createProcessData } from '../../src/core/lynx-data-processors.js';
+
+const g = globalThis as typeof globalThis & {
+  __I18N_RESOURCE_TRANSLATION__?: unknown;
+  __EXTRACT_STR__?: boolean;
+  __EXTRACT_STR_IDENT_FLAG__?: unknown;
+  __PROFILE__?: boolean;
+};
+
+describe('createProcessData', () => {
+  let originalI18n: typeof g.__I18N_RESOURCE_TRANSLATION__;
+  let originalExtractStr: typeof g.__EXTRACT_STR__;
+  let originalExtractStrIdentFlag: typeof g.__EXTRACT_STR_IDENT_FLAG__;
+  let originalProfile: typeof g.__PROFILE__;
+  let originalReportError: typeof lynx.reportError;
+
+  beforeEach(() => {
+    originalI18n = g.__I18N_RESOURCE_TRANSLATION__;
+    originalExtractStr = g.__EXTRACT_STR__;
+    originalExtractStrIdentFlag = g.__EXTRACT_STR_IDENT_FLAG__;
+    originalProfile = g.__PROFILE__;
+    originalReportError = lynx.reportError;
+
+    delete g.__I18N_RESOURCE_TRANSLATION__;
+    g.__EXTRACT_STR__ = false;
+    delete g.__EXTRACT_STR_IDENT_FLAG__;
+    g.__PROFILE__ = false;
+  });
+
+  afterEach(() => {
+    if (originalI18n === undefined) {
+      delete g.__I18N_RESOURCE_TRANSLATION__;
+    } else {
+      g.__I18N_RESOURCE_TRANSLATION__ = originalI18n;
+    }
+
+    if (originalExtractStr === undefined) {
+      delete g.__EXTRACT_STR__;
+    } else {
+      g.__EXTRACT_STR__ = originalExtractStr;
+    }
+
+    if (originalExtractStrIdentFlag === undefined) {
+      delete g.__EXTRACT_STR_IDENT_FLAG__;
+    } else {
+      g.__EXTRACT_STR_IDENT_FLAG__ = originalExtractStrIdentFlag;
+    }
+
+    if (originalProfile === undefined) {
+      delete g.__PROFILE__;
+    } else {
+      g.__PROFILE__ = originalProfile;
+    }
+
+    lynx.reportError = originalReportError;
+  });
+
+  it('uses named and default processors and falls back to raw data', () => {
+    const defaultDataProcessor = vi.fn((data: { value: number }) => ({ doubled: data.value * 2 }));
+    const namedDataProcessor = vi.fn((data: { value: number }) => ({ named: data.value }));
+    lynx.reportError = vi.fn();
+    const processData = createProcessData({
+      defaultDataProcessor,
+      dataProcessors: {
+        named: namedDataProcessor,
+      },
+    });
+
+    expect(processData({ value: 2 }, 'named')).toEqual({ named: 2 });
+    expect(processData({ value: 3 })).toEqual({ doubled: 6 });
+    expect(processData({ value: 4 }, 'missing')).toEqual({ value: 4 });
+    expect(namedDataProcessor).toHaveBeenCalledTimes(1);
+    expect(defaultDataProcessor).toHaveBeenCalledTimes(1);
+    expect(lynx.reportError).not.toHaveBeenCalled();
+  });
+
+  it('reports processor errors and returns an empty object', () => {
+    const error = new Error('processor failed');
+    lynx.reportError = vi.fn();
+    const processData = createProcessData({
+      defaultDataProcessor() {
+        throw error;
+      },
+    });
+
+    expect(processData({ value: 1 })).toEqual({});
+    expect(lynx.reportError).toHaveBeenCalledWith(error);
+  });
+
+  it('injects metadata until the first default processor call completes', () => {
+    g.__I18N_RESOURCE_TRANSLATION__ = { hello: 'world' };
+    g.__EXTRACT_STR__ = true;
+    g.__EXTRACT_STR_IDENT_FLAG__ = '__extract__';
+
+    const processData = createProcessData({
+      dataProcessors: {
+        named: (data: { value: number }) => ({ named: data.value }),
+      },
+    });
+
+    expect(processData({ value: 1 }, 'named')).toEqual({
+      named: 1,
+      __I18N_RESOURCE_TRANSLATION__: { hello: 'world' },
+      _EXTRACT_STR: '__extract__',
+    });
+    expect(processData({ value: 2 }, 'named')).toEqual({
+      named: 2,
+      __I18N_RESOURCE_TRANSLATION__: { hello: 'world' },
+      _EXTRACT_STR: '__extract__',
+    });
+    expect(processData({ value: 3 })).toEqual({
+      value: 3,
+      __I18N_RESOURCE_TRANSLATION__: { hello: 'world' },
+      _EXTRACT_STR: '__extract__',
+    });
+    expect(processData({ value: 4 })).toEqual({ value: 4 });
+  });
+
+  it('wraps processor execution with profile hooks when profiling is enabled', () => {
+    g.__PROFILE__ = true;
+    const processData = createProcessData({
+      defaultDataProcessor: (data: { value: number }) => ({ value: data.value + 1 }),
+    });
+
+    expect(processData({ value: 1 })).toEqual({ value: 2 });
+    expect(lynx.performance.profileStart).toHaveBeenCalledWith('processData');
+    expect(lynx.performance.profileEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/runtime/__test__/element-template/imports/register-data-processors.test.ts
+++ b/packages/react/runtime/__test__/element-template/imports/register-data-processors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { root } from '@lynx-js/react/element-template';
+import type { DataProcessorDefinition, DataProcessors, InitData, InitDataRaw } from '@lynx-js/react/element-template';
+
+describe('element-template registerDataProcessors entry', () => {
+  it('forwards definitions through the public root alias', () => {
+    const originalRegisterDataProcessors = lynx.registerDataProcessors;
+    const registerDataProcessors = vi.fn();
+    lynx.registerDataProcessors = registerDataProcessors;
+
+    try {
+      const dataProcessors: DataProcessors = {
+        named(raw: { value: number }) {
+          return { named: raw.value };
+        },
+      };
+      const definition: DataProcessorDefinition = {
+        defaultDataProcessor(raw: InitDataRaw): InitData {
+          return raw as InitData;
+        },
+        dataProcessors,
+      };
+
+      root.registerDataProcessors(definition);
+      root.registerDataProcessors();
+
+      expect(registerDataProcessors).toHaveBeenNthCalledWith(1, definition);
+      expect(registerDataProcessors).toHaveBeenNthCalledWith(2, undefined);
+    } finally {
+      lynx.registerDataProcessors = originalRegisterDataProcessors;
+    }
+  });
+});

--- a/packages/react/runtime/__test__/element-template/vitest.config.ts
+++ b/packages/react/runtime/__test__/element-template/vitest.config.ts
@@ -114,6 +114,7 @@ const config: UserConfigExport = defineConfig({
       '@lynx-js/react/lepus': path.resolve(__dirname, '../../lepus/index.js'),
       '@lynx-js/react/legacy-react-runtime': path.resolve(__dirname, '../../src/legacy-react-runtime/index.ts'),
       '@lynx-js/react/element-template/internal': path.resolve(__dirname, '../../src/element-template/internal.ts'),
+      '@lynx-js/react/element-template': path.resolve(__dirname, '../../src/element-template/index.ts'),
       '@lynx-js/react': path.resolve(
         __dirname,
         './test-utils/debug/layeredReact.ts',

--- a/packages/react/runtime/__test__/snapshot/lynx-data-processors.test.ts
+++ b/packages/react/runtime/__test__/snapshot/lynx-data-processors.test.ts
@@ -1,0 +1,3 @@
+// Keep the shared data processor helper covered by the snapshot suite because
+// snapshot env imports it and test:snapshot enforces 100% coverage on imports.
+import '../core/lynx-data-processors.test.js';

--- a/packages/react/runtime/src/core/lynx-data-processors.ts
+++ b/packages/react/runtime/src/core/lynx-data-processors.ts
@@ -1,0 +1,66 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { DataProcessorDefinition, InitData, InitDataRaw } from '../lynx-api.js';
+import { profileEnd, profileStart } from '../shared/profile.js';
+
+export function createProcessData(
+  dataProcessorDefinition?: DataProcessorDefinition,
+): (data: InitDataRaw, processorName?: string) => InitData | InitDataRaw {
+  let hasDefaultDataProcessorExecuted = false;
+
+  return (data, processorName) => {
+    if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
+      profileStart('processData');
+    }
+
+    let result: InitData | InitDataRaw;
+    try {
+      if (processorName) {
+        result = dataProcessorDefinition?.dataProcessors?.[processorName]?.(data) as InitData ?? data;
+      } else {
+        result = dataProcessorDefinition?.defaultDataProcessor?.(data) ?? data;
+      }
+    } catch (error: unknown) {
+      lynx.reportError(error as Error);
+      result = {};
+    }
+
+    if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
+      profileEnd();
+    }
+
+    if (!hasDefaultDataProcessorExecuted) {
+      result = appendInitDataMetadata(result);
+    }
+
+    if (!processorName) {
+      hasDefaultDataProcessorExecuted = true;
+    }
+
+    return result;
+  };
+}
+
+function appendInitDataMetadata(result: InitData | InitDataRaw): InitData | InitDataRaw {
+  // @ts-expect-error todo: add types to i18n logic
+  const i18nResourceTranslation: unknown = globalThis.__I18N_RESOURCE_TRANSLATION__;
+  if (i18nResourceTranslation) {
+    result = {
+      ...result,
+      __I18N_RESOURCE_TRANSLATION__: i18nResourceTranslation,
+    };
+  }
+
+  // @ts-expect-error todo: add types to __EXTRACT_STR__
+  if (__EXTRACT_STR__) {
+    // @ts-expect-error todo: add types to __EXTRACT_STR__
+    const extractStrIdentFlag: unknown = __EXTRACT_STR_IDENT_FLAG__;
+    result = {
+      ...result,
+      _EXTRACT_STR: extractStrIdentFlag,
+    };
+  }
+
+  return result;
+}

--- a/packages/react/runtime/src/element-template/client/root.ts
+++ b/packages/react/runtime/src/element-template/client/root.ts
@@ -3,14 +3,12 @@
 // LICENSE file in the root directory of this source tree.
 // import { createContext, createElement } from 'preact/compat';
 // import { useState } from 'preact/hooks';
-// import type { Consumer, FC, ReactNode } from 'react';
 import type { ComponentChild, ContainerNode } from 'preact';
 import { render } from 'preact';
 import type { ReactNode } from 'react';
 
-// import { factory, withInitDataInState } from '../../compat/initData.js';
+import type { DataProcessorDefinition } from '../../lynx-api.js';
 import { profileEnd, profileStart } from '../debug/profile.js';
-// import { useLynxGlobalEventListener } from '../../core/hooks/useLynxGlobalEventListener.js';
 import { __root } from '../runtime/page/root-instance.js';
 
 /**
@@ -37,12 +35,12 @@ export interface Root {
    * @public
    */
   render: (jsx: ReactNode) => void;
-  // /**
-  //  * {@inheritDoc Lynx.registerDataProcessors}
-  //  * @deprecated use {@link Lynx.registerDataProcessors | lynx.registerDataProcessors} instead
-  //  * @public
-  //  */
-  // registerDataProcessors: (dataProcessorDefinition: DataProcessorDefinition) => void;
+  /**
+   * {@inheritDoc Lynx.registerDataProcessors}
+   * @deprecated use {@link Lynx.registerDataProcessors | lynx.registerDataProcessors} instead
+   * @public
+   */
+  registerDataProcessors: (dataProcessorDefinition?: DataProcessorDefinition) => void;
 }
 
 /**
@@ -67,8 +65,7 @@ export const root: Root = {
       }
     }
   },
-  /* v8 ignore next 3 */
-  // registerDataProcessors: (dataProcessorDefinition: DataProcessorDefinition): void => {
-  //   lynx.registerDataProcessors(dataProcessorDefinition);
-  // },
+  registerDataProcessors: (dataProcessorDefinition?: DataProcessorDefinition): void => {
+    lynx.registerDataProcessors(dataProcessorDefinition);
+  },
 };

--- a/packages/react/runtime/src/element-template/index.ts
+++ b/packages/react/runtime/src/element-template/index.ts
@@ -84,3 +84,5 @@ export {
 };
 
 export * from './client/root.js';
+
+export type { DataProcessorDefinition, DataProcessors, InitData, InitDataRaw } from '../lynx-api.js';

--- a/packages/react/runtime/src/element-template/lynx/env.ts
+++ b/packages/react/runtime/src/element-template/lynx/env.ts
@@ -1,8 +1,8 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { DataProcessorDefinition, InitData, InitDataRaw } from '../../lynx-api.js';
-import { profileEnd, profileStart } from '../debug/profile.js';
+import { createProcessData } from '../../core/lynx-data-processors.js';
+import type { DataProcessorDefinition } from '../../lynx-api.js';
 
 export function setupLynxEnv(): void {
   if (!__LEPUS__) {
@@ -52,57 +52,7 @@ export function setupLynxEnv(): void {
     lynx.registerDataProcessors = function(
       dataProcessorDefinition?: DataProcessorDefinition,
     ) {
-      let hasDefaultDataProcessorExecuted = false;
-      globalThis.processData = (data, processorName) => {
-        if (__PROFILE__) {
-          profileStart('processData');
-        }
-
-        let r: InitData | InitDataRaw;
-        try {
-          if (processorName) {
-            r = dataProcessorDefinition?.dataProcessors?.[processorName]?.(data) as InitData ?? data;
-          } else {
-            r = dataProcessorDefinition?.defaultDataProcessor?.(data) ?? data;
-          }
-        } catch (e: any) {
-          lynx.reportError(e as Error);
-          r = {};
-        }
-
-        if (__PROFILE__) {
-          profileEnd();
-        }
-
-        if (hasDefaultDataProcessorExecuted === false) {
-          // @ts-expect-error todo: add types to i18n logic
-          if (globalThis.__I18N_RESOURCE_TRANSLATION__) {
-            r = {
-              ...r,
-              // @ts-expect-error todo: add types to i18n logic
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              __I18N_RESOURCE_TRANSLATION__: globalThis.__I18N_RESOURCE_TRANSLATION__,
-            };
-          }
-
-          // @ts-expect-error todo: add types to __EXTRACT_STR__
-          if (__EXTRACT_STR__) {
-            r = {
-              ...r,
-              // @ts-expect-error todo: add types to __EXTRACT_STR__
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              _EXTRACT_STR: __EXTRACT_STR_IDENT_FLAG__,
-            };
-          }
-        }
-
-        if (processorName) {}
-        else {
-          hasDefaultDataProcessorExecuted = true;
-        }
-
-        return r;
-      };
+      globalThis.processData = createProcessData(dataProcessorDefinition);
     };
 
     lynx.registerDataProcessors();

--- a/packages/react/runtime/src/snapshot/lynx/env.ts
+++ b/packages/react/runtime/src/snapshot/lynx/env.ts
@@ -1,8 +1,8 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { DataProcessorDefinition, InitData, InitDataRaw } from '../../lynx-api.js';
-import { profileEnd, profileStart } from '../../shared/profile.js';
+import { createProcessData } from '../../core/lynx-data-processors.js';
+import type { DataProcessorDefinition } from '../../lynx-api.js';
 
 export function setupLynxEnv(): void {
   if (!__LEPUS__) {
@@ -49,60 +49,7 @@ export function setupLynxEnv(): void {
     lynx.registerDataProcessors = function(
       dataProcessorDefinition?: DataProcessorDefinition,
     ) {
-      let hasDefaultDataProcessorExecuted = false;
-      globalThis.processData = (data, processorName) => {
-        if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
-          profileStart('processData');
-        }
-
-        let r: InitData | InitDataRaw;
-        try {
-          if (processorName) {
-            r = dataProcessorDefinition?.dataProcessors?.[processorName]?.(data) as InitData ?? data;
-          } else {
-            r = dataProcessorDefinition?.defaultDataProcessor?.(data) ?? data;
-          }
-        } catch (e: any) {
-          lynx.reportError(e as Error);
-          // when there is an error
-          // we should perform like dataProcessor returns nothing
-          // so use `{}` rather than `data`
-          r = {};
-        }
-
-        if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
-          profileEnd();
-        }
-
-        if (hasDefaultDataProcessorExecuted === false) {
-          // @ts-expect-error todo: add types to i18n logic
-          if (globalThis.__I18N_RESOURCE_TRANSLATION__) {
-            r = {
-              ...r,
-              // @ts-expect-error todo: add types to i18n logic
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              __I18N_RESOURCE_TRANSLATION__: globalThis.__I18N_RESOURCE_TRANSLATION__,
-            };
-          }
-
-          // @ts-expect-error todo: add types to __EXTRACT_STR__
-          if (__EXTRACT_STR__) {
-            r = {
-              ...r,
-              // @ts-expect-error todo: add types to __EXTRACT_STR__
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              _EXTRACT_STR: __EXTRACT_STR_IDENT_FLAG__,
-            };
-          }
-        }
-
-        if (processorName) {}
-        else {
-          hasDefaultDataProcessorExecuted = true;
-        }
-
-        return r;
-      };
+      globalThis.processData = createProcessData(dataProcessorDefinition);
     };
 
     // register empty DataProcessors to make sure `globalThis.processData` is set


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for data processor creation and registration, covering routing, error handling, metadata injection, and profiling.

* **Refactor**
  * Extracted data-processing logic into a reusable factory used by registration.
  * Made a deprecated optional registration method available on Root and re-exported related type definitions for consumers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

- Exposes `root.registerDataProcessors` from the Element Template entry so ET roots can register InitData processors through the same Lynx environment hook used by Snapshot.
- Extracts the environment bridge into shared core runtime code to avoid keeping two backend-specific implementations of the same processor registration behavior.

## Key Points

- Adds a core data processor helper that normalizes the `lynx.registerDataProcessors` call path for Snapshot and ET.
- Updates the ET root object and public ET entry types so `@lynx-js/react/element-template` users can call `root.registerDataProcessors(...)`.
- Keeps the scope limited to data processors; broader InitData and GlobalProps parity remains outside this PR.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
