### PR TITLE
feat(a2ui-playground): show preview performance metrics

### DIFF
--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -110,6 +110,7 @@ interface PreviewMetricMessage {
 export interface PreviewPanelMetricItem {
   key: string;
   label: string;
+  description?: string;
   title?: string;
   value?: number;
 }
@@ -117,11 +118,30 @@ export interface PreviewPanelMetricItem {
 const PREVIEW_METRIC_ITEMS: Array<{
   key: PreviewMetricName;
   label: string;
+  description: string;
   title: string;
 }> = [
-  { key: 'fcp', label: 'FCP', title: 'First Contentful Paint' },
-  { key: 'fmp', label: 'FMP', title: 'First Meaningful Paint' },
-  { key: 'tti', label: 'TTI', title: 'Time to Interactive' },
+  {
+    key: 'fcp',
+    label: 'FCP',
+    title: 'First Contentful Paint',
+    description:
+      'Time from preview load until the first visible content is painted.',
+  },
+  {
+    key: 'fmp',
+    label: 'FMP',
+    title: 'First Meaningful Paint',
+    description:
+      'Time until the first meaningful A2UI content is delivered and painted.',
+  },
+  {
+    key: 'tti',
+    label: 'TTI',
+    title: 'Time to Interactive',
+    description:
+      'Time until the preview finishes initial rendering and is idle enough for actions.',
+  },
 ];
 
 interface PreviewPanelProps {
@@ -933,47 +953,52 @@ export function PreviewPanel(props: PreviewPanelProps) {
   const renderPreviewMetrics = () => {
     if (!hasPreviewMetrics) return null;
 
+    const renderMetricItem = (item: PreviewPanelMetricItem) => {
+      const value = item.value;
+      const description = item.description ?? item.title;
+      return (
+        <span
+          key={item.key}
+          className='previewMetricItem'
+          title={description ?? item.title}
+          tabIndex={description ? 0 : undefined}
+          aria-label={description
+            ? `${item.label}: ${description}`
+            : item.label}
+        >
+          <span className='previewMetricName'>{item.label}</span>
+          <span
+            className={value === undefined
+              ? 'previewMetricValue previewMetricValuePending'
+              : 'previewMetricValue'}
+          >
+            {formatMetricValue(value)}
+          </span>
+          {description
+            ? (
+              <span className='previewMetricTooltip' role='tooltip'>
+                <span className='previewMetricTooltipTitle'>{item.title}</span>
+                <span>{description}</span>
+              </span>
+            )
+            : null}
+        </span>
+      );
+    };
+
     return (
       <div className='previewMetricStack' aria-live='polite'>
         <span className='previewMetricLabel'>Metrics</span>
         <div className='previewMetricList'>
           {(hasPreviewMetricSource ? PREVIEW_METRIC_ITEMS : []).map(
             (item) => {
-              const value = previewMetrics[item.key];
-              return (
-                <span
-                  key={item.key}
-                  className='previewMetricItem'
-                  title={item.title}
-                >
-                  <span className='previewMetricName'>{item.label}</span>
-                  <span
-                    className={value === undefined
-                      ? 'previewMetricValue previewMetricValuePending'
-                      : 'previewMetricValue'}
-                  >
-                    {formatMetricValue(value)}
-                  </span>
-                </span>
-              );
+              return renderMetricItem({
+                ...item,
+                value: previewMetrics[item.key],
+              });
             },
           )}
-          {extraMetrics.map((item) => (
-            <span
-              key={item.key}
-              className='previewMetricItem'
-              title={item.title}
-            >
-              <span className='previewMetricName'>{item.label}</span>
-              <span
-                className={item.value === undefined
-                  ? 'previewMetricValue previewMetricValuePending'
-                  : 'previewMetricValue'}
-              >
-                {formatMetricValue(item.value)}
-              </span>
-            </span>
-          ))}
+          {extraMetrics.map((item) => renderMetricItem(item))}
         </div>
       </div>
     );

--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import {
   createContext,
+  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -40,6 +41,15 @@ export interface PreviewPanelRenderContextValue {
 
 export const PreviewPanelRenderContext = createContext<
   PreviewPanelRenderContextValue | null
+>(null);
+
+export interface PreviewPanelMetricsContextValue {
+  metricId: string;
+  onFrameSrcChange: (src: string) => void;
+}
+
+export const PreviewPanelMetricsContext = createContext<
+  PreviewPanelMetricsContextValue | null
 >(null);
 
 export interface PreviewQrItem {
@@ -85,6 +95,27 @@ export type PreviewPanelSource =
   | A2UIPreviewSource
   | OpenUIPreviewSource
   | PlaceholderPreviewSource;
+
+type PreviewMetricName = 'fcp' | 'fmp' | 'tti';
+
+type PreviewMetrics = Partial<Record<PreviewMetricName, number>>;
+
+interface PreviewMetricMessage {
+  type: 'A2UI_PREVIEW_METRIC';
+  metricId: string;
+  metric: PreviewMetricName;
+  value: number;
+}
+
+const PREVIEW_METRIC_ITEMS: Array<{
+  key: PreviewMetricName;
+  label: string;
+  title: string;
+}> = [
+  { key: 'fcp', label: 'FCP', title: 'First Contentful Paint' },
+  { key: 'fmp', label: 'FMP', title: 'First Meaningful Paint' },
+  { key: 'tti', label: 'TTI', title: 'Time to Interactive' },
+];
 
 interface PreviewPanelProps {
   className?: string;
@@ -196,6 +227,26 @@ function shouldUseClientPayloadStore(): boolean {
   return __A2UI_PLAYGROUND_CLIENT_PAYLOAD_STORE__;
 }
 
+function isPreviewMetricName(value: unknown): value is PreviewMetricName {
+  return value === 'fcp' || value === 'fmp' || value === 'tti';
+}
+
+function isPreviewMetricMessage(
+  data: unknown,
+): data is PreviewMetricMessage {
+  if (!data || typeof data !== 'object') return false;
+  const payload = data as Partial<PreviewMetricMessage>;
+  return payload.type === 'A2UI_PREVIEW_METRIC'
+    && typeof payload.metricId === 'string'
+    && isPreviewMetricName(payload.metric)
+    && typeof payload.value === 'number'
+    && Number.isFinite(payload.value);
+}
+
+function formatMetricValue(value: number | undefined): string {
+  return typeof value === 'number' ? `${Math.round(value)}ms` : '...';
+}
+
 export function PreviewPanel(props: PreviewPanelProps) {
   const {
     afterBody,
@@ -235,6 +286,20 @@ export function PreviewPanel(props: PreviewPanelProps) {
   const liveTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const buildSeqRef = useRef(0);
   const speedInputId = useId();
+  const rawMetricId = useId();
+  const metricId = useMemo(
+    () => rawMetricId.replace(/[^\w-]/g, ''),
+    [rawMetricId],
+  );
+  const [previewMetrics, setPreviewMetrics] = useState<PreviewMetrics>({});
+  const [metricFrameSrc, setMetricFrameSrc] = useState('');
+  const metricFrameSrcRef = useRef('');
+  const handleMetricFrameSrcChange = useCallback((src: string) => {
+    if (metricFrameSrcRef.current === src) return;
+    metricFrameSrcRef.current = src;
+    setMetricFrameSrc(src);
+    setPreviewMetrics({});
+  }, []);
 
   const rspeedyDevUrl = useRspeedyDevUrl();
   const baseUrl = useMemo(() => window.location.href.replace(/#.*$/, ''), []);
@@ -257,6 +322,10 @@ export function PreviewPanel(props: PreviewPanelProps) {
     () => ({ renderUrl }),
     [renderUrl],
   );
+  const metricsContext = useMemo<PreviewPanelMetricsContextValue>(
+    () => ({ metricId, onFrameSrcChange: handleMetricFrameSrcChange }),
+    [handleMetricFrameSrcChange, metricId],
+  );
   const bodyClass = bodyClassName
     ?? (mode === 'full' || isFullscreen
       ? 'previewPanelBody previewPanelBodyFull'
@@ -270,6 +339,37 @@ export function PreviewPanel(props: PreviewPanelProps) {
       height: '100vh',
     }
     : style;
+
+  useEffect(() => {
+    let expectedOrigin = '';
+    if (metricFrameSrc) {
+      try {
+        expectedOrigin = new URL(metricFrameSrc, window.location.href).origin;
+      } catch {
+        expectedOrigin = '';
+      }
+    }
+
+    const handleMessage = (event: MessageEvent<unknown>) => {
+      if (expectedOrigin && event.origin !== expectedOrigin) return;
+      if (!isPreviewMetricMessage(event.data)) return;
+      if (event.data.metricId !== metricId) return;
+
+      const { metric, value } = event.data;
+      setPreviewMetrics((current) => {
+        if (current[metric] === value) {
+          return current;
+        }
+        return {
+          ...current,
+          [metric]: value,
+        };
+      });
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [metricFrameSrc, metricId]);
 
   useEffect(() => {
     setWebCopied(false);
@@ -811,6 +911,40 @@ export function PreviewPanel(props: PreviewPanelProps) {
     );
   };
 
+  const hasPreviewMetrics = previewSource !== undefined
+    && previewSource.kind !== 'placeholder';
+
+  const renderPreviewMetrics = () => {
+    if (!hasPreviewMetrics) return null;
+
+    return (
+      <div className='previewMetricStack' aria-live='polite'>
+        <span className='previewMetricLabel'>Metrics</span>
+        <div className='previewMetricList'>
+          {PREVIEW_METRIC_ITEMS.map((item) => {
+            const value = previewMetrics[item.key];
+            return (
+              <span
+                key={item.key}
+                className='previewMetricItem'
+                title={item.title}
+              >
+                <span className='previewMetricName'>{item.label}</span>
+                <span
+                  className={value === undefined
+                    ? 'previewMetricValue previewMetricValuePending'
+                    : 'previewMetricValue'}
+                >
+                  {formatMetricValue(value)}
+                </span>
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
   // Rendered both inline (when the panel is wide enough) and inside the
   // bottom sheet (when the panel is narrow). The function closes over all
   // local state so both instances stay in sync without prop plumbing.
@@ -849,115 +983,118 @@ export function PreviewPanel(props: PreviewPanelProps) {
 
   return (
     <PreviewPanelPreviewModeContext.Provider value={{ mode, setMode }}>
-      <PreviewPanelRenderContext.Provider value={renderContext}>
-        <div
-          className={className
-            ? `${className}${isFullscreen ? ' previewPanelFullscreen' : ''}`
-            : (isFullscreen
-              ? 'previewPanel previewPanelFullscreen'
-              : 'previewPanel')}
-          style={panelStyle}
-        >
-          <CopyToast toast={copyToast} />
-          <div className='previewPanelHeader'>
-            <span className='previewPanelTitle'>{title}</span>
-            {headerAfterTitle}
-            <div className='spacer' />
-            {showPreviewModeSwitch
-              ? <PreviewModeSwitch mode={mode} onChange={setMode} />
-              : null}
-            {hasExtras
-              ? (
-                <button
-                  type='button'
-                  className='previewInfoBtn'
-                  onClick={() => setShareOpen(true)}
-                  title='Open on phone'
-                  aria-label='Open this preview on a phone'
-                >
-                  <svg
-                    viewBox='0 0 24 24'
-                    width='16'
-                    height='16'
-                    fill='none'
-                    stroke='currentColor'
-                    strokeWidth='2'
-                    strokeLinecap='round'
-                    strokeLinejoin='round'
-                    aria-hidden='true'
+      <PreviewPanelMetricsContext.Provider value={metricsContext}>
+        <PreviewPanelRenderContext.Provider value={renderContext}>
+          <div
+            className={className
+              ? `${className}${isFullscreen ? ' previewPanelFullscreen' : ''}`
+              : (isFullscreen
+                ? 'previewPanel previewPanelFullscreen'
+                : 'previewPanel')}
+            style={panelStyle}
+          >
+            <CopyToast toast={copyToast} />
+            <div className='previewPanelHeader'>
+              <span className='previewPanelTitle'>{title}</span>
+              {headerAfterTitle}
+              <div className='spacer' />
+              {showPreviewModeSwitch
+                ? <PreviewModeSwitch mode={mode} onChange={setMode} />
+                : null}
+              {hasExtras
+                ? (
+                  <button
+                    type='button'
+                    className='previewInfoBtn'
+                    onClick={() => setShareOpen(true)}
+                    title='Open on phone'
+                    aria-label='Open this preview on a phone'
                   >
-                    <rect
-                      x='6'
-                      y='2'
-                      width='12'
-                      height='20'
-                      rx='2.5'
-                      ry='2.5'
-                    />
-                    <line x1='12' y1='18' x2='12.01' y2='18' />
-                  </svg>
-                </button>
+                    <svg
+                      viewBox='0 0 24 24'
+                      width='16'
+                      height='16'
+                      fill='none'
+                      stroke='currentColor'
+                      strokeWidth='2'
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
+                      aria-hidden='true'
+                    >
+                      <rect
+                        x='6'
+                        y='2'
+                        width='12'
+                        height='20'
+                        rx='2.5'
+                        ry='2.5'
+                      />
+                      <line x1='12' y1='18' x2='12.01' y2='18' />
+                    </svg>
+                  </button>
+                )
+                : null}
+              <button
+                type='button'
+                className='previewExpandBtn'
+                onClick={() => setIsFullscreen((v) => !v)}
+                title={isFullscreen ? 'Exit fullscreen' : 'Expand preview'}
+              >
+                {isFullscreen ? '\u2715' : '\u2922'}
+              </button>
+            </div>
+            {beforeBody}
+            {renderPreviewMetrics()}
+            {showSimulationBar
+                && previewSource
+                && previewSource.kind !== 'placeholder'
+              ? (
+                <PreviewSimulationBar
+                  speed={speed}
+                  speedInputId={speedInputId}
+                  onSpeedChange={setSpeed}
+                  label='Simulated'
+                  infoTooltip={previewSource.kind === 'a2ui'
+                    ? (
+                      <div>
+                        Pre-recorded messages replayed at simulated speed. No AI
+                        model is running.
+                      </div>
+                    )
+                    : undefined}
+                  infoTooltipOpen={simulationInfoOpen}
+                  onToggleInfoTooltip={() => setSimulationInfoOpen((v) => !v)}
+                />
               )
               : null}
-            <button
-              type='button'
-              className='previewExpandBtn'
-              onClick={() => setIsFullscreen((v) => !v)}
-              title={isFullscreen ? 'Exit fullscreen' : 'Expand preview'}
-            >
-              {isFullscreen ? '\u2715' : '\u2922'}
-            </button>
+            <div className={bodyClass}>{children}</div>
+            <div className='previewPanelExtras'>{renderExtras()}</div>
+            {hasExtras
+              ? (
+                <Drawer.Root
+                  open={shareOpen}
+                  onOpenChange={setShareOpen}
+                >
+                  <Drawer.Portal>
+                    <Drawer.Overlay className='previewShareOverlay' />
+                    <Drawer.Content className='previewShareSheet'>
+                      <div className='previewShareHandle' aria-hidden='true' />
+                      <Drawer.Title className='previewShareTitle'>
+                        Preview info
+                      </Drawer.Title>
+                      <Drawer.Description className='previewShareDescription'>
+                        Components rendered and links to share this preview.
+                      </Drawer.Description>
+                      <div className='previewShareBody'>{renderExtras()}</div>
+                    </Drawer.Content>
+                  </Drawer.Portal>
+                </Drawer.Root>
+              )
+              : null}
+            {afterBody}
           </div>
-          {beforeBody}
-          {showSimulationBar
-              && previewSource
-              && previewSource.kind !== 'placeholder'
-            ? (
-              <PreviewSimulationBar
-                speed={speed}
-                speedInputId={speedInputId}
-                onSpeedChange={setSpeed}
-                label='Simulated'
-                infoTooltip={previewSource.kind === 'a2ui'
-                  ? (
-                    <div>
-                      Pre-recorded messages replayed at simulated speed. No AI
-                      model is running.
-                    </div>
-                  )
-                  : undefined}
-                infoTooltipOpen={simulationInfoOpen}
-                onToggleInfoTooltip={() => setSimulationInfoOpen((v) => !v)}
-              />
-            )
-            : null}
-          <div className={bodyClass}>{children}</div>
-          <div className='previewPanelExtras'>{renderExtras()}</div>
-          {hasExtras
-            ? (
-              <Drawer.Root
-                open={shareOpen}
-                onOpenChange={setShareOpen}
-              >
-                <Drawer.Portal>
-                  <Drawer.Overlay className='previewShareOverlay' />
-                  <Drawer.Content className='previewShareSheet'>
-                    <div className='previewShareHandle' aria-hidden='true' />
-                    <Drawer.Title className='previewShareTitle'>
-                      Preview info
-                    </Drawer.Title>
-                    <Drawer.Description className='previewShareDescription'>
-                      Components rendered and links to share this preview.
-                    </Drawer.Description>
-                    <div className='previewShareBody'>{renderExtras()}</div>
-                  </Drawer.Content>
-                </Drawer.Portal>
-              </Drawer.Root>
-            )
-            : null}
-          {afterBody}
-        </div>
-      </PreviewPanelRenderContext.Provider>
+        </PreviewPanelRenderContext.Provider>
+      </PreviewPanelMetricsContext.Provider>
     </PreviewPanelPreviewModeContext.Provider>
   );
 }

--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -96,7 +96,7 @@ export type PreviewPanelSource =
   | OpenUIPreviewSource
   | PlaceholderPreviewSource;
 
-type PreviewMetricName = 'fcp' | 'fmp' | 'tti';
+export type PreviewMetricName = 'fcp' | 'fmp' | 'tti' | 'render';
 
 type PreviewMetrics = Partial<Record<PreviewMetricName, number>>;
 
@@ -105,6 +105,13 @@ interface PreviewMetricMessage {
   metricId: string;
   metric: PreviewMetricName;
   value: number;
+}
+
+export interface PreviewPanelMetricItem {
+  key: string;
+  label: string;
+  title?: string;
+  value?: number;
 }
 
 const PREVIEW_METRIC_ITEMS: Array<{
@@ -135,6 +142,8 @@ interface PreviewPanelProps {
   bodyClassName?: string;
   children: ReactNode;
   afterBody?: ReactNode;
+  extraMetrics?: PreviewPanelMetricItem[];
+  onPreviewMetric?: (metric: PreviewMetricName, value: number) => void;
   previewInfoHint?: ReactNode;
 }
 
@@ -228,7 +237,10 @@ function shouldUseClientPayloadStore(): boolean {
 }
 
 function isPreviewMetricName(value: unknown): value is PreviewMetricName {
-  return value === 'fcp' || value === 'fmp' || value === 'tti';
+  return value === 'fcp'
+    || value === 'fmp'
+    || value === 'tti'
+    || value === 'render';
 }
 
 function isPreviewMetricMessage(
@@ -254,13 +266,15 @@ export function PreviewPanel(props: PreviewPanelProps) {
     bodyClassName,
     children,
     className,
+    extraMetrics = [],
     headerAfterTitle,
+    onPreviewMetric,
+    onSpeedChange,
     previewSource,
     previewInfoHint,
     showPreviewModeSwitch = false,
     showSimulationBar = true,
     speed: speedProp,
-    onSpeedChange,
     style,
     title,
   } = props;
@@ -356,6 +370,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
       if (event.data.metricId !== metricId) return;
 
       const { metric, value } = event.data;
+      onPreviewMetric?.(metric, value);
       setPreviewMetrics((current) => {
         if (current[metric] === value) {
           return current;
@@ -369,7 +384,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [metricFrameSrc, metricId]);
+  }, [metricFrameSrc, metricId, onPreviewMetric]);
 
   useEffect(() => {
     setWebCopied(false);
@@ -911,8 +926,9 @@ export function PreviewPanel(props: PreviewPanelProps) {
     );
   };
 
-  const hasPreviewMetrics = previewSource !== undefined
+  const hasPreviewMetricSource = previewSource !== undefined
     && previewSource.kind !== 'placeholder';
+  const hasPreviewMetrics = hasPreviewMetricSource || extraMetrics.length > 0;
 
   const renderPreviewMetrics = () => {
     if (!hasPreviewMetrics) return null;
@@ -921,25 +937,43 @@ export function PreviewPanel(props: PreviewPanelProps) {
       <div className='previewMetricStack' aria-live='polite'>
         <span className='previewMetricLabel'>Metrics</span>
         <div className='previewMetricList'>
-          {PREVIEW_METRIC_ITEMS.map((item) => {
-            const value = previewMetrics[item.key];
-            return (
-              <span
-                key={item.key}
-                className='previewMetricItem'
-                title={item.title}
-              >
-                <span className='previewMetricName'>{item.label}</span>
+          {(hasPreviewMetricSource ? PREVIEW_METRIC_ITEMS : []).map(
+            (item) => {
+              const value = previewMetrics[item.key];
+              return (
                 <span
-                  className={value === undefined
-                    ? 'previewMetricValue previewMetricValuePending'
-                    : 'previewMetricValue'}
+                  key={item.key}
+                  className='previewMetricItem'
+                  title={item.title}
                 >
-                  {formatMetricValue(value)}
+                  <span className='previewMetricName'>{item.label}</span>
+                  <span
+                    className={value === undefined
+                      ? 'previewMetricValue previewMetricValuePending'
+                      : 'previewMetricValue'}
+                  >
+                    {formatMetricValue(value)}
+                  </span>
                 </span>
+              );
+            },
+          )}
+          {extraMetrics.map((item) => (
+            <span
+              key={item.key}
+              className='previewMetricItem'
+              title={item.title}
+            >
+              <span className='previewMetricName'>{item.label}</span>
+              <span
+                className={item.value === undefined
+                  ? 'previewMetricValue previewMetricValuePending'
+                  : 'previewMetricValue'}
+              >
+                {formatMetricValue(item.value)}
               </span>
-            );
-          })}
+            </span>
+          ))}
         </div>
       </div>
     );
@@ -975,7 +1009,6 @@ export function PreviewPanel(props: PreviewPanelProps) {
       {renderPreviewQrExtras()}
     </>
   );
-
   const hasExtras = previewSource?.kind === 'a2ui'
     || !!previewQrPlaceholder
     || previewQrCards.length > 0

--- a/packages/genui/a2ui-playground/src/components/PreviewViewport.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewViewport.tsx
@@ -1,14 +1,16 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode, Ref } from 'react';
 
 import {
+  PreviewPanelMetricsContext,
   PreviewPanelPreviewModeContext,
   PreviewPanelRenderContext,
 } from './PreviewPanel.js';
 import type { PreviewMode } from './PreviewPanel.js';
+import { RENDER_METRIC_ID_QUERY_PARAM } from '../utils/renderUrl.js';
 
 interface PreviewViewportProps {
   src?: string;
@@ -51,6 +53,19 @@ function PhoneShell(props: { children: ReactNode }) {
   );
 }
 
+function withPreviewMetricId(src: string, metricId: string): string {
+  if (!src || !metricId) return src;
+
+  try {
+    const url = new URL(src, window.location.href);
+    if (!url.pathname.endsWith('/render.html')) return src;
+    url.searchParams.set(RENDER_METRIC_ID_QUERY_PARAM, metricId);
+    return url.toString();
+  } catch {
+    return src;
+  }
+}
+
 export function PreviewViewport(props: PreviewViewportProps) {
   const {
     emptyIcon = '▶',
@@ -68,8 +83,21 @@ export function PreviewViewport(props: PreviewViewportProps) {
   const pendingSrcRef = useRef<string | null>(null);
   const previewModeContext = useContext(PreviewPanelPreviewModeContext);
   const previewRenderContext = useContext(PreviewPanelRenderContext);
+  const previewMetricsContext = useContext(PreviewPanelMetricsContext);
   const mode: PreviewMode = displayMode ?? previewModeContext?.mode ?? 'phone';
-  const resolvedSrc = src ?? previewRenderContext?.renderUrl ?? '';
+  const rawResolvedSrc = src ?? previewRenderContext?.renderUrl ?? '';
+  const resolvedSrc = useMemo(
+    () =>
+      withPreviewMetricId(
+        rawResolvedSrc,
+        previewMetricsContext?.metricId ?? '',
+      ),
+    [previewMetricsContext?.metricId, rawResolvedSrc],
+  );
+
+  useEffect(() => {
+    previewMetricsContext?.onFrameSrcChange(resolvedSrc);
+  }, [previewMetricsContext, resolvedSrc]);
 
   useEffect(() => {
     pendingSrcRef.current = pendingSrc;

--- a/packages/genui/a2ui-playground/src/hooks/useConversation.ts
+++ b/packages/genui/a2ui-playground/src/hooks/useConversation.ts
@@ -19,12 +19,14 @@ import type {
   DataModelSnapshot,
   PersistedMessage,
   PreviewPayloadUrls,
+  PreviewPerformanceMetrics,
 } from '../storage/types.js';
 
 export interface ModelChatMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
   previewPayloadUrls?: PreviewPayloadUrls;
+  previewMetrics?: PreviewPerformanceMetrics;
 }
 
 export interface ConversationContext {
@@ -47,6 +49,7 @@ export interface RecordTurnInput {
   previewMessages?: unknown[];
   previewPayloadUrls?: PreviewPayloadUrls | null;
   snapshotPreviewPayloadUrls?: PreviewPayloadUrls | null;
+  previewMetrics?: PreviewPerformanceMetrics | null;
 }
 
 export interface UseConversationReturn {
@@ -64,6 +67,9 @@ export interface UseConversationReturn {
   remove: (id: string) => Promise<void>;
   rename: (id: string, title: string) => Promise<void>;
   recordTurn: (input: RecordTurnInput) => Promise<void>;
+  updateLastAssistantPreviewMetrics: (
+    metrics: PreviewPerformanceMetrics,
+  ) => Promise<void>;
   buildConversationContext: () => ConversationContext;
 }
 
@@ -87,6 +93,21 @@ function cloneDataValue(value: unknown): unknown {
   } catch {
     return value;
   }
+}
+
+function clonePreviewPerformanceMetrics(
+  value: PreviewPerformanceMetrics | null | undefined,
+): PreviewPerformanceMetrics | undefined {
+  if (!value) return undefined;
+  const next: PreviewPerformanceMetrics = {};
+  if (typeof value.fcpMs === 'number') next.fcpMs = value.fcpMs;
+  if (typeof value.fmpMs === 'number') next.fmpMs = value.fmpMs;
+  if (typeof value.ttiMs === 'number') next.ttiMs = value.ttiMs;
+  if (typeof value.agentOutputMs === 'number') {
+    next.agentOutputMs = value.agentOutputMs;
+  }
+  if (typeof value.renderMs === 'number') next.renderMs = value.renderMs;
+  return Object.keys(next).length > 0 ? next : undefined;
 }
 
 function truncateConversationHistory(
@@ -202,6 +223,7 @@ function toPersistedMessages(
     role: message.role,
     content: message.content,
     previewPayloadUrls: message.previewPayloadUrls,
+    previewMetrics: clonePreviewPerformanceMetrics(message.previewMetrics),
     createdAt: now + index,
   }));
 }
@@ -213,6 +235,7 @@ function fromPersistedMessages(
     role: message.role,
     content: message.content,
     previewPayloadUrls: message.previewPayloadUrls,
+    previewMetrics: clonePreviewPerformanceMetrics(message.previewMetrics),
   }));
 }
 
@@ -259,11 +282,16 @@ export function useConversation(): UseConversationReturn {
   const previewMessagesRef = useRef<unknown[]>([]);
   const previewPayloadUrlsRef = useRef<PreviewPayloadUrls | null>(null);
   const activeIdRef = useRef<string | null>(null);
+  const conversationsRef = useRef<ConversationMeta[]>([]);
   const activationTokenRef = useRef<symbol | null>(null);
   const conversationHotStateMapRef = useRef<Map<string, ConversationHotState>>(
     new Map(),
   );
   const persistentRef = useRef(true);
+
+  useEffect(() => {
+    conversationsRef.current = conversations;
+  }, [conversations]);
 
   const syncHotState = useCallback(
     (
@@ -471,6 +499,7 @@ export function useConversation(): UseConversationReturn {
           role: 'assistant' as const,
           content: input.assistantContent,
           previewPayloadUrls: input.previewPayloadUrls ?? undefined,
+          previewMetrics: clonePreviewPerformanceMetrics(input.previewMetrics),
         },
       ];
       const nextDataModel = cloneDataModel(dataModelRef.current);
@@ -486,8 +515,9 @@ export function useConversation(): UseConversationReturn {
         ?? null;
       const now = Date.now();
 
-      const existingMeta = conversations.find((item) => item.id === id)
-        ?? createConversationMeta();
+      const existingMeta =
+        conversationsRef.current.find((item) => item.id === id)
+          ?? createConversationMeta();
       const nextMeta: ConversationMeta = {
         ...existingMeta,
         id,
@@ -514,10 +544,12 @@ export function useConversation(): UseConversationReturn {
         nextPreviewMessages,
         nextPreviewPayloadUrls,
       );
-      setConversations((prev) => {
-        const without = prev.filter((item) => item.id !== id);
-        return [nextMeta, ...without].sort((a, b) => b.updatedAt - a.updatedAt);
-      });
+      const nextConversations = [
+        nextMeta,
+        ...conversationsRef.current.filter((item) => item.id !== id),
+      ].sort((a, b) => b.updatedAt - a.updatedAt);
+      conversationsRef.current = nextConversations;
+      setConversations(nextConversations);
 
       if (persistentRef.current) {
         try {
@@ -545,7 +577,83 @@ export function useConversation(): UseConversationReturn {
         }
       }
     },
-    [conversations, createNew, syncHotState],
+    [createNew, syncHotState],
+  );
+
+  const updateLastAssistantPreviewMetrics = useCallback(
+    async (metrics: PreviewPerformanceMetrics) => {
+      const id = activeIdRef.current;
+      if (!id) return;
+
+      const nextPreviewMetrics = clonePreviewPerformanceMetrics(metrics);
+      if (!nextPreviewMetrics) return;
+
+      const currentMessages = messagesRef.current;
+      const assistantIndex = (() => {
+        for (let i = currentMessages.length - 1; i >= 0; i--) {
+          if (currentMessages[i]?.role === 'assistant') return i;
+        }
+        return -1;
+      })();
+      if (assistantIndex < 0) return;
+
+      const nextMessages = currentMessages.slice();
+      nextMessages[assistantIndex] = {
+        ...nextMessages[assistantIndex],
+        previewMetrics: nextPreviewMetrics,
+      };
+      const nextDataModel = cloneDataModel(dataModelRef.current);
+      const nextSurfaceIds = new Set(surfaceIdsRef.current);
+      const nextPreviewMessages = previewMessagesRef.current.slice();
+      const nextPreviewPayloadUrls = previewPayloadUrlsRef.current;
+
+      syncHotState(
+        nextMessages,
+        nextDataModel,
+        nextSurfaceIds,
+        nextPreviewMessages,
+        nextPreviewPayloadUrls,
+      );
+
+      const existingMeta = conversationsRef.current.find((item) =>
+        item.id === id
+      );
+      if (!persistentRef.current || !existingMeta) return;
+
+      const snapshot: DataModelSnapshot = {
+        conversationId: id,
+        dataModel: nextDataModel,
+        surfaceIds: [...nextSurfaceIds],
+        previewMessages: nextPreviewMessages,
+        previewPayloadUrls: nextPreviewPayloadUrls ?? undefined,
+        updatedAt: existingMeta.updatedAt,
+      };
+
+      try {
+        await saveConversationMessages(
+          existingMeta,
+          toPersistedMessages(id, nextMessages),
+          snapshot,
+        );
+      } catch (err) {
+        console.warn(
+          '[a2ui] Failed to persist preview metrics; continuing in memory',
+          err,
+        );
+        persistentRef.current = false;
+        setIsPersistent(false);
+        conversationHotStateMapRef.current.set(id, {
+          messages: nextMessages.slice(),
+          dataModel: cloneDataModel(nextDataModel),
+          surfaceIds: new Set(nextSurfaceIds),
+          previewMessages: nextPreviewMessages.slice(),
+          previewPayloadUrls: nextPreviewPayloadUrls
+            ? { ...nextPreviewPayloadUrls }
+            : null,
+        });
+      }
+    },
+    [syncHotState],
   );
 
   const buildConversationContext = useCallback(
@@ -571,6 +679,7 @@ export function useConversation(): UseConversationReturn {
     remove,
     rename,
     recordTurn,
+    updateLastAssistantPreviewMetrics,
     buildConversationContext,
   };
 }

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.css
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.css
@@ -664,8 +664,9 @@
 .chatMessageStatus {
   align-self: stretch;
   display: flex;
-  align-items: center;
-  gap: 8px;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 6px;
   max-width: 100%;
   padding: 6px 10px;
   border: none;
@@ -698,6 +699,105 @@
   color: var(--geist-foreground);
   font-family: var(--geist-mono);
   font-size: 11px;
+}
+
+.chatMessageMetrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-left: 22px;
+}
+
+.chatMessageMetricItem {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  min-height: 22px;
+  padding: 2px 6px;
+  border: 1px solid var(--geist-border);
+  border-radius: 4px;
+  background: var(--geist-background);
+  color: var(--geist-secondary);
+  cursor: help;
+  outline: none;
+  white-space: nowrap;
+}
+
+.chatMessageMetricItem:focus-visible {
+  border-color: var(--geist-border-hover);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--geist-foreground) 12%, transparent);
+}
+
+.chatMessageMetricName {
+  color: var(--geist-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.chatMessageMetricValue {
+  color: var(--geist-foreground);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.chatMessageMetricTooltip {
+  position: absolute;
+  z-index: 30;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  width: max-content;
+  max-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 10px;
+  border: 1px solid var(--geist-border);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--geist-background) 96%, transparent);
+  box-shadow: var(--geist-shadow-md);
+  color: var(--geist-foreground);
+  font-family: var(--geist-font);
+  font-size: 11px;
+  line-height: 1.35;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translate(-50%, 4px);
+  transition:
+    opacity var(--geist-transition),
+    transform var(--geist-transition),
+    visibility var(--geist-transition);
+  visibility: hidden;
+  white-space: normal;
+}
+
+.chatMessageMetricTooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-right: 1px solid var(--geist-border);
+  border-bottom: 1px solid var(--geist-border);
+  background: color-mix(in srgb, var(--geist-background) 96%, transparent);
+  transform: translate(-50%, -4px) rotate(45deg);
+}
+
+.chatMessageMetricItem:hover .chatMessageMetricTooltip,
+.chatMessageMetricItem:focus-visible .chatMessageMetricTooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  visibility: visible;
+}
+
+.chatMessageMetricTooltipTitle {
+  color: var(--geist-foreground);
+  font-weight: 700;
 }
 
 .chatMessageStatus-info {

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -1079,12 +1079,16 @@ export function AIChatPage(
           {
             key: 'agent-output',
             label: 'Agent',
+            description:
+              'Time from sending the request until the final A2UI output is received.',
             title: 'Agent output duration',
             value: createMetricValues.agentOutputMs,
           },
           {
             key: 'render',
             label: 'Render',
+            description:
+              'Time from delivering A2UI messages to the preview runtime until the next painted frame.',
             title: 'Preview render duration after A2UI messages are delivered',
             value: createMetricValues.renderMs,
           },

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -23,16 +23,19 @@ import type { StaticDemo } from '../demos.js';
 import { useConversation } from '../hooks/useConversation.js';
 import type { ModelChatMessage } from '../hooks/useConversation.js';
 import { useResizablePanels } from '../hooks/useResizablePanels.js';
+import type { PreviewPerformanceMetrics } from '../storage/types.js';
 import { copyToClipboard } from '../utils/clipboard.js';
 import { DEFAULT_A2UI_DEMO_URL } from '../utils/demoUrl.js';
 import type { Protocol } from '../utils/protocol.js';
 import { buildRenderUrl } from '../utils/renderUrl.js';
 
 interface ChatMessage {
+  id?: string;
   role: 'user' | 'ai' | 'action' | 'json' | 'status';
   content: string | React.ReactNode;
   payload?: unknown;
   tone?: 'info' | 'pending' | 'success' | 'error';
+  metrics?: PreviewPerformanceMetrics;
 }
 
 interface SseEvent {
@@ -64,10 +67,7 @@ interface TokenUsage {
   totalTokens: number;
 }
 
-interface CreateMetricValues {
-  agentOutputMs?: number;
-  renderMs?: number;
-}
+type CreateMetricValues = PreviewPerformanceMetrics;
 
 interface A2UIResponseMessageMeta {
   final: boolean;
@@ -132,6 +132,101 @@ function formatTokenCount(value: number): string {
   if (value < 10_000) return `${(value / 1000).toFixed(2)}k`;
   if (value < 1_000_000) return `${(value / 1000).toFixed(1)}k`;
   return `${(value / 1_000_000).toFixed(2)}M`;
+}
+
+function formatMetricValue(value: number | undefined): string {
+  return typeof value === 'number' ? `${Math.round(value)}ms` : '...';
+}
+
+type CreateMetricValueKey = keyof PreviewPerformanceMetrics;
+
+interface CreateMetricDefinition {
+  key: CreateMetricValueKey;
+  label: string;
+  description: string;
+  title: string;
+}
+
+const CREATE_PREVIEW_METRIC_DEFINITIONS: CreateMetricDefinition[] = [
+  {
+    key: 'fcpMs',
+    label: 'FCP',
+    title: 'First Contentful Paint',
+    description:
+      'Time from preview load until the first visible content is painted.',
+  },
+  {
+    key: 'fmpMs',
+    label: 'FMP',
+    title: 'First Meaningful Paint',
+    description:
+      'Time until the first meaningful A2UI content is delivered and painted.',
+  },
+  {
+    key: 'ttiMs',
+    label: 'TTI',
+    title: 'Time to Interactive',
+    description:
+      'Time until the preview finishes initial rendering and is idle enough for actions.',
+  },
+  {
+    key: 'agentOutputMs',
+    label: 'Agent',
+    title: 'Agent output duration',
+    description:
+      'Time from sending the request until the final A2UI output is received.',
+  },
+  {
+    key: 'renderMs',
+    label: 'Render',
+    title: 'Preview render duration',
+    description:
+      'Time from delivering A2UI messages to the preview runtime until the next painted frame.',
+  },
+];
+
+const CREATE_PREVIEW_EXTRA_METRIC_KEYS = new Set<CreateMetricValueKey>([
+  'agentOutputMs',
+  'renderMs',
+]);
+
+function hasCreateMetrics(
+  metrics: PreviewPerformanceMetrics | null | undefined,
+): boolean {
+  if (!metrics) return false;
+  return CREATE_PREVIEW_METRIC_DEFINITIONS.some((item) =>
+    typeof metrics[item.key] === 'number'
+  );
+}
+
+function mergeCreateMetrics(
+  current: PreviewPerformanceMetrics,
+  patch: PreviewPerformanceMetrics,
+): PreviewPerformanceMetrics {
+  const next: PreviewPerformanceMetrics = { ...current };
+  for (const item of CREATE_PREVIEW_METRIC_DEFINITIONS) {
+    const value = patch[item.key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      next[item.key] = value;
+    }
+  }
+  return next;
+}
+
+function previewMetricToCreateMetrics(
+  metric: PreviewMetricName,
+  value: number,
+): PreviewPerformanceMetrics {
+  if (metric === 'fcp') return { fcpMs: value };
+  if (metric === 'fmp') return { fmpMs: value };
+  if (metric === 'tti') return { ttiMs: value };
+  return { renderMs: value };
+}
+
+function createChatMessageId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${
+    Math.random().toString(36).slice(2)
+  }`;
 }
 
 interface BrowserResponse {
@@ -765,10 +860,15 @@ function createActionForwardingStatus(actionName: string): ChatMessage {
   };
 }
 
-function createAgentRespondedStatus(count: number): ChatMessage {
+function createAgentRespondedStatus(
+  count: number,
+  options: { id?: string; metrics?: PreviewPerformanceMetrics } = {},
+): ChatMessage {
   return {
+    id: options.id,
     role: 'status',
     tone: 'success',
+    metrics: options.metrics,
     content: (
       <>
         <span className='chatMessageStatusIcon' aria-hidden='true'>
@@ -778,6 +878,26 @@ function createAgentRespondedStatus(count: number): ChatMessage {
           Agent responded with {count} A2UI{' '}
           {count === 1 ? 'message' : 'messages'}.
         </span>
+      </>
+    ),
+  };
+}
+
+function createPreviewMetricsStatus(
+  metrics: PreviewPerformanceMetrics,
+  id?: string,
+): ChatMessage {
+  return {
+    id,
+    role: 'status',
+    tone: 'info',
+    metrics,
+    content: (
+      <>
+        <span className='chatMessageStatusIcon' aria-hidden='true'>
+          ⏱
+        </span>
+        <span>Preview metrics captured for this response.</span>
       </>
     ),
   };
@@ -796,6 +916,40 @@ function createPreviewReadyStatus(): ChatMessage {
       </>
     ),
   };
+}
+
+function renderChatStatusMetrics(
+  metrics: PreviewPerformanceMetrics | undefined,
+) {
+  if (!hasCreateMetrics(metrics)) return null;
+  return (
+    <div className='chatMessageMetrics' aria-label='Metrics'>
+      {CREATE_PREVIEW_METRIC_DEFINITIONS.map((item) => {
+        const value = metrics?.[item.key];
+        if (typeof value !== 'number') return null;
+        return (
+          <span
+            key={item.key}
+            className='chatMessageMetricItem'
+            title={item.description}
+            tabIndex={0}
+            aria-label={`${item.label}: ${item.description}`}
+          >
+            <span className='chatMessageMetricName'>{item.label}</span>
+            <span className='chatMessageMetricValue'>
+              {formatMetricValue(value)}
+            </span>
+            <span className='chatMessageMetricTooltip' role='tooltip'>
+              <span className='chatMessageMetricTooltipTitle'>
+                {item.title}
+              </span>
+              <span>{item.description}</span>
+            </span>
+          </span>
+        );
+      })}
+    </div>
+  );
 }
 
 function buildChatMessagesFromHistory(
@@ -825,7 +979,9 @@ function buildChatMessagesFromHistory(
       if (previousWasAction) {
         const actionMessages = normalizeA2UIMessages(message.content);
         if (actionMessages.length > 0) {
-          next.push(createAgentRespondedStatus(actionMessages.length));
+          next.push(createAgentRespondedStatus(actionMessages.length, {
+            metrics: message.previewMetrics,
+          }));
           next.push({
             role: 'action',
             content: `✅ Applied ${actionMessages.length} ${
@@ -847,6 +1003,9 @@ function buildChatMessagesFromHistory(
             getGeneratedCharacterCount(message.content),
           ),
         });
+        if (hasCreateMetrics(message.previewMetrics)) {
+          next.push(createPreviewMetricsStatus(message.previewMetrics));
+        }
       }
       next.push({
         role: 'json',
@@ -857,6 +1016,16 @@ function buildChatMessagesFromHistory(
     }
   }
   return next;
+}
+
+function getLastPreviewMetricsFromHistory(
+  history: ModelChatMessage[],
+): PreviewPerformanceMetrics {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const metrics = history[i]?.previewMetrics;
+    if (hasCreateMetrics(metrics)) return metrics;
+  }
+  return {};
 }
 
 export function AIChatPage(
@@ -878,6 +1047,7 @@ export function AIChatPage(
     remove,
     rename,
     switchTo,
+    updateLastAssistantPreviewMetrics,
   } = conversation;
   const [messages, setMessages] = useState<ChatMessage[]>([WELCOME_MESSAGE]);
   const [inputValue, setInputValue] = useState<string>('');
@@ -918,6 +1088,9 @@ export function AIChatPage(
   const generatedCharacterCountRef = useRef(0);
   const latestPreviewPayloadUrlsRef = useRef<PreviewPayloadUrls | null>(null);
   const renderUrlRef = useRef('');
+  const activeCreateMetricValuesRef = useRef<CreateMetricValues>({});
+  const activeMetricStatusMessageIdRef = useRef<string | null>(null);
+  const activeMetricPersistenceReadyRef = useRef(false);
   const bootstrappedRenderUrlRef = useRef<string | null>(null);
   const bootstrappedMessagesRef = useRef<unknown[] | null>(null);
   const bootstrappedReplayTimersRef = useRef<number[]>([]);
@@ -1068,48 +1241,60 @@ export function AIChatPage(
     : (isGenerating
       ? 'Generation is in progress. Web Preview and Native Preview links will appear once A2UI data arrives.'
       : 'No A2UI data has been received yet. Send a message to generate Web Preview and Native Preview links.');
+  const resetCreateMetrics = useCallback(() => {
+    activeCreateMetricValuesRef.current = {};
+    activeMetricStatusMessageIdRef.current = null;
+    activeMetricPersistenceReadyRef.current = false;
+    setCreateMetricValues({});
+  }, []);
+  const updateCreateMetrics = useCallback((
+    patch: PreviewPerformanceMetrics,
+  ) => {
+    const nextMetrics = mergeCreateMetrics(
+      activeCreateMetricValuesRef.current,
+      patch,
+    );
+    activeCreateMetricValuesRef.current = nextMetrics;
+    setCreateMetricValues(nextMetrics);
+    const statusMessageId = activeMetricStatusMessageIdRef.current;
+    if (statusMessageId) {
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === statusMessageId
+            ? { ...message, metrics: nextMetrics }
+            : message
+        )
+      );
+      if (activeMetricPersistenceReadyRef.current) {
+        void updateLastAssistantPreviewMetrics(nextMetrics);
+      }
+    }
+    return nextMetrics;
+  }, [updateLastAssistantPreviewMetrics]);
   const showCreateMetrics = isGenerating
     || previewMessages !== null
-    || createMetricValues.agentOutputMs !== undefined
-    || createMetricValues.renderMs !== undefined;
+    || hasCreateMetrics(createMetricValues);
   const createMetrics = useMemo<PreviewPanelMetricItem[]>(
     () =>
       showCreateMetrics
-        ? [
-          {
-            key: 'agent-output',
-            label: 'Agent',
-            description:
-              'Time from sending the request until the final A2UI output is received.',
-            title: 'Agent output duration',
-            value: createMetricValues.agentOutputMs,
-          },
-          {
-            key: 'render',
-            label: 'Render',
-            description:
-              'Time from delivering A2UI messages to the preview runtime until the next painted frame.',
-            title: 'Preview render duration after A2UI messages are delivered',
-            value: createMetricValues.renderMs,
-          },
-        ]
+        ? CREATE_PREVIEW_METRIC_DEFINITIONS
+          .filter((item) => CREATE_PREVIEW_EXTRA_METRIC_KEYS.has(item.key))
+          .map((item) => ({
+            key: item.key,
+            label: item.label,
+            description: item.description,
+            title: item.title,
+            value: createMetricValues[item.key],
+          }))
         : [],
-    [
-      createMetricValues.agentOutputMs,
-      createMetricValues.renderMs,
-      showCreateMetrics,
-    ],
+    [createMetricValues, showCreateMetrics],
   );
   const handlePreviewMetric = useCallback((
     metric: PreviewMetricName,
     value: number,
   ) => {
-    if (metric !== 'render') return;
-    setCreateMetricValues((prev) => ({
-      ...prev,
-      renderMs: value,
-    }));
-  }, []);
+    updateCreateMetrics(previewMetricToCreateMetrics(metric, value));
+  }, [updateCreateMetrics]);
 
   const clearBootstrappedPreview = useCallback(() => {
     bootstrappedRenderUrlRef.current = null;
@@ -1278,6 +1463,13 @@ export function AIChatPage(
     }
 
     hydratedActiveIdRef.current = activeId;
+    activeMetricStatusMessageIdRef.current = null;
+    activeMetricPersistenceReadyRef.current = false;
+    const restoredMetrics = getLastPreviewMetricsFromHistory(
+      persistedMessages,
+    );
+    activeCreateMetricValuesRef.current = restoredMetrics;
+    setCreateMetricValues(restoredMetrics);
     setMessages(buildChatMessagesFromHistory(persistedMessages));
     setTokenUsage({
       promptTokens: 0,
@@ -1343,10 +1535,7 @@ export function AIChatPage(
       completionTokens: 0,
       totalTokens: 0,
     });
-    setCreateMetricValues({
-      agentOutputMs: undefined,
-      renderMs: undefined,
-    });
+    resetCreateMetrics();
     setIsGenerating(true);
 
     void (async () => {
@@ -1439,18 +1628,21 @@ export function AIChatPage(
         }
 
         const agentOutputMs = performance.now() - agentOutputStart;
-        setCreateMetricValues((prev) => ({
-          ...prev,
-          agentOutputMs,
-          renderMs: undefined,
-        }));
+        const metrics = updateCreateMetrics({ agentOutputMs });
+        const metricStatusMessageId = createChatMessageId('metrics');
+        activeMetricStatusMessageIdRef.current = metricStatusMessageId;
         await recordTurn({
           userMessage,
           assistantContent: JSON.stringify(finalMessages),
           a2uiMessages: finalMessages,
           previewMessages: finalMessages,
           previewPayloadUrls: latestPreviewPayloadUrlsRef.current,
+          previewMetrics: metrics,
         });
+        activeMetricPersistenceReadyRef.current = true;
+        void updateLastAssistantPreviewMetrics(
+          activeCreateMetricValuesRef.current,
+        );
         setMessages((prev) => {
           const next = prev.slice();
           const characterCount = getGeneratedCharacterCount(finalMessages);
@@ -1462,6 +1654,10 @@ export function AIChatPage(
               characterCount,
             ),
           };
+          next.push(createPreviewMetricsStatus(
+            activeCreateMetricValuesRef.current,
+            metricStatusMessageId,
+          ));
           next.push({
             role: 'json',
             content: 'Generated Output',
@@ -1494,6 +1690,9 @@ export function AIChatPage(
     publishStreamingPreviewMessages,
     providerRequestOptions,
     recordTurn,
+    resetCreateMetrics,
+    updateCreateMetrics,
+    updateLastAssistantPreviewMetrics,
     updatePreviewPayloadUrls,
   ]);
 
@@ -1544,10 +1743,9 @@ export function AIChatPage(
 
       let pendingIndex = -1;
       let streamingIndex = -1;
-      setCreateMetricValues({
-        agentOutputMs: undefined,
-        renderMs: undefined,
-      });
+      resetCreateMetrics();
+      const metricStatusMessageId = createChatMessageId('action-metrics');
+      activeMetricStatusMessageIdRef.current = metricStatusMessageId;
       setMessages((prev) => {
         const next: ChatMessage[] = [
           ...prev,
@@ -1558,6 +1756,7 @@ export function AIChatPage(
             payload: action,
           },
           {
+            id: metricStatusMessageId,
             role: 'status' as const,
             tone: 'pending',
             content: (
@@ -1619,6 +1818,8 @@ export function AIChatPage(
                   return next;
                 }
                 next[pendingIndex] = {
+                  ...next[pendingIndex],
+                  id: metricStatusMessageId,
                   role: 'status' as const,
                   tone: 'pending',
                   content: (
@@ -1688,11 +1889,7 @@ export function AIChatPage(
           }
 
           const agentOutputMs = performance.now() - agentOutputStart;
-          setCreateMetricValues((prev) => ({
-            ...prev,
-            agentOutputMs,
-            renderMs: undefined,
-          }));
+          const metrics = updateCreateMetrics({ agentOutputMs });
           const count = responseMessages.length;
           const replayMessages = [
             ...latestPreviewMessagesRef.current,
@@ -1708,11 +1905,19 @@ export function AIChatPage(
             previewMessages: replayMessages,
             previewPayloadUrls: responsePreviewPayloadUrls,
             snapshotPreviewPayloadUrls: null,
+            previewMetrics: metrics,
           });
+          activeMetricPersistenceReadyRef.current = true;
+          void updateLastAssistantPreviewMetrics(
+            activeCreateMetricValuesRef.current,
+          );
           setMessages((prev) => {
             const next = prev.slice();
             if (pendingIndex >= 0 && pendingIndex < next.length) {
-              next[pendingIndex] = createAgentRespondedStatus(count);
+              next[pendingIndex] = createAgentRespondedStatus(count, {
+                id: metricStatusMessageId,
+                metrics: activeCreateMetricValuesRef.current,
+              });
             }
             const finalCard: ChatMessage = {
               role: 'action' as const,
@@ -1776,6 +1981,9 @@ export function AIChatPage(
     postBootstrappedMessages,
     publishPreviewMessages,
     recordTurn,
+    resetCreateMetrics,
+    updateCreateMetrics,
+    updateLastAssistantPreviewMetrics,
     updatePreviewPayloadUrls,
   ]);
 
@@ -1800,10 +2008,7 @@ export function AIChatPage(
 
       abortRef.current?.abort();
       actionAbortRef.current?.abort();
-      setCreateMetricValues({
-        agentOutputMs: undefined,
-        renderMs: undefined,
-      });
+      resetCreateMetrics();
 
       // Synthetic user message keeps follow-up prompts in context (e.g.
       // "change the price to $99" sees what's on screen) while clearly
@@ -1852,21 +2057,21 @@ export function AIChatPage(
         previewMessages: messages,
       });
     },
-    [isGenerating, publishPreviewMessages, recordTurn],
+    [isGenerating, publishPreviewMessages, recordTurn, resetCreateMetrics],
   );
 
   const handleCreateConversation = useCallback(() => {
-    setCreateMetricValues({});
+    resetCreateMetrics();
     void createNew();
-  }, [createNew]);
+  }, [createNew, resetCreateMetrics]);
 
   const handleSwitchConversation = useCallback((id: string) => {
     if (isGenerating) return;
     abortRef.current?.abort();
     actionAbortRef.current?.abort();
-    setCreateMetricValues({});
+    resetCreateMetrics();
     void switchTo(id);
-  }, [isGenerating, switchTo]);
+  }, [isGenerating, resetCreateMetrics, switchTo]);
 
   const handleRenameConversation = useCallback((id: string, title: string) => {
     void rename(id, title);
@@ -2016,6 +2221,9 @@ export function AIChatPage(
                         singleBlock={isActionRequest}
                       />
                     )
+                    : null}
+                  {msg.role === 'status'
+                    ? renderChatStatusMetrics(msg.metrics)
                     : null}
                 </div>
               );

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -14,6 +14,10 @@ import type { MobilePaneTab } from '../components/MobileTabBar.js';
 import { PageHeader } from '../components/PageHeader.js';
 import { PanelResizeHandle } from '../components/PanelResizeHandle.js';
 import { PreviewPanel } from '../components/PreviewPanel.js';
+import type {
+  PreviewMetricName,
+  PreviewPanelMetricItem,
+} from '../components/PreviewPanel.js';
 import { PreviewViewport } from '../components/PreviewViewport.js';
 import type { StaticDemo } from '../demos.js';
 import { useConversation } from '../hooks/useConversation.js';
@@ -58,6 +62,11 @@ interface TokenUsage {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+}
+
+interface CreateMetricValues {
+  agentOutputMs?: number;
+  renderMs?: number;
 }
 
 interface A2UIResponseMessageMeta {
@@ -894,6 +903,9 @@ export function AIChatPage(
     completionTokens: 0,
     totalTokens: 0,
   });
+  const [createMetricValues, setCreateMetricValues] = useState<
+    CreateMetricValues
+  >({});
   const { showCopyToast, toast: copyToast } = useCopyToast();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const chatMessagesRef = useRef<HTMLDivElement>(null);
@@ -1056,6 +1068,44 @@ export function AIChatPage(
     : (isGenerating
       ? 'Generation is in progress. Web Preview and Native Preview links will appear once A2UI data arrives.'
       : 'No A2UI data has been received yet. Send a message to generate Web Preview and Native Preview links.');
+  const showCreateMetrics = isGenerating
+    || previewMessages !== null
+    || createMetricValues.agentOutputMs !== undefined
+    || createMetricValues.renderMs !== undefined;
+  const createMetrics = useMemo<PreviewPanelMetricItem[]>(
+    () =>
+      showCreateMetrics
+        ? [
+          {
+            key: 'agent-output',
+            label: 'Agent',
+            title: 'Agent output duration',
+            value: createMetricValues.agentOutputMs,
+          },
+          {
+            key: 'render',
+            label: 'Render',
+            title: 'Preview render duration after A2UI messages are delivered',
+            value: createMetricValues.renderMs,
+          },
+        ]
+        : [],
+    [
+      createMetricValues.agentOutputMs,
+      createMetricValues.renderMs,
+      showCreateMetrics,
+    ],
+  );
+  const handlePreviewMetric = useCallback((
+    metric: PreviewMetricName,
+    value: number,
+  ) => {
+    if (metric !== 'render') return;
+    setCreateMetricValues((prev) => ({
+      ...prev,
+      renderMs: value,
+    }));
+  }, []);
 
   const clearBootstrappedPreview = useCallback(() => {
     bootstrappedRenderUrlRef.current = null;
@@ -1269,6 +1319,7 @@ export function AIChatPage(
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
+    const agentOutputStart = performance.now();
 
     const userMessage: ModelChatMessage = { role: 'user', content: text };
     const requestConversation = buildConversationContext();
@@ -1287,6 +1338,10 @@ export function AIChatPage(
       promptTokens: 0,
       completionTokens: 0,
       totalTokens: 0,
+    });
+    setCreateMetricValues({
+      agentOutputMs: undefined,
+      renderMs: undefined,
     });
     setIsGenerating(true);
 
@@ -1379,6 +1434,12 @@ export function AIChatPage(
           throw new Error('A2UI agent did not return valid messages');
         }
 
+        const agentOutputMs = performance.now() - agentOutputStart;
+        setCreateMetricValues((prev) => ({
+          ...prev,
+          agentOutputMs,
+          renderMs: undefined,
+        }));
         await recordTurn({
           userMessage,
           assistantContent: JSON.stringify(finalMessages),
@@ -1475,9 +1536,14 @@ export function AIChatPage(
       const controller = new AbortController();
       actionAbortRef.current = controller;
       const signal = controller.signal;
+      const agentOutputStart = performance.now();
 
       let pendingIndex = -1;
       let streamingIndex = -1;
+      setCreateMetricValues({
+        agentOutputMs: undefined,
+        renderMs: undefined,
+      });
       setMessages((prev) => {
         const next: ChatMessage[] = [
           ...prev,
@@ -1617,6 +1683,12 @@ export function AIChatPage(
             throw new Error('Agent returned no A2UI messages');
           }
 
+          const agentOutputMs = performance.now() - agentOutputStart;
+          setCreateMetricValues((prev) => ({
+            ...prev,
+            agentOutputMs,
+            renderMs: undefined,
+          }));
           const count = responseMessages.length;
           const replayMessages = [
             ...latestPreviewMessagesRef.current,
@@ -1724,6 +1796,10 @@ export function AIChatPage(
 
       abortRef.current?.abort();
       actionAbortRef.current?.abort();
+      setCreateMetricValues({
+        agentOutputMs: undefined,
+        renderMs: undefined,
+      });
 
       // Synthetic user message keeps follow-up prompts in context (e.g.
       // "change the price to $99" sees what's on screen) while clearly
@@ -1776,6 +1852,7 @@ export function AIChatPage(
   );
 
   const handleCreateConversation = useCallback(() => {
+    setCreateMetricValues({});
     void createNew();
   }, [createNew]);
 
@@ -1783,6 +1860,7 @@ export function AIChatPage(
     if (isGenerating) return;
     abortRef.current?.abort();
     actionAbortRef.current?.abort();
+    setCreateMetricValues({});
     void switchTo(id);
   }, [isGenerating, switchTo]);
 
@@ -2111,6 +2189,8 @@ export function AIChatPage(
           showSimulationBar={false}
           previewSource={previewSource}
           previewInfoHint={previewInfoHint}
+          extraMetrics={createMetrics}
+          onPreviewMetric={handlePreviewMetric}
         >
           <PreviewViewport
             src={renderUrl}

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.css
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.css
@@ -585,7 +585,7 @@ html[data-theme="dark"] .detailBackButton:hover {
 .examplesPreviewPanel {
   display: grid;
   grid-template-columns: minmax(360px, 1fr) minmax(280px, 340px);
-  grid-template-rows: auto auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto auto auto minmax(0, 1fr);
   overflow: hidden;
 }
 
@@ -596,13 +596,18 @@ html[data-theme="dark"] .detailBackButton:hover {
 
 .examplesPreviewPanel .previewPanelBody {
   grid-column: 1;
-  grid-row: 2 / 5;
+  grid-row: 2 / 6;
   border-right: 1px solid var(--geist-border);
+}
+
+.examplesPreviewPanel .previewMetricStack {
+  grid-column: 2;
+  grid-row: 2;
 }
 
 .examplesPreviewPanel .simulationBar {
   grid-column: 2;
-  grid-row: 2;
+  grid-row: 3;
   align-items: flex-start;
   flex-wrap: wrap;
   padding: 10px 16px;
@@ -611,7 +616,7 @@ html[data-theme="dark"] .detailBackButton:hover {
 
 .examplesPreviewPanel .liveComponentStack {
   grid-column: 2;
-  grid-row: 3;
+  grid-row: 4;
   align-items: stretch;
   flex-direction: column;
   flex-wrap: wrap;
@@ -630,7 +635,7 @@ html[data-theme="dark"] .detailBackButton:hover {
 
 .examplesPreviewPanel .previewQrSection {
   grid-column: 2;
-  grid-row: 4;
+  grid-row: 5;
   min-height: 0;
   overflow: auto;
   border-top: none;
@@ -650,6 +655,7 @@ html[data-theme="dark"] .detailBackButton:hover {
 
   .examplesPreviewPanel .previewPanelHeader,
   .examplesPreviewPanel .previewPanelBody,
+  .examplesPreviewPanel .previewMetricStack,
   .examplesPreviewPanel .simulationBar,
   .examplesPreviewPanel .liveComponentStack,
   .examplesPreviewPanel .previewQrSection {

--- a/packages/genui/a2ui-playground/src/render.tsx
+++ b/packages/genui/a2ui-playground/src/render.tsx
@@ -18,7 +18,10 @@ import '@lynx-js/web-elements/index.css';
 
 import { decodeBase64Url } from './utils/base64url.js';
 import { DEFAULT_A2UI_DEMO_URL } from './utils/demoUrl.js';
-import { RENDER_INIT_DATA_QUERY_PARAM } from './utils/renderUrl.js';
+import {
+  RENDER_INIT_DATA_QUERY_PARAM,
+  RENDER_METRIC_ID_QUERY_PARAM,
+} from './utils/renderUrl.js';
 
 interface InitData {
   protocol?: '0.9' | 'a2ui' | 'openui';
@@ -71,10 +74,27 @@ interface LiveMessagesMessage {
   messages: unknown[];
 }
 
+type PreviewMetricName = 'fcp' | 'fmp' | 'tti';
+
+interface PreviewMetricMessage {
+  type: 'A2UI_PREVIEW_METRIC';
+  metricId: string;
+  metric: PreviewMetricName;
+  value: number;
+}
+
+interface PaintTimingEntryLike {
+  name: string;
+  startTime: number;
+}
+
 interface ReplayMessagesMessage {
   type: 'A2UI_REPLAY_MESSAGES';
   messages: unknown[];
 }
+
+const TTI_IDLE_WINDOW_MS = 500;
+const TTI_READY_FALLBACK_MS = 1200;
 
 interface LynxViewElement extends HTMLElement {
   initData?: InitData;
@@ -235,6 +255,21 @@ function parseGlobalPropsFromQuery(): Record<string, unknown> | null {
   return null;
 }
 
+function readPreviewMetricId(): string {
+  return new URLSearchParams(window.location.search).get(
+    RENDER_METRIC_ID_QUERY_PARAM,
+  ) ?? '';
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
 function buildGlobalPropsFromInitData(
   initData: InitData | null,
 ): Record<string, unknown> | null {
@@ -299,11 +334,107 @@ function Render() {
   const pendingActionResponsesRef = useRef<unknown[][]>([]);
   const pendingFlushTimerRef = useRef<number | null>(null);
   const pendingFlushAttemptsRef = useRef(0);
+  const previewMetricId = useMemo(() => readPreviewMetricId(), []);
+  const initDataRef = useRef<InitData | null>(initData);
+  const reportedMetricsRef = useRef<Set<PreviewMetricName>>(new Set());
+  const ttiTimerRef = useRef<number | null>(null);
+
+  const postPreviewMetric = useCallback((
+    metric: PreviewMetricName,
+    value: number,
+  ) => {
+    if (!previewMetricId) return;
+    if (!window.parent || window.parent === window) return;
+    if (reportedMetricsRef.current.has(metric)) return;
+
+    reportedMetricsRef.current.add(metric);
+    const message: PreviewMetricMessage = {
+      type: 'A2UI_PREVIEW_METRIC',
+      metricId: previewMetricId,
+      metric,
+      value: Math.max(0, Math.round(value)),
+    };
+    window.parent.postMessage(message, '*');
+  }, [previewMetricId]);
+
+  const clearTtiTimer = useCallback(() => {
+    if (ttiTimerRef.current === null) return;
+    window.clearTimeout(ttiTimerRef.current);
+    ttiTimerRef.current = null;
+  }, []);
+
+  const scheduleTtiMetric = useCallback((delayMs = TTI_IDLE_WINDOW_MS) => {
+    if (!previewMetricId || reportedMetricsRef.current.has('tti')) return;
+    clearTtiTimer();
+    ttiTimerRef.current = window.setTimeout(() => {
+      ttiTimerRef.current = null;
+      postPreviewMetric('tti', performance.now());
+    }, delayMs);
+  }, [clearTtiTimer, postPreviewMetric, previewMetricId]);
+
+  const scheduleFmpMetric = useCallback(() => {
+    if (!previewMetricId || reportedMetricsRef.current.has('fmp')) return;
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        postPreviewMetric('fmp', performance.now());
+      });
+    });
+  }, [postPreviewMetric, previewMetricId]);
+
+  const scheduleFcpFallbackMetric = useCallback(() => {
+    if (!previewMetricId || reportedMetricsRef.current.has('fcp')) return;
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        postPreviewMetric('fcp', performance.now());
+      });
+    });
+  }, [postPreviewMetric, previewMetricId]);
 
   const postRenderReady = useCallback(() => {
     if (!window.parent || window.parent === window) return;
     window.parent.postMessage({ type: 'A2UI_RENDER_READY' }, '*');
-  }, []);
+    scheduleFcpFallbackMetric();
+    if (initDataRef.current?.protocol !== 'a2ui') {
+      scheduleFmpMetric();
+      scheduleTtiMetric(TTI_READY_FALLBACK_MS);
+    }
+  }, [scheduleFcpFallbackMetric, scheduleFmpMetric, scheduleTtiMetric]);
+
+  useEffect(() => {
+    initDataRef.current = initData;
+  }, [initData]);
+
+  useEffect(() => {
+    if (!previewMetricId) return;
+
+    const reportPaintEntries = (entries: readonly PaintTimingEntryLike[]) => {
+      for (const entry of entries) {
+        if (entry.name === 'first-contentful-paint') {
+          postPreviewMetric('fcp', entry.startTime);
+          return;
+        }
+      }
+    };
+
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    reportPaintEntries(performance.getEntriesByType('paint'));
+
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    let observer: PerformanceObserver | null = null;
+    try {
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      observer = new PerformanceObserver((list) => {
+        reportPaintEntries(list.getEntries());
+      });
+      observer.observe({ type: 'paint', buffered: true });
+    } catch {
+      observer = null;
+    }
+
+    return () => {
+      observer?.disconnect();
+    };
+  }, [postPreviewMetric, previewMetricId]);
 
   const hasPendingA2UIEvents = useCallback(() => {
     return pendingReplayMessagesRef.current !== null
@@ -385,6 +516,28 @@ function Render() {
     lynxView.onNativeModulesCall = (name, data, moduleName) => {
       if (moduleName !== 'bridge') return;
       if (name === 'A2UI_PLAYBACK_SYNC') {
+        if (data && typeof data === 'object') {
+          const payload = data as Record<string, unknown>;
+          const status = payload.status;
+          const deliveredCount = readFiniteNumber(payload.deliveredCount);
+          const totalCount = readFiniteNumber(payload.totalCount);
+          const hasDeliveredContent = deliveredCount !== null
+            && deliveredCount > 0;
+          const isDone = status === 'done'
+            || (deliveredCount !== null
+              && totalCount !== null
+              && totalCount > 0
+              && deliveredCount >= totalCount);
+
+          if (hasDeliveredContent || isDone) {
+            scheduleFmpMetric();
+          }
+          if (isDone) {
+            scheduleTtiMetric();
+          } else if (status === 'streaming' || status === 'paused') {
+            clearTtiTimer();
+          }
+        }
         if (window.parent && window.parent !== window) {
           window.parent.postMessage(
             {
@@ -411,7 +564,7 @@ function Render() {
       if (lynxView.onNativeModulesCall === undefined) return;
       lynxView.onNativeModulesCall = undefined;
     };
-  }, []);
+  }, [clearTtiTimer, scheduleFmpMetric, scheduleTtiMetric]);
 
   useEffect(() => {
     const handleMessage = (e: MessageEvent<unknown>) => {
@@ -551,6 +704,9 @@ function Render() {
     return () => {
       if (pendingFlushTimerRef.current !== null) {
         window.clearTimeout(pendingFlushTimerRef.current);
+      }
+      if (ttiTimerRef.current !== null) {
+        window.clearTimeout(ttiTimerRef.current);
       }
     };
   }, []);

--- a/packages/genui/a2ui-playground/src/render.tsx
+++ b/packages/genui/a2ui-playground/src/render.tsx
@@ -74,7 +74,7 @@ interface LiveMessagesMessage {
   messages: unknown[];
 }
 
-type PreviewMetricName = 'fcp' | 'fmp' | 'tti';
+type PreviewMetricName = 'fcp' | 'fmp' | 'tti' | 'render';
 
 interface PreviewMetricMessage {
   type: 'A2UI_PREVIEW_METRIC';
@@ -332,6 +332,9 @@ function Render() {
   const pendingReplayMessagesRef = useRef<unknown[] | null>(null);
   const pendingLiveMessagesRef = useRef<unknown[] | null>(null);
   const pendingActionResponsesRef = useRef<unknown[][]>([]);
+  const pendingReplayMetricStartRef = useRef<number | null>(null);
+  const pendingLiveMetricStartRef = useRef<number | null>(null);
+  const pendingActionMetricStartsRef = useRef<number[]>([]);
   const pendingFlushTimerRef = useRef<number | null>(null);
   const pendingFlushAttemptsRef = useRef(0);
   const previewMetricId = useMemo(() => readPreviewMetricId(), []);
@@ -342,12 +345,15 @@ function Render() {
   const postPreviewMetric = useCallback((
     metric: PreviewMetricName,
     value: number,
+    options: { repeatable?: boolean } = {},
   ) => {
     if (!previewMetricId) return;
     if (!window.parent || window.parent === window) return;
-    if (reportedMetricsRef.current.has(metric)) return;
+    if (!options.repeatable && reportedMetricsRef.current.has(metric)) return;
 
-    reportedMetricsRef.current.add(metric);
+    if (!options.repeatable) {
+      reportedMetricsRef.current.add(metric);
+    }
     const message: PreviewMetricMessage = {
       type: 'A2UI_PREVIEW_METRIC',
       metricId: previewMetricId,
@@ -386,6 +392,19 @@ function Render() {
     window.requestAnimationFrame(() => {
       window.requestAnimationFrame(() => {
         postPreviewMetric('fcp', performance.now());
+      });
+    });
+  }, [postPreviewMetric, previewMetricId]);
+
+  const scheduleRenderMetric = useCallback((startTime: number) => {
+    if (!previewMetricId) return;
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        postPreviewMetric(
+          'render',
+          performance.now() - startTime,
+          { repeatable: true },
+        );
       });
     });
   }, [postPreviewMetric, previewMetricId]);
@@ -450,23 +469,40 @@ function Render() {
 
     const replayMessages = pendingReplayMessagesRef.current;
     if (replayMessages) {
+      const metricStart = pendingReplayMetricStartRef.current
+        ?? performance.now();
       pendingReplayMessagesRef.current = null;
+      pendingReplayMetricStartRef.current = null;
       lynxView.sendGlobalEvent('A2UI_REPLAY_MESSAGES', [replayMessages]);
+      scheduleFmpMetric();
+      scheduleTtiMetric();
+      scheduleRenderMetric(metricStart);
     }
 
     const liveMessages = pendingLiveMessagesRef.current;
     if (liveMessages) {
+      const metricStart = pendingLiveMetricStartRef.current
+        ?? performance.now();
       pendingLiveMessagesRef.current = null;
+      pendingLiveMetricStartRef.current = null;
       lynxView.sendGlobalEvent('A2UI_LIVE_MESSAGES', [liveMessages]);
+      scheduleFmpMetric();
+      scheduleTtiMetric();
+      scheduleRenderMetric(metricStart);
     }
 
     const actionResponses = pendingActionResponsesRef.current.splice(0);
-    for (const messages of actionResponses) {
+    const actionMetricStarts = pendingActionMetricStartsRef.current.splice(0);
+    for (const [index, messages] of actionResponses.entries()) {
+      const metricStart = actionMetricStarts[index] ?? performance.now();
       lynxView.sendGlobalEvent('A2UI_ACTION_RESPONSE', [messages]);
+      scheduleFmpMetric();
+      scheduleTtiMetric();
+      scheduleRenderMetric(metricStart);
     }
 
     return true;
-  }, []);
+  }, [scheduleFmpMetric, scheduleRenderMetric, scheduleTtiMetric]);
 
   const schedulePendingA2UIFlush = useCallback(() => {
     if (pendingFlushTimerRef.current !== null) return;
@@ -594,6 +630,7 @@ function Render() {
         && typeof e.data === 'object'
         && (e.data as ActionResponseMessage).type === 'A2UI_ACTION_RESPONSE'
       ) {
+        pendingActionMetricStartsRef.current.push(performance.now());
         pendingActionResponsesRef.current.push(
           (e.data as ActionResponseMessage).messages,
         );
@@ -608,6 +645,7 @@ function Render() {
         && typeof e.data === 'object'
         && (e.data as ReplayMessagesMessage).type === 'A2UI_REPLAY_MESSAGES'
       ) {
+        pendingReplayMetricStartRef.current = performance.now();
         pendingReplayMessagesRef.current = (e.data as ReplayMessagesMessage)
           .messages;
         pendingFlushAttemptsRef.current = 0;
@@ -621,6 +659,7 @@ function Render() {
         && typeof e.data === 'object'
         && (e.data as LiveMessagesMessage).type === 'A2UI_LIVE_MESSAGES'
       ) {
+        pendingLiveMetricStartRef.current = performance.now();
         pendingLiveMessagesRef.current = (e.data as LiveMessagesMessage)
           .messages;
         pendingFlushAttemptsRef.current = 0;

--- a/packages/genui/a2ui-playground/src/storage/types.ts
+++ b/packages/genui/a2ui-playground/src/storage/types.ts
@@ -16,12 +16,21 @@ export interface PreviewPayloadUrls {
   actionMocksUrl?: string;
 }
 
+export interface PreviewPerformanceMetrics {
+  fcpMs?: number;
+  fmpMs?: number;
+  ttiMs?: number;
+  agentOutputMs?: number;
+  renderMs?: number;
+}
+
 export interface PersistedMessage {
   conversationId: string;
   seq: number;
   role: 'user' | 'assistant' | 'system';
   content: string;
   previewPayloadUrls?: PreviewPayloadUrls;
+  previewMetrics?: PreviewPerformanceMetrics;
   createdAt: number;
 }
 

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -868,6 +868,65 @@ html[data-theme="dark"] .phoneHomeIndicator {
   justify-content: stretch;
 }
 
+/* ── Preview Metrics ── */
+.previewMetricStack {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  border-bottom: 1px solid var(--geist-border);
+  background: var(--geist-background);
+  font-size: 12px;
+  min-height: 38px;
+  overflow-x: auto;
+}
+
+.previewMetricLabel {
+  font-weight: 600;
+  color: var(--geist-secondary);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.previewMetricList {
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+}
+
+.previewMetricItem {
+  min-width: 70px;
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 2px 8px;
+  border: 1px solid var(--geist-border);
+  border-radius: 4px;
+  background: var(--geist-surface);
+  white-space: nowrap;
+}
+
+.previewMetricName {
+  color: var(--geist-secondary);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.previewMetricValue {
+  color: var(--geist-foreground);
+  font-family: var(--geist-mono);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.previewMetricValuePending {
+  color: var(--geist-secondary);
+}
+
 /* ── Live Component Stack ── */
 .liveComponentStack {
   flex-shrink: 0;

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -873,13 +873,14 @@ html[data-theme="dark"] .phoneHomeIndicator {
   flex-shrink: 0;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 6px 16px;
   border-bottom: 1px solid var(--geist-border);
   background: var(--geist-background);
   font-size: 12px;
   min-height: 38px;
-  overflow-x: auto;
+  overflow: visible;
 }
 
 .previewMetricLabel {
@@ -893,11 +894,13 @@ html[data-theme="dark"] .phoneHomeIndicator {
 
 .previewMetricList {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
   min-width: 0;
 }
 
 .previewMetricItem {
+  position: relative;
   min-width: 70px;
   display: inline-flex;
   align-items: baseline;
@@ -908,6 +911,14 @@ html[data-theme="dark"] .phoneHomeIndicator {
   border-radius: 4px;
   background: var(--geist-surface);
   white-space: nowrap;
+  cursor: help;
+  outline: none;
+}
+
+.previewMetricItem:focus-visible {
+  border-color: var(--geist-border-hover);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--geist-foreground) 12%, transparent);
 }
 
 .previewMetricName {
@@ -925,6 +936,61 @@ html[data-theme="dark"] .phoneHomeIndicator {
 
 .previewMetricValuePending {
   color: var(--geist-secondary);
+}
+
+.previewMetricTooltip {
+  position: absolute;
+  z-index: 30;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  width: max-content;
+  max-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 10px;
+  border: 1px solid var(--geist-border);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--geist-background) 96%, transparent);
+  box-shadow: var(--geist-shadow-md);
+  color: var(--geist-foreground);
+  font-size: 11px;
+  line-height: 1.35;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translate(-50%, 4px);
+  transition:
+    opacity var(--geist-transition),
+    transform var(--geist-transition),
+    visibility var(--geist-transition);
+  visibility: hidden;
+  white-space: normal;
+}
+
+.previewMetricTooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-right: 1px solid var(--geist-border);
+  border-bottom: 1px solid var(--geist-border);
+  background: color-mix(in srgb, var(--geist-background) 96%, transparent);
+  transform: translate(-50%, -4px) rotate(45deg);
+}
+
+.previewMetricItem:hover .previewMetricTooltip,
+.previewMetricItem:focus-visible .previewMetricTooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  visibility: visible;
+}
+
+.previewMetricTooltipTitle {
+  color: var(--geist-foreground);
+  font-weight: 700;
 }
 
 /* ── Live Component Stack ── */

--- a/packages/genui/a2ui-playground/src/utils/renderUrl.ts
+++ b/packages/genui/a2ui-playground/src/utils/renderUrl.ts
@@ -5,6 +5,7 @@ import { encodeBase64Url } from './base64url.js';
 import type { Protocol } from './protocol.js';
 
 export const RENDER_INIT_DATA_QUERY_PARAM = 'initData';
+export const RENDER_METRIC_ID_QUERY_PARAM = 'previewMetricId';
 
 export interface RenderInit {
   protocol: Protocol;


### PR DESCRIPTION
## Summary
- add preview performance metric wiring for FCP, FMP, and TTI
- surface the metrics above the simulation bar in the a2ui playground preview
- show metrics in the Create preview, including Agent output duration and Render duration
- persist Create metrics per assistant turn and display them in each `chatMessageStatus`
- add hover/focus explanations for every preview metric
- reset and scope metric collection per preview iframe URL

## Validation
- pnpm exec eslint --cache --fix --no-warn-ignored --flag v10_config_lookup_from_file packages/genui/a2ui-playground/src/components/PreviewPanel.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/render.tsx
- pnpm exec biome lint --write --no-errors-on-unmatched --files-ignore-unknown=true packages/genui/a2ui-playground/src/components/PreviewPanel.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/render.tsx
- pnpm dprint fmt packages/genui/a2ui-playground/src/components/PreviewPanel.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/styles.css packages/genui/a2ui-playground/src/pages/DemosPage.css
- pnpm exec eslint --cache --fix --no-warn-ignored --flag v10_config_lookup_from_file packages/genui/a2ui-playground/src/components/PreviewPanel.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/styles.css packages/genui/a2ui-playground/src/pages/DemosPage.css
- pnpm exec biome lint --write --no-errors-on-unmatched --files-ignore-unknown=true packages/genui/a2ui-playground/src/components/PreviewPanel.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/styles.css packages/genui/a2ui-playground/src/pages/DemosPage.css
- pnpm dprint fmt packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.css packages/genui/a2ui-playground/src/hooks/useConversation.ts packages/genui/a2ui-playground/src/storage/types.ts
- pnpm exec eslint --cache --fix --no-warn-ignored --flag v10_config_lookup_from_file packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.css packages/genui/a2ui-playground/src/hooks/useConversation.ts packages/genui/a2ui-playground/src/storage/types.ts
- pnpm exec biome lint --write --no-errors-on-unmatched --files-ignore-unknown=true packages/genui/a2ui-playground/src/pages/AIChatPage.tsx packages/genui/a2ui-playground/src/pages/AIChatPage.css packages/genui/a2ui-playground/src/hooks/useConversation.ts packages/genui/a2ui-playground/src/storage/types.ts
- pnpm turbo build --filter=a2ui-playground
- headless Chrome smoke test on /#/a2ui/create with local mock agent: FCP/FMP/TTI/Agent/Render metrics rendered
- browser verified metrics render above the simulation bar on /#/a2ui/examples/recs
- headless Chrome hover smoke test on /#/a2ui/examples/recs: FCP tooltip becomes visible on hover
- headless Chrome IndexedDB smoke test on /#/a2ui/create: persisted FCP/FMP/TTI/Agent/Render metrics render in `chatMessageStatus`; FCP status tooltip becomes visible on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview now displays performance metrics (FCP, FMP, TTI, Render) and accepts additional metric items.
  * Preview frames can report metrics to the app; reported metrics surface in chat status messages as metric chips.
  * Assistant message metrics are persisted and can be updated after generation.

* **Style**
  * Layout and styles updated for metric display, tooltips, and chat metric chips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->