### PR TITLE
fix(template-webpack-plugin): always inline lazy bundle background

### DIFF
--- a/.changeset/inline-lazy-bundle-bts.md
+++ b/.changeset/inline-lazy-bundle-bts.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Always inline a lazy bundle's background (bts) chunk.
+
+A lazy bundle (`appType: "DynamicComponent"`) runs its background synchronously when the bundle is required, so its bts must be inlined into `app-service.js`. Previously a non-matching `inlineScripts` matcher could externalize it via `lynx.requireModuleAsync`, leaving the module unavailable at `installChunk` time and breaking the bundle. The bts of a lazy bundle is now always inlined regardless of `inlineScripts`; the option still applies to card templates.

--- a/packages/rspeedy/plugin-react/test/lazy.test.ts
+++ b/packages/rspeedy/plugin-react/test/lazy.test.ts
@@ -436,4 +436,154 @@ describe('Lazy', () => {
       vi.unstubAllEnvs()
     }
   })
+
+  // Regression test for a lazy bundle whose background (bts) was externalized
+  // via `lynx.requireModuleAsync` and therefore unavailable when the bundle is
+  // required synchronously (the module is empty at `installChunk` time and
+  // loading crashes). This reproduces the production setup: `inlineScripts` is
+  // `false`, which is also the default once chunk splitting is enabled, and
+  // would externalize the background. A lazy bundle's background must always be
+  // inlined and required synchronously regardless of `inlineScripts`.
+  test('inlines lazy bundle background when inlineScripts is disabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+    let appServiceJSContent = ''
+
+    // Isolate the dist root so this build cannot race other tests in this
+    // package writing to the default `test/dist/` directory.
+    const tmp = await fs.mkdtemp(
+      path.join(tmpdir(), 'rspeedy-react-test-lazy-inline-scripts-'),
+    )
+
+    const rsbuild = await createRspeedy({
+      rspeedyConfig: {
+        source: {
+          entry: {
+            main: new URL(
+              './fixtures/lazy-bundle/index.tsx',
+              import.meta.url,
+            ).pathname,
+          },
+        },
+        output: {
+          distPath: {
+            root: tmp,
+          },
+          inlineScripts: false,
+        },
+        plugins: [
+          pluginReactLynx(),
+          {
+            name: 'test',
+            pre: ['lynx:react'],
+            setup(api) {
+              api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+                const rule = chain.module
+                  .rules.get('css:react:main-thread')
+                  .uses.get(CHAIN_ID.USE.IGNORE_CSS)
+                rule.loader(
+                  // add .ts suffix to ignore-css-loader
+                  // this workaround is needed because vitest
+                  // runs on our ts files.
+                  rule.get('loader') as string + '.ts',
+                )
+              })
+            },
+          } as RsbuildPlugin,
+        ],
+        tools: {
+          rspack: {
+            plugins: [
+              {
+                name: 'capture-lazy-app-service',
+                apply(compiler) {
+                  compiler.hooks.compilation.tap(
+                    'capture-lazy-app-service',
+                    (compilation) => {
+                      const hooks = LynxTemplatePlugin
+                        .getLynxTemplatePluginHooks(
+                          compilation as unknown as Parameters<
+                            typeof LynxTemplatePlugin.getLynxTemplatePluginHooks
+                          >[0],
+                        )
+                      hooks.beforeEmit.tap(
+                        'capture-lazy-app-service',
+                        (args) => {
+                          // The host card legitimately loads the lazy bundle via
+                          // requireModuleAsync, so only inspect the dynamic
+                          // component's own template.
+                          if (
+                            args.entryNames.some((name) =>
+                              name.includes('LazyComponent')
+                            )
+                          ) {
+                            appServiceJSContent = args.finalEncodeOptions
+                              .manifest['/app-service.js']!
+                          }
+                          return args
+                        },
+                      )
+                    },
+                  )
+                },
+              } as Rspack.RspackPluginInstance,
+            ],
+          },
+        },
+      },
+    })
+
+    try {
+      await rsbuild.build()
+
+      // The lazy bundle's background is inlined and required synchronously.
+      expect(appServiceJSContent).toContain('lynx.requireModule(')
+      expect(appServiceJSContent).not.toContain('requireModuleAsync')
+
+      // Execute the generated app-service to confirm the background is required
+      // synchronously: a `requireModuleAsync` here would leave `module.exports`
+      // empty, which is the runtime failure observed in production.
+      const componentExports = { name: 'LazyComponent' }
+      let requireModuleAsyncWasCalled = false
+      const lynx = {
+        requireModule: () => componentExports,
+        requireModuleAsync: () => {
+          requireModuleAsyncWasCalled = true
+        },
+      }
+      // `globDynamicComponentEntry` is a global injected by the Lynx runtime and
+      // referenced by the generated app-service.
+      // @ts-expect-error injected runtime global
+      globalThis.globDynamicComponentEntry = undefined
+      // biome-ignore lint/suspicious/noExplicitAny: module factory cache
+      const mod: Record<string, any> = {}
+      const tt = {
+        define: (key: string, fn: (...args: unknown[]) => void) => {
+          mod[key] = fn
+        },
+        require: (key: string) => {
+          const mockModule = { exports: {} as unknown }
+          const args: unknown[] = Array(17).fill(undefined)
+          args[1] = mockModule
+          args[16] = lynx
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+          mod[key](...args)
+          return mockModule.exports
+        },
+      }
+
+      const { init } = eval(appServiceJSContent) as {
+        init: (arg: { tt: typeof tt }) => unknown
+      }
+      const result = init({ tt })
+
+      expect(requireModuleAsyncWasCalled).toBe(false)
+      expect(result).toBe(componentExports)
+    } finally {
+      // @ts-expect-error injected runtime global
+      delete globalThis.globDynamicComponentEntry
+      vi.unstubAllEnvs()
+    }
+  })
 })

--- a/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxEncodePlugin.ts
@@ -152,6 +152,15 @@ export class LynxEncodePluginImpl {
         const { encodeData, intermediateAssets } = args;
         const { manifest } = encodeData;
 
+        // A lazy bundle runs its background (bts) synchronously when the bundle
+        // is required, so every chunk in its manifest must be inlined into
+        // app-service.js; externalizing one via `requireModuleAsync` leaves the
+        // module unavailable at `installChunk` time. `inlineScripts` therefore
+        // only applies to card templates. (`DynamicComponent` is the encoder's
+        // appType for a lazy bundle.)
+        const isLazyBundle =
+          encodeData.sourceContent.appType === 'DynamicComponent';
+
         const [inlinedManifest, externalManifest] = Object.entries(
           manifest,
         )
@@ -166,7 +175,7 @@ export class LynxEncodePluginImpl {
                 }
               }
               let shouldInline = true;
-              if (!chunk?.hasRuntime()) {
+              if (!isLazyBundle && !chunk?.hasRuntime()) {
                 shouldInline = this.#shouldInlineScript(
                   name,
                   assert!.source.size(),

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
@@ -23,7 +23,7 @@ it('should have correct chunk content', async () => {
   expect(fooBackground.foo()).toBe(42);
 });
 
-it('manifest only contains /app-service.js', async () => {
+it('lazy bundle bts is inlined even with inlineScripts: false', async () => {
   const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
@@ -37,13 +37,19 @@ it('manifest only contains /app-service.js', async () => {
 
   expect(sourceContent).toHaveProperty('appType', 'DynamicComponent');
 
-  expect(manifest).not.toHaveProperty('/foo:background.rspack.bundle.js');
+  // A lazy bundle's background must be loaded synchronously when the bundle
+  // is required, so it is always inlined into the bundle regardless of
+  // `inlineScripts: false`. Otherwise it would be loaded via
+  // `requireModuleAsync` and be unavailable at `installChunk` time.
   expect(manifest).toHaveProperty('/app-service.js');
-
-  // should have requireModuleAsyncCache polyfill
-  expect(manifest['/app-service.js']).toContain('var moduleCache = {}');
+  expect(manifest).toHaveProperty('/foo:background.rspack.bundle.js');
 
   expect(manifest['/app-service.js']).toContain(
+    `module.exports=lynx.requireModule(\"/foo:background.rspack.bundle.js\"`,
+  );
+
+  // the bts must not be externalized via requireModuleAsync
+  expect(manifest['/app-service.js']).not.toContain(
     `lynx.requireModuleAsync(\"/foo:background.rspack.bundle.js\")`,
   );
 

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
@@ -57,7 +57,6 @@ it('lazy bundle bts is inlined even with inlineScripts: false', async () => {
     `module.exports=;`,
   );
 
-  it('inlined scripts should not have syntax error', () => {
-    eval(manifest['/app-service.js']);
-  });
+  // the inlined app-service should be valid JavaScript
+  expect(() => eval(manifest['/app-service.js'])).not.toThrow();
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-fn/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-fn/index.js
@@ -73,7 +73,6 @@ it('should generate correct bar template', async () => {
     `lynx.requireModuleAsync(\"/bar:background.rspack.bundle.js\")`,
   );
 
-  it('inlined scripts should not have syntax error', () => {
-    eval(manifest['/app-service.js']);
-  });
+  // the inlined app-service should be valid JavaScript
+  expect(() => eval(manifest['/app-service.js'])).not.toThrow();
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-fn/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-fn/index.js
@@ -60,11 +60,16 @@ it('should generate correct bar template', async () => {
   const { sourceContent, manifest } = JSON.parse(content);
   expect(sourceContent).toHaveProperty('appType', 'DynamicComponent');
   expect(manifest).toHaveProperty('/app-service.js');
-  // should have requireModuleAsyncCache polyfill
-  expect(manifest['/app-service.js']).toContain('var moduleCache = {}');
 
-  expect(manifest).not.toHaveProperty('/bar:background.rspack.bundle.js');
+  // A lazy bundle's background is always inlined regardless of
+  // `inlineScripts`, even though the matcher here does not select `bar`. It
+  // must be loaded synchronously when the bundle is required; externalizing
+  // it via `requireModuleAsync` leaves it unavailable at `installChunk` time.
+  expect(manifest).toHaveProperty('/bar:background.rspack.bundle.js');
   expect(manifest['/app-service.js']).toContain(
+    `module.exports=lynx.requireModule(\"/bar:background.rspack.bundle.js\"`,
+  );
+  expect(manifest['/app-service.js']).not.toContain(
     `lynx.requireModuleAsync(\"/bar:background.rspack.bundle.js\")`,
   );
 

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-object/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-object/index.js
@@ -73,7 +73,6 @@ it('should generate correct bar template', async () => {
     `lynx.requireModuleAsync(\"/bar:background.rspack.bundle.js\")`,
   );
 
-  it('inlined scripts should not have syntax error', () => {
-    eval(manifest['/app-service.js']);
-  });
+  // the inlined app-service should be valid JavaScript
+  expect(() => eval(manifest['/app-service.js'])).not.toThrow();
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-object/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-object/index.js
@@ -60,11 +60,16 @@ it('should generate correct bar template', async () => {
   const { sourceContent, manifest } = JSON.parse(content);
   expect(sourceContent).toHaveProperty('appType', 'DynamicComponent');
   expect(manifest).toHaveProperty('/app-service.js');
-  // should have requireModuleAsyncCache polyfill
-  expect(manifest['/app-service.js']).toContain('var moduleCache = {}');
 
-  expect(manifest).not.toHaveProperty('/bar:background.rspack.bundle.js');
+  // A lazy bundle's background is always inlined regardless of
+  // `inlineScripts`, even though the matcher here does not select `bar`. It
+  // must be loaded synchronously when the bundle is required; externalizing
+  // it via `requireModuleAsync` leaves it unavailable at `installChunk` time.
+  expect(manifest).toHaveProperty('/bar:background.rspack.bundle.js');
   expect(manifest['/app-service.js']).toContain(
+    `module.exports=lynx.requireModule(\"/bar:background.rspack.bundle.js\"`,
+  );
+  expect(manifest['/app-service.js']).not.toContain(
     `lynx.requireModuleAsync(\"/bar:background.rspack.bundle.js\")`,
   );
 

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-regex/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-regex/index.js
@@ -73,7 +73,6 @@ it('should generate correct bar template', async () => {
     `lynx.requireModuleAsync(\"/bar:background.rspack.bundle.js\")`,
   );
 
-  it('inlined scripts should not have syntax error', () => {
-    eval(manifest['/app-service.js']);
-  });
+  // the inlined app-service should be valid JavaScript
+  expect(() => eval(manifest['/app-service.js'])).not.toThrow();
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-regex/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-regex/index.js
@@ -60,11 +60,16 @@ it('should generate correct bar template', async () => {
   const { sourceContent, manifest } = JSON.parse(content);
   expect(sourceContent).toHaveProperty('appType', 'DynamicComponent');
   expect(manifest).toHaveProperty('/app-service.js');
-  // should have requireModuleAsyncCache polyfill
-  expect(manifest['/app-service.js']).toContain('var moduleCache = {}');
 
-  expect(manifest).not.toHaveProperty('/bar:background.rspack.bundle.js');
+  // A lazy bundle's background is always inlined regardless of
+  // `inlineScripts`, even though the matcher here does not select `bar`. It
+  // must be loaded synchronously when the bundle is required; externalizing
+  // it via `requireModuleAsync` leaves it unavailable at `installChunk` time.
+  expect(manifest).toHaveProperty('/bar:background.rspack.bundle.js');
   expect(manifest['/app-service.js']).toContain(
+    `module.exports=lynx.requireModule(\"/bar:background.rspack.bundle.js\"`,
+  );
+  expect(manifest['/app-service.js']).not.toContain(
     `lynx.requireModuleAsync(\"/bar:background.rspack.bundle.js\")`,
   );
 

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/component.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/component.js
@@ -1,0 +1,5 @@
+import { shared } from './shared.js';
+
+export function component() {
+  return shared() + ':component';
+}

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/index.js
@@ -51,7 +51,6 @@ it('inlines every split background chunk of a lazy bundle', async () => {
   );
   expect(manifest['/app-service.js']).not.toContain('requireModuleAsync');
 
-  it('inlined scripts should not have syntax error', () => {
-    eval(manifest['/app-service.js']);
-  });
+  // the inlined app-service should be valid JavaScript
+  expect(() => eval(manifest['/app-service.js'])).not.toThrow();
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/index.js
@@ -1,0 +1,57 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+/// <reference types="@rstest/core/globals" />
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+it('should load the lazy bundle', async () => {
+  const { component } = await import(
+    /* webpackChunkName: 'component:background' */
+    './component.js'
+  );
+  expect(component()).toBe('shared:component');
+});
+
+// Regression test: with bundle splitting enabled, a lazy bundle's background is
+// split into multiple chunks (here `shared` + `component`). A user-provided
+// `inlineScripts` regex that is meant to match `background.js` does not match
+// these chunk names. Previously every background chunk that failed the matcher
+// was externalized via `lynx.requireModuleAsync`, leaving the modules
+// unavailable when `installChunk` runs synchronously and breaking the bundle.
+// All background chunks of a lazy bundle must be inlined.
+it('inlines every split background chunk of a lazy bundle', async () => {
+  const tasmJSONPath = resolve(
+    __dirname,
+    '.rspeedy/async/component/tasm.json',
+  );
+  expect(existsSync(tasmJSONPath)).toBeTruthy();
+
+  const content = await readFile(tasmJSONPath, 'utf-8');
+  const { sourceContent, manifest } = JSON.parse(content);
+
+  expect(sourceContent).toHaveProperty('appType', 'DynamicComponent');
+
+  // Both split background chunks are inlined into the bundle.
+  const keys = Object.keys(manifest);
+  expect(keys).toContain('/app-service.js');
+  expect(keys).toContain('/shared.rspack.bundle.js');
+  expect(keys).toContain('/component:background.rspack.bundle.js');
+
+  // They are required synchronously, not via requireModuleAsync.
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule(\"/shared.rspack.bundle.js\"`,
+  );
+  expect(manifest['/app-service.js']).toContain(
+    `lynx.requireModule(\"/component:background.rspack.bundle.js\"`,
+  );
+  expect(manifest['/app-service.js']).not.toContain('requireModuleAsync');
+
+  it('inlined scripts should not have syntax error', () => {
+    eval(manifest['/app-service.js']);
+  });
+});

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/rspack.config.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/rspack.config.js
@@ -1,0 +1,51 @@
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../../../../lib/index.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  devtool: false,
+  mode: 'development',
+  optimization: {
+    // Enable bundle splitting so the lazy bundle's background is split
+    // into more than one chunk.
+    splitChunks: {
+      chunks: 'all',
+      minSize: 0,
+      cacheGroups: {
+        shared: {
+          test: /shared\.js/,
+          name: 'shared',
+          enforce: true,
+        },
+      },
+    },
+  },
+  plugins: [
+    new LynxEncodePlugin({
+      // The production config used a regex intended to match `background.js`,
+      // but it does not match the real chunk name (e.g. `component__background.js`).
+      // The lazy bundle's background must still be inlined.
+      inlineScripts: /[\\/]background\.\w+\.js$/,
+    }),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      intermediate: '.rspeedy/main',
+    }),
+    /**
+     * @param {import('@rspack/core').Compiler} compiler - Rspack Compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap('test', (compilation) => {
+        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+          compilation,
+        );
+        hooks.asyncChunkName.tap(
+          'test',
+          chunkName =>
+            chunkName
+              .replace(':main-thread', '')
+              .replace(':background', ''),
+        );
+      });
+    },
+  ],
+};

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/shared.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/shared.js
@@ -1,0 +1,3 @@
+export function shared() {
+  return 'shared';
+}


### PR DESCRIPTION
## Summary

A lazy bundle (`appType: "DynamicComponent"`) should use `lynx.requireModule` instead of `lynx.requireModuleAsync` to load its bts. Otherwise it will fail to get exports when `installChunk`.

### Fix

For a lazy bundle (`appType === 'DynamicComponent'`), the bts is **always inlined** regardless of `inlineScripts`. The option still applies to `card` templates.

## Tests

- **Artifact level** (`template-webpack-plugin`): new `inline-scripts/lazy-bundle-split` case — a split lazy bundle with a non-matching `inlineScripts` regex; asserts every split background chunk is inlined (`requireModule`, no `requireModuleAsync`). Updated `external` / `inline-fn` / `inline-object` / `inline-regex` which previously asserted the externalized (broken) shape.
- **Execution level** (`plugin-react`): new `lazy.test.ts` case builds a real lazy bundle via the rspeedy pipeline with `inlineScripts: false`, then executes the generated `app-service.js` through a `tt`/`lynx` mock and asserts the bundle is available synchronously. Verified to fail without the fix (reproduces `lynx.requireModuleAsync(".../__background.js")`, the production failure shape).

## Notes

- Behavior change to the public `inlineScripts` option: it is now a no-op for lazy bundles (card behavior unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lazy bundle background chunks are no longer externalized by the inline-scripts matcher; they are always inlined into the service bundle to prevent runtime load failures.

* **Tests**
  * Added regression tests covering lazy-bundle inlining and split-bundle scenarios.
  * Updated existing tests to assert synchronous background module loading and validate the inlined service bundle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->