### PR TITLE
chore: bump pnpm to 11.5.0

### DIFF
--- a/.github/pnpm-11.instructions.md
+++ b/.github/pnpm-11.instructions.md
@@ -4,6 +4,8 @@ applyTo: "{pnpm-workspace.yaml,**/package.json,.github/renovate.json5}"
 
 When upgrading or maintaining pnpm 11, use the `allowBuilds` map in `pnpm-workspace.yaml`; `onlyBuiltDependencies` and `ignoredBuiltDependencies` are pnpm 10-era settings and should not be reintroduced.
 
+When bumping the `packageManager` pnpm version in package.json files, keep the `+sha512.<hex>` suffix aligned with the npm package tarball integrity; convert the `npm view pnpm@<version> dist.integrity` base64 payload to hex for Corepack's strict package-manager pin.
+
 When adding Renovate npm minimum-release-age presets, mirror the delay in pnpm with `minimumReleaseAge` in `pnpm-workspace.yaml`; Renovate delegates lockfile maintenance to the package manager and does not enforce its own minimum release age for those updates.
 
 Do not add broad React or React DOM overrides in `pnpm-workspace.yaml`. Keep workspace React consumers on exact `react` and `react-dom` patch versions, and use scoped package metadata fixes when a tool package such as Rspress needs its internal React dependencies pinned to the same patch; Rspress SSG fails when pnpm resolves `react` and `react-dom` to different patch versions.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript-eslint": "^8.56.0",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "engines": {
     "node": "^22 || ^24"
   },

--- a/packages/lynx/autolink-codegen/package.json
+++ b/packages/lynx/autolink-codegen/package.json
@@ -34,7 +34,6 @@
     "dev": "rslib build --watch",
     "test": "vitest run"
   },
-  "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
   "engines": {
     "node": "^20 || ^22 || ^24"
   }


### PR DESCRIPTION
## Summary
- bump the root Corepack pnpm pin to 11.5.0 with the matching sha512 integrity suffix
- remove the nested packageManager pin from @lynx-js/autolink-codegen so the root pin is authoritative
- document how to derive the Corepack sha512 suffix for future pnpm bumps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pnpm 11 maintenance and upgrade guidance for project maintainers.

* **Chores**
  * Updated pnpm version to 11.5.0.
  * Cleaned up package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->