### PR TITLE
feat(a2ui-playground): container queries + mobile share sheet

### DIFF
--- a/packages/genui/a2ui-playground/package.json
+++ b/packages/genui/a2ui-playground/package.json
@@ -24,7 +24,8 @@
     "idb": "^8.0.3",
     "qrcode": "^1.5.4",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@lynx-js/config-rsbuild-plugin": "workspace:*",

--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
+import { Drawer } from 'vaul';
 
 import { CopyToast, useCopyToast } from './CopyToast.js';
 import { PreviewSimulationBar } from './PreviewSimulationBar.js';
@@ -190,6 +191,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
   } = props;
   const [mode, setMode] = useState<PreviewMode>('phone');
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const [speed, setSpeed] = useState(1);
   const [simulationInfoOpen, setSimulationInfoOpen] = useState(false);
   const [renderUrl, setRenderUrl] = useState('');
@@ -515,6 +517,151 @@ export function PreviewPanel(props: PreviewPanelProps) {
     });
   };
 
+  // Rendered both inline (when the panel is wide enough) and inside the
+  // bottom sheet (when the panel is narrow). The function closes over all
+  // local state so both instances stay in sync without prop plumbing.
+  const renderExtras = () => (
+    <>
+      {previewSource?.kind === 'a2ui'
+        ? (
+          <div className='liveComponentStack' aria-live='polite'>
+            <span className='liveComponentLabel'>Components</span>
+            {liveComponents.length > 0
+              ? (
+                <div className='liveComponentTags'>
+                  {liveComponents.map((name) => (
+                    <span key={name} className='liveComponentTag'>
+                      {name}
+                    </span>
+                  ))}
+                </div>
+              )
+              : (
+                <span className='liveComponentEmpty'>
+                  Waiting for streamed components
+                </span>
+              )}
+          </div>
+        )
+        : null}
+      {previewQrPlaceholder
+        ? (
+          <div className='previewQrSection'>
+            <div className='previewQrContent'>
+              <div className='previewQrInfo'>
+                <div className='previewQrTitle'>
+                  {previewQrPlaceholder.title}
+                </div>
+                <div className='previewQrDesc'>
+                  {previewQrPlaceholder.description}
+                </div>
+                <div className='previewQrPlaceholder'>
+                  <span className='previewQrPlaceholderText'>
+                    {previewQrPlaceholder.placeholder}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+        : (previewQrCards.length > 0
+          ? (
+            <div className='previewQrSection'>
+              {previewQrCards.map(({ key, item }) => {
+                const copied = key === 'webPreview' ? webCopied : nativeCopied;
+                const copyFailed = key === 'webPreview'
+                  ? webCopyFailed
+                  : nativeCopyFailed;
+                const error = key === 'webPreview' ? webQrError : nativeQrError;
+                const setError = key === 'webPreview'
+                  ? setWebQrError
+                  : setNativeQrError;
+
+                return (
+                  <div
+                    key={key}
+                    className={item.variant === 'alt'
+                      ? 'previewQrContent previewQrContentAlt'
+                      : 'previewQrContent'}
+                  >
+                    <div className='previewQrInfo'>
+                      <div className='previewQrTitle'>{item.title}</div>
+                      <div className='previewQrDesc'>
+                        {error && item.errorDescription
+                          ? item.errorDescription
+                          : item.description}
+                      </div>
+                      <div className='previewQrUrlRow'>
+                        <div
+                          className='previewQrUrlText'
+                          title={item.urlTitle ?? item.url}
+                        >
+                          {item.urlTitle ?? item.url}
+                        </div>
+                        <button
+                          type='button'
+                          className='previewQrCopyBtn'
+                          aria-label={item.copyButtonTitle ?? 'Copy URL'}
+                          title={copied
+                            ? 'Copied'
+                            : (copyFailed
+                              ? 'Copy failed'
+                              : (item.copyButtonTitle ?? 'Copy URL'))}
+                          onClick={() => {
+                            if (item.url) {
+                              handleCopyUrl(key, item.url);
+                            }
+                          }}
+                        >
+                          {copied
+                            ? 'Copied'
+                            : (copyFailed ? 'Failed' : 'Copy')}
+                        </button>
+                      </div>
+                    </div>
+                    {item.url && item.showQrCode !== false
+                      ? (
+                        <QrCode
+                          value={item.url}
+                          size={128}
+                          onErrorChange={setError}
+                        />
+                      )
+                      : null}
+                    {item.url && item.showQrCode === false
+                      ? (
+                        <div className='previewQrUnavailable'>
+                          <span className='previewQrUnavailableLabel'>
+                            QR unavailable
+                          </span>
+                          <span className='previewQrUnavailableSubtext'>
+                            URL too long to encode
+                          </span>
+                        </div>
+                      )
+                      : null}
+                    {!item.url && item.placeholder
+                      ? (
+                        <div className='previewQrPlaceholder'>
+                          <span className='previewQrPlaceholderText'>
+                            {item.placeholder}
+                          </span>
+                        </div>
+                      )
+                      : null}
+                  </div>
+                );
+              })}
+            </div>
+          )
+          : null)}
+    </>
+  );
+
+  const hasExtras = previewSource?.kind === 'a2ui'
+    || !!previewQrPlaceholder
+    || previewQrCards.length > 0;
+
   return (
     <PreviewPanelPreviewModeContext.Provider value={{ mode, setMode }}>
       <PreviewPanelRenderContext.Provider value={renderContext}>
@@ -533,6 +680,39 @@ export function PreviewPanel(props: PreviewPanelProps) {
             <div className='spacer' />
             {showPreviewModeSwitch
               ? <PreviewModeSwitch mode={mode} onChange={setMode} />
+              : null}
+            {hasExtras
+              ? (
+                <button
+                  type='button'
+                  className='previewInfoBtn'
+                  onClick={() => setShareOpen(true)}
+                  title='Open on phone'
+                  aria-label='Open this preview on a phone'
+                >
+                  <svg
+                    viewBox='0 0 24 24'
+                    width='16'
+                    height='16'
+                    fill='none'
+                    stroke='currentColor'
+                    strokeWidth='2'
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    aria-hidden='true'
+                  >
+                    <rect
+                      x='6'
+                      y='2'
+                      width='12'
+                      height='20'
+                      rx='2.5'
+                      ry='2.5'
+                    />
+                    <line x1='12' y1='18' x2='12.01' y2='18' />
+                  </svg>
+                </button>
+              )
               : null}
             <button
               type='button'
@@ -567,133 +747,29 @@ export function PreviewPanel(props: PreviewPanelProps) {
             )
             : null}
           <div className={bodyClass}>{children}</div>
-          {previewSource?.kind === 'a2ui'
+          <div className='previewPanelExtras'>{renderExtras()}</div>
+          {hasExtras
             ? (
-              <div className='liveComponentStack' aria-live='polite'>
-                <span className='liveComponentLabel'>Components</span>
-                {liveComponents.length > 0
-                  ? (
-                    <div className='liveComponentTags'>
-                      {liveComponents.map((name) => (
-                        <span key={name} className='liveComponentTag'>
-                          {name}
-                        </span>
-                      ))}
-                    </div>
-                  )
-                  : (
-                    <span className='liveComponentEmpty'>
-                      Waiting for streamed components
-                    </span>
-                  )}
-              </div>
+              <Drawer.Root
+                open={shareOpen}
+                onOpenChange={setShareOpen}
+              >
+                <Drawer.Portal>
+                  <Drawer.Overlay className='previewShareOverlay' />
+                  <Drawer.Content className='previewShareSheet'>
+                    <div className='previewShareHandle' aria-hidden='true' />
+                    <Drawer.Title className='previewShareTitle'>
+                      Preview info
+                    </Drawer.Title>
+                    <Drawer.Description className='previewShareDescription'>
+                      Components rendered and links to share this preview.
+                    </Drawer.Description>
+                    <div className='previewShareBody'>{renderExtras()}</div>
+                  </Drawer.Content>
+                </Drawer.Portal>
+              </Drawer.Root>
             )
             : null}
-          {previewQrPlaceholder
-            ? (
-              <div className='previewQrSection'>
-                <div className='previewQrContent'>
-                  <div className='previewQrInfo'>
-                    <div className='previewQrTitle'>
-                      {previewQrPlaceholder.title}
-                    </div>
-                    <div className='previewQrDesc'>
-                      {previewQrPlaceholder.description}
-                    </div>
-                    <div className='previewQrPlaceholder'>
-                      <span className='previewQrPlaceholderText'>
-                        {previewQrPlaceholder.placeholder}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )
-            : (
-              previewQrCards.length > 0
-                ? (
-                  <div className='previewQrSection'>
-                    {previewQrCards.map(({ key, item }) => {
-                      const copied = key === 'webPreview'
-                        ? webCopied
-                        : nativeCopied;
-                      const copyFailed = key === 'webPreview'
-                        ? webCopyFailed
-                        : nativeCopyFailed;
-                      const error = key === 'webPreview'
-                        ? webQrError
-                        : nativeQrError;
-                      const setError = key === 'webPreview'
-                        ? setWebQrError
-                        : setNativeQrError;
-
-                      return (
-                        <div
-                          key={key}
-                          className={item.variant === 'alt'
-                            ? 'previewQrContent previewQrContentAlt'
-                            : 'previewQrContent'}
-                        >
-                          <div className='previewQrInfo'>
-                            <div className='previewQrTitle'>{item.title}</div>
-                            <div className='previewQrDesc'>
-                              {error && item.errorDescription
-                                ? item.errorDescription
-                                : item.description}
-                            </div>
-                            <div className='previewQrUrlRow'>
-                              <div
-                                className='previewQrUrlText'
-                                title={item.urlTitle ?? item.url}
-                              >
-                                {item.urlTitle ?? item.url}
-                              </div>
-                              <button
-                                type='button'
-                                className='previewQrCopyBtn'
-                                aria-label={item.copyButtonTitle ?? 'Copy URL'}
-                                title={copied
-                                  ? 'Copied'
-                                  : (copyFailed
-                                    ? 'Copy failed'
-                                    : (item.copyButtonTitle ?? 'Copy URL'))}
-                                onClick={() => {
-                                  if (item.url) {
-                                    handleCopyUrl(key, item.url);
-                                  }
-                                }}
-                              >
-                                {copied
-                                  ? 'Copied'
-                                  : (copyFailed ? 'Failed' : 'Copy')}
-                              </button>
-                            </div>
-                          </div>
-                          {item.url && item.showQrCode !== false
-                            ? (
-                              <QrCode
-                                value={item.url}
-                                size={128}
-                                onErrorChange={setError}
-                              />
-                            )
-                            : null}
-                          {!item.url && item.placeholder
-                            ? (
-                              <div className='previewQrPlaceholder'>
-                                <span className='previewQrPlaceholderText'>
-                                  {item.placeholder}
-                                </span>
-                              </div>
-                            )
-                            : null}
-                        </div>
-                      );
-                    })}
-                  </div>
-                )
-                : null
-            )}
           {afterBody}
         </div>
       </PreviewPanelRenderContext.Provider>

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.css
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.css
@@ -543,7 +543,26 @@ html[data-theme="dark"] .detailBackButton:hover {
   flex-shrink: 0;
 }
 
-/* ── Examples Preview Split ── */
+/* ── Examples Preview Split ──
+   The wrapper is the container query host so the panel's internal layout
+   (split vs stacked) reacts to the panel's actual width, not the viewport.
+   That way dragging the JSON/preview resize handle re-flows the split as
+   the panel itself crosses the threshold. */
+.examplesPreviewWrap {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex-shrink: 0;
+  container-type: inline-size;
+  container-name: previewPanel;
+}
+
+.examplesPreviewWrap > .previewPanel {
+  width: 100%;
+  max-width: none;
+  flex: 1;
+}
+
 .examplesPreviewPanel {
   display: grid;
   grid-template-columns: minmax(360px, 1fr) minmax(280px, 340px);
@@ -598,9 +617,16 @@ html[data-theme="dark"] .detailBackButton:hover {
   border-top: none;
 }
 
-@media (min-width: 981px) and (max-width: 1280px) {
+/* Collapse to a single vertical stack only when the panel can no longer
+   fit the split layout (phone col 360 + controls col 280 = 640 floor).
+   Keep the threshold close to that floor so dragging the JSON/preview
+   resize handle stays in the split layout through most of its range —
+   the user can drag from the 760 default down to ~660 before collapse. */
+@container previewPanel (max-width: 660px) {
   .examplesPreviewPanel {
     display: flex;
+    flex-direction: column;
+    overflow: visible;
   }
 
   .examplesPreviewPanel .previewPanelHeader,
@@ -608,21 +634,21 @@ html[data-theme="dark"] .detailBackButton:hover {
   .examplesPreviewPanel .simulationBar,
   .examplesPreviewPanel .liveComponentStack,
   .examplesPreviewPanel .previewQrSection {
-    border-right: none;
     grid-column: auto;
     grid-row: auto;
+    border-right: none;
   }
 
   .examplesPreviewPanel .liveComponentStack,
   .examplesPreviewPanel .previewQrSection {
     border-top: 1px solid var(--geist-border);
   }
-
-  .examplesPreviewPanel .previewQrSection {
-    overflow: auto;
-  }
 }
 
+/* Page-level mobile layout: sidebar/codePanel/previewPanel stack vertically.
+   The panel-internal layout still uses the container query above — once the
+   wrapper hits full viewport width, it's almost always >720 and the split
+   reappears even on tablet-sized screens. */
 @media (max-width: 980px) {
   .demosPage {
     flex-direction: column;
@@ -640,34 +666,13 @@ html[data-theme="dark"] .detailBackButton:hover {
     flex: 0 0 auto;
   }
 
-  .previewPanel {
+  .examplesPreviewWrap {
     width: 100%;
     min-height: 480px;
+  }
+
+  .examplesPreviewWrap > .previewPanel {
     border-left: none;
     border-top: 1px solid var(--geist-border);
-  }
-
-  .examplesPreviewPanel {
-    display: flex;
-    overflow: visible;
-  }
-
-  .examplesPreviewPanel .previewPanelHeader,
-  .examplesPreviewPanel .previewPanelBody,
-  .examplesPreviewPanel .simulationBar,
-  .examplesPreviewPanel .liveComponentStack,
-  .examplesPreviewPanel .previewQrSection {
-    border-right: none;
-    grid-column: auto;
-    grid-row: auto;
-  }
-
-  .examplesPreviewPanel .liveComponentStack {
-    border-top: 1px solid var(--geist-border);
-  }
-
-  .examplesPreviewPanel .previewQrSection {
-    border-top: 1px solid var(--geist-border);
-    overflow: visible;
   }
 }

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -299,19 +299,20 @@ export function DemosPage(props: {
         onPointerDown={handlePanelResizeStart}
       />
 
-      <PreviewPanel
-        className='previewPanel examplesPreviewPanel'
-        style={previewPanelStyle}
-        title='Lynx Preview'
-        showPreviewModeSwitch
-        previewSource={previewSource}
-      >
-        <PreviewViewport
-          key={previewRenderKey}
-          emptyTitle='Select a demo to preview'
-          emptySubTitle='Lynx rendering will appear here'
-        />
-      </PreviewPanel>
+      <div className='examplesPreviewWrap' style={previewPanelStyle}>
+        <PreviewPanel
+          className='previewPanel examplesPreviewPanel'
+          title='Lynx Preview'
+          showPreviewModeSwitch
+          previewSource={previewSource}
+        >
+          <PreviewViewport
+            key={previewRenderKey}
+            emptyTitle='Select a demo to preview'
+            emptySubTitle='Lynx rendering will appear here'
+          />
+        </PreviewPanel>
+      </div>
     </div>
   );
 }

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -730,6 +730,48 @@ html[data-theme="dark"] .phoneHomeIndicator {
   flex-direction: column;
   background: var(--geist-surface);
   border-left: 1px solid var(--geist-border);
+  /* Container query host so the panel's own width drives extras visibility,
+     unaffected by viewport-level decisions like the page's sidebar/code split. */
+  container-type: inline-size;
+  container-name: previewPanel;
+}
+
+/* Pass-through wrapper: children participate directly in the panel's
+   flex/grid layout. Hidden on narrow panels so the Drawer takes over. */
+.previewPanelExtras {
+  display: contents;
+}
+
+.previewInfoBtn {
+  display: none;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--geist-radius-sm);
+  background: transparent;
+  color: var(--geist-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--geist-transition);
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.previewInfoBtn:hover {
+  color: var(--geist-foreground);
+  background: var(--geist-surface);
+}
+
+@container previewPanel (max-width: 660px) {
+  .previewPanelExtras {
+    display: none;
+  }
+  .previewInfoBtn {
+    display: inline-flex;
+  }
 }
 
 .previewPanelFullscreen {
@@ -1001,21 +1043,35 @@ html[data-theme="dark"] .phoneHomeIndicator {
   flex-shrink: 0;
   border-top: 1px solid var(--geist-border);
   background: var(--geist-background);
-  padding: 10px 16px;
+  padding: 12px 16px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+  container-type: inline-size;
+  container-name: previewQr;
 }
 
 .previewQrContent {
   display: flex;
-  align-items: center;
-  gap: 10px;
+  align-items: flex-start;
+  gap: 12px;
 }
 
 .previewQrContentAlt {
-  padding-top: 8px;
+  padding-top: 10px;
   border-top: 1px dashed var(--geist-border);
+}
+
+/* When this section is narrow (e.g. example page's 280-340px right column),
+   give the QR a bit less weight so URL + Copy stay readable. */
+@container previewQr (max-width: 380px) {
+  .previewQrContent {
+    gap: 10px;
+  }
+
+  .previewQrDesc {
+    display: none;
+  }
 }
 
 .previewQrInfo {
@@ -1097,6 +1153,106 @@ html[data-theme="dark"] .phoneHomeIndicator {
   color: var(--geist-secondary);
 }
 
+/* Slot the same size as the QR code, shown when a URL exists but is too
+   long to encode (live drafts). Keeps the card structure identical to the
+   QR-present case so the create and example panels visually align. */
+.previewQrUnavailable {
+  flex-shrink: 0;
+  width: 128px;
+  height: 128px;
+  border-radius: var(--geist-radius-md);
+  border: 1px dashed var(--geist-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px;
+  text-align: center;
+}
+
+.previewQrUnavailableLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--geist-foreground);
+  letter-spacing: 0.01em;
+}
+
+.previewQrUnavailableSubtext {
+  font-size: 10.5px;
+  color: var(--geist-secondary);
+  line-height: 1.35;
+}
+
+/* ── Mobile share sheet (Vaul) ── */
+.previewShareOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  /* Must beat .previewPanelFullscreen (z-index: 200); the share sheet is
+     triggered from inside the panel and should appear above it. */
+  z-index: 300;
+}
+
+.previewShareSheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 310;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--geist-background);
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  border-top: 1px solid var(--geist-border);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  overflow: hidden;
+  outline: none;
+}
+
+.previewShareHandle {
+  flex-shrink: 0;
+  width: 36px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--geist-border);
+  margin: 10px auto 4px;
+}
+
+.previewShareTitle {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--geist-secondary);
+  padding: 8px 16px 10px;
+  margin: 0;
+}
+
+/* Visually hidden but accessible — Vaul requires Drawer.Description */
+.previewShareDescription {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.previewShareBody {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
 .previewEmpty {
   text-align: center;
   color: var(--geist-secondary);
@@ -1168,13 +1324,5 @@ html[data-theme="dark"] .phoneHomeIndicator {
 
   .phoneWrap {
     padding: 10px;
-  }
-
-  .previewQrContent {
-    align-items: flex-start;
-  }
-
-  .previewQrDesc {
-    display: none;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,6 +687,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@lynx-js/config-rsbuild-plugin':
         specifier: workspace:*
@@ -4573,6 +4576,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -4641,6 +4657,19 @@ packages:
 
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -11713,6 +11742,12 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -14526,6 +14561,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -14590,6 +14647,16 @@ snapshots:
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -22862,6 +22929,15 @@ snapshots:
   varint@6.0.0: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

Refactors the A2UI playground preview panel so its layout reacts to **the panel's own width** instead of the viewport. Dragging the JSON/preview resize handle now correctly collapses the split when the panel itself can no longer fit it — previously only viewport size triggered the collapse, so resizing did nothing.

Also adds a **mobile bottom sheet** for the Components stack and Web/Native Preview cards on narrow panels, so the phone mockup can dominate the available space.

### Container queries

- `.examplesPreviewWrap` is the new container host (`container-name: previewPanel`). Split → stacked threshold drops from `@media (max-width: 1280px)` to `@container previewPanel (max-width: 660px)`, matching the grid's natural floor (`360 phone min + 280 controls min`).
- `.previewQrSection` is its own container (`container-name: previewQr`) so QR card layouts respond to their own column width (description hides in narrow examples columns).

### QR section polish

- Top-aligns title with the QR thumbnail (was `align-items: center`, which left short text floating mid-QR).
- Adds a `QR unavailable / URL too long to encode` placeholder (128×128, matching the QR slot) for live drafts whose URLs can't be encoded. Keeps create and example panels structurally aligned (both cards now have a right-side slot).

### Mobile share sheet

- Adds `vaul@^1.1.2`.
- On panels narrower than 660px, the Components stack and URL/QR cards collapse out of the panel and into a bottom sheet, opened by a phone-icon button in the panel header.
- A single `renderExtras()` closure feeds both the inline (via `display: contents` on `.previewPanelExtras`) and sheet renderings, so Copy state stays in sync between them.

## Test plan

- [ ] Demos page at wide viewport: drag the JSON/preview resize handle to shrink the preview panel past ~660px → it should collapse from split (phone | controls) to a vertical stack. Drag wider → split returns.
- [ ] Mobile-width viewport / narrow preview panel: phone-icon button appears in the panel header; tapping slides up a sheet with Components + Web/Native Preview cards. Swipe down / tap overlay / press Esc dismisses.
- [ ] Create (AIChat) page: each preview card shows a dashed `QR unavailable` placeholder in place of the QR; visual rhythm aligns with the example page's QR cards.
- [ ] Example page wide: QR card title/URL+Copy top-align with the 128px QR (no longer centered).
- [ ] Light + dark themes: sheet, placeholder, and panel split all render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile preview share sheet with a new "Open this preview on a phone" button in the preview panel header for streamlined mobile device testing and preview sharing workflows.

* **Improvements**
  * Enhanced responsive design architecture with improved mobile and tablet layout handling, featuring refined content spacing, intelligent visibility controls, and better adaptive behavior across varying device widths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->