### PR TITLE
fix(cache-events): uninstall mocks on load to fix memory leak

### DIFF
--- a/.changeset/fix-cache-events-memory-leak.md
+++ b/.changeset/fix-cache-events-memory-leak.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/cache-events-webpack-plugin": patch
+---
+
+Fix a memory leak in the cache-events runtime where the `tt` / `globalThis` method mocks were never uninstalled after all chunks loaded.
+
+The mock functions installed on `globalThis.loadDynamicComponent` and `tt[...]` were left in place after `loaded` became `true`. Because they stayed reachable from `globalThis` / `tt`, their closures pinned the whole cache machinery (`lynx_ce`, `setupList`, the captured `tt` / `GlobalEventEmitter` and the original bound functions) for the entire app lifetime.
+
+The replay functions now restore the original methods (guarded so they only revert their own mocks), `onLoaded` clears `cleanupList`, and `setupList` is reset so the setup closures can be collected.

--- a/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsRuntimeModule.ts
+++ b/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsRuntimeModule.ts
@@ -34,7 +34,9 @@ const onLoaded = () => {
     for (const cleanup of cleanupList) {
       cleanup()
     }
+    cleanupList.length = 0;
     ${LynxRuntimeGlobals.lynxCacheEvents}.cachedActions = [];
+    ${LynxRuntimeGlobals.lynxCacheEventsSetupList} = [];
   }
 var next = ${RuntimeGlobals.startup};
 ${RuntimeGlobals.startup} = () => {

--- a/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsSetupListRuntimeModule.ts
+++ b/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsSetupListRuntimeModule.ts
@@ -83,6 +83,12 @@ ${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
               tt[action.data.type](...action.data.args);
             }
           });
+          // uninstall mocks so the closures over tt can be released
+          methodsToMock.forEach(methodName => {
+            if (tt[methodName] === methodsToMockFn[methodName]) {
+              tt[methodName] = methodsToOldFn[methodName];
+            }
+          });
         }
       },
     }`,
@@ -167,6 +173,12 @@ ${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
           ${LynxRuntimeGlobals.lynxCacheEvents}.cachedActions.forEach(action => {
             if (action.type === 'globalThisMethod') {
               g[action.data.type](...action.data.args);
+            }
+          });
+          // uninstall mocks so the closures over globalThis can be released
+          methodsToMock.forEach(methodName => {
+            if (g[methodName] === methodsToMockFn[methodName]) {
+              g[methodName] = methodsToOldFn[methodName];
             }
           });
         }

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting-with-setupListTransformer/index.js
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting-with-setupListTransformer/index.js
@@ -2,15 +2,24 @@
 
 import { add } from './lib-common.js';
 
+// Captured at module-eval time: `onLoaded` clears `setupList` (and `cachedActions`)
+// once startup settles to release the closures over `tt`/`globalThis`, so the
+// registered setups can only be observed before load completes.
+const setupNames = __webpack_require__['lynx_ce']['setupList'].map(
+  (item) => item.name,
+);
+
 it('should append new setup list item', () => {
   expect(add(1, 2)).toBe(3);
   expect(__webpack_require__['lynx_ce']).toBeTruthy();
-  expect(__webpack_require__['lynx_ce']['setupList'].length).toBe(4);
-  expect(
-    __webpack_require__['lynx_ce']['setupList'].map((item) => item.name),
-  ).toEqual(['ttMethod', 'performanceEvent', 'globalThis', 'customCacheEvent']);
+  expect(setupNames).toEqual([
+    'ttMethod',
+    'performanceEvent',
+    'globalThis',
+    'customCacheEvent',
+  ]);
   expect(__webpack_require__['lynx_ce']['loaded']).toBe(true);
-  expect(__webpack_require__['lynx_ce']['cachedActions'].length).toBe(
-    0,
-  );
+  // Released on load to avoid retaining mock closures (memory-leak fix).
+  expect(__webpack_require__['lynx_ce']['setupList'].length).toBe(0);
+  expect(__webpack_require__['lynx_ce']['cachedActions'].length).toBe(0);
 });

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting/index.js
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting/index.js
@@ -2,15 +2,19 @@
 
 import { add } from './lib-common.js';
 
+// Captured at module-eval time: `onLoaded` clears `setupList` (and `cachedActions`)
+// once startup settles to release the closures over `tt`/`globalThis`, so the
+// registered setups can only be observed before load completes.
+const setupNames = __webpack_require__['lynx_ce']['setupList'].map(
+  (item) => item.name,
+);
+
 it('should have `__webpack_require__.lynx_ce`', () => {
   expect(add(1, 2)).toBe(3);
   expect(__webpack_require__['lynx_ce']).toBeTruthy();
-  expect(__webpack_require__['lynx_ce']['setupList'].length).toBe(3);
-  expect(
-    __webpack_require__['lynx_ce']['setupList'].map((item) => item.name),
-  ).toEqual(['ttMethod', 'performanceEvent', 'globalThis']);
+  expect(setupNames).toEqual(['ttMethod', 'performanceEvent', 'globalThis']);
   expect(__webpack_require__['lynx_ce']['loaded']).toBe(true);
-  expect(__webpack_require__['lynx_ce']['cachedActions'].length).toBe(
-    0,
-  );
+  // Released on load to avoid retaining mock closures (memory-leak fix).
+  expect(__webpack_require__['lynx_ce']['setupList'].length).toBe(0);
+  expect(__webpack_require__['lynx_ce']['cachedActions'].length).toBe(0);
 });


### PR DESCRIPTION
## Problem

A heap snapshot of a split-bundle app showed `globalThis.loadDynamicComponent` as a live GC root retaining the entire cache-events machinery:

```
globalThis.loadDynamicComponent (mock, never uninstalled)
  → captured lynx_ce → lynx_ce.setupList → setup closures → tt / GlobalEventEmitter / original fns
```

The `cache-events` runtime monkey-patches `tt[...]` and `globalThis.loadDynamicComponent` to cache native events before all chunks finish loading, then replays them on `loaded`. But the `ttMethod` and `globalThis` setups only **replayed** — they never **uninstalled** the mocks. Since the mock functions stayed reachable from `globalThis` / `tt`, their closures pinned `lynx_ce`, the whole `setupList`, the captured `tt` / `GlobalEventEmitter`, and the original bound functions for the entire app lifetime.

(The `performanceEvent` setup was already correct — it removes its listeners in teardown.)

## Fix

- `LynxCacheEventsSetupListRuntimeModule`: the `ttMethod` and `globalThis` replay functions now restore the original methods after replaying, guarded by `tt[m] === methodsToMockFn[m]` so they only revert their own mock (and never clobber a wrapper someone else layered on top).
- `LynxCacheEventsRuntimeModule`: after running all teardowns, `onLoaded` clears `cleanupList` (releases the returned replay closures, which capture `tt` / `emitter` / original fns) and resets `setupList` so the setup closures become collectable. `lynx_ce` itself is kept intact so any straggler reader of `.loaded` / `.cachedActions` doesn't NPE.

## Test

`pnpm --filter @lynx-js/cache-events-webpack-plugin test` — 23/23 pass. The existing tests already exercise the post-`loaded` call path (calling `tt.publishEvent` / `loadDynamicComponent` after `cleanup()`), confirming forwarding to the original still works after uninstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak in cache-events runtime that prevented temporary methods from being properly cleaned up after application startup, improving memory efficiency and allowing memory to be reclaimed during garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->