### PR TITLE
fix(motion): bundle deps with window→globalThis to fix Lynx for Web TypeError

### DIFF
--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -16,8 +16,8 @@
   },
   "license": "Apache-2.0",
   "sideEffects": [
-    "./dist/polyfill/shim.js",
-    "./dist/mini/polyfill.js"
+    "./dist/index.js",
+    "./dist/mini/index.js"
   ],
   "type": "module",
   "exports": {

--- a/packages/motion/rslib.config.ts
+++ b/packages/motion/rslib.config.ts
@@ -7,11 +7,47 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2022',
       dts: true,
-      bundle: false,
+      bundle: true,
+      autoExternal: false,
     },
   ],
   source: {
     tsconfigPath: './tsconfig.build.json',
+    entry: {
+      index: './src/index.ts',
+      'mini/index': './src/mini/index.ts',
+    },
+    define: {
+      // Replace bare `window` with `globalThis` so motion-dom/framer-motion code
+      // works inside web-core's MTS IIFE wrapper (which shadows window = void 0).
+      // On native Lynx, the shim populates globalThis with the needed APIs.
+      'window': 'globalThis',
+      // Preserve Lynx build-time constants for the consumer's bundler to define.
+      '__MAIN_THREAD__': '__MAIN_THREAD__',
+      '__DEV__': '__DEV__',
+      '__BACKGROUND__': '__BACKGROUND__',
+    },
+  },
+  output: {
+    externals: [
+      '@lynx-js/react',
+      '@lynx-js/types',
+      /^@lynx-js\//,
+    ],
+  },
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            // The shim is imported for side effects only (no exports).
+            // Without this, the bundler tree-shakes it away.
+            test: /polyfill[\\/]shim/,
+            sideEffects: true,
+          },
+        ],
+      },
+    },
   },
   plugins: [pluginPublint()],
   performance: {

--- a/packages/motion/src/animation/index.ts
+++ b/packages/motion/src/animation/index.ts
@@ -8,7 +8,7 @@ import {
   clamp as clamp_,
   progress as progress_,
   stagger as stagger_,
-} from 'framer-motion/dom' with { runtime: 'shared' };
+} from 'framer-motion/dom';
 import type {
   AnimationSequence,
   ObjectTarget,
@@ -21,7 +21,7 @@ import {
   spring as spring_,
   styleEffect as styleEffect_,
   transformValue as transformValue_,
-} from 'motion-dom' with { runtime: 'shared' };
+} from 'motion-dom';
 import type {
   AnimationOptions,
   AnimationPlaybackControlsWithThen,
@@ -39,7 +39,7 @@ import type {
 } from 'motion-dom';
 
 import { useMotionValueRefEvent } from '../hooks/useMotionEvent.js';
-import { motionValue as motionValue_ } from '../polyfill/MotionValue.js' with { runtime: 'shared' };
+import { motionValue as motionValue_ } from '../polyfill/MotionValue.js';
 import type { ElementOrElements } from '../types/index.js';
 import { elementOrSelector2Dom } from '../utils/elementHelper.js';
 import { noopMT } from '../utils/noop.js';

--- a/packages/motion/src/utils/elementHelper.ts
+++ b/packages/motion/src/utils/elementHelper.ts
@@ -9,7 +9,7 @@ import {
   isMainThreadElement,
   isMainThreadElementArray,
 } from './isMainThreadElement.js';
-import { ElementCompt } from '../polyfill/element.js' with { runtime: 'shared' };
+import { ElementCompt } from '../polyfill/element.js';
 import type { ElementOrElements } from '../types/index.js';
 
 export function elementOrSelector2Dom(


### PR DESCRIPTION
## Summary

`motion-dom` accesses `window.MotionHandoffAnimation` (and ~29 other bare `window` accesses) without a `typeof window` guard. On Lynx for Web, web-core's MTS IIFE wrapper declares `const window = void 0`, shadowing the real window object. This causes a `TypeError: Cannot read properties of undefined (reading 'MotionHandoffAnimation')` when `animate()` is called.

### Root cause

The crash path: `motion.animate()` → `framer-motion.animateSubject()` → `motion-dom.animateTarget()` → `window.MotionHandoffAnimation` (line 62 of `visual-element-target.mjs`).

The `window` identifier resolves to `void 0` (the IIFE-local `const`), not the iframe's real window, so any property access on it throws TypeError.

### Fix

This PR changes the build configuration to bundle `framer-motion`/`motion-dom`/`motion-utils` into `@lynx-js/motion`'s output and replaces bare `window` identifiers with `globalThis` at build time.

`globalThis` works correctly in both Lynx environments:
- **Native Lynx**: The shim creates `globalThis.window`, `globalThis.getComputedStyle`, etc. Since there's no IIFE shadow, `globalThis` reaches the shim-provided APIs.
- **Lynx for Web**: `globalThis` IS the iframe's real window object (not affected by `const window = void 0`).

### Changes

| File | Change |
|------|--------|
| `rslib.config.ts` | `bundle: true`, `autoExternal: false`, `window→globalThis` define, preserve `__MAIN_THREAD__`/`__DEV__`/`__BACKGROUND__` constants |
| `src/animation/index.ts` | Remove `with { runtime: 'shared' }` import attributes (incompatible with rslib bundling) |
| `src/utils/elementHelper.ts` | Remove `with { runtime: 'shared' }` import attribute |
| `package.json` | Update `sideEffects` paths for bundled output |

### Verification

After build, the output contains:
- ✅ Zero bare `window` accesses (replaced with `globalThis`)
- ✅ `globalThis.MotionHandoffAnimation` instead of crashing `window.MotionHandoffAnimation`
- ✅ Shim code preserved (`shimGlobals`, `shimQueueMicroTask`, `__MAIN_THREAD__` guard)
- ✅ Lynx build constants (`__MAIN_THREAD__`, `__DEV__`, `__BACKGROUND__`) preserved for consumer's bundler

### Notes

- **Import attributes**: The `with { runtime: 'shared' }` attributes were removed because rslib cannot parse them during bundling. Since framer-motion/motion-dom are now bundled into the output, the consumer's Lynx bundler handles threading context at the `@lynx-js/motion` module level instead.
- **Bundle size**: Output is ~229KB total (vs individual modules before). The consumer's bundler still tree-shakes unused exports.
- **Types**: `.d.ts` files still reference `motion-dom`/`framer-motion/dom`, so these remain as `dependencies` for TypeScript resolution.

### Related

- Upstream issue: https://github.com/motiondivision/motion/issues/3735
- Web-core complementary fix: #2696
- Web-core issue: #2695

## Test plan

- [ ] Verify `pnpm build` succeeds in `packages/motion`
- [ ] Verify no bare `window` in output: `grep -r '\bwindow\b' dist/ --include='*.js'`
- [ ] Verify shim preserved: `grep '__MAIN_THREAD__\|shimGlobals' dist/index.js`
- [ ] Test `animate()` on Lynx for Web (no TypeError)
- [ ] Test animation on native Lynx (shim still works correctly)
- [ ] Verify `with { runtime: 'shared' }` removal doesn't break dual-thread context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and module imports for optimization and consistency.

---

**Note:** This release contains internal build and configuration improvements with no direct user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->