### PR TITLE
fix(a2ui): improve preview generation status

### DIFF
--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -104,6 +104,7 @@ interface PreviewPanelProps {
   bodyClassName?: string;
   children: ReactNode;
   afterBody?: ReactNode;
+  previewInfoHint?: ReactNode;
 }
 
 function PreviewModeSwitch(props: {
@@ -204,6 +205,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
     className,
     headerAfterTitle,
     previewSource,
+    previewInfoHint,
     showPreviewModeSwitch = false,
     showSimulationBar = true,
     speed: speedProp,
@@ -681,6 +683,134 @@ export function PreviewPanel(props: PreviewPanelProps) {
     });
   };
 
+  const renderPreviewQrExtras = () => {
+    if (previewQrPlaceholder) {
+      return (
+        <div className='previewQrSection'>
+          <div className='previewQrContent'>
+            <div className='previewQrInfo'>
+              <div className='previewQrTitle'>
+                {previewQrPlaceholder.title}
+              </div>
+              <div className='previewQrDesc'>
+                {previewQrPlaceholder.description}
+              </div>
+              <div className='previewQrPlaceholder'>
+                <span className='previewQrPlaceholderText'>
+                  {previewQrPlaceholder.placeholder}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (previewQrCards.length > 0) {
+      return (
+        <div className='previewQrSection'>
+          {previewQrCards.map(({ key, item }) => {
+            const copied = key === 'webPreview' ? webCopied : nativeCopied;
+            const copyFailed = key === 'webPreview'
+              ? webCopyFailed
+              : nativeCopyFailed;
+            const error = key === 'webPreview' ? webQrError : nativeQrError;
+            const setError = key === 'webPreview'
+              ? setWebQrError
+              : setNativeQrError;
+
+            return (
+              <div
+                key={key}
+                className={item.variant === 'alt'
+                  ? 'previewQrContent previewQrContentAlt'
+                  : 'previewQrContent'}
+              >
+                <div className='previewQrInfo'>
+                  <div className='previewQrTitle'>{item.title}</div>
+                  <div className='previewQrDesc'>
+                    {error && item.errorDescription
+                      ? item.errorDescription
+                      : item.description}
+                  </div>
+                  <div className='previewQrUrlRow'>
+                    <div
+                      className='previewQrUrlText'
+                      title={item.urlTitle ?? item.url}
+                    >
+                      {item.urlTitle ?? item.url}
+                    </div>
+                    <button
+                      type='button'
+                      className='previewQrCopyBtn'
+                      aria-label={item.copyButtonTitle ?? 'Copy URL'}
+                      title={copied
+                        ? 'Copied'
+                        : (copyFailed
+                          ? 'Copy failed'
+                          : (item.copyButtonTitle ?? 'Copy URL'))}
+                      onClick={() => {
+                        if (item.url) {
+                          handleCopyUrl(key, item.url);
+                        }
+                      }}
+                    >
+                      {copied ? 'Copied' : (copyFailed ? 'Failed' : 'Copy')}
+                    </button>
+                  </div>
+                </div>
+                {item.url && item.showQrCode !== false
+                  ? (
+                    <QrCode
+                      value={item.url}
+                      size={128}
+                      onErrorChange={setError}
+                    />
+                  )
+                  : null}
+                {item.url && item.showQrCode === false
+                  ? (
+                    <div className='previewQrUnavailable'>
+                      <span className='previewQrUnavailableLabel'>
+                        QR unavailable
+                      </span>
+                      <span className='previewQrUnavailableSubtext'>
+                        URL too long to encode
+                      </span>
+                    </div>
+                  )
+                  : null}
+                {!item.url && item.placeholder
+                  ? (
+                    <div className='previewQrPlaceholder'>
+                      <span className='previewQrPlaceholderText'>
+                        {item.placeholder}
+                      </span>
+                    </div>
+                  )
+                  : null}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    if (!previewInfoHint) return null;
+    return (
+      <div className='previewQrSection previewQrSectionEmpty'>
+        <div className='previewQrEmptyState'>
+          <div className='previewQrEmptyTitle'>
+            Preview links are not ready yet
+          </div>
+          <div className='previewQrEmptyDesc'>
+            {previewInfoHint}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   // Rendered both inline (when the panel is wide enough) and inside the
   // bottom sheet (when the panel is narrow). The function closes over all
   // local state so both instances stay in sync without prop plumbing.
@@ -708,123 +838,14 @@ export function PreviewPanel(props: PreviewPanelProps) {
           </div>
         )
         : null}
-      {previewQrPlaceholder
-        ? (
-          <div className='previewQrSection'>
-            <div className='previewQrContent'>
-              <div className='previewQrInfo'>
-                <div className='previewQrTitle'>
-                  {previewQrPlaceholder.title}
-                </div>
-                <div className='previewQrDesc'>
-                  {previewQrPlaceholder.description}
-                </div>
-                <div className='previewQrPlaceholder'>
-                  <span className='previewQrPlaceholderText'>
-                    {previewQrPlaceholder.placeholder}
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        )
-        : (previewQrCards.length > 0
-          ? (
-            <div className='previewQrSection'>
-              {previewQrCards.map(({ key, item }) => {
-                const copied = key === 'webPreview' ? webCopied : nativeCopied;
-                const copyFailed = key === 'webPreview'
-                  ? webCopyFailed
-                  : nativeCopyFailed;
-                const error = key === 'webPreview' ? webQrError : nativeQrError;
-                const setError = key === 'webPreview'
-                  ? setWebQrError
-                  : setNativeQrError;
-
-                return (
-                  <div
-                    key={key}
-                    className={item.variant === 'alt'
-                      ? 'previewQrContent previewQrContentAlt'
-                      : 'previewQrContent'}
-                  >
-                    <div className='previewQrInfo'>
-                      <div className='previewQrTitle'>{item.title}</div>
-                      <div className='previewQrDesc'>
-                        {error && item.errorDescription
-                          ? item.errorDescription
-                          : item.description}
-                      </div>
-                      <div className='previewQrUrlRow'>
-                        <div
-                          className='previewQrUrlText'
-                          title={item.urlTitle ?? item.url}
-                        >
-                          {item.urlTitle ?? item.url}
-                        </div>
-                        <button
-                          type='button'
-                          className='previewQrCopyBtn'
-                          aria-label={item.copyButtonTitle ?? 'Copy URL'}
-                          title={copied
-                            ? 'Copied'
-                            : (copyFailed
-                              ? 'Copy failed'
-                              : (item.copyButtonTitle ?? 'Copy URL'))}
-                          onClick={() => {
-                            if (item.url) {
-                              handleCopyUrl(key, item.url);
-                            }
-                          }}
-                        >
-                          {copied
-                            ? 'Copied'
-                            : (copyFailed ? 'Failed' : 'Copy')}
-                        </button>
-                      </div>
-                    </div>
-                    {item.url && item.showQrCode !== false
-                      ? (
-                        <QrCode
-                          value={item.url}
-                          size={128}
-                          onErrorChange={setError}
-                        />
-                      )
-                      : null}
-                    {item.url && item.showQrCode === false
-                      ? (
-                        <div className='previewQrUnavailable'>
-                          <span className='previewQrUnavailableLabel'>
-                            QR unavailable
-                          </span>
-                          <span className='previewQrUnavailableSubtext'>
-                            URL too long to encode
-                          </span>
-                        </div>
-                      )
-                      : null}
-                    {!item.url && item.placeholder
-                      ? (
-                        <div className='previewQrPlaceholder'>
-                          <span className='previewQrPlaceholderText'>
-                            {item.placeholder}
-                          </span>
-                        </div>
-                      )
-                      : null}
-                  </div>
-                );
-              })}
-            </div>
-          )
-          : null)}
+      {renderPreviewQrExtras()}
     </>
   );
 
   const hasExtras = previewSource?.kind === 'a2ui'
     || !!previewQrPlaceholder
-    || previewQrCards.length > 0;
+    || previewQrCards.length > 0
+    || !!previewInfoHint;
 
   return (
     <PreviewPanelPreviewModeContext.Provider value={{ mode, setMode }}>

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -324,6 +324,23 @@ function safeStringifyPayload(value: unknown): string {
   }
 }
 
+function getGeneratedCharacterCount(value: unknown): number {
+  return safeStringifyPayload(value).length;
+}
+
+function formatCharacterCount(count: number): string {
+  return `${count.toLocaleString()} char${count === 1 ? '' : 's'}`;
+}
+
+function createRenderedPreviewContent(
+  messageCount: number,
+  characterCount: number,
+): string {
+  return `✅ Rendered ${messageCount} A2UI message${
+    messageCount === 1 ? '' : 's'
+  } (${formatCharacterCount(characterCount)}) to Lynx Preview`;
+}
+
 function payloadToChunks(value: unknown): unknown[] {
   if (Array.isArray(value)) return value;
   if (typeof value !== 'string') return [value];
@@ -812,6 +829,16 @@ function buildChatMessagesFromHistory(
           continue;
         }
       }
+      const generatedMessages = normalizeA2UIMessages(message.content);
+      if (generatedMessages.length > 0) {
+        next.push({
+          role: 'ai',
+          content: createRenderedPreviewContent(
+            generatedMessages.length,
+            getGeneratedCharacterCount(message.content),
+          ),
+        });
+      }
       next.push({
         role: 'json',
         content: 'Generated Output',
@@ -876,6 +903,7 @@ export function AIChatPage(
   const actionAbortRef = useRef<AbortController | null>(null);
   const hydratedActiveIdRef = useRef<string | null>(null);
   const latestPreviewMessagesRef = useRef<unknown[]>([]);
+  const generatedCharacterCountRef = useRef(0);
   const latestPreviewPayloadUrlsRef = useRef<PreviewPayloadUrls | null>(null);
   const renderUrlRef = useRef('');
   const bootstrappedRenderUrlRef = useRef<string | null>(null);
@@ -1023,6 +1051,11 @@ export function AIChatPage(
       actionMocksUrl: previewPayloadUrls?.actionMocksUrl,
     };
   }, [previewMessages, previewPayloadUrls, protocol, theme]);
+  const previewInfoHint = previewMessages
+    ? undefined
+    : (isGenerating
+      ? 'Generation is in progress. Web Preview and Native Preview links will appear once A2UI data arrives.'
+      : 'No A2UI data has been received yet. Send a message to generate Web Preview and Native Preview links.');
 
   const clearBootstrappedPreview = useCallback(() => {
     bootstrappedRenderUrlRef.current = null;
@@ -1249,6 +1282,7 @@ export function AIChatPage(
     setPreviewMessages(null);
     updatePreviewPayloadUrls(null);
     latestPreviewMessagesRef.current = [];
+    generatedCharacterCountRef.current = 0;
     setTokenUsage({
       promptTokens: 0,
       completionTokens: 0,
@@ -1280,18 +1314,32 @@ export function AIChatPage(
 
         const finalMessages = await readA2UIResponse(
           response,
-          () => {
+          (generatedText) => {
+            const characterCount = getGeneratedCharacterCount(generatedText);
+            generatedCharacterCountRef.current = characterCount;
             setMessages((prev) => {
               const next = prev.slice();
+              const messageCount = latestPreviewMessagesRef.current.length;
               next[next.length - 1] = {
                 role: 'ai',
-                content: 'Streaming A2UI messages...',
+                content: messageCount > 0
+                  ? `${
+                    createRenderedPreviewContent(
+                      messageCount,
+                      characterCount,
+                    )
+                  }...`
+                  : `Streaming A2UI messages (${
+                    formatCharacterCount(characterCount)
+                  })...`,
               };
               return next;
             });
           },
           (nextMessages, meta) => {
             if (controller.signal.aborted) return;
+            const characterCount = getGeneratedCharacterCount(nextMessages);
+            generatedCharacterCountRef.current = characterCount;
             if (meta.final) {
               publishPreviewMessages(nextMessages);
               return;
@@ -1301,10 +1349,12 @@ export function AIChatPage(
               const next = prev.slice();
               next[next.length - 1] = {
                 role: 'ai',
-                content:
-                  `Streaming ${latestPreviewMessagesRef.current.length} A2UI message${
-                    latestPreviewMessagesRef.current.length === 1 ? '' : 's'
-                  }...`,
+                content: `${
+                  createRenderedPreviewContent(
+                    latestPreviewMessagesRef.current.length,
+                    characterCount,
+                  )
+                }...`,
               };
               return next;
             });
@@ -1319,7 +1369,8 @@ export function AIChatPage(
           },
           {
             parseDeltaMessages: false,
-            publishText: false,
+            publishText: true,
+            publishPartialMessages: true,
             onPreviewPayload: updatePreviewPayloadUrls,
           },
         );
@@ -1337,11 +1388,14 @@ export function AIChatPage(
         });
         setMessages((prev) => {
           const next = prev.slice();
+          const characterCount = getGeneratedCharacterCount(finalMessages);
+          generatedCharacterCountRef.current = characterCount;
           next[next.length - 1] = {
             role: 'ai',
-            content: `✅ Rendered ${finalMessages.length} A2UI message${
-              finalMessages.length === 1 ? '' : 's'
-            } to Lynx Preview`,
+            content: createRenderedPreviewContent(
+              finalMessages.length,
+              characterCount,
+            ),
           };
           next.push({
             role: 'json',
@@ -2056,6 +2110,7 @@ export function AIChatPage(
           showPreviewModeSwitch
           showSimulationBar={false}
           previewSource={previewSource}
+          previewInfoHint={previewInfoHint}
         >
           <PreviewViewport
             src={renderUrl}

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -1051,10 +1051,39 @@ html[data-theme="dark"] .phoneHomeIndicator {
   container-name: preview-qr;
 }
 
+.previewQrSectionEmpty {
+  min-height: 148px;
+  justify-content: center;
+}
+
+.previewQrEmptyState {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border: 1px dashed var(--geist-border);
+  border-radius: var(--geist-radius-md);
+  background: var(--geist-surface);
+}
+
+.previewQrEmptyTitle {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--geist-foreground);
+}
+
+.previewQrEmptyDesc {
+  max-width: 560px;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--geist-secondary);
+}
+
 .previewQrContent {
   display: flex;
   align-items: flex-start;
   gap: 12px;
+  min-height: 128px;
 }
 
 .previewQrContentAlt {


### PR DESCRIPTION
## Summary

- Show generated character counts in the A2UI preview status while streaming and after completion.
- Restore the rendered preview status from persisted chat history after refresh.
- Add Preview Info empty/generating hints and stable minimum height for Web Preview / Native Preview rows.

## Test Plan

- `DPRINT_CACHE_DIR=/private/tmp/dprint-cache ./node_modules/.bin/dprint check packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/components/PreviewPanel.tsx packages/genui/a2ui-playground/src/styles.css`
- `git diff --check`
- `CI=1 PATH=/private/tmp/codex-pnpm-bin:/Users/bytedance/.nvm/versions/node/v24.15.0/bin:$PATH /Users/bytedance/.nvm/versions/node/v24.15.0/bin/corepack pnpm exec turbo build --filter=a2ui-playground`
- Pre-commit hook: eslint, biome lint, dprint fmt on staged files
- Local browser check: Preview Info empty state renders with the new hint

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added character-count tracking and display in chat status for generated A2UI payloads.
  * Preview panel now shows contextual hints (generation in progress or no A2UI data) and surfaces preview info in the share/preview area.

* **Style**
  * Improved empty-state styling and consistent vertical spacing for the QR/preview section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->