### PR TITLE
fix(ci): dep-changeset check must ignore unbumped (type:none) packages

### DIFF
--- a/.github/scripts/check-dep-changes-have-changeset.cjs
+++ b/.github/scripts/check-dep-changes-have-changeset.cjs
@@ -44,7 +44,15 @@ function findMissingChangesets({
   readCurrent,
   readBase,
 }) {
-  const willBump = new Set(releases.map((r) => r.name));
+  // `changeset status` lists every package in `releases`, including the ones
+  // that are not bumped (`type: 'none'`). Only the packages that are actually
+  // bumped ship their `package.json` change, so the rest must not be treated as
+  // covered by a changeset.
+  const willBump = new Set(
+    releases
+      .filter((r) => r.type && r.type !== 'none')
+      .map((r) => r.name),
+  );
   const missing = [];
   for (const file of changedFiles) {
     const cur = readCurrent(file);


### PR DESCRIPTION
## Problem

`check-dep-changes-have-changeset.cjs` is supposed to fail when a package changes its `dependencies`/`peerDependencies` but has no changeset bumping it (so the dependency change actually ships).

It builds the "covered" set from **every** entry in `changeset status`'s `releases`:

```js
const willBump = new Set(releases.map((r) => r.name));
```

But `changeset status` lists every workspace package in `releases`, including the ones that are **not** bumped (`type: 'none'`). In a typical run only a handful are bumped and the rest are `type: 'none'` (e.g. 5 bumped vs 27 `none`). Since every package appears in `releases`, `willBump.has(name)` is essentially always `true`, so the check never reports anything.

### How it was found

On #2701, `@lynx-js/config-rsbuild-plugin`'s `peerDependencies` range was widened (`… || ^0.15.0`) **without** a changeset bumping it. The package is `type: 'none'`, so its `package.json` change won't ship — exactly what this check should catch. It passed anyway:

```
{"name":"@lynx-js/config-rsbuild-plugin","type":"none","oldVersion":"0.0.2","newVersion":"0.0.2","changesets":[]}
willBump.has('@lynx-js/config-rsbuild-plugin') === true   // bug
```

## Fix

Build `willBump` only from packages that are actually bumped (`type` set and not `'none'`):

```js
const willBump = new Set(
  releases.filter((r) => r.type && r.type !== 'none').map((r) => r.name),
);
```

Verified against #2701's status JSON: with the fix, the unbumped `config-rsbuild-plugin` peerDependency change is correctly reported; the same PR now adds a `patch` changeset for it so it ships.

> Note: this is a `.github/scripts/**` change only, so no changeset is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal validation process for dependency update tracking to ensure accurate change documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->