### PR TITLE
fix(a2ui-playground): bump preview QR code size to 128px

### DIFF
--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -664,7 +664,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
                             ? (
                               <QrCode
                                 value={item.url}
-                                size={80}
+                                size={128}
                                 onErrorChange={setError}
                               />
                             )

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -956,8 +956,6 @@ html[data-theme="dark"] .phoneHomeIndicator {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  max-height: 132px;
-  overflow-y: auto;
 }
 
 .previewQrContent {
@@ -1085,10 +1083,6 @@ html[data-theme="dark"] .phoneHomeIndicator {
 
   .previewPanelBody {
     min-height: 460px;
-  }
-
-  .previewQrSection {
-    max-height: 120px;
   }
 }
 


### PR DESCRIPTION
## Summary

Bumps the Web/Native preview QR codes in the A2UI playground from 80px to 128px so they're actually scannable from a phone camera.

For known-demo URLs (~100–120 chars → QR version 5–6, ~40×40 modules), 80px gave each module only ~2px — right at the lower bound of phone camera scanning. 128px gives ~3px per module, much more forgiving.

Side effect: `.previewQrContent` uses `align-items: center` with no fixed height, so the row naturally grows with the QR. Multi-line text blocks (title + description + URL row) no longer feel cramped next to a tiny code.

The encoder settings (`errorCorrectionLevel: 'L'`, `margin: 1`) are already minimal — there's no compression headroom left on the encoder side, so the only meaningful fix for scannability is to render the same modules at more pixels.

## Test plan

- [ ] Open the A2UI playground, render any demo, scan both Web Preview and Native Preview QR codes from a phone — both decode reliably.
- [ ] Verify the preview panel layout still looks balanced (QR no longer cramped against the text block).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased QR code display size in preview panels for better scanning and visibility.
  * Adjusted preview layout to a vertical stack with explicit spacing, removed height-limited scrolling, and improved mobile responsiveness by introducing a larger minimum panel height on narrow viewports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->