### PR TITLE
test(react): update ET template tree mock fixture

### DIFF
--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.test.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.test.ts
@@ -3,18 +3,20 @@ import { describe, expect, it } from 'vitest';
 import { instantiateCompiledTemplate, setAttributeSlotOnTemplateInstance } from './templateTree.js';
 import type { CompiledTemplateNode } from './templateTree.js';
 
+type CompiledElementTemplate = NonNullable<CompiledTemplateNode['__compiledTemplate']>;
+
 describe('mock native template tree spread slots', () => {
   it('expands spread slots in descriptor order', () => {
     const template = {
       kind: 'element',
       type: 'view',
       attributesArray: [
-        { kind: 'attribute', binding: 'static', key: 'id', value: 'static-id' },
-        { kind: 'spread', binding: 'slot', attrSlotIndex: 0 },
-        { kind: 'attribute', binding: 'slot', key: 'id', attrSlotIndex: 1 },
+        { kind: 'static', key: 'id', value: 'static-id' },
+        { kind: 'spread', attrSlotIndex: 0 },
+        { kind: 'slot', key: 'id', attrSlotIndex: 1 },
       ],
       children: [],
-    };
+    } satisfies CompiledElementTemplate;
 
     const root = instantiateCompiledTemplate(
       template,
@@ -33,13 +35,13 @@ describe('mock native template tree spread slots', () => {
       kind: 'element',
       type: 'view',
       attributesArray: [
-        { kind: 'spread', binding: 'slot', attrSlotIndex: 0 },
+        { kind: 'spread', attrSlotIndex: 0 },
       ],
       children: [],
-    };
+    } satisfies CompiledElementTemplate;
     const initialSpread = { id: 'cta', class: 'primary' };
     const root = instantiateCompiledTemplate(template, [initialSpread], []);
-    root.__compiledTemplate = template as CompiledTemplateNode['__compiledTemplate'];
+    root.__compiledTemplate = template;
     root.__attributeSlots = [initialSpread];
 
     setAttributeSlotOnTemplateInstance(root, 0, { id: 'cta-next' });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated internal test utilities to use a revised template descriptor structure.

*Note: These changes are internal testing infrastructure updates with no impact to end-user functionality.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

This updates the mock native PAPI template tree test fixture to match the current Element Template descriptor contract. The mock parser already consumes descriptors as `kind: "static" | "slot" | "spread"`; the test was still constructing the older `kind: "attribute"` plus `binding` shape, so the slot override assertion was exercising stale fixture input rather than the current template JSON.

## Key Points

- Replaces the stale handcrafted descriptor fixtures with the current `static`, `slot`, and `spread` JSON shape.
- Adds a `satisfies CompiledElementTemplate` constraint so future test fixtures are checked against the mock parser schema.
- Leaves runtime behavior, generated output, and public package surface unchanged.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
