### PR TITLE
test(css-extract): decode css hot-update manifest in hot snapshots

### DIFF
--- a/packages/webpack/css-extract-webpack-plugin/test/HotSnapshot.test.ts
+++ b/packages/webpack/css-extract-webpack-plugin/test/HotSnapshot.test.ts
@@ -12,4 +12,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 hotSnapshotCases({
   name: 'hot-snapshot',
   casePath: path.join(__dirname, 'hotCases'),
+}, {
+  // Store the decoded, pretty-printed `*.css.hot-update.json` manifest instead
+  // of the raw base64 blob, so page-config changes diff line-by-line.
+  decodeHotUpdateManifest: true,
 });

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/0.snap.txt
@@ -12,7 +12,84 @@
 ### main.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuZm9vIiwibG9jIjp7ImxpbmUiOjYsImNvbHVtbiI6NX19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".foo",
+              "loc": {
+                "line": 6,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/1.snap.txt
@@ -14,7 +14,84 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmZvbyIsImxvYyI6eyJsaW5lIjoxLCJjb2x1bW4iOjV9fSwidmFyaWFibGVzIjp7fX1dfSwiY3NzU291cmNlIjp7IjAiOiIvY3NzSWQvMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".foo",
+              "loc": {
+                "line": 1,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +99,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/2.snap.txt
@@ -14,7 +14,84 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmJhciIsImxvYyI6eyJsaW5lIjoxLCJjb2x1bW4iOjV9fSwidmFyaWFibGVzIjp7fX1dfSwiY3NzU291cmNlIjp7IjAiOiIvY3NzSWQvMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".bar",
+              "loc": {
+                "line": 1,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +99,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/0.snap.txt
@@ -12,7 +12,84 @@
 ### main.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6dHJ1ZSwidGFyZ2V0U2RrVmVyc2lvbiI6IjMuMiIsImRlZmF1bHRPdmVyZmxvd1Zpc2libGUiOnRydWV9LCJzb3VyY2VDb250ZW50Ijp7ImRzbCI6InJlYWN0X25vZGlmZiIsImFwcFR5cGUiOiJjYXJkIiwiY29uZmlnIjp7ImxlcHVzU3RyaWN0Ijp0cnVlLCJ1c2VOZXdTd2lwZXIiOnRydWUsImVuYWJsZU5ld0ludGVyc2VjdGlvbk9ic2VydmVyIjp0cnVlLCJlbmFibGVOYXRpdmVMaXN0Ijp0cnVlLCJzeW5jWEVsZW1lbnRSZWdpc3RyeSI6dHJ1ZSwiZW5hYmxlQTExeSI6dHJ1ZSwiZW5hYmxlQWNjZXNzaWJpbGl0eUVsZW1lbnQiOmZhbHNlLCJlbmFibGVDU1NJbmhlcml0YW5jZSI6ZmFsc2UsImVuYWJsZU5ld0dlc3R1cmUiOmZhbHNlLCJyZW1vdmVEZXNjZW5kYW50U2VsZWN0b3JTY29wZSI6ZmFsc2UsImRlYnVnTWV0YWRhdGFVcmwiOiIifXXsImNzcyI6eyJjc3NNYXAiOnsiMCI6WXsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYXsb3IiLCJ2YWx1ZSI6IlwicmVkXCIiLCJrZXlMb2MiOnsibGluZSI6NywiYXsdW1uIjo4fSwidmFsTG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6MTZ9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5mb28iLCJsb2MiOnsibGluZSI6NiwiYXsdW1uIjo1fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": true,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".foo",
+              "loc": {
+                "line": 6,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/1.snap.txt
@@ -14,7 +14,84 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6dHJ1ZSwidGFyZ2V0U2RrVmVyc2lvbiI6IjMuMiIsImRlZmF1bHRPdmVyZmxvd1Zpc2libGUiOnRydWV9LCJzb3VyY2VDb250ZW50Ijp7ImRzbCI6InJlYWN0X25vZGlmZiIsImFwcFR5cGUiOiJjYXJkIiwiY29uZmlnIjp7ImxlcHVzU3RyaWN0Ijp0cnVlLCJ1c2VOZXdTd2lwZXIiOnRydWUsImVuYWJsZU5ld0ludGVyc2VjdGlvbk9ic2VydmVyIjp0cnVlLCJlbmFibGVOYXRpdmVMaXN0Ijp0cnVlLCJzeW5jWEVsZW1lbnRSZWdpc3RyeSI6dHJ1ZSwiZW5hYmxlQTExeSI6dHJ1ZSwiZW5hYmxlQWNjZXNzaWJpbGl0eUVsZW1lbnQiOmZhbHNlLCJlbmFibGVDU1NJbmhlcml0YW5jZSI6ZmFsc2UsImVuYWJsZU5ld0dlc3R1cmUiOmZhbHNlLCJyZW1vdmVEZXNjZW5kYW50U2VsZWN0b3JTY29wZSI6ZmFsc2UsImRlYnVnTWV0YWRhdGFVcmwiOiIifXXsImNzcyI6eyJjc3NNYXAiOnsiMCI6WXsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYXsb3IiLCJ2YWx1ZSI6IlwiYmx1ZVwiIiwia2V5TG9jIjp7ImxpbmUiOjIsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjE3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuZm9vIiwibG9jIjp7ImxpbmUiOjEsImNvbHVtbiI6NX19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": true,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".foo",
+              "loc": {
+                "line": 1,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +99,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/2.snap.txt
@@ -14,7 +14,109 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6dHJ1ZSwidGFyZ2V0U2RrVmVyc2lvbiI6IjMuMiIsImRlZmF1bHRPdmVyZmxvd1Zpc2libGUiOnRydWV9LCJzb3VyY2VDb250ZW50Ijp7ImRzbCI6InJlYWN0X25vZGlmZiIsImFwcFR5cGUiOiJjYXJkIiwiY29uZmlnIjp7ImxlcHVzU3RyaWN0Ijp0cnVlLCJ1c2VOZXdTd2lwZXIiOnRydWUsImVuYWJsZU5ld0ludGVyc2VjdGlvbk9ic2VydmVyIjp0cnVlLCJlbmFibGVOYXRpdmVMaXN0Ijp0cnVlLCJzeW5jWEVsZW1lbnRSZWdpc3RyeSI6dHJ1ZSwiZW5hYmxlQTExeSI6dHJ1ZSwiZW5hYmxlQWNjZXNzaWJpbGl0eUVsZW1lbnQiOmZhbHNlLCJlbmFibGVDU1NJbmhlcml0YW5jZSI6ZmFsc2UsImVuYWJsZU5ld0dlc3R1cmUiOmZhbHNlLCJyZW1vdmVEZXNjZW5kYW50U2VsZWN0b3JTY29wZSI6ZmFsc2UsImRlYnVnTWV0YWRhdGFVcmwiOiIifXXsImNzcyI6eyJjc3NNYXAiOnsiMCI6WXsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYXsb3IiLCJ2YWx1ZSI6IlwiYmx1ZVwiIiwia2V5TG9jIjp7ImxpbmUiOjIsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjE3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuYmF6IiwibG9jIjp7ImxpbmUiOjEsImNvbHVtbiI6NX19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjo1LCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6NSwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmJhciIsImxvYyI6eyJsaW5lIjo0LCJjb2x1bW4iOjV9fSwidmFyaWFibGVzIjp7fX1dfSwiY3NzU291cmNlIjp7IjAiOiIvY3NzSWQvMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": true,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".baz",
+              "loc": {
+                "line": 1,
+                "column": 5
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 5,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 5,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".bar",
+              "loc": {
+                "line": 4,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +124,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/0.snap.txt
@@ -12,7 +12,101 @@
 ### main.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjEiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjgsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo4LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuZm9vIiwibG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6NX19LCJ2YXJpYWJsZXMiOnt9fVXsIjEwMCI6WXsidHlwZSI6IkltcG9ydFJ1bGUiLCJvcmlnaW4iOiIwIiwiaHJlZiI6IjAifSx7InR5cGUiOiJJbXBvcnRSdWxlIiwib3JpZ2luIjoiMSIsImhyZWYiOiIxIn1dfSwiY3NzU291cmNlIjp7IjEiOiIvY3NzSWQvMS5jc3MiLCIxMDAiOiIvY3NzSWQvMTAwLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"1":[],"100":["0","1"]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "1": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 8,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 8,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".foo",
+              "loc": {
+                "line": 7,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ],
+        "100": [
+          {
+            "type": "ImportRule",
+            "origin": "0",
+            "href": "0"
+          },
+          {
+            "type": "ImportRule",
+            "origin": "1",
+            "href": "1"
+          }
+        ]
+      },
+      "cssSource": {
+        "1": "/cssId/1.css",
+        "100": "/cssId/100.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "1": [],
+    "100": [
+      "0",
+      "1"
+    ]
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/1.snap.txt
@@ -14,7 +14,101 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjEiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjozLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MywiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmZvbyIsImxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjV9fSwidmFyaWFibGVzIjp7fX1dLCIxMDAiOlt7InR5cGUiOiJJbXBvcnRSdWxlIiwib3JpZ2luIjoiMCIsImhyZWYiOiIwInXseyJ0eXBlIjoiSW1wb3J0UnVsZSIsIm9yaWdpbiI6IjEiLCJocmVmIjoiMSJ9XXXsImNzc1NvdXJjZSI6eyIxIjoiL2Nzc0lkLzEuY3NzIiwiMTAwIjoiL2Nzc0lkLzEwMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"1":[],"100":["0","1"]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "1": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 3,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 3,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".foo",
+              "loc": {
+                "line": 2,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ],
+        "100": [
+          {
+            "type": "ImportRule",
+            "origin": "0",
+            "href": "0"
+          },
+          {
+            "type": "ImportRule",
+            "origin": "1",
+            "href": "1"
+          }
+        ]
+      },
+      "cssSource": {
+        "1": "/cssId/1.css",
+        "100": "/cssId/100.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "1": [],
+    "100": [
+      "0",
+      "1"
+    ]
+  }
+}
 ```
 
 
@@ -22,7 +116,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/2.snap.txt
@@ -14,7 +14,126 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjEiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjozLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MywiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmJheiIsImxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjV9fSwidmFyaWFibGVzIjp7fXXseyJ0eXBlIjoiU3R5bGVSdWxlIiwic3R5bGUiOlt7Im5hbWUiOiJiYWNrZ3JvdW5kLWNvbG9yIiwidmFsdWUiOiJcInJnYmEoMTUsIDE4LCAxOSwgMC41KVwiIiwia2V5TG9jIjp7ImxpbmUiOjYsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6NiwiYXsdW1uIjo0NX19XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmJhciIsImxvYyI6eyJsaW5lIjo1LCJjb2x1bW4iOjV9fSwidmFyaWFibGVzIjp7fX1dLCIxMDAiOlt7InR5cGUiOiJJbXBvcnRSdWxlIiwib3JpZ2luIjoiMCIsImhyZWYiOiIwInXseyJ0eXBlIjoiSW1wb3J0UnVsZSIsIm9yaWdpbiI6IjEiLCJocmVmIjoiMSJ9XXXsImNzc1NvdXJjZSI6eyIxIjoiL2Nzc0lkLzEuY3NzIiwiMTAwIjoiL2Nzc0lkLzEwMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"1":[],"100":["0","1"]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "1": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 3,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 3,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".baz",
+              "loc": {
+                "line": 2,
+                "column": 5
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "\"rgba(15, 18, 19, 0.5)\"",
+                "keyLoc": {
+                  "line": 6,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 6,
+                  "column": 45
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".bar",
+              "loc": {
+                "line": 5,
+                "column": 5
+              }
+            },
+            "variables": {}
+          }
+        ],
+        "100": [
+          {
+            "type": "ImportRule",
+            "origin": "0",
+            "href": "0"
+          },
+          {
+            "type": "ImportRule",
+            "origin": "1",
+            "href": "1"
+          }
+        ]
+      },
+      "cssSource": {
+        "1": "/cssId/1.css",
+        "100": "/cssId/100.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "1": [],
+    "100": [
+      "0",
+      "1"
+    ]
+  }
+}
 ```
 
 
@@ -22,7 +141,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/bundle-splitting/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/bundle-splitting/__snapshot__/rspack/0.snap.txt
@@ -16,7 +16,52 @@
 ### async/common.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiRHluYW1pY0NvbXBvbmVudCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7fSwiY3NzU291cmNlIjp7fSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "DynamicComponent",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {},
+      "cssSource": {},
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {}
+}
 ```
 
 
@@ -24,7 +69,84 @@
 ### async/lazy.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiRHluYW1pY0NvbXBvbmVudCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJibHVlIiwia2V5TG9jIjp7ImxpbmUiOjIsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjE1fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubGF6eSIsImxvYyI6eyJsaW5lIjoxLCJjb2x1bW4iOjZ9fSwidmFyaWFibGVzIjp7fX1dfSwiY3NzU291cmNlIjp7IjAiOiIvY3NzSWQvMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "DynamicComponent",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "blue",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 15
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".lazy",
+              "loc": {
+                "line": 1,
+                "column": 6
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -32,7 +154,84 @@
 ### entry.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJyZWQiLCJrZXlMb2MiOnsibGluZSI6MiwiYXsdW1uIjo4fSwidmFsTG9jIjp7ImxpbmUiOjIsImNvbHVtbiI6MTR9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5lbnRyeSIsImxvYyI6eyJsaW5lIjoxLCJjb2x1bW4iOjd9fSwidmFyaWFibGVzIjp7fX1dfSwiY3NzU291cmNlIjp7IjAiOiIvY3NzSWQvMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "red",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 14
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".entry",
+              "loc": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/bundle-splitting/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/bundle-splitting/__snapshot__/rspack/1.snap.txt
@@ -18,7 +18,52 @@
 ### async/common.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiRHluYW1pY0NvbXBvbmVudCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7fSwiY3NzU291cmNlIjp7fSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "DynamicComponent",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {},
+      "cssSource": {},
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {}
+}
 ```
 
 
@@ -26,7 +71,84 @@
 ### async/lazy.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiRHluYW1pY0NvbXBvbmVudCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJibHVlIiwia2V5TG9jIjp7ImxpbmUiOjIsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjE1fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubGF6eSIsImxvYyI6eyJsaW5lIjoxLCJjb2x1bW4iOjZ9fSwidmFyaWFibGVzIjp7fX1dfSwiY3NzU291cmNlIjp7IjAiOiIvY3NzSWQvMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "DynamicComponent",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "blue",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 15
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".lazy",
+              "loc": {
+                "line": 1,
+                "column": 6
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -34,7 +156,84 @@
 ### entry.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmVudHJ5IiwibG9jIjp7ImxpbmUiOjEsImNvbHVtbiI6N319LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".entry",
+              "loc": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -42,7 +241,13 @@
 ### entry.LAST_HASH.hot-update.json
 
 ```json
-{"c":["entry"],"r":[],"m":[]}
+{
+  "c": [
+    "entry"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/0.snap.txt
@@ -24,7 +24,109 @@
 ### index.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubnRNM0pRU2ZIc1BWMHJXSSIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTUsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTUsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5YQVl1dWFxMnJFSVdpWE02IiwibG9jIjp7ImxpbmUiOjE0LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ntM3JQSfHsPV0rWI",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 15,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 15,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 14,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -32,7 +134,109 @@
 ### main2.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubnRNM0pRU2ZIc1BWMHJXSSIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTUsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTUsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5YQVl1dWFxMnJFSVdpWE02IiwibG9jIjp7ImxpbmUiOjE0LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ntM3JQSfHsPV0rWI",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 15,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 15,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 14,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -40,7 +244,109 @@
 ### main3.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubnRNM0pRU2ZIc1BWMHJXSSIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTUsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTUsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5YQVl1dWFxMnJFSVdpWE02IiwibG9jIjp7ImxpbmUiOjE0LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ntM3JQSfHsPV0rWI",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 15,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 15,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 14,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -48,7 +354,109 @@
 ### main4.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubnRNM0pRU2ZIc1BWMHJXSSIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTUsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTUsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5YQVl1dWFxMnJFSVdpWE02IiwibG9jIjp7ImxpbmUiOjE0LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ntM3JQSfHsPV0rWI",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 15,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 15,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 14,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/1.snap.txt
@@ -33,7 +33,109 @@
 ### index.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLm50TTNKUVNmSHNQVjByV0kiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuWEFZdXVhcTJyRUlXaVhNNiIsImxvYyI6eyJsaW5lIjo5LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ntM3JQSfHsPV0rWI",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 10,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 9,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -41,7 +143,14 @@
 ### index.LAST_HASH.hot-update.json
 
 ```json
-{"c":["index","lib-common"],"r":[],"m":[]}
+{
+  "c": [
+    "index",
+    "lib-common"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -49,7 +158,109 @@
 ### main2.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLm50TTNKUVNmSHNQVjByV0kiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuWEFZdXVhcTJyRUlXaVhNNiIsImxvYyI6eyJsaW5lIjo5LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ntM3JQSfHsPV0rWI",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 10,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 9,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -57,7 +268,14 @@
 ### main2.LAST_HASH.hot-update.json
 
 ```json
-{"c":["lib-common","main2"],"r":[],"m":[]}
+{
+  "c": [
+    "lib-common",
+    "main2"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -65,7 +283,109 @@
 ### main3.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLm50TTNKUVNmSHNQVjByV0kiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuWEFZdXVhcTJyRUlXaVhNNiIsImxvYyI6eyJsaW5lIjo5LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ntM3JQSfHsPV0rWI",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 10,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 9,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -73,7 +393,14 @@
 ### main3.LAST_HASH.hot-update.json
 
 ```json
-{"c":["lib-common","main3"],"r":[],"m":[]}
+{
+  "c": [
+    "lib-common",
+    "main3"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -81,7 +408,109 @@
 ### main4.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLm50TTNKUVNmSHNQVjByV0kiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuWEFZdXVhcTJyRUlXaVhNNiIsImxvYyI6eyJsaW5lIjo5LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ntM3JQSfHsPV0rWI",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 10,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 9,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -89,7 +518,14 @@
 ### main4.LAST_HASH.hot-update.json
 
 ```json
-{"c":["lib-common","main4"],"r":[],"m":[]}
+{
+  "c": [
+    "lib-common",
+    "main4"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/2.snap.txt
@@ -33,7 +33,109 @@
 ### index.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLkRFbjJaZ01kM1hnVmdaZUwiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuWEFZdXVhcTJyRUlXaVhNNiIsImxvYyI6eyJsaW5lIjo5LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".DEn2ZgMd3XgVgZeL",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 10,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 9,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -41,7 +143,14 @@
 ### index.LAST_HASH.hot-update.json
 
 ```json
-{"c":["index","lib-common"],"r":[],"m":[]}
+{
+  "c": [
+    "index",
+    "lib-common"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -49,7 +158,109 @@
 ### main2.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLkRFbjJaZ01kM1hnVmdaZUwiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuWEFZdXVhcTJyRUlXaVhNNiIsImxvYyI6eyJsaW5lIjo5LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".DEn2ZgMd3XgVgZeL",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 10,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 9,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -57,7 +268,14 @@
 ### main2.LAST_HASH.hot-update.json
 
 ```json
-{"c":["lib-common","main2"],"r":[],"m":[]}
+{
+  "c": [
+    "lib-common",
+    "main2"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -65,7 +283,109 @@
 ### main3.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLkRFbjJaZ01kM1hnVmdaZUwiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuWEFZdXVhcTJyRUlXaVhNNiIsImxvYyI6eyJsaW5lIjo5LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".DEn2ZgMd3XgVgZeL",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 10,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 9,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -73,7 +393,14 @@
 ### main3.LAST_HASH.hot-update.json
 
 ```json
-{"c":["lib-common","main3"],"r":[],"m":[]}
+{
+  "c": [
+    "lib-common",
+    "main3"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -81,7 +408,109 @@
 ### main4.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLkRFbjJaZ01kM1hnVmdaZUwiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuWEFZdXVhcTJyRUlXaVhNNiIsImxvYyI6eyJsaW5lIjo5LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".DEn2ZgMd3XgVgZeL",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 10,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 10,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".XAYuuaq2rEIWiXM6",
+              "loc": {
+                "line": 9,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -89,7 +518,14 @@
 ### main4.LAST_HASH.hot-update.json
 
 ```json
-{"c":["lib-common","main4"],"r":[],"m":[]}
+{
+  "c": [
+    "lib-common",
+    "main4"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/0.snap.txt
@@ -12,7 +12,109 @@
 ### main.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIucWwxMW9tdTVCZDhKVXlycyIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5mUkZFdklIbnlNZHhsVUNJIiwibG9jIjp7ImxpbmUiOjE1LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ql11omu5Bd8JUyrs",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 16,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 16,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".fRFEvIHnyMdxlUCI",
+              "loc": {
+                "line": 15,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/1.snap.txt
@@ -14,7 +14,109 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLnFsMTFvbXU1QmQ4SlV5cnMiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuZlJGRXZJSG55TWR4bFVDSSIsImxvYyI6eyJsaW5lIjoxMCwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ql11omu5Bd8JUyrs",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".fRFEvIHnyMdxlUCI",
+              "loc": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +124,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/2.snap.txt
@@ -14,7 +14,109 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLnZDazNTckRhWkZrZmVVSnMiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuZlJGRXZJSG55TWR4bFVDSSIsImxvYyI6eyJsaW5lIjoxMCwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".vCk3SrDaZFkfeUJs",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".fRFEvIHnyMdxlUCI",
+              "loc": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +124,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/0.snap.txt
@@ -12,7 +12,109 @@
 ### main/main.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuTV9JeV9SeThadzBBeUVZWCIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5qY2FuSF9BRGp0QXB2UkNLIiwibG9jIjp7ImxpbmUiOjE1LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".M_Iy_Ry8Zw0AyEYX",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 16,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 16,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".jcanH_ADjtApvRCK",
+              "loc": {
+                "line": 15,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/1.snap.txt
@@ -14,7 +14,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -22,7 +28,109 @@
 ### main/main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLk1fSXlfUnk4WncwQXlFWVgiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuamNhbkhfQURqdEFwdlJDSyIsImxvYyI6eyJsaW5lIjoxMCwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".M_Iy_Ry8Zw0AyEYX",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".jcanH_ADjtApvRCK",
+              "loc": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/2.snap.txt
@@ -14,7 +14,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -22,7 +28,109 @@
 ### main/main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLnNZTThuVEFCVWF3bU9MSEwiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuamNhbkhfQURqdEFwdlJDSyIsImxvYyI6eyJsaW5lIjoxMCwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".sYM8nTABUawmOLHL",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".jcanH_ADjtApvRCK",
+              "loc": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/0.snap.txt
@@ -12,7 +12,109 @@
 ### pages/main/pages/main.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubFNDWmNHbzRWUzQ4NGo4QiIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5FYUFHYkM4N0xBME5DSUlSIiwibG9jIjp7ImxpbmUiOjE1LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".lSCZcGo4VS484j8B",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 16,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 16,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".EaAGbC87LA0NCIIR",
+              "loc": {
+                "line": 15,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/1.snap.txt
@@ -14,7 +14,13 @@
 ### pages/main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["pages/main"],"r":[],"m":[]}
+{
+  "c": [
+    "pages/main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -22,7 +28,109 @@
 ### pages/main/pages/main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmxTQ1pjR280VlM0ODRqOEIiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuRWFBR2JDODdMQTBOQ0lJUiIsImxvYyI6eyJsaW5lIjoxMCwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".lSCZcGo4VS484j8B",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".EaAGbC87LA0NCIIR",
+              "loc": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/2.snap.txt
@@ -14,7 +14,13 @@
 ### pages/main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["pages/main"],"r":[],"m":[]}
+{
+  "c": [
+    "pages/main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 
@@ -22,7 +28,109 @@
 ### pages/main/pages/main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLnZqa0hLOGc5Z0x5OTFjdEQiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuRWFBR2JDODdMQTBOQ0lJUiIsImxvYyI6eyJsaW5lIjoxMCwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".vjkHK8g9gLy91ctD",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".EaAGbC87LA0NCIIR",
+              "loc": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/0.snap.txt
@@ -12,7 +12,109 @@
 ### main.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuR1c5MjU5WHFxUUFKd3ZaSiIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5ob3hPdWE5NGU5NGhvUlI4IiwibG9jIjp7ImxpbmUiOjE1LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".GW9259XqqQAJwvZJ",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 16,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 16,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".hoxOua94e94hoRR8",
+              "loc": {
+                "line": 15,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/1.snap.txt
@@ -14,7 +14,109 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLkdXOTI1OVhxcVFBSnd2WkoiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuaG94T3VhOTRlOTRob1JSOCIsImxvYyI6eyJsaW5lIjoxMCwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".GW9259XqqQAJwvZJ",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".hoxOua94e94hoRR8",
+              "loc": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +124,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/2.snap.txt
@@ -14,7 +14,109 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLlEyZ25iSm9ES0lVYUV1dXkiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIuaG94T3VhOTRlOTRob1JSOCIsImxvYyI6eyJsaW5lIjoxMCwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fV19LCJjc3NTb3VyY2UiOnsiMCI6Ii9jc3NJZC8wLmNzcyJ9LCJjb250ZW50TWFwIjp7fXXsImxlcHVzQ29kZSI6eyJsZXB1c0NodW5rIjp7fXXsIm1hbmlmZXN0Ijp7fSwiY3VzdG9tU2VjdGlvbnMiOnt9fQ==","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".Q2gnbJoDKIUaEuuy",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".hoxOua94e94hoRR8",
+              "loc": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +124,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/0.snap.txt
@@ -12,7 +12,109 @@
 ### main.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcInJlZFwiIiwia2V5TG9jIjp7ImxpbmUiOjcsImNvbHVtbiI6OHXsInZhbExvYyI6eyJsaW5lIjo3LCJjb2x1bW4iOjE2fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIucHN1VDFqWTE4eGdUOHlxYSIsImxvYyI6eyJsaW5lIjo2LCJjb2x1bW4iOjE4fXXsInZhcmlhYmxlcyI6e319LHsidHlwZSI6IlN0eWxlUnVsZSIsInN0eWxlIjpbeyJuYW1lIjoiYmFja2dyb3VuZC1jb2xvciIsInZhbHVlIjoiYmxhYXsiLCJrZXlMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6MTl9LCJ2YWxMb2MiOnsibGluZSI6MTYsImNvbHVtbiI6Mjd9fVXsInNlbGVjdG9yVGV4dCI6eyJ2YWx1ZSI6Ii5uby1jaGFuZ2UiLCJsb2MiOnsibGluZSI6MTUsImNvbHVtbiI6MTF9fSwidmFyaWFibGVzIjp7fX1dfSwiY3NzU291cmNlIjp7IjAiOiIvY3NzSWQvMC5jc3MifSwiY29udGVudE1hcCI6e319LCJsZXB1c0NvZGUiOnsibGVwdXNDaHVuayI6e319LCJtYW5pZmVzdCI6eXsImN1c3RvbVNlY3Rpb25zIjp7fX0=","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"red\"",
+                "keyLoc": {
+                  "line": 7,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 7,
+                  "column": 16
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".psuT1jY18xgT8yqa",
+              "loc": {
+                "line": 6,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 16,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 16,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".no-change",
+              "loc": {
+                "line": 15,
+                "column": 11
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/1.snap.txt
@@ -14,7 +14,109 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLnBzdVQxalkxOHhnVDh5cWEiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubm8tY2hhbmdlIiwibG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjExfXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".psuT1jY18xgT8yqa",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".no-change",
+              "loc": {
+                "line": 10,
+                "column": 11
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +124,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/2.snap.txt
@@ -14,7 +14,109 @@
 ### main.LAST_HASH.css.hot-update.json
 
 ```json
-{"content":"eyJjb21waWxlck9wdGlvbnMiOnsiZW5hYmxlRmliZXJBcmNoIjp0cnVlLCJ1c2VMZXB1c05HIjp0cnVlLCJlbmFibGVSZXVzZUNvbnRleHQiOnRydWUsImJ1bmRsZU1vZHVsZU1vZGUiOiJSZXR1cm5CeUZ1bmN0aW9uIiwiZGVidWdJbmZvT3V0c2lkZSI6dHJ1ZSwiZGVmYXVsdERpc3BsYXlMaW5lYXIiOnRydWUsImVuYWJsZUNTU0ludmFsaWRhdGlvbiI6ZmFsc2UsImVuYWJsZUNTU1NlbGVjdG9yIjp0cnVlLCJlbmFibGVMZXB1c0RlYnVnIjp0cnVlLCJlbmFibGVSZW1vdmVDU1NTY29wZSI6ZmFsc2UsInRhcmdldFNka1ZlcnNpb24iOiIzLjIiLCJkZWZhdWx0T3ZlcmZsb3dWaXNpYmxlIjp0cnVlfSwic291cmNlQ29udGVudCI6eyJkc2wiOiJyZWFjdF9ub2RpZmYiLCJhcHBUeXBlIjoiY2FyZCIsImNvbmZpZyI6eyJsZXB1c1N0cmljdCI6dHJ1ZSwidXNlTmV3U3dpcGVyIjp0cnVlLCJlbmFibGVOZXdJbnRlcnNlY3Rpb25PYnNlcnZlciI6dHJ1ZSwiZW5hYmxlTmF0aXZlTGlzdCI6dHJ1ZSwic3luY1hFbGVtZW50UmVnaXN0cnkiOnRydWUsImVuYWJsZUExMXkiOnRydWUsImVuYWJsZUFjY2Vzc2liaWxpdHlFbGVtZW50IjpmYWxzZSwiZW5hYmxlQ1NTSW5oZXJpdGFuY2UiOmZhbHNlLCJlbmFibGVOZXdHZXN0dXJlIjpmYWxzZSwicmVtb3ZlRGVzY2VuZGFudFNlbGVjdG9yU2NvcGUiOmZhbHNlLCJkZWJ1Z01ldGFkYXRhVXJsIjoiIn19LCJjc3MiOnsiY3NzTWFwIjp7IjAiOlt7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImNvbG9yIiwidmFsdWUiOiJcImJsdWVcIiIsImtleUxvYyI6eyJsaW5lIjoyLCJjb2x1bW4iOjh9LCJ2YWxMb2MiOnsibGluZSI6MiwiYXsdW1uIjoxN319XSwic2VsZWN0b3JUZXh0Ijp7InZhbHVlIjoiLmNlWXRYYk9OMVpVYUJpelIiLCJsb2MiOnsibGluZSI6MSwiYXsdW1uIjoxOH19LCJ2YXJpYWJsZXMiOnt9fSx7InR5cGUiOiJTdHlsZVJ1bGUiLCJzdHlsZSI6WXsibmFtZSI6ImJhY2tncm91bmQtYXsb3IiLCJ2YWx1ZSI6ImJsYWNrIiwia2V5TG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjE5fSwidmFsTG9jIjp7ImxpbmUiOjExLCJjb2x1bW4iOjI3fX1dLCJzZWxlY3RvclRleHQiOnsidmFsdWUiOiIubm8tY2hhbmdlIiwibG9jIjp7ImxpbmUiOjEwLCJjb2x1bW4iOjExfXXsInZhcmlhYmxlcyI6e319XXXsImNzc1NvdXJjZSI6eyIwIjoiL2Nzc0lkLzAuY3NzInXsImNvbnRlbnRNYXAiOnt9fSwibGVwdXNDb2RlIjp7ImxlcHVzQ2h1bmsiOnt9fSwibWFuaWZlc3QiOnt9LCJjdXN0b21TZWN0aW9ucyI6e319","deps":{"0":[]}}
+{
+  "content": {
+    "compilerOptions": {
+      "enableFiberArch": true,
+      "useLepusNG": true,
+      "enableReuseContext": true,
+      "bundleModuleMode": "ReturnByFunction",
+      "debugInfoOutside": true,
+      "defaultDisplayLinear": true,
+      "enableCSSInvalidation": false,
+      "enableCSSSelector": true,
+      "enableLepusDebug": true,
+      "enableRemoveCSSScope": false,
+      "targetSdkVersion": "3.2",
+      "defaultOverflowVisible": true
+    },
+    "sourceContent": {
+      "dsl": "react_nodiff",
+      "appType": "card",
+      "config": {
+        "lepusStrict": true,
+        "useNewSwiper": true,
+        "enableNewIntersectionObserver": true,
+        "enableNativeList": true,
+        "syncXElementRegistry": true,
+        "enableA11y": true,
+        "enableAccessibilityElement": false,
+        "enableCSSInheritance": false,
+        "enableNewGesture": false,
+        "removeDescendantSelectorScope": false,
+        "debugMetadataUrl": ""
+      }
+    },
+    "css": {
+      "cssMap": {
+        "0": [
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "color",
+                "value": "\"blue\"",
+                "keyLoc": {
+                  "line": 2,
+                  "column": 8
+                },
+                "valLoc": {
+                  "line": 2,
+                  "column": 17
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".ceYtXbON1ZUaBizR",
+              "loc": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "variables": {}
+          },
+          {
+            "type": "StyleRule",
+            "style": [
+              {
+                "name": "background-color",
+                "value": "black",
+                "keyLoc": {
+                  "line": 11,
+                  "column": 19
+                },
+                "valLoc": {
+                  "line": 11,
+                  "column": 27
+                }
+              }
+            ],
+            "selectorText": {
+              "value": ".no-change",
+              "loc": {
+                "line": 10,
+                "column": 11
+              }
+            },
+            "variables": {}
+          }
+        ]
+      },
+      "cssSource": {
+        "0": "/cssId/0.css"
+      },
+      "contentMap": {}
+    },
+    "lepusCode": {
+      "lepusChunk": {}
+    },
+    "manifest": {},
+    "customSections": {}
+  },
+  "deps": {
+    "0": []
+  }
+}
 ```
 
 
@@ -22,7 +124,13 @@
 ### main.LAST_HASH.hot-update.json
 
 ```json
-{"c":["main"],"r":[],"m":[]}
+{
+  "c": [
+    "main"
+  ],
+  "r": [],
+  "m": []
+}
 ```
 
 

--- a/packages/webpack/test-tools/src/hot-snapshot.ts
+++ b/packages/webpack/test-tools/src/hot-snapshot.ts
@@ -10,7 +10,12 @@ import {
   HotSnapshotProcessor,
   describeByWalk,
 } from '@rspack/test-tools';
-import type { TCompilerOptions } from '@rspack/test-tools';
+import type {
+  ITestContext,
+  ITestEnv,
+  TCompilerOptions,
+  TCompilerStatsCompilation,
+} from '@rspack/test-tools';
 import fs from 'fs-extra';
 import { rimrafSync } from 'rimraf';
 
@@ -30,11 +35,21 @@ export interface IRspeedyHotSnapshotProcessorOptions<T extends ECompilerType>
   extends IRspeedyHotProcessorOptions<T>
 {
   snapshot: string;
+  /**
+   * Decode the base64 `content` of `*.hot-update.json` manifests into plain,
+   * pretty-printed JSON in the snapshot. Opt-in, so existing suites are
+   * unaffected.
+   *
+   * @defaultValue `false`
+   */
+  decodeHotUpdateManifest?: boolean;
 }
 
 class RspeedyHotSnapshotProcessor<T extends ECompilerType>
   extends HotSnapshotProcessor<T>
 {
+  readonly #decodeHotUpdateManifest: boolean;
+
   constructor(options: IRspeedyHotSnapshotProcessorOptions<T>) {
     super({
       ...createHotOptions(options),
@@ -48,10 +63,110 @@ class RspeedyHotSnapshotProcessor<T extends ECompilerType>
         return Object.keys(require(file).modules) || [];
       },
     });
+    this.#decodeHotUpdateManifest = options.decodeHotUpdateManifest ?? false;
+  }
+
+  // A `*.css.hot-update.json` manifest carries the re-encoded template in a
+  // base64 `content` field. Snapshotting it verbatim turns every page-config
+  // change into a giant opaque one-line diff (and the hash normalization below
+  // even corrupts the base64). When opted in, decode `content` into plain JSON
+  // before normalization (via the `snapshotContent` hook), then pretty-print the
+  // manifest blocks so the snapshot is readable and diffs line-by-line.
+  protected override matchStepSnapshot(
+    env: ITestEnv,
+    context: ITestContext,
+    step: number,
+    stats: TCompilerStatsCompilation<T>,
+    runtime?: Parameters<HotSnapshotProcessor<T>['matchStepSnapshot']>[4],
+  ): void {
+    if (!this.#decodeHotUpdateManifest) {
+      super.matchStepSnapshot(env, context, step, stats, runtime);
+      return;
+    }
+
+    const testConfig = context.getTestConfig();
+    // `snapshotContent` is a plain function property, not a bound method.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const previous = testConfig.snapshotContent;
+    testConfig.snapshotContent = (content: string) =>
+      decodeManifestContent(previous ? previous(content) : content);
+
+    // The base implementation re-serializes the manifest with a compact
+    // `JSON.stringify`, so pretty-print the rendered snapshot string (the only
+    // seam exposed is `env.expect`). `jest.Expect` is untyped here, hence casts.
+    const wrappedEnv: ITestEnv = {
+      ...env,
+      /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+      expect: ((received: unknown) =>
+        env.expect(
+          typeof received === 'string'
+            ? prettyPrintJsonBlocks(received)
+            : received,
+        )) as ITestEnv['expect'],
+      /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+    };
+
+    try {
+      super.matchStepSnapshot(wrappedEnv, context, step, stats, runtime);
+    } finally {
+      if (previous) {
+        testConfig.snapshotContent = previous;
+      } else {
+        delete testConfig.snapshotContent;
+      }
+    }
   }
 }
 
-function createCase(name: string, src: string, dist: string, cwd: string) {
+/**
+ * Decode the base64 `content` of a `*.hot-update.json` manifest into plain JSON
+ * so the snapshot is human-readable. Runs through the official `snapshotContent`
+ * hook (before hash normalization), so it sees the pristine base64. Non-manifest
+ * assets (e.g. a `hot-update.js` bundle) are passed through untouched.
+ */
+function decodeManifestContent(content: string): string {
+  let manifest: { content?: unknown };
+  try {
+    manifest = JSON.parse(content) as { content?: unknown };
+  } catch {
+    return content;
+  }
+  if (manifest && typeof manifest.content === 'string') {
+    try {
+      manifest.content = JSON.parse(
+        Buffer.from(manifest.content, 'base64').toString('utf-8'),
+      ) as unknown;
+    } catch {
+      return content;
+    }
+    return JSON.stringify(manifest);
+  }
+  return content;
+}
+
+/** Re-indent every ```` ```json ```` block so the decoded manifest diffs line-by-line. */
+function prettyPrintJsonBlocks(snapshot: string): string {
+  return snapshot.replaceAll(
+    /```json\n([\s\S]*?)\n```/g,
+    (match, body: string) => {
+      try {
+        return `\`\`\`json\n${
+          JSON.stringify(JSON.parse(body), null, 2)
+        }\n\`\`\``;
+      } catch {
+        return match;
+      }
+    },
+  );
+}
+
+function createCase(
+  name: string,
+  src: string,
+  dist: string,
+  cwd: string,
+  decodeHotUpdateManifest: boolean,
+) {
   describe(name, () => {
     for (const compilerType of [ECompilerType.Rspack]) {
       const caseName = `${name} - ${compilerType}`;
@@ -82,6 +197,7 @@ function createCase(name: string, src: string, dist: string, cwd: string) {
             name: caseName,
             compilerType,
             snapshot: `__snapshot__/${compilerType}`,
+            decodeHotUpdateManifest,
           }),
         );
       });
@@ -89,11 +205,31 @@ function createCase(name: string, src: string, dist: string, cwd: string) {
   });
 }
 
-export function hotSnapshotCases(suite: ITestSuite): void {
+export interface IHotSnapshotCasesOptions {
+  /**
+   * Decode the base64 `content` of `*.hot-update.json` manifests into plain,
+   * pretty-printed JSON in the snapshot. Opt-in, so existing suites keep their
+   * current (raw base64) snapshots.
+   *
+   * @defaultValue `false`
+   */
+  decodeHotUpdateManifest?: boolean;
+}
+
+export function hotSnapshotCases(
+  suite: ITestSuite,
+  options: IHotSnapshotCasesOptions = {},
+): void {
   const distPath = path.resolve(suite.casePath, '../js/hot-snapshot');
   rimrafSync(distPath);
   describeByWalk(suite.name, (name, src, dist) => {
-    createCase(name, src, dist, suite.casePath);
+    createCase(
+      name,
+      src,
+      dist,
+      suite.casePath,
+      options.decodeHotUpdateManifest ?? false,
+    );
   }, {
     source: suite.casePath,
     dist: distPath,


### PR DESCRIPTION
## Summary

The CSS-HMR snapshots in `css-extract-webpack-plugin` embed each `*.css.hot-update.json` manifest's `content` as a **base64 blob**. That makes the snapshots:

- **Noisy to diff** — any page-config change (e.g. the recent `syncXElementRegistry`) rewrites the entire opaque base64 line; reviewers can't see *what* changed.
- **Subtly corrupted** — the hot-snapshot framework's hash-normalization runs over the base64 and mangles it (the committed blobs don't even cleanly decode).

This adds an **opt-in** `decodeHotUpdateManifest` flag to `hotSnapshotCases` that decodes `content` into pretty-printed JSON before normalization, and enables it for the css-extract hot snapshots. Now a page-config change is a **single-line diff** and the snapshot is human-readable.

## Scope / regression safety

- The flag **defaults to `false`** — when off, the processor calls the base `matchStepSnapshot` unchanged, so behavior is byte-for-byte identical to today.
- `hotSnapshotCases` is consumed **only by `css-extract`**, which is the sole opt-in. No other suite is affected.
- `@lynx-js/test-tools` is private (not published), so no changeset is needed; the css-extract change is test-only.

## Changes

- `packages/webpack/test-tools/src/hot-snapshot.ts` — opt-in `decodeHotUpdateManifest` flag + decode/pretty-print logic in `RspeedyHotSnapshotProcessor`.
- `packages/webpack/css-extract-webpack-plugin/test/HotSnapshot.test.ts` — opt in.
- 29 regenerated `*.snap.txt` — one-time base64 → readable JSON reformat.

## Test

`pnpm run test --project webpack/css-extract` → **239 passed** (deterministic, verified without `-u`). tsc + eslint clean.

## Note

The one awkward seam: upstream `@rspack/test-tools` hard-codes the manifest as compact `JSON.stringify(manifest)`, and the only interception point for pretty-printing is wrapping `env.expect` — hence a few scoped `eslint-disable`s for the untyped `jest.Expect`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated hot module replacement manifest snapshots to display decoded JSON content in expanded, human-readable format instead of base64-encoded strings for improved readability and maintainability.

* **Chores**
  * Added decoding and pretty-printing infrastructure to hot-snapshot test framework for manifest content visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->