### PR TITLE
fix(genui): Fix DateTimeInput calendar modal layout

### DIFF
--- a/.github/a2ui-catalog.instructions.md
+++ b/.github/a2ui-catalog.instructions.md
@@ -12,6 +12,10 @@ Avoid adding `@defaultValue` for string defaults in A2UI catalog component props
 
 Keep built-in catalog CSS assets in `packages/genui/a2ui/styles/catalog/*.css`, not under `src/catalog`. Catalog component TSX files should import those assets through paths that stay valid after TypeScript emits `dist/catalog/<Component>/index.jsx`, for example `../../../styles/catalog/Button.css`.
 
+When styling A2UI catalog `DialogView` overlays that should be page-centered, give the overlay view page-filling bounds such as `width: 100%`, `height: 100%`, and explicit `top` / `right` / `bottom` / `left` offsets before relying on flex centering. Avoid `inset`, because the Lynx template encoder drops it.
+
+For compact picker dialogs in A2UI phone previews, keep the natural content height below the small preview viewport; `max-height` is useful as a fallback, but dense controls such as calendar rows and time steppers may need smaller row heights so the dialog visually leaves top and bottom breathing room.
+
 When implementing leaf input components in `packages/genui/a2ui/src/catalog`, import `Input`/`TextArea` from `@lynx-js/lynx-ui-input` directly and let the host decide whether to wrap the surface in keyboard-aware layout. Do not wrap individual catalog leaf components in `KeyboardAwareTrigger` unless the component owns the surrounding keyboard-aware responder/root contract.
 
 For the `<A2UI>` shell, treat `className` and `wrapSurface` as complementary theming hooks. `className` belongs on the `surface-${surfaceId}` view itself, while `wrapSurface` is the outer wrapper for layout or theme shells. Prefer `className` when the theme lives on the surface root, and `wrapSurface` when you need an additional enclosing element.

--- a/packages/genui/a2ui/src/catalog/DateTimeInput/index.tsx
+++ b/packages/genui/a2ui/src/catalog/DateTimeInput/index.tsx
@@ -14,7 +14,6 @@ import {
   buildDateTimeMonthPage,
   dateTimePartsToDate,
   formatDateTimeInputValue,
-  getDateTimeDialogTitle,
   getDateTimeInputPlaceholder,
   getDefaultDateTimeParts,
   getWeekdayLabels,
@@ -252,19 +251,6 @@ export function DateTimeInput(
             transition={true}
           />
           <DialogContent className='datetime-dialog-content' transition={true}>
-            <view className='datetime-dialog-header'>
-              <text className='datetime-dialog-title'>
-                {getDateTimeDialogTitle(labelText, mode)}
-              </text>
-              <view
-                className='datetime-dialog-close'
-                bindtap={handleCancel}
-                event-through={false}
-              >
-                <text className='datetime-dialog-close-icon'>close</text>
-              </view>
-            </view>
-
             {mode.enableDate
               ? (
                 <view className='datetime-calendar'>

--- a/packages/genui/a2ui/src/catalog/DateTimeInput/utils.ts
+++ b/packages/genui/a2ui/src/catalog/DateTimeInput/utils.ts
@@ -371,13 +371,6 @@ export function getDateTimeInputPlaceholder(mode: DateTimeInputMode): string {
   return 'Select date';
 }
 
-export function getDateTimeDialogTitle(
-  label: string,
-  mode: DateTimeInputMode,
-): string {
-  return label || getDateTimeInputPlaceholder(mode);
-}
-
 export function withDate(
   parts: DateTimeParts,
   date: Date,

--- a/packages/genui/a2ui/styles/catalog/DateTimeInput.css
+++ b/packages/genui/a2ui/styles/catalog/DateTimeInput.css
@@ -51,7 +51,6 @@
 }
 
 .datetime-input-icon,
-.datetime-dialog-close-icon,
 .datetime-calendar-nav-icon,
 .datetime-time-stepper-icon {
   font-family: var(--a2ui-icon-font-family);
@@ -79,7 +78,11 @@
   justify-content: center;
   width: 100%;
   height: 100%;
-  padding: 20px;
+  padding: 24px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   box-sizing: border-box;
 }
 
@@ -101,10 +104,11 @@
 .datetime-dialog-content {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   width: 100%;
   max-width: 380px;
-  padding: 18px;
+  max-height: 82%;
+  padding: 16px;
   border-width: 1px;
   border-style: solid;
   border-color: var(--a2ui-color-border-strong);
@@ -112,6 +116,7 @@
   background-color: var(--a2ui-color-surface-strong);
   box-shadow: 0 16px 40px var(--a2ui-color-overlay);
   box-sizing: border-box;
+  overflow-y: auto;
   transition: opacity 0.18s ease, transform 0.18s ease;
 }
 
@@ -127,7 +132,6 @@
   transform: translateY(8px);
 }
 
-.datetime-dialog-header,
 .datetime-calendar-header,
 .datetime-dialog-actions {
   display: flex;
@@ -135,21 +139,11 @@
   align-items: center;
 }
 
-.datetime-dialog-header,
 .datetime-calendar-header {
   justify-content: space-between;
   gap: 12px;
 }
 
-.datetime-dialog-title {
-  min-width: 0;
-  color: var(--a2ui-color-on-surface);
-  font-size: 17px;
-  font-weight: 700;
-  line-height: 1.4;
-}
-
-.datetime-dialog-close,
 .datetime-calendar-nav {
   display: flex;
   align-items: center;
@@ -162,12 +156,10 @@
   color: var(--a2ui-color-text-muted);
 }
 
-.datetime-dialog-close.ui-active,
 .datetime-calendar-nav.ui-active {
   background-color: var(--a2ui-color-secondary);
 }
 
-.datetime-dialog-close-icon,
 .datetime-calendar-nav-icon {
   color: inherit;
   font-size: 20px;
@@ -176,7 +168,7 @@
 .datetime-calendar {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
   min-width: 0;
 }
@@ -201,7 +193,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 24px;
+  height: 20px;
 }
 
 .datetime-weekday-text {
@@ -212,14 +204,14 @@
 }
 
 .datetime-month {
-  grid-template-rows: 40px 40px 40px 40px 40px 40px;
+  grid-template-rows: 34px 34px 34px 34px 34px 34px;
 }
 
 .datetime-day {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 2px;
+  margin: 1px;
   border-width: 1px;
   border-style: solid;
   border-color: transparent;
@@ -262,7 +254,7 @@
 .datetime-time {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
   min-width: 0;
 }
@@ -279,7 +271,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 10px;
 }
 
 .datetime-time-field {
@@ -287,7 +279,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 72px;
+  width: 66px;
   min-width: 0;
   overflow: hidden;
   border-width: 1px;
@@ -299,16 +291,16 @@
 
 .datetime-time-value {
   color: var(--a2ui-color-on-surface);
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
-  line-height: 1.4;
+  line-height: 1.3;
 }
 
 .datetime-time-separator {
   color: var(--a2ui-color-text-muted);
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
-  line-height: 1.4;
+  line-height: 1.3;
 }
 
 .datetime-time-stepper {
@@ -316,7 +308,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 30px;
+  height: 24px;
   color: var(--a2ui-color-text-muted);
 }
 
@@ -326,7 +318,7 @@
 
 .datetime-time-stepper-icon {
   color: inherit;
-  font-size: 22px;
+  font-size: 20px;
 }
 
 .datetime-dialog-actions {

--- a/packages/genui/a2ui/test/dateTimeInput.test.ts
+++ b/packages/genui/a2ui/test/dateTimeInput.test.ts
@@ -7,7 +7,6 @@ import {
   buildDateTimeMonthPage,
   compareDateTimeParts,
   formatDateTimeInputValue,
-  getDateTimeDialogTitle,
   getDateTimeInputPlaceholder,
   getWeekdayLabels,
   incrementDateTimePart,
@@ -162,19 +161,10 @@ describe('DateTimeInput utils', () => {
     ).toBe(58);
   });
 
-  test('normalizes labels, titles, placeholders, and weekday labels', () => {
+  test('normalizes labels, placeholders, and weekday labels', () => {
     expect(normalizeDateTimeInputLabel('Due')).toBe('Due');
     expect(normalizeDateTimeInputLabel(7)).toBe('7');
     expect(normalizeDateTimeInputLabel({ path: '/label' })).toBe('');
-    expect(
-      getDateTimeDialogTitle('', { enableDate: false, enableTime: true }),
-    ).toBe('Select time');
-    expect(
-      getDateTimeDialogTitle('', { enableDate: true, enableTime: false }),
-    ).toBe('Select date');
-    expect(
-      getDateTimeDialogTitle('Due', { enableDate: false, enableTime: true }),
-    ).toBe('Due');
     expect(
       getDateTimeInputPlaceholder({ enableDate: true, enableTime: true }),
     ).toBe('Select date and time');


### PR DESCRIPTION
## Summary

- Center the DateTimeInput dialog against the full page overlay using supported positional bounds.
- Remove the DateTimeInput dialog title/header and the unused `getDateTimeDialogTitle` helper.
- Compact the calendar/time picker sizing so the modal leaves top and bottom breathing room in phone previews.

## Why

The DateTimeInput modal was visually too tall in the playground phone preview and its header was no longer needed. The previous overlay centering also used `inset`, which the Lynx template encoder drops.

## Validation

- `pnpm -C packages/genui/a2ui test test/dateTimeInput.test.ts`
- `pnpm -C packages/genui/a2ui build`
- `pnpm -C packages/genui/a2ui-playground build:lynx`

Note: the playground build still reports an existing `Modal.css` `inset` warning unrelated to this DateTimeInput change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidelines for overlay centering specifications and compact picker dialogs in phone previews.

* **Style**
  * Simplified DateTimeInput dialog by removing header component.
  * Refined layout spacing, sizing, and typography for more compact presentation.

* **Tests**
  * Updated DateTimeInput tests to reflect dialog structure changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->