### PR TITLE
chore: update GenUI code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,5 +8,5 @@ packages/lynx/create-lynx-library/** @jianliang00
 packages/rspeedy/plugin-react/** @upupming
 packages/react/** @hzy @HuJean @Yradex
 packages/react/transform/** @gaoachao
-packages/genui/a2ui/** @pupiltong @Sherry-hue @HuJean @gaoachao @fzx2666-fz
+packages/genui/** @pupiltong @Sherry-hue @gaoachao @HuJean
 benchmark/react/** @hzy @HuJean


### PR DESCRIPTION
## Summary

- Update the GenUI CODEOWNERS entry to cover all files under `packages/genui/**`.
- Keep the owner list within the requested 2-4 maintainer range.

## Validation

- Confirmed the working tree diff only touched `CODEOWNERS`.
- Confirmed the GenUI CODEOWNERS rule has 4 owners.
- No tests run because this is a CODEOWNERS-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration for package maintenance and review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->