### PR TITLE
ci: publish pkg.pr.new previews for fork PRs too

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -126,14 +126,16 @@ jobs:
           overwrite: true
           include-hidden-files: true
       # Publish PR previews to pkg.pr.new. Only runs on the Ubuntu leg of the
-      # build matrix, only for same-repo pull_request events (fork-controlled
-      # install scripts shouldn't run with this job's privileges), and only
-      # when the PR adds a changeset that actually bumps a publishable package.
+      # build matrix, and only when the PR adds a changeset that actually
+      # bumps a publishable package. Fork PRs are included: this is a
+      # `pull_request` (not `pull_request_target`) workflow, so fork runs use
+      # a read-only token with no base-repo secrets, and are gated by the
+      # repo's required-approval setting — the same trust boundary the Build
+      # step above (which already runs fork install/build scripts) relies on.
       - name: Fetch base ref for changeset status
         if: >
           matrix.runs-on.label == 'lynx-ubuntu-24.04-xlarge' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
         # actions/checkout uses depth=1, so neither `origin/<base>` nor the
@@ -156,8 +158,7 @@ jobs:
         id: changeset
         if: >
           matrix.runs-on.label == 'lynx-ubuntu-24.04-xlarge' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |


### PR DESCRIPTION
## Summary

`pkg.pr.new` preview publishing was gated to same-repo PRs via `github.event.pull_request.head.repo.full_name == github.repository`, so fork contributors never got preview packages.

This drops that condition. The change is safe because:

- The job runs in `workflow-build.yml`, called from `test.yml` on **`pull_request`** (not `pull_request_target`). Fork runs therefore use a **read-only `GITHUB_TOKEN` with no access to base-repo secrets**.
- Fork PR workflow runs are gated by the repo's **required-approval** setting, so a maintainer approves before anything runs.
- The **Build** step above already runs fork-controlled `pnpm install` / `pnpm build` scripts under the same trust boundary — this adds no new code-execution surface.
- The **changeset gate stays**: previews publish only when a changeset actually bumps a publishable package.

## Note

This relies on the repo having "Require approval for all external contributors" (Settings → Actions → Fork pull request workflows) enabled. Please confirm that is on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow to enhance support for pull requests from forked repositories, enabling better preview publishing capabilities for all contribution types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->