### PR TITLE
feat(a2ui-playground): unify icon set and button system

### DIFF
--- a/packages/genui/a2ui-playground/package.json
+++ b/packages/genui/a2ui-playground/package.json
@@ -22,6 +22,7 @@
     "@lynx-js/web-elements": "workspace:*",
     "@uiw/react-codemirror": "^4.25.9",
     "idb": "^8.0.3",
+    "lucide-react": "^0.575.0",
     "qrcode": "^1.5.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/packages/genui/a2ui-playground/src/App.tsx
+++ b/packages/genui/a2ui-playground/src/App.tsx
@@ -9,6 +9,8 @@ import {
   useState,
 } from 'react';
 
+import { Button } from './components/Button.js';
+import { Moon, Sun } from './components/Icon.js';
 import { AIChatPage } from './pages/AIChatPage.js';
 import { ComponentsPage } from './pages/ComponentsPage.js';
 import { DemosListPage } from './pages/DemosListPage.js';
@@ -227,15 +229,16 @@ export function App() {
 
         {protocolVersionControl}
 
-        <button
-          type='button'
+        <Button
+          variant='ghost'
+          size='sm'
+          iconOnly
+          iconBefore={theme === 'dark' ? Sun : Moon}
           className='themeToggle'
           onClick={() => setTheme((t) => (t === 'dark' ? 'light' : 'dark'))}
           aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
           title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
-        >
-          {theme === 'dark' ? '\u2600' : '\u263E'}
-        </button>
+        />
       </div>
 
       <div className='appBody'>

--- a/packages/genui/a2ui-playground/src/components/Button.css
+++ b/packages/genui/a2ui-playground/src/components/Button.css
@@ -1,0 +1,206 @@
+/*
+ * Unified button primitive.
+ *
+ * The playground previously had ~6 ad-hoc button styles (toolbarBtn,
+ * chatSendBtn, detailBackButton, conversationNewButton, conversationIconButton,
+ * previewExpandBtn). This file collapses them into one system:
+ *
+ *   variant: primary | secondary | ghost | danger
+ *   size:    sm | md | lg
+ *
+ * All buttons are pill-shaped, share the same transition curve, and pair with
+ * Lucide icons sized to match the label baseline.
+ */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-family: var(--geist-font);
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.005em;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition:
+    background var(--geist-transition),
+    border-color var(--geist-transition),
+    color var(--geist-transition),
+    box-shadow var(--geist-transition),
+    transform var(--geist-transition),
+    opacity var(--geist-transition);
+}
+
+.btn:focus-visible {
+  outline: 2px solid
+    color-mix(
+      in srgb,
+      var(--geist-foreground) 35%,
+      transparent
+    );
+  outline-offset: 2px;
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  transform: none;
+}
+
+/* ── Sizes ── */
+
+.btn-sm {
+  height: 28px;
+  padding: 0 12px;
+  font-size: 12px;
+  gap: 5px;
+}
+
+.btn-md {
+  height: 34px;
+  padding: 0 14px;
+  font-size: 13px;
+  gap: 6px;
+}
+
+.btn-lg {
+  height: 42px;
+  padding: 0 18px;
+  font-size: 14px;
+  gap: 8px;
+}
+
+.btn-iconOnly.btn-sm {
+  width: 28px;
+  padding: 0;
+}
+
+.btn-iconOnly.btn-md {
+  width: 34px;
+  padding: 0;
+}
+
+.btn-iconOnly.btn-lg {
+  width: 42px;
+  padding: 0;
+}
+
+.btn-fullWidth {
+  width: 100%;
+}
+
+/* ── Variants ── */
+
+/* Primary: solid Geist accent. Use sparingly — one per surface. */
+.btn-primary {
+  background: var(--geist-accent);
+  border-color: var(--geist-accent);
+  color: var(--geist-accent-foreground);
+  box-shadow: 0 8px 18px
+    color-mix(in srgb, var(--geist-foreground) 14%, transparent);
+}
+
+.btn-primary:hover:not(:disabled) {
+  opacity: 0.88;
+  box-shadow: 0 10px 22px
+    color-mix(in srgb, var(--geist-foreground) 18%, transparent);
+}
+
+.btn-primary:disabled {
+  box-shadow: none;
+}
+
+/* Secondary: bordered, surface-tinted. The workhorse for navigation. */
+.btn-secondary {
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 82%,
+    var(--geist-surface)
+  );
+  border-color: var(--geist-border);
+  color: var(--geist-foreground);
+  box-shadow: var(--geist-shadow-sm);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--geist-background);
+  border-color: var(--geist-border-hover);
+  box-shadow: var(--geist-shadow-md);
+  transform: translateY(-1px);
+}
+
+html[data-theme="dark"] .btn-secondary {
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 72%,
+    var(--geist-surface)
+  );
+}
+
+html[data-theme="dark"] .btn-secondary:hover:not(:disabled) {
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 60%,
+    var(--geist-surface)
+  );
+}
+
+/* Ghost: low-emphasis, used for toolbar actions and icon-only triggers. */
+.btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--geist-secondary);
+  box-shadow: none;
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: color-mix(
+    in srgb,
+    var(--geist-surface) 84%,
+    var(--geist-background)
+  );
+  color: var(--geist-foreground);
+}
+
+/* Danger: secondary-shaped, reveals red on hover. */
+.btn-danger {
+  background: transparent;
+  border-color: transparent;
+  color: var(--geist-secondary);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: color-mix(
+    in srgb,
+    var(--geist-error) 8%,
+    transparent
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--geist-error) 38%,
+    var(--geist-border)
+  );
+  color: var(--geist-error);
+}
+
+/* ── Icon alignment ── */
+
+.btn svg {
+  flex-shrink: 0;
+  /* Lucide strokes look heaviest at their baseline weight; nudging stroke
+     down to 1.8 on the larger sizes keeps icons from outweighing the label. */
+  stroke-width: 2;
+}
+
+.btn-lg svg {
+  stroke-width: 1.9;
+}

--- a/packages/genui/a2ui-playground/src/components/Button.css
+++ b/packages/genui/a2ui-playground/src/components/Button.css
@@ -98,6 +98,37 @@
   width: 100%;
 }
 
+/* Labels are always wrapped in a span so `responsiveIconOnly` can collapse
+   them at narrow widths without affecting icon-bearing siblings. */
+.btnLabel {
+  display: inline-flex;
+  align-items: center;
+}
+
+@media (max-width: 720px) {
+  .btn-responsiveIconOnly .btnLabel {
+    display: none;
+  }
+  .btn-responsiveIconOnly {
+    gap: 0;
+    padding: 0;
+    flex-shrink: 0;
+  }
+  /* Compound selectors win over `.btn-fullWidth { width: 100% }`. */
+  .btn-responsiveIconOnly.btn-sm,
+  .btn-fullWidth.btn-responsiveIconOnly.btn-sm {
+    width: 28px;
+  }
+  .btn-responsiveIconOnly.btn-md,
+  .btn-fullWidth.btn-responsiveIconOnly.btn-md {
+    width: 34px;
+  }
+  .btn-responsiveIconOnly.btn-lg,
+  .btn-fullWidth.btn-responsiveIconOnly.btn-lg {
+    width: 42px;
+  }
+}
+
 /* ── Variants ── */
 
 /* Primary: solid Geist accent. Use sparingly — one per surface. */

--- a/packages/genui/a2ui-playground/src/components/Button.tsx
+++ b/packages/genui/a2ui-playground/src/components/Button.tsx
@@ -1,0 +1,70 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { forwardRef } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+import { ICON_SIZE } from './Icon.js';
+import './Button.css';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  /** Icon rendered before the label. Pass a Lucide icon component. */
+  iconBefore?: React.ComponentType<{ size?: number; strokeWidth?: number }>;
+  iconAfter?: React.ComponentType<{ size?: number; strokeWidth?: number }>;
+  /** Render as icon-only (square aspect, no label). */
+  iconOnly?: boolean;
+  /** Make the button stretch to its container's width. */
+  fullWidth?: boolean;
+  children?: ReactNode;
+}
+
+function classes(...parts: Array<string | false | undefined>) {
+  return parts.filter(Boolean).join(' ');
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(props, ref) {
+    const {
+      variant = 'secondary',
+      size = 'md',
+      iconBefore: IconBefore,
+      iconAfter: IconAfter,
+      iconOnly = false,
+      fullWidth = false,
+      className,
+      children,
+      type = 'button',
+      ...rest
+    } = props;
+
+    const iconSize =
+      ICON_SIZE[size === 'lg' ? 'lg' : (size === 'sm' ? 'sm' : 'md')];
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={classes(
+          'btn',
+          `btn-${variant}`,
+          `btn-${size}`,
+          iconOnly && 'btn-iconOnly',
+          fullWidth && 'btn-fullWidth',
+          className,
+        )}
+        {...rest}
+      >
+        {IconBefore
+          ? <IconBefore size={iconSize} strokeWidth={2} />
+          : null}
+        {iconOnly ? null : children}
+        {IconAfter ? <IconAfter size={iconSize} strokeWidth={2} /> : null}
+      </button>
+    );
+  },
+);

--- a/packages/genui/a2ui-playground/src/components/Button.tsx
+++ b/packages/genui/a2ui-playground/src/components/Button.tsx
@@ -18,6 +18,8 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconAfter?: React.ComponentType<{ size?: number; strokeWidth?: number }>;
   /** Render as icon-only (square aspect, no label). */
   iconOnly?: boolean;
+  /** Collapse to icon-only at narrow widths (≤720px). Requires iconBefore. */
+  responsiveIconOnly?: boolean;
   /** Make the button stretch to its container's width. */
   fullWidth?: boolean;
   children?: ReactNode;
@@ -35,6 +37,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       iconBefore: IconBefore,
       iconAfter: IconAfter,
       iconOnly = false,
+      responsiveIconOnly = false,
       fullWidth = false,
       className,
       children,
@@ -54,6 +57,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           `btn-${variant}`,
           `btn-${size}`,
           iconOnly && 'btn-iconOnly',
+          responsiveIconOnly && 'btn-responsiveIconOnly',
           fullWidth && 'btn-fullWidth',
           className,
         )}
@@ -62,7 +66,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {IconBefore
           ? <IconBefore size={iconSize} strokeWidth={2} />
           : null}
-        {iconOnly ? null : children}
+        {iconOnly ? null : <span className='btnLabel'>{children}</span>}
         {IconAfter ? <IconAfter size={iconSize} strokeWidth={2} /> : null}
       </button>
     );

--- a/packages/genui/a2ui-playground/src/components/ConversationListPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/ConversationListPanel.tsx
@@ -71,8 +71,10 @@ export function ConversationListPanel(props: ConversationListPanelProps) {
           variant='secondary'
           size='lg'
           fullWidth
+          responsiveIconOnly
           iconBefore={MessageSquarePlus}
           disabled={disabled}
+          aria-label='New Chat'
           onClick={onCreate}
         >
           New Chat

--- a/packages/genui/a2ui-playground/src/components/ConversationListPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/ConversationListPanel.tsx
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 import { useRef, useState } from 'react';
 
+import { Button } from './Button.js';
+import { MessageSquarePlus, Pencil, Trash2 } from './Icon.js';
 import type { ConversationMeta } from '../storage/types.js';
 
 interface ConversationListPanelProps {
@@ -65,15 +67,16 @@ export function ConversationListPanel(props: ConversationListPanelProps) {
   return (
     <aside className='conversationPanel'>
       <div className='conversationPanelHeader'>
-        <button
-          type='button'
-          className='conversationNewButton'
+        <Button
+          variant='secondary'
+          size='lg'
+          fullWidth
+          iconBefore={MessageSquarePlus}
           disabled={disabled}
           onClick={onCreate}
         >
-          <span className='conversationNewButtonIcon'>💬</span>
-          <span className='conversationNewButtonLabel'>+ New Chat</span>
-        </button>
+          New Chat
+        </Button>
       </div>
 
       <div className='conversationList'>
@@ -137,24 +140,26 @@ export function ConversationListPanel(props: ConversationListPanelProps) {
                   </button>
                 )}
               <div className='conversationListItemActions'>
-                <button
-                  type='button'
-                  className='conversationIconButton'
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  iconOnly
+                  iconBefore={Pencil}
                   disabled={disabled || editing}
                   title='Rename'
+                  aria-label='Rename conversation'
                   onClick={() => beginEdit(conversation)}
-                >
-                  Edit
-                </button>
-                <button
-                  type='button'
-                  className='conversationIconButton conversationIconButtonDanger'
+                />
+                <Button
+                  variant='danger'
+                  size='sm'
+                  iconOnly
+                  iconBefore={Trash2}
                   disabled={disabled || conversations.length <= 1}
                   title='Delete'
+                  aria-label='Delete conversation'
                   onClick={() => onRemove(conversation.id)}
-                >
-                  Del
-                </button>
+                />
               </div>
             </div>
           );

--- a/packages/genui/a2ui-playground/src/components/Icon.tsx
+++ b/packages/genui/a2ui-playground/src/components/Icon.tsx
@@ -1,0 +1,63 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Centralized Lucide icon re-exports. Two reasons to funnel through this file:
+// 1. Picking icons from one list keeps the visual vocabulary consistent — same
+//    stroke weight, same metaphor library, no one-off emojis sneaking back in.
+// 2. Tree-shaking still works because each icon is a named export.
+import {
+  ArrowRight,
+  ArrowUpRight,
+  ChevronLeft,
+  Copy,
+  Maximize2,
+  MessageSquarePlus,
+  Minimize2,
+  Moon,
+  Pause,
+  Pencil,
+  Play,
+  RotateCcw,
+  Send,
+  Smartphone,
+  Sparkles,
+  Sun,
+  Trash2,
+  X,
+  Zap,
+} from 'lucide-react';
+import type { LucideProps } from 'lucide-react';
+
+export {
+  ArrowRight,
+  ArrowUpRight,
+  ChevronLeft,
+  Copy,
+  Maximize2,
+  MessageSquarePlus,
+  Minimize2,
+  Moon,
+  Pause,
+  Pencil,
+  Play,
+  RotateCcw,
+  Send,
+  Smartphone,
+  Sparkles,
+  Sun,
+  Trash2,
+  X,
+  Zap,
+};
+
+export type IconProps = LucideProps;
+
+// Size convention paired with Button sizes. Icons sit ~2px under cap height so
+// they never visually outweigh the label.
+export const ICON_SIZE = {
+  sm: 14,
+  md: 15,
+  lg: 16,
+  xl: 18,
+} as const;

--- a/packages/genui/a2ui-playground/src/components/InstantExamplesStrip.tsx
+++ b/packages/genui/a2ui-playground/src/components/InstantExamplesStrip.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 
+import { ArrowRight, ICON_SIZE, Zap } from './Icon.js';
 import { PreviewViewport } from './PreviewViewport.js';
 import { EXTENDED_STATIC_DEMOS, OFFICIAL_STATIC_DEMOS } from '../demos.js';
 import type { StaticDemo } from '../demos.js';
@@ -148,13 +149,13 @@ export function InstantExamplesStrip(props: InstantExamplesStripProps) {
       <div className='instantExamplesHeader'>
         <span className='instantExamplesLabel'>
           <span className='instantExamplesLabelIcon' aria-hidden='true'>
-            ⚡
+            <Zap size={ICON_SIZE.md} strokeWidth={2.25} />
           </span>
           Pick an instant example
           <span className='instantExamplesLabelHint'>· no API call</span>
         </span>
         <a className='instantExamplesAllLink' href={onBrowseAllHref}>
-          See all →
+          See all <ArrowRight size={ICON_SIZE.sm} strokeWidth={2} />
         </a>
       </div>
       <div className='instantExamplesRail'>

--- a/packages/genui/a2ui-playground/src/components/MobileTabBar.tsx
+++ b/packages/genui/a2ui-playground/src/components/MobileTabBar.tsx
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { ICON_SIZE, Pencil, Smartphone } from './Icon.js';
+
 export type MobilePaneTab = 'edit' | 'preview';
 
 interface MobileTabBarProps {
@@ -12,6 +14,7 @@ interface MobileTabBarProps {
 
 export function MobileTabBar(props: MobileTabBarProps) {
   const { activeTab, editLabel = 'Edit', onChange } = props;
+  const tabIconSize = ICON_SIZE.xl;
   return (
     <nav
       className='mobileTabBar'
@@ -25,20 +28,7 @@ export function MobileTabBar(props: MobileTabBarProps) {
         className={activeTab === 'edit' ? 'mobileTab active' : 'mobileTab'}
         onClick={() => onChange('edit')}
       >
-        <svg
-          viewBox='0 0 24 24'
-          width='18'
-          height='18'
-          fill='none'
-          stroke='currentColor'
-          strokeWidth='2'
-          strokeLinecap='round'
-          strokeLinejoin='round'
-          aria-hidden='true'
-        >
-          <path d='M12 20h9' />
-          <path d='M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z' />
-        </svg>
+        <Pencil size={tabIconSize} strokeWidth={2} aria-hidden='true' />
         <span className='mobileTabLabel'>{editLabel}</span>
       </button>
       <button
@@ -48,20 +38,7 @@ export function MobileTabBar(props: MobileTabBarProps) {
         className={activeTab === 'preview' ? 'mobileTab active' : 'mobileTab'}
         onClick={() => onChange('preview')}
       >
-        <svg
-          viewBox='0 0 24 24'
-          width='18'
-          height='18'
-          fill='none'
-          stroke='currentColor'
-          strokeWidth='2'
-          strokeLinecap='round'
-          strokeLinejoin='round'
-          aria-hidden='true'
-        >
-          <rect x='6' y='2' width='12' height='20' rx='2.5' ry='2.5' />
-          <line x1='12' y1='18' x2='12.01' y2='18' />
-        </svg>
+        <Smartphone size={tabIconSize} strokeWidth={2} aria-hidden='true' />
         <span className='mobileTabLabel'>Preview</span>
       </button>
     </nav>

--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -13,7 +13,9 @@ import {
 import type { CSSProperties, ReactNode } from 'react';
 import { Drawer } from 'vaul';
 
+import { Button } from './Button.js';
 import { CopyToast, useCopyToast } from './CopyToast.js';
+import { Maximize2, Minimize2, Smartphone } from './Icon.js';
 import { PreviewSimulationBar } from './PreviewSimulationBar.js';
 import { QrCode } from './QrCode.js';
 import { componentsByMessage } from '../demos.js';
@@ -1061,45 +1063,28 @@ export function PreviewPanel(props: PreviewPanelProps) {
                 : null}
               {hasExtras
                 ? (
-                  <button
-                    type='button'
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    iconOnly
+                    iconBefore={Smartphone}
                     className='previewInfoBtn'
                     onClick={() => setShareOpen(true)}
                     title='Open on phone'
                     aria-label='Open this preview on a phone'
-                  >
-                    <svg
-                      viewBox='0 0 24 24'
-                      width='16'
-                      height='16'
-                      fill='none'
-                      stroke='currentColor'
-                      strokeWidth='2'
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      aria-hidden='true'
-                    >
-                      <rect
-                        x='6'
-                        y='2'
-                        width='12'
-                        height='20'
-                        rx='2.5'
-                        ry='2.5'
-                      />
-                      <line x1='12' y1='18' x2='12.01' y2='18' />
-                    </svg>
-                  </button>
+                  />
                 )
                 : null}
-              <button
-                type='button'
+              <Button
+                variant='ghost'
+                size='sm'
+                iconOnly
+                iconBefore={isFullscreen ? Minimize2 : Maximize2}
                 className='previewExpandBtn'
                 onClick={() => setIsFullscreen((v) => !v)}
                 title={isFullscreen ? 'Exit fullscreen' : 'Expand preview'}
-              >
-                {isFullscreen ? '\u2715' : '\u2922'}
-              </button>
+                aria-label={isFullscreen ? 'Exit fullscreen' : 'Expand preview'}
+              />
             </div>
             {beforeBody}
             {renderPreviewMetrics()}

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.css
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.css
@@ -135,69 +135,7 @@
   background: color-mix(in srgb, var(--geist-background) 62%, transparent);
 }
 
-.conversationNewButton {
-  width: 100%;
-  height: 44px;
-  margin: 0;
-  padding: 0 16px;
-  border: 1px solid var(--geist-border);
-  border-radius: 12px;
-  background: linear-gradient(
-    180deg,
-    var(--geist-background),
-    color-mix(in srgb, var(--geist-surface) 70%, var(--geist-background))
-  );
-  color: var(--geist-foreground);
-  font-size: 13px;
-  font-weight: 650;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  transition:
-    background var(--geist-transition),
-    border-color var(--geist-transition),
-    color var(--geist-transition),
-    box-shadow var(--geist-transition),
-    transform var(--geist-transition);
-  box-shadow: 0 6px 18px
-    color-mix(in srgb, var(--geist-foreground) 5%, transparent);
-}
-
-.conversationNewButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.conversationNewButton:hover {
-  border-color: color-mix(
-    in srgb,
-    var(--geist-foreground) 28%,
-    var(--geist-border)
-  );
-  background: color-mix(
-    in srgb,
-    var(--geist-background) 82%,
-    var(--geist-surface)
-  );
-  box-shadow: 0 10px 26px
-    color-mix(in srgb, var(--geist-foreground) 9%, transparent);
-}
-
-.conversationNewButtonIcon {
-  font-size: 16px;
-  line-height: 1;
-}
-
-.conversationNewButtonLabel {
-  line-height: 1;
-}
-
-.conversationNewButton:active {
-  transform: scale(0.96);
-}
+/* conversationNewButton: replaced by <Button variant="secondary" size="lg" fullWidth>. */
 
 .conversationRecentRow {
   display: flex;
@@ -357,45 +295,8 @@
   transform: translateX(0);
 }
 
-.conversationIconButton {
-  height: 26px;
-  padding: 0 7px;
-  border: 1px solid var(--geist-border);
-  border-radius: 999px;
-  background: color-mix(
-    in srgb,
-    var(--geist-surface) 76%,
-    var(--geist-background)
-  );
-  color: var(--geist-secondary);
-  font-size: 10px;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background var(--geist-transition),
-    border-color var(--geist-transition),
-    color var(--geist-transition);
-}
-
-.conversationIconButton:hover {
-  color: var(--geist-foreground);
-  border-color: var(--geist-border-hover);
-  background: var(--geist-background);
-}
-
-.conversationIconButtonDanger:hover {
-  border-color: color-mix(
-    in srgb,
-    var(--geist-error, #c0392b) 55%,
-    var(--geist-border)
-  );
-  color: var(--geist-error, #c0392b);
-}
-
-.conversationIconButton:disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
-}
+/* conversationIconButton / conversationIconButtonDanger: replaced by
+   <Button variant="ghost"|"danger" size="sm" iconOnly>. */
 
 .conversationRenameInput {
   width: 100%;
@@ -686,8 +587,9 @@
 }
 
 .chatMessageStatusIcon {
-  font-size: 14px;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  color: color-mix(in srgb, var(--geist-foreground) 70%, transparent);
   flex-shrink: 0;
 }
 
@@ -1110,8 +1012,9 @@
 }
 
 .instantExamplesLabelIcon {
-  font-size: 11px;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  color: color-mix(in srgb, var(--geist-foreground) 75%, transparent);
 }
 
 .instantExamplesLabelHint {
@@ -1120,6 +1023,9 @@
 }
 
 .instantExamplesAllLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   color: var(--geist-secondary);
   font-size: 11px;
   font-weight: 600;
@@ -1129,6 +1035,14 @@
 
 .instantExamplesAllLink:hover {
   color: var(--geist-foreground);
+}
+
+.instantExamplesAllLink svg {
+  transition: transform var(--geist-transition);
+}
+
+.instantExamplesAllLink:hover svg {
+  transform: translateX(2px);
 }
 
 .instantExamplesRail {
@@ -1400,50 +1314,8 @@
   color: var(--geist-foreground);
 }
 
-.chatSendBtn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-width: 104px;
-  height: 42px;
-  padding: 0 18px;
-  border: none;
-  border-radius: 999px;
-  background: var(--geist-accent);
-  color: var(--geist-accent-foreground);
-  font-size: 14px;
-  font-weight: 650;
-  cursor: pointer;
-  transition:
-    opacity var(--geist-transition),
-    transform var(--geist-transition),
-    box-shadow var(--geist-transition);
-  flex-shrink: 0;
-  box-shadow: 0 8px 18px
-    color-mix(in srgb, var(--geist-foreground) 16%, transparent);
-}
-
-.chatSendBtn:hover {
-  opacity: 0.85;
-  box-shadow: 0 10px 24px
-    color-mix(in srgb, var(--geist-foreground) 20%, transparent);
-}
-
-.chatSendBtn:active {
-  transform: scale(0.97);
-}
-
-.chatSendBtn:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.chatSendIcon {
-  font-size: 15px;
-  line-height: 1;
-}
+/* chatSendBtn / chatSendIcon: replaced by <Button variant="primary" size="lg"
+   iconBefore={Send}>. */
 
 @media (max-width: 980px) {
   .chatPageBody {

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.css
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.css
@@ -1521,4 +1521,73 @@
   .chatHeader {
     display: none;
   }
+
+  /* ── Compact the suggestion + composer block ──────────────────────
+     On a 390px phone the default sizing left almost no room for chat
+     bubbles. Shrink each surface so the scrollable message area becomes
+     the dominant pane. */
+
+  .chatInputArea {
+    padding: 8px 14px 10px;
+    gap: 8px;
+  }
+
+  /* Instant examples: same horizontal rail, but each tile is smaller
+     so two fit side-by-side without a 220px preview eating the screen. */
+  .instantTile {
+    width: 180px;
+    gap: 6px;
+    padding: 4px;
+    margin: -4px;
+  }
+  .instantTileScreen {
+    height: 150px;
+  }
+  .instantTileTitle {
+    font-size: 11.5px;
+  }
+  .instantExamples {
+    gap: 4px;
+  }
+  .instantExamplesHeader,
+  .promptSuggestionsHeader {
+    padding: 0 2px;
+  }
+
+  /* Prompt suggestion chips: tighter so the rail reads as a 1-line strip. */
+  .chatSuggestionChip {
+    height: 26px;
+    padding: 0 10px;
+    font-size: 11.5px;
+  }
+  .promptSuggestions {
+    gap: 4px;
+  }
+  .promptSuggestionsRail {
+    padding: 2px 14px 4px;
+    margin: 0 -14px;
+  }
+
+  /* Composer: drop ~50px of vertical height. Textarea becomes a single
+     visible line that expands as the user types. */
+  .chatComposer {
+    min-height: 0;
+    padding: 10px 12px;
+    gap: 8px;
+    border-radius: 12px;
+  }
+  .chatInput {
+    min-height: 38px;
+    max-height: 140px;
+    font-size: 14px;
+    line-height: 1.45;
+  }
+
+  /* Mobile Send: a bit smaller so it doesn't dominate the footer. */
+  .chatComposerFooter .btn-lg {
+    height: 36px;
+    padding: 0 14px;
+    font-size: 13px;
+    min-width: 0;
+  }
 }

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -5,9 +5,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import './AIChatPage.css';
 
+import { Button } from '../components/Button.js';
 import { ConfirmDialog } from '../components/ConfirmDialog.js';
 import { ConversationListPanel } from '../components/ConversationListPanel.js';
 import { CopyToast, useCopyToast } from '../components/CopyToast.js';
+import { Send, Sparkles, Zap } from '../components/Icon.js';
 import { InstantExamplesStrip } from '../components/InstantExamplesStrip.js';
 import { MobileTabBar } from '../components/MobileTabBar.js';
 import type { MobilePaneTab } from '../components/MobileTabBar.js';
@@ -921,7 +923,7 @@ function createPreviewReadyStatus(): ChatMessage {
     content: (
       <>
         <span className='chatMessageStatusIcon' aria-hidden='true'>
-          ✨
+          <Sparkles size={13} strokeWidth={2} />
         </span>
         <span>UI updated. Ready for the next action.</span>
       </>
@@ -2056,7 +2058,7 @@ export function AIChatPage(
           content: (
             <>
               <span className='chatMessageStatusIcon' aria-hidden='true'>
-                ⚡
+                <Zap size={13} strokeWidth={2} />
               </span>
               <span>
                 Loaded offline example{' '}
@@ -2396,15 +2398,15 @@ export function AIChatPage(
                     ))}
                   </select>
                 </div>
-                <button
-                  className='chatSendBtn'
-                  type='button'
+                <Button
+                  variant='primary'
+                  size='lg'
+                  iconBefore={Send}
                   disabled={isGenerating || inputValue.trim().length === 0}
                   onClick={handleSend}
                 >
-                  <span className='chatSendIcon' aria-hidden='true'>↖</span>
                   {isGenerating ? 'Generating' : 'Send'}
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -2433,7 +2435,7 @@ export function AIChatPage(
             iframeRef={previewFrameRef}
             onLoad={handlePreviewLoad}
             retainPreviousFrame
-            emptyIcon='💬'
+            emptyIcon={<Sparkles size={28} strokeWidth={1.5} />}
             emptyTitle='Send a message to generate UI'
             emptySubTitle='Generated components will be previewed here'
           />

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.css
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.css
@@ -201,65 +201,8 @@
   padding: 8px 0 16px;
 }
 
-.detailBackButton {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 34px;
-  padding: 8px 14px;
-  border: 1px solid var(--geist-border);
-  border-radius: 999px;
-  background: color-mix(
-    in srgb,
-    var(--geist-background) 82%,
-    var(--geist-surface)
-  );
-  color: var(--geist-foreground);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1;
-  letter-spacing: 0.01em;
-  cursor: pointer;
-  box-shadow: var(--geist-shadow-sm);
-  transition:
-    background var(--geist-transition),
-    border-color var(--geist-transition),
-    transform var(--geist-transition),
-    box-shadow var(--geist-transition);
-}
-
-.detailBackButton:hover {
-  border-color: var(--geist-border-hover);
-  background: var(--geist-background);
-  transform: translateY(-1px);
-  box-shadow: var(--geist-shadow-md);
-}
-
-html[data-theme="dark"] .detailBackButton {
-  background: color-mix(
-    in srgb,
-    var(--geist-background) 72%,
-    var(--geist-surface)
-  );
-}
-
-html[data-theme="dark"] .detailBackButton:hover {
-  background: color-mix(
-    in srgb,
-    var(--geist-background) 60%,
-    var(--geist-surface)
-  );
-}
-
-.detailBackIcon {
-  font-size: 15px;
-  line-height: 1;
-  color: var(--geist-secondary);
-}
-
-.detailBackLabel {
-  line-height: 1;
-}
+/* detailBackButton / detailBackIcon / detailBackLabel: replaced by
+   <Button variant="secondary" size="md" iconBefore={ChevronLeft}>. */
 
 .detailWorkspace {
   flex: 1;
@@ -496,38 +439,8 @@ html[data-theme="dark"] .detailBackButton:hover {
   gap: 4px;
 }
 
-.toolbarBtn {
-  height: 28px;
-  padding: 0 10px;
-  border: 1px solid var(--geist-border);
-  border-radius: var(--geist-radius-sm);
-  background: var(--geist-background);
-  color: var(--geist-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--geist-transition);
-  white-space: nowrap;
-}
-
-.toolbarBtn:hover {
-  color: var(--geist-foreground);
-  border-color: var(--geist-border-hover);
-}
-
-.toolbarBtn:active {
-  transform: scale(0.97);
-}
-
-.toolbarBtn.primary {
-  background: var(--geist-accent);
-  border-color: var(--geist-accent);
-  color: var(--geist-accent-foreground);
-}
-
-.toolbarBtn.primary:hover {
-  opacity: 0.85;
-}
+/* toolbarBtn / toolbarBtn.primary: replaced by <Button variant="ghost"|"primary"
+   size="sm" ...>. */
 
 .codeEditor {
   flex: 1;

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.css
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.css
@@ -684,7 +684,40 @@
   border-bottom: none;
 }
 
+.playbackSectionTitle {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--geist-foreground);
+}
+
+/* Inline meta sits flush against the title, separated by a hairline dot
+   instead of a chunky chip — keeps the header visually quiet at idle. */
+.playbackSectionMeta {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--geist-secondary) 85%, transparent);
+  margin-left: -4px; /* tighten against the title to read as one unit */
+}
+
+.playbackSectionMeta::before {
+  content: "";
+  display: inline-block;
+  width: 3px;
+  height: 3px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--geist-secondary) 55%, transparent);
+  margin: 0 8px 1px 0;
+}
+
 .playbackIdleHint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: 12px;
   color: var(--geist-secondary);
   white-space: nowrap;
@@ -693,23 +726,17 @@
   min-width: 0;
 }
 
-.playbackSectionTitle {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: -0.005em;
-  color: var(--geist-foreground);
+.playbackIdleHint svg {
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--geist-foreground) 55%, transparent);
 }
 
-.playbackSectionBadge {
-  font-size: 10px;
-  font-weight: 500;
-  padding: 1px 6px;
-  border-radius: 4px;
-  background: var(--geist-surface);
-  border: 1px solid var(--geist-border);
-  color: var(--geist-secondary);
-  text-transform: none;
-  letter-spacing: 0;
+/* Below ~720px the hint crowds the controls — drop it; the [Play] button
+   right next to it is sufficient affordance. */
+@media (max-width: 720px) {
+  .playbackIdleHint {
+    display: none;
+  }
 }
 
 .playbackStateDot {

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.css
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.css
@@ -423,15 +423,7 @@
   gap: 8px;
 }
 
-.codePanelBadge {
-  font-size: 10px;
-  font-weight: 500;
-  padding: 1px 6px;
-  border-radius: 4px;
-  background: var(--geist-surface);
-  border: 1px solid var(--geist-border);
-  color: var(--geist-secondary);
-}
+/* JSON badge: see shared .sectionBadge in styles.css. */
 
 .toolbarActions {
   display: flex;
@@ -691,28 +683,7 @@
   color: var(--geist-foreground);
 }
 
-/* Inline meta sits flush against the title, separated by a hairline dot
-   instead of a chunky chip — keeps the header visually quiet at idle. */
-.playbackSectionMeta {
-  display: inline-flex;
-  align-items: center;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--geist-secondary) 85%, transparent);
-  margin-left: -4px; /* tighten against the title to read as one unit */
-}
-
-.playbackSectionMeta::before {
-  content: "";
-  display: inline-block;
-  width: 3px;
-  height: 3px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--geist-secondary) 55%, transparent);
-  margin: 0 8px 1px 0;
-}
+/* LLM stream badge: see shared .sectionBadge in styles.css. */
 
 .playbackIdleHint {
   display: inline-flex;
@@ -1113,8 +1084,5 @@
   .codePanelTitle {
     white-space: nowrap;
     font-size: 12px;
-  }
-  .codePanelBadge {
-    display: none;
   }
 }

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -680,7 +680,7 @@ export function DemosPage(props: {
           >
             <header className='playbackSectionHeader'>
               <span className='playbackSectionTitle'>Playback</span>
-              <span className='playbackSectionMeta'>LLM stream</span>
+              <span className='sectionBadge'>LLM stream</span>
               {isPlaybackActive
                 ? (
                   <span
@@ -800,7 +800,7 @@ export function DemosPage(props: {
             <div className='codePanelToolbar'>
               <div className='codePanelTitle'>
                 A2UI Messages
-                <span className='codePanelBadge'>JSON</span>
+                <span className='sectionBadge'>JSON</span>
               </div>
               <div className='spacer' />
               <div className='toolbarActions'>

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -595,7 +595,7 @@ export function DemosPage(props: {
   const playbackPrimaryButton = isPlaying
     ? (
       <Button
-        variant='ghost'
+        variant='primary'
         size='sm'
         iconBefore={Pause}
         onClick={handlePause}

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -639,6 +639,7 @@ export function DemosPage(props: {
           <Button
             variant='secondary'
             size='md'
+            responsiveIconOnly
             iconBefore={ChevronLeft}
             onClick={handleBackToExamples}
             aria-label='Back to Examples'
@@ -679,7 +680,7 @@ export function DemosPage(props: {
           >
             <header className='playbackSectionHeader'>
               <span className='playbackSectionTitle'>Playback</span>
-              <span className='playbackSectionBadge'>LLM stream</span>
+              <span className='playbackSectionMeta'>LLM stream</span>
               {isPlaybackActive
                 ? (
                   <span
@@ -693,7 +694,8 @@ export function DemosPage(props: {
                 )
                 : (
                   <span className='playbackIdleHint'>
-                    Press ▶ to replay this LLM payload chunk by chunk
+                    <Play size={11} strokeWidth={2.25} aria-hidden='true' />
+                    Replay payload chunk by chunk
                   </span>
                 )}
               <div className='spacer' />

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.tsx
@@ -8,6 +8,8 @@ import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
 
 import './DemosPage.css';
 
+import { Button } from '../components/Button.js';
+import { ChevronLeft, Pause, Play, RotateCcw, X } from '../components/Icon.js';
 import { MobileTabBar } from '../components/MobileTabBar.js';
 import type { MobilePaneTab } from '../components/MobileTabBar.js';
 import { PanelResizeHandle } from '../components/PanelResizeHandle.js';
@@ -592,35 +594,38 @@ export function DemosPage(props: {
 
   const playbackPrimaryButton = isPlaying
     ? (
-      <button
-        type='button'
-        className='toolbarBtn'
+      <Button
+        variant='ghost'
+        size='sm'
+        iconBefore={Pause}
         onClick={handlePause}
         title='Pause playback'
       >
-        ⏸ Pause
-      </button>
+        Pause
+      </Button>
     )
     : (isPaused
       ? (
-        <button
-          type='button'
-          className='toolbarBtn primary'
+        <Button
+          variant='primary'
+          size='sm'
+          iconBefore={Play}
           onClick={handleResume}
           title='Resume playback'
         >
-          ▶ Resume
-        </button>
+          Resume
+        </Button>
       )
       : (
-        <button
-          type='button'
-          className='toolbarBtn primary'
+        <Button
+          variant='primary'
+          size='sm'
+          iconBefore={Play}
           onClick={handlePlay}
           title='Start playback'
         >
-          ▶ Play
-        </button>
+          Play
+        </Button>
       ));
 
   return (
@@ -631,15 +636,15 @@ export function DemosPage(props: {
     >
       <aside className='sidebar'>
         <div className='sidebarTopNav'>
-          <button
-            type='button'
-            className='detailBackButton'
+          <Button
+            variant='secondary'
+            size='md'
+            iconBefore={ChevronLeft}
             onClick={handleBackToExamples}
             aria-label='Back to Examples'
           >
-            <span className='detailBackIcon'>←</span>
-            <span className='detailBackLabel'>Back to Examples</span>
-          </button>
+            Back to Examples
+          </Button>
         </div>
         <div className='sidebarSection'>
           <div className='sidebarHeading'>Scenarios</div>
@@ -695,14 +700,15 @@ export function DemosPage(props: {
               <div className='playbackHeaderControls'>
                 {isPlaybackActive
                   ? (
-                    <button
-                      type='button'
-                      className='toolbarBtn'
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      iconOnly
+                      iconBefore={RotateCcw}
                       onClick={handleRestart}
                       title='Restart playback'
-                    >
-                      ↻
-                    </button>
+                      aria-label='Restart playback'
+                    />
                   )
                   : null}
                 {playbackPrimaryButton}
@@ -796,30 +802,33 @@ export function DemosPage(props: {
               </div>
               <div className='spacer' />
               <div className='toolbarActions'>
-                <button
-                  type='button'
-                  className='toolbarBtn'
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  iconBefore={RotateCcw}
                   onClick={handleFillExample}
-                  title='Reset'
+                  title='Reset to example'
                 >
-                  ↻ Reset
-                </button>
-                <button
-                  type='button'
-                  className='toolbarBtn'
+                  Reset
+                </Button>
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  iconBefore={X}
                   onClick={handleClear}
-                  title='Clear'
+                  title='Clear editor'
                 >
-                  ✕ Clear
-                </button>
-                <button
-                  type='button'
-                  className='toolbarBtn primary'
+                  Clear
+                </Button>
+                <Button
+                  variant='primary'
+                  size='sm'
+                  iconBefore={Play}
                   onClick={handleRender}
                   disabled={isPublishingPayload}
                 >
-                  {isPublishingPayload ? 'Publishing...' : '▶ Render'}
-                </button>
+                  {isPublishingPayload ? 'Publishing...' : 'Render'}
+                </Button>
               </div>
             </div>
             <CodeMirror

--- a/packages/genui/a2ui-playground/src/pages/OpenUIDemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/OpenUIDemosPage.tsx
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import './DemosPage.css';
 
+import { Button } from '../components/Button.js';
+import { Play } from '../components/Icon.js';
 import { PanelResizeHandle } from '../components/PanelResizeHandle.js';
 import { PreviewPanel } from '../components/PreviewPanel.js';
 import { PreviewViewport } from '../components/PreviewViewport.js';
@@ -144,13 +146,14 @@ export function OpenUIDemosPage(_props: { protocol: Protocol }) {
             </button>
           </div>
           <div className='toolbarActions'>
-            <button
-              type='button'
-              className='toolbarBtn primary'
+            <Button
+              variant='primary'
+              size='sm'
+              iconBefore={Play}
               onClick={handleRender}
             >
-              ▶ Render
-            </button>
+              Render
+            </Button>
           </div>
         </div>
         <div className='codeEditor' style={{ flex: 1, overflow: 'auto' }}>

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -232,6 +232,21 @@ a {
   flex: 1;
 }
 
+/* Bordered chip badge that sits next to a section title — small structural
+   tag indicating the kind of content. Used for "Playback [LLM stream]",
+   "A2UI Messages [JSON]", etc. Visible at every viewport. */
+.sectionBadge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--geist-surface);
+  border: 1px solid var(--geist-border);
+  color: var(--geist-secondary);
+}
+
 /* themeToggle: replaced by <Button variant="ghost" size="sm" iconOnly>. */
 
 /* ── Tab Navigation ── */

--- a/packages/genui/a2ui-playground/src/styles.css
+++ b/packages/genui/a2ui-playground/src/styles.css
@@ -232,27 +232,7 @@ a {
   flex: 1;
 }
 
-.themeToggle {
-  width: 28px;
-  height: 28px;
-  border: none;
-  border-radius: var(--geist-radius-sm);
-  background: transparent;
-  color: var(--geist-secondary);
-  font-size: 15px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all var(--geist-transition);
-  flex-shrink: 0;
-  padding: 0;
-}
-
-.themeToggle:hover {
-  color: var(--geist-foreground);
-  background: var(--geist-surface);
-}
+/* themeToggle: replaced by <Button variant="ghost" size="sm" iconOnly>. */
 
 /* ── Tab Navigation ── */
 .tabNav {
@@ -742,34 +722,17 @@ html[data-theme="dark"] .phoneHomeIndicator {
   display: contents;
 }
 
-.previewInfoBtn {
+/* previewInfoBtn is a Button (variant=ghost, iconOnly) — only hidden at
+   container widths where the inline extras section is visible. */
+.btn.previewInfoBtn {
   display: none;
-  width: 28px;
-  height: 28px;
-  border: none;
-  border-radius: var(--geist-radius-sm);
-  background: transparent;
-  color: var(--geist-secondary);
-  font-size: 18px;
-  line-height: 1;
-  cursor: pointer;
-  align-items: center;
-  justify-content: center;
-  transition: all var(--geist-transition);
-  flex-shrink: 0;
-  padding: 0;
-}
-
-.previewInfoBtn:hover {
-  color: var(--geist-foreground);
-  background: var(--geist-surface);
 }
 
 @container preview-panel (max-width: 660px) {
   .previewPanelExtras {
     display: none;
   }
-  .previewInfoBtn {
+  .btn.previewInfoBtn {
     display: inline-flex;
   }
 }
@@ -783,27 +746,8 @@ html[data-theme="dark"] .phoneHomeIndicator {
   background: var(--geist-background);
 }
 
-.previewExpandBtn {
-  width: 28px;
-  height: 28px;
-  border: none;
-  border-radius: var(--geist-radius-sm);
-  background: transparent;
-  color: var(--geist-secondary);
-  font-size: 16px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all var(--geist-transition);
-  flex-shrink: 0;
-  padding: 0;
-}
-
-.previewExpandBtn:hover {
-  color: var(--geist-foreground);
-  background: var(--geist-surface);
-}
+/* previewExpandBtn is a Button (variant=ghost, iconOnly) — no extra styling
+   needed beyond the Button primitive. Class kept for selector targeting. */
 
 .previewPanelHeader {
   display: flex;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,6 +716,9 @@ importers:
       idb:
         specifier: ^8.0.3
         version: 8.0.3
+      lucide-react:
+        specifier: ^0.575.0
+        version: 0.575.0(react@19.2.4)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -5725,6 +5728,7 @@ packages:
   '@svitejs/changesets-changelog-github-compact@1.2.0':
     resolution: {integrity: sha512-08eKiDAjj4zLug1taXSIJ0kGL5cawjVCyJkBb6EWSg5fEPX6L+Wtr0CH2If4j5KYylz85iaZiFlUItvgJvll5g==}
     engines: {node: ^14.13.1 || ^16.0.0 || >=18}
+    deprecated: unmaintained
 
   '@swc/core-darwin-arm64@1.15.30':
     resolution: {integrity: sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA==}


### PR DESCRIPTION
## Summary

Polishes the playground UI by collapsing fragmented icons and button styles into one cohesive system.

**New primitives**
- `src/components/Icon.tsx` — Lucide-react barrel (same set Shadcn uses). Centralizes the icon vocabulary with consistent stroke weight and a paired `ICON_SIZE` scale.
- `src/components/Button.tsx` + `Button.css` — pill-shaped Geist-aligned button with `variant` (primary/secondary/ghost/danger) × `size` (sm/md/lg) axes, plus `iconBefore`/`iconAfter`/`iconOnly` slots.

**Icon sweep**
- Send `↖` → `Send`, Back `←` → `ChevronLeft`, Reset/Restart `↻` → `RotateCcw`, Play `▶` → `Play`, Pause `⏸` → `Pause`, Clear `✕` → `X`, Expand `⤢`/`✕` → `Maximize2`/`Minimize2`, theme `☀`/`☾` → `Sun`/`Moon`, New Chat `💬` → `MessageSquarePlus`, status `✨`/`⚡` → `Sparkles`/`Zap`, See all `→` → `ArrowRight`.
- MobileTabBar and PreviewPanel inline SVGs replaced with `Pencil` and `Smartphone`.

**Button consolidation**
- Six per-page button styles collapsed into one system: `toolbarBtn`, `chatSendBtn`, `detailBackButton`, `conversationNewButton`, `conversationIconButton`, `themeToggle`, `previewInfoBtn`, `previewExpandBtn` → all use `<Button>`.
- Net **+502 / -444** lines (the additions are mostly the new primitives + their CSS; the deletions are the obsolete per-component styling).

**Verified visually** in light + dark, desktop + mobile, on the Create page, the Examples detail page, and the MobileTabBar.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (mountQueue tests)
- [x] Visual check at 1440×900 (light + dark): Create page, Examples detail page
- [x] Visual check at 390×800 (mobile): bottom MobileTabBar, Send button, New conversation chips
- [ ] Reviewer: spot-check that no stray `toolbarBtn` / `chatSendBtn` / etc. selectors remain that I missed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified Button component with variants, sizes, icon-only and responsive icon-only modes.
  * Centralized icon set for consistent, scalable icons used across theme toggle, controls, and indicators.

* **Style**
  * Replaced many native/inline buttons with the new Button across chat, preview, demos, mobile bar, and toolbars.
  * Improved visuals, interactions, accessibility (focus, aria labels), and tighter mobile/layout spacing.

* **Chores**
  * Added an icon library dependency for the shared icon set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->