### PR TITLE
feat(a2ui-playground): share whole conversation instead of final result

### DIFF
--- a/packages/genui/a2ui-playground/src/components/ConversationListPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/ConversationListPanel.tsx
@@ -150,7 +150,7 @@ export function ConversationListPanel(props: ConversationListPanelProps) {
                   iconOnly
                   iconBefore={Share2}
                   disabled={disabled || editing}
-                  title='Copy share link'
+                  title='Copy conversation link'
                   aria-label='Share conversation'
                   onClick={() => onShare(conversation.id)}
                 />

--- a/packages/genui/a2ui-playground/src/hooks/useConversation.ts
+++ b/packages/genui/a2ui-playground/src/hooks/useConversation.ts
@@ -8,12 +8,14 @@ import {
   createConversationMeta,
   deleteConversation,
   getActiveConversationId,
+  importConversation,
   listConversations,
   loadConversation,
   renameConversation,
   saveConversationMessages,
   setActiveConversationId,
 } from '../storage/conversationRepo.js';
+import type { SharedConversationDoc } from '../storage/sharedConversation.js';
 import type {
   ConversationMeta,
   DataModelSnapshot,
@@ -64,6 +66,7 @@ export interface UseConversationReturn {
   isPersistent: boolean;
   switchTo: (id: string) => Promise<void>;
   createNew: () => Promise<string>;
+  importShared: (doc: SharedConversationDoc) => Promise<string>;
   remove: (id: string) => Promise<void>;
   rename: (id: string, title: string) => Promise<void>;
   recordTurn: (input: RecordTurnInput) => Promise<void>;
@@ -450,6 +453,55 @@ export function useConversation(): UseConversationReturn {
     return meta.id;
   }, [syncHotState]);
 
+  const importShared = useCallback(
+    async (doc: SharedConversationDoc): Promise<string> => {
+      // In-memory fallback (IndexedDB unavailable): build hot state directly.
+      if (!persistentRef.current) {
+        const meta: ConversationMeta = {
+          ...createConversationMeta(doc.title || 'Shared conversation'),
+          messageCount: doc.messages.length,
+        };
+        const hotState: ConversationHotState = {
+          messages: doc.messages.map((message) => ({
+            role: message.role,
+            content: message.content,
+            previewPayloadUrls: message.previewPayloadUrls,
+            previewMetrics: clonePreviewPerformanceMetrics(
+              message.previewMetrics,
+            ),
+          })),
+          dataModel: cloneDataModel(doc.snapshot?.dataModel ?? {}),
+          surfaceIds: new Set(doc.snapshot?.surfaceIds ?? []),
+          previewMessages: [],
+          previewPayloadUrls: doc.snapshot?.previewPayloadUrls ?? null,
+        };
+        conversationHotStateMapRef.current.set(
+          meta.id,
+          cloneHotState(hotState),
+        );
+        setConversations((prev) => [meta, ...prev]);
+        activationTokenRef.current = Symbol(meta.id);
+        activeIdRef.current = meta.id;
+        setActiveId(meta.id);
+        syncHotState(
+          hotState.messages,
+          hotState.dataModel,
+          hotState.surfaceIds,
+          hotState.previewMessages,
+          hotState.previewPayloadUrls,
+        );
+        return meta.id;
+      }
+
+      const meta = await importConversation(doc);
+      await setActiveConversationId(meta.id);
+      await refreshConversations();
+      await activateRecord(meta.id);
+      return meta.id;
+    },
+    [activateRecord, refreshConversations, syncHotState],
+  );
+
   const remove = useCallback(
     async (id: string) => {
       if (persistentRef.current) {
@@ -676,6 +728,7 @@ export function useConversation(): UseConversationReturn {
     isPersistent,
     switchTo,
     createNew,
+    importShared,
     remove,
     rename,
     recordTurn,

--- a/packages/genui/a2ui-playground/src/hooks/useConversation.ts
+++ b/packages/genui/a2ui-playground/src/hooks/useConversation.ts
@@ -11,6 +11,7 @@ import {
   importConversation,
   listConversations,
   loadConversation,
+  previewTextFromSharedMessages,
   renameConversation,
   saveConversationMessages,
   setActiveConversationId,
@@ -460,6 +461,7 @@ export function useConversation(): UseConversationReturn {
         const meta: ConversationMeta = {
           ...createConversationMeta(doc.title || 'Shared conversation'),
           messageCount: doc.messages.length,
+          previewText: previewTextFromSharedMessages(doc.messages),
         };
         const hotState: ConversationHotState = {
           messages: doc.messages.map((message) => ({

--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -26,12 +26,22 @@ import { useConversation } from '../hooks/useConversation.js';
 import type { ModelChatMessage } from '../hooks/useConversation.js';
 import { useResizablePanels } from '../hooks/useResizablePanels.js';
 import { loadConversation } from '../storage/conversationRepo.js';
+import {
+  isSharedConversationDoc,
+  serializeConversation,
+} from '../storage/sharedConversation.js';
 import type { PreviewPerformanceMetrics } from '../storage/types.js';
 import { copyToClipboard } from '../utils/clipboard.js';
 import { DEFAULT_A2UI_DEMO_URL } from '../utils/demoUrl.js';
 import type { Protocol } from '../utils/protocol.js';
-import { isDevHost, publishA2UIPayload } from '../utils/publishPayload.js';
+import { isDevHost } from '../utils/publishPayload.js';
 import { buildRenderUrl } from '../utils/renderUrl.js';
+import {
+  buildConversationShareUrl,
+  clearImportConversationParam,
+  publishConversation,
+  readImportConversationParam,
+} from '../utils/shareConversation.js';
 
 interface ChatMessage {
   id?: string;
@@ -1042,6 +1052,7 @@ export function AIChatPage(
     buildConversationContext,
     conversations,
     createNew,
+    importShared,
     isPersistent,
     isReady,
     messages: persistedMessages,
@@ -1088,6 +1099,7 @@ export function AIChatPage(
   const abortRef = useRef<AbortController | null>(null);
   const actionAbortRef = useRef<AbortController | null>(null);
   const hydratedActiveIdRef = useRef<string | null>(null);
+  const importHandledRef = useRef(false);
   const latestPreviewMessagesRef = useRef<unknown[]>([]);
   const generatedCharacterCountRef = useRef(0);
   const latestPreviewPayloadUrlsRef = useRef<PreviewPayloadUrls | null>(null);
@@ -1516,6 +1528,38 @@ export function AIChatPage(
     renderUrl,
     updatePreviewPayloadUrls,
   ]);
+
+  // Import-on-open: when the page is loaded with a shared-conversation link,
+  // fetch the document once, rehydrate it into a new local conversation, then
+  // strip the param so a reload does not re-import.
+  useEffect(() => {
+    if (!isReady || importHandledRef.current) return;
+    const importUrl = readImportConversationParam();
+    if (!importUrl) {
+      importHandledRef.current = true;
+      return;
+    }
+    importHandledRef.current = true;
+    void (async () => {
+      try {
+        const response = await window.fetch(importUrl);
+        if (!response.ok) {
+          throw new Error(
+            `Failed to load shared conversation: ${response.status}`,
+          );
+        }
+        const doc = (await response.json()) as unknown;
+        if (!isSharedConversationDoc(doc)) {
+          throw new Error('Invalid shared conversation document');
+        }
+        await importShared(doc);
+      } catch (err) {
+        console.warn('[a2ui] Failed to import shared conversation', err);
+      } finally {
+        clearImportConversationParam();
+      }
+    })();
+  }, [isReady, importShared]);
 
   useEffect(() => {
     return () => {
@@ -2102,77 +2146,27 @@ export function AIChatPage(
   const shareConversation = useCallback(
     async (id: string) => {
       try {
-        let urls: PreviewPayloadUrls | null = null;
-        let fallbackMessages: unknown[] | null = null;
-
-        // Active conversation: the freshest URLs/messages live in refs.
-        if (id === activeId) {
-          urls = latestPreviewPayloadUrlsRef.current;
-          fallbackMessages = latestPreviewMessagesRef.current;
-        }
-
-        // Otherwise (or if the active one hasn't published yet) read the
-        // durable Supabase URLs persisted on the conversation snapshot.
-        if (!urls?.messagesUrl) {
-          const record = await loadConversation(id);
-          const snapshot = record?.snapshot;
-          const fromSnapshot = snapshot?.previewPayloadUrls;
-          let fromMessage: PreviewPayloadUrls | undefined;
-          if (record) {
-            for (let i = record.messages.length - 1; i >= 0; i--) {
-              const message = record.messages[i];
-              if (message?.previewPayloadUrls?.messagesUrl) {
-                fromMessage = message.previewPayloadUrls;
-                break;
-              }
-            }
-          }
-          urls = (fromSnapshot?.messagesUrl ? fromSnapshot : fromMessage)
-            ?? urls;
-          if (
-            !urls?.messagesUrl
-            && (!fallbackMessages || fallbackMessages.length === 0)
-          ) {
-            const previewMessages = snapshot?.previewMessages;
-            if (Array.isArray(previewMessages) && previewMessages.length > 0) {
-              fallbackMessages = previewMessages;
-            } else if (record && record.messages.length > 0) {
-              // Older snapshots: rebuild A2UI preview from assistant history.
-              const rebuilt = buildPreviewMessagesFromHistory(record.messages);
-              if (rebuilt.length > 0) fallbackMessages = rebuilt;
-            }
-          }
-        }
-
-        // No durable URL yet: publish the raw A2UI messages to Supabase.
-        if (
-          !urls?.messagesUrl && fallbackMessages && fallbackMessages.length > 0
-        ) {
-          urls = await publishA2UIPayload(fallbackMessages);
-        }
-
-        if (!urls?.messagesUrl) {
+        // Share the whole conversation: serialize the persisted record,
+        // upload it, and build a link that imports it into the recipient's
+        // playground (transcript + data model), not just the final UI.
+        const record = await loadConversation(id);
+        if (!record || record.messages.length === 0) {
           showCopyToast(false);
           return;
         }
-
-        const link = buildRenderUrl(
-          {
-            protocol,
-            demoUrl: DEFAULT_A2UI_DEMO_URL,
-            messages: [],
-            messagesUrl: urls.messagesUrl,
-            actionMocksUrl: urls.actionMocksUrl,
-            theme,
-          },
+        const doc = serializeConversation(record, protocol.name);
+        const conversationUrl = await publishConversation(doc);
+        const link = buildConversationShareUrl(
+          conversationUrl,
           baseUrl,
+          protocol.name,
         );
         showCopyToast(await copyToClipboard(link));
       } catch {
         showCopyToast(false);
       }
     },
-    [activeId, baseUrl, protocol, showCopyToast, theme],
+    [baseUrl, protocol, showCopyToast],
   );
 
   const handleShareConversation = useCallback((id: string) => {

--- a/packages/genui/a2ui-playground/src/storage/conversationRepo.ts
+++ b/packages/genui/a2ui-playground/src/storage/conversationRepo.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { getDB } from './db.js';
+import type { SharedConversationDoc } from './sharedConversation.js';
 import type {
   ConversationMeta,
   DataModelSnapshot,
@@ -129,6 +130,55 @@ export async function saveConversationMessages(
   }
   await tx.objectStore('snapshots').put(snapshot);
   await tx.done;
+}
+
+function previewTextFromSharedMessages(
+  messages: SharedConversationDoc['messages'],
+): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role === 'user') {
+      const compact = message.content.replace(/\s+/gu, ' ').trim();
+      return compact.length > 80 ? `${compact.slice(0, 80)}...` : compact;
+    }
+  }
+  return '';
+}
+
+/**
+ * Write a shared conversation document into a brand-new local conversation
+ * (fresh id, re-sequenced messages) and return its meta. The snapshot's
+ * `previewMessages` is left empty on purpose — the chat page rebuilds the
+ * preview from the assistant message history when the conversation activates.
+ */
+export async function importConversation(
+  doc: SharedConversationDoc,
+): Promise<ConversationMeta> {
+  const now = Date.now();
+  const meta: ConversationMeta = {
+    ...createConversationMeta(doc.title || 'Shared conversation'),
+    messageCount: doc.messages.length,
+    previewText: previewTextFromSharedMessages(doc.messages),
+  };
+  const messages: PersistedMessage[] = doc.messages.map((message, index) => ({
+    conversationId: meta.id,
+    seq: index,
+    role: message.role,
+    content: message.content,
+    previewPayloadUrls: message.previewPayloadUrls,
+    previewMetrics: message.previewMetrics,
+    createdAt: now + index,
+  }));
+  const snapshot: DataModelSnapshot = {
+    conversationId: meta.id,
+    dataModel: doc.snapshot?.dataModel ?? {},
+    surfaceIds: doc.snapshot?.surfaceIds ?? [],
+    previewMessages: [],
+    previewPayloadUrls: doc.snapshot?.previewPayloadUrls,
+    updatedAt: now,
+  };
+  await saveConversationMessages(meta, messages, snapshot);
+  return meta;
 }
 
 export async function renameConversation(

--- a/packages/genui/a2ui-playground/src/storage/conversationRepo.ts
+++ b/packages/genui/a2ui-playground/src/storage/conversationRepo.ts
@@ -132,7 +132,7 @@ export async function saveConversationMessages(
   await tx.done;
 }
 
-function previewTextFromSharedMessages(
+export function previewTextFromSharedMessages(
   messages: SharedConversationDoc['messages'],
 ): string {
   for (let i = messages.length - 1; i >= 0; i--) {

--- a/packages/genui/a2ui-playground/src/storage/sharedConversation.ts
+++ b/packages/genui/a2ui-playground/src/storage/sharedConversation.ts
@@ -86,6 +86,19 @@ export function serializeConversation(
   };
 }
 
+function isSharedConversationMessage(
+  value: unknown,
+): value is SharedConversationMessage {
+  if (!value || typeof value !== 'object') return false;
+  const message = value as Partial<SharedConversationMessage>;
+  return (
+    (message.role === 'user'
+      || message.role === 'assistant'
+      || message.role === 'system')
+    && typeof message.content === 'string'
+  );
+}
+
 export function isSharedConversationDoc(
   value: unknown,
 ): value is SharedConversationDoc {
@@ -95,5 +108,6 @@ export function isSharedConversationDoc(
     doc.kind === SHARED_CONVERSATION_KIND
     && doc.v === 1
     && Array.isArray(doc.messages)
+    && doc.messages.every((message) => isSharedConversationMessage(message))
   );
 }

--- a/packages/genui/a2ui-playground/src/storage/sharedConversation.ts
+++ b/packages/genui/a2ui-playground/src/storage/sharedConversation.ts
@@ -1,0 +1,99 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { ConversationRecord } from './conversationRepo.js';
+import type { PreviewPayloadUrls, PreviewPerformanceMetrics } from './types.js';
+
+export const SHARED_CONVERSATION_KIND = 'a2ui-conversation';
+
+/**
+ * A single turn in a shared conversation. Structurally a `ModelChatMessage`,
+ * redeclared here so the storage layer does not import from `hooks/`.
+ */
+export interface SharedConversationMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  previewPayloadUrls?: PreviewPayloadUrls;
+  previewMetrics?: PreviewPerformanceMetrics;
+}
+
+export interface SharedConversationSnapshot {
+  dataModel: Record<string, unknown>;
+  surfaceIds: string[];
+  previewPayloadUrls?: PreviewPayloadUrls;
+}
+
+/**
+ * Self-contained, versioned snapshot of an entire conversation. Uploaded to
+ * durable storage so a share link can rehydrate the conversation (transcript +
+ * data model) into the recipient's playground. Deliberately omits
+ * `snapshot.previewMessages`: it is a client-side render cache that is rebuilt
+ * from the assistant message history on import, and dropping it keeps the
+ * uploaded document well under the server's body-size limit.
+ */
+export interface SharedConversationDoc {
+  v: 1;
+  kind: typeof SHARED_CONVERSATION_KIND;
+  protocol?: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  messages: SharedConversationMessage[];
+  snapshot: SharedConversationSnapshot | null;
+}
+
+export function serializeConversation(
+  record: ConversationRecord,
+  protocol?: string,
+): SharedConversationDoc {
+  const messages: SharedConversationMessage[] = record.messages.map(
+    (message) => {
+      const next: SharedConversationMessage = {
+        role: message.role,
+        content: message.content,
+      };
+      if (message.previewPayloadUrls) {
+        next.previewPayloadUrls = message.previewPayloadUrls;
+      }
+      if (message.previewMetrics) {
+        next.previewMetrics = message.previewMetrics;
+      }
+      return next;
+    },
+  );
+
+  let snapshot: SharedConversationSnapshot | null = null;
+  if (record.snapshot) {
+    snapshot = {
+      dataModel: record.snapshot.dataModel ?? {},
+      surfaceIds: record.snapshot.surfaceIds ?? [],
+    };
+    if (record.snapshot.previewPayloadUrls) {
+      snapshot.previewPayloadUrls = record.snapshot.previewPayloadUrls;
+    }
+  }
+
+  return {
+    v: 1,
+    kind: SHARED_CONVERSATION_KIND,
+    protocol,
+    title: record.meta.title,
+    createdAt: record.meta.createdAt,
+    updatedAt: record.meta.updatedAt,
+    messages,
+    snapshot,
+  };
+}
+
+export function isSharedConversationDoc(
+  value: unknown,
+): value is SharedConversationDoc {
+  if (!value || typeof value !== 'object') return false;
+  const doc = value as Partial<SharedConversationDoc>;
+  return (
+    doc.kind === SHARED_CONVERSATION_KIND
+    && doc.v === 1
+    && Array.isArray(doc.messages)
+  );
+}

--- a/packages/genui/a2ui-playground/src/utils/shareConversation.ts
+++ b/packages/genui/a2ui-playground/src/utils/shareConversation.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { publishA2UIPayload } from './publishPayload.js';
+import type { SharedConversationDoc } from '../storage/sharedConversation.js';
+
+/** Query param that carries the URL of a shared conversation document. */
+export const IMPORT_CONVERSATION_PARAM = 'importConv';
+
+/**
+ * Upload a serialized conversation to the GenUI server (Supabase Storage) and
+ * return the durable public URL of the stored document. Reuses the generic
+ * A2UI payload upload path — the server stores the JSON body verbatim, so the
+ * conversation document is persisted as-is.
+ */
+export async function publishConversation(
+  doc: SharedConversationDoc,
+): Promise<string> {
+  const { messagesUrl } = await publishA2UIPayload(doc);
+  return messagesUrl;
+}
+
+/**
+ * Build a link that, when opened, imports the conversation into the recipient's
+ * playground. Pins the hash route to `#/<protocol>/create` so the playground
+ * lands on the chat tab where the import handler runs.
+ */
+export function buildConversationShareUrl(
+  conversationUrl: string,
+  baseUrl: string,
+  protocolName: string,
+): string {
+  const url = new URL(baseUrl);
+  url.search = '';
+  url.searchParams.set(IMPORT_CONVERSATION_PARAM, conversationUrl);
+  url.hash = `#/${protocolName}/create`;
+  return url.toString();
+}
+
+export function readImportConversationParam(): string | null {
+  return new URLSearchParams(window.location.search).get(
+    IMPORT_CONVERSATION_PARAM,
+  );
+}
+
+/** Remove the import param from the URL so a reload does not re-import. */
+export function clearImportConversationParam(): void {
+  if (!readImportConversationParam()) return;
+  window.history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.hash,
+  );
+}

--- a/packages/genui/a2ui-playground/src/utils/shareConversation.ts
+++ b/packages/genui/a2ui-playground/src/utils/shareConversation.ts
@@ -47,9 +47,11 @@ export function readImportConversationParam(): string | null {
 /** Remove the import param from the URL so a reload does not re-import. */
 export function clearImportConversationParam(): void {
   if (!readImportConversationParam()) return;
+  const url = new URL(window.location.href);
+  url.searchParams.delete(IMPORT_CONVERSATION_PARAM);
   window.history.replaceState(
     null,
     '',
-    window.location.pathname + window.location.hash,
+    `${url.pathname}${url.search}${url.hash}`,
   );
 }


### PR DESCRIPTION
The per-conversation Share button used to copy a render.html link that only showed the final generated UI. It now serializes the entire conversation (transcript + data-model snapshot), uploads it via the existing Supabase payload endpoint, and builds an `?importConv=<url>` link. Opening that link rehydrates the conversation into the recipient's playground as a fresh local conversation, so they can read every prompt -> result turn and continue chatting from there.

The shared document keeps each message's content and the snapshot dataModel -- exactly what the agent needs to restore its ConversationContext (history + a dataModel system message) on the next turn. The redundant previewMessages render cache is dropped and rebuilt from history on import to stay under the server body-size limit.

Changes:
- storage/sharedConversation.ts (new): SharedConversationDoc, serializeConversation, isSharedConversationDoc
- utils/shareConversation.ts (new): publishConversation, buildConversationShareUrl, import-param helpers
- storage/conversationRepo.ts: importConversation()
- hooks/useConversation.ts: importShared()
- pages/AIChatPage.tsx: rewritten share handler + one-time import effect
- components/ConversationListPanel.tsx: relabel share button

<img width="721" height="776" alt="image" src="https://github.com/user-attachments/assets/3e973798-9382-45d4-8e20-8a062ec65416" />


<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Share complete conversations with others via shareable links
  * Automatically import shared conversations when opening shared links
  * Updated share button tooltip text for improved clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
