### PR TITLE
fix(a2ui): add Google Material icon name enum

### DIFF
--- a/packages/genui/a2ui/src/catalog/Icon/index.tsx
+++ b/packages/genui/a2ui/src/catalog/Icon/index.tsx
@@ -13,8 +13,38 @@ function toMaterialName(name: string): string {
  * @a2uiCatalog Icon
  */
 export interface IconProps extends GenericComponentProps {
-  /** Material icon name (camelCase or snake_case), e.g. "info", "skipNext", "play_arrow". */
-  name: string | { path: string };
+  /** Google Material icon ligature name, e.g. "info", "account_circle", "arrow_back". */
+  name:
+    | 'account_circle'
+    | 'add'
+    | 'arrow_back'
+    | 'arrow_forward'
+    | 'camera'
+    | 'check'
+    | 'close'
+    | 'delete'
+    | 'edit'
+    | 'error'
+    | 'favorite'
+    | 'help'
+    | 'home'
+    | 'info'
+    | 'location_on'
+    | 'lock'
+    | 'mail'
+    | 'menu'
+    | 'more_vert'
+    | 'pause'
+    | 'person'
+    | 'play_arrow'
+    | 'refresh'
+    | 'search'
+    | 'send'
+    | 'settings'
+    | 'share'
+    | 'star'
+    | 'warning'
+    | { path: string };
   size?: 'sm' | 'md' | 'lg';
   color?: 'primary' | 'muted' | 'inherit';
 }

--- a/packages/genui/server/agent/catalog/Icon/catalog.json
+++ b/packages/genui/server/agent/catalog/Icon/catalog.json
@@ -4,7 +4,38 @@
       "name": {
         "oneOf": [
           {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "account_circle",
+              "add",
+              "arrow_back",
+              "arrow_forward",
+              "camera",
+              "check",
+              "close",
+              "delete",
+              "edit",
+              "error",
+              "favorite",
+              "help",
+              "home",
+              "info",
+              "location_on",
+              "lock",
+              "mail",
+              "menu",
+              "more_vert",
+              "pause",
+              "person",
+              "play_arrow",
+              "refresh",
+              "search",
+              "send",
+              "settings",
+              "share",
+              "star",
+              "warning"
+            ]
           },
           {
             "type": "object",
@@ -19,7 +50,7 @@
             "additionalProperties": false
           }
         ],
-        "description": "Material icon name (camelCase or snake_case), e.g. \"info\", \"skipNext\", \"play_arrow\"."
+        "description": "Google Material icon ligature name, e.g. \"info\", \"account_circle\", \"arrow_back\"."
       },
       "size": {
         "type": "string",


### PR DESCRIPTION
## Summary

- add a focused Google Material icon ligature enum for the A2UI Icon `name` prop
- sync the server agent's copied Icon catalog schema with the A2UI catalog contract
- update the Icon description to reference Google Material ligature names

## Validation

- `pnpm dprint check packages/genui/a2ui/src/catalog/Icon/index.tsx packages/genui/server/agent/catalog/Icon/catalog.json`
- `pnpm -C packages/genui/a2ui build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the Icon component with improved type constraints on icon names, restricting them to a predefined set of valid Google Material icon ligatures. This provides better IDE autocomplete and prevents invalid selections.
  * Updated documentation and schema definitions to reflect the supported icon ligature naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->