### PR TITLE
fix(web-core): shadow window as globalThis instead of void 0 in MTS wrapper

### DIFF
--- a/packages/web-platform/web-core/ts/client/decodeWorker/decode.worker.ts
+++ b/packages/web-platform/web-core/ts/client/decodeWorker/decode.worker.ts
@@ -305,7 +305,7 @@ async function handleStream(
         const blobMap: Record<string, string> = {};
         for (const [key, code] of Object.entries(codeMap)) {
           const blob = new Blob([
-            '//# allFunctionsCalledOnLoad\n(function(){ "use strict"; const navigator=void 0,postMessage=void 0,window=void 0; ',
+            '//# allFunctionsCalledOnLoad\n(function(){ "use strict"; const navigator=void 0,postMessage=void 0,window=globalThis; ',
             isLazy ? 'module.exports=' : '',
             code as unknown as BlobPart,
             ' \n })()\n//# sourceURL=',
@@ -434,7 +434,7 @@ async function handleJSON(
     for (const [key, code] of Object.entries(json.lepusCode)) {
       if (typeof code !== 'string') continue;
       const prefix =
-        `//# allFunctionsCalledOnLoad\n(function(){ "use strict"; const navigator=void 0,postMessage=void 0,window=void 0; ${
+        `//# allFunctionsCalledOnLoad\n(function(){ "use strict"; const navigator=void 0,postMessage=void 0,window=globalThis; ${
           isLazy ? 'module.exports=' : ''
         } `;
       const suffix = ` \n })()\n//# sourceURL=${url}/${key}\n`;


### PR DESCRIPTION
## Problem

The MTS (main-thread script) IIFE wrapper in `decode.worker.ts` shadows `window` as `void 0`:

```js
(function(){ "use strict"; const navigator=void 0,postMessage=void 0,window=void 0; ... })()
```

This breaks third-party libraries that access `window` properties directly. For example, `framer-motion` (used by `@lynx-js/motion`) accesses `window.MotionHandoffAnimation` in its `animateTarget()` function, causing:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'MotionHandoffAnimation')
```

This error occurs on **Lynx for Web** only (the Go web preview). Native Lynx is unaffected because it doesn't use this IIFE wrapper.

## Root cause

The `const window = void 0` creates a lexical binding that cannot be overridden from within the same scope. The `@lynx-js/motion` shim correctly sets `globalThis.window`, but bare `window` resolves to the local `const` (which is `undefined`), not `globalThis.window`.

Meanwhile, `globalThis` itself is NOT shadowed, so `globalThis.window`, `globalThis.document`, etc. are already accessible from MTS code. The `window` shadowing only catches bare `window.X` usage, creating an inconsistency rather than true isolation.

## Fix

Change `window=void 0` to `window=globalThis` in the two locations where the MTS wrapper prefix is constructed. This makes bare `window` resolve to `globalThis`, which:

- On **native Lynx**: `globalThis.window` is set up by the `@lynx-js/motion` shim with polyfilled APIs (`getComputedStyle`, etc.), so `window` in MTS code has those APIs available.
- On **Lynx for Web**: `globalThis` is the iframe's `window` object, so `window` matches what browser-targeting libraries expect.

## Test plan

- [x] All 157 existing web-core tests pass
- [ ] Verify `@lynx-js/motion` examples no longer throw `MotionHandoffAnimation` error in Go web preview
- [ ] Verify existing Lynx for Web apps still work correctly

## Related

- Fixes #2695
- Context: https://github.com/lynx-family/lynx-website/pull/1024 (motion docs)

## Alternative approaches considered

1. **Motion package bundles framer-motion with `window→globalThis` replacement**: self-contained but changes the package structure significantly and is fragile with `import ... with { runtime: 'shared' }` attributes.
2. **Motion shim fixes**: impossible -- the shim runs inside the same IIFE wrapper and cannot override a `const` binding.
3. **Restricted proxy for `window`**: could shadow `window` as a proxy that allows property reads but blocks navigation/DOM mutations. More complex but provides stricter isolation if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected the runtime environment configuration to properly expose the global window object to executed code scripts. This ensures that scripts can reliably access and utilize the window object and its associated APIs, improving overall script compatibility and reducing potential runtime errors during code execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->