### PR TITLE
fix(testing-library): avoid index output race

### DIFF
--- a/packages/react/testing-library/rslib.config.ts
+++ b/packages/react/testing-library/rslib.config.ts
@@ -60,6 +60,11 @@ export default defineConfig({
         bundle: true,
         tsgo: true,
       },
+      output: {
+        filename: {
+          js: 'type-entry/[name].js',
+        },
+      },
       source: {
         entry: {
           'index': './src/entry.ts',


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to explicitly specify output filename pattern for library build entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2647)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

- Fix a flaky ReactLynx Testing Library build where the runtime entry and the type aggregation entry could both emit `dist/index.js`.
- Keep the aggregated declaration output at `dist/index.d.ts`, while redirecting the unused JS side output from the type aggregation target to `dist/type-entry/index.js`.

## Key Points

- `@lynx-js/react/testing-library` keeps resolving JavaScript through the runtime `dist/index.js`, which re-exports `pure.js` and provides `render`, `act`, and `renderHook`.
- The empty JS generated for the type aggregation target is no longer written to an exported package path, so parallel Rslib targets cannot race over the public entry file.
- No public API or documentation changes are needed; this is a build-output stability fix.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
