### PR TITLE
ci: scope turbo cache by dependency graph to fix stale snapshot replay

### DIFF
--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -28,8 +28,9 @@ jobs:
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo
-          # We have to be strict here to make sure getting the cache of build-all
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          # We have to be strict here to make sure getting the cache of build-all.
+          # Must stay byte-for-byte identical to the key in workflow-build.yml.
+          key: turbo-v5-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install
         run: |

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -95,15 +95,19 @@ jobs:
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.sha }}
-          # We can restore caches from:
+          # The key is scoped by both the Rust transform sources (*.rs) and the
+          # dependency graph (pnpm-lock.yaml). Turbo's per-task hash does not
+          # fully capture the compiled snapshot output, so a cache built against
+          # a different dependency graph must NOT be replayed here.
+          key: turbo-v5-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          # We can only restore caches that share the same Rust transform sources
+          # AND the same dependency graph (same *.rs hash and pnpm-lock.yaml hash):
           #   1. Previous commit from base branch (merge base or base SHA)
-          #   2. Any cache
+          #   2. Any cache with a matching *.rs + lockfile hash
           restore-keys: |
-            turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ needs.get-merge-base.outputs.merge-base }}
-            turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
-            turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-
-            turbo-v4-${{ runner.os }}-
+            turbo-v5-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ needs.get-merge-base.outputs.merge-base }}
+            turbo-v5-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
+            turbo-v5-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ hashFiles('pnpm-lock.yaml') }}-
       - name: Install
         run: |
           npm install -g corepack@latest

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -42,8 +42,9 @@ jobs:
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo
-          # We have to be strict here to make sure getting the cache of build-all
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          # We have to be strict here to make sure getting the cache of build-all.
+          # Must stay byte-for-byte identical to the key in workflow-build.yml.
+          key: turbo-v5-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install
         run: |

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -87,8 +87,11 @@ jobs:
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo
-          # We have to be strict here to make sure getting the cache of build-all
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          # We have to be strict here to make sure getting the cache of build-all.
+          # This key MUST stay byte-for-byte identical to the one in
+          # workflow-build.yml (same globs, same hash inputs) so that
+          # fail-on-cache-miss reliably restores that commit's build-all .turbo.
+          key: turbo-v5-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install
         run: |

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -23,7 +23,9 @@ jobs:
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          # Must stay byte-for-byte identical to the key in workflow-build.yml
+          # so fail-on-cache-miss restores that commit's build-all .turbo.
+          key: turbo-v5-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
## Symptom

The Vitest jobs fail with **227 `BackgroundSnapshot not found: __snapshot_*` errors across 51 unrelated test files** (`51 failed | 262 passed`), e.g. on #2712 — a PR that only *adds* the `@lynx-js/genui` packages and touches no test logic.

That error is thrown from `packages/react/runtime/src/snapshot/snapshot/backgroundSnapshot.ts:158` only when a *compiled* `__snapshot_*` id is never registered into `snapshotManager` — i.e. the snapshot **registration** and **reference** were generated with **different ids**. It is a build-artifact consistency problem, not a logic regression.

## Root cause: snapshot ids are derived from the file path, but the turbo cache is only invalidated by `*.rs`

The compiled snapshot id is generated in `packages/react/transform/crates/swc_plugin_snapshot/lib.rs`:

```rust
// lib.rs
filename_hash: calc_hash(&cfg.filename),           // sha1(filename)[0..5]
content_hash:  "test",                             // constant in test mode
let snapshot_uid = format!("__snapshot_{}_{}_{}", filename_hash, content_hash, snapshot_counter);
```

```rust
// swc_plugins_shared/utils.rs
pub fn calc_hash(s: &str) -> String {
  let mut hasher = Sha1::new();
  hasher.update(s.as_bytes());
  hex::encode(hasher.finalize())[0..5].to_string()
}
```

So an id like `__snapshot_ed6f7_test_1` is `sha1(<module filename>)[0..5]` + `test` + per-file counter. **The id is a function of the module's file path, not of the transform (`*.rs`) logic.**

pnpm stores every dependency (and workspace package) under `node_modules/.pnpm/<name>@<version>_<peer-hash>/...`. The failing stacks all run through such a path:

```
node_modules/.pnpm/@lynx-js+react@0.121.0_@lynx-js+types@3.7.0_@types+react@19.2.14/.../testing-library/dist/pure.js
                                  └────────────── pnpm peer-deps hash ──────────────┘
```

The `_<peer-hash>` segment changes whenever the dependency graph changes. #2712 adds 9 packages and changes **394 lines of `pnpm-lock.yaml`**, which shifts those `.pnpm/...` paths → the same module now hashes to a **different `filename_hash`** → a **different snapshot id** — even though no `*.rs` changed.

### How the stale cache turns this into a failure

`.turbo` is produced by the `build-all` job and handed off (via `fail-on-cache-miss: true`) to every downstream test job at the same `github.sha`. The key was:

```
turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.sha }}
```

with `restore-keys` falling back to the merge-base, the PR base, **any cache with the same `*.rs` hash**, and finally **any cache for the same OS**.

On the failing run, `build-all` (attempt #4) missed the exact `github.sha` key and restored the **base/main** cache via a restore-key (`...-62c1af39...`, the base commit *without* genui). Turbo replayed compiled modules whose ids were computed from the **old** `.pnpm` paths, while other modules were recompiled under the **new** paths → registration/reference ids diverge → `BackgroundSnapshot not found`. Re-runs kept failing because the poisoned cache was re-saved under this commit's `github.sha` and restored exactly on every retry.

**The `*.rs` hash was never the right invalidation signal: the snapshot id depends on the resolved file path, which is determined by the dependency graph (`pnpm-lock.yaml`), not by the transform sources.**

## Fix

- **Add `hashFiles('pnpm-lock.yaml')` to the cache key.** This is the input that actually determines the `.pnpm/...` paths the ids are hashed from, so a changed dependency graph no longer inherits a cache built against different paths.
- **Drop the over-broad `restore-keys` fallbacks** (the `*.rs`-only line and the OS-only line) that allowed inheriting a cache from an unrelated graph. The most permissive remaining fallback requires the same `*.rs` **and** lockfile hash.
- **Align the glob in the consumer workflows** (`workflow-test/website/bench/bundle-analysis`) from `**/packages/**/src/**/*.rs` to `packages/**/src/**/*.rs` so each key is byte-for-byte identical to `workflow-build.yml` — required by the `fail-on-cache-miss` handoff.
- **Bump `turbo-v4` -> `turbo-v5`** to discard the currently-poisoned caches.

### Trade-off

PRs that change `pnpm-lock.yaml` will cold-build the monorepo once (no warm turbo cache inherited across a dependency-graph change). This is intentional — correctness over reuse for dep-changing PRs. PRs that don't touch deps keep warm-cache reuse exactly as before.

### Deeper follow-up (not in this PR)

The cleaner fix is to make the snapshot id stable across dependency-graph changes (e.g. derive `filename_hash` from a workspace-relative path that excludes the pnpm peer-hash segment) and/or to track the transform's effective inputs in turbo's hashing. This PR hardens the CI cache layer so the handoff stops producing inconsistent artifacts.

## Evidence

- Failing run 26498982771, `build / Build (Ubuntu)` attempt #4: `Unable to find cache with primary key: ...-9f1158750...` → `Cache restored from key: ...-62c1af3921...` (base/main, pre-genui) → `Cache saved with key: ...-9f1158750...`. Attempt #5 then restored `...-9f1158750...` exactly (the already-poisoned cache).
- `9f1158750...` is the PR merge commit (`Merge ba716689 into 62c1af39`); `62c1af39...` is its base parent on `main`.
- Build step was `58 cached / 61 total`; the react runtime and all failing fixtures were `cache hit, replaying logs`.
- #2712 changes `pnpm-lock.yaml` (394 +/-) but no `*.rs`, so the old key did not invalidate.