### PR TITLE
chore(renovate): track @lynx-js/preact-devtools + internal-preact latest builds

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -92,6 +92,19 @@
       ]
     },
     {
+      // `@lynx-js/preact-devtools` only publishes dated snapshot builds
+      // (`5.0.1-<YYYYMMDDHHMMSS>-<sha>`) under the `latest` dist-tag. These are
+      // semver prereleases that sort *below* the stable `5.0.1` baseline, so a
+      // `^5.0.1` range never sees them and Renovate gets stuck. Follow the
+      // `latest` tag and pin to it so each new build produces an update PR.
+      "matchPackageNames": [
+        "@lynx-js/preact-devtools",
+      ],
+      "followTag": "latest",
+      "ignoreUnstable": false,
+      "rangeStrategy": "pin",
+    },
+    {
       "groupName": "API Extractor",
       "groupSlug": "api-extractor",
       "matchPackageNames": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -92,13 +92,17 @@
       ]
     },
     {
-      // `@lynx-js/preact-devtools` only publishes dated snapshot builds
-      // (`5.0.1-<YYYYMMDDHHMMSS>-<sha>`) under the `latest` dist-tag. These are
-      // semver prereleases that sort *below* the stable `5.0.1` baseline, so a
-      // `^5.0.1` range never sees them and Renovate gets stuck. Follow the
+      // These packages only publish dated snapshot builds (e.g.
+      // `5.0.1-<YYYYMMDDHHMMSS>-<sha>`) under the `latest` dist-tag. They are
+      // semver prereleases that sort *below* their stable baseline, so a plain
+      // `^x.y.z` range never sees them and Renovate gets stuck. Follow the
       // `latest` tag and pin to it so each new build produces an update PR.
+      // Note: `@lynx-js/internal-preact` is consumed via the
+      // `"preact": "npm:@lynx-js/internal-preact@..."` alias; Renovate matches
+      // it by its resolved packageName.
       "matchPackageNames": [
         "@lynx-js/preact-devtools",
+        "@lynx-js/internal-preact",
       ],
       "followTag": "latest",
       "ignoreUnstable": false,


### PR DESCRIPTION
## Problem

Renovate stopped upgrading `@lynx-js/preact-devtools` (see Dependency Dashboard #36 — no available update shown for it), and `@lynx-js/internal-preact` isn't auto-tracked either.

Root cause: both packages only publish **dated snapshot builds** under the `latest` dist-tag:
- `@lynx-js/preact-devtools` → `5.0.1-20260525091601-cc32764`
- `@lynx-js/internal-preact` → `10.29.1-20260519060144-e6da44c`

Everything after the `-` is a **semver prerelease identifier**, so these builds:
1. sort **below** their stable baseline (`5.0.1-x` < `5.0.1`);
2. don't satisfy plain `^x.y.z` ranges; and
3. are ignored by Renovate's default `ignoreUnstable`.

For preact-devtools specifically, you can see the trap in history: #1784 tracked the prerelease line (`^5.0.1-cf9aef5`), then #2163 "upgraded" everyone to stable `^5.0.1` (stable outranks any prerelease), after which all newer dated builds became invisible. `5.0.1` is now deprecated on npm.

## Fix

A `packageRule` that makes Renovate **follow the `latest` dist-tag** and pin to it for both packages, bypassing the range/stability comparison:

```json5
{
  "matchPackageNames": [
    "@lynx-js/preact-devtools",
    "@lynx-js/internal-preact",
  ],
  "followTag": "latest",
  "ignoreUnstable": false,
  "rangeStrategy": "pin",
}
```

Each new merge-to-main build now raises an update PR.

## Notes

- `@lynx-js/internal-preact` is consumed via the `"preact": "npm:@lynx-js/internal-preact@..."` alias in `packages/react/package.json`; Renovate matches it by its resolved `packageName`, which is why it's listed directly.
- ⚠️ **Heads-up on internal-preact:** several recent bumps (#2319, #2512, #2664) were hand-authored, pointing at specific `pkg.pr.new` PR-preview builds rather than npm `latest`. With this rule, Renovate will track npm `latest` and may propose moving off a manually-pinned `pkg.pr.new` build. If you want to keep hand-steering it during active development, either drop it from this rule or rely on closing/ignoring those Renovate PRs while iterating.
- Longer-term alternative (not done here): publish real **stable** versions (CalVer / incrementing patch with the sha as build metadata) so `^x.y.z` upgrades with no Renovate config at all.

Draft pending maintainer confirmation of the pin strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enhance dependency update management for internal development tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->