### PR TITLE
perf(template-webpack-plugin): encode entry templates concurrently

### DIFF
--- a/.changeset/fast-templates-encode.md
+++ b/.changeset/fast-templates-encode.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Encode entry templates concurrently on the shared worker pool instead of one at a time. `react-rsbuild-plugin` registers one `LynxTemplatePlugin` instance per entry, and same-stage `processAssets` taps run serially, so the per-entry encodes were dispatched to the pool one after another. Each entry now pushes its un-awaited build into a shared per-compilation queue that a single coordinator tap awaits together, so multi-page builds use the full worker pool.

--- a/.changeset/fast-templates-encode.md
+++ b/.changeset/fast-templates-encode.md
@@ -2,4 +2,4 @@
 "@lynx-js/template-webpack-plugin": patch
 ---
 
-Encode entry templates concurrently on the shared worker pool instead of one at a time. `react-rsbuild-plugin` registers one `LynxTemplatePlugin` instance per entry, and same-stage `processAssets` taps run serially, so the per-entry encodes were dispatched to the pool one after another. Each entry now pushes its un-awaited build into a shared per-compilation queue that a single coordinator tap awaits together, so multi-page builds use the full worker pool.
+Encode entry templates concurrently on the shared worker pool, speeding up multi-page builds.

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -476,13 +476,8 @@ class LynxTemplatePluginImpl {
 
   static #taskQueue: Array<() => Promise<void>> | null = null;
 
-  // Per-compilation queue of in-flight template builds. react-rsbuild-plugin
-  // registers ONE LynxTemplatePlugin instance per entry, and `processAssets`
-  // taps at the same stage run serially — so awaiting each entry's build in its
-  // own tap would feed the worker pool one template at a time. Instead every
-  // entry pushes its un-awaited build promise into this shared (static, so it
-  // spans all the per-entry instances) queue, and a single coordinator tap
-  // awaits them together, letting the encodes run concurrently on the pool.
+  // Static so it spans the one-instance-per-entry plugins, whose serial
+  // same-stage taps would otherwise feed the encode pool one template at a time.
   static #templateQueues: WeakMap<Compilation, Promise<void>[]> = new WeakMap();
 
   constructor(
@@ -535,9 +530,8 @@ class LynxTemplatePluginImpl {
                */
               compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
           },
-          // Start this entry's build but don't await it here, so sibling
-          // entries' encodes all reach the worker pool together; the coordinator
-          // registered by `#templateQueue` awaits the whole queue.
+          // Don't await here — the coordinator awaits the whole queue, so
+          // sibling entries' encodes reach the pool concurrently.
           () => {
             templateQueue.push(
               this.#generateTemplate(compiler, compilation, filename),
@@ -611,12 +605,8 @@ class LynxTemplatePluginImpl {
     }
   }
 
-  /**
-   * The shared, per-compilation queue of in-flight template builds. The first
-   * call for a given compilation also registers the coordinator tap that awaits
-   * the whole queue — one stage after the per-entry generate taps have started
-   * the builds — so the encodes run concurrently on the worker pool.
-   */
+  // Returns the compilation's template-build queue, lazily creating it and
+  // registering the coordinator tap (one stage later) that awaits the queue.
   static #templateQueue(
     compilation: Compilation,
     compiler: Compiler,
@@ -937,9 +927,8 @@ class LynxTemplatePluginImpl {
       const filename = compilation.getPath(filenameTemplate, {
         // @ts-expect-error we have a mock chunk here to make contenthash works in webpack
         chunk: {},
-        // Hash this entry's own buffer with a fresh hash instance: templates are
-        // built concurrently, so a shared instance hash would interleave updates
-        // across entries and corrupt the content hash.
+        // Fresh hash per buffer: builds run concurrently, so a shared instance
+        // hash would interleave updates across entries.
         contentHash: compiler.webpack.util
           .createHash(compiler.options.output.hashFunction ?? 'xxhash64')
           .update(buffer)

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -471,33 +471,25 @@ export class LynxTemplatePlugin {
   }
 }
 
-interface Hash {
-  /**
-   * Update hash {@link https://nodejs.org/api/crypto.html#crypto_hash_update_data_inputencoding}
-   */
-  update(data: string | Buffer, inputEncoding?: string): Hash;
-
-  /**
-   * Calculates the digest {@link https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding}
-   */
-  digest(encoding?: string): string | Buffer;
-}
-
 class LynxTemplatePluginImpl {
   name = 'LynxTemplatePlugin';
 
   static #taskQueue: Array<() => Promise<void>> | null = null;
-  protected hash: Hash;
+
+  // Per-compilation queue of in-flight template builds. react-rsbuild-plugin
+  // registers ONE LynxTemplatePlugin instance per entry, and `processAssets`
+  // taps at the same stage run serially — so awaiting each entry's build in its
+  // own tap would feed the worker pool one template at a time. Instead every
+  // entry pushes its un-awaited build promise into this shared (static, so it
+  // spans all the per-entry instances) queue, and a single coordinator tap
+  // awaits them together, letting the encodes run concurrently on the pool.
+  static #templateQueues: WeakMap<Compilation, Promise<void>[]> = new WeakMap();
 
   constructor(
     compiler: Compiler,
     options: Required<LynxTemplatePluginOptions>,
   ) {
     this.#options = options;
-
-    const { createHash } = compiler.webpack.util;
-
-    this.hash = createHash(compiler.options.output.hashFunction ?? 'xxhash64');
 
     // entryName to fileName conversion function
     const userOptionFilename = this.#options.filename;
@@ -516,20 +508,24 @@ class LynxTemplatePluginImpl {
       ),
     );
 
-    outputFileNames.forEach((outputFileName) => {
-      // convert absolute filename into relative so that webpack can
-      // generate it at correct location
-      let filename = outputFileName;
-      if (path.resolve(filename) === path.normalize(filename)) {
-        filename = path.relative(
-          /** Once initialized the path is always a string */
-          compiler.options.output.path!,
-          filename,
-        );
+    // convert absolute filenames into relative ones so that webpack can
+    // generate them at the correct location
+    const filenames = [...outputFileNames].map((outputFileName) => {
+      if (path.resolve(outputFileName) === path.normalize(outputFileName)) {
+        /** Once initialized the path is always a string */
+        return path.relative(compiler.options.output.path!, outputFileName);
       }
+      return outputFileName;
+    });
 
-      compiler.hooks.thisCompilation.tap(this.name, (compilation) => {
-        compilation.hooks.processAssets.tapPromise(
+    compiler.hooks.thisCompilation.tap(this.name, (compilation) => {
+      const templateQueue = LynxTemplatePluginImpl.#templateQueue(
+        compilation,
+        compiler,
+      );
+
+      for (const filename of filenames) {
+        compilation.hooks.processAssets.tap(
           {
             name: this.name,
             stage:
@@ -537,18 +533,18 @@ class LynxTemplatePluginImpl {
                * Generate the html after minification and dev tooling is done
                * and source-map is generated
                */
-              compiler.webpack.Compilation
-                .PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
+              compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
           },
+          // Start this entry's build but don't await it here, so sibling
+          // entries' encodes all reach the worker pool together; the coordinator
+          // registered by `#templateQueue` awaits the whole queue.
           () => {
-            return this.#generateTemplate(
-              compiler,
-              compilation,
-              filename,
+            templateQueue.push(
+              this.#generateTemplate(compiler, compilation, filename),
             );
           },
         );
-      });
+      }
     });
 
     compiler.hooks.thisCompilation.tap(this.name, compilation => {
@@ -613,6 +609,33 @@ class LynxTemplatePluginImpl {
         }
       });
     }
+  }
+
+  /**
+   * The shared, per-compilation queue of in-flight template builds. The first
+   * call for a given compilation also registers the coordinator tap that awaits
+   * the whole queue — one stage after the per-entry generate taps have started
+   * the builds — so the encodes run concurrently on the worker pool.
+   */
+  static #templateQueue(
+    compilation: Compilation,
+    compiler: Compiler,
+  ): Promise<void>[] {
+    const existing = LynxTemplatePluginImpl.#templateQueues.get(compilation);
+    if (existing) {
+      return existing;
+    }
+
+    const queue: Promise<void>[] = [];
+    LynxTemplatePluginImpl.#templateQueues.set(compilation, queue);
+    compilation.hooks.processAssets.tapPromise({
+      name: 'LynxTemplatePlugin:await-templates',
+      stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
+        + 1,
+    }, async () => {
+      await Promise.all(queue.splice(0));
+    });
+    return queue;
   }
 
   async #generateTemplate(
@@ -914,7 +937,14 @@ class LynxTemplatePluginImpl {
       const filename = compilation.getPath(filenameTemplate, {
         // @ts-expect-error we have a mock chunk here to make contenthash works in webpack
         chunk: {},
-        contentHash: this.hash.update(buffer).digest('hex').toString(),
+        // Hash this entry's own buffer with a fresh hash instance: templates are
+        // built concurrently, so a shared instance hash would interleave updates
+        // across entries and corrupt the content hash.
+        contentHash: compiler.webpack.util
+          .createHash(compiler.options.output.hashFunction ?? 'xxhash64')
+          .update(buffer)
+          .digest('hex')
+          .toString(),
       });
 
       const { template } = await hooks.beforeEmit.promise({

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -623,7 +623,15 @@ class LynxTemplatePluginImpl {
       stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
         + 1,
     }, async () => {
-      await Promise.all(queue.splice(0));
+      // allSettled (not all): every encode was started eagerly, so wait for all
+      // of them to finish before the phase unwinds — otherwise a single
+      // rejection would let webpack move on while siblings still emit assets.
+      const results = await Promise.allSettled(queue.splice(0));
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          compilation.errors.push(result.reason as WebpackError);
+        }
+      }
     });
     return queue;
   }


### PR DESCRIPTION
## Summary

`react-rsbuild-plugin` registers **one `LynxTemplatePlugin` instance per entry**, and `processAssets` taps registered at the same stage run **serially**. As a result each entry's template encode was dispatched to the shared `LynxEncodePlugin.encodePool` **one at a time** — the worker pool was effectively idle on multi-page apps (only ever one encode in flight).

This change keeps a single, per-compilation queue of in-flight template builds. Each entry's generate tap now **starts its build without awaiting it** and pushes the promise into the shared queue; a single coordinator tap (registered once per compilation, one stage later) awaits the whole queue with `Promise.all`. The per-entry encodes therefore run **concurrently** across the worker pool.

The encode output is unchanged — same templates, same content hashes (the content hash now uses a fresh `createHash` per buffer, since builds run concurrently and a shared instance hash would interleave).

## Performance

Measured on a generated multi-page ReactLynx app (60 entries, ~500 elements + ~400 CSS rules each), timing the `processAssets` template/encode phase only (isolated from constant bundling cost):

| | encode phase | peak encodes in-flight | pool threads |
| --- | --- | --- | --- |
| before (serial) | ~4.7s | 1 | 7 |
| after (concurrent) | ~2.7s | 60 | 14 |

≈ **40% off the template phase**, purely from feeding the pool concurrently. The absolute win scales with per-entry encode cost: here `@lynx-js/tasm` encode is cheap so the remaining floor is the serial main-thread prep (`cssChunksToMap`, `.source().toString()`); apps with heavier per-page encode benefit more.

## How verified

- `tsc --build` clean; `@lynx-js/template-webpack-plugin` test suite passes (366 tests), including the existing multi-entry worker-pool test.
- A peak-concurrency probe (tap `encode`, record max simultaneously in-flight) confirms 1 → N with this change on the real one-instance-per-entry pipeline.

## Checklist

- [x] Tests updated (or not required) — covered by existing suite; output/snapshots unchanged.
- [x] Documentation updated (or not required) — internal behavior only.
- [x] Changeset added (`@lynx-js/template-webpack-plugin` patch).

## Test plan

- [ ] `turbo build` + `turbo test` for `@lynx-js/template-webpack-plugin`
- [ ] `changeset status` shows `@lynx-js/template-webpack-plugin` bumping patch
- [ ] Build a multi-page app and confirm emitted templates / hashes are unchanged vs `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Template encoding for multi-page webpack builds is now faster through concurrent processing.

* **Chores**
  * Updated template-webpack-plugin with internal optimizations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-stack/pull/2757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->