### PR TITLE
chore: remove changeset files

### DIFF
--- a/.changeset/a2ui-icon-component.md
+++ b/.changeset/a2ui-icon-component.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/a2ui-reactlynx": patch
----
-
-Add `Icon` catalog component with Material Icons Round font support.

--- a/.changeset/many-pandas-breathe.md
+++ b/.changeset/many-pandas-breathe.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/a2ui-reactlynx": patch
----
-
-refactor theme styles

--- a/.changeset/soft-lemons-burn.md
+++ b/.changeset/soft-lemons-burn.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/a2ui-reactlynx": patch
----
-
-Refine A2UI unsupported handling to use a single `renderUnsupported` entry and unify the default unsupported notice for component and syntax cases.

--- a/.changeset/soft-tomatoes-wave.md
+++ b/.changeset/soft-tomatoes-wave.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/a2ui-reactlynx": patch
----
-
-feat(a2ui): refactor ui and support theme

--- a/.changeset/tabs-catalog-and-playground.md
+++ b/.changeset/tabs-catalog-and-playground.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/a2ui-reactlynx": patch
----
-
-Add the `Tabs` catalog component, generate its `catalog.json` schema, and export the new catalog entry and subpath from `@lynx-js/a2ui-reactlynx`.

--- a/.changeset/tame-bears-happen.md
+++ b/.changeset/tame-bears-happen.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/a2ui-reactlynx": patch
----
-
-Fix `Column` template rendering so nested bindings keep the correct `dataContextPath`, and preserve the caller-provided context in `NodeRenderer` instead of overwriting it from the stored component snapshot.

--- a/.changeset/wise-birds-lift.md
+++ b/.changeset/wise-birds-lift.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/a2ui-reactlynx": patch
----
-
-Add className prop to A2UI to allow custom styling.


### PR DESCRIPTION
## Summary

Remove all pending changeset files from `.changeset/` directory.

### Removed files:
- `a2ui-icon-component.md`
- `many-pandas-breathe.md`
- `soft-lemons-burn.md`
- `soft-tomatoes-wave.md`
- `tabs-catalog-and-playground.md`
- `tame-bears-happen.md`
- `wise-birds-lift.md`

These changesets have already been consumed in the latest release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Icon catalog component with Material Icons Round support
  * Added Tabs catalog component
  * A2UI component now supports custom styling via className prop

* **Bug Fixes**
  * Fixed Column template rendering to correctly preserve nested binding context
  * Fixed context handling in component rendering
  * Improved unsupported component and syntax behavior handling

* **Style**
  * Refactored theme styles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->