### PR TITLE
feat(a2ui): improve playground preview layout

### DIFF
--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -83,6 +83,7 @@ interface PreviewPanelProps {
   headerAfterTitle?: ReactNode;
   previewSource?: PreviewPanelSource;
   showPreviewModeSwitch?: boolean;
+  showSimulationBar?: boolean;
   beforeBody?: ReactNode;
   bodyClassName?: string;
   children: ReactNode;
@@ -183,6 +184,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
     headerAfterTitle,
     previewSource,
     showPreviewModeSwitch = false,
+    showSimulationBar = true,
     style,
     title,
   } = props;
@@ -542,7 +544,9 @@ export function PreviewPanel(props: PreviewPanelProps) {
             </button>
           </div>
           {beforeBody}
-          {previewSource && previewSource.kind !== 'placeholder'
+          {showSimulationBar
+              && previewSource
+              && previewSource.kind !== 'placeholder'
             ? (
               <PreviewSimulationBar
                 speed={speed}

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -1803,6 +1803,7 @@ export function AIChatPage(
           style={previewPanelStyle}
           title='Lynx Preview'
           showPreviewModeSwitch
+          showSimulationBar={false}
           previewSource={previewSource}
         >
           <PreviewViewport

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.css
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.css
@@ -543,6 +543,86 @@ html[data-theme="dark"] .detailBackButton:hover {
   flex-shrink: 0;
 }
 
+/* ── Examples Preview Split ── */
+.examplesPreviewPanel {
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) minmax(280px, 340px);
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.examplesPreviewPanel .previewPanelHeader {
+  grid-column: 1 / -1;
+  grid-row: 1;
+}
+
+.examplesPreviewPanel .previewPanelBody {
+  grid-column: 1;
+  grid-row: 2 / 5;
+  border-right: 1px solid var(--geist-border);
+}
+
+.examplesPreviewPanel .simulationBar {
+  grid-column: 2;
+  grid-row: 2;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--geist-border);
+}
+
+.examplesPreviewPanel .liveComponentStack {
+  grid-column: 2;
+  grid-row: 3;
+  align-items: stretch;
+  flex-direction: column;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 64px;
+  padding: 10px 16px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  border-top: none;
+  border-bottom: 1px solid var(--geist-border);
+}
+
+.examplesPreviewPanel .liveComponentTags {
+  flex-wrap: wrap;
+}
+
+.examplesPreviewPanel .previewQrSection {
+  grid-column: 2;
+  grid-row: 4;
+  min-height: 0;
+  overflow: auto;
+  border-top: none;
+}
+
+@media (min-width: 981px) and (max-width: 1280px) {
+  .examplesPreviewPanel {
+    display: flex;
+  }
+
+  .examplesPreviewPanel .previewPanelHeader,
+  .examplesPreviewPanel .previewPanelBody,
+  .examplesPreviewPanel .simulationBar,
+  .examplesPreviewPanel .liveComponentStack,
+  .examplesPreviewPanel .previewQrSection {
+    border-right: none;
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .examplesPreviewPanel .liveComponentStack,
+  .examplesPreviewPanel .previewQrSection {
+    border-top: 1px solid var(--geist-border);
+  }
+
+  .examplesPreviewPanel .previewQrSection {
+    overflow: auto;
+  }
+}
+
 @media (max-width: 980px) {
   .demosPage {
     flex-direction: column;
@@ -565,5 +645,29 @@ html[data-theme="dark"] .detailBackButton:hover {
     min-height: 480px;
     border-left: none;
     border-top: 1px solid var(--geist-border);
+  }
+
+  .examplesPreviewPanel {
+    display: flex;
+    overflow: visible;
+  }
+
+  .examplesPreviewPanel .previewPanelHeader,
+  .examplesPreviewPanel .previewPanelBody,
+  .examplesPreviewPanel .simulationBar,
+  .examplesPreviewPanel .liveComponentStack,
+  .examplesPreviewPanel .previewQrSection {
+    border-right: none;
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .examplesPreviewPanel .liveComponentStack {
+    border-top: 1px solid var(--geist-border);
+  }
+
+  .examplesPreviewPanel .previewQrSection {
+    border-top: 1px solid var(--geist-border);
+    overflow: visible;
   }
 }

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -45,7 +45,7 @@ const ALL_SCENARIOS: Scenario[] = [
   ...DYNAMIC_PRESETS,
 ];
 
-const DESKTOP_PREVIEW_MIN_WIDTH = 360;
+const DESKTOP_PREVIEW_MIN_WIDTH = 420;
 const DESKTOP_CODE_MIN_WIDTH = 360;
 const COMPACT_CODE_MIN_HEIGHT = 220;
 const COMPACT_PREVIEW_MIN_HEIGHT = 320;
@@ -93,8 +93,8 @@ export function DemosPage(props: {
     desktopOffsetSelector: '.sidebar',
     desktopPrimaryMinSize: DESKTOP_CODE_MIN_WIDTH,
     desktopSecondaryMinSize: DESKTOP_PREVIEW_MIN_WIDTH,
-    initialPrimarySize: 320,
-    initialSecondarySize: 480,
+    initialPrimarySize: 360,
+    initialSecondarySize: 760,
   });
 
   const currentScenario = useMemo(
@@ -300,7 +300,7 @@ export function DemosPage(props: {
       />
 
       <PreviewPanel
-        className='previewPanel'
+        className='previewPanel examplesPreviewPanel'
         style={previewPanelStyle}
         title='Lynx Preview'
         showPreviewModeSwitch


### PR DESCRIPTION
## Summary

- Split the A2UI Examples preview panel so the Lynx preview gets its own column on wide screens.
- Move simulation controls, streamed components, and QR preview links into a separate right-side column.
- Allow streamed component tags to wrap and place them below the `COMPONENTS` label.
- Hide the simulated replay bar on the Create page while keeping it on demo playback surfaces.

## Validation

- `pnpm dprint check packages/genui/a2ui-playground/src/pages/DemosPage.css`
- `pnpm dprint check packages/genui/a2ui-playground/src/components/PreviewPanel.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.tsx`
- `pnpm -C packages/genui/a2ui-playground build`
- `pnpm turbo build --filter a2ui-playground`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Simulation bar visibility in the preview panel is now configurable.

* **Style**
  * Updated preview panel layout with improved responsive design for various screen widths.

* **Refactor**
  * Adjusted preview panel sizing constants for better desktop display proportions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->