### PR TITLE
fix(a2ui): restore preview messages after refresh

### DIFF
--- a/.github/a2ui-catalog.instructions.md
+++ b/.github/a2ui-catalog.instructions.md
@@ -39,6 +39,8 @@ When verifying `packages/genui/a2ui-playground`, remember that `pnpm -F @lynx-js
 
 For known A2UI playground examples, keep the web preview URL on `?demo=<id>` instead of swapping it to the payload-store `messagesUrl`. `render.html` intentionally fetches known demo JSON in the browser shell and passes resolved messages into Lynx, avoiding fetch differences in the Lynx worker runtime; use payload-store URLs for custom edited JSON.
 
+When restoring A2UI playground Create previews after a page refresh, boot the render iframe separately from restored message delivery. Send restored messages through an idempotent replay event that `render.html` can queue until `<lynx-view>.sendGlobalEvent` and the Lynx `MessageStore` are both available; do not rely on a single eager `postMessage` during iframe startup.
+
 For interactive A2UI playground component examples, bind mutable props through `{ path: ... }` and provide matching example data so the component preview emits an initial `updateDataModel` before `updateComponents`. Literal values render the initial state but cannot be changed by `setValue`, which only writes back to data-bound props.
 
 For the built-in `DateTimeInput`, keep date-enabled default output as `YYYY-MM-DD` unless `outputFormat` is explicitly provided. Implement calendar behavior inside `packages/genui/a2ui` with local helpers that borrow the `lynx-ui-calendar` windowing/date patterns as needed, because `@lynx-js/lynx-ui-calendar` is not an available package dependency here.

--- a/packages/genui/a2ui-playground/lynx-src/a2ui/App.tsx
+++ b/packages/genui/a2ui-playground/lynx-src/a2ui/App.tsx
@@ -318,6 +318,7 @@ export function App() {
 
   const storeRef = useRef<MessageStore | null>(null);
   const agentRef = useRef<ReturnType<typeof createMockAgent> | null>(null);
+  const pendingReplayMessagesRef = useRef<unknown[] | null>(null);
   const pendingLiveMessagesRef = useRef<unknown[] | null>(null);
   const [store, setStore] = useState<MessageStore | null>(null);
   const [error, setError] = useState<string>('');
@@ -369,6 +370,13 @@ export function App() {
       }
     },
     [],
+  );
+  const replayMessagesToStore = useCallback(
+    (targetStore: MessageStore, messages: unknown) => {
+      targetStore.clear();
+      pushLiveMessagesToStore(targetStore, messages);
+    },
+    [pushLiveMessagesToStore],
   );
   const postPlaybackSync = useCallback((state: MockAgentProgress) => {
     NativeModules.bridge?.call?.(
@@ -462,6 +470,24 @@ export function App() {
   );
 
   useLynxGlobalEventListener(
+    'A2UI_REPLAY_MESSAGES',
+    (messages: unknown) => {
+      const currentStore = storeRef.current;
+      if (!currentStore) {
+        pendingReplayMessagesRef.current = Array.isArray(messages)
+          ? messages
+          : [messages];
+        return;
+      }
+      // Replays replace the preview buffer, making parent retries idempotent
+      // while the iframe and Lynx store finish booting.
+      replayMessagesToStore(currentStore, messages);
+      agentRef.current?.stop();
+      agentRef.current = null;
+    },
+  );
+
+  useLynxGlobalEventListener(
     'A2UI_LIVE_MESSAGES',
     (messages: unknown) => {
       const currentStore = storeRef.current;
@@ -534,6 +560,13 @@ export function App() {
       storeRef.current = next;
       agentRef.current = agent;
       setStore(next);
+      const pendingReplayMessages = pendingReplayMessagesRef.current;
+      if (pendingReplayMessages) {
+        pendingReplayMessagesRef.current = null;
+        replayMessagesToStore(next, pendingReplayMessages);
+        agent.stop();
+        agentRef.current = null;
+      }
       const pendingLiveMessages = pendingLiveMessagesRef.current;
       if (pendingLiveMessages) {
         pendingLiveMessagesRef.current = null;
@@ -567,6 +600,7 @@ export function App() {
     playbackMode,
     postPlaybackSync,
     pushLiveMessagesToStore,
+    replayMessagesToStore,
     streamConfig,
     streamDelay,
   ]);

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -878,6 +878,9 @@ export function AIChatPage(
   const latestPreviewMessagesRef = useRef<unknown[]>([]);
   const latestPreviewPayloadUrlsRef = useRef<PreviewPayloadUrls | null>(null);
   const renderUrlRef = useRef('');
+  const bootstrappedRenderUrlRef = useRef<string | null>(null);
+  const bootstrappedMessagesRef = useRef<unknown[] | null>(null);
+  const bootstrappedReplayTimersRef = useRef<number[]>([]);
   const {
     containerRef: pageRef,
     handleResizeStart: handlePanelResizeStart,
@@ -1021,6 +1024,57 @@ export function AIChatPage(
     };
   }, [previewMessages, previewPayloadUrls, protocol, theme]);
 
+  const clearBootstrappedPreview = useCallback(() => {
+    bootstrappedRenderUrlRef.current = null;
+    bootstrappedMessagesRef.current = null;
+    for (const timer of bootstrappedReplayTimersRef.current) {
+      window.clearTimeout(timer);
+    }
+    bootstrappedReplayTimersRef.current = [];
+  }, []);
+
+  const postLiveMessagesToPreview = useCallback((messages: unknown[]) => {
+    const targetOrigin = targetOriginForFrame(renderUrlRef.current);
+    previewFrameRef.current?.contentWindow?.postMessage(
+      { type: 'A2UI_LIVE_MESSAGES', messages },
+      targetOrigin,
+    );
+  }, []);
+
+  const postReplayMessagesToPreview = useCallback((messages: unknown[]) => {
+    const targetOrigin = targetOriginForFrame(renderUrlRef.current);
+    previewFrameRef.current?.contentWindow?.postMessage(
+      { type: 'A2UI_REPLAY_MESSAGES', messages },
+      targetOrigin,
+    );
+  }, []);
+
+  const postBootstrappedMessages = useCallback(() => {
+    const currentUrl = renderUrlRef.current;
+    if (bootstrappedRenderUrlRef.current !== currentUrl) return;
+    const messages = bootstrappedMessagesRef.current;
+    if (!messages || messages.length === 0) return;
+    // The first render URL only boots the Lynx runtime. Replay restored
+    // messages after iframe startup so render.html can queue them until
+    // sendGlobalEvent and the Lynx MessageStore are both ready.
+    for (const timer of bootstrappedReplayTimersRef.current) {
+      window.clearTimeout(timer);
+    }
+    bootstrappedReplayTimersRef.current = [];
+    postReplayMessagesToPreview(messages);
+    for (const delay of [100, 300, 800]) {
+      const timer = window.setTimeout(() => {
+        bootstrappedReplayTimersRef.current = bootstrappedReplayTimersRef
+          .current.filter((item) => item !== timer);
+        if (bootstrappedRenderUrlRef.current !== renderUrlRef.current) return;
+        const latestMessages = bootstrappedMessagesRef.current;
+        if (!latestMessages || latestMessages.length === 0) return;
+        postReplayMessagesToPreview(latestMessages);
+      }, delay);
+      bootstrappedReplayTimersRef.current.push(timer);
+    }
+  }, [postReplayMessagesToPreview]);
+
   const publishPreviewMessages = useCallback(
     (nextMessages: unknown[]) => {
       if (nextMessages.length === 0) return;
@@ -1038,19 +1092,32 @@ export function AIChatPage(
 
       setRenderUrl((current) => {
         if (current) {
-          const targetOrigin = targetOriginForFrame(current);
-          previewFrameRef.current?.contentWindow?.postMessage(
-            { type: 'A2UI_LIVE_MESSAGES', messages: nextMessages },
-            targetOrigin,
-          );
+          renderUrlRef.current = current;
+          if (bootstrappedRenderUrlRef.current === current) {
+            bootstrappedMessagesRef.current = nextMessages;
+            postBootstrappedMessages();
+            return current;
+          }
+          clearBootstrappedPreview();
+          postLiveMessagesToPreview(nextMessages);
           return current;
         }
 
         const nextRenderUrl = buildRenderUrl(initData, baseUrl);
+        renderUrlRef.current = nextRenderUrl;
+        bootstrappedRenderUrlRef.current = nextRenderUrl;
+        bootstrappedMessagesRef.current = nextMessages;
         return nextRenderUrl;
       });
     },
-    [baseUrl, protocol, theme],
+    [
+      baseUrl,
+      clearBootstrappedPreview,
+      postBootstrappedMessages,
+      postLiveMessagesToPreview,
+      protocol,
+      theme,
+    ],
   );
 
   const publishStreamingPreviewMessages = useCallback(
@@ -1075,23 +1142,40 @@ export function AIChatPage(
 
       setRenderUrl((current) => {
         if (current) {
-          const targetOrigin = targetOriginForFrame(current);
-          previewFrameRef.current?.contentWindow?.postMessage(
-            { type: 'A2UI_LIVE_MESSAGES', messages: deltaMessages },
-            targetOrigin,
-          );
+          renderUrlRef.current = current;
+          if (bootstrappedRenderUrlRef.current === current) {
+            bootstrappedMessagesRef.current = accumulatedMessages;
+            postBootstrappedMessages();
+            return current;
+          }
+          postLiveMessagesToPreview(deltaMessages);
           return current;
         }
 
-        return buildRenderUrl(initData, baseUrl);
+        const nextRenderUrl = buildRenderUrl(initData, baseUrl);
+        renderUrlRef.current = nextRenderUrl;
+        bootstrappedRenderUrlRef.current = nextRenderUrl;
+        bootstrappedMessagesRef.current = accumulatedMessages;
+        return nextRenderUrl;
       });
     },
-    [baseUrl, protocol, theme, updatePreviewPayloadUrls],
+    [
+      baseUrl,
+      postBootstrappedMessages,
+      postLiveMessagesToPreview,
+      protocol,
+      theme,
+      updatePreviewPayloadUrls,
+    ],
   );
 
   const handlePreviewLoad = useCallback(() => {
+    if (bootstrappedRenderUrlRef.current === renderUrlRef.current) {
+      postBootstrappedMessages();
+      return;
+    }
     publishPreviewMessages(latestPreviewMessagesRef.current);
-  }, [publishPreviewMessages]);
+  }, [postBootstrappedMessages, publishPreviewMessages]);
 
   useEffect(() => {
     if (!isReady || isGenerating) return;
@@ -1120,10 +1204,13 @@ export function AIChatPage(
       latestPreviewMessagesRef.current = [];
       setPreviewMessages(null);
       updatePreviewPayloadUrls(null);
+      clearBootstrappedPreview();
+      renderUrlRef.current = '';
       setRenderUrl('');
     }
   }, [
     activeId,
+    clearBootstrappedPreview,
     isReady,
     isGenerating,
     persistedMessages,
@@ -1299,6 +1386,10 @@ export function AIChatPage(
       if (!e.data || typeof e.data !== 'object') return;
       const msg = e.data as Record<string, unknown>;
       if (msg.type === 'A2UI_RENDER_READY') {
+        if (bootstrappedRenderUrlRef.current === renderUrlRef.current) {
+          postBootstrappedMessages();
+          return;
+        }
         publishPreviewMessages(latestPreviewMessagesRef.current);
         return;
       }
@@ -1552,6 +1643,7 @@ export function AIChatPage(
     };
   }, [
     buildConversationContext,
+    postBootstrappedMessages,
     publishPreviewMessages,
     recordTurn,
     updatePreviewPayloadUrls,

--- a/packages/genui/a2ui-playground/src/render.tsx
+++ b/packages/genui/a2ui-playground/src/render.tsx
@@ -71,6 +71,11 @@ interface LiveMessagesMessage {
   messages: unknown[];
 }
 
+interface ReplayMessagesMessage {
+  type: 'A2UI_REPLAY_MESSAGES';
+  messages: unknown[];
+}
+
 interface LynxViewElement extends HTMLElement {
   initData?: InitData;
   globalProps?: unknown;
@@ -289,6 +294,7 @@ function Render() {
   const [playbackMode, setPlaybackMode] = useState(false);
   const lynxViewRef = useRef<LynxViewElement | null>(null);
   const lastPlaybackPausedRef = useRef<boolean | null>(null);
+  const pendingReplayMessagesRef = useRef<unknown[] | null>(null);
   const pendingLiveMessagesRef = useRef<unknown[] | null>(null);
   const pendingActionResponsesRef = useRef<unknown[][]>([]);
   const pendingFlushTimerRef = useRef<number | null>(null);
@@ -300,7 +306,8 @@ function Render() {
   }, []);
 
   const hasPendingA2UIEvents = useCallback(() => {
-    return pendingLiveMessagesRef.current !== null
+    return pendingReplayMessagesRef.current !== null
+      || pendingLiveMessagesRef.current !== null
       || pendingActionResponsesRef.current.length > 0;
   }, []);
 
@@ -308,6 +315,12 @@ function Render() {
     const lynxView = lynxViewRef.current;
     if (!lynxView || typeof lynxView.sendGlobalEvent !== 'function') {
       return false;
+    }
+
+    const replayMessages = pendingReplayMessagesRef.current;
+    if (replayMessages) {
+      pendingReplayMessagesRef.current = null;
+      lynxView.sendGlobalEvent('A2UI_REPLAY_MESSAGES', [replayMessages]);
     }
 
     const liveMessages = pendingLiveMessagesRef.current;
@@ -431,6 +444,19 @@ function Render() {
         pendingActionResponsesRef.current.push(
           (e.data as ActionResponseMessage).messages,
         );
+        pendingFlushAttemptsRef.current = 0;
+        if (!flushPendingA2UIEvents()) {
+          schedulePendingA2UIFlush();
+        }
+        return;
+      }
+      if (
+        e.data
+        && typeof e.data === 'object'
+        && (e.data as ReplayMessagesMessage).type === 'A2UI_REPLAY_MESSAGES'
+      ) {
+        pendingReplayMessagesRef.current = (e.data as ReplayMessagesMessage)
+          .messages;
         pendingFlushAttemptsRef.current = 0;
         if (!flushPendingA2UIEvents()) {
           schedulePendingA2UIFlush();


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the playground preview flow and safe message restoration after a refresh.

* **Improvements**
  * More reliable preview iframe initialization and sequencing to avoid missed startup messages.
  * Buffered and idempotent message replay so restored previews consistently reach the renderer.
  * Bootstrapped preview flow to ensure initial messages are replayed once the renderer is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

## Validation

- `pnpm dprint fmt packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/render.tsx packages/genui/a2ui-playground/lynx-src/a2ui/App.tsx .github/a2ui-catalog.instructions.md`
- `git diff --check`
- `pnpm -C packages/genui/a2ui-playground run build:lynx`
- `pnpm -C packages/genui/a2ui-playground exec rsbuild build`