### PR TITLE
chore(renovate): add npm minimum release age

### DIFF
--- a/.github/pnpm-11.instructions.md
+++ b/.github/pnpm-11.instructions.md
@@ -1,7 +1,9 @@
 ---
-applyTo: "{pnpm-workspace.yaml,**/package.json}"
+applyTo: "{pnpm-workspace.yaml,**/package.json,.github/renovate.json5}"
 ---
 
 When upgrading or maintaining pnpm 11, use the `allowBuilds` map in `pnpm-workspace.yaml`; `onlyBuiltDependencies` and `ignoredBuiltDependencies` are pnpm 10-era settings and should not be reintroduced.
+
+When adding Renovate npm minimum-release-age presets, mirror the delay in pnpm with `minimumReleaseAge` in `pnpm-workspace.yaml`; Renovate delegates lockfile maintenance to the package manager and does not enforce its own minimum release age for those updates.
 
 Do not add broad React or React DOM overrides in `pnpm-workspace.yaml`. Keep workspace React consumers on exact `react` and `react-dom` patch versions, and use scoped package metadata fixes when a tool package such as Rspress needs its internal React dependencies pinned to the same patch; Rspress SSG fails when pnpm resolves `react` and `react-dom` to different patch versions.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,8 @@
     "config:recommended",
     ":maintainLockFilesWeekly",
     "helpers:pinGitHubActionDigests",
+    // Delay npm updates by 3 days so risky or unpublished releases have time to surface.
+    "security:minimumReleaseAgeNpm",
   ],
 
   // Exclude `examples` from "config:recommended"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,9 @@ ignorePatchFailures: false
 optimisticRepeatInstall: true
 resolutionMode: "lowest-direct"
 
+# Match Renovate's npm minimum release age; pnpm also guards lockfile maintenance.
+minimumReleaseAge: 4320
+
 # Default catalogs
 catalog:
   "@microsoft/api-extractor": "7.58.2"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Delayed automatic npm dependency updates by 3 days to allow releases to surface before tooling applies upgrades.
  * Ensured workspace lockfile maintenance honors the same minimum release age.
  * Broadened maintenance guidance to include workspace config and package manifests.
  * Reinforced guidance to avoid broad React/React DOM overrides and prefer exact patch versions and scoped tooling fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
