### PR TITLE
fix: pnpm 11 project config

### DIFF
--- a/.github/pnpm-11.instructions.md
+++ b/.github/pnpm-11.instructions.md
@@ -4,6 +4,8 @@ applyTo: "{pnpm-workspace.yaml,**/package.json,.github/renovate.json5}"
 
 When upgrading or maintaining pnpm 11, use the `allowBuilds` map in `pnpm-workspace.yaml`; `onlyBuiltDependencies` and `ignoredBuiltDependencies` are pnpm 10-era settings and should not be reintroduced.
 
+For pnpm 11, keep project settings in `pnpm-workspace.yaml`, not in the `pnpm` field of `package.json` or non-auth `.npmrc` keys. For example, migrate `peerDependencyRules`, `engineStrict`, `strictPeerDependencies`, `hoistWorkspacePackages`, and `publicHoistPattern` into `pnpm-workspace.yaml`; leave `.npmrc` for registry/auth settings.
+
 When bumping the `packageManager` pnpm version in package.json files, keep the `+sha512.<hex>` suffix aligned with the npm package tarball integrity; convert the `npm view pnpm@<version> dist.integrity` base64 payload to hex for Corepack's strict package-manager pin.
 
 When adding Renovate npm minimum-release-age presets, mirror the delay in pnpm with `minimumReleaseAge` in `pnpm-workspace.yaml`; Renovate delegates lockfile maintenance to the package manager and does not enforce its own minimum release age for those updates.

--- a/.github/pnpm-11.instructions.md
+++ b/.github/pnpm-11.instructions.md
@@ -6,6 +6,8 @@ When upgrading or maintaining pnpm 11, use the `allowBuilds` map in `pnpm-worksp
 
 For pnpm 11, keep project settings in `pnpm-workspace.yaml`, not in the `pnpm` field of `package.json` or non-auth `.npmrc` keys. For example, migrate `peerDependencyRules`, `engineStrict`, `strictPeerDependencies`, `hoistWorkspacePackages`, and `publicHoistPattern` into `pnpm-workspace.yaml`; leave `.npmrc` for registry/auth settings.
 
+When enabling `strictPeerDependencies`, keep known compatibility exceptions in `peerDependencyRules.allowedVersions` in `pnpm-workspace.yaml`; do not disable strict peer checks or move peer settings back into `package.json`/`.npmrc` to hide published packages whose peer ranges lag the versions used by this workspace.
+
 When bumping the `packageManager` pnpm version in package.json files, keep the `+sha512.<hex>` suffix aligned with the npm package tarball integrity; convert the `npm view pnpm@<version> dist.integrity` base64 payload to hex for Corepack's strict package-manager pin.
 
 When adding Renovate npm minimum-release-age presets, mirror the delay in pnpm with `minimumReleaseAge` in `pnpm-workspace.yaml`; Renovate delegates lockfile maintenance to the package manager and does not enforce its own minimum release age for those updates.

--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,1 @@
-# We are using flatten config of eslint and not using prettier
-# Disable the default public-hoist-pattern(*-eslint-*, *-prettier-*)
-public-hoist-pattern=
-hoist-workspace-packages=true
-strict-peer-dependencies=true
-engine-strict=true
 registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -65,12 +65,5 @@
   "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "engines": {
     "node": "^22 || ^24"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "rsbuild-plugin-tailwindcss>tailwindcss": "^3 || ^4"
-      }
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,9 +30,13 @@ packages:
 
 # From `@pnpm/plugin-better-defaults`
 enablePrePostScripts: false
+engineStrict: true
+hoistWorkspacePackages: true
 ignorePatchFailures: false
 optimisticRepeatInstall: true
+publicHoistPattern: []
 resolutionMode: "lowest-direct"
+strictPeerDependencies: true
 
 # Match Renovate's npm minimum release age; pnpm also guards lockfile maintenance.
 minimumReleaseAge: 4320
@@ -48,6 +52,10 @@ minimumReleaseAgeExclude:
 # `pnpm dedupe --check`. Run non-strict so the age check is enforced when `time`
 # is available and skipped (with a warning) when it is not.
 minimumReleaseAgeStrict: false
+
+peerDependencyRules:
+  allowedVersions:
+    "rsbuild-plugin-tailwindcss>tailwindcss": "^3 || ^4"
 
 # Default catalogs
 catalog:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,6 +55,30 @@ minimumReleaseAgeStrict: false
 
 peerDependencyRules:
   allowedVersions:
+    "@lynx-js/lynx-ui>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-button>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-checkbox>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-common>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-dialog>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-draggable>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-feed-list>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-form>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-input>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-lazy-component>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-list>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-overlay>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-popover>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-presence>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-radio-group>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-scroll-view>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-sheet>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-slider>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-sortable>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-swipe-action>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-swiper>@types/react": "^19.2.0"
+    "@lynx-js/lynx-ui-switch>@types/react": "^19.2.0"
+    "@standard-community/standard-json>quansync": "^0.2.10 || ^0.2.11"
+    "@types/react-dom>@types/react": "^18 || ^19.2.0"
     "rsbuild-plugin-tailwindcss>tailwindcss": "^3 || ^4"
 
 # Default catalogs


### PR DESCRIPTION
## Summary

- Move pnpm 11 project settings from ignored locations into `pnpm-workspace.yaml`.
- Remove the deprecated root `package.json` `pnpm.peerDependencyRules` field.
- Keep `.npmrc` scoped to registry configuration and document the pnpm 11 migration rule for future maintenance.

## Root Cause

pnpm 11 no longer reads project settings from the `pnpm` field in `package.json`, and non-auth/non-registry settings are expected in `pnpm-workspace.yaml`. As a result, `peerDependencyRules` and several `.npmrc` settings were ignored during install.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm config get peerDependencyRules.allowedVersions`
- pre-commit staged-file checks: eslint, biome, dprint, sort-package-json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced stricter dependency and engine checks at workspace level for more consistent installs
  * Consolidated project-level package manager settings into workspace configuration, simplifying per-package files
  * Cleaned up redundant npm config entries and reduced noise in project config
  * Updated maintenance instructions with migration examples and guidance for preserving peer-dependency exceptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->