### PR TITLE
refactor: set target to es2017 by default

### DIFF
--- a/.changeset/ninety-rooms-behave.md
+++ b/.changeset/ninety-rooms-behave.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": minor
+---
+
+refactor: set target to es2017 by default

--- a/packages/rspeedy/core/src/plugins/swc.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/swc.plugin.ts
@@ -7,7 +7,6 @@ import type { RsbuildPlugin } from '@rsbuild/core'
 import {
   ES_ENV_TARGETS,
   getESVersionEnvInclude,
-  getESVersionTarget,
 } from '../utils/getESVersionTarget.js'
 
 export function pluginSwc(): RsbuildPlugin {
@@ -15,7 +14,6 @@ export function pluginSwc(): RsbuildPlugin {
     name: 'lynx:rsbuild:swc',
     setup(api) {
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-        const isProd = config.mode === 'production'
         return mergeRsbuildConfig(config, {
           tools: {
             swc(config) {
@@ -40,7 +38,7 @@ export function pluginSwc(): RsbuildPlugin {
                   // Lower `let`/`const` to `var`; QuickJS parses `var` faster.
                   // Listing it in `env.exclude` opts out (exclude > include).
                   'transform-block-scoping',
-                  ...getESVersionEnvInclude(getESVersionTarget(isProd)),
+                  ...getESVersionEnvInclude(),
                   ...(config.env?.include ?? []),
                 ],
               }

--- a/packages/rspeedy/core/src/plugins/target.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/target.plugin.ts
@@ -11,15 +11,15 @@ export function pluginTarget(): RsbuildPlugin {
   return {
     name: 'lynx:rsbuild:target',
     setup(api) {
-      api.modifyBundlerChain((options, { environment, isProd }) => {
+      api.modifyBundlerChain((options, { environment }) => {
         if (isWeb(environment)) {
           options.target([
-            getESVersionTarget(isProd),
+            getESVersionTarget(),
             // Add `target: 'web'` to make Rsbuild inject HMR related code.
             'web',
           ])
         } else {
-          options.target([getESVersionTarget(isProd)])
+          options.target([getESVersionTarget()])
         }
       })
     },

--- a/packages/rspeedy/core/src/utils/getESVersionTarget.ts
+++ b/packages/rspeedy/core/src/utils/getESVersionTarget.ts
@@ -1,8 +1,8 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-export function getESVersionTarget(isProd: boolean): 'es2015' | 'es2019' {
-  return isProd ? 'es2015' : 'es2019'
+export function getESVersionTarget(): 'es2017' {
+  return 'es2017'
 }
 
 // Transforms newer than ES2019 (i.e. ES2020+) — exactly what an
@@ -22,14 +22,10 @@ const ES2019_INCLUDE = [
   'transform-private-property-in-object',
 ]
 
-// Transforms newer than ES2015 (i.e. ES2016+) — exactly what an
-// `jsc.target: 'es2015'` lowers: ES2016~ES2019, plus everything in
+// Transforms newer than ES2017 (i.e. ES2018+) — exactly what an
+// `jsc.target: 'es2017'` lowers: ES2018~ES2019, plus everything in
 // {@link ES2019_INCLUDE}.
-const ES2015_INCLUDE = [
-  // ES2016
-  'transform-exponentiation-operator',
-  // ES2017
-  'transform-async-to-generator',
+const ES2017_INCLUDE = [
   // ES2018
   'transform-async-generator-functions',
   'transform-dotall-regex',
@@ -51,10 +47,8 @@ const ES2015_INCLUDE = [
  * Pair it with a high `env.targets` (so `env` auto-includes nothing and the
  * returned list is the canonical transform set).
  */
-export function getESVersionEnvInclude(
-  target: 'es2015' | 'es2019',
-): string[] {
-  return target === 'es2015' ? [...ES2015_INCLUDE] : [...ES2019_INCLUDE]
+export function getESVersionEnvInclude(): string[] {
+  return [...ES2017_INCLUDE]
 }
 
 // A high baseline so SWC `env` auto-includes nothing; the `include` list

--- a/packages/rspeedy/core/test/plugins/swc.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/swc.plugin.test.ts
@@ -26,8 +26,6 @@ describe('Plugins - SWC', () => {
           "env": {
             "include": [
               "transform-block-scoping",
-              "transform-exponentiation-operator",
-              "transform-async-to-generator",
               "transform-async-generator-functions",
               "transform-dotall-regex",
               "transform-named-capturing-groups-regex",
@@ -89,6 +87,13 @@ describe('Plugins - SWC', () => {
           "env": {
             "include": [
               "transform-block-scoping",
+              "transform-async-generator-functions",
+              "transform-dotall-regex",
+              "transform-named-capturing-groups-regex",
+              "transform-object-rest-spread",
+              "transform-unicode-property-regex",
+              "transform-json-strings",
+              "transform-optional-catch-binding",
               "transform-nullish-coalescing-operator",
               "transform-optional-chaining",
               "transform-export-namespace-from",
@@ -166,7 +171,7 @@ describe('Plugins - SWC', () => {
     // exclude opts out of the let/const → var lowering.
     expect(loaderOptions?.env?.exclude).toEqual(['transform-block-scoping'])
     expect(loaderOptions?.env?.include).toContain(
-      'transform-async-to-generator',
+      'transform-async-generator-functions',
     )
   })
 
@@ -191,9 +196,9 @@ describe('Plugins - SWC', () => {
 
     // The user's transform is honored ...
     expect(loaderOptions?.env?.include).toContain('transform-block-scoping')
-    // ... on top of Rspeedy's baseline (es2015-equivalent in production) ...
+    // ... on top of Rspeedy's ES2017-equivalent baseline ...
     expect(loaderOptions?.env?.include).toContain(
-      'transform-async-to-generator',
+      'transform-async-generator-functions',
     )
     // ... and Rspeedy still owns `targets`.
     expect(loaderOptions?.env?.targets).toEqual({ chrome: '120' })
@@ -233,6 +238,13 @@ describe('Plugins - SWC', () => {
           "env": {
             "include": [
               "transform-block-scoping",
+              "transform-async-generator-functions",
+              "transform-dotall-regex",
+              "transform-named-capturing-groups-regex",
+              "transform-object-rest-spread",
+              "transform-unicode-property-regex",
+              "transform-json-strings",
+              "transform-optional-catch-binding",
               "transform-nullish-coalescing-operator",
               "transform-optional-chaining",
               "transform-export-namespace-from",

--- a/packages/rspeedy/core/test/plugins/target.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/target.plugin.test.ts
@@ -6,27 +6,27 @@ import { describe, expect, test, vi } from 'vitest'
 import { createStubRspeedy } from '../createStubRspeedy.js'
 
 describe('target.plugin', () => {
-  test('the target should be es2015 in production', async () => {
+  test('the target should be es2017 in production', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     const rspeedy = await createStubRspeedy({})
     const config = await rspeedy.unwrapConfig()
 
-    expect(config.target).toEqual(['es2015'])
+    expect(config.target).toEqual(['es2017'])
   })
 
-  test('the target should be es2019 in development', async () => {
+  test('the target should be es2017 in development', async () => {
     vi.stubEnv('NODE_ENV', 'development')
     const rspeedy = await createStubRspeedy({})
     const config = await rspeedy.unwrapConfig()
 
-    expect(config.target).toEqual(['es2019'])
+    expect(config.target).toEqual(['es2017'])
   })
 
-  test('should be es2019', async () => {
+  test('should be es2017', async () => {
     const rspeedy = await createStubRspeedy({})
     const config = await rspeedy.unwrapConfig()
 
-    expect(config.target).toEqual(['es2019'])
+    expect(config.target).toEqual(['es2017'])
   })
 
   test('Web', async () => {
@@ -38,7 +38,7 @@ describe('target.plugin', () => {
 
     const config = await rspeedy.unwrapConfig()
 
-    expect(config.target).toEqual(['es2019', 'web'])
+    expect(config.target).toEqual(['es2017', 'web'])
   })
 
   test('multiple environments', async () => {
@@ -51,7 +51,7 @@ describe('target.plugin', () => {
 
     const [webConfig, lynxConfig] = await rspeedy.initConfigs()
 
-    expect(webConfig?.target).toEqual(['es2019', 'web'])
-    expect(lynxConfig?.target).toEqual(['es2019'])
+    expect(webConfig?.target).toEqual(['es2017', 'web'])
+    expect(lynxConfig?.target).toEqual(['es2017'])
   })
 })

--- a/packages/rspeedy/core/test/utils/getESVersionEnvInclude.test.ts
+++ b/packages/rspeedy/core/test/utils/getESVersionEnvInclude.test.ts
@@ -9,7 +9,7 @@ import {
   getESVersionEnvInclude,
 } from '../../src/utils/getESVersionTarget.js'
 
-// Syntax spanning ES2016 through ES2025+ (the regex `v` flag, regex modifiers
+// Syntax spanning ES2018 through ES2025+ (the regex `v` flag, regex modifiers
 // and duplicate named capture groups are the newest entries). The guard below
 // compiles this with `jsc.target` (SWC's canonical lowering for an ES version)
 // and with our `env` config, then asserts byte-identical output.
@@ -38,18 +38,18 @@ const MODERN_SYNTAX = [
   'const dupNamed = /(?<a>x)|(?<a>y)/;',
 ].join('\n')
 
-function viaTarget(target: 'es2015' | 'es2019'): string {
+function viaTarget(): string {
   return transformSync(MODERN_SYNTAX, {
     isModule: true,
-    jsc: { parser: { syntax: 'ecmascript' }, target },
+    jsc: { parser: { syntax: 'ecmascript' }, target: 'es2017' },
   }).code
 }
 
-function viaEnv(target: 'es2015' | 'es2019'): string {
+function viaEnv(): string {
   return transformSync(MODERN_SYNTAX, {
     isModule: true,
     jsc: { parser: { syntax: 'ecmascript' } },
-    env: { targets: ES_ENV_TARGETS, include: getESVersionEnvInclude(target) },
+    env: { targets: ES_ENV_TARGETS, include: getESVersionEnvInclude() },
   }).code
 }
 
@@ -57,10 +57,7 @@ describe('getESVersionEnvInclude', () => {
   // Uses `@swc/core` as a stand-in for rspack's builtin SWC: the
   // `env.include` <-> `jsc.target` equivalence is a preset-env property
   // shared by both.
-  test.each(['es2015', 'es2019'] as const)(
-    'env.include reproduces `jsc.target: %s` exactly',
-    (target) => {
-      expect(viaEnv(target)).toBe(viaTarget(target))
-    },
-  )
+  test('env.include reproduces `jsc.target: es2017` exactly', () => {
+    expect(viaEnv()).toBe(viaTarget())
+  })
 })

--- a/packages/rspeedy/plugin-react/test/swc-config.test.ts
+++ b/packages/rspeedy/plugin-react/test/swc-config.test.ts
@@ -13,6 +13,19 @@ import { pluginStubRspeedyAPI } from './stub-rspeedy-api.plugin.js'
 // The Default JS RegExp of Rsbuild
 const SCRIPT_REGEXP = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/
 
+const MAIN_THREAD_ES2019_ENV_INCLUDE = [
+  'transform-block-scoping',
+  'transform-nullish-coalescing-operator',
+  'transform-optional-chaining',
+  'transform-export-namespace-from',
+  'transform-logical-assignment-operators',
+  'transform-numeric-separator',
+  'transform-class-properties',
+  'transform-class-static-block',
+  'transform-private-methods',
+  'transform-private-property-in-object',
+]
+
 function isRspackRule(rule: unknown): rule is Rspack.RuleSetRule {
   return !!rule && typeof rule === 'object'
 }
@@ -70,6 +83,13 @@ describe('SWC configuration', () => {
           "env": {
             "include": [
               "transform-block-scoping",
+              "transform-async-generator-functions",
+              "transform-dotall-regex",
+              "transform-named-capturing-groups-regex",
+              "transform-object-rest-spread",
+              "transform-unicode-property-regex",
+              "transform-json-strings",
+              "transform-optional-catch-binding",
               "transform-nullish-coalescing-operator",
               "transform-optional-chaining",
               "transform-export-namespace-from",
@@ -270,15 +290,11 @@ describe('SWC configuration', () => {
     }, 'builtin:swc-loader')
     // Main thread is es2019-equivalent, expressed via `env` (no `jsc.target`).
     expect(mainThreadLoaderOptions?.jsc?.target).toBeUndefined()
-    expect(mainThreadLoaderOptions?.env?.include).toContain(
-      'transform-optional-chaining',
-    )
-    expect(mainThreadLoaderOptions?.env?.include).not.toContain(
-      'transform-async-to-generator',
-    )
-    // `let`/`const` are lowered to `var` on the main thread too.
-    expect(mainThreadLoaderOptions?.env?.include).toContain(
-      'transform-block-scoping',
+    expect(mainThreadLoaderOptions?.env?.targets).toEqual({ chrome: '120' })
+    // Keep this exact: the normal Rspeedy/DSL target may change, but the
+    // ReactLynx main-thread product must stay on the es2019 baseline.
+    expect(mainThreadLoaderOptions?.env?.include).toEqual(
+      MAIN_THREAD_ES2019_ENV_INCLUDE,
     )
   })
 
@@ -381,8 +397,8 @@ describe('SWC configuration', () => {
     expect(mainThreadLoaderOptions?.env?.include).not.toContain(
       'transform-arrow-functions',
     )
-    expect(mainThreadLoaderOptions?.env?.include).toContain(
-      'transform-optional-chaining',
+    expect(mainThreadLoaderOptions?.env?.include).toEqual(
+      MAIN_THREAD_ES2019_ENV_INCLUDE,
     )
   })
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Default JavaScript compilation target set to ES2017; build transforms and baseline include lists updated to match.
  * Main-thread baseline transform ordering tightened to a fixed ES2019/ES2017-compatible set.

* **Tests**
  * Updated expectations and snapshots across loaders and plugins to reflect the new ES2017 baseline and stricter main-thread assertions.

* **Chores**
  * Added release metadata for a minor version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
