### PR TITLE
chore(lynx): update native library API names

### DIFF
--- a/.changeset/autolink-library-manifest.md
+++ b/.changeset/autolink-library-manifest.md
@@ -3,4 +3,4 @@
 "create-lynx-library": minor
 ---
 
-Rename the Native Autolink scaffold flow to libraries and switch codegen manifests to `lynx.lib.json`.
+Rename the native scaffold flow to libraries and switch codegen manifests to `lynx.lib.json`.

--- a/.github/autolink-library.instructions.md
+++ b/.github/autolink-library.instructions.md
@@ -1,20 +1,17 @@
-# Native Autolink Library Instructions
+# Lynx Native Library Instructions
 
-Use the current Native Autolink package names and marker names when creating or
+Use the current Lynx native package names and marker names when creating or
 updating Lynx libraries.
 
 - The codegen package is `@lynx-js/autolink-codegen`.
 - The codegen binary is `lynx-autolink-codegen`.
 - Create new libraries with `create-lynx-library`.
-- Android library APIs use only the Autolink names:
-  `LynxAutolinkElement`, `LynxAutolinkNativeModule`, and
-  `LynxAutolinkService`.
-- iOS library APIs should use `@LynxAutolinkUI`,
-  `@LynxAutolinkNativeModule`, and `@LynxAutolinkService`.
-- Do not generate or document RFC-draft marker names such as `@LynxElement`,
-  `@LynxNativeModule`, `@LynxService`, or `LynxNativeModule("...")`.
+- Android library APIs use `LynxElement`, `LynxNativeModule`, and
+  `LynxService`. Android services should implement `IServiceProvider`.
+- iOS library APIs should use `@LynxUIRegister`,
+  `@LynxNativeModuleRegister`, and `@LynxServiceRegister`.
 - The current create-library and codegen packages are Native-only. Do not add
-  Web Autolink or Web spec output in these packages.
+  Web library or Web spec output in these packages.
 - Keep `create-lynx-library` interactive prompts aligned with
   `create-rspeedy` by using `@clack/prompts` prompt primitives. Library feature
   selection should be a required multi-select that can produce Native Module,
@@ -23,6 +20,6 @@ updating Lynx libraries.
   templates, then replace them from `create-lynx-library` package metadata at
   scaffold time so published CLIs emit published versions.
 
-iOS Autolink scanners in the native repo may still recognize existing Lynx lazy
+iOS scanners in the native repo may still recognize older Lynx lazy
 registration forms for compatibility, but new generated templates should prefer
-the Autolink marker names above.
+the marker names above.

--- a/packages/lynx/autolink-codegen/README.md
+++ b/packages/lynx/autolink-codegen/README.md
@@ -1,6 +1,6 @@
 # @lynx-js/autolink-codegen
 
-Native Autolink code generator for Lynx libraries.
+Lynx native library code generator.
 
 It scans `types/**/*.d.ts` for native module declarations annotated with
 `/** @lynxmodule */`, reads `lynx.lib.json`, and generates:
@@ -26,5 +26,5 @@ can use:
 }
 ```
 
-The first version intentionally supports only Native Autolink. Web Autolink and
-Web spec generation are outside this package.
+The first version intentionally supports only Lynx native libraries. Web spec
+generation is outside this package.

--- a/packages/lynx/autolink-codegen/package.json
+++ b/packages/lynx/autolink-codegen/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@lynx-js/autolink-codegen",
   "version": "0.1.0",
-  "description": "Native Autolink code generator for Lynx libraries",
+  "description": "Lynx native library code generator",
   "keywords": [
     "Lynx",
-    "Autolink",
+    "Library",
     "codegen"
   ],
   "repository": {

--- a/packages/lynx/autolink-codegen/src/cli.ts
+++ b/packages/lynx/autolink-codegen/src/cli.ts
@@ -50,7 +50,7 @@ function parseArgs(argv: string[]): CliOptions {
 function printHelp(): void {
   console.info(`Usage: lynx-autolink-codegen [--root <dir>]
 
-Generate Native Autolink JS, Android, and iOS specs from types/**/*.d.ts.
+Generate Lynx native JS, Android, and iOS specs from types/**/*.d.ts.
 
 Options:
   --root, -r <dir>  Library package root. Defaults to the current directory.

--- a/packages/lynx/autolink-codegen/src/index.ts
+++ b/packages/lynx/autolink-codegen/src/index.ts
@@ -545,7 +545,7 @@ function parseParams(
 
     if (optional) {
       throw new Error(
-        `Optional parameter "${moduleName}.${methodName}.${name}" is not supported by Native Autolink codegen v1`,
+        `Optional parameter "${moduleName}.${methodName}.${name}" is not supported by Lynx native library codegen v1`,
       );
     }
 
@@ -557,7 +557,7 @@ function parseParams(
 
     if (type.name === 'void') {
       throw new Error(
-        `Unsupported parameter type "void" for ${moduleName}.${methodName}.${name} in ${filename}. Native Autolink codegen v1 only supports void as a return type.`,
+        `Unsupported parameter type "void" for ${moduleName}.${methodName}.${name} in ${filename}. Lynx native library codegen v1 only supports void as a return type.`,
       );
     }
 
@@ -610,7 +610,7 @@ function assertNoSymlinkTraversal(root: string, target: string): void {
 }
 
 /**
- * Parses a supported Native Autolink type, including nullable unions.
+ * Parses a supported Lynx native type, including nullable unions.
  */
 function parseType(
   source: string,
@@ -655,7 +655,7 @@ function unsupportedType(
   context: string,
 ): Error {
   return new Error(
-    `Unsupported type "${source}" for ${context} in ${filename}. Native Autolink codegen v1 supports void, string, number, boolean, and unions with null.`,
+    `Unsupported type "${source}" for ${context} in ${filename}. Lynx native library codegen v1 supports void, string, number, boolean, and unions with null.`,
   );
 }
 
@@ -704,14 +704,14 @@ function walkFiles(dir: string): string[] {
 }
 
 /**
- * Reads and normalizes the Native Autolink library manifest.
+ * Reads and normalizes the Lynx native library manifest.
  */
 function readManifest(root: string): LynxLibJson {
   const manifestPath = path.join(root, 'lynx.lib.json');
 
   if (!fs.existsSync(manifestPath)) {
     throw new Error(
-      `Missing lynx.lib.json in ${root}. Native Autolink codegen must run from a library package root.`,
+      `Missing lynx.lib.json in ${root}. Lynx native library codegen must run from a library package root.`,
     );
   }
 

--- a/packages/lynx/create-lynx-library/README.md
+++ b/packages/lynx/create-lynx-library/README.md
@@ -1,6 +1,6 @@
 # create-lynx-library
 
-Create Native Autolink Lynx libraries.
+Create Lynx native libraries.
 
 ```bash
 npm create lynx-library

--- a/packages/lynx/create-lynx-library/package.json
+++ b/packages/lynx/create-lynx-library/package.json
@@ -1,10 +1,10 @@
 {
   "name": "create-lynx-library",
   "version": "0.1.0",
-  "description": "Create Native Autolink Lynx libraries",
+  "description": "Create Lynx native libraries",
   "keywords": [
     "Lynx",
-    "Autolink",
+    "Library",
     "create"
   ],
   "repository": {

--- a/packages/lynx/create-lynx-library/src/cli.ts
+++ b/packages/lynx/create-lynx-library/src/cli.ts
@@ -66,7 +66,7 @@ const LIBRARY_FEATURE_LABELS: Record<LibraryFeature, string> = {
 };
 const LIBRARY_FEATURE_HINTS: Record<LibraryFeature, string> = {
   'native-module': 'JS bridge APIs implemented by native code',
-  element: 'native UI element registered through Autolink',
+  element: 'native UI element registered through Lynx',
   service: 'native service implementation registered globally',
 };
 
@@ -178,7 +178,7 @@ Options:
 
 Library features:
   native-module                JS bridge APIs implemented by native code.
-  element                      Native UI element registered through Autolink.
+  element                      Native UI element registered through Lynx.
   service                      Native service implementation registered globally.
 
 Examples:

--- a/packages/lynx/create-lynx-library/src/index.ts
+++ b/packages/lynx/create-lynx-library/src/index.ts
@@ -62,7 +62,7 @@ const PACKAGE_JSON_DEPENDENCY_FIELDS = [
 ] as const satisfies ReadonlyArray<keyof PackageJson>;
 
 /**
- * Creates a Native Autolink library scaffold on disk.
+ * Creates a Lynx native library scaffold on disk.
  */
 export function createLynxLibrary(
   options: CreateLynxLibraryOptions,
@@ -403,7 +403,7 @@ function resolveInside(targetDir: string, filePath: string): string {
  */
 function sourceIndex(context: TemplateContext): string {
   if (!context.features.has('native-module')) {
-    return `// Native Autolink package entry.
+    return `// Lynx native library package entry.
 `;
   }
 

--- a/packages/lynx/create-lynx-library/template-common/README.md
+++ b/packages/lynx/create-lynx-library/template-common/README.md
@@ -1,6 +1,6 @@
 # **PACKAGE_NAME**
 
-Native Autolink Lynx library.
+Lynx native library.
 
 ## Development
 
@@ -10,4 +10,4 @@ npm run codegen
 ```
 
 The generated native specs are written to `generated/`, `android/`, and
-`ios/`. The package is discovered by Lynx Autolink through `lynx.lib.json`.
+`ios/`. The package is discovered by Lynx through `lynx.lib.json`.

--- a/packages/lynx/create-lynx-library/template-common/ios/build.podspec
+++ b/packages/lynx/create-lynx-library/template-common/ios/build.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = '__PODSPEC_NAME__'
   s.version = '0.0.1'
-  s.summary = 'Native Autolink Lynx library'
+  s.summary = 'Lynx native library'
   s.license = { :type => 'Apache-2.0' }
   s.author = 'Lynx'
   s.source = { :path => '..' }

--- a/packages/lynx/create-lynx-library/template-common/package.json
+++ b/packages/lynx/create-lynx-library/template-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "__PACKAGE_NAME__",
   "version": "0.0.1",
-  "description": "A Native Autolink Lynx library",
+  "description": "A Lynx native library",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/lynx/create-lynx-library/template-element/android/src/main/java/__ANDROID_PACKAGE_PATH__/__ELEMENT_CLASS_NAME__.java
+++ b/packages/lynx/create-lynx-library/template-element/android/src/main/java/__ANDROID_PACKAGE_PATH__/__ELEMENT_CLASS_NAME__.java
@@ -2,11 +2,11 @@ package __ANDROID_PACKAGE__;
 
 import android.content.Context;
 import android.widget.TextView;
-import com.lynx.tasm.behavior.LynxAutolinkElement;
 import com.lynx.tasm.behavior.LynxContext;
+import com.lynx.tasm.behavior.LynxElement;
 import com.lynx.tasm.behavior.ui.LynxUI;
 
-@LynxAutolinkElement(name = "__ELEMENT_NAME__")
+@LynxElement(name = "__ELEMENT_NAME__")
 public class __ELEMENT_CLASS_NAME__ extends LynxUI<TextView> {
   public __ELEMENT_CLASS_NAME__(LynxContext context) {
     super(context);

--- a/packages/lynx/create-lynx-library/template-element/ios/src/__ELEMENT_CLASS_NAME__.h
+++ b/packages/lynx/create-lynx-library/template-element/ios/src/__ELEMENT_CLASS_NAME__.h
@@ -3,7 +3,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@LynxAutolinkUI("__ELEMENT_NAME__")
 @interface __ELEMENT_CLASS_NAME__ : LynxUI<UILabel *>
 
 @end

--- a/packages/lynx/create-lynx-library/template-element/ios/src/__ELEMENT_CLASS_NAME__.m
+++ b/packages/lynx/create-lynx-library/template-element/ios/src/__ELEMENT_CLASS_NAME__.m
@@ -1,5 +1,6 @@
 #import "__ELEMENT_CLASS_NAME__.h"
 
+@LynxUIRegister("__ELEMENT_NAME__")
 @implementation __ELEMENT_CLASS_NAME__
 
 - (UILabel *)createView {

--- a/packages/lynx/create-lynx-library/template-native-module/android/src/main/java/__ANDROID_PACKAGE_PATH__/__MODULE_NAME__.java
+++ b/packages/lynx/create-lynx-library/template-native-module/android/src/main/java/__ANDROID_PACKAGE_PATH__/__MODULE_NAME__.java
@@ -1,12 +1,12 @@
 package __ANDROID_PACKAGE__;
 
 import androidx.annotation.Nullable;
-import com.lynx.jsbridge.LynxAutolinkNativeModule;
 import com.lynx.jsbridge.LynxMethod;
+import com.lynx.jsbridge.LynxNativeModule;
 import com.lynx.tasm.behavior.LynxContext;
 import __ANDROID_PACKAGE__.generated.__MODULE_NAME__Spec;
 
-@LynxAutolinkNativeModule(name = "__MODULE_NAME__")
+@LynxNativeModule(name = "__MODULE_NAME__")
 public class __MODULE_NAME__ extends __MODULE_NAME__Spec {
   public __MODULE_NAME__(LynxContext context) {
     super(context);

--- a/packages/lynx/create-lynx-library/template-native-module/ios/src/__MODULE_NAME__.h
+++ b/packages/lynx/create-lynx-library/template-native-module/ios/src/__MODULE_NAME__.h
@@ -4,7 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@LynxAutolinkNativeModule("__MODULE_NAME__")
+@LynxNativeModuleRegister("__MODULE_NAME__")
 @interface __MODULE_NAME__ : NSObject <__MODULE_NAME__Spec>
 
 @end

--- a/packages/lynx/create-lynx-library/template-service/android/src/main/java/__ANDROID_PACKAGE_PATH__/__SERVICE_NAME__.java
+++ b/packages/lynx/create-lynx-library/template-service/android/src/main/java/__ANDROID_PACKAGE_PATH__/__SERVICE_NAME__.java
@@ -1,10 +1,15 @@
 package __ANDROID_PACKAGE__;
 
-import com.lynx.tasm.service.LynxAutolinkService;
+import com.lynx.tasm.service.IServiceProvider;
 import com.lynx.tasm.service.LynxService;
 
-@LynxAutolinkService
-public class __SERVICE_NAME__ implements LynxService {
+@LynxService
+public class __SERVICE_NAME__ implements IServiceProvider {
+  @Override
+  public Class<? extends IServiceProvider> getServiceClass() {
+    return __SERVICE_NAME__.class;
+  }
+
   public String name() {
     return "__SERVICE_NAME__";
   }

--- a/packages/lynx/create-lynx-library/template-service/ios/src/__SERVICE_NAME__.m
+++ b/packages/lynx/create-lynx-library/template-service/ios/src/__SERVICE_NAME__.m
@@ -1,6 +1,6 @@
 #import "__SERVICE_NAME__.h"
 
-@LynxAutolinkService(__SERVICE_NAME__, __SERVICE_PROTOCOL_NAME__)
+@LynxServiceRegister(__SERVICE_NAME__, __SERVICE_PROTOCOL_NAME__)
 @implementation __SERVICE_NAME__
 
 - (NSString *)name {

--- a/packages/lynx/create-lynx-library/test/cli.test.ts
+++ b/packages/lynx/create-lynx-library/test/cli.test.ts
@@ -117,9 +117,9 @@ describe('create-lynx-library CLI', () => {
       '"name": "@example/cli-library"',
     );
     expect(read(dir, 'android/src/main/java/com/example/cli/CliModule.java'))
-      .toContain('@LynxAutolinkNativeModule(name = "CliModule")');
-    expect(read(dir, 'ios/src/CliElement.h')).toContain(
-      '@LynxAutolinkUI("x-cli")',
+      .toContain('@LynxNativeModule(name = "CliModule")');
+    expect(read(dir, 'ios/src/CliElement.m')).toContain(
+      '@LynxUIRegister("x-cli")',
     );
   });
 
@@ -147,21 +147,21 @@ describe('create-lynx-library CLI', () => {
         'android/src/main/java/com/example/all/AllLibraryModule.java',
       ),
     )
-      .toContain('@LynxAutolinkNativeModule(name = "AllLibraryModule")');
+      .toContain('@LynxNativeModule(name = "AllLibraryModule")');
     expect(
       read(
         dir,
         'android/src/main/java/com/example/all/AllLibraryElement.java',
       ),
     )
-      .toContain('@LynxAutolinkElement(name = "x-all-library")');
+      .toContain('@LynxElement(name = "x-all-library")');
     expect(
       read(
         dir,
         'android/src/main/java/com/example/all/AllLibraryService.java',
       ),
     )
-      .toContain('@LynxAutolinkService');
+      .toContain('@LynxService');
   });
 
   it('fails in non-interactive mode when required options are missing', async () => {

--- a/packages/lynx/create-lynx-library/test/create.test.ts
+++ b/packages/lynx/create-lynx-library/test/create.test.ts
@@ -34,7 +34,7 @@ describe('create-lynx-library', () => {
     );
   });
 
-  it('creates a mixed Native Autolink library', () => {
+  it('creates a mixed Lynx native library', () => {
     const dir = createTempDir('mixed');
     const files = createLynxLibrary({
       dir,
@@ -89,36 +89,36 @@ describe('create-lynx-library', () => {
     );
     expect(
       read(dir, 'android/src/main/java/com/example/button/ButtonModule.java'),
-    ).toContain('@LynxAutolinkNativeModule(name = "ButtonModule")');
+    ).toContain('@LynxNativeModule(name = "ButtonModule")');
     expect(
       read(dir, 'android/src/main/java/com/example/button/ButtonModule.java'),
-    ).toContain('import com.lynx.jsbridge.LynxAutolinkNativeModule;');
+    ).toContain('import com.lynx.jsbridge.LynxNativeModule;');
     expect(
       read(dir, 'android/src/main/java/com/example/button/ButtonModule.java'),
     ).toContain('import com.lynx.jsbridge.LynxMethod;');
     expect(
       read(dir, 'android/src/main/java/com/example/button/ButtonElement.java'),
-    ).toContain('@LynxAutolinkElement(name = "x-button")');
+    ).toContain('@LynxElement(name = "x-button")');
     expect(
       read(dir, 'android/src/main/java/com/example/button/ButtonElement.java'),
-    ).toContain('import com.lynx.tasm.behavior.LynxAutolinkElement;');
+    ).toContain('import com.lynx.tasm.behavior.LynxElement;');
     expect(
       read(dir, 'android/src/main/java/com/example/button/ButtonService.java'),
-    ).toContain('@LynxAutolinkService');
+    ).toContain('@LynxService');
     expect(
       read(dir, 'android/src/main/java/com/example/button/ButtonService.java'),
-    ).toContain('import com.lynx.tasm.service.LynxAutolinkService;');
+    ).toContain('import com.lynx.tasm.service.IServiceProvider;');
     expect(read(dir, 'ios/src/ButtonModule.h')).toContain(
-      '@LynxAutolinkNativeModule("ButtonModule")',
+      '@LynxNativeModuleRegister("ButtonModule")',
     );
     expect(read(dir, 'ios/src/ButtonModule.m')).toContain(
       '+ (NSDictionary<NSString *, NSString *> *)methodLookup',
     );
-    expect(read(dir, 'ios/src/ButtonElement.h')).toContain(
-      '@LynxAutolinkUI("x-button")',
+    expect(read(dir, 'ios/src/ButtonElement.m')).toContain(
+      '@LynxUIRegister("x-button")',
     );
     expect(read(dir, 'ios/src/ButtonService.m')).toContain(
-      '@LynxAutolinkService(ButtonService, ButtonServiceProtocol)',
+      '@LynxServiceRegister(ButtonService, ButtonServiceProtocol)',
     );
     expect(read(dir, 'ios/src/ButtonService.h')).toContain(
       '@protocol ButtonServiceProtocol <LynxServiceProtocol>',
@@ -156,7 +156,7 @@ describe('create-lynx-library', () => {
     expect(read(dir, 'ios/build.podspec')).not.toContain('LynxServiceAPI');
   });
 
-  it('creates Element and Service projects with Autolink markers', () => {
+  it('creates Element and Service projects with Lynx markers', () => {
     const dir = createTempDir('view');
     const files = createLynxLibrary({
       dir,
@@ -177,12 +177,12 @@ describe('create-lynx-library', () => {
       'Add native module declarations',
     );
     expect(read(dir, 'src/index.ts')).toContain(
-      'Native Autolink package entry',
+      'Lynx native library package entry',
     );
     expect(read(dir, 'android/src/main/java/com/example/view/ViewElement.java'))
-      .toContain('@LynxAutolinkElement(name = "x-view")');
+      .toContain('@LynxElement(name = "x-view")');
     expect(read(dir, 'ios/src/ViewService.m')).toContain(
-      '@LynxAutolinkService(ViewService, ViewServiceProtocol)',
+      '@LynxServiceRegister(ViewService, ViewServiceProtocol)',
     );
     expect(read(dir, 'example/src/App.tsx')).not.toContain('import {');
   });


### PR DESCRIPTION
## Summary
- Update generated Android library markers to `LynxNativeModule`, `LynxElement`, and `LynxService`, with services implementing `IServiceProvider`.
- Update generated iOS library markers to `LynxNativeModuleRegister`, `LynxUIRegister`, and `LynxServiceRegister`.
- Refresh library and codegen descriptions, examples, tests, and project instructions to use the current native library naming.

## Validation
- `pnpm --filter create-lynx-library test`
- `pnpm --filter @lynx-js/autolink-codegen test`
- `pnpm turbo build --filter=create-lynx-library --filter=@lynx-js/autolink-codegen`
- `pnpm dprint check <changed files>`
- `pnpm biome check <changed files>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology from "Native Autolink" to "Lynx native library" across all documentation, instructions, and CLI help text.
  * Updated Android API markers in generated templates to `@LynxElement`, `@LynxNativeModule`, and `@LynxService`.
  * Updated iOS registration markers to `@LynxUIRegister`, `@LynxNativeModuleRegister`, and `@LynxServiceRegister`.

* **Tests**
  * Updated test assertions to verify new API marker names in generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->