### PR TITLE
fix(genui): order a2ui-catalog-extractor build before a2ui api-extractor

### DIFF
--- a/.changeset/fix-genui-a2ui-catalog-build-order.md
+++ b/.changeset/fix-genui-a2ui-catalog-build-order.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Build `@lynx-js/genui-a2ui-catalog-extractor` before `@lynx-js/genui-a2ui`'s `api-extractor` task, so its `build:catalog` step can resolve the catalog extractor CLI instead of racing against it.

--- a/packages/genui/a2ui/turbo.json
+++ b/packages/genui/a2ui/turbo.json
@@ -15,6 +15,13 @@
       "outputs": [
         "dist/**"
       ]
+    },
+    "api-extractor": {
+      "dependsOn": [
+        "//#build",
+        "@lynx-js/genui-a2ui-catalog-extractor#build"
+      ],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary

`@lynx-js/genui-a2ui`'s `api-extractor` task runs `pnpm run build`, whose `build:catalog` step invokes the `genui` CLI and dynamically imports `@lynx-js/genui-a2ui-catalog-extractor/dist/cli.js`.

The shared `api-extractor` task only declared `dependsOn: ["//#build"]`, so turbo never guaranteed `@lynx-js/genui-a2ui-catalog-extractor` was built before `genui-a2ui`'s api-extractor ran. The genui packages run `run-api-extractor.mjs` under a shared lock that serializes them but does **not** order them, so whichever genui package's api-extractor happened to run first decided the outcome. When `genui-a2ui` won the race, its `build:catalog` failed with:

```
Cannot find module '.../packages/genui/a2ui-catalog-extractor/dist/cli.js'
  imported from .../packages/genui/cli/bin/cli.js
```

This intermittently broke `code-style-check` and `test-api` on unrelated PRs.

## Fix

Give `genui-a2ui`'s `api-extractor` task an explicit `@lynx-js/genui-a2ui-catalog-extractor#build` dependency (in addition to the existing `//#build`), so turbo always builds the catalog extractor — producing `dist/cli.js` — before the catalog generation step runs.

No dependency cycle: `@lynx-js/genui-a2ui-catalog-extractor` only depends on `typedoc`.

## Failing CI (before this fix)

- `code-style-check` on #2748 (after merging main, without this fix): https://github.com/lynx-family/lynx-stack/actions/runs/26581640592/job/78316111246 — fails with `Cannot find module .../a2ui-catalog-extractor/dist/cli.js`.

## Verification that the fix works

- `turbo api-extractor --filter=@lynx-js/genui-a2ui --dry-run=json` now reports `@lynx-js/genui-a2ui#api-extractor -> ['//#build', '@lynx-js/genui-a2ui-catalog-extractor#build']` (previously `-> ['//#build']`).
- This PR's own `code-style-check` passes: https://github.com/lynx-family/lynx-stack/actions/runs/26584778467/job/78327588583
- Cherry-picked onto #2748 (the branch that was failing), the same `code-style-check` job goes from red to green: https://github.com/lynx-family/lynx-stack/actions/runs/26584934732/job/78328149767

## Test plan

- [x] `code-style-check` passes in CI.