### PR TITLE
fix: avoid wasm 4kb error on chrome < 115

### DIFF
--- a/.changeset/late-snakes-try.md
+++ b/.changeset/late-snakes-try.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix: avoid wasm 4kb error on chrome < 115
+
+fix `Uncaught (in promise) RangeError: WebAssembly.Instanceis disallowed on the main thread, if the buffer size islargerthan 4KB. Use WebAssembly.instantiate.` error on `chrome < 115`

--- a/.changeset/late-snakes-try.md
+++ b/.changeset/late-snakes-try.md
@@ -4,4 +4,4 @@
 
 fix: avoid wasm 4kb error on chrome < 115
 
-fix `Uncaught (in promise) RangeError: WebAssembly.Instanceis disallowed on the main thread, if the buffer size islargerthan 4KB. Use WebAssembly.instantiate.` error on `chrome < 115`
+fix `Uncaught (in promise) RangeError: WebAssembly.Instance is disallowed on the main thread, if the buffer size is larger than 4KB. Use WebAssembly.instantiate.` error on `chrome < 115`

--- a/packages/web-platform/web-core/ts/client/wasm.ts
+++ b/packages/web-platform/web-core/ts/client/wasm.ts
@@ -61,7 +61,7 @@ const wasmLoaded = Promise.all([referenceTypes(), simd()]).then(
 ) as Promise<[typeof WasmInstanceType, WebAssembly.Module]>;
 export const [wasmInstance, wasmModule] = await wasmLoaded;
 if (!isWorker) {
-  wasmInstance.initSync({ module: wasmModule! });
+  await wasmInstance.default(wasmModule!);
 }
 
 export type MainThreadWasmContext =


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebAssembly instantiation errors on Chrome versions earlier than 115, preventing 4KB buffer-related failures and "instance disallowed on the main thread" RangeError.
  * Adjusted main-thread WebAssembly initialization to avoid synchronous instantiation issues, reducing crashes and failed WASM loads in affected browsers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
