### PR TITLE
test(rspeedy): use fileURLToPath for lazy test entry to fix windows ci

### DIFF
--- a/packages/rspeedy/plugin-react/test/lazy.test.ts
+++ b/packages/rspeedy/plugin-react/test/lazy.test.ts
@@ -469,10 +469,12 @@ describe('Lazy', () => {
       rspeedyConfig: {
         source: {
           entry: {
-            main: new URL(
-              './fixtures/lazy-bundle/index.tsx',
-              import.meta.url,
-            ).pathname,
+            main: fileURLToPath(
+              new URL(
+                './fixtures/lazy-bundle/index.tsx',
+                import.meta.url,
+              ),
+            ),
           },
         },
         output: {


### PR DESCRIPTION
## Problem

`Vitest (Windows) / check` fails across multiple PRs (e.g. #2712, #2724) on a single test:

```
FAIL  rspeedy/react  test/lazy.test.ts > Lazy > inlines lazy bundle background when inlineScripts is disabled
Error: Rspack build failed.
```

It passes on `Vitest (Ubuntu)` — a classic Windows-only path bug.

## Root cause

That test builds its rspack entry from:

```ts
main: new URL('./fixtures/lazy-bundle/index.tsx', import.meta.url).pathname
```

On Windows, a `file://` URL's `.pathname` is `/C:/Users/.../index.tsx` — a leading slash before the drive letter, which is **not** a valid Windows filesystem path. rspack cannot resolve the entry, so the build throws `Rspack build failed.`. On POSIX `.pathname` happens to be a valid path, so Ubuntu passes.

The three other entry definitions in the same file (lines 93 / 203 / 341) already use the cross-platform-safe `fileURLToPath(new URL(...))`; this one was the odd one out.

## Fix

Use `fileURLToPath(new URL(...))` (already imported in the file) so the entry resolves to a valid path on all platforms.

## Verification

- Locally (macOS) the test passes before and after (POSIX is unaffected).
- The fix is the same pattern as the sibling tests that already pass on Windows CI.