### PR TITLE
fix(rspeedy): alias element template react entries

### DIFF
--- a/.changeset/et-react-alias-no-release.md
+++ b/.changeset/et-react-alias-no-release.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Add no release changes for the Element Template React alias fix because Element Template support has not been published yet.

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -219,6 +219,28 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
             jsxDevRuntime.background,
           )
 
+        if (elementTemplate) {
+          chain
+            .resolve
+            .alias
+            .set(
+              '@lynx-js/react/element-template$',
+              elementTemplateEntry!,
+            )
+            .set(
+              '@lynx-js/react/element-template/internal$',
+              elementTemplateInternalEntry!,
+            )
+            .set(
+              '@lynx-js/react/element-template/jsx-runtime',
+              elementTemplateJsxRuntime!,
+            )
+            .set(
+              '@lynx-js/react/element-template/jsx-dev-runtime',
+              elementTemplateJsxDevRuntime!,
+            )
+        }
+
         if (reactCompat) {
           chain
             .resolve

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -452,6 +452,34 @@ describe('Config', () => {
       ),
     )
     expect(config?.resolve?.alias).toHaveProperty(
+      '@lynx-js/react/element-template$',
+      expect.stringContaining(
+        '/packages/react/runtime/lib/element-template/index.js'
+          .replaceAll('/', path.sep),
+      ),
+    )
+    expect(config?.resolve?.alias).toHaveProperty(
+      '@lynx-js/react/element-template/internal$',
+      expect.stringContaining(
+        '/packages/react/runtime/lib/element-template/internal.js'
+          .replaceAll('/', path.sep),
+      ),
+    )
+    expect(config?.resolve?.alias).toHaveProperty(
+      '@lynx-js/react/element-template/jsx-runtime',
+      expect.stringContaining(
+        '/packages/react/runtime/lib/element-template/jsx-runtime/index.js'
+          .replaceAll('/', path.sep),
+      ),
+    )
+    expect(config?.resolve?.alias).toHaveProperty(
+      '@lynx-js/react/element-template/jsx-dev-runtime',
+      expect.stringContaining(
+        '/packages/react/runtime/lib/element-template/jsx-dev-runtime/index.js'
+          .replaceAll('/', path.sep),
+      ),
+    )
+    expect(config?.resolve?.alias).toHaveProperty(
       '@lynx-js/react/jsx-runtime',
       expect.stringContaining(
         '/packages/react/runtime/jsx-runtime/index.js'.replaceAll(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Module aliasing for element-template entry points now only applies when the element-template feature is enabled, ensuring correct module resolution.

* **Tests**
  * Updated tests to assert alias entries for element-template entry points and their runtime variants.

* **Chores**
  * Added a changeset marking the element-template alias fix as not requiring a release yet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

Fix Element Template builds that import explicit `@lynx-js/react/element-template` entry points while using Rspeedy's React alias plugin. With `experimental_useElementTemplate` enabled, the plugin already redirected the bare React runtime entries, but the Element Template subpath entries could still resolve through package exports instead of the local React runtime build.

## Key Points

- Adds Element Template aliases for the runtime entry, internal entry, JSX runtime, and JSX dev runtime in `@lynx-js/react-alias-rsbuild-plugin`.
- Extends the Rspeedy React config test to assert that Element Template mode wires both the existing React aliases and the explicit Element Template subpath aliases.
- Keeps the scope limited to experimental Element Template resolution; no release changeset is included because Element Template support is not published yet.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
