### PR TITLE
feat(a2ui): emit full catalog artifact

### DIFF
--- a/.changeset/a2ui-full-catalog-json.md
+++ b/.changeset/a2ui-full-catalog-json.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": patch
+---
+
+Publish a full A2UI catalog JSON artifact at `a2ui/dist/catalog/catalog.json`.

--- a/packages/genui/a2ui-catalog-extractor/README.md
+++ b/packages/genui/a2ui-catalog-extractor/README.md
@@ -406,11 +406,16 @@ genui a2ui generate catalog [options]
 | `--source <path>`       | Source file or directory to scan. Repeatable.                                | None           |
 | `--typedoc-json <file>` | Read an existing TypeDoc JSON project instead of running TypeDoc conversion. | None           |
 | `--out-dir <dir>`       | Directory where component catalog files are written.                         | `dist/catalog` |
+| `--catalog-id <id>`     | Catalog ID written to the full catalog file.                                 | `catalog.json` |
 | `--version`, `-v`       | Print the package version.                                                   | None           |
 | `--help`, `-h`          | Print usage.                                                                 | None           |
 
 `--source` and `--catalog-dir` can be used together. The extractor merges
 all inputs, removes duplicates, sorts them, and then runs TypeDoc.
+
+The extractor writes both per-component files such as
+`dist/catalog/QuickStartCard/catalog.json` and a full catalog file at
+`dist/catalog/catalog.json`.
 
 The scanner accepts `.ts`, `.tsx`, `.js`, `.jsx`, `.mts`, and `.cts`
 files. It ignores `.d.ts`, `node_modules`, `dist`, and `.turbo`.

--- a/packages/genui/a2ui-catalog-extractor/etc/genui-a2ui-catalog-extractor.api.md
+++ b/packages/genui/a2ui-catalog-extractor/etc/genui-a2ui-catalog-extractor.api.md
@@ -293,6 +293,14 @@ export interface TypeDocType {
     value?: bigint | boolean | number | string | null;
 }
 
+// Warning: (ae-missing-release-tag) "writeA2UICatalog" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function writeA2UICatalog(catalog: A2UICatalog, options: {
+    cwd?: string;
+    outDir: string;
+}): void;
+
 // Warning: (ae-missing-release-tag) "writeCatalogArtifacts" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -323,6 +331,8 @@ export function writeCatalogFunctions(functions: CatalogFunction[], options: {
 //
 // @public (undocumented)
 export interface WriteComponentCatalogOptions extends ExtractCatalogOptions {
+    // (undocumented)
+    catalogId?: string;
     // (undocumented)
     outDir: string;
 }

--- a/packages/genui/a2ui-catalog-extractor/readme.zh_cn.md
+++ b/packages/genui/a2ui-catalog-extractor/readme.zh_cn.md
@@ -396,11 +396,15 @@ genui a2ui generate catalog [options]
 | `--source <path>`       | 要扫描的源码文件或目录。可重复。                               | 无             |
 | `--typedoc-json <file>` | 读取已有 TypeDoc JSON project，不重新运行 TypeDoc conversion。 | 无             |
 | `--out-dir <dir>`       | 写出组件 catalog 文件的目录。                                  | `dist/catalog` |
+| `--catalog-id <id>`     | 写入全集 catalog 文件的 catalog ID。                           | `catalog.json` |
 | `--version`, `-v`       | 打印包版本。                                                   | 无             |
 | `--help`, `-h`          | 打印用法。                                                     | 无             |
 
 `--source` 和 `--catalog-dir` 可以一起使用。extractor 会合并全部输入、去重、
 排序，然后运行 TypeDoc。
+
+extractor 会同时写出 `dist/catalog/QuickStartCard/catalog.json` 这类单组件文件，
+以及 `dist/catalog/catalog.json` 全集 catalog 文件。
 
 扫描器接受 `.ts`、`.tsx`、`.js`、`.jsx`、`.mts` 和 `.cts` 文件。它会忽略
 `.d.ts`、`node_modules`、`dist` 和 `.turbo`。

--- a/packages/genui/a2ui-catalog-extractor/src/cli.ts
+++ b/packages/genui/a2ui-catalog-extractor/src/cli.ts
@@ -8,9 +8,11 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import {
+  createA2UICatalog,
   extractCatalogComponentsFromTypeDocJson,
   extractCatalogFunctionsFromTypeDocJson,
   findCatalogSourceFiles,
+  writeA2UICatalog,
   writeCatalogArtifacts,
   writeCatalogComponents,
   writeCatalogFunctions,
@@ -18,6 +20,7 @@ import {
 import type { TypeDocProject } from './index.js';
 
 interface CliOptions {
+  catalogId?: string;
   catalogDirs: string[];
   help: boolean;
   outDir: string;
@@ -35,6 +38,7 @@ Options:
                        Read an existing TypeDoc JSON project instead of
                        running TypeDoc conversion.
   --out-dir <dir>      Output directory for component catalog.json files.
+  --catalog-id <id>    Catalog ID written to the full catalog.json file.
   --version            Print the package version.
   --help               Print this help message.
 
@@ -68,6 +72,9 @@ export function parseCliArgs(args: string[]): CliOptions {
         break;
       case '--out-dir':
         options.outDir = readValue(args, ++index, arg);
+        break;
+      case '--catalog-id':
+        options.catalogId = readValue(args, ++index, arg);
         break;
       case '--help':
       case '-h':
@@ -123,6 +130,17 @@ export async function runCli(
       cwd,
       outDir: options.outDir,
     });
+    writeA2UICatalog(
+      createA2UICatalog({
+        catalogId: options.catalogId ?? 'catalog.json',
+        components,
+        functions,
+      }),
+      {
+        cwd,
+        outDir: options.outDir,
+      },
+    );
     printGeneratedComponents(components);
     printGeneratedFunctions(functions);
     return 0;
@@ -153,6 +171,7 @@ export async function runCli(
     cwd,
     outDir: options.outDir,
     sourceFiles: uniqueSourceFiles,
+    ...(options.catalogId ? { catalogId: options.catalogId } : {}),
   });
 
   printGeneratedComponents(components);

--- a/packages/genui/a2ui-catalog-extractor/src/index.ts
+++ b/packages/genui/a2ui-catalog-extractor/src/index.ts
@@ -39,6 +39,7 @@ export interface ExtractCatalogFromTypeDocOptions {
 }
 
 export interface WriteComponentCatalogOptions extends ExtractCatalogOptions {
+  catalogId?: string;
   outDir: string;
 }
 
@@ -328,6 +329,14 @@ export async function writeCatalogArtifacts(
   );
   writeCatalogComponents(components, options);
   writeCatalogFunctions(functions, options);
+  writeA2UICatalog(
+    createA2UICatalog({
+      catalogId: options.catalogId ?? 'catalog.json',
+      components,
+      functions,
+    }),
+    options,
+  );
   return { components, functions };
 }
 
@@ -379,9 +388,35 @@ export function createA2UICatalog(options: {
   return {
     catalogId: options.catalogId,
     components: catalogComponents,
-    ...(options.functions ? { functions: options.functions } : {}),
+    ...(options.functions
+      ? { functions: normalizeFunctionDefinitions(options.functions) }
+      : {}),
     ...(options.theme ? { theme: options.theme } : {}),
   };
+}
+
+function normalizeFunctionDefinitions(
+  functions: FunctionDefinition[],
+): FunctionDefinition[] {
+  return functions.map(({ description, name, parameters, returnType }) => ({
+    ...(description ? { description } : {}),
+    name,
+    parameters,
+    returnType,
+  }));
+}
+
+export function writeA2UICatalog(
+  catalog: A2UICatalog,
+  options: { cwd?: string; outDir: string },
+): void {
+  const cwd = options.cwd ? path.resolve(options.cwd) : process.cwd();
+  const outDir = path.resolve(cwd, options.outDir);
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(outDir, 'catalog.json'),
+    `${JSON.stringify(catalog, null, 2)}\n`,
+  );
 }
 
 async function createTypeDocProject(

--- a/packages/genui/a2ui-catalog-extractor/test/extractor-functions.test.ts
+++ b/packages/genui/a2ui-catalog-extractor/test/extractor-functions.test.ts
@@ -83,6 +83,15 @@ describe('extractCatalogFunctions', () => {
     expect(readFunctionJson(outDir, 'formatString')).toEqual(
       readExpectedFunctionJson('formatString'),
     );
+    const fullCatalog = readFullCatalogJson(outDir);
+    const fullCatalogFunctions = fullCatalog['functions'];
+    expect(Array.isArray(fullCatalogFunctions)).toBe(true);
+    const fullCatalogFunctionList = fullCatalogFunctions as unknown[];
+    expect([...fullCatalogFunctionList].sort(compareByName)).toEqual([
+      readExpectedFunctionJson('formatString')['formatString'],
+      readExpectedFunctionJson('required')['required'],
+    ]);
+    expect(JSON.stringify(fullCatalog)).not.toContain('filePath');
   });
 
   test('rejects async return types', async () => {
@@ -118,4 +127,21 @@ function readFunctionJson(
       'utf8',
     ),
   ) as Record<string, unknown>;
+}
+
+function readFullCatalogJson(rootDir: string): Record<string, unknown> {
+  return JSON.parse(
+    fs.readFileSync(path.join(rootDir, 'catalog.json'), 'utf8'),
+  ) as Record<string, unknown>;
+}
+
+function compareByName(a: unknown, b: unknown): number {
+  return getName(a).localeCompare(getName(b));
+}
+
+function getName(value: unknown): string {
+  return typeof value === 'object' && value !== null && 'name' in value
+      && typeof value.name === 'string'
+    ? value.name
+    : '';
 }

--- a/packages/genui/a2ui-catalog-extractor/test/extractor.test.ts
+++ b/packages/genui/a2ui-catalog-extractor/test/extractor.test.ts
@@ -13,7 +13,7 @@ import {
   createA2UICatalog,
   extractCatalogComponents,
   findCatalogSourceFiles,
-  writeComponentCatalogs,
+  writeCatalogArtifacts,
 } from '../src/index.js';
 import type { TypeDocProject } from '../src/index.js';
 
@@ -80,7 +80,7 @@ describe('extractCatalogComponents', () => {
     const outDir = createTempDir();
     const expectedCatalogs = readExpectedCatalogs();
 
-    const components = await writeComponentCatalogs({
+    const { components } = await writeCatalogArtifacts({
       cwd: fixtureDir,
       outDir,
       sourceFiles: findCatalogSourceFiles(catalogFixtureDir),
@@ -98,6 +98,15 @@ describe('extractCatalogComponents', () => {
         expectedCatalogs[componentName],
       );
     }
+    expect(readFullCatalogJson(outDir)).toEqual({
+      catalogId: 'catalog.json',
+      components: {
+        DemoCard: expectedCatalogs['DemoCard']!['DemoCard'],
+        DemoText: expectedCatalogs['DemoText']!['DemoText'],
+        QuickStartCard: expectedCatalogs['QuickStartCard']!['QuickStartCard'],
+      },
+      functions: [],
+    });
   });
 
   test('creates a full catalog from TSX-extracted components', async () => {
@@ -184,6 +193,39 @@ describe('extractCatalogComponents', () => {
         description: 'CLI badge fixture.',
       },
     });
+    expect(readFullCatalogJson(path.join(cwd, 'catalog-out'))).toEqual({
+      catalogId: 'catalog.json',
+      components: {
+        CliBadge: {
+          properties: {
+            label: {
+              type: 'string',
+              description: 'Badge label.',
+            },
+          },
+          required: ['label'],
+          description: 'CLI badge fixture.',
+        },
+      },
+      functions: [],
+    });
+  });
+
+  test('writes the configured catalog ID to the full catalog file', async () => {
+    const outDir = createTempDir();
+
+    await expect(runCli([
+      '--catalog-dir',
+      catalogFixtureDir,
+      '--out-dir',
+      outDir,
+      '--catalog-id',
+      'https://cdn.example.com/a2ui/catalog.json',
+    ], fixtureDir)).resolves.toBe(0);
+
+    expect(readFullCatalogJson(outDir)['catalogId']).toBe(
+      'https://cdn.example.com/a2ui/catalog.json',
+    );
   });
 
   test('throws for ambiguous intrinsic catalog property types in TSX fixtures', async () => {
@@ -230,6 +272,12 @@ function readCatalogJson(
       path.join(rootDir, componentName, 'catalog.json'),
       'utf8',
     ),
+  ) as Record<string, unknown>;
+}
+
+function readFullCatalogJson(rootDir: string): Record<string, unknown> {
+  return JSON.parse(
+    fs.readFileSync(path.join(rootDir, 'catalog.json'), 'utf8'),
   ) as Record<string, unknown>;
 }
 

--- a/packages/genui/a2ui/package.json
+++ b/packages/genui/a2ui/package.json
@@ -21,6 +21,7 @@
       "types": "./dist/catalog/index.d.ts",
       "default": "./dist/catalog/index.js"
     },
+    "./catalog/catalog.json": "./dist/catalog/catalog.json",
     "./catalog/utils/chart": {
       "types": "./dist/catalog/utils/chart.d.ts",
       "default": "./dist/catalog/utils/chart.js"
@@ -140,7 +141,7 @@
     "api-extractor": "node ../scripts/run-api-extractor.mjs",
     "build": "tsc --project tsconfig.build.json && npm run build:catalog",
     "build:api": "tsc --project tsconfig.build.json",
-    "build:catalog": "genui a2ui generate catalog --catalog-dir src/catalog --out-dir dist/catalog && node scripts/writeCatalogManifestIndex.js",
+    "build:catalog": "genui a2ui generate catalog --catalog-dir src/catalog --out-dir dist/catalog --catalog-id https://unpkg.com/@lynx-js/genui/a2ui/dist/catalog/catalog.json && node scripts/writeCatalogManifestIndex.js",
     "test": "rstest"
   },
   "dependencies": {

--- a/packages/genui/etc/genui.api.md
+++ b/packages/genui/etc/genui.api.md
@@ -1030,6 +1030,8 @@ export function writeCatalogFunctions(functions: CatalogFunction[], options: {
 // @public (undocumented)
 export interface WriteComponentCatalogOptions extends ExtractCatalogOptions {
     // (undocumented)
+    catalogId?: string;
+    // (undocumented)
     outDir: string;
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--catalog-id` CLI option to specify a custom identifier for the full catalog output
  * Full A2UI catalog is now generated and published as a consolidated JSON artifact alongside component-level catalogs

* **Documentation**
  * Updated CLI reference and localized docs to document `--catalog-id` and clarify catalog outputs

* **Tests**
  * Updated/added tests to verify the generated full catalog contents and `catalogId` behavior

* **Chores**
  * Exposed the consolidated catalog artifact in package distribution and adjusted build script to emit it
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
