### PR TITLE
feat(react): support ET compat legacy runtime

### DIFF
--- a/.changeset/et-compat-legacy-runtime-no-release.md
+++ b/.changeset/et-compat-legacy-runtime-no-release.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Add no release changes for Element Template compat legacy runtime support because Element Template support has not been published yet.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -112,9 +112,9 @@
       "default": "./runtime/lib/worklet-runtime/bindings/index.js"
     },
     "./legacy-react-runtime": {
-      "types": "./runtime/lib/snapshot/legacy-react-runtime/index.d.ts",
+      "types": "./runtime/lib/core/compat/legacy-react-runtime.d.ts",
       "lazy": "./runtime/lazy/legacy-react-runtime.js",
-      "default": "./runtime/lib/snapshot/legacy-react-runtime/index.js"
+      "default": "./runtime/lib/core/compat/legacy-react-runtime.js"
     },
     "./testing-library": {
       "types": "./testing-library/types/index.d.ts",
@@ -202,7 +202,7 @@
         "./runtime/lib/worklet-runtime/bindings/index.d.ts"
       ],
       "legacy-react-runtime": [
-        "./runtime/lib/snapshot/legacy-react-runtime/index.d.ts"
+        "./runtime/lib/core/compat/legacy-react-runtime.d.ts"
       ]
     }
   },

--- a/packages/react/runtime/__test__/element-template/imports/legacy-react-runtime.test.ts
+++ b/packages/react/runtime/__test__/element-template/imports/legacy-react-runtime.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import ReactLegacyRuntime, * as ReactLegacyRuntimeNamespace from '@lynx-js/react/legacy-react-runtime';
+import { wrapWithLynxComponent } from '@lynx-js/react/element-template/internal';
+import {
+  __runInJS,
+  Component,
+  PureComponent,
+  createContext,
+  createRef,
+  lazy,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from '@lynx-js/react/legacy-react-runtime';
+
+const expectedLegacyRuntimeKeys = [
+  'Component',
+  'PureComponent',
+  '__runInJS',
+  'createContext',
+  'createRef',
+  'default',
+  'lazy',
+  'useCallback',
+  'useEffect',
+  'useMemo',
+  'useReducer',
+  'useRef',
+  'useState',
+];
+
+const expectedLegacyRuntimeDefaultKeys = expectedLegacyRuntimeKeys.filter(key => key !== 'default');
+
+describe('element-template legacy-react-runtime adapter', () => {
+  it('exposes the compat legacy runtime surface in element-template mode', () => {
+    expect(Component).toEqual(expect.any(Function));
+    expect(PureComponent).toEqual(expect.any(Function));
+    expect(createContext).toEqual(expect.any(Function));
+    expect(createRef).toEqual(expect.any(Function));
+    expect(lazy).toEqual(expect.any(Function));
+    expect(useState).toEqual(expect.any(Function));
+    expect(useReducer).toEqual(expect.any(Function));
+    expect(useEffect).toEqual(expect.any(Function));
+    expect(useMemo).toEqual(expect.any(Function));
+    expect(useCallback).toEqual(expect.any(Function));
+    expect(useRef).toEqual(expect.any(Function));
+    expect(__runInJS).toEqual(expect.any(Function));
+    expect(__runInJS(42)).toBe(42);
+
+    expect(Object.keys(ReactLegacyRuntimeNamespace).sort()).toEqual(expectedLegacyRuntimeKeys);
+    expect(Object.keys(ReactLegacyRuntime).sort()).toEqual(expectedLegacyRuntimeDefaultKeys);
+
+    expect(ReactLegacyRuntime).toEqual({
+      Component,
+      PureComponent,
+      createContext,
+      createRef,
+      lazy,
+      useState,
+      useReducer,
+      useRef,
+      useEffect,
+      useMemo,
+      useCallback,
+      __runInJS,
+    });
+  });
+
+  it('marks compat runtime components for ET internal component wrapping', () => {
+    class CompatComponent extends Component {}
+    const componentVNode = {
+      type: CompatComponent,
+      props: {
+        className: 'compat-class',
+        id: 'compat-id',
+        retained: 'component-prop',
+      },
+    };
+
+    const wrapped = wrapWithLynxComponent(
+      (child, spread) => ({ child, spread }),
+      componentVNode,
+    );
+
+    expect(wrapped).toEqual({
+      child: componentVNode,
+      spread: {
+        className: 'compat-class',
+        id: 'compat-id',
+      },
+    });
+    expect(componentVNode.props).toEqual({
+      retained: 'component-prop',
+    });
+  });
+});

--- a/packages/react/runtime/__test__/element-template/vitest.config.ts
+++ b/packages/react/runtime/__test__/element-template/vitest.config.ts
@@ -94,7 +94,10 @@ const config: UserConfigExport = defineConfig({
         '../../src/core/hooks/mainThread.ts',
       ),
       '@lynx-js/react/lepus': path.resolve(__dirname, '../../lepus/index.js'),
-      '@lynx-js/react/legacy-react-runtime': path.resolve(__dirname, '../../src/legacy-react-runtime/index.ts'),
+      '@lynx-js/react/legacy-react-runtime': path.resolve(
+        __dirname,
+        '../../src/core/compat/legacy-react-runtime.ts',
+      ),
       '@lynx-js/react/element-template/internal': path.resolve(__dirname, '../../src/element-template/internal.ts'),
       '@lynx-js/react/element-template': path.resolve(__dirname, '../../src/element-template/index.ts'),
       '@lynx-js/react': path.resolve(__dirname, '../../src/element-template/index.ts'),

--- a/packages/react/runtime/__test__/guardrails/snapshot-containment.test.ts
+++ b/packages/react/runtime/__test__/guardrails/snapshot-containment.test.ts
@@ -22,7 +22,6 @@ const legacySourceDirs = [
   'compat',
   'debug',
   'gesture',
-  'legacy-react-runtime',
   'lifecycle',
   'list',
   'lynx',
@@ -131,6 +130,12 @@ describe('snapshot containment guardrails', () => {
     expect(fs.existsSync(path.join(srcRoot, 'core', 'hooks'))).toBe(true);
   });
 
+  test('keeps legacy-react-runtime entry implementation in core compat', () => {
+    expect(fs.existsSync(path.join(srcRoot, 'snapshot', 'legacy-react-runtime'))).toBe(false);
+    expect(fs.existsSync(path.join(srcRoot, 'element-template', 'legacy-react-runtime'))).toBe(false);
+    expect(fs.existsSync(path.join(srcRoot, 'core', 'compat', 'legacy-react-runtime.ts'))).toBe(true);
+  });
+
   test('prevents transform output from referencing untracked old runtime source paths', () => {
     const oldPackageSourcePattern = new RegExp(
       String.raw`@lynx-js/react/src/(?:${legacySourceDirPattern})(?:/|['"])`,
@@ -151,13 +156,21 @@ describe('snapshot containment guardrails', () => {
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(reactRoot, 'package.json'), 'utf8'),
     );
+    expect(packageJson.exports['./element-template/legacy-react-runtime']).toBeUndefined();
+    expect(packageJson.exports['./legacy-react-runtime']).toEqual({
+      types: './runtime/lib/core/compat/legacy-react-runtime.d.ts',
+      lazy: './runtime/lazy/legacy-react-runtime.js',
+      default: './runtime/lib/core/compat/legacy-react-runtime.js',
+    });
+
     const typesVersions = JSON.stringify(packageJson.typesVersions ?? {});
 
     expect(typesVersions).not.toContain('./runtime/lib/hooks/');
     expect(typesVersions).not.toContain('./runtime/lib/legacy-react-runtime/');
+    expect(typesVersions).not.toContain('element-template/legacy-react-runtime');
+    expect(typesVersions).not.toContain('./runtime/lib/snapshot/legacy-react-runtime/');
+    expect(typesVersions).not.toContain('./runtime/lib/element-template/legacy-react-runtime/');
     expect(typesVersions).toContain('./runtime/lib/core/hooks/react.d.ts');
-    expect(typesVersions).toContain(
-      './runtime/lib/snapshot/legacy-react-runtime/index.d.ts',
-    );
+    expect(typesVersions).toContain('./runtime/lib/core/compat/legacy-react-runtime.d.ts');
   });
 });

--- a/packages/react/runtime/__test__/snapshot/compat.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/compat.test.jsx
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 
 import { elementTree } from './utils/nativeMethod';
 import { setupPage, snapshotInstanceManager, backgroundSnapshotInstanceManager } from '../../src/snapshot';
-import { ComponentFromReactRuntime, wrapWithLynxComponent } from '../../src/snapshot/compat/lynxComponent';
+import { ComponentFromReactRuntime, wrapWithLynxComponent } from '../../src/core/compat/lynxComponent';
 import { setupDocument } from '../../src/document';
 import { Fragment, render } from 'preact';
 import { globalEnvManager } from './utils/envManager';

--- a/packages/react/runtime/src/core/compat/legacy-react-runtime.ts
+++ b/packages/react/runtime/src/core/compat/legacy-react-runtime.ts
@@ -4,11 +4,8 @@
 import { createContext, createRef } from 'preact';
 import { lazy } from 'preact/compat';
 
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from '../../core/hooks/react.js';
-import {
-  ComponentFromReactRuntime as Component,
-  ComponentFromReactRuntime as PureComponent,
-} from '../compat/lynxComponent.js';
+import { ComponentFromReactRuntime as Component, ComponentFromReactRuntime as PureComponent } from './lynxComponent.js';
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from '../hooks/react.js';
 
 /* v8 ignore next 3 */
 function __runInJS<T>(value: T): T | undefined | null {
@@ -16,11 +13,11 @@ function __runInJS<T>(value: T): T | undefined | null {
 }
 
 // should mirror @lynx-js/react-runtime's exports
-export { ComponentFromReactRuntime as Component } from '../compat/lynxComponent.js';
-export { ComponentFromReactRuntime as PureComponent } from '../compat/lynxComponent.js';
+export { ComponentFromReactRuntime as Component } from './lynxComponent.js';
+export { ComponentFromReactRuntime as PureComponent } from './lynxComponent.js';
 export { createContext } from 'preact';
 export { lazy } from 'preact/compat';
-export { useState, useReducer, useEffect, useMemo, useCallback /*, useInstance */ } from '../../core/hooks/react.js';
+export { useState, useReducer, useEffect, useMemo, useCallback /*, useInstance */ } from '../hooks/react.js';
 export { __runInJS, createRef, useRef };
 
 /**

--- a/packages/react/runtime/src/core/compat/lynxComponent.ts
+++ b/packages/react/runtime/src/core/compat/lynxComponent.ts
@@ -4,28 +4,40 @@
 import { Component } from 'preact';
 import type { ReactNode } from 'react';
 
+interface CompatComponentVNode {
+  type: unknown;
+  props: Record<string, unknown>;
+}
+
 export function wrapWithLynxComponent(
-  jsxSnapshot: (c: ReactNode, spread?: Record<string, any>) => ReactNode,
-  jsxComponent: any,
+  jsxSnapshot: (c: ReactNode, spread?: Record<string, unknown>) => ReactNode,
+  jsxComponent: ReactNode,
 ): ReactNode {
-  const C = jsxComponent.type;
+  const componentVNode = jsxComponent as CompatComponentVNode;
+  const C = componentVNode.type;
   if (
-    typeof C === 'function' && (C === ComponentFromReactRuntime || C.prototype instanceof ComponentFromReactRuntime)
+    typeof C === 'function'
+    && (C === ComponentFromReactRuntime
+      || (C as { prototype?: unknown }).prototype instanceof ComponentFromReactRuntime)
   ) {
     if (jsxSnapshot.length === 1) {
       return jsxSnapshot(jsxComponent);
     } else {
       // spread
-      if (!jsxComponent.props.removeComponentElement) {
-        return jsxSnapshot(jsxComponent, takeComponentAttributes(jsxComponent));
+      if (!componentVNode.props['removeComponentElement']) {
+        return jsxSnapshot(jsxComponent, takeComponentAttributes(componentVNode));
       }
     }
   }
   return jsxComponent;
 }
 
-// @ts-expect-error
-export class ComponentFromReactRuntime extends Component {}
+export class ComponentFromReactRuntime extends Component {
+  /* v8 ignore next 3 -- marker component, never rendered directly. */
+  render(): null {
+    return null;
+  }
+}
 
 const __COMPONENT_ATTRIBUTES__ = /* @__PURE__ */ new Set([
   'name',
@@ -55,8 +67,8 @@ const __COMPONENT_ATTRIBUTES__ = /* @__PURE__ */ new Set([
   'enable-new-animator',
 ]);
 
-function takeComponentAttributes(jsxComponent: any): Record<string, any> {
-  const attributes: Record<string, any> = {};
+function takeComponentAttributes(jsxComponent: CompatComponentVNode): Record<string, unknown> {
+  const attributes: Record<string, unknown> = {};
   Object.keys(jsxComponent.props).forEach((k) => {
     // let re1 = Regex::new(r"^(global-bind|bind|catch|capture-bind|capture-catch)([A-Za-z]+)$").unwrap();
     // let re2 = Regex::new(r"^data-([A-Za-z]+)$").unwrap();

--- a/packages/react/runtime/src/element-template/internal.ts
+++ b/packages/react/runtime/src/element-template/internal.ts
@@ -36,7 +36,7 @@ export type { Options } from 'preact';
 
 export { withInitDataInState } from '../core/initData.js';
 
-// export { wrapWithLynxComponent } from '../compat/lynxComponent.js';
+export { wrapWithLynxComponent } from '../core/compat/lynxComponent.js';
 
 /**
  * @internal a polyfill for <component is=? />

--- a/packages/react/runtime/src/internal.ts
+++ b/packages/react/runtime/src/internal.ts
@@ -60,7 +60,7 @@ export { loadDynamicJS, __dynamicImport } from './snapshot/lynx/dynamic-js.js';
 
 export { withInitDataInState } from './core/initData.js';
 
-export { wrapWithLynxComponent } from './snapshot/compat/lynxComponent.js';
+export { wrapWithLynxComponent } from './core/compat/lynxComponent.js';
 
 /**
  * @internal a polyfill for <component is=? />

--- a/packages/react/runtime/vitest.config.ts
+++ b/packages/react/runtime/vitest.config.ts
@@ -88,7 +88,7 @@ export default defineConfig({
       { find: '@lynx-js/react/lepus', replacement: path.resolve(__dirname, './lepus/index.js') },
       {
         find: '@lynx-js/react/legacy-react-runtime',
-        replacement: path.resolve(__dirname, './src/snapshot/legacy-react-runtime/index.ts'),
+        replacement: path.resolve(__dirname, './src/core/compat/legacy-react-runtime.ts'),
       },
       { find: '@lynx-js/react', replacement: path.resolve(__dirname, './src/index.ts') },
     ],

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -705,7 +705,7 @@ describe('pluginReactLynx', () => {
         "@lynx-js/react/internal$": "<ROOT>/packages/react/runtime/lib/internal.js",
         "@lynx-js/react/jsx-dev-runtime": "<ROOT>/packages/react/runtime/jsx-dev-runtime/index.js",
         "@lynx-js/react/jsx-runtime": "<ROOT>/packages/react/runtime/jsx-runtime/index.js",
-        "@lynx-js/react/legacy-react-runtime$": "<ROOT>/packages/react/runtime/lib/snapshot/legacy-react-runtime/index.js",
+        "@lynx-js/react/legacy-react-runtime$": "<ROOT>/packages/react/runtime/lib/core/compat/legacy-react-runtime.js",
         "@lynx-js/react/runtime-components$": "<ROOT>/packages/react/components/lib/index.js",
         "@lynx-js/react/worklet-runtime/bindings$": "<ROOT>/packages/react/runtime/lib/worklet-runtime/bindings/index.js",
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -153,7 +153,7 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
                   .set('react/jsx-dev-runtime', jsxDevRuntime.background)
                   .set('@lynx-js/react/jsx-runtime', jsxRuntime.background)
                   .set('@lynx-js/react/jsx-dev-runtime', jsxDevRuntime.background)
-                  .set('@lynx-js/react/lepus$', reactLepus.background)
+                  .set('@lynx-js/react/lepus$', elementTemplateEntry ?? reactLepus.background)
                   .set('preact/hooks', reactHooks.preact)
                   .set('@lynx-js/react/hooks', reactHooks.background)
                 .end()

--- a/packages/rspeedy/plugin-react-alias/test/index.test.ts
+++ b/packages/rspeedy/plugin-react-alias/test/index.test.ts
@@ -178,6 +178,71 @@ describe('React - alias', () => {
     )
   })
 
+  test('element-template aliases transformed legacy runtime and background lepus entry to ET runtime', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const { pluginReactAlias } = await import('../src/index.js')
+
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          pluginReactAlias({
+            LAYERS,
+            elementTemplate: true,
+          }),
+        ],
+      },
+      cwd: path.dirname(fileURLToPath(import.meta.url)),
+    })
+
+    const [config] = await rsbuild.initConfigs()
+
+    if (!config?.resolve?.alias) {
+      expect.fail('should have config.resolve.alias')
+    }
+
+    expect(config.resolve.alias).toHaveProperty(
+      '@lynx-js/react$',
+      expect.stringContaining(
+        '/packages/react/runtime/lib/element-template/index.js'.replaceAll(
+          '/',
+          path.sep,
+        ),
+      ),
+    )
+    expect(config.resolve.alias).toHaveProperty(
+      '@lynx-js/react/legacy-react-runtime$',
+      expect.stringContaining(
+        '/packages/react/runtime/lib/core/compat/legacy-react-runtime.js'
+          .replaceAll('/', path.sep),
+      ),
+    )
+
+    if (!config.module?.rules) {
+      expect.fail('should have config.module.rules')
+    }
+
+    const backgroundRule = config.module.rules.find((rule) => {
+      if (!rule || typeof rule !== 'object') {
+        return false
+      }
+      return rule.issuerLayer === LAYERS.BACKGROUND && !!rule.resolve?.alias
+    }) as RuleSetRule
+
+    if (!backgroundRule || !backgroundRule.resolve?.alias) {
+      expect.fail('should have background alias rule')
+    }
+
+    expect(backgroundRule.resolve.alias).toHaveProperty(
+      '@lynx-js/react/lepus$',
+      expect.stringContaining(
+        '/packages/react/runtime/lib/element-template/index.js'.replaceAll(
+          '/',
+          path.sep,
+        ),
+      ),
+    )
+  })
+
   test('layered lepus hooks alias for main thread', async () => {
     vi.stubEnv('NODE_ENV', 'development')
     const { pluginReactAlias } = await import('../src/index.js')

--- a/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/testing-loader.test.ts
@@ -122,4 +122,58 @@ describe('testing loader', () => {
     expect(result.code).toContain('const _et_');
     expect(result.code).not.toContain('const __snapshot_');
   });
+
+  it('targets the shared legacy runtime for compat output in element-template mode', async () => {
+    const jsxContent = `
+      import { Component } from '@lynx-js/react-runtime';
+      export class App extends Component {
+        render() {
+          return null;
+        }
+      }
+    `;
+
+    const result = await runTestingLoader(jsxContent, {
+      compat: {},
+      engineVersion: '3.2',
+      experimental_useElementTemplate: true,
+    });
+
+    expect(result.code).toContain(
+      '@lynx-js/react/legacy-react-runtime',
+    );
+    expect(result.code).not.toContain(
+      '@lynx-js/react/element-template/legacy-react-runtime',
+    );
+  });
+
+  it('targets public internal helpers for compat component wrappers in element-template mode', async () => {
+    const jsxContent = `
+      import { Component } from '@lynx-js/react-runtime';
+      class CompatChild extends Component {
+        render() {
+          return <text />;
+        }
+      }
+      export function App() {
+        return <CompatChild id="child-id" className="child-class" />;
+      }
+    `;
+
+    const result = await runTestingLoader(jsxContent, {
+      compat: {
+        addComponentElement: true,
+      },
+      engineVersion: '3.2',
+      experimental_useElementTemplate: true,
+    });
+
+    expect(result.code).toContain(
+      '@lynx-js/react/internal',
+    );
+    expect(result.code).toContain('wrapWithLynxComponent');
+    expect(result.code).not.toContain(
+      '@lynx-js/react/element-template/internal',
+    );
+  });
 });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added release metadata to suppress publishing for a specific compat package.

* **Tests**
  * Expanded test coverage for legacy React runtime and element-template compatibility, including resolver/alias and loader behavior.
  * Added tests validating compat output targeting and wrapper generation in element-template scenarios.

* **Refactor**
  * Retargeted legacy React runtime exports and improved typing/handling for the component compatibility wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

Enable compat transform output to stay on the Element Template runtime when `experimental_useElementTemplate` is enabled. The transform-generated legacy runtime target now resolves under `@lynx-js/react/element-template`, and rspeedy aliases the generated legacy runtime and background `@lynx-js/react/lepus` entry to ET runtime entries so lazy preload collection does not pull Snapshot background runtime paths into ET builds.

## Generated Output Contract

- `@lynx-js/react/element-template/legacy-react-runtime` exposes the ET compat runtime surface from the ET runtime entry, with `__runInJS` kept as a main-thread passthrough helper.
- `@lynx-js/react-webpack-plugin` defaults compat `newRuntimePkg` to `@lynx-js/react/element-template` only in ET mode. Explicit compat target overrides and hand-written Snapshot legacy runtime imports remain unchanged.
- In ET mode, `@lynx-js/react-alias-rsbuild-plugin` routes transformed `@lynx-js/react/legacy-react-runtime` and background `@lynx-js/react/lepus` imports to ET entries, keeping lazy preload dependency discovery within the ET runtime boundary.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
