### PR TITLE
chore: Auto scroll A2UI preview on content changes

### DIFF
--- a/packages/genui/a2ui-playground/lynx-src/a2ui/App.tsx
+++ b/packages/genui/a2ui-playground/lynx-src/a2ui/App.tsx
@@ -50,6 +50,8 @@ import { createMockAgent } from '../../examples/io-mock/mockAgent.js';
 import type { MockAgentProgress } from '../../examples/io-mock/mockAgent.js';
 
 const DEFAULT_STREAM_DELAY_MS = 800;
+const A2UI_SCROLL_VIEW_ID = 'a2ui-scroll-view';
+const A2UI_SCROLL_BOTTOM_OFFSET = 1000000;
 
 function manifestEntry(
   component: unknown,
@@ -389,6 +391,23 @@ export function App() {
     agent.resume();
   }, []);
 
+  const scrollPreviewToBottom = useCallback(() => {
+    if (playbackPausedRef.current) return;
+    lynx.createSelectorQuery()
+      .select(`#${A2UI_SCROLL_VIEW_ID}`)
+      .invoke({
+        method: 'scrollTo',
+        params: {
+          offset: A2UI_SCROLL_BOTTOM_OFFSET,
+          smooth: true,
+        },
+        fail: () => {
+          // The first content-size event can fire before UI methods are ready.
+        },
+      })
+      .exec();
+  }, []);
+
   useLynxGlobalEventListener(
     'A2UI_PLAYBACK_CONTROL',
     (action: unknown) => {
@@ -555,7 +574,9 @@ export function App() {
             {store
               ? (
                 <scroll-view
+                  id={A2UI_SCROLL_VIEW_ID}
                   scroll-y
+                  bindcontentsizechanged={scrollPreviewToBottom}
                   style={{ flex: 1, minHeight: 0 }}
                   className={isPlaybackPaused ? 'a2ui-scrollPaused' : ''}
                 >


### PR DESCRIPTION
## Summary

- Add a stable id to the A2UI playground preview `scroll-view`.
- Bind `contentsizechanged` to scroll the preview to the bottom using `scrollTo` with `smooth: true`.
- Ignore the early UI-method timing failure path so initial layout events do not surface noisy errors.

## Why

During streamed A2UI playback, preview content can grow after each message. The preview should keep following new content without requiring manual scrolling.

## Validation

- `pnpm dprint check packages/genui/a2ui-playground/lynx-src/a2ui/App.tsx`
- `git diff --check -- packages/genui/a2ui-playground/lynx-src/a2ui/App.tsx`
- `pnpm -C packages/genui/a2ui-playground build:lynx`

Note: the playground build still reports an existing `Modal.css` `inset` warning unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Lynx A2UI playground preview now auto-scrolls to the bottom as content grows during playback (unless paused), ensuring newly rendered content remains visible without manual scrolling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->