### PR TITLE
feat(a2ui): load server catalog from cdn

### DIFF
--- a/packages/genui/a2ui-prompt/README.md
+++ b/packages/genui/a2ui-prompt/README.md
@@ -14,9 +14,9 @@ package.
 Build a prompt with the built-in A2UI basic catalog:
 
 ```ts
-import { buildA2UISystemPrompt } from '@lynx-js/genui/a2ui-prompt';
+import { buildA2UISystemPromptAsync } from '@lynx-js/genui/a2ui-prompt';
 
-const prompt = buildA2UISystemPrompt();
+const prompt = await buildA2UISystemPromptAsync();
 ```
 
 Read generated catalog artifacts and build a prompt for a custom catalog:
@@ -43,11 +43,11 @@ Use `genui a2ui generate catalog` to create those artifacts.
 ## Exports
 
 - `buildA2UISystemPrompt`
-- `A2UI_SYSTEM_PROMPT`
-- `BASIC_CATALOG`
 - `BASIC_CATALOG_ID`
 - `renderCatalogReference`
 - `createA2UICatalogFromManifests`
+- `loadBasicCatalog`
+- `buildA2UISystemPromptAsync`
 - `readA2UICatalogFromDirectory`
 
 ## Local Development

--- a/packages/genui/a2ui-prompt/tsconfig.build.json
+++ b/packages/genui/a2ui-prompt/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "src",
+    "../server/agent/a2ui-catalog-id.ts",
     "../server/agent/a2ui-catalog.ts",
     "../server/agent/a2ui-examples.ts",
     "../server/agent/a2ui-prompt.ts",

--- a/packages/genui/a2ui-prompt/tsconfig.json
+++ b/packages/genui/a2ui-prompt/tsconfig.json
@@ -13,6 +13,7 @@
   "include": [
     "src",
     "rslib.config.ts",
+    "../server/agent/a2ui-catalog-id.ts",
     "../server/agent/a2ui-catalog.ts",
     "../server/agent/a2ui-examples.ts",
     "../server/agent/a2ui-prompt.ts",

--- a/packages/genui/a2ui-prompt/turbo.json
+++ b/packages/genui/a2ui-prompt/turbo.json
@@ -10,6 +10,7 @@
       ],
       "inputs": [
         "src/**",
+        "../server/agent/a2ui-catalog-id.ts",
         "../server/agent/a2ui-catalog.ts",
         "../server/agent/a2ui-examples.ts",
         "../server/agent/a2ui-prompt.ts",

--- a/packages/genui/cli/src/a2ui/index.ts
+++ b/packages/genui/cli/src/a2ui/index.ts
@@ -136,6 +136,7 @@ async function runGeneratePromptCli(
     BASIC_CATALOG,
     BASIC_CATALOG_ID,
     buildA2UISystemPrompt,
+    buildA2UISystemPromptAsync,
     readA2UICatalogFromDirectory,
   } = await import('../../../a2ui-prompt/dist/index.js');
   const catalog = options.catalogDir
@@ -152,10 +153,13 @@ async function runGeneratePromptCli(
       `[${programName}] No components or functions found in generated catalog directory: ${options.catalogDir}`,
     );
   }
-  const systemPrompt = buildA2UISystemPrompt({
+  const promptOptions = {
     ...(catalog ? { catalog } : {}),
     ...(options.appendix ? { appendix: options.appendix } : {}),
-  });
+  };
+  const systemPrompt = catalog
+    ? buildA2UISystemPrompt(promptOptions)
+    : await buildA2UISystemPromptAsync(promptOptions);
 
   if (options.out) {
     const outPath = path.resolve(cwd, options.out);

--- a/packages/genui/index.ts
+++ b/packages/genui/index.ts
@@ -59,12 +59,12 @@ export {
 export * from '@lynx-js/genui/openui';
 export {
   A2UI_PROTOCOL_VERSION,
-  A2UI_SYSTEM_PROMPT,
-  BASIC_CATALOG,
   BASIC_CATALOG_EXAMPLES,
   BASIC_CATALOG_ID,
   buildA2UISystemPrompt,
+  buildA2UISystemPromptAsync,
   createA2UICatalogFromManifests,
+  loadBasicCatalog,
   readA2UICatalogFromDirectory,
   renderCatalogReference,
 } from '@lynx-js/genui/a2ui-prompt';

--- a/packages/genui/server/agent/a2ui-agent.ts
+++ b/packages/genui/server/agent/a2ui-agent.ts
@@ -4,8 +4,8 @@
 
 import { Agent } from '@mastra/core/agent';
 
-import { BASIC_CATALOG } from './a2ui-catalog';
 import type { A2UICatalog } from './a2ui-catalog';
+import { loadBasicCatalog } from './a2ui-catalog';
 import { buildA2UISystemPrompt } from './a2ui-prompt';
 import { createLLMProvider } from './openai-provider';
 import type { OpenAIProviderOptions } from './openai-provider';
@@ -30,10 +30,10 @@ export interface A2UIAgent {
   ) => unknown;
 }
 
-export function createA2UIAgent(opts: A2UIAgentOptions = {}) {
+export async function createA2UIAgent(opts: A2UIAgentOptions = {}) {
   const { buildModel, model } = createLLMProvider(opts);
 
-  const catalog = opts.catalog ?? BASIC_CATALOG;
+  const catalog = opts.catalog ?? await loadBasicCatalog();
   const promptOptions = {
     catalog,
     ...(opts.systemAppendix === undefined

--- a/packages/genui/server/agent/a2ui-catalog-id.ts
+++ b/packages/genui/server/agent/a2ui-catalog-id.ts
@@ -1,0 +1,6 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const BASIC_CATALOG_ID =
+  'https://unpkg.com/@lynx-js/genui/a2ui/dist/catalog.json';

--- a/packages/genui/server/agent/a2ui-catalog.ts
+++ b/packages/genui/server/agent/a2ui-catalog.ts
@@ -2,9 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { BASIC_CATALOG_ID } from './a2ui-catalog-id';
 import { BASIC_CATALOG_EXAMPLES } from './a2ui-examples';
 import type { A2UIExample } from './a2ui-examples';
 import generatedCatalog from './catalog.json';
+
+export { BASIC_CATALOG_ID } from './a2ui-catalog-id';
 
 /**
  * Prompt-facing description of a single A2UI component prop.
@@ -60,9 +63,6 @@ export interface A2UIFunctionSpec {
     | 'void';
 }
 
-export const BASIC_CATALOG_ID =
-  'https://a2ui.org/specification/v0_9/basic_catalog.json';
-
 /**
  * JSON Schema subset used in prompt-facing catalog descriptions.
  */
@@ -80,6 +80,15 @@ export interface JsonSchema {
 }
 
 interface CatalogManifest extends Record<string, JsonSchema> {}
+
+interface ExtractedCatalogManifest {
+  catalogId?: string;
+  components?: Record<string, JsonSchema>;
+  functions?: unknown;
+}
+
+let pendingBasicCatalog: Promise<A2UICatalog> | undefined;
+let cachedBasicCatalog: A2UICatalog | undefined;
 
 const COMPONENT_SUMMARIES: Record<string, string> = {
   Button:
@@ -345,6 +354,74 @@ export const BASIC_CATALOG: A2UICatalog = {
   functions: functionsFromGeneratedCatalog(generatedCatalog),
   examples: BASIC_CATALOG_EXAMPLES,
 };
+
+export async function loadBasicCatalog(): Promise<A2UICatalog> {
+  if (cachedBasicCatalog) return cachedBasicCatalog;
+  pendingBasicCatalog ??= fetchBasicCatalog().finally(() => {
+    pendingBasicCatalog = undefined;
+  });
+  cachedBasicCatalog = await pendingBasicCatalog;
+  return cachedBasicCatalog;
+}
+
+async function fetchBasicCatalog(): Promise<A2UICatalog> {
+  try {
+    const response = await fetch(BASIC_CATALOG_ID, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+
+    const manifest = await response.json() as unknown;
+    if (!isExtractedCatalogManifest(manifest)) {
+      throw new Error('invalid catalog payload');
+    }
+    return createA2UICatalogFromExtractedManifest(manifest);
+  } catch (error) {
+    console.warn(
+      `[a2ui-catalog] Failed to fetch catalog ${BASIC_CATALOG_ID}; `
+        + 'using local fallback catalog.',
+      error,
+    );
+  }
+
+  return createA2UICatalogFromExtractedManifest(
+    {
+      ...(generatedCatalog as unknown as ExtractedCatalogManifest),
+      catalogId: BASIC_CATALOG_ID,
+    },
+  );
+}
+
+function createA2UICatalogFromExtractedManifest(
+  manifest: ExtractedCatalogManifest,
+): A2UICatalog {
+  return createA2UICatalogFromManifests({
+    catalogId: manifest.catalogId ?? BASIC_CATALOG_ID,
+    componentManifests: componentManifestsFromGeneratedCatalog(manifest),
+    functions: functionsFromGeneratedCatalog(manifest),
+    label: 'Lynx A2UI basic catalog (v0.9)',
+    version: 'v0.9',
+    extraRules: [
+      'Use only components listed in this catalog; unsupported examples such as Video, AudioPlayer, DatePicker, or Checkbox are not available unless they appear here.',
+      'The implemented checkbox component is named "CheckBox" with a capital B.',
+    ],
+    examples: BASIC_CATALOG_EXAMPLES,
+  });
+}
+
+function isExtractedCatalogManifest(
+  value: unknown,
+): value is ExtractedCatalogManifest {
+  if (!isRecord(value)) return false;
+  const manifest = value as Partial<ExtractedCatalogManifest>;
+  const catalogId = manifest.catalogId;
+  const components = manifest.components;
+  const functions = manifest.functions;
+  return (catalogId === undefined || typeof catalogId === 'string')
+    && (components === undefined || isRecord(components))
+    && (functions === undefined || Array.isArray(functions)
+      || isRecord(functions));
+}
 
 /**
  * Render an A2UI catalog into the Markdown reference embedded in prompts.

--- a/packages/genui/server/agent/a2ui-examples.ts
+++ b/packages/genui/server/agent/a2ui-examples.ts
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { BASIC_CATALOG_ID } from './a2ui-catalog-id';
+
 /**
  * Validated user request and message sequence included as an in-context A2UI
  * example.
@@ -11,9 +13,6 @@ export interface A2UIExample {
   user: string;
   messages: unknown[];
 }
-
-const BASIC_CATALOG_ID =
-  'https://a2ui.org/specification/v0_9/basic_catalog.json';
 
 export const BASIC_CATALOG_EXAMPLES: A2UIExample[] = [
   {

--- a/packages/genui/server/agent/a2ui-prompt.ts
+++ b/packages/genui/server/agent/a2ui-prompt.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import type { A2UICatalog } from './a2ui-catalog';
-import { BASIC_CATALOG, renderCatalogReference } from './a2ui-catalog';
+import { loadBasicCatalog, renderCatalogReference } from './a2ui-catalog';
 
 export const A2UI_PROTOCOL_VERSION = 'v0.9';
 
@@ -215,13 +215,22 @@ export interface BuildSystemPromptOptions {
   appendix?: string;
 }
 
-/**
- * Build the full A2UI system prompt for the supplied catalog.
- */
 export function buildA2UISystemPrompt(
-  opts: BuildSystemPromptOptions = {},
+  opts?: BuildSystemPromptOptions,
 ): string {
-  const catalog = opts.catalog ?? BASIC_CATALOG;
+  if (!opts) {
+    throw new Error(
+      '[a2ui-prompt] buildA2UISystemPrompt requires a catalog. '
+        + 'Use buildA2UISystemPromptAsync() to load the basic catalog.',
+    );
+  }
+  const { catalog } = opts;
+  if (!catalog) {
+    throw new Error(
+      '[a2ui-prompt] buildA2UISystemPrompt requires a catalog. '
+        + 'Use buildA2UISystemPromptAsync() to load the basic catalog.',
+    );
+  }
   const parts = [
     'You are an A2UI (Agent-to-UI) generation agent. Translate the user\'s',
     'natural-language request into a stream of A2UI v0.9 JSON messages that a',
@@ -242,4 +251,9 @@ export function buildA2UISystemPrompt(
   return parts.join('\n');
 }
 
-export const A2UI_SYSTEM_PROMPT: string = buildA2UISystemPrompt();
+export async function buildA2UISystemPromptAsync(
+  opts: BuildSystemPromptOptions = {},
+): Promise<string> {
+  const catalog = opts.catalog ?? await loadBasicCatalog();
+  return buildA2UISystemPrompt({ ...opts, catalog });
+}

--- a/packages/genui/server/app/a2ui/action/stream/route.ts
+++ b/packages/genui/server/app/a2ui/action/stream/route.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import type { A2UICatalog } from '../../../../agent/a2ui-catalog';
-import { BASIC_CATALOG } from '../../../../agent/a2ui-catalog';
+import { loadBasicCatalog } from '../../../../agent/a2ui-catalog';
 import {
   A2UIProtocolMessageStreamParser,
   splitA2UIProtocolMessages,
@@ -198,6 +198,15 @@ export async function POST(req: Request) {
       log(event, details);
     },
   };
+  let catalog: A2UICatalog;
+  try {
+    catalog = opts.catalog ?? await loadBasicCatalog();
+  } catch (err: unknown) {
+    const error = errorMessage(err);
+    log('catalog.load.failed', error);
+    return jsonWithCors(req, { ok: false, error }, { status: 502 });
+  }
+  const optsWithCatalog = { ...opts, catalog };
 
   log('request.accepted', {
     surfaceId: body.surfaceId,
@@ -216,7 +225,7 @@ export async function POST(req: Request) {
     userContentLength: userContent.length,
     model: opts.model,
     hasBaseURL: Boolean(opts.baseURL),
-    catalogId: opts.catalog?.id ?? BASIC_CATALOG.id,
+    catalogId: catalog.id,
     maxRepairAttempts: opts.maxRepairAttempts,
   });
 
@@ -258,7 +267,7 @@ export async function POST(req: Request) {
         log('agent.connect.started');
         const { textStream, finalize } = await service.streamAsAsyncIterable(
           [userMessage],
-          opts,
+          optsWithCatalog,
           validatedConversation.conversation,
         );
         log('agent.connect.completed', {
@@ -371,7 +380,7 @@ export async function POST(req: Request) {
         };
         const v = validateA2UIOutput(
           finalText ?? '',
-          opts.catalog ?? BASIC_CATALOG,
+          catalog,
           validationOptions,
         );
         let resolvedMessages = v.ok
@@ -401,7 +410,7 @@ export async function POST(req: Request) {
             });
             const repaired = await service.generateValidated(
               [userMessage],
-              opts,
+              optsWithCatalog,
               validatedConversation.conversation,
               validationOptions,
             );

--- a/packages/genui/server/app/a2ui/stream/route.ts
+++ b/packages/genui/server/app/a2ui/stream/route.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { BASIC_CATALOG } from '../../../agent/a2ui-catalog';
+import { loadBasicCatalog } from '../../../agent/a2ui-catalog';
 import {
   A2UIProtocolMessageStreamParser,
   splitA2UIProtocolMessages,
@@ -141,6 +141,15 @@ export async function POST(req: Request) {
       log(event, details);
     },
   };
+  let catalog: A2UIChatBody['catalog'];
+  try {
+    catalog = opts.catalog ?? await loadBasicCatalog();
+  } catch (err: unknown) {
+    const error = errorMessage(err);
+    log('catalog.load.failed', error);
+    return jsonWithCors(req, { ok: false, error }, { status: 502 });
+  }
+  const optsWithCatalog = { ...opts, catalog };
   const service = getA2UIAgentService();
 
   log('request.accepted', {
@@ -161,7 +170,7 @@ export async function POST(req: Request) {
       : 0,
     model: opts.model,
     hasBaseURL: Boolean(opts.baseURL),
-    catalogId: opts.catalog?.id ?? BASIC_CATALOG.id,
+    catalogId: catalog.id,
     maxRepairAttempts: opts.maxRepairAttempts,
   });
 
@@ -203,7 +212,7 @@ export async function POST(req: Request) {
         log('agent.connect.started');
         const { textStream, finalize } = await service.streamAsAsyncIterable(
           messages,
-          opts,
+          optsWithCatalog,
           validatedConversation.conversation,
         );
         log('agent.connect.completed', {
@@ -306,7 +315,7 @@ export async function POST(req: Request) {
         };
         const v = validateA2UIOutput(
           finalText ?? '',
-          opts.catalog ?? BASIC_CATALOG,
+          catalog,
         );
         let resolvedMessages = v.ok
           ? await resolveMessagesForStreaming(v.messages)
@@ -335,7 +344,7 @@ export async function POST(req: Request) {
             });
             const repaired = await service.generateValidated(
               messages,
-              opts,
+              optsWithCatalog,
               validatedConversation.conversation,
             );
             repair = {

--- a/packages/genui/server/service/a2ui-agent.ts
+++ b/packages/genui/server/service/a2ui-agent.ts
@@ -6,8 +6,8 @@ import { createHash } from 'node:crypto';
 
 import { createA2UIAgent } from '../agent/a2ui-agent';
 import type { A2UIAgent } from '../agent/a2ui-agent';
-import { BASIC_CATALOG } from '../agent/a2ui-catalog';
 import type { A2UICatalog } from '../agent/a2ui-catalog';
+import { loadBasicCatalog } from '../agent/a2ui-catalog';
 import {
   formatErrorsForModel,
   validateA2UIOutput,
@@ -105,11 +105,12 @@ function sumContentChars(messages: ChatMessage[]): number {
 export default class A2UIAgentService {
   private agentCache = new Map<string, Promise<A2UIAgent>>();
 
-  private getAgent(opts: ChatOptions): Promise<A2UIAgent> {
+  private async getAgent(opts: ChatOptions): Promise<A2UIAgent> {
     const startedAt = performance.now();
+    const catalog = opts.catalog ?? await loadBasicCatalog();
     const cacheKey = `${opts.baseURL ?? 'default'}:${opts.model ?? 'default'}:${
       hashApiKey(opts.apiKey)
-    }:${opts.api ?? 'default'}:${opts.catalog?.id ?? 'basic'}`;
+    }:${opts.api ?? 'default'}:${catalog.id}`;
     let cached = this.agentCache.get(cacheKey);
     if (cached) {
       opts.onPerformanceEvent?.('agent.cache.hit', {
@@ -119,15 +120,13 @@ export default class A2UIAgentService {
       return cached;
     }
 
-    cached = Promise.resolve(
-      createA2UIAgent(pickDefined({
-        apiKey: opts.apiKey,
-        baseURL: opts.baseURL,
-        model: opts.model,
-        api: opts.api,
-        catalog: opts.catalog,
-      })).agent,
-    );
+    cached = createA2UIAgent(pickDefined({
+      apiKey: opts.apiKey,
+      baseURL: opts.baseURL,
+      model: opts.model,
+      api: opts.api,
+      catalog,
+    })).then(({ agent }) => agent);
     this.agentCache.set(cacheKey, cached);
     opts.onPerformanceEvent?.('agent.cache.miss', {
       durationMs: performance.now() - startedAt,
@@ -277,7 +276,7 @@ export default class A2UIAgentService {
     conversation?: ConversationContext,
     validationOptions?: ValidationOptions,
   ): Promise<A2UIResponse> {
-    const catalog = opts.catalog ?? BASIC_CATALOG;
+    const catalog = opts.catalog ?? await loadBasicCatalog();
     const maxAttempts = Math.max(1, opts.maxRepairAttempts ?? 2) + 1;
     const agent = await this.getAgent({ ...opts, catalog });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default A2UI catalog is now loaded at runtime when none is provided via a cached async loader (with concurrent de-duping) and validation with fallback to a bundled version.
  * Added `buildA2UISystemPromptAsync` for async prompt construction when the catalog isn’t available yet.
* **Bug Fixes**
  * Streaming endpoints now return `502` if catalog resolution fails.
* **Refactor**
  * Agent and prompt generation now use async flows; request handling consistently uses the resolved catalog.
* **Documentation**
  * README and public exports updated to document the new async loader/prompt APIs and remove the eager system prompt export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
