### PR TITLE
test(plugin-qrcode): stop QR re-render poll assertions from flaking on CI

### DIFF
--- a/.changeset/qrcode-test-timeout.md
+++ b/.changeset/qrcode-test-timeout.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Raise the dev-server test timeouts in `@lynx-js/qrcode-rsbuild-plugin` so the QR re-render `expect.poll` assertions no longer flake on busy CI runners (test-only change).

--- a/packages/rspeedy/plugin-qrcode/test/index.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/index.test.ts
@@ -195,7 +195,8 @@ describe('Plugins - Terminal', () => {
       // @ts-expect-error xxx
       resolve('bar')
 
-      await expect.poll(() => renderUnicodeCompact).toBeCalledTimes(2)
+      await expect.poll(() => renderUnicodeCompact, { timeout: 10_000 })
+        .toBeCalledTimes(2)
       expect(renderUnicodeCompact).toBeCalledWith(
         `$$http://example.com/foo/main.lynx.bundle$$`,
       )
@@ -272,7 +273,8 @@ describe('Plugins - Terminal', () => {
       // @ts-expect-error xxx
       resolve('main2')
 
-      await expect.poll(() => renderUnicodeCompact).toBeCalledTimes(2)
+      await expect.poll(() => renderUnicodeCompact, { timeout: 10_000 })
+        .toBeCalledTimes(2)
       expect(renderUnicodeCompact).toBeCalledWith(
         `==http://example.com/foo/main2.lynx.bundle==`,
       )

--- a/packages/rspeedy/plugin-qrcode/vitest.config.ts
+++ b/packages/rspeedy/plugin-qrcode/vitest.config.ts
@@ -4,6 +4,10 @@ import type { UserWorkspaceConfig } from 'vitest/config'
 const config: UserWorkspaceConfig = defineProject({
   test: {
     name: 'rspeedy/qrcode',
+    // These tests spin up a real dev server and wait for compiles/re-renders.
+    // The default 5s budget is too tight on busy CI runners (the dev-compile
+    // wait alone allows up to 5s), which made the QR re-render polls flake.
+    testTimeout: 20_000,
   },
 })
 


### PR DESCRIPTION
## Summary

The `Vitest (Ubuntu)` job intermittently fails on `plugin-qrcode`:

```
packages/rspeedy/plugin-qrcode/test/index.test.ts:198 (and :275)
Error: Matcher did not succeed in time.
expected "renderUnicodeCompact" to be called 2 times, but got 1 times
```

Both sites do `await expect.poll(() => renderUnicodeCompact).toBeCalledTimes(2)`, waiting for the QR re-render triggered when an interactive-prompt promise resolves (`resolve('bar')` / `resolve('main2')`). They used `expect.poll`'s **default 1000ms** timeout, which busy CI runners routinely exceed, so the poll gives up before the 2nd render lands. Locally (fast machine) it passes 9/9.

The dev-server tests also ran on the default **5s** test budget, even though `waitDevCompileDone` alone allows up to 5s — so simply bumping the poll timeout would just hit the test timeout instead.

## Failing CI (before this fix)

- `Vitest (Ubuntu)` on #2755: https://github.com/lynx-family/lynx-stack/actions/runs/26627685311/job/78469717405 — fails with "Matcher did not succeed in time" at `index.test.ts:198` and `:275`.

## Fix

- `vitest.config.ts`: raise the package `testTimeout` to 20s (these tests legitimately spin up a real dev server).
- The two re-render polls: pass `{ timeout: 10_000 }`.

Test-only change (no version bump). Can't be reproduced locally (passes here), so the validation is CI staying green.

## Verified fixed

- `Vitest (Ubuntu)` on this PR now passes: https://github.com/lynx-family/lynx-stack/actions/runs/26629013150/job/78474014792

(The `Vitest (Windows)` failure on this PR is an unrelated CI-infra issue — `hashFiles(...)` in the workflow template timing out on the Windows runner — not a test failure.)

## Test plan

- [x] `Vitest (Ubuntu)` passes.
- [ ] `Vitest (Windows)` — re-run to clear the unrelated `hashFiles` infra timeout.