### PR TITLE
fix(deps): make npm minimum release age workable (#2719 follow-up)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,6 +111,15 @@
       "rangeStrategy": "pin",
     },
     {
+      // First-party `@lynx-js/*` packages are trusted and publish fresh
+      // releases (e.g. the dated-snapshot preact builds above), so they should
+      // not be delayed by `security:minimumReleaseAgeNpm`.
+      "matchPackageNames": [
+        "@lynx-js/**",
+      ],
+      "minimumReleaseAge": "0 days",
+    },
+    {
       "groupName": "API Extractor",
       "groupSlug": "api-extractor",
       "matchPackageNames": [

--- a/.github/workflows/nodejs-dependencies.yml
+++ b/.github/workflows/nodejs-dependencies.yml
@@ -6,6 +6,7 @@ name: NodeJS Dependencies
     paths:
       - package.json
       - pnpm-lock.yaml
+      - pnpm-workspace.yaml
       - "**/package.json"
   merge_group:
     types: [checks_requested]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,11 @@ resolutionMode: "lowest-direct"
 
 # Match Renovate's npm minimum release age; pnpm also guards lockfile maintenance.
 minimumReleaseAge: 4320
+# First-party `@lynx-js/*` packages (e.g. the dated-snapshot `@lynx-js/internal-preact`
+# and `@lynx-js/preact-devtools` builds) are trusted and publish fresh releases that
+# would otherwise be blocked by `minimumReleaseAge`.
+minimumReleaseAgeExclude:
+  - "@lynx-js/*"
 
 # Default catalogs
 catalog:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,11 @@ minimumReleaseAge: 4320
 # would otherwise be blocked by `minimumReleaseAge`.
 minimumReleaseAgeExclude:
   - "@lynx-js/*"
+# npm's abbreviated metadata omits the `time` field, so a strict check hard-fails
+# (`ERR_PNPM_MISSING_TIME`) on packages it cannot date — e.g. during
+# `pnpm dedupe --check`. Run non-strict so the age check is enforced when `time`
+# is available and skipped (with a warning) when it is not.
+minimumReleaseAgeStrict: false
 
 # Default catalogs
 catalog:


### PR DESCRIPTION
## Summary

Follow-up to #2719, which added a 3-day npm **minimum release age** (`minimumReleaseAge: 4320` in `pnpm-workspace.yaml`, plus Renovate's `security:minimumReleaseAgeNpm`). The setting was never actually exercised by CI, so two problems went unnoticed. This PR makes it workable.

## Background: where the check runs

`minimumReleaseAge` is enforced during **version resolution** (pnpm's version-picking), so it fires on `pnpm install` (non-frozen), `pnpm update`, and `pnpm dedupe` — but **not** on `pnpm install --frozen-lockfile`. Every CI build/test job uses frozen install, so #2719 never triggered the check. The only job that re-resolves is `NodeJS Dependencies` (`pnpm dedupe --check`), and it only triggered on `package.json` / `pnpm-lock.yaml` changes — not on `pnpm-workspace.yaml`. So the new setting shipped untested.

## Changes

### 1. Run `NodeJS Dependencies` on `pnpm-workspace.yaml` changes
`pnpm-workspace.yaml` controls resolution (catalogs, overrides, `minimumReleaseAge`), so `.github/workflows/nodejs-dependencies.yml` now includes it in the trigger `paths`. This is what surfaced the two failures below.

### 2. `minimumReleaseAgeExclude: ["@lynx-js/*"]`  — fixes the *too-new* failure
First-party `@lynx-js/*` packages (notably `@lynx-js/preact-devtools` and `@lynx-js/internal-preact`, consumed via the `preact: npm:@lynx-js/internal-preact@…` alias) publish **dated-snapshot** builds under `latest`, so they are always younger than the 3-day window and get rejected:

```
[ERR_PNPM_NO_MATURE_MATCHING_VERSION] Version 5.0.1-20260525112551-dfe2d03 (released 45 hours ago)
of @lynx-js/preact-devtools does not meet the minimumReleaseAge constraint
```
(pnpm itself suggests adding the package to `minimumReleaseAgeExclude`.) A matching Renovate rule (`@lynx-js/**` → `minimumReleaseAge: "0 days"`) keeps their update PRs from being delayed too.

### 3. `minimumReleaseAgeStrict: false`  — fixes the *missing-`time`* failure
Even after excluding `@lynx-js/*`, the check still hard-failed on a different package:

```
[ERR_PNPM_MISSING_TIME] The metadata of @ai-sdk/provider-utils is missing the "time" field
```

Why: pnpm fetches npm's **abbreviated** metadata, which omits the `time` field. When per-version `time` is unavailable, pnpm falls back to the package's `modified` date:
- `modified` proves it is old enough → skip with a warning (e.g. `tailwindcss`);
- `modified` is recent / absent → it cannot confirm the age → **default strict mode throws `ERR_PNPM_MISSING_TIME`** (e.g. `@ai-sdk/provider-utils`, a dep of `@mastra/core`).

`minimumReleaseAgeStrict: false` turns that hard failure into the same warn-and-skip. It does **not** weaken the gate for packages pnpm *can* date — the age check still rejects too-new versions; `strict` only controls the undatable case (error vs skip). Verified locally: with a cutoff placed between `lodash@4.17.20` and `4.17.21`, both `strict: true` and `strict: false` resolve to `4.17.20`, rejecting the too-new `4.17.21`.

## The two failure modes, summarized
| package | reason | error | fixed by |
|---|---|---|---|
| `@lynx-js/preact-devtools` | published 45h ago (< 3 days) | `NO_MATURE_MATCHING_VERSION` | `minimumReleaseAgeExclude: ["@lynx-js/*"]` |
| `@ai-sdk/provider-utils` | abbreviated metadata lacks `time`, can't fall back | `MISSING_TIME` | `minimumReleaseAgeStrict: false` |

## Verification
- The `NodeJS Dependencies` check (first run ever with `minimumReleaseAge` active) failed on both errors above, then went **green** after these changes.
- `pnpm dedupe --check` and `sherif` pass.

## Note
Because npm's abbreviated metadata commonly lacks `time`, non-strict mode means the age gate is skipped for some packages during resolution. Tightening that would require pnpm to fetch full metadata (which includes `time`); the repo deliberately uses `resolution-mode: "lowest-direct"`, so that's a separate tradeoff. No package code changed, so no changeset.