### PR TITLE
feat(react): support ET GlobalProps

### DIFF
--- a/packages/react/runtime/__test__/core/forceRootRender.test.ts
+++ b/packages/react/runtime/__test__/core/forceRootRender.test.ts
@@ -9,10 +9,15 @@ import { runWithForceRootRender } from '../../src/core/forceRootRender.js';
 import { COMPONENT, DIFF2, FORCE, ORIGINAL } from '../../src/shared/render-constants.js';
 
 const mutablePreactOptions = preactOptions as typeof preactOptions & Record<string, any>;
+const initialDiff2 = mutablePreactOptions[DIFF2];
 
 describe('core/forceRootRender', () => {
   afterEach(() => {
-    delete mutablePreactOptions[DIFF2];
+    if (typeof initialDiff2 === 'undefined') {
+      delete mutablePreactOptions[DIFF2];
+    } else {
+      mutablePreactOptions[DIFF2] = initialDiff2;
+    }
     vi.restoreAllMocks();
   });
 
@@ -55,6 +60,6 @@ describe('core/forceRootRender', () => {
     ).toThrow(error);
 
     expect(setRootVNode).not.toHaveBeenCalled();
-    expect(mutablePreactOptions[DIFF2]).toBeUndefined();
+    expect(mutablePreactOptions[DIFF2]).toBe(initialDiff2);
   });
 });

--- a/packages/react/runtime/__test__/core/forceRootRender.test.ts
+++ b/packages/react/runtime/__test__/core/forceRootRender.test.ts
@@ -1,0 +1,60 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { options as preactOptions } from 'preact';
+import type { VNode } from 'preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runWithForceRootRender } from '../../src/core/forceRootRender.js';
+import { COMPONENT, DIFF2, FORCE, ORIGINAL } from '../../src/shared/render-constants.js';
+
+const mutablePreactOptions = preactOptions as typeof preactOptions & Record<string, any>;
+
+describe('core/forceRootRender', () => {
+  afterEach(() => {
+    delete mutablePreactOptions[DIFF2];
+    vi.restoreAllMocks();
+  });
+
+  it('bumps root vnode identity and marks existing components as forced', () => {
+    const oldDiff = vi.fn();
+    mutablePreactOptions[DIFF2] = oldDiff;
+    const component = {};
+    const rootVNode = { [ORIGINAL]: 1 } as VNode;
+    const setRootVNode = vi.fn();
+
+    runWithForceRootRender({
+      getRootVNode: () => rootVNode,
+      setRootVNode,
+      render: () => {
+        mutablePreactOptions[DIFF2]({} as VNode, { [COMPONENT]: component } as VNode);
+      },
+    });
+
+    expect(setRootVNode).toHaveBeenCalledTimes(1);
+    expect(setRootVNode.mock.calls[0]![0]).not.toBe(rootVNode);
+    expect(setRootVNode.mock.calls[0]![0][ORIGINAL]).toBe(2);
+    expect(oldDiff).toHaveBeenCalledTimes(1);
+    expect(component[FORCE]).toBe(true);
+    expect(mutablePreactOptions[DIFF2]).toBe(oldDiff);
+  });
+
+  it('handles mount-phase vnodes and restores diff hook after render throws', () => {
+    const setRootVNode = vi.fn();
+    const error = new Error('render failed');
+
+    expect(() =>
+      runWithForceRootRender({
+        getRootVNode: () => undefined,
+        setRootVNode,
+        render: () => {
+          mutablePreactOptions[DIFF2]({} as VNode, {} as VNode);
+          throw error;
+        },
+      })
+    ).toThrow(error);
+
+    expect(setRootVNode).not.toHaveBeenCalled();
+    expect(mutablePreactOptions[DIFF2]).toBeUndefined();
+  });
+});

--- a/packages/react/runtime/__test__/core/globalProps.test.ts
+++ b/packages/react/runtime/__test__/core/globalProps.test.ts
@@ -1,0 +1,141 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { createContext } from 'preact';
+import { createElement } from 'preact/compat';
+import { useState } from 'preact/hooks';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createGlobalProps, isGlobalPropsEventMode, updateGlobalProps } from '../../src/core/globalProps.js';
+import type { useLynxGlobalEventListener } from '../../src/core/hooks/useLynxGlobalEventListener.js';
+import { LynxTestEventEmitter } from '../test-utils/lynx-event-emitter.js';
+
+describe('core/globalProps', () => {
+  let originalGlobalProps: typeof lynx.__globalProps;
+  let originalEmitter: typeof lynxCoreInject.tt.GlobalEventEmitter;
+  let emitter: LynxTestEventEmitter;
+
+  beforeEach(() => {
+    originalGlobalProps = lynx.__globalProps;
+    originalEmitter = lynxCoreInject.tt.GlobalEventEmitter;
+    emitter = new LynxTestEventEmitter();
+    lynx.__globalProps = {};
+    lynxCoreInject.tt.GlobalEventEmitter = emitter as typeof lynxCoreInject.tt.GlobalEventEmitter;
+  });
+
+  afterEach(() => {
+    lynx.__globalProps = originalGlobalProps;
+    lynxCoreInject.tt.GlobalEventEmitter = originalEmitter;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function createDeps(useListener: typeof useLynxGlobalEventListener) {
+    return {
+      createContext,
+      useState,
+      createElement,
+      useLynxGlobalEventListener: useListener,
+    };
+  }
+
+  it('creates the reactive fallback shell with warning and changed listener support', () => {
+    vi.stubGlobal('__GLOBAL_PROPS_MODE__', 'reactive');
+    vi.stubGlobal('__LEPUS__', false);
+    vi.stubGlobal('__DEV__', true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const useListener = vi.fn() as unknown as typeof useLynxGlobalEventListener;
+    lynx.__globalProps = { theme: 'dark' };
+
+    const globalProps = createGlobalProps<{ theme: string }>(createDeps(useListener));
+    const callback = vi.fn();
+
+    expect((globalProps.Provider() as any)({ children: 'child' })).toBe('child');
+    expect((globalProps.Consumer() as any)({ children: (data: { theme: string }) => data.theme })).toBe('dark');
+    expect(globalProps.use()()).toEqual({ theme: 'dark' });
+    globalProps.useChanged()(callback);
+
+    expect(warn).toHaveBeenCalledTimes(3);
+    expect(useListener).toHaveBeenCalledWith('onGlobalPropsChanged', callback);
+  });
+
+  it('keeps the fallback shell quiet and listener-free on lepus', () => {
+    vi.stubGlobal('__GLOBAL_PROPS_MODE__', 'reactive');
+    vi.stubGlobal('__LEPUS__', true);
+    vi.stubGlobal('__DEV__', true);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const useListener = vi.fn() as unknown as typeof useLynxGlobalEventListener;
+
+    const globalProps = createGlobalProps(createDeps(useListener));
+    globalProps.use()();
+    globalProps.useChanged()(vi.fn());
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(useListener).not.toHaveBeenCalled();
+  });
+
+  it('creates the event-mode shell through the shared InitData factory', () => {
+    vi.stubGlobal('__GLOBAL_PROPS_MODE__', 'event');
+    const useListener = vi.fn() as unknown as typeof useLynxGlobalEventListener;
+
+    const globalProps = createGlobalProps(createDeps(useListener));
+
+    expect(isGlobalPropsEventMode()).toBe(true);
+    expect(globalProps.Provider()).toBeTypeOf('function');
+    expect(globalProps.Consumer()).toBeTypeOf('function');
+    expect(globalProps.use()).toBeTypeOf('function');
+    expect(globalProps.useChanged()).toBeTypeOf('function');
+  });
+
+  it('treats missing mode as reactive mode', () => {
+    vi.stubGlobal('__GLOBAL_PROPS_MODE__', undefined);
+
+    expect(isGlobalPropsEventMode()).toBe(false);
+  });
+
+  it('mutates globalProps in reactive mode, emits current data, and queues force render', async () => {
+    vi.stubGlobal('__GLOBAL_PROPS_MODE__', 'reactive');
+    const listener = vi.fn();
+    const forceRerender = vi.fn();
+    const previousGlobalProps = { theme: 'dark', stable: true };
+    lynx.__globalProps = previousGlobalProps;
+    emitter.addListener('onGlobalPropsChanged', listener);
+
+    updateGlobalProps({ theme: 'light', next: 1 }, { forceRerender });
+
+    expect(lynx.__globalProps).toBe(previousGlobalProps);
+    expect(lynx.__globalProps).toEqual({ theme: 'light', stable: true, next: 1 });
+    expect(listener).toHaveBeenCalledWith(lynx.__globalProps);
+    expect(forceRerender).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+
+    expect(forceRerender).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows reactive updates without a force callback', async () => {
+    vi.stubGlobal('__GLOBAL_PROPS_MODE__', 'reactive');
+    lynx.__globalProps = { theme: 'dark' };
+
+    expect(() => updateGlobalProps({ theme: 'light' })).not.toThrow();
+    await Promise.resolve();
+    expect(lynx.__globalProps).toEqual({ theme: 'light' });
+  });
+
+  it('COW merges globalProps in event mode and skips force render', async () => {
+    vi.stubGlobal('__GLOBAL_PROPS_MODE__', 'event');
+    const listener = vi.fn();
+    const forceRerender = vi.fn();
+    const previousGlobalProps = { theme: 'dark', stable: true };
+    lynx.__globalProps = previousGlobalProps;
+    emitter.addListener('onGlobalPropsChanged', listener);
+
+    updateGlobalProps({ theme: 'light', next: 1 }, { forceRerender });
+    await Promise.resolve();
+
+    expect(lynx.__globalProps).not.toBe(previousGlobalProps);
+    expect(lynx.__globalProps).toEqual({ theme: 'light', stable: true, next: 1 });
+    expect(listener).toHaveBeenCalledWith(lynx.__globalProps);
+    expect(forceRerender).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/runtime/__test__/element-template/fixtures/background/global-props/direct-read/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/global-props/direct-read/index.tsx
@@ -1,0 +1,7 @@
+export function App(): JSX.Element {
+  return (
+    <view>
+      <text>{lynx.__globalProps.theme}</text>
+    </view>
+  );
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/background/global-props/event-hook/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/global-props/event-hook/index.tsx
@@ -1,0 +1,34 @@
+import {
+  GlobalPropsConsumer,
+  GlobalPropsProvider,
+  useGlobalProps,
+  useGlobalPropsChanged,
+} from '@lynx-js/react/element-template';
+import type { GlobalProps } from '@lynx-js/react/element-template';
+
+interface ThemeGlobalProps extends GlobalProps {
+  theme?: string;
+}
+
+interface AppProps {
+  onChanged?: (data: ThemeGlobalProps) => void;
+}
+
+export function App({ onChanged }: AppProps): JSX.Element {
+  const globalProps = useGlobalProps() as ThemeGlobalProps;
+  useGlobalPropsChanged(data => {
+    onChanged?.(data as ThemeGlobalProps);
+  });
+
+  return (
+    <GlobalPropsProvider>
+      <GlobalPropsConsumer>
+        {provided => (
+          <view>
+            <text>{`${globalProps.theme}:${(provided as ThemeGlobalProps).theme}`}</text>
+          </view>
+        )}
+      </GlobalPropsConsumer>
+    </GlobalPropsProvider>
+  );
+}

--- a/packages/react/runtime/__test__/element-template/imports/global-props-api.test.ts
+++ b/packages/react/runtime/__test__/element-template/imports/global-props-api.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GlobalPropsConsumer,
+  GlobalPropsProvider,
+  useGlobalProps,
+  useGlobalPropsChanged,
+  useLynxGlobalEventListener,
+} from '@lynx-js/react/element-template';
+import type { GlobalProps } from '@lynx-js/react/element-template';
+
+describe('element-template GlobalProps entry', () => {
+  it('exposes GlobalProps APIs from the public ET alias', () => {
+    const globalProps: GlobalProps = {};
+
+    expect(globalProps).toEqual({});
+    expect(GlobalPropsProvider).toBeTruthy();
+    expect(GlobalPropsConsumer).toBeTruthy();
+    expect(useGlobalProps).toEqual(expect.any(Function));
+    expect(useGlobalPropsChanged).toEqual(expect.any(Function));
+    expect(useLynxGlobalEventListener).toEqual(expect.any(Function));
+  });
+});

--- a/packages/react/runtime/__test__/element-template/native/index.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/index.test.ts
@@ -32,6 +32,7 @@ describe('element-template native index wiring', () => {
     vi.doUnmock('../../../src/element-template/lynx/env.js');
     vi.doUnmock('../../../src/element-template/lynx/performance.js');
     vi.doUnmock('../../../src/core/lynx-update-data.js');
+    vi.doUnmock('../../../src/core/globalProps.js');
     vi.doUnmock('../../../src/element-template/runtime/page/root-instance.js');
   });
 
@@ -128,6 +129,7 @@ describe('element-template native index wiring', () => {
     const publicComponentEvent = vi.fn();
     const resetEventStateForRuntime = vi.fn();
     const updateCardData = vi.fn();
+    const updateGlobalProps = vi.fn();
     const reloadBackground = vi.fn();
 
     vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
@@ -159,6 +161,9 @@ describe('element-template native index wiring', () => {
     }));
     vi.doMock('../../../src/core/lynx-update-data.js', () => ({
       updateCardData,
+    }));
+    vi.doMock('../../../src/core/globalProps.js', () => ({
+      updateGlobalProps,
     }));
     vi.doMock('../../../src/element-template/runtime/page/root-instance.js', () => ({
       setRoot,
@@ -193,8 +198,15 @@ describe('element-template native index wiring', () => {
     expect(globalThis.lynxCoreInject.tt.callDestroyLifetimeFun).toBe(callDestroyLifetimeFun);
     expect(globalThis.lynxCoreInject.tt.publishEvent).toBe(publishEvent);
     expect(globalThis.lynxCoreInject.tt.publicComponentEvent).toBe(publicComponentEvent);
+    expect(globalThis.lynxCoreInject.tt.updateGlobalProps).toEqual(expect.any(Function));
     expect(globalThis.lynxCoreInject.tt.updateCardData).toBe(updateCardData);
     expect(globalThis.lynxCoreInject.tt.onAppReload).toBe(reloadBackground);
+
+    globalThis.lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+    expect(updateGlobalProps).toHaveBeenCalledWith(
+      { theme: 'light' },
+      { forceRerender: expect.any(Function) },
+    );
 
     expect(injectCalledByNative).not.toHaveBeenCalled();
     expect(installElementTemplatePatchListener).not.toHaveBeenCalled();

--- a/packages/react/runtime/__test__/element-template/native/main-thread-api.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/main-thread-api.test.ts
@@ -62,6 +62,46 @@ describe('injectCalledByNative', () => {
     expect(() => globalAny.removeComponents()).not.toThrow();
   });
 
+  it('flushes updateGlobalProps with the current page when options exist', () => {
+    injectCalledByNative();
+    const globalAny = globalThis as typeof globalThis & {
+      renderPage: (data?: Record<string, unknown>) => void;
+      updateGlobalProps: (data?: Record<string, unknown>, options?: UpdatePageOption) => void;
+    };
+    const page = { type: 'page', id: '0', children: [] };
+    vi.mocked(createElementTemplatePage).mockReturnValue(page as unknown as ElementRef);
+    globalThis.lynx.__globalProps = { theme: 'dark' };
+
+    globalAny.renderPage({ msg: 'init' });
+    vi.mocked(__FlushElementTree).mockClear();
+    vi.mocked(renderMainThread).mockClear();
+    const options = { pipelineOptions: { pipelineID: 'global-props' } };
+
+    globalAny.updateGlobalProps({ theme: 'light' }, options);
+
+    expect(__FlushElementTree).toHaveBeenCalledWith(page, options);
+    expect(globalThis.lynx.__globalProps).toEqual({ theme: 'dark' });
+    expect(globalThis.lynx.__initData).toEqual({ msg: 'init' });
+    expect(vi.mocked(renderMainThread)).not.toHaveBeenCalled();
+    expect(vi.mocked(reloadMainThread)).not.toHaveBeenCalled();
+  });
+
+  it('flushes updateGlobalProps without page or options when options are absent', () => {
+    injectCalledByNative();
+    const globalAny = globalThis as typeof globalThis & {
+      updateGlobalProps: (data?: Record<string, unknown>, options?: UpdatePageOption) => void;
+    };
+    globalThis.lynx.__globalProps = { theme: 'dark' };
+    vi.mocked(__FlushElementTree).mockClear();
+
+    globalAny.updateGlobalProps({ theme: 'light' });
+
+    expect(__FlushElementTree).toHaveBeenCalledWith();
+    expect(globalThis.lynx.__globalProps).toEqual({ theme: 'dark' });
+    expect(vi.mocked(renderMainThread)).not.toHaveBeenCalled();
+    expect(vi.mocked(reloadMainThread)).not.toHaveBeenCalled();
+  });
+
   it('wires renderPage through initData, setupPage and renderMainThread', () => {
     injectCalledByNative();
     const globalAny = globalThis as typeof globalThis & {

--- a/packages/react/runtime/__test__/element-template/runtime/background/global-props.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/global-props.test.tsx
@@ -1,0 +1,170 @@
+import { createElement } from 'preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LynxTestEventEmitter } from '../../../test-utils/lynx-event-emitter.js';
+
+type UpdateEvent = {
+  ops: unknown[];
+  flushOptions: Record<string, unknown>;
+};
+
+function waitForRender(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function setupGlobalPropsRuntime(mode: 'reactive' | 'event') {
+  vi.resetModules();
+  vi.stubGlobal('__GLOBAL_PROPS_MODE__', mode);
+
+  const { ElementTemplateEnvManager } = await import('../../test-utils/debug/envManager.js');
+  const { ElementTemplateLifecycleConstant } = await import(
+    '../../../../src/element-template/protocol/lifecycle-constant.js'
+  );
+  const { markElementTemplateHydrated, resetElementTemplateCommitState } = await import(
+    '../../../../src/element-template/background/commit-hook.js'
+  );
+  const { resetElementTemplateHydrationListener } = await import(
+    '../../../../src/element-template/background/hydration-listener.js'
+  );
+  const { clearEtAttrPlanMap } = await import(
+    '../../../../src/element-template/runtime/template/attr-slot-plan.js'
+  );
+
+  const envManager = new ElementTemplateEnvManager();
+  const emitter = new LynxTestEventEmitter();
+  const updateEvents: UpdateEvent[] = [];
+  const onUpdate = (event: { data: unknown }) => {
+    updateEvents.push(event.data as UpdateEvent);
+  };
+
+  resetElementTemplateCommitState();
+  clearEtAttrPlanMap();
+  envManager.resetEnv('background');
+  envManager.setUseElementTemplate(true);
+
+  const baseLynx = globalThis.lynx;
+  vi.stubGlobal('lynx', {
+    ...baseLynx,
+    __globalProps: { theme: 'dark', stable: true },
+    getJSModule(moduleName: string) {
+      if (moduleName === 'GlobalEventEmitter') {
+        return emitter;
+      }
+      return baseLynx.getJSModule?.(moduleName);
+    },
+  });
+  globalThis.lynxCoreInject.tt.GlobalEventEmitter = emitter as typeof lynxCoreInject.tt.GlobalEventEmitter;
+
+  const et = await import('../../../../src/element-template/index.js');
+
+  envManager.switchToMainThread();
+  lynx.getJSContext().addEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+  envManager.switchToBackground();
+  markElementTemplateHydrated();
+
+  return {
+    ...et,
+    emitter,
+    envManager,
+    updateEvents,
+    cleanup() {
+      envManager.switchToMainThread();
+      lynx.getJSContext().removeEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+      envManager.switchToBackground();
+      resetElementTemplateHydrationListener();
+      resetElementTemplateCommitState();
+    },
+  };
+}
+
+describe('ElementTemplate background GlobalProps', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reactive updateGlobalProps force-renders direct globalProps reads', async () => {
+    const runtime = await setupGlobalPropsRuntime('reactive');
+    const emitted = vi.fn();
+    const renderedThemes: unknown[] = [];
+
+    try {
+      runtime.emitter.addListener('onGlobalPropsChanged', emitted);
+
+      function App() {
+        renderedThemes.push(lynx.__globalProps.theme);
+        return createElement('text', null, lynx.__globalProps.theme);
+      }
+
+      runtime.root.render(createElement(App));
+      runtime.updateEvents.length = 0;
+
+      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      await waitForRender();
+
+      expect(lynx.__globalProps).toEqual({ theme: 'light', stable: true });
+      expect(renderedThemes).toEqual(['dark', 'light']);
+      expect(emitted).toHaveBeenCalledWith(lynx.__globalProps);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
+  it('event mode emits without force-rendering direct globalProps reads', async () => {
+    const runtime = await setupGlobalPropsRuntime('event');
+    const emitted = vi.fn();
+    const renderedThemes: unknown[] = [];
+
+    try {
+      runtime.emitter.addListener('onGlobalPropsChanged', emitted);
+
+      function App() {
+        renderedThemes.push(lynx.__globalProps.theme);
+        return createElement('text', null, lynx.__globalProps.theme);
+      }
+
+      runtime.root.render(createElement(App));
+      runtime.updateEvents.length = 0;
+
+      const previousGlobalProps = lynx.__globalProps;
+      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      await waitForRender();
+
+      expect(lynx.__globalProps).not.toBe(previousGlobalProps);
+      expect(lynx.__globalProps).toEqual({ theme: 'light', stable: true });
+      expect(renderedThemes).toEqual(['dark']);
+      expect(emitted).toHaveBeenCalledWith(lynx.__globalProps);
+
+      runtime.envManager.switchToMainThread();
+      expect(runtime.updateEvents).toEqual([]);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
+  it('event mode updates GlobalProps hook users through the changed event', async () => {
+    const runtime = await setupGlobalPropsRuntime('event');
+    const changed = vi.fn();
+    const renderedThemes: unknown[] = [];
+
+    try {
+      function App() {
+        const globalProps = runtime.useGlobalProps();
+        runtime.useGlobalPropsChanged(changed);
+        renderedThemes.push(globalProps.theme);
+        return createElement('text', null, globalProps.theme);
+      }
+
+      runtime.root.render(createElement(App));
+      runtime.updateEvents.length = 0;
+
+      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      await waitForRender();
+
+      expect(changed).toHaveBeenCalledWith(lynx.__globalProps);
+      expect(renderedThemes).toEqual(['dark', 'light']);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/background/global-props.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/global-props.test.tsx
@@ -43,6 +43,7 @@ async function setupGlobalPropsRuntime(mode: 'reactive' | 'event') {
   envManager.setUseElementTemplate(true);
 
   const baseLynx = globalThis.lynx;
+  const originalGlobalEventEmitter = globalThis.lynxCoreInject.tt.GlobalEventEmitter;
   vi.stubGlobal('lynx', {
     ...baseLynx,
     __globalProps: { theme: 'dark', stable: true },
@@ -73,6 +74,7 @@ async function setupGlobalPropsRuntime(mode: 'reactive' | 'event') {
       envManager.switchToBackground();
       resetElementTemplateHydrationListener();
       resetElementTemplateCommitState();
+      globalThis.lynxCoreInject.tt.GlobalEventEmitter = originalGlobalEventEmitter;
     },
   };
 }

--- a/packages/react/runtime/__test__/element-template/runtime/background/global-props/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/global-props/compiled-fixtures.test.tsx
@@ -69,6 +69,7 @@ async function settleInitialHydration(envManager: InstanceType<typeof ElementTem
 describe('Compiled ET GlobalProps update fixtures', () => {
   const envManager = new ElementTemplateEnvManager();
   let originalLynx: typeof lynx;
+  let originalGlobalEventEmitter: typeof lynxCoreInject.tt.GlobalEventEmitter;
   let emitter: InstanceType<typeof LynxTestEventEmitter>;
   let updateEvents: ElementTemplateUpdateCommitContext[] = [];
 
@@ -109,6 +110,7 @@ describe('Compiled ET GlobalProps update fixtures', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     originalLynx = globalThis.lynx;
+    originalGlobalEventEmitter = globalThis.lynxCoreInject.tt.GlobalEventEmitter;
     emitter = new LynxTestEventEmitter();
     updateEvents = [];
     resetElementTemplateCommitState();
@@ -135,6 +137,7 @@ describe('Compiled ET GlobalProps update fixtures', () => {
     resetElementTemplateCommitState();
     envManager.setUseElementTemplate(false);
     globalThis.__GLOBAL_PROPS_MODE__ = 'event';
+    globalThis.lynxCoreInject.tt.GlobalEventEmitter = originalGlobalEventEmitter;
     vi.stubGlobal('lynx', originalLynx);
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/background/global-props/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/global-props/compiled-fixtures.test.tsx
@@ -1,0 +1,219 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ElementTemplateUpdateCommitContext } from '../../../../../src/element-template/protocol/types.js';
+import type { CompiledFixtureModuleExports } from '../../../test-utils/debug/compiledFixtureModule.js';
+
+globalThis.__GLOBAL_PROPS_MODE__ = 'event';
+
+const [
+  { installElementTemplateCommitHook, resetElementTemplateCommitState },
+  { installElementTemplateHydrationListener, resetElementTemplateHydrationListener },
+  { installElementTemplatePatchListener, resetElementTemplatePatchListener },
+  { injectCalledByNative },
+  { ElementTemplateLifecycleConstant },
+  pageModule,
+  { clearEtAttrPlanMap },
+  { LynxTestEventEmitter },
+  { loadCompiledFixturePair },
+  { ElementTemplateEnvManager },
+  { serializeToJSX },
+  { createElement },
+  { root },
+] = await Promise.all([
+  import('../../../../../src/element-template/background/commit-hook.js'),
+  import('../../../../../src/element-template/background/hydration-listener.js'),
+  import('../../../../../src/element-template/native/patch-listener.js'),
+  import('../../../../../src/element-template/native/main-thread-api.js'),
+  import('../../../../../src/element-template/protocol/lifecycle-constant.js'),
+  import('../../../../../src/element-template/runtime/page/page.js'),
+  import('../../../../../src/element-template/runtime/template/attr-slot-plan.js'),
+  import('../../../../test-utils/lynx-event-emitter.js'),
+  import('../../../test-utils/debug/compiledFixtureModule.js'),
+  import('../../../test-utils/debug/envManager.js'),
+  import('../../../test-utils/debug/serializer.js'),
+  import('preact'),
+  import('../../../../../src/element-template/index.js'),
+]);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DIRECT_READ_FIXTURE = path.resolve(
+  __dirname,
+  '../../../fixtures/background/global-props/direct-read/index.tsx',
+);
+const EVENT_HOOK_FIXTURE = path.resolve(
+  __dirname,
+  '../../../fixtures/background/global-props/event-hook/index.tsx',
+);
+
+interface GlobalPropsFixtureProps {
+  onChanged?: (data: { theme?: string }) => void;
+}
+
+interface CompiledGlobalPropsModule extends CompiledFixtureModuleExports {
+  App: (props?: GlobalPropsFixtureProps) => JSX.Element;
+}
+
+function waitForRender(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function settleInitialHydration(envManager: InstanceType<typeof ElementTemplateEnvManager>): Promise<void> {
+  await waitForRender();
+  envManager.switchToMainThread();
+  envManager.switchToBackground();
+  await waitForRender();
+}
+
+describe('Compiled ET GlobalProps update fixtures', () => {
+  const envManager = new ElementTemplateEnvManager();
+  let originalLynx: typeof lynx;
+  let emitter: InstanceType<typeof LynxTestEventEmitter>;
+  let updateEvents: ElementTemplateUpdateCommitContext[] = [];
+
+  const onUpdate = (event: { data: unknown }) => {
+    updateEvents.push(event.data as ElementTemplateUpdateCommitContext);
+  };
+
+  function installGlobalProps(globalProps: Record<string, unknown>): void {
+    const baseLynx = globalThis.lynx;
+    vi.stubGlobal('lynx', {
+      ...baseLynx,
+      __globalProps: globalProps,
+      getJSModule(moduleName: string) {
+        if (moduleName === 'GlobalEventEmitter') {
+          return emitter;
+        }
+        return baseLynx.getJSModule?.(moduleName);
+      },
+    });
+    globalThis.lynxCoreInject.tt.GlobalEventEmitter = emitter as typeof lynxCoreInject.tt.GlobalEventEmitter;
+  }
+
+  function renderFixtureOnBackground(
+    moduleExports: CompiledGlobalPropsModule,
+    props?: GlobalPropsFixtureProps,
+  ): void {
+    envManager.switchToBackground();
+    root.render(createElement(moduleExports.App, props));
+  }
+
+  function renderFixtureOnMainThread(
+    moduleExports: CompiledGlobalPropsModule,
+    props?: GlobalPropsFixtureProps,
+  ): void {
+    envManager.switchToMainThread();
+    root.render(createElement(moduleExports.App, props));
+    renderPage({});
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalLynx = globalThis.lynx;
+    emitter = new LynxTestEventEmitter();
+    updateEvents = [];
+    resetElementTemplateCommitState();
+    clearEtAttrPlanMap();
+    envManager.resetEnv('background');
+    envManager.setUseElementTemplate(true);
+    installGlobalProps({ theme: 'dark', stable: true });
+    installElementTemplateCommitHook();
+    installElementTemplateHydrationListener();
+
+    envManager.switchToMainThread();
+    injectCalledByNative();
+    installElementTemplatePatchListener();
+    lynx.getJSContext().addEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+    envManager.switchToBackground();
+  });
+
+  afterEach(() => {
+    envManager.switchToMainThread();
+    lynx.getJSContext().removeEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+    resetElementTemplatePatchListener();
+    envManager.switchToBackground();
+    resetElementTemplateHydrationListener();
+    resetElementTemplateCommitState();
+    envManager.setUseElementTemplate(false);
+    globalThis.__GLOBAL_PROPS_MODE__ = 'event';
+    vi.stubGlobal('lynx', originalLynx);
+  });
+
+  it('reactive updateGlobalProps force-renders direct globalProps reads into native update ops', async () => {
+    globalThis.__GLOBAL_PROPS_MODE__ = 'reactive';
+    const { backgroundModule, mainModule } = await loadCompiledFixturePair<CompiledGlobalPropsModule>(
+      DIRECT_READ_FIXTURE,
+    );
+
+    renderFixtureOnBackground(backgroundModule);
+    renderFixtureOnMainThread(mainModule);
+    envManager.switchToMainThread();
+    expect(serializeToJSX(pageModule.__page)).toContain('dark');
+    envManager.switchToBackground();
+    await settleInitialHydration(envManager);
+    updateEvents = [];
+
+    lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+    await waitForRender();
+
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops.length).toBeGreaterThan(0);
+    expect(serializeToJSX(pageModule.__page)).toContain('light');
+  });
+
+  it('event mode emits without updating compiled direct globalProps reads', async () => {
+    globalThis.__GLOBAL_PROPS_MODE__ = 'event';
+    const emitted = vi.fn();
+    const { backgroundModule, mainModule } = await loadCompiledFixturePair<CompiledGlobalPropsModule>(
+      DIRECT_READ_FIXTURE,
+    );
+
+    renderFixtureOnBackground(backgroundModule);
+    renderFixtureOnMainThread(mainModule);
+    envManager.switchToMainThread();
+    expect(serializeToJSX(pageModule.__page)).toContain('dark');
+    envManager.switchToBackground();
+    emitter.addListener('onGlobalPropsChanged', emitted);
+    await settleInitialHydration(envManager);
+    updateEvents = [];
+
+    const previousGlobalProps = lynx.__globalProps;
+    lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+    await waitForRender();
+
+    expect(lynx.__globalProps).not.toBe(previousGlobalProps);
+    expect(lynx.__globalProps).toEqual({ theme: 'light', stable: true });
+    expect(emitted).toHaveBeenCalledWith(lynx.__globalProps);
+
+    envManager.switchToMainThread();
+    expect(updateEvents).toEqual([]);
+    expect(serializeToJSX(pageModule.__page)).toContain('dark');
+  });
+
+  it('event mode updates compiled GlobalProps hook and provider users through the changed event', async () => {
+    globalThis.__GLOBAL_PROPS_MODE__ = 'event';
+    const changed = vi.fn();
+    const { backgroundModule, mainModule } = await loadCompiledFixturePair<CompiledGlobalPropsModule>(
+      EVENT_HOOK_FIXTURE,
+    );
+
+    renderFixtureOnBackground(backgroundModule, { onChanged: changed });
+    renderFixtureOnMainThread(mainModule);
+    envManager.switchToMainThread();
+    expect(serializeToJSX(pageModule.__page)).toContain('dark:dark');
+    envManager.switchToBackground();
+    await settleInitialHydration(envManager);
+    updateEvents = [];
+
+    lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+    await waitForRender();
+
+    expect(changed).toHaveBeenCalledWith(lynx.__globalProps);
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops.length).toBeGreaterThan(0);
+    expect(serializeToJSX(pageModule.__page)).toContain('light:light');
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/background/global-props/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/global-props/compiled-fixtures.test.tsx
@@ -18,10 +18,9 @@ const [
   { clearEtAttrPlanMap },
   { LynxTestEventEmitter },
   { loadCompiledFixturePair },
+  { renderCompiledFixtureOnBackground, renderCompiledFixtureOnMainThread },
   { ElementTemplateEnvManager },
   { serializeToJSX },
-  { createElement },
-  { root },
 ] = await Promise.all([
   import('../../../../../src/element-template/background/commit-hook.js'),
   import('../../../../../src/element-template/background/hydration-listener.js'),
@@ -32,10 +31,9 @@ const [
   import('../../../../../src/element-template/runtime/template/attr-slot-plan.js'),
   import('../../../../test-utils/lynx-event-emitter.js'),
   import('../../../test-utils/debug/compiledFixtureModule.js'),
+  import('../../../test-utils/debug/compiledThreadRunner.js'),
   import('../../../test-utils/debug/envManager.js'),
   import('../../../test-utils/debug/serializer.js'),
-  import('preact'),
-  import('../../../../../src/element-template/index.js'),
 ]);
 
 const __filename = fileURLToPath(import.meta.url);
@@ -97,17 +95,15 @@ describe('Compiled ET GlobalProps update fixtures', () => {
     moduleExports: CompiledGlobalPropsModule,
     props?: GlobalPropsFixtureProps,
   ): void {
-    envManager.switchToBackground();
-    root.render(createElement(moduleExports.App, props));
+    renderCompiledFixtureOnBackground(moduleExports, envManager, props);
   }
 
   function renderFixtureOnMainThread(
     moduleExports: CompiledGlobalPropsModule,
     props?: GlobalPropsFixtureProps,
   ): void {
+    renderCompiledFixtureOnMainThread(moduleExports, envManager, props);
     envManager.switchToMainThread();
-    root.render(createElement(moduleExports.App, props));
-    renderPage({});
   }
 
   beforeEach(() => {

--- a/packages/react/runtime/src/core/forceRootRender.ts
+++ b/packages/react/runtime/src/core/forceRootRender.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { options as preactOptions } from 'preact';
+import type { VNode } from 'preact';
+
+import { COMPONENT, DIFF2, FORCE, ORIGINAL } from '../shared/render-constants.js';
+
+export interface ForceRootRenderOptions {
+  getRootVNode: () => unknown;
+  setRootVNode: (vnode: VNode) => void;
+  render: () => void;
+}
+
+export function runWithForceRootRender(
+  { getRootVNode, setRootVNode, render }: ForceRootRenderOptions,
+): void {
+  // Preact can skip root render if `_original` is unchanged; bumping it keeps
+  // backend force renders aligned with Preact's own rerender path.
+  const rootVNode = getRootVNode();
+  if (rootVNode) {
+    const newVNode = Object.assign({}, rootVNode) as VNode;
+    if (newVNode[ORIGINAL] != null) {
+      newVNode[ORIGINAL] += 1;
+      setRootVNode(newVNode);
+    }
+  }
+
+  const oldDiff = preactOptions[DIFF2];
+  preactOptions[DIFF2] = (vnode: VNode, oldVNode: VNode) => {
+    /* v8 ignore start */
+    if (oldDiff) {
+      oldDiff(vnode, oldVNode);
+    }
+    /* v8 ignore stop */
+
+    const c = oldVNode[COMPONENT];
+    if (c) {
+      c[FORCE] = true;
+    } else {
+      // mount phase of a new Component
+      // `isNew` is true, no need to set FORCE
+    }
+  };
+
+  try {
+    render();
+  } finally {
+    preactOptions[DIFF2] = oldDiff as (vnode: VNode, oldVNode: VNode) => void;
+  }
+}

--- a/packages/react/runtime/src/core/globalProps.ts
+++ b/packages/react/runtime/src/core/globalProps.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { ComponentChildren, Consumer, Provider } from 'preact';
+
+import type { useLynxGlobalEventListener } from './hooks/useLynxGlobalEventListener.js';
+import { factory } from './initData.js';
+
+type Getter<T> = {
+  [key in keyof T]: () => T[key];
+};
+
+interface GlobalPropsRuntimeDeps {
+  createContext: typeof import('preact').createContext;
+  useState: typeof import('preact/hooks').useState;
+  createElement: typeof import('preact/compat').createElement;
+  useLynxGlobalEventListener: typeof useLynxGlobalEventListener;
+}
+
+interface GlobalPropsApi<Data> {
+  Provider: Provider<Data>;
+  Consumer: Consumer<Data>;
+  use: () => Data;
+  useChanged: (callback: (data: Data) => void) => void;
+}
+
+/**
+ * The interface you can extends so that the `useGlobalProps` returning value can be customized
+ *
+ * @public
+ */
+export interface GlobalProps {}
+
+export interface UpdateGlobalPropsOptions {
+  forceRerender?: (() => void) | undefined;
+}
+
+export function isGlobalPropsEventMode(): boolean {
+  return typeof __GLOBAL_PROPS_MODE__ !== 'undefined' && __GLOBAL_PROPS_MODE__ === 'event';
+}
+
+export function createGlobalProps<Data = GlobalProps>(
+  deps: GlobalPropsRuntimeDeps,
+): Getter<GlobalPropsApi<Data>> {
+  return isGlobalPropsEventMode()
+    ? /* @__PURE__ */ factory<Data>(
+      deps,
+      '__globalProps',
+      'onGlobalPropsChanged',
+    )
+    : /* @__PURE__ */ createFallbackGlobalProps<Data>(deps.useLynxGlobalEventListener);
+}
+
+export function updateGlobalProps(
+  newData: Record<string, any>,
+  { forceRerender }: UpdateGlobalPropsOptions = {},
+): void {
+  if (isGlobalPropsEventMode()) {
+    // COW keeps Provider / Consumer state readers aligned in event mode.
+    lynx.__globalProps = Object.assign({}, lynx.__globalProps, newData);
+  } else {
+    Object.assign(lynx.__globalProps, newData);
+    if (forceRerender) {
+      void Promise.resolve().then(forceRerender);
+    }
+  }
+
+  lynxCoreInject.tt.GlobalEventEmitter.emit('onGlobalPropsChanged', [lynx.__globalProps]);
+}
+
+function warnGlobalPropsMode(): void {
+  if (typeof __LEPUS__ !== 'undefined' && !__LEPUS__ && typeof __DEV__ !== 'undefined' && __DEV__) {
+    console.warn(
+      `No need to use this API when 'globalPropsMode' is not 'event', `
+        + `updates will be triggered automatically by full re-render. `
+        + `Please set 'globalPropsMode' to 'event' to enable optimized updates.`,
+    );
+  }
+}
+
+function FallbackProvider({ children }: { children?: ComponentChildren | undefined }): ComponentChildren {
+  warnGlobalPropsMode();
+  return children;
+}
+
+function FallbackConsumer<Data>({ children }: { children: (data: Data) => ComponentChildren }): ComponentChildren {
+  warnGlobalPropsMode();
+  return children(lynx.__globalProps as Data);
+}
+
+function useFallbackGlobalProps<Data>(): Data {
+  warnGlobalPropsMode();
+  return lynx.__globalProps as Data;
+}
+
+function createFallbackGlobalProps<Data>(
+  useListener: typeof useLynxGlobalEventListener,
+): Getter<GlobalPropsApi<Data>> {
+  const useChanged = (callback: (data: Data) => void): void => {
+    if (!__LEPUS__) {
+      useListener('onGlobalPropsChanged', callback);
+    }
+  };
+
+  return {
+    Provider: () => FallbackProvider,
+    Consumer: () => FallbackConsumer as Consumer<Data>,
+    use: () => useFallbackGlobalProps as () => Data,
+    useChanged: () => useChanged,
+  };
+}

--- a/packages/react/runtime/src/core/globalProps.ts
+++ b/packages/react/runtime/src/core/globalProps.ts
@@ -97,7 +97,7 @@ function createFallbackGlobalProps<Data>(
   useListener: typeof useLynxGlobalEventListener,
 ): Getter<GlobalPropsApi<Data>> {
   const useChanged = (callback: (data: Data) => void): void => {
-    if (!__LEPUS__) {
+    if (typeof __LEPUS__ === 'undefined' || !__LEPUS__) {
       useListener('onGlobalPropsChanged', callback);
     }
   };

--- a/packages/react/runtime/src/element-template/index.ts
+++ b/packages/react/runtime/src/element-template/index.ts
@@ -32,6 +32,8 @@ import {
   useState,
 } from '@lynx-js/react/hooks';
 
+import { createGlobalProps } from '../core/globalProps.js';
+import type { GlobalProps } from '../core/globalProps.js';
 import { useLynxGlobalEventListener } from '../core/hooks/useLynxGlobalEventListener.js';
 import { factory, withInitDataInState } from '../core/initData.js';
 import type { InitData } from '../lynx-api.js';
@@ -106,8 +108,25 @@ export const InitDataConsumer: Consumer<InitData> = /* @__PURE__ */ _InitData.Co
 export const useInitData: () => InitData = /* @__PURE__ */ _InitData.use();
 export const useInitDataChanged: (callback: (data: InitData) => void) => void = /* @__PURE__ */ _InitData.useChanged();
 
+const _GlobalProps = /* @__PURE__ */ createGlobalProps<GlobalProps>({
+  createContext,
+  useState,
+  createElement,
+  useLynxGlobalEventListener,
+});
+
+// @ts-expect-error make preact and react types work
+export const GlobalPropsProvider: FC<{ children?: ReactNode | undefined }> = /* @__PURE__ */ _GlobalProps.Provider();
+// @ts-expect-error make preact and react types work
+export const GlobalPropsConsumer: Consumer<GlobalProps> = /* @__PURE__ */ _GlobalProps.Consumer();
+export const useGlobalProps: () => GlobalProps = /* @__PURE__ */ _GlobalProps.use();
+export const useGlobalPropsChanged: (callback: (data: GlobalProps) => void) => void = /* @__PURE__ */ _GlobalProps
+  .useChanged();
+
 export { withInitDataInState };
+export { useLynxGlobalEventListener };
 
 export * from './client/root.js';
 
+export type { GlobalProps } from '../core/globalProps.js';
 export type { DataProcessorDefinition, DataProcessors, InitData, InitDataRaw } from '../lynx-api.js';

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -2,11 +2,16 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import '@lynx-js/react/hooks';
+import type { ComponentChild, ContainerNode, VNode } from 'preact';
+import { render } from 'preact';
+
 import { callDestroyLifetimeFun } from './callDestroyLifetimeFun.js';
 import { injectCalledByNative } from './main-thread-api.js';
 import { installOnMtsDestruction } from './mts-destroy.js';
 import { installElementTemplatePatchListener } from './patch-listener.js';
 import { reloadBackground } from './reload.js';
+import { runWithForceRootRender } from '../../core/forceRootRender.js';
+import { updateGlobalProps as updateGlobalPropsCore } from '../../core/globalProps.js';
 import { installMainThreadHooks } from '../../core/hooks/mainThreadImpl.js';
 import { updateCardData } from '../../core/lynx-update-data.js';
 import { installElementTemplateCommitHook } from '../background/commit-hook.js';
@@ -18,7 +23,28 @@ import { initProfileHook } from '../debug/profile.js';
 import { setupLynxEnv } from '../lynx/env.js';
 import { initTimingAPI } from '../lynx/performance.js';
 import { publicComponentEvent, publishEvent, resetEventStateForRuntime } from '../prop-adapters/event.js';
-import { setRoot } from '../runtime/page/root-instance.js';
+import { __root, setRoot } from '../runtime/page/root-instance.js';
+
+function forceRootRender(): void {
+  runWithForceRootRender({
+    getRootVNode: () => __root.__jsx,
+    setRootVNode: (vnode: VNode) => {
+      // @ts-expect-error: __root.__jsx is a Preact VNode during background force render.
+      __root.__jsx = vnode;
+    },
+    render: () => {
+      render(__root.__jsx as ComponentChild, __root as unknown as ContainerNode);
+    },
+  });
+}
+
+const updateGlobalPropsOptions = {
+  forceRerender: forceRootRender,
+};
+
+function updateGlobalProps(newData: Record<string, any>): void {
+  updateGlobalPropsCore(newData, updateGlobalPropsOptions);
+}
 
 function init(): void {
   if (typeof __ALOG_ELEMENT_API__ !== 'undefined' && __ALOG_ELEMENT_API__) {
@@ -44,6 +70,7 @@ function init(): void {
     lynxCoreInject.tt.callDestroyLifetimeFun = callDestroyLifetimeFun;
     lynxCoreInject.tt.publishEvent = publishEvent;
     lynxCoreInject.tt.publicComponentEvent = publicComponentEvent;
+    lynxCoreInject.tt.updateGlobalProps = updateGlobalProps;
     lynxCoreInject.tt.updateCardData = updateCardData;
     lynxCoreInject.tt.onAppReload = reloadBackground;
     installElementTemplateCommitHook();

--- a/packages/react/runtime/src/element-template/native/main-thread-api.ts
+++ b/packages/react/runtime/src/element-template/native/main-thread-api.ts
@@ -11,7 +11,7 @@ function injectCalledByNative(): void {
   const calledByNative: LynxCallByNative = {
     renderPage,
     updatePage,
-    updateGlobalProps: function(): void {},
+    updateGlobalProps,
     getPageData: function() {
       return null;
     },
@@ -40,6 +40,14 @@ function updatePage(data: Record<string, unknown> | undefined, options?: UpdateP
 
   applyUpdatePageData(data, options);
   __FlushElementTree(__page, options ?? {});
+}
+
+function updateGlobalProps(_data: unknown, options?: UpdatePageOption): void {
+  if (options) {
+    __FlushElementTree(__page, options);
+  } else {
+    __FlushElementTree();
+  }
 }
 
 /**

--- a/packages/react/runtime/src/lynx-api.ts
+++ b/packages/react/runtime/src/lynx-api.ts
@@ -6,6 +6,8 @@ import { createContext, createElement } from 'preact/compat';
 import { useState } from 'preact/hooks';
 import type { Consumer, FC, ReactNode } from 'react';
 
+import { createGlobalProps } from './core/globalProps.js';
+import type { GlobalProps } from './core/globalProps.js';
 import { useLynxGlobalEventListener } from './core/hooks/useLynxGlobalEventListener.js';
 import { factory, withInitDataInState } from './core/initData.js';
 import { __root } from './root.js';
@@ -189,65 +191,14 @@ export const useInitData: () => InitData = /* @__PURE__ */ _InitData.use();
  */
 export const useInitDataChanged: (callback: (data: InitData) => void) => void = /* @__PURE__ */ _InitData.useChanged();
 
-/**
- * The interface you can extends so that the `useGlobalProps` returning value can be customized
- *
- * @public
- */
-export interface GlobalProps {}
+export type { GlobalProps } from './core/globalProps.js';
 
-const _GlobalProps = typeof __GLOBAL_PROPS_MODE__ !== 'undefined' && __GLOBAL_PROPS_MODE__ === 'event'
-  ? /* @__PURE__ */ factory<GlobalProps>(
-    {
-      createContext,
-      useState,
-      createElement,
-      useLynxGlobalEventListener,
-    },
-    '__globalProps',
-    'onGlobalPropsChanged',
-  )
-  : /* @__PURE__ */ createFallbackGlobalProps();
-
-function warnGlobalPropsMode() {
-  if (typeof __LEPUS__ !== 'undefined' && !__LEPUS__ && typeof __DEV__ !== 'undefined' && __DEV__) {
-    console.warn(
-      `No need to use this API when 'globalPropsMode' is not 'event', `
-        + `updates will be triggered automatically by full re-render. `
-        + `Please set 'globalPropsMode' to 'event' to enable optimized updates.`,
-    );
-  }
-}
-
-function createFallbackGlobalProps() {
-  return {
-    Provider: () => {
-      return ({ children }: { children?: ReactNode | undefined }) => {
-        warnGlobalPropsMode();
-        return children;
-      };
-    },
-    Consumer: () => {
-      return ({ children }: { children: (data: GlobalProps) => ReactNode }) => {
-        warnGlobalPropsMode();
-        return children(lynx.__globalProps);
-      };
-    },
-    use: () => {
-      return (): GlobalProps => {
-        warnGlobalPropsMode();
-        return lynx.__globalProps;
-      };
-    },
-    useChanged: () => {
-      return (callback: (data: GlobalProps) => void): void => {
-        if (!__LEPUS__) {
-          useLynxGlobalEventListener('onGlobalPropsChanged', callback);
-        }
-      };
-    },
-  };
-}
+const _GlobalProps = /* @__PURE__ */ createGlobalProps<GlobalProps>({
+  createContext,
+  useState,
+  createElement,
+  useLynxGlobalEventListener,
+});
 
 /**
  * The {@link https://react.dev/reference/react/createContext#provider | Provider} Component that provide `lynx.__globalProps`,

--- a/packages/react/runtime/src/snapshot/lynx/runWithForce.ts
+++ b/packages/react/runtime/src/snapshot/lynx/runWithForce.ts
@@ -1,46 +1,18 @@
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { options } from 'preact';
 import type { VNode } from 'preact';
 
+import { runWithForceRootRender } from '../../core/forceRootRender.js';
 import { __root } from '../../root.js';
-import { COMPONENT, DIFF2, FORCE, ORIGINAL } from '../../shared/render-constants.js';
 
 export function runWithForce(cb: () => void): void {
-  // In https://github.com/preactjs/preact/pull/4724, preact will
-  // skip render if the `vnode._original` is not changed, even if `c._force` is true
-  // So we need to increment `vnode._original` to make sure the `__root.__jsx` is re-rendered
-  // This is the same logic with: https://github.com/preactjs/preact/blob/43178581442fa0f2428e5bdbca355860b2d12e5d/src/component.js#L131
-  if (__root.__jsx) {
-    const newVNode = Object.assign({}, __root.__jsx) as unknown as VNode;
-    if (newVNode[ORIGINAL] != null) {
-      newVNode[ORIGINAL] += 1;
-      // @ts-expect-error: __root.__jsx is a VNode
-      __root.__jsx = newVNode;
-    }
-  }
-
-  const oldDiff = options[DIFF2];
-  options[DIFF2] = (vnode: VNode, oldVNode: VNode) => {
-    /* v8 ignore start */
-    if (oldDiff) {
-      oldDiff(vnode, oldVNode);
-    }
-    /* v8 ignore stop */
-
-    const c = oldVNode[COMPONENT];
-    if (c) {
-      c[FORCE] = true;
-    } else {
-      // mount phase of a new Component
-      // `isNew` is true, no need to set FORCE
-    }
-  };
-
-  try {
-    cb();
-  } finally {
-    options[DIFF2] = oldDiff as (vnode: VNode, oldVNode: VNode) => void;
-  }
+  runWithForceRootRender({
+    getRootVNode: () => __root.__jsx,
+    setRootVNode: (vnode: VNode) => {
+      // @ts-expect-error: __root.__jsx is a Preact VNode during background force render.
+      __root.__jsx = vnode;
+    },
+    render: cb,
+  });
 }

--- a/packages/react/runtime/src/snapshot/lynx/tt.ts
+++ b/packages/react/runtime/src/snapshot/lynx/tt.ts
@@ -5,6 +5,7 @@ import { process, render } from 'preact';
 
 import { PerformanceTimingFlags, PipelineOrigins, beginPipeline, markTiming } from './performance.js';
 import { runWithForce } from './runWithForce.js';
+import { updateGlobalProps as updateGlobalPropsCore } from '../../core/globalProps.js';
 import { updateCardData } from '../../core/lynx-update-data.js';
 import { __root } from '../../root.js';
 import { profileEnd, profileStart } from '../../shared/profile.js';
@@ -267,22 +268,14 @@ function delayedPublicComponentEvent(_componentId: string, handlerName: string, 
 }
 
 function updateGlobalProps(newData: Record<string, any>): void {
-  if (typeof __GLOBAL_PROPS_MODE__ !== 'undefined' && __GLOBAL_PROPS_MODE__ === 'event') {
-    // COW when modify `lynx.__globalProps` to make sure Provider & Consumer works
-    lynx.__globalProps = Object.assign({}, lynx.__globalProps, newData);
-  } else {
-    // only when __GLOBAL_PROPS_MODE__ is reactive, we need to batch the update with updateFromRoot
-    Object.assign(lynx.__globalProps, newData);
-    // Our purpose is to make sure SYNC setState inside `emit`'s listeners
-    // can be batched with updateFromRoot
-    // This is already done because updateFromRoot will consume all dirty flags marked by
-    // the setState, and setState's flush will be a noop. No extra diffs will be needed.
-    void Promise.resolve().then(() => {
+  updateGlobalPropsCore(newData, {
+    // Snapshot force render consumes any sync setState dirty flags produced by
+    // onGlobalPropsChanged listeners, avoiding an extra diff pass.
+    forceRerender: () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       runWithForce(() => render(__root.__jsx, __root as any));
-    });
-  }
-  lynxCoreInject.tt.GlobalEventEmitter.emit('onGlobalPropsChanged', [lynx.__globalProps]);
+    },
+  });
 }
 
 export { injectTt, flushDelayedLifecycleEvents };


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added global properties management system with Provider/Consumer components and hooks for reactive state sharing
  * Introduced `useGlobalProps` and `useGlobalPropsChanged` hooks for accessing and monitoring global property updates
  * Implemented support for both reactive and event-driven modes for global property handling

* **Tests**
  * Added comprehensive test coverage for global properties functionality, fixtures, and integration scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

This adds Element Template support for the existing GlobalProps runtime contract by moving the shared Snapshot behavior into core helpers and wiring the ET public entry/native bridge to those helpers. Snapshot keeps the same observable behavior, while ET now exposes the GlobalProps APIs and handles both reactive and event globalProps modes.

## Runtime Contract

- `@lynx-js/react/element-template` now exports `GlobalProps`, `GlobalPropsProvider`, `GlobalPropsConsumer`, `useGlobalProps`, `useGlobalPropsChanged`, and `useLynxGlobalEventListener`.
- Background `lynxCoreInject.tt.updateGlobalProps(data)` merges into `lynx.__globalProps`, emits `onGlobalPropsChanged`, and uses the shared force-root-render path when reactive mode needs a root rerender.
- Event mode keeps copy-on-write `lynx.__globalProps` updates so provider/consumer state readers observe changed identity without forcing direct global prop reads to rerender.
- ET main-thread `updateGlobalProps(data, options?)` only flushes the current element tree for native-provided options; global props mutation remains on the background runtime side.

## Key Points

- Shared `core/globalProps` and `core/forceRootRender` helpers remove Snapshot-only ownership of GlobalProps update behavior.
- ET native/background wiring mirrors Snapshot semantics without inheriting Snapshot-specific internals.
- Compiled ET fixtures cover direct global prop reads and hook/provider users across reactive and event modes.

## Checklist

- [x] Tests updated.
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
