### PR TITLE
fix(react): disable reuse of different slot index child vnodes

### DIFF
--- a/.changeset/metal-dots-peel.md
+++ b/.changeset/metal-dots-peel.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/testing-environment": patch
+---
+
+Report error when `__RemoveElement` called on wrong parent and child.

--- a/.changeset/scope-vnode-reuse-to-slot-index.md
+++ b/.changeset/scope-vnode-reuse-to-slot-index.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Scope vnode reuse to the same structural slot in preact's diff, fixing cross-slot state swap of stateful components and snapshot dynamic parts.

--- a/.changeset/scope-vnode-reuse-to-slot-index.md
+++ b/.changeset/scope-vnode-reuse-to-slot-index.md
@@ -2,4 +2,4 @@
 "@lynx-js/react": patch
 ---
 
-Scope vnode reuse to the same structural slot in preact's diff, fixing cross-slot state swap of stateful components and snapshot dynamic parts.
+Disable vnode reuse of different slot index in preact's diff, fixing a bug that `__RemoveElement` was called with mismatched parent and child element.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -224,7 +224,7 @@
     "build": "rslib build"
   },
   "dependencies": {
-    "preact": "npm:@lynx-js/internal-preact@10.29.1-20260424024911-12b794f"
+    "preact": "https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78"
   },
   "devDependencies": {
     "@lynx-js/types": "3.7.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -224,7 +224,7 @@
     "build": "rslib build"
   },
   "dependencies": {
-    "preact": "https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78"
+    "preact": "https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8"
   },
   "devDependencies": {
     "@lynx-js/types": "3.7.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -224,7 +224,7 @@
     "build": "rslib build"
   },
   "dependencies": {
-    "preact": "https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8"
+    "preact": "npm:@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c"
   },
   "devDependencies": {
     "@lynx-js/types": "3.7.0",

--- a/packages/react/runtime/__test__/snapshot/basic.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/basic.test.jsx
@@ -338,6 +338,12 @@ describe('removeChild', () => {
       `[Error: child 4 is not in parent 3, cannot remove it!]`,
     );
 
+    // suppress the error of `__RemoveElement` called with mismatched parent and child element
+    vi.spyOn(globalThis, '__RemoveElement').mockImplementation(() => {});
+    expect(() => a.removeChild(b)).toThrowErrorMatchingInlineSnapshot(
+      `[Error: The node to be removed is not a child of this node.]`,
+    );
+
     expect(a.__element_root).toMatchInlineSnapshot(`
       <view>
         <text>

--- a/packages/react/runtime/__test__/snapshot/basic.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/basic.test.jsx
@@ -327,9 +327,13 @@ describe('removeChild', () => {
 
     expect(snapshotInstanceManager.values.size).toMatchInlineSnapshot(`2`);
 
+    const __elements = b.__elements;
+    const __element_root = b.__element_root;
     a.removeChild(b);
+    b.__element_root = __element_root;
+    b.__elements = __elements;
     expect(() => a.removeChild(b)).toThrowErrorMatchingInlineSnapshot(
-      `[Error: The node to be removed is not a child of this node.]`,
+      `[Error: child 4 is not in parent 3, cannot remove it!]`,
     );
 
     expect(a.__element_root).toMatchInlineSnapshot(`

--- a/packages/react/runtime/__test__/snapshot/basic.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/basic.test.jsx
@@ -330,6 +330,8 @@ describe('removeChild', () => {
     const __elements = b.__elements;
     const __element_root = b.__element_root;
     a.removeChild(b);
+    // Restore b.__element_root and b.__elements
+    // to make `__RemoveElement` receive real parent and child element
     b.__element_root = __element_root;
     b.__elements = __elements;
     expect(() => a.removeChild(b)).toThrowErrorMatchingInlineSnapshot(

--- a/packages/react/runtime/__test__/snapshot/debug/object-as-child.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/debug/object-as-child.test.jsx
@@ -25,7 +25,7 @@ test('preact/debug - Objects are not valid as a child', async () => {
 
   expect(() => root.render(<App />)).toThrowErrorMatchingInlineSnapshot(
     `
-    [Error: Objects are not valid as a child. Encountered an object with the keys {foo,bar,baz,__,__b,__i,__u}.
+    [Error: Objects are not valid as a child. Encountered an object with the keys {foo,bar,baz,_slotIndex,__,__b,__i,__u}.
 
       in Bar
       in App

--- a/packages/react/runtime/__test__/snapshot/page.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/page.test.jsx
@@ -257,7 +257,7 @@ describe('support <page /> element attributes', () => {
     `);
   });
 
-  it('should support adjacent <page /> elements', () => {
+  it('should report error on multiple <page /> elements', async () => {
     function Comp() {
       return (
         <page>
@@ -274,11 +274,6 @@ describe('support <page /> element attributes', () => {
     }
     __root.__jsx = <Comp />;
     renderPage();
-    if (__root.__firstChild) {
-      __root.__firstChild.__element_root = __page;
-      __root.__firstChild.__firstChild = __root.__firstChild.__nextSibling;
-      __root.removeChild(__root.__firstChild);
-    }
     expect(__root.__element_root).toMatchInlineSnapshot(`
       <page
         cssId="default-entry-from-native:0"
@@ -286,6 +281,29 @@ describe('support <page /> element attributes', () => {
         <view />
       </page>
     `);
+
+    let errors = [];
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      vi.spyOn(lynx, 'reportError').mockImplementation((...args) => {
+        errors.push(args[0]);
+      });
+
+      render(<Comp />, __root);
+    }
+    await waitSchedule();
+    expect(errors).toMatchInlineSnapshot(`
+      [
+        [Error: Attempt to render more than one \`<page />\`, which is not supported.],
+        [Error: Attempt to render more than one \`<page />\`, which is not supported.],
+        [Error: Attempt to render more than one \`<page />\`, which is not supported.],
+        [Error: Attempt to render more than one \`<page />\`, which is not supported.],
+        [Error: Attempt to render more than one \`<page />\`, which is not supported.],
+        [Error: Attempt to render more than one \`<page />\`, which is not supported.],
+      ]
+    `);
+    vi.clearAllMocks();
   });
 
   it('should support switch <page /> to other element', async () => {

--- a/packages/react/runtime/__test__/snapshot/utils/nativeMethod.ts
+++ b/packages/react/runtime/__test__/snapshot/utils/nativeMethod.ts
@@ -268,6 +268,8 @@ export const elementTree = new (class {
     parent.children.forEach((ch, index) => {
       if (ch === oldElement) {
         parent.children[index] = newElement;
+        parentMap.set(newElement, parent);
+        parentMap.delete(oldElement);
         return;
       }
     });

--- a/packages/react/runtime/__test__/snapshot/utils/nativeMethod.ts
+++ b/packages/react/runtime/__test__/snapshot/utils/nativeMethod.ts
@@ -235,13 +235,14 @@ export const elementTree = new (class {
   }
 
   __RemoveElement(parent: Element, child: Element) {
-    parent.children.forEach((ch, index) => {
-      if (ch === child) {
-        parent.children.splice(index, 1);
-        return;
-      }
-    });
-    parentMap.delete(child);
+    if (parentMap.get(child) === parent) {
+      parent.children.splice(parent.children.indexOf(child), 1);
+      parentMap.delete(child);
+    } else {
+      throw new Error(
+        `child ${child.$$uiSign} is not in parent ${parent.$$uiSign}, cannot remove it!`,
+      );
+    }
   }
 
   __InsertElementBefore(

--- a/packages/react/runtime/__test__/snapshot/utils/nativeMethod.ts
+++ b/packages/react/runtime/__test__/snapshot/utils/nativeMethod.ts
@@ -240,6 +240,7 @@ export const elementTree = new (class {
       parentMap.delete(child);
     } else {
       throw new Error(
+        // @ts-ignore
         `child ${child.$$uiSign} is not in parent ${parent.$$uiSign}, cannot remove it!`,
       );
     }

--- a/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
+++ b/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
@@ -1,0 +1,778 @@
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { render, fireEvent } from '..';
+import { expect } from 'vitest';
+import { useState } from 'preact/hooks';
+import { prettyFormatSnapshotPatch } from '../../../runtime/lib/snapshot/debug/formatPatch';
+
+describe('should not reuse cross slot index', () => {
+  it('raw text should not be reused', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    const Comp = () => {
+      return <text>Comp</text>;
+    };
+
+    let setState;
+    const App = () => {
+      let [state, _setState] = useState(1);
+      setState = _setState;
+
+      return (
+        <view
+          data-testid='view'
+          bindtap={() => {
+            setState(state === 1 ? 2 : 1);
+          }}
+        >
+          {state === 1 ? <Comp /> : 'RawText2'}
+          <text>---</text>
+          <text>{'RawText'}</text>
+        </view>
+      );
+    };
+    const { container, getByTestId } = render(<App />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              Comp
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <text>
+            RawText
+          </text>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 2,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_2",
+          },
+          {
+            "id": 2,
+            "op": "SetAttributes",
+            "values": [
+              1,
+            ],
+          },
+          {
+            "id": 3,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_1",
+          },
+          {
+            "beforeId": null,
+            "childId": 3,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 4,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "id": 4,
+            "op": "SetAttributes",
+            "values": [
+              "RawText",
+            ],
+          },
+          {
+            "beforeId": null,
+            "childId": 4,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            RawText2
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <text>
+            RawText
+          </text>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[1][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "childId": 3,
+            "op": "RemoveChild",
+            "parentId": 2,
+          },
+          {
+            "id": 5,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "dynamicPartIndex": 0,
+            "id": 5,
+            "op": "SetAttribute",
+            "value": "RawText2",
+          },
+          {
+            "beforeId": 4,
+            "childId": 5,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+  });
+
+  it('text node should not be reused', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    const Comp = () => {
+      return <text>Comp</text>;
+    };
+
+    let setState;
+    const App = () => {
+      let [state, _setState] = useState(1);
+      setState = _setState;
+
+      const textJsx = <text>A</text>;
+
+      return (
+        <view
+          data-testid='view'
+          bindtap={() => {
+            setState(state === 1 ? 2 : 1);
+          }}
+        >
+          {state === 1 ? <Comp /> : textJsx}
+          <text>---</text>
+          {textJsx}
+        </view>
+      );
+    };
+    const { container, getByTestId } = render(<App />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              Comp
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              A
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 2,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_5",
+          },
+          {
+            "id": 2,
+            "op": "SetAttributes",
+            "values": [
+              1,
+            ],
+          },
+          {
+            "id": 3,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_3",
+          },
+          {
+            "beforeId": null,
+            "childId": 3,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 4,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_4",
+          },
+          {
+            "beforeId": null,
+            "childId": 4,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              A
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              A
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[1][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "childId": 3,
+            "op": "RemoveChild",
+            "parentId": 2,
+          },
+          {
+            "id": 5,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_4",
+          },
+          {
+            "beforeId": 4,
+            "childId": 5,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+  });
+
+  it('keyed text node should not be reused', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    const Comp = () => {
+      return <text>Comp</text>;
+    };
+
+    let setState;
+    const App = () => {
+      let [state, _setState] = useState(1);
+      setState = _setState;
+
+      const textJsx = <text key='text'>A</text>;
+
+      return (
+        <view
+          data-testid='view'
+          bindtap={() => {
+            setState(state === 1 ? 2 : 1);
+          }}
+        >
+          {state === 1 ? <Comp /> : textJsx}
+          <text>---</text>
+          {textJsx}
+        </view>
+      );
+    };
+    const { container, getByTestId } = render(<App />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              Comp
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              A
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 2,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_8",
+          },
+          {
+            "id": 2,
+            "op": "SetAttributes",
+            "values": [
+              1,
+            ],
+          },
+          {
+            "id": 3,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_6",
+          },
+          {
+            "beforeId": null,
+            "childId": 3,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 4,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_7",
+          },
+          {
+            "beforeId": null,
+            "childId": 4,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper />
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              A
+            </text>
+            <text>
+              A
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[1][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "childId": 3,
+            "op": "RemoveChild",
+            "parentId": 2,
+          },
+          {
+            "id": 5,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_7",
+          },
+          {
+            "beforeId": null,
+            "childId": 5,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+        ]
+      `);
+    }
+  });
+
+  it('function component should not be reused', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    const CompA = () => {
+      return <text>CompA</text>;
+    };
+    const CompB = () => {
+      return <text>CompB</text>;
+    };
+
+    let setState;
+    const App = () => {
+      let [state, _setState] = useState(1);
+      setState = _setState;
+
+      return (
+        <view
+          data-testid='view'
+          bindtap={() => {
+            setState(state === 1 ? 2 : 1);
+          }}
+        >
+          {state === 1 ? <CompA /> : <CompB />}
+          <text>---</text>
+          {<CompB />}
+        </view>
+      );
+    };
+    const { container, getByTestId } = render(<App />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              CompA
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              CompB
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 2,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_11",
+          },
+          {
+            "id": 2,
+            "op": "SetAttributes",
+            "values": [
+              1,
+            ],
+          },
+          {
+            "id": 3,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_9",
+          },
+          {
+            "beforeId": null,
+            "childId": 3,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 4,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_10",
+          },
+          {
+            "beforeId": null,
+            "childId": 4,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              CompB
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              CompB
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[1][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "childId": 3,
+            "op": "RemoveChild",
+            "parentId": 2,
+          },
+          {
+            "id": 5,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_10",
+          },
+          {
+            "beforeId": 4,
+            "childId": 5,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+  });
+
+  it('keyed function component should not be reused', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    const CompA = () => {
+      return <text>CompA</text>;
+    };
+    const CompB = () => {
+      return <text>CompB</text>;
+    };
+
+    let setState;
+    const App = () => {
+      let [state, _setState] = useState(1);
+      setState = _setState;
+
+      return (
+        <view
+          data-testid='view'
+          bindtap={() => {
+            setState(state === 1 ? 2 : 1);
+          }}
+        >
+          {state === 1 ? <CompA key='CompA' /> : <CompB key='CompB' />}
+          <text>---</text>
+          {<CompB key='CompB' />}
+        </view>
+      );
+    };
+    const { container, getByTestId } = render(<App />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              CompA
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              CompB
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 2,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_14",
+          },
+          {
+            "id": 2,
+            "op": "SetAttributes",
+            "values": [
+              1,
+            ],
+          },
+          {
+            "id": 3,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_12",
+          },
+          {
+            "beforeId": null,
+            "childId": 3,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 4,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_13",
+          },
+          {
+            "beforeId": null,
+            "childId": 4,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper />
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              CompB
+            </text>
+            <text>
+              CompB
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[1][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "childId": 3,
+            "op": "RemoveChild",
+            "parentId": 2,
+          },
+          {
+            "id": 5,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_13",
+          },
+          {
+            "beforeId": null,
+            "childId": 5,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+        ]
+      `);
+    }
+  });
+});

--- a/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
+++ b/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
@@ -274,14 +274,15 @@ describe('should not reuse cross slot index', () => {
         <view
           data-testid="view"
         >
-          <wrapper />
-          <text>
-            ---
-          </text>
           <wrapper>
             <text>
               A
             </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
             <text>
               A
             </text>
@@ -305,11 +306,11 @@ describe('should not reuse cross slot index', () => {
             "type": "__snapshot_42dc9_test_4",
           },
           {
-            "beforeId": null,
+            "beforeId": 4,
             "childId": 5,
             "op": "InsertBefore",
             "parentId": 2,
-            "slotIndex": 1,
+            "slotIndex": 0,
           },
         ]
       `);
@@ -426,14 +427,15 @@ describe('should not reuse cross slot index', () => {
         <view
           data-testid="view"
         >
-          <wrapper />
-          <text>
-            ---
-          </text>
           <wrapper>
             <text>
               A
             </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
             <text>
               A
             </text>
@@ -457,11 +459,11 @@ describe('should not reuse cross slot index', () => {
             "type": "__snapshot_42dc9_test_7",
           },
           {
-            "beforeId": null,
+            "beforeId": 4,
             "childId": 5,
             "op": "InsertBefore",
             "parentId": 2,
-            "slotIndex": 1,
+            "slotIndex": 0,
           },
         ]
       `);
@@ -579,14 +581,15 @@ describe('should not reuse cross slot index', () => {
         <view
           data-testid="view"
         >
-          <wrapper />
-          <text>
-            ---
-          </text>
           <wrapper>
             <text>
               CompB
             </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
             <text>
               CompB
             </text>
@@ -610,11 +613,11 @@ describe('should not reuse cross slot index', () => {
             "type": "__snapshot_42dc9_test_10",
           },
           {
-            "beforeId": null,
+            "beforeId": 4,
             "childId": 5,
             "op": "InsertBefore",
             "parentId": 2,
-            "slotIndex": 1,
+            "slotIndex": 0,
           },
         ]
       `);
@@ -732,14 +735,15 @@ describe('should not reuse cross slot index', () => {
         <view
           data-testid="view"
         >
-          <wrapper />
-          <text>
-            ---
-          </text>
           <wrapper>
             <text>
               CompB
             </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
             <text>
               CompB
             </text>
@@ -763,11 +767,11 @@ describe('should not reuse cross slot index', () => {
             "type": "__snapshot_42dc9_test_13",
           },
           {
-            "beforeId": null,
+            "beforeId": 4,
             "childId": 5,
             "op": "InsertBefore",
             "parentId": 2,
-            "slotIndex": 1,
+            "slotIndex": 0,
           },
         ]
       `);

--- a/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
+++ b/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
@@ -274,15 +274,14 @@ describe('should not reuse cross slot index', () => {
         <view
           data-testid="view"
         >
-          <wrapper>
-            <text>
-              A
-            </text>
-          </wrapper>
+          <wrapper />
           <text>
             ---
           </text>
           <wrapper>
+            <text>
+              A
+            </text>
             <text>
               A
             </text>
@@ -306,11 +305,11 @@ describe('should not reuse cross slot index', () => {
             "type": "__snapshot_42dc9_test_4",
           },
           {
-            "beforeId": 4,
+            "beforeId": null,
             "childId": 5,
             "op": "InsertBefore",
             "parentId": 2,
-            "slotIndex": 0,
+            "slotIndex": 1,
           },
         ]
       `);
@@ -580,15 +579,14 @@ describe('should not reuse cross slot index', () => {
         <view
           data-testid="view"
         >
-          <wrapper>
-            <text>
-              CompB
-            </text>
-          </wrapper>
+          <wrapper />
           <text>
             ---
           </text>
           <wrapper>
+            <text>
+              CompB
+            </text>
             <text>
               CompB
             </text>
@@ -612,11 +610,11 @@ describe('should not reuse cross slot index', () => {
             "type": "__snapshot_42dc9_test_10",
           },
           {
-            "beforeId": 4,
+            "beforeId": null,
             "childId": 5,
             "op": "InsertBefore",
             "parentId": 2,
-            "slotIndex": 0,
+            "slotIndex": 1,
           },
         ]
       `);
@@ -774,5 +772,141 @@ describe('should not reuse cross slot index', () => {
         ]
       `);
     }
+  });
+});
+
+describe('should reuse dom', () => {
+  it('keyed list reorder inside Fragment should still work', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    let setState;
+    const App = () => {
+      const [state, _setState] = useState(1);
+      setState = _setState;
+      const items = state === 1 ? ['a', 'b', 'c'] : ['c', 'a', 'b'];
+
+      return (
+        <view
+          data-testid='view'
+          bindtap={() => setState(state === 1 ? 2 : 1)}
+        >
+          {items.map(i => <text key={i}>{i}</text>)}
+        </view>
+      );
+    };
+
+    const { container, getByTestId } = render(<App />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <text>
+            a
+          </text>
+          <text>
+            b
+          </text>
+          <text>
+            c
+          </text>
+        </view>
+      </page>
+    `);
+
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <text>
+            c
+          </text>
+          <text>
+            a
+          </text>
+          <text>
+            b
+          </text>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[1][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      const createOps = formattedSnapshotPatch.filter(p => p.op === 'CreateElement');
+      // No new elements should be created on reorder
+      expect(createOps).toEqual([]);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "beforeId": 3,
+            "childId": 7,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+  });
+
+  it('slot 1 component hooks state must be preserved when slot 0 type changes', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+
+    const Comp = () => <text>Comp</text>;
+
+    const Counter = ({ name }) => {
+      const [count, setCount] = useState(0);
+      return (
+        <text
+          data-testid={`counter-${name}`}
+          bindtap={() => setCount(c => c + 1)}
+        >
+          {name}-{count}
+        </text>
+      );
+    };
+
+    let toggle;
+    const App = () => {
+      const [state, _setState] = useState(1);
+      toggle = () => _setState(s => s === 1 ? 2 : 1);
+      return (
+        <view>
+          <view
+            data-testid='toggle'
+            bindtap={toggle}
+          />
+          <view>
+            {state === 1 ? <Comp /> : <Counter name='slot0' />}
+            <text>---</text>
+            <Counter name='slot1' />
+          </view>
+        </view>
+      );
+    };
+
+    const { container, getByTestId } = render(<App />);
+    // initial: slot 1 Counter at count=0
+    expect(getByTestId('counter-slot1').textContent).toBe('slot1-0');
+
+    // bump slot 1's Counter 3 times
+    fireEvent.tap(getByTestId('counter-slot1'));
+    fireEvent.tap(getByTestId('counter-slot1'));
+    fireEvent.tap(getByTestId('counter-slot1'));
+    expect(getByTestId('counter-slot1').textContent).toBe('slot1-3');
+
+    // toggle: slot 0 becomes a fresh Counter, slot 1 must keep its state
+    fireEvent.tap(getByTestId('toggle'));
+
+    // If the bug returns: slot 0 would steal slot 1's instance and show
+    // "slot0-3", while slot 1 would be a fresh "slot1-0".
+    expect(getByTestId('counter-slot0').textContent).toBe('slot0-0');
+    expect(getByTestId('counter-slot1').textContent).toBe('slot1-3');
   });
 });

--- a/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
+++ b/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { render, fireEvent } from '..';
 import { expect } from 'vitest';
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import { prettyFormatSnapshotPatch } from '../../../runtime/lib/snapshot/debug/formatPatch';
 
 describe('should not reuse cross slot index', () => {
@@ -164,6 +164,197 @@ describe('should not reuse cross slot index', () => {
     }
   });
 
+  it('raw text in the middle should not be reused', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    const Comp = () => {
+      return <text>Comp</text>;
+    };
+
+    let setState;
+    const App = () => {
+      let [state, _setState] = useState(1);
+      setState = _setState;
+
+      return (
+        <view
+          data-testid='view'
+          bindtap={() => {
+            setState(state === 1 ? 2 : 1);
+          }}
+        >
+          <text>{'RawText1'}</text>
+          <text>---</text>
+          {state === 1 ? <Comp /> : 'RawTextInMiddle'}
+          <text>---</text>
+          <text>{'RawText2'}</text>
+        </view>
+      );
+    };
+    const { container, getByTestId } = render(<App />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <text>
+            RawText1
+          </text>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              Comp
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <text>
+            RawText2
+          </text>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 2,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_4",
+          },
+          {
+            "id": 2,
+            "op": "SetAttributes",
+            "values": [
+              1,
+            ],
+          },
+          {
+            "id": 3,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "id": 3,
+            "op": "SetAttributes",
+            "values": [
+              "RawText1",
+            ],
+          },
+          {
+            "beforeId": null,
+            "childId": 3,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 4,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_3",
+          },
+          {
+            "beforeId": null,
+            "childId": 4,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+          {
+            "id": 5,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "id": 5,
+            "op": "SetAttributes",
+            "values": [
+              "RawText2",
+            ],
+          },
+          {
+            "beforeId": null,
+            "childId": 5,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 2,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <text>
+            RawText1
+          </text>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            RawTextInMiddle
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <text>
+            RawText2
+          </text>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[1][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "childId": 4,
+            "op": "RemoveChild",
+            "parentId": 2,
+          },
+          {
+            "id": 6,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "dynamicPartIndex": 0,
+            "id": 6,
+            "op": "SetAttribute",
+            "value": "RawTextInMiddle",
+          },
+          {
+            "beforeId": 5,
+            "childId": 6,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+        ]
+      `);
+    }
+  });
+
   it('text node should not be reused', () => {
     vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
     const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
@@ -224,7 +415,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 2,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_5",
+            "type": "__snapshot_42dc9_test_7",
           },
           {
             "id": 2,
@@ -236,7 +427,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 3,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_3",
+            "type": "__snapshot_42dc9_test_5",
           },
           {
             "beforeId": null,
@@ -248,7 +439,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 4,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_4",
+            "type": "__snapshot_42dc9_test_6",
           },
           {
             "beforeId": null,
@@ -303,7 +494,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 5,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_4",
+            "type": "__snapshot_42dc9_test_6",
           },
           {
             "beforeId": 4,
@@ -377,7 +568,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 2,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_8",
+            "type": "__snapshot_42dc9_test_10",
           },
           {
             "id": 2,
@@ -389,7 +580,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 3,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_6",
+            "type": "__snapshot_42dc9_test_8",
           },
           {
             "beforeId": null,
@@ -401,7 +592,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 4,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_7",
+            "type": "__snapshot_42dc9_test_9",
           },
           {
             "beforeId": null,
@@ -456,7 +647,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 5,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_7",
+            "type": "__snapshot_42dc9_test_9",
           },
           {
             "beforeId": 4,
@@ -531,7 +722,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 2,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_11",
+            "type": "__snapshot_42dc9_test_13",
           },
           {
             "id": 2,
@@ -543,7 +734,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 3,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_9",
+            "type": "__snapshot_42dc9_test_11",
           },
           {
             "beforeId": null,
@@ -555,7 +746,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 4,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_10",
+            "type": "__snapshot_42dc9_test_12",
           },
           {
             "beforeId": null,
@@ -610,7 +801,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 5,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_10",
+            "type": "__snapshot_42dc9_test_12",
           },
           {
             "beforeId": 4,
@@ -685,7 +876,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 2,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_14",
+            "type": "__snapshot_42dc9_test_16",
           },
           {
             "id": 2,
@@ -697,7 +888,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 3,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_12",
+            "type": "__snapshot_42dc9_test_14",
           },
           {
             "beforeId": null,
@@ -709,7 +900,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 4,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_13",
+            "type": "__snapshot_42dc9_test_15",
           },
           {
             "beforeId": null,
@@ -764,7 +955,7 @@ describe('should not reuse cross slot index', () => {
           {
             "id": 5,
             "op": "CreateElement",
-            "type": "__snapshot_42dc9_test_13",
+            "type": "__snapshot_42dc9_test_15",
           },
           {
             "beforeId": 4,
@@ -776,6 +967,324 @@ describe('should not reuse cross slot index', () => {
         ]
       `);
     }
+  });
+
+  it('keyed function component in Fragment should not be reused', () => {
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    const onLifecycleEventCalls = lynxTestingEnv.backgroundThread.lynxCoreInject.tt.OnLifecycleEvent.mock.calls;
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+    const callLepusMethodCalls = lynx.getNativeApp().callLepusMethod.mock.calls;
+
+    const log = [];
+    const CompA = () => {
+      return <text>CompA</text>;
+    };
+    const CompB = ({ name }) => {
+      useEffect(() => {
+        log.push(`mount ${name}`);
+        return () => {
+          log.push(`unmount ${name}`);
+        };
+      }, []);
+
+      return <text>{name}</text>;
+    };
+
+    let setState;
+    const App = () => {
+      let [state, _setState] = useState(1);
+      setState = _setState;
+
+      return (
+        <view
+          data-testid='view'
+          bindtap={() => {
+            setState(state === 1 ? 2 : 1);
+          }}
+        >
+          {state === 1 ? <CompA key='CompA' name='CompA' /> : [
+            // slot 0 Fragment[0] intentionally shares `key='CompB'` with slot 1 below to
+            // exercise cross-scope duplicate-key isolation; the distinct `name` prop lets
+            // us identify each instance in the mount/unmount log.
+            <CompB key='CompB' name='CompB-0' />,
+            <CompB key='CompB-1' name='CompB-1' />,
+            <CompB key='CompB-2' name='CompB-2' />,
+          ]}
+          <text>---</text>
+          {<CompB key='CompB' name='CompB' />}
+        </view>
+      );
+    };
+    const { container, getByTestId } = render(<App />);
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              CompA
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              CompB
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "id": 2,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_19",
+          },
+          {
+            "id": 2,
+            "op": "SetAttributes",
+            "values": [
+              1,
+            ],
+          },
+          {
+            "id": 3,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_17",
+          },
+          {
+            "beforeId": null,
+            "childId": 3,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 4,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_18",
+          },
+          {
+            "id": 5,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "id": 5,
+            "op": "SetAttributes",
+            "values": [
+              "CompB",
+            ],
+          },
+          {
+            "beforeId": null,
+            "childId": 5,
+            "op": "InsertBefore",
+            "parentId": 4,
+            "slotIndex": 0,
+          },
+          {
+            "beforeId": null,
+            "childId": 4,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 1,
+          },
+          {
+            "beforeId": null,
+            "childId": 2,
+            "op": "InsertBefore",
+            "parentId": -1,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              CompB-0
+            </text>
+            <text>
+              CompB-1
+            </text>
+            <text>
+              CompB-2
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              CompB
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    {
+      const snapshotPatch = JSON.parse(callLepusMethodCalls[1][1]['data']).patchList[0].snapshotPatch;
+      const formattedSnapshotPatch = prettyFormatSnapshotPatch(snapshotPatch);
+      expect(formattedSnapshotPatch).toMatchInlineSnapshot(`
+        [
+          {
+            "childId": 3,
+            "op": "RemoveChild",
+            "parentId": 2,
+          },
+          {
+            "id": 6,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_18",
+          },
+          {
+            "id": 7,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "dynamicPartIndex": 0,
+            "id": 7,
+            "op": "SetAttribute",
+            "value": "CompB-0",
+          },
+          {
+            "beforeId": null,
+            "childId": 7,
+            "op": "InsertBefore",
+            "parentId": 6,
+            "slotIndex": 0,
+          },
+          {
+            "beforeId": 4,
+            "childId": 6,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 8,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_18",
+          },
+          {
+            "id": 9,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "dynamicPartIndex": 0,
+            "id": 9,
+            "op": "SetAttribute",
+            "value": "CompB-1",
+          },
+          {
+            "beforeId": null,
+            "childId": 9,
+            "op": "InsertBefore",
+            "parentId": 8,
+            "slotIndex": 0,
+          },
+          {
+            "beforeId": 4,
+            "childId": 8,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+          {
+            "id": 10,
+            "op": "CreateElement",
+            "type": "__snapshot_42dc9_test_18",
+          },
+          {
+            "id": 11,
+            "op": "CreateElement",
+            "type": null,
+          },
+          {
+            "dynamicPartIndex": 0,
+            "id": 11,
+            "op": "SetAttribute",
+            "value": "CompB-2",
+          },
+          {
+            "beforeId": null,
+            "childId": 11,
+            "op": "InsertBefore",
+            "parentId": 10,
+            "slotIndex": 0,
+          },
+          {
+            "beforeId": 4,
+            "childId": 10,
+            "op": "InsertBefore",
+            "parentId": 2,
+            "slotIndex": 0,
+          },
+        ]
+      `);
+    }
+    // No unmount (reuse) will happen
+    expect(log).toMatchInlineSnapshot(`
+      [
+        "mount CompB",
+        "mount CompB-0",
+        "mount CompB-1",
+        "mount CompB-2",
+      ]
+    `);
+
+    // Reverse transition (state 2 -> 1): slot 0 Fragment unmounts, slot 1 must
+    // still NOT be touched. We expect exactly 3 unmounts from the Fragment
+    // children and zero from slot 1.
+    fireEvent.tap(getByTestId('view'));
+    expect(container).toMatchInlineSnapshot(`
+      <page>
+        <view
+          data-testid="view"
+        >
+          <wrapper>
+            <text>
+              CompA
+            </text>
+          </wrapper>
+          <text>
+            ---
+          </text>
+          <wrapper>
+            <text>
+              CompB
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+    expect(log).toMatchInlineSnapshot(`
+      [
+        "mount CompB",
+        "mount CompB-0",
+        "mount CompB-1",
+        "mount CompB-2",
+        "unmount CompB-0",
+        "unmount CompB-1",
+        "unmount CompB-2",
+      ]
+    `);
   });
 });
 
@@ -864,8 +1373,15 @@ describe('should reuse dom', () => {
 
     const Comp = () => <text>Comp</text>;
 
+    const log = [];
     const Counter = ({ name }) => {
       const [count, setCount] = useState(0);
+
+      useEffect(() => {
+        log.push(`mount-${name}`);
+        return () => log.push(`unmount-${name}`);
+      }, []);
+
       return (
         <text
           data-testid={`counter-${name}`}
@@ -904,6 +1420,11 @@ describe('should reuse dom', () => {
     fireEvent.tap(getByTestId('counter-slot1'));
     fireEvent.tap(getByTestId('counter-slot1'));
     expect(getByTestId('counter-slot1').textContent).toBe('slot1-3');
+    expect(log).toMatchInlineSnapshot(`
+      [
+        "mount-slot1",
+      ]
+    `);
 
     // toggle: slot 0 becomes a fresh Counter, slot 1 must keep its state
     fireEvent.tap(getByTestId('toggle'));
@@ -912,5 +1433,31 @@ describe('should reuse dom', () => {
     // "slot0-3", while slot 1 would be a fresh "slot1-0".
     expect(getByTestId('counter-slot0').textContent).toBe('slot0-0');
     expect(getByTestId('counter-slot1').textContent).toBe('slot1-3');
+    expect(log).toMatchInlineSnapshot(`
+      [
+        "mount-slot1",
+        "mount-slot0",
+      ]
+    `);
+
+    fireEvent.tap(getByTestId('toggle'));
+
+    expect(log).toMatchInlineSnapshot(`
+      [
+        "mount-slot1",
+        "mount-slot0",
+        "unmount-slot0",
+      ]
+    `);
+
+    fireEvent.tap(getByTestId('toggle'));
+    expect(log).toMatchInlineSnapshot(`
+      [
+        "mount-slot1",
+        "mount-slot0",
+        "unmount-slot0",
+        "mount-slot0",
+      ]
+    `);
   });
 });

--- a/packages/react/testing-library/src/__tests__/slot-jsx.test.jsx
+++ b/packages/react/testing-library/src/__tests__/slot-jsx.test.jsx
@@ -407,7 +407,10 @@ test('cross-slot keyed move: E is placed before A with correct beforeId in patch
   // Lock in the exact element-PAPI sequence so an extra DOM op shows up as a diff.
   expect(trace.trace()).toMatchInlineSnapshot(`
     "remove(<wrapper>X</wrapper> -x <text>X</text>)
-    remove(<wrapper> -x <text>E</text>)
+    remove(<wrapper>E</wrapper> -x <text>E</text>)
+    create(text)
+    create(raw-text "E")
+    append(<text> <- <raw>E</raw>)
     append(<wrapper> <- <text>E</text>)
     create(text)
     create(raw-text "N")
@@ -463,20 +466,30 @@ test('cross-slot keyed move: E is placed before A with correct beforeId in patch
         "parentId": 2,
       },
       {
-        "beforeId": 4,
         "childId": 5,
+        "op": "RemoveChild",
+        "parentId": 2,
+      },
+      {
+        "id": 7,
+        "op": "CreateElement",
+        "type": "__snapshot_c1db7_test_7",
+      },
+      {
+        "beforeId": 4,
+        "childId": 7,
         "op": "InsertBefore",
         "parentId": 2,
         "slotIndex": 0,
       },
       {
-        "id": 7,
+        "id": 8,
         "op": "CreateElement",
         "type": "__snapshot_c1db7_test_9",
       },
       {
         "beforeId": 6,
-        "childId": 7,
+        "childId": 8,
         "op": "InsertBefore",
         "parentId": 2,
         "slotIndex": 2,
@@ -488,9 +501,9 @@ test('cross-slot keyed move: E is placed before A with correct beforeId in patch
   expect(printSnapshotInstanceToString(__root)).toMatchInlineSnapshot(`
     "| -1(root): undefined
       | 2(__snapshot_c1db7_test_10): [null]
-        | 5(__snapshot_c1db7_test_7): undefined
+        | 7(__snapshot_c1db7_test_7): undefined
         | 4(__snapshot_c1db7_test_6): undefined
-        | 7(__snapshot_c1db7_test_9): undefined
+        | 8(__snapshot_c1db7_test_9): undefined
         | 6(__snapshot_c1db7_test_8): undefined"
   `);
 });
@@ -544,19 +557,25 @@ test('multi-key cross-slot moves keep background snapshot tree in slot order', a
   act(() => setMoved(true));
 
   expect(trace.trace()).toMatchInlineSnapshot(`
-    "remove(<wrapper>A</wrapper> -x <text>A</text>)
+    "remove(<wrapper>H</wrapper> -x <text>H</text>)
+    remove(<wrapper>A</wrapper> -x <text>A</text>)
+    remove(<wrapper>G</wrapper> -x <text>G</text>)
     remove(<wrapper>B</wrapper> -x <text>B</text>)
     create(text)
     create(raw-text "F")
     append(<text> <- <raw>F</raw>)
-    insertBefore(<wrapper>H</wrapper>: <text>F</text> before <text>H</text>)
-    remove(<wrapper> -x <text>H</text>)
+    append(<wrapper> <- <text>F</text>)
+    create(text)
+    create(raw-text "H")
+    append(<text> <- <raw>H</raw>)
     append(<wrapper> <- <text>H</text>)
     create(text)
     create(raw-text "E")
     append(<text> <- <raw>E</raw>)
-    insertBefore(<wrapper>G</wrapper>: <text>E</text> before <text>G</text>)
-    remove(<wrapper> -x <text>G</text>)
+    append(<wrapper> <- <text>E</text>)
+    create(text)
+    create(raw-text "G")
+    append(<text> <- <raw>G</raw>)
     append(<wrapper> <- <text>G</text>)"
   `);
 
@@ -565,9 +584,9 @@ test('multi-key cross-slot moves keep background snapshot tree in slot order', a
     "| -1(root): undefined
       | 2(__snapshot_c1db7_test_19): undefined
         | 7(__snapshot_c1db7_test_16): undefined
-        | 3(__snapshot_c1db7_test_18): undefined
-        | 8(__snapshot_c1db7_test_15): undefined
-        | 5(__snapshot_c1db7_test_17): undefined"
+        | 8(__snapshot_c1db7_test_18): undefined
+        | 9(__snapshot_c1db7_test_15): undefined
+        | 10(__snapshot_c1db7_test_17): undefined"
   `);
   expect(container).toMatchInlineSnapshot(`
     <page>
@@ -652,10 +671,14 @@ test('three-key cross-slot move applies cleanly on main thread', async () => {
   trace.mark();
   act(() => setMoved(true));
   expect(trace.trace()).toMatchInlineSnapshot(`
-    "remove(<wrapper>E</wrapper> -x <text>E</text>)
+    "remove(<wrapper>F</wrapper> -x <text>F</text>)
+    remove(<wrapper>H</wrapper> -x <text>H</text>)
+    remove(<wrapper>E</wrapper> -x <text>E</text>)
     remove(<wrapper>G</wrapper> -x <text>G</text>)
-    remove(<wrapper>F</wrapper> -x <text>H</text>)
-    insertBefore(<wrapper>F</wrapper>: <text>H</text> before <text>F</text>)
+    create(text)
+    create(raw-text "H")
+    append(<text> <- <raw>H</raw>)
+    append(<wrapper> <- <text>H</text>)
     create(text)
     create(raw-text "A")
     append(<text> <- <raw>A</raw>)
@@ -664,7 +687,9 @@ test('three-key cross-slot move applies cleanly on main thread', async () => {
     create(raw-text "D")
     append(<text> <- <raw>D</raw>)
     append(<wrapper> <- <text>D</text>)
-    remove(<wrapper> -x <text>F</text>)
+    create(text)
+    create(raw-text "F")
+    append(<text> <- <raw>F</raw>)
     append(<wrapper> <- <text>F</text>)"
   `);
 
@@ -709,10 +734,10 @@ test('three-key cross-slot move applies cleanly on main thread', async () => {
   expect(printSnapshotInstanceToString(__root)).toMatchInlineSnapshot(`
     "| -1(root): undefined
       | 2(__snapshot_c1db7_test_26): undefined
-        | 4(__snapshot_c1db7_test_25): undefined
-        | 7(__snapshot_c1db7_test_20): undefined
-        | 8(__snapshot_c1db7_test_21): undefined
-        | 3(__snapshot_c1db7_test_23): undefined"
+        | 7(__snapshot_c1db7_test_25): undefined
+        | 8(__snapshot_c1db7_test_20): undefined
+        | 9(__snapshot_c1db7_test_21): undefined
+        | 10(__snapshot_c1db7_test_23): undefined"
   `);
 });
 
@@ -807,9 +832,15 @@ test('cross-slot keyed swap between two single-VNode slots', async () => {
   act(() => setSwap(true));
 
   expect(trace.trace()).toMatchInlineSnapshot(`
-    "remove(<wrapper>A</wrapper> -x <text>B</text>)
-    insertBefore(<wrapper>A</wrapper>: <text>B</text> before <text>A</text>)
-    remove(<wrapper> -x <text>A</text>)
+    "remove(<wrapper>A</wrapper> -x <text>A</text>)
+    remove(<wrapper>B</wrapper> -x <text>B</text>)
+    create(text)
+    create(raw-text "B")
+    append(<text> <- <raw>B</raw>)
+    append(<wrapper> <- <text>B</text>)
+    create(text)
+    create(raw-text "A")
+    append(<text> <- <raw>A</raw>)
     append(<wrapper> <- <text>A</text>)"
   `);
   expect(container).toMatchInlineSnapshot(`

--- a/packages/react/testing-library/src/plugins/vitest.ts
+++ b/packages/react/testing-library/src/plugins/vitest.ts
@@ -316,10 +316,10 @@ export function testingLibraryPlugin(
           ],
           alias: [...runtimeOSSAlias, ...runtimeAlias, ...preactAlias, ...reactAlias],
           // Force any module that touches `preact` (or its forks like
-          // `@lynx-js/internal-preact`, `@preact/signals`, `@prefresh/core`)
-          // through Vite's transform pipeline so the aliases above can
-          // redirect every `import 'preact'` / `import 'preact/hooks'` to a
-          // SINGLE physical module.
+          // `@lynx-js/internal-preact`, `@preact/signals`) through Vite's
+          // transform pipeline so the aliases above can redirect every
+          // `import 'preact'` / `import 'preact/hooks'` to a SINGLE physical
+          // module.
           //
           // Without this, vitest externalizes those deps and Node's resolver
           // pulls each one's own copy of preact straight from

--- a/packages/react/testing-library/src/plugins/vitest.ts
+++ b/packages/react/testing-library/src/plugins/vitest.ts
@@ -315,6 +315,27 @@ export function testingLibraryPlugin(
             require.resolve('../setupFiles/vitest'),
           ],
           alias: [...runtimeOSSAlias, ...runtimeAlias, ...preactAlias, ...reactAlias],
+          // Force any module that touches `preact` (or its forks like
+          // `@lynx-js/internal-preact`, `@preact/signals`, `@prefresh/core`)
+          // through Vite's transform pipeline so the aliases above can
+          // redirect every `import 'preact'` / `import 'preact/hooks'` to a
+          // SINGLE physical module.
+          //
+          // Without this, vitest externalizes those deps and Node's resolver
+          // pulls each one's own copy of preact straight from
+          // `node_modules/.pnpm`, producing two `options` singletons. Hooks
+          // register `_render` on one, but the diff path uses the other —
+          // `currentComponent` stays undefined → `Cannot read properties of
+          // undefined (reading '__H')` the moment `useState` runs.
+          server: {
+            deps: {
+              inline: [
+                /preact/,
+                runtimeOSSPkgName,
+                ...(runtimePkgName !== runtimeOSSPkgName ? [runtimePkgName] : []),
+              ],
+            },
+          },
         },
       }),
       configResolved(_config) {

--- a/packages/testing-library/testing-environment/src/lynx/ElementPAPI.ts
+++ b/packages/testing-library/testing-environment/src/lynx/ElementPAPI.ts
@@ -326,14 +326,13 @@ export const initElementTree = () => {
     }
 
     __RemoveElement(parent: LynxElement, child: LynxElement) {
-      let ch = parent.firstChild;
-      while (ch) {
-        if (ch === child) {
-          parent.removeChild(ch);
-          break;
-        }
-        ch = ch.nextSibling;
+      if (child.parentNode !== parent) {
+        throw new Error(
+          `child ${child.$$uiSign} is not in parent ${parent.$$uiSign}, cannot remove it!`,
+        );
       }
+
+      child.parentNode.removeChild(child);
     }
 
     __InsertElementBefore(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@1.7.5)
+        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -794,7 +794,7 @@ importers:
         version: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
       rsbuild-plugin-i18next-extractor:
         specifier: 0.2.1
-        version: 0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
+        version: 0.2.1(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
 
   packages/lynx/autolink-codegen: {}
 
@@ -949,8 +949,8 @@ importers:
   packages/react:
     dependencies:
       preact:
-        specifier: npm:@lynx-js/internal-preact@10.29.1-20260424024911-12b794f
-        version: '@lynx-js/internal-preact@10.29.1-20260424024911-12b794f'
+        specifier: https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78
+        version: https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78
     devDependencies:
       '@lynx-js/types':
         specifier: 3.7.0
@@ -1517,10 +1517,10 @@ importers:
         version: link:../../web-platform/web-elements
       '@rsbuild/plugin-less':
         specifier: 1.6.0
-        version: 1.6.0(@rsbuild/core@1.7.5)
+        version: 1.6.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@1.7.5)
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -1535,7 +1535,7 @@ importers:
         version: 1.1.1
       rsbuild-plugin-tailwindcss:
         specifier: 0.2.4
-        version: 0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1)
+        version: 0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@4.2.1)
       rslog:
         specifier: ^1.3.2
         version: 1.3.2
@@ -1629,7 +1629,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@1.7.5)
+        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -2382,13 +2382,13 @@ importers:
         version: 7.33.6(@types/node@24.10.13)
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@1.7.5)
+        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@rsbuild/plugin-type-check':
         specifier: 1.3.4
-        version: 1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.3.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 1.2.2
-        version: 1.2.2(@rsbuild/core@1.7.5)
+        version: 1.2.2(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
       '@rspress/core':
         specifier: 2.0.3
         version: 2.0.3(@module-federation/runtime-tools@0.22.0)(@types/react@19.2.14)(core-js@3.48.0)
@@ -4025,9 +4025,6 @@ packages:
     peerDependencies:
       '@lynx-js/react': '*'
       '@lynx-js/types': '*'
-
-  '@lynx-js/internal-preact@10.29.1-20260424024911-12b794f':
-    resolution: {integrity: sha512-MQ+xjPL2f1P9/eCAdkT2h9cJRXl1qqhSJDX9GkPETt3UAepLo5N+HbGB8Qr3IUzqGDWMr3Mj76my1P0pLkKVDg==}
 
   '@lynx-js/luna-styles@0.1.0':
     resolution: {integrity: sha512-1DVx/mLmsnfdrTF1E9CWhl39/CWmR3nal38nY6QJ6sOImSC77HFDuE4Xr1g0V0hcX/8lAmTzgNwnqPEJE1a6JQ==}
@@ -10018,6 +10015,10 @@ packages:
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
+  preact@https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78:
+    resolution: {integrity: sha512-3EgVY2oNMve4oo2I5NdVWv27R/nlWVNR6PGLuAvnGZ01evJonVXHqSp8XjeLr1CoesXgRLMq+6Rv6/ZHlcBKVA==, tarball: https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78}
+    version: 10.29.1
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -13556,8 +13557,6 @@ snapshots:
       '@lynx-js/react': link:packages/react
       '@lynx-js/types': 3.7.0
 
-  '@lynx-js/internal-preact@10.29.1-20260424024911-12b794f': {}
-
   '@lynx-js/luna-styles@0.1.0': {}
 
   '@lynx-js/lynx-core@0.1.3': {}
@@ -14591,13 +14590,13 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@1.7.5)':
+  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@rsbuild/core': 1.7.5
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -14637,9 +14636,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.7.5
 
-  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@1.7.5)':
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
     dependencies:
-      '@rsbuild/core': 1.7.5
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
@@ -14668,6 +14667,15 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.97.3
 
+  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
+    dependencies:
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.5.6
+      reduce-configs: 1.1.1
+      sass-embedded: 1.97.3
+
   '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@1.7.5)':
     dependencies:
       fast-glob: 3.3.3
@@ -14675,19 +14683,6 @@ snapshots:
       yaml: 2.8.3
     optionalDependencies:
       '@rsbuild/core': 1.7.5
-
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
-    dependencies:
-      deepmerge: 4.3.1
-      json5: 2.2.3
-      reduce-configs: 1.1.1
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - tslib
-      - typescript
 
   '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
@@ -14705,6 +14700,10 @@ snapshots:
   '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@1.7.5)':
     optionalDependencies:
       '@rsbuild/core': 1.7.5
+
+  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 
   '@rsdoctor/client@1.5.6': {}
 
@@ -20519,6 +20518,8 @@ snapshots:
 
   preact@10.29.1: {}
 
+  preact@https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -21019,10 +21020,10 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260212.1
       typescript: 5.9.3
 
-  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
+  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
-      '@rsbuild/core': 1.7.5
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
       '@rspack/lite-tapable': 1.1.0
       i18next-cli: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
@@ -21042,15 +21043,15 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 
-  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1):
-    dependencies:
-      tailwindcss: 4.2.1
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
-
   rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@3.4.19):
     dependencies:
       tailwindcss: 3.4.19
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+
+  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@4.2.1):
+    dependencies:
+      tailwindcss: 4.2.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,8 +949,8 @@ importers:
   packages/react:
     dependencies:
       preact:
-        specifier: https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8
-        version: https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8
+        specifier: npm:@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c
+        version: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
     devDependencies:
       '@lynx-js/types':
         specifier: 3.7.0
@@ -4025,6 +4025,9 @@ packages:
     peerDependencies:
       '@lynx-js/react': '*'
       '@lynx-js/types': '*'
+
+  '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c':
+    resolution: {integrity: sha512-h2pRrt5oLK9LT1NkjyprtzJij/AdZGvv3CN6B5edL4chixqvITbxoCSdYy667Hl6+uKOBuxmCNZoDddgRfcLnw==}
 
   '@lynx-js/luna-styles@0.1.0':
     resolution: {integrity: sha512-1DVx/mLmsnfdrTF1E9CWhl39/CWmR3nal38nY6QJ6sOImSC77HFDuE4Xr1g0V0hcX/8lAmTzgNwnqPEJE1a6JQ==}
@@ -10015,10 +10018,6 @@ packages:
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
-  preact@https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8:
-    resolution: {tarball: https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8}
-    version: 10.29.1
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -13556,6 +13555,8 @@ snapshots:
     dependencies:
       '@lynx-js/react': link:packages/react
       '@lynx-js/types': 3.7.0
+
+  '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c': {}
 
   '@lynx-js/luna-styles@0.1.0': {}
 
@@ -20517,8 +20518,6 @@ snapshots:
       source-map-js: 1.2.1
 
   preact@10.29.1: {}
-
-  preact@https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8: {}
 
   prelude-ls@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.1.0(@rsbuild/core@1.7.5)
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
@@ -794,7 +794,7 @@ importers:
         version: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
       rsbuild-plugin-i18next-extractor:
         specifier: 0.2.1
-        version: 0.2.1(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
+        version: 0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9)
 
   packages/lynx/autolink-codegen: {}
 
@@ -1517,10 +1517,10 @@ importers:
         version: link:../../web-platform/web-elements
       '@rsbuild/plugin-less':
         specifier: 1.6.0
-        version: 1.6.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.6.0(@rsbuild/core@1.7.5)
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.5.0(@rsbuild/core@1.7.5)
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -1535,7 +1535,7 @@ importers:
         version: 1.1.1
       rsbuild-plugin-tailwindcss:
         specifier: 0.2.4
-        version: 0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@4.2.1)
+        version: 0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1)
       rslog:
         specifier: ^1.3.2
         version: 1.3.2
@@ -1629,7 +1629,7 @@ importers:
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: 1.1.0
-        version: 1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.1.0(@rsbuild/core@1.7.5)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -2382,13 +2382,13 @@ importers:
         version: 7.33.6(@types/node@24.10.13)
       '@rsbuild/plugin-sass':
         specifier: 1.5.0
-        version: 1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.5.0(@rsbuild/core@1.7.5)
       '@rsbuild/plugin-type-check':
         specifier: 1.3.4
-        version: 1.3.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
       '@rsbuild/plugin-typed-css-modules':
         specifier: 1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))
+        version: 1.2.2(@rsbuild/core@1.7.5)
       '@rspress/core':
         specifier: 2.0.3
         version: 2.0.3(@module-federation/runtime-tools@0.22.0)(@types/react@19.2.14)(core-js@3.48.0)
@@ -10016,7 +10016,7 @@ packages:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
   preact@https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78:
-    resolution: {integrity: sha512-3EgVY2oNMve4oo2I5NdVWv27R/nlWVNR6PGLuAvnGZ01evJonVXHqSp8XjeLr1CoesXgRLMq+6Rv6/ZHlcBKVA==, tarball: https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78}
+    resolution: {tarball: https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78}
     version: 10.29.1
 
   prelude-ls@1.2.1:
@@ -14590,13 +14590,13 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
+  '@rsbuild/plugin-babel@1.1.0(@rsbuild/core@1.7.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+      '@rsbuild/core': 1.7.5
       '@types/babel__core': 7.20.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
@@ -14636,9 +14636,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.7.5
 
-  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
+  '@rsbuild/plugin-less@1.6.0(@rsbuild/core@1.7.5)':
     dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+      '@rsbuild/core': 1.7.5
       deepmerge: 4.3.1
       reduce-configs: 1.1.1
 
@@ -14667,15 +14667,6 @@ snapshots:
       reduce-configs: 1.1.1
       sass-embedded: 1.97.3
 
-  '@rsbuild/plugin-sass@1.5.0(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
-    dependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.6
-      reduce-configs: 1.1.1
-      sass-embedded: 1.97.3
-
   '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@1.7.5)':
     dependencies:
       fast-glob: 3.3.3
@@ -14683,6 +14674,19 @@ snapshots:
       yaml: 2.8.3
     optionalDependencies:
       '@rsbuild/core': 1.7.5
+
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@1.7.5)(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
+    dependencies:
+      deepmerge: 4.3.1
+      json5: 2.2.3
+      reduce-configs: 1.1.1
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)
+    optionalDependencies:
+      '@rsbuild/core': 1.7.5
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - tslib
+      - typescript
 
   '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(@rspack/core@1.7.9(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
@@ -14700,10 +14704,6 @@ snapshots:
   '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@1.7.5)':
     optionalDependencies:
       '@rsbuild/core': 1.7.5
-
-  '@rsbuild/plugin-typed-css-modules@1.2.2(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))':
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 
   '@rsdoctor/client@1.5.6': {}
 
@@ -21020,10 +21020,10 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260212.1
       typescript: 5.9.3
 
-  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
+  rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@1.7.5)(i18next-cli@1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3))(rollup@4.34.9):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.34.9)
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
+      '@rsbuild/core': 1.7.5
       '@rspack/lite-tapable': 1.1.0
       i18next-cli: 1.54.2(@swc/helpers@0.5.21)(@types/node@24.10.13)(i18next@26.0.6(typescript@5.9.3))(typescript@5.9.3)
     transitivePeerDependencies:
@@ -21043,15 +21043,15 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 
+  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@1.7.5)(tailwindcss@4.2.1):
+    dependencies:
+      tailwindcss: 4.2.1
+    optionalDependencies:
+      '@rsbuild/core': 1.7.5
+
   rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@3.4.19):
     dependencies:
       tailwindcss: 3.4.19
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
-
-  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0))(tailwindcss@4.2.1):
-    dependencies:
-      tailwindcss: 4.2.1
     optionalDependencies:
       '@rsbuild/core': 2.0.0-beta.3(@module-federation/runtime-tools@0.22.0)(core-js@3.48.0)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,8 +949,8 @@ importers:
   packages/react:
     dependencies:
       preact:
-        specifier: https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78
-        version: https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78
+        specifier: https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8
+        version: https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8
     devDependencies:
       '@lynx-js/types':
         specifier: 3.7.0
@@ -10015,8 +10015,8 @@ packages:
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
-  preact@https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78:
-    resolution: {tarball: https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78}
+  preact@https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8:
+    resolution: {tarball: https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8}
     version: 10.29.1
 
   prelude-ls@1.2.1:
@@ -20518,7 +20518,7 @@ snapshots:
 
   preact@10.29.1: {}
 
-  preact@https://pkg.pr.new/lynx-family/internal-preact/preact@88ccd78: {}
+  preact@https://pkg.pr.new/lynx-family/internal-preact/preact@c2b97a8: {}
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Bumps `@lynx-js/internal-preact` to a pkg.pr.new build of [lynx-family/internal-preact#20](https://github.com/lynx-family/internal-preact/pull/20), which scopes vnode reuse in `findMatchingIndex` to the same structural slot via a new `_slotIndex` constraint.

### Why

`findMatchingIndex` previously matched by `key + type` across positions, which let a vnode in one structural slot silently re-use a vnode from a different slot.

Minimun repro:

```jsx
import { useState } from "react";

const Comp = () => {
	return <text>Comp</text>
}

export function App() {
	let [state, setState] = useState(1);

	return <page bindtap={() => setState(state === 1 ? 2 : 1)}>
		<view>
			{state === 1 ? <Comp/> : "Text"}
			<text>----</text>
			<text>{"Hello"}</text>
		</view>
	</page>
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stateful components from incorrectly reusing or swapping state across different structural slots, avoiding unexpected UI/state changes.
  * Improved validation and error reporting for invalid parent/child element operations, providing clearer, specific error messages when removals are invalid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->