### PR TITLE
feat(debug-metadata): expose customizable sourceMappingURL rewriter

### DIFF
--- a/.changeset/debug-metadata-source-mapping-url-customizer.md
+++ b/.changeset/debug-metadata-source-mapping-url-customizer.md
@@ -1,0 +1,3 @@
+---
+"@lynx-js/debug-metadata-rsbuild-plugin": minor
+---

--- a/packages/rspeedy/plugin-debug-metadata/etc/debug-metadata-rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-debug-metadata/etc/debug-metadata-rsbuild-plugin.api.md
@@ -5,11 +5,24 @@
 ```ts
 
 import type { RsbuildPlugin } from '@rsbuild/core';
+import type { Rspack } from '@rsbuild/core';
+import type { TemplateHooks } from '@lynx-js/template-webpack-plugin';
 
 // @public
 export const DEBUG_METADATA_ASSET_NAME = "debug-metadata.json";
 
 // @public
 export function pluginLynxDebugMetadata(): RsbuildPlugin;
+
+// @public
+export function rewriteSourceMappingURLs(compilation: Rspack.Compilation, args: Parameters<Parameters<TemplateHooks['beforeEncode']['tap']>[1]>[0], options?: RewriteSourceMappingURLsOptions): void;
+
+// @public
+export interface RewriteSourceMappingURLsOptions {
+    getSourceMappingURL?: (info: {
+        mapPath: string;
+        debugMetadataUrl: string;
+    }) => string;
+}
 
 ```

--- a/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
@@ -33,7 +33,10 @@ import {
   getReleaseDefine,
   getReleaseRuntime,
 } from './release-banner.js'
-import { rewriteTrailerToAbsoluteUrl } from './source-mapping-url-rewriter.js'
+import {
+  rewriteSourceMappingURL,
+  rewriteSourceMappingURLToAbsolute,
+} from './source-mapping-url-rewriter.js'
 
 /**
  * The options of the {@link LynxDebugMetadataPlugin}.
@@ -233,7 +236,7 @@ export class LynxDebugMetadataPluginImpl {
               }`
           }
 
-          rewriteSourceMappingURLTrailers(compilation, args)
+          rewriteSourceMappingURLs(compilation, args)
 
           return args
         },
@@ -321,13 +324,32 @@ function readTasmSection(
     : undefined
 }
 
-type BeforeEncodeArgs = Parameters<
-  Parameters<TemplateHooks['beforeEncode']['tap']>[1]
->[0]
+/**
+ * Options for {@link rewriteSourceMappingURLs}.
+ *
+ * @public
+ */
+export interface RewriteSourceMappingURLsOptions {
+  /**
+   * Override the URL written into each rewritten sourceMappingURL. Defaults
+   * to `${debugMetadataUrl}?field=source-map&path=<encoded mapPath>`.
+   */
+  getSourceMappingURL?: (
+    info: { mapPath: string, debugMetadataUrl: string },
+  ) => string
+}
 
-function rewriteSourceMappingURLTrailers(
+/**
+ * Rewrite the `//# sourceMappingURL=...` directive of every JS asset in the
+ * current template to an absolute URL. No-op when `debugMetadataUrl`
+ * (`args.encodeData.sourceContent.config['debugMetadataUrl']`) is unset.
+ *
+ * @public
+ */
+export function rewriteSourceMappingURLs(
   compilation: Rspack.Compilation,
-  args: BeforeEncodeArgs,
+  args: Parameters<Parameters<TemplateHooks['beforeEncode']['tap']>[1]>[0],
+  options?: RewriteSourceMappingURLsOptions,
 ): void {
   const debugMetadataUrl = args.encodeData.sourceContent.config[
     'debugMetadataUrl'
@@ -354,11 +376,14 @@ function rewriteSourceMappingURLTrailers(
     const asset = compilation.getAsset(assetName)
     if (!asset) continue
     const before = asset.source.source().toString()
-    const after = rewriteTrailerToAbsoluteUrl(
-      before,
+    const mapPath = `${assetName}.map`
+    const customUrl = options?.getSourceMappingURL?.({
+      mapPath,
       debugMetadataUrl,
-      `${assetName}.map`,
-    )
+    })
+    const after = customUrl === undefined
+      ? rewriteSourceMappingURLToAbsolute(before, debugMetadataUrl, mapPath)
+      : rewriteSourceMappingURL(before, customUrl)
     if (after === undefined) continue
     const newSource = new RawSource(after)
     compilation.updateAsset(assetName, newSource, asset.info)

--- a/packages/rspeedy/plugin-debug-metadata/src/index.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/index.ts
@@ -15,3 +15,7 @@
 
 export { pluginLynxDebugMetadata } from './pluginLynxDebugMetadata.js'
 export { DEBUG_METADATA_ASSET_NAME } from './constants.js'
+export {
+  type RewriteSourceMappingURLsOptions,
+  rewriteSourceMappingURLs,
+} from './LynxDebugMetadataPlugin.js'

--- a/packages/rspeedy/plugin-debug-metadata/src/source-mapping-url-rewriter.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/source-mapping-url-rewriter.ts
@@ -4,28 +4,57 @@
 
 import { DEBUG_METADATA_ASSET_NAME } from './constants.js'
 
-const SOURCE_MAPPING_URL_TRAILER =
+const SOURCE_MAPPING_URL_RE =
   /(?:\/\/[#@]\s*sourceMappingURL=(\S+)|\/\*[#@]\s*sourceMappingURL=([^\s*]+)\s*\*\/)\s*$/
 
 /**
+ * Replace the trailing `//# sourceMappingURL=...` (or block-comment form)
+ * with `newUrl`. Returns the new source string, or `undefined` when the
+ * directive is absent or points at a `data:` URI. Consumer-supplied URLs
+ * always overwrite — no idempotency guard at this layer, so a consumer
+ * callback can replace a URL the default flow baked first.
+ *
  * @internal Exported for unit testing only.
  */
-export function rewriteTrailerToAbsoluteUrl(
+export function rewriteSourceMappingURL(
+  source: string,
+  newUrl: string,
+): string | undefined {
+  const match = SOURCE_MAPPING_URL_RE.exec(source)
+  if (!match) return undefined
+  const isBlockComment = match[2] !== undefined
+  const originalUrl = isBlockComment ? match[2] : match[1]
+  if (!originalUrl || originalUrl.startsWith('data:')) return undefined
+  const directive = isBlockComment
+    ? `/*# sourceMappingURL=${newUrl}*/`
+    : `//# sourceMappingURL=${newUrl}`
+  return source.slice(0, match.index) + directive
+}
+
+/**
+ * Default URL builder used by the dev-server path: rewrites the
+ * sourceMappingURL to point at the local-or-uploaded debug-metadata
+ * container, asking the container's host for the `source-map` field of the
+ * given `mapAssetPath`. Assumes `metadataUrl` is query-less. Idempotent —
+ * skips directives already pointing at a debug-metadata container so a
+ * later consumer-callback pass can still overwrite via
+ * {@link rewriteSourceMappingURL}.
+ *
+ * @internal Exported for unit testing only.
+ */
+export function rewriteSourceMappingURLToAbsolute(
   source: string,
   metadataUrl: string,
   mapAssetPath: string,
 ): string | undefined {
-  const match = SOURCE_MAPPING_URL_TRAILER.exec(source)
+  const match = SOURCE_MAPPING_URL_RE.exec(source)
   if (!match) return undefined
   const isBlockComment = match[2] !== undefined
   const originalUrl = isBlockComment ? match[2] : match[1]
   if (!originalUrl || originalUrl.startsWith('data:')) return undefined
   if (originalUrl.includes(DEBUG_METADATA_ASSET_NAME)) return undefined
-  const newUrl = `${metadataUrl}?field=source-map&path=${
-    encodeURIComponent(mapAssetPath)
-  }`
-  const trailer = isBlockComment
-    ? `/*# sourceMappingURL=${newUrl}*/`
-    : `//# sourceMappingURL=${newUrl}`
-  return source.slice(0, match.index) + trailer
+  return rewriteSourceMappingURL(
+    source,
+    `${metadataUrl}?field=source-map&path=${encodeURIComponent(mapAssetPath)}`,
+  )
 }

--- a/packages/rspeedy/plugin-debug-metadata/test/source-mapping-url-rewriter.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/source-mapping-url-rewriter.test.ts
@@ -4,71 +4,92 @@
 
 import { describe, expect, test } from 'vitest'
 
-import { rewriteTrailerToAbsoluteUrl } from '../src/source-mapping-url-rewriter.js'
+import {
+  rewriteSourceMappingURL,
+  rewriteSourceMappingURLToAbsolute,
+} from '../src/source-mapping-url-rewriter.js'
 
 const SAMPLE_BODY = 'var __webpack_modules__ = {};\nconsole.log(42);\n'
-const wrap = (trailer: string): string => SAMPLE_BODY + trailer
+const wrap = (directive: string): string => SAMPLE_BODY + directive
 
-describe('rewriteTrailerToAbsoluteUrl', () => {
+describe('rewriteSourceMappingURLToAbsolute', () => {
   const ASYNC_MAP = 'static/js/async/Lazy-react__main-thread.js.map'
   const ASYNC_MAP_ENC = encodeURIComponent(ASYNC_MAP)
   const BUNDLE_URL =
     'http://host:3020/.rspeedy/async/Lazy.js/debug-metadata.json'
 
-  test('replaces the trailer with the caller-supplied metadata URL plus path query', () => {
+  test('replaces the directive with the caller-supplied metadata URL plus path query', () => {
     const before = wrap(
       '//# sourceMappingURL=http://host:3020/static/js/async/Lazy-react__main-thread.js.map',
     )
-    const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, ASYNC_MAP)
+    const after = rewriteSourceMappingURLToAbsolute(
+      before,
+      BUNDLE_URL,
+      ASYNC_MAP,
+    )
     expect(after).toBe(
       `${SAMPLE_BODY}//# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${ASYNC_MAP_ENC}`,
     )
   })
 
-  test('discards the original trailer\'s dir entirely (cross-dir case)', () => {
+  test('discards the original directive\'s dir entirely (cross-dir case)', () => {
     const before = wrap(
       '//# sourceMappingURL=/static/js/async/Lazy-react__main-thread.js.map',
     )
-    const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, ASYNC_MAP)
+    const after = rewriteSourceMappingURLToAbsolute(
+      before,
+      BUNDLE_URL,
+      ASYNC_MAP,
+    )
     expect(after).not.toContain(
       '/static/js/async/Lazy-react__main-thread.js.map',
     )
     expect(after).toContain(BUNDLE_URL)
   })
 
-  test('overwrites any existing query string on the original trailer', () => {
+  test('overwrites any existing query string on the original directive', () => {
     const before = wrap(
       '//# sourceMappingURL=/static/js/async/Lazy-react__main-thread.js.map?token=abc',
     )
-    const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, ASYNC_MAP)
+    const after = rewriteSourceMappingURLToAbsolute(
+      before,
+      BUNDLE_URL,
+      ASYNC_MAP,
+    )
     expect(after).not.toContain('token=abc')
     expect(after).toContain(`${BUNDLE_URL}?field=source-map&path=`)
   })
 
   test('accepts the legacy `//@ sourceMappingURL=` form', () => {
     const before = wrap('//@ sourceMappingURL=Lazy.js.map')
-    const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, ASYNC_MAP)
+    const after = rewriteSourceMappingURLToAbsolute(
+      before,
+      BUNDLE_URL,
+      ASYNC_MAP,
+    )
     expect(after).toBe(
       `${SAMPLE_BODY}//# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${ASYNC_MAP_ENC}`,
     )
   })
 
-  test('returns undefined for data: URL trailers', () => {
+  test('returns undefined for data: URL directives', () => {
     const before = wrap(
       '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
     )
-    expect(rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, ASYNC_MAP))
+    expect(rewriteSourceMappingURLToAbsolute(before, BUNDLE_URL, ASYNC_MAP))
       .toBeUndefined()
   })
 
-  test('returns undefined when there is no trailer', () => {
-    expect(rewriteTrailerToAbsoluteUrl(SAMPLE_BODY, BUNDLE_URL, ASYNC_MAP))
-      .toBeUndefined()
-  })
-
-  test('returns undefined for an empty-URL trailer', () => {
+  test('returns undefined when there is no directive', () => {
     expect(
-      rewriteTrailerToAbsoluteUrl(
+      rewriteSourceMappingURLToAbsolute(SAMPLE_BODY, BUNDLE_URL, ASYNC_MAP),
+    )
+      .toBeUndefined()
+  })
+
+  test('returns undefined for an empty-URL directive', () => {
+    expect(
+      rewriteSourceMappingURLToAbsolute(
         '//# sourceMappingURL=',
         BUNDLE_URL,
         ASYNC_MAP,
@@ -77,17 +98,21 @@ describe('rewriteTrailerToAbsoluteUrl', () => {
       .toBeUndefined()
   })
 
-  test('is idempotent — skips a trailer that already points at debug-metadata.json', () => {
+  test('is idempotent — skips a directive that already points at debug-metadata.json', () => {
     const before = wrap(
       `//# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${ASYNC_MAP_ENC}`,
     )
-    expect(rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, ASYNC_MAP))
+    expect(rewriteSourceMappingURLToAbsolute(before, BUNDLE_URL, ASYNC_MAP))
       .toBeUndefined()
   })
 
   test('tolerates trailing whitespace after the URL', () => {
     const before = `${SAMPLE_BODY}//# sourceMappingURL=Lazy.js.map  \n`
-    const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, ASYNC_MAP)!
+    const after = rewriteSourceMappingURLToAbsolute(
+      before,
+      BUNDLE_URL,
+      ASYNC_MAP,
+    )!
     expect(after).toContain(
       `//# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${ASYNC_MAP_ENC}`,
     )
@@ -96,20 +121,28 @@ describe('rewriteTrailerToAbsoluteUrl', () => {
   test('encodes mapAssetPath segments (./ artifact from webpack chunk naming)', () => {
     const mapWithDot = 'static/js/async/./Lazy-react__main-thread.js.map'
     const before = wrap('//# sourceMappingURL=Lazy.js.map')
-    const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, mapWithDot)
+    const after = rewriteSourceMappingURLToAbsolute(
+      before,
+      BUNDLE_URL,
+      mapWithDot,
+    )
     expect(after).toContain(
       `path=${encodeURIComponent(mapWithDot)}`,
     )
   })
 
-  test('matches only the FINAL trailer, not inner module-body lookalikes', () => {
+  test('matches only the FINAL directive, not inner module-body lookalikes', () => {
     const source = [
       '// inner module body:',
       '//# sourceMappingURL=should-not-touch.js.map',
       '// more code',
       '//# sourceMappingURL=Lazy.js.map',
     ].join('\n')
-    const after = rewriteTrailerToAbsoluteUrl(source, BUNDLE_URL, ASYNC_MAP)!
+    const after = rewriteSourceMappingURLToAbsolute(
+      source,
+      BUNDLE_URL,
+      ASYNC_MAP,
+    )!
     expect(after).toContain(
       `//# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${ASYNC_MAP_ENC}`,
     )
@@ -120,24 +153,29 @@ describe('rewriteTrailerToAbsoluteUrl', () => {
     const appMap = 'app/index.js.map'
     const vendorMap = 'vendor/index.js.map'
     const before = wrap('//# sourceMappingURL=index.js.map')
-    expect(rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, appMap)).toContain(
-      `path=${encodeURIComponent(appMap)}`,
-    )
-    expect(rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, vendorMap))
+    expect(rewriteSourceMappingURLToAbsolute(before, BUNDLE_URL, appMap))
+      .toContain(
+        `path=${encodeURIComponent(appMap)}`,
+      )
+    expect(rewriteSourceMappingURLToAbsolute(before, BUNDLE_URL, vendorMap))
       .toContain(
         `path=${encodeURIComponent(vendorMap)}`,
       )
   })
 
-  describe('CSS block-comment trailer', () => {
+  describe('CSS block-comment directive', () => {
     const CSS_BODY = '.App { color: red; }\n'
     const CSS_MAP = 'main.css.map'
     const CSS_MAP_ENC = encodeURIComponent(CSS_MAP)
 
-    test('rewrites a `/*# sourceMappingURL=… */` trailer and keeps the block-comment form', () => {
+    test('rewrites a `/*# sourceMappingURL=… */` directive and keeps the block-comment form', () => {
       const before =
         `${CSS_BODY}/*# sourceMappingURL=http://host:3020/main.css.map*/`
-      const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, CSS_MAP)
+      const after = rewriteSourceMappingURLToAbsolute(
+        before,
+        BUNDLE_URL,
+        CSS_MAP,
+      )
       expect(after).toBe(
         `${CSS_BODY}/*# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${CSS_MAP_ENC}*/`,
       )
@@ -145,7 +183,11 @@ describe('rewriteTrailerToAbsoluteUrl', () => {
 
     test('accepts the legacy `/*@ sourceMappingURL=` form', () => {
       const before = `${CSS_BODY}/*@ sourceMappingURL=main.css.map*/`
-      const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, CSS_MAP)
+      const after = rewriteSourceMappingURLToAbsolute(
+        before,
+        BUNDLE_URL,
+        CSS_MAP,
+      )
       expect(after).toBe(
         `${CSS_BODY}/*# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${CSS_MAP_ENC}*/`,
       )
@@ -153,24 +195,90 @@ describe('rewriteTrailerToAbsoluteUrl', () => {
 
     test('tolerates whitespace before the closing block-comment', () => {
       const before = `${CSS_BODY}/*# sourceMappingURL=main.css.map */\n`
-      const after = rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, CSS_MAP)!
+      const after = rewriteSourceMappingURLToAbsolute(
+        before,
+        BUNDLE_URL,
+        CSS_MAP,
+      )!
       expect(after).toContain(
         `/*# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${CSS_MAP_ENC}*/`,
       )
     })
 
-    test('is idempotent for CSS trailers already pointing at debug-metadata.json', () => {
+    test('is idempotent for CSS directives already pointing at debug-metadata.json', () => {
       const before =
         `${CSS_BODY}/*# sourceMappingURL=${BUNDLE_URL}?field=source-map&path=${CSS_MAP_ENC}*/`
-      expect(rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, CSS_MAP))
+      expect(rewriteSourceMappingURLToAbsolute(before, BUNDLE_URL, CSS_MAP))
         .toBeUndefined()
     })
 
-    test('does not match a JS-style trailer hiding inside a CSS file body', () => {
+    test('does not match a JS-style directive hiding inside a CSS file body', () => {
       const before =
         `.content::before { content: "//# sourceMappingURL=lure.js.map"; }\n`
-      expect(rewriteTrailerToAbsoluteUrl(before, BUNDLE_URL, CSS_MAP))
+      expect(rewriteSourceMappingURLToAbsolute(before, BUNDLE_URL, CSS_MAP))
         .toBeUndefined()
     })
+  })
+})
+
+describe('rewriteSourceMappingURL', () => {
+  const CUSTOM_URL =
+    'https://gateway.example/raw?tos_key=abc123&field=source-map&path=foo.js.map'
+
+  test('substitutes the caller URL verbatim into a `//#` directive', () => {
+    const before = wrap('//# sourceMappingURL=foo.js.map')
+    expect(rewriteSourceMappingURL(before, CUSTOM_URL))
+      .toBe(`${SAMPLE_BODY}//# sourceMappingURL=${CUSTOM_URL}`)
+  })
+
+  test('substitutes verbatim into a `/*#` block-comment directive', () => {
+    const before = `.app{color:red}\n/*# sourceMappingURL=app.css.map*/`
+    expect(rewriteSourceMappingURL(before, CUSTOM_URL))
+      .toBe(`.app{color:red}\n/*# sourceMappingURL=${CUSTOM_URL}*/`)
+  })
+
+  test('accepts a legacy `//@ sourceMappingURL=` directive', () => {
+    const before = wrap('//@ sourceMappingURL=foo.js.map')
+    expect(rewriteSourceMappingURL(before, CUSTOM_URL))
+      .toBe(`${SAMPLE_BODY}//# sourceMappingURL=${CUSTOM_URL}`)
+  })
+
+  test('returns undefined when there is no directive', () => {
+    expect(rewriteSourceMappingURL(SAMPLE_BODY, CUSTOM_URL)).toBeUndefined()
+  })
+
+  test('returns undefined for a `data:` URI directive', () => {
+    const before = wrap(
+      '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
+    )
+    expect(rewriteSourceMappingURL(before, CUSTOM_URL)).toBeUndefined()
+  })
+
+  test('returns undefined for an empty-URL directive', () => {
+    expect(rewriteSourceMappingURL('//# sourceMappingURL=', CUSTOM_URL))
+      .toBeUndefined()
+  })
+
+  test('overwrites a directive that already points at the default debug-metadata container', () => {
+    // The default `rewriteSourceMappingURLToAbsolute` path is idempotent on
+    // the debug-metadata URL; the low-level primitive intentionally is not —
+    // it lets a consumer callback replace a URL the default flow baked first.
+    const before = wrap(
+      '//# sourceMappingURL=http://host/path/debug-metadata.json?field=source-map&path=foo.js.map',
+    )
+    expect(rewriteSourceMappingURL(before, CUSTOM_URL))
+      .toBe(`${SAMPLE_BODY}//# sourceMappingURL=${CUSTOM_URL}`)
+  })
+
+  test('matches only the final directive, not lookalike inner module bodies', () => {
+    const source = [
+      '// inner module body:',
+      '//# sourceMappingURL=should-not-touch.js.map',
+      '// more code',
+      '//# sourceMappingURL=Lazy.js.map',
+    ].join('\n')
+    const after = rewriteSourceMappingURL(source, CUSTOM_URL)!
+    expect(after).toContain(`//# sourceMappingURL=${CUSTOM_URL}`)
+    expect(after).toContain('//# sourceMappingURL=should-not-touch.js.map')
   })
 })


### PR DESCRIPTION
## Summary

Expose `rewriteSourceMappingURLs` and `RewriteSourceMappingURLsOptions` from `@lynx-js/debug-metadata-rsbuild-plugin`. Consumers can call the rewriter from their own `beforeEncode` tap and supply a `getSourceMappingURL` callback to customize the per-asset URL — e.g. point each chunk's directive at a gateway that supports server-side field filtering.

## Motivation

The plugin already rewrites `//# sourceMappingURL=...` directives to an absolute URL in dev (when `devServerOrigin` is provided), using `${debugMetadataUrl}?field=source-map&path=<encoded mapPath>` — a container pattern that downloads the whole metadata client-side.

Downstream plugins that compute a content hash at build time and upload the metadata to a gateway with field filtering need to bake a per-chunk URL of the form `?tos_key=<hash>&field=source-map&path=<mapPath>` instead, so consumers fetch a small per-chunk source map rather than the full container. Previously the rewriter was a private helper, leaving no way to share the iteration/regex without duplicating it.

## What changed

- `source-mapping-url-rewriter.ts`: factor out `rewriteSourceMappingURL(source, newUrl)` as the directive-replacement primitive. `rewriteSourceMappingURLToAbsolute` (formerly `rewriteTrailerToAbsoluteUrl`) becomes a thin wrapper that builds the default container URL and delegates.
- `LynxDebugMetadataPlugin.ts`: `rewriteSourceMappingURLs` (formerly file-private `rewriteSourceMappingURLTrailers`) is now exported. New optional `options.getSourceMappingURL: ({ mapPath, debugMetadataUrl }) => string` lets consumers compute a custom URL per asset. Default behavior unchanged.
- `index.ts`: re-exports `rewriteSourceMappingURLs` and `RewriteSourceMappingURLsOptions`.
- Unit tests updated to the renamed identifiers.

## Test plan

- [x] OSS package vitest: 91/91 pass.
- [x] tsc \`--build\` resolves the new exports.
- [x] Pre-commit (eslint / biome / dprint / cspell) passes.
- [x] api-extractor report (\`etc/debug-metadata-rsbuild-plugin.api.md\`) regenerated.

A changeset (\`minor\`) is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public rewrite capability to customize generated sourceMappingURL values via an optional callback.

* **Bug Fixes / Behavior**
  * Rewriter safely skips data: URLs and existing debug-metadata links; preserves comment style and rewrites only appropriate trailers.

* **Tests**
  * Expanded tests to validate JS/CSS trailer handling, idempotency, encoding, and edge cases.

* **Chores**
  * Release metadata added for a minor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->