### PR TITLE
chore(deps): bump @lynx-js/preact-devtools to latest dated build

### DIFF
--- a/.changeset/bump-preact-devtools-templates.md
+++ b/.changeset/bump-preact-devtools-templates.md
@@ -1,0 +1,5 @@
+---
+"create-rspeedy": patch
+---
+
+Bump `@lynx-js/preact-devtools` to `5.0.1-20260525112551-dfe2d03` in the React templates.

--- a/examples/gesture/package.json
+++ b/examples/gesture/package.json
@@ -13,7 +13,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/motion/package.json
+++ b/examples/motion/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-element-template/package.json
+++ b/examples/react-element-template/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-element/package.json
+++ b/examples/react-element/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-externals/package.json
+++ b/examples/react-externals/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@lynx-js/external-bundle-rsbuild-plugin": "workspace:*",
     "@lynx-js/lynx-bundle-rslib-config": "workspace:*",
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-keyboard/package.json
+++ b/examples/react-keyboard/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-lazy-bundle-standalone/package.json
+++ b/examples/react-lazy-bundle-standalone/package.json
@@ -18,7 +18,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-lazy-bundle/package.json
+++ b/examples/react-lazy-bundle/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-main-thread-function/package.json
+++ b/examples/react-main-thread-function/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-ui-sourcemap/package.json
+++ b/examples/react-ui-sourcemap/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/create-rspeedy/template-react-js/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-js/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*"

--- a/packages/rspeedy/create-rspeedy/template-react-ts/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/testing-library/kitten-lynx/package.json
+++ b/packages/testing-library/kitten-lynx/package.json
@@ -41,7 +41,7 @@
     "@yume-chan/adb-server-node-tcp": "catalog:adb"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "^5.0.1",
+    "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,8 +222,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -250,8 +250,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -275,8 +275,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -331,8 +331,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -356,8 +356,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -387,8 +387,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspeedy/lynx-bundle-rslib-config
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -415,8 +415,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -440,8 +440,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -465,8 +465,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -490,8 +490,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -515,8 +515,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -1684,8 +1684,8 @@ importers:
         version: 2.5.2
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: 5.0.1-20260525112551-dfe2d03
+        version: 5.0.1-20260525112551-dfe2d03
       '@lynx-js/react':
         specifier: workspace:*
         version: link:../../react
@@ -4165,8 +4165,8 @@ packages:
       '@lynx-js/types':
         optional: true
 
-  '@lynx-js/preact-devtools@5.0.1':
-    resolution: {integrity: sha512-ayUU8PJ0TVWABbd5/d/04KI18W9RY4kkaRekBXXbRE/eBkGMZ3lVJ0zOB+B+85B9RUpvEVK2FleqJkS+qBKG6Q==}
+  '@lynx-js/preact-devtools@5.0.1-20260525112551-dfe2d03':
+    resolution: {integrity: sha512-q6zlNTtYIA8jCGmnGE6umf6/caTiMa/tkjk+omaBX3Uj4JyIDuV/oWRi/UPDYS9VodBe4Fl6kWsZBQNAK9f9gQ==}
 
   '@lynx-js/react-use@0.1.3':
     resolution: {integrity: sha512-48NX1DZfIqdpcFPKR3SdI/E0D2INJzgMDtl9IK0vbqWKPgj6LgUPZN0iqIDd7Juy3in5c2bv6E9jCpoq5ONeVw==}
@@ -13928,7 +13928,7 @@ snapshots:
       - react
       - react-dom
 
-  '@lynx-js/preact-devtools@5.0.1':
+  '@lynx-js/preact-devtools@5.0.1-20260525112551-dfe2d03':
     dependencies:
       errorstacks: 2.4.1
       htm: 3.1.1


### PR DESCRIPTION
## What

Manually bump `@lynx-js/preact-devtools` from `^5.0.1` to the exact dated build `5.0.1-20260525112551-dfe2d03` (current `latest` dist-tag) across all 14 references (examples, `create-rspeedy` templates, `kitten-lynx`), plus the corresponding `pnpm-lock.yaml` update.

## Why Renovate can't do this automatically

`@lynx-js/preact-devtools` only ever publishes dated snapshot builds (`5.0.1-<YYYYMMDDHHMMSS>-<sha>`) under the `latest` tag. These are **semver prereleases that sort *below* the stable `5.0.1` baseline**. Consumers here are on `^5.0.1`, which installs the stable `5.0.1`. So the `latest` build is effectively a *downgrade* in semver terms, and Renovate will not open a downgrade PR — `followTag` / `ignoreUnstable` / `pin` cannot overcome this because the target version number is lower.

Pinning to the exact dated build (the same model already used for `@lynx-js/internal-preact`) is the only way to actually consume the newest build today. Once pinned to a dated build, future builds are genuine upgrades, so the Renovate rule added in #2706 will keep these references moving from here on.

> Longer term, the clean fix is for `preact-devtools` to publish **monotonically increasing stable versions** (e.g. CalVer `5.<YYYYMMDD>.<run>`), which would let plain `^` ranges resolve to the latest and remove the need for exact pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned a development dependency to a specific prerelease/build version across example and template packages to ensure reproducible local builds and consistent testing environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->