### PR TITLE
feat: upgrade create-rstack to 2.x

### DIFF
--- a/.changeset/create-rspeedy-rstack-2.md
+++ b/.changeset/create-rspeedy-rstack-2.md
@@ -1,0 +1,7 @@
+---
+"create-rspeedy": minor
+---
+
+**BREAKING CHANGE**
+
+Update `create-rstack` to 2.1.3 and align `create-rspeedy`'s Node.js engine metadata with its runtime requirements: Node.js 20.19+ or 22.12+.

--- a/.github/create-rspeedy-pack.instructions.md
+++ b/.github/create-rspeedy-pack.instructions.md
@@ -1,5 +1,7 @@
 ---
-applyTo: "packages/rspeedy/create-rspeedy/package.json"
+applyTo: "packages/rspeedy/create-rspeedy/**"
 ---
 
 When maintaining the `create-rspeedy` package `files` list under pnpm 11, include template directories with `template-*/**`; a bare `template-*` only packs the matched directory entries and can omit nested template files from the published tarball.
+
+When defining `create-rstack` extra tools in `packages/rspeedy/create-rspeedy/src/index.ts`, use the `create-rstack` 2.x callback shape for `when`: destructure `({ templateName })` instead of accepting a bare template-name string.

--- a/packages/rspeedy/create-rspeedy/package.json
+++ b/packages/rspeedy/create-rspeedy/package.json
@@ -35,7 +35,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "create-rstack": "1.9.2"
+    "create-rstack": "2.1.3"
   },
   "devDependencies": {
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:^",
@@ -46,6 +46,6 @@
     "@rstest/core": "catalog:rstest"
   },
   "engines": {
-    "node": ">=18"
+    "node": "^20.19.0 || >=22.12.0"
   }
 }

--- a/packages/rspeedy/create-rspeedy/src/index.ts
+++ b/packages/rspeedy/create-rspeedy/src/index.ts
@@ -84,7 +84,7 @@ void create({
       value: 'vitest-rltl',
       label: 'Vitest',
       order: 'pre',
-      when: (templateName) =>
+      when: ({ templateName }) =>
         templateName === 'react-js' || templateName === 'react-ts',
       action: ({ distFolder, addAgentsMdSearchDirs }) => {
         const from = path.resolve(__dirname, '..', 'template-react-vitest-rltl')
@@ -100,7 +100,7 @@ void create({
       value: 'rstest-rltl',
       label: 'Rstest',
       order: 'pre',
-      when: (templateName) =>
+      when: ({ templateName }) =>
         templateName === 'react-js' || templateName === 'react-ts',
       action: ({ distFolder, addAgentsMdSearchDirs }) => {
         const from = path.resolve(__dirname, '..', 'template-react-rstest-rltl')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1364,8 +1364,8 @@ importers:
   packages/rspeedy/create-rspeedy:
     dependencies:
       create-rstack:
-        specifier: 1.9.2
-        version: 1.9.2
+        specifier: 2.1.3
+        version: 2.1.3
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:^
@@ -7265,8 +7265,8 @@ packages:
     resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
     engines: {node: '>= 0.4.0'}
 
-  create-rstack@1.9.2:
-    resolution: {integrity: sha512-nN4ThiyEZ/hRgafQRlLDoxJnoBa1m3SErwzxsqUg0Zr5bSQ5DREBhcEOsd7NNbfM4Z6GJAAqJvPge7cwtuFmCQ==}
+  create-rstack@2.1.3:
+    resolution: {integrity: sha512-3n8JzuzbMYger7fnhIb8DDYs7b4lnNgLJm6kKve+qCKeqpCsTZaiZBQ3cYy7/FjWNtccbJ4XhfA/WNvzETD3vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   crelt@1.0.6:
@@ -18170,7 +18170,7 @@ snapshots:
 
   corser@2.0.1: {}
 
-  create-rstack@1.9.2: {}
+  create-rstack@2.1.3: {}
 
   crelt@1.0.6: {}
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated create-rstack dependency to 2.1.3.
  * Raised Node.js runtime requirement to 20.19+ or 22.12+, which may require upgrading local Node installs.
* **Documentation**
  * Pack/packaging instructions expanded to cover additional package paths and packaging patterns.
* **Compatibility**
  * Tool integration adjusted for the create-rstack 2.x callback shape to ensure compatibility with relevant templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
