### PR TITLE
feat(openui): optimize OpenUI components page

### DIFF
--- a/packages/genui/a2ui-playground/src/pages/ComponentsPage.css
+++ b/packages/genui/a2ui-playground/src/pages/ComponentsPage.css
@@ -659,3 +659,374 @@
     padding: 20px;
   }
 }
+
+/* ── OpenUI Components ── */
+.compPlaygroundSideHint {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  margin-left: auto;
+  padding: 2px 8px;
+  border: 1px solid color-mix(in srgb, var(--geist-border) 76%, transparent);
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 78%,
+    var(--geist-surface)
+  );
+  color: var(--geist-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.compBreadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 18px;
+  color: var(--geist-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.compBreadcrumbLink {
+  color: var(--geist-secondary);
+  font-weight: 600;
+  transition: color var(--geist-transition);
+}
+
+.compBreadcrumbLink:hover {
+  color: var(--geist-foreground);
+}
+
+.compBreadcrumbSep {
+  color: color-mix(in srgb, var(--geist-secondary) 60%, transparent);
+}
+
+.compBreadcrumbCurrent {
+  color: var(--geist-foreground);
+  font-weight: 600;
+}
+
+.compCategoryBadge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 24px;
+  margin-bottom: 12px;
+  padding: 2px 9px;
+  border: 1px solid color-mix(in srgb, var(--geist-border) 76%, transparent);
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--geist-surface) 76%,
+    var(--geist-background)
+  );
+  color: var(--geist-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.openuiCompCatalogPage {
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 92%,
+    var(--geist-surface)
+  );
+}
+
+.openuiCompHeader {
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 88%,
+    var(--geist-surface)
+  );
+}
+
+.openuiCompSplit {
+  grid-template-columns: minmax(220px, 248px) minmax(0, 1fr);
+  gap: 16px;
+  padding: 16px 20px 36px;
+}
+
+.openuiCompSidebar {
+  width: 100%;
+  max-height: calc(100vh - 148px);
+  border: 1px solid color-mix(in srgb, var(--geist-border) 76%, transparent);
+  border-radius: var(--geist-radius-md);
+  box-shadow: var(--geist-shadow-sm);
+}
+
+.openuiCompSidebar .compSidebarAll {
+  margin-bottom: 12px;
+}
+
+.openuiCompSidebar .compSidebarGroup {
+  margin-bottom: 10px;
+}
+
+.openuiCompDetail {
+  min-width: 0;
+}
+
+.openuiCompContent {
+  padding: 6px 0 0;
+  overflow: visible;
+}
+
+.openuiCompDetailContent {
+  max-width: 980px;
+}
+
+.openuiCompIntro {
+  margin-bottom: 18px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--geist-border) 72%, transparent);
+}
+
+.openuiCompIntro .compDesc,
+.openuiCompContent > .compDesc {
+  max-width: 760px;
+}
+
+.openuiCompCategoryHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.openuiCompCategoryHeader .compCategoryTitle {
+  margin: 0;
+}
+
+.openuiCompCategoryCount {
+  flex: 0 0 auto;
+  color: var(--geist-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.openuiCompGridCard {
+  min-height: 112px;
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--geist-radius-md);
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 82%,
+    var(--geist-surface)
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.openuiCompGridCard:hover {
+  transform: translateY(-2px);
+}
+
+.openuiCompGridCard .compGridCardName {
+  margin-bottom: 8px;
+}
+
+.openuiCompSection {
+  margin-bottom: 16px;
+  padding: 16px;
+  border-radius: var(--geist-radius-md);
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 84%,
+    var(--geist-surface)
+  );
+  box-shadow: var(--geist-shadow-sm);
+}
+
+.openuiCompPropsTableWrap {
+  max-height: none;
+  border-radius: var(--geist-radius-md);
+}
+
+.openuiCompPropsTableWrap .compPropsTable .compTableHeader:first-child {
+  width: 18%;
+}
+
+.openuiCompPropsTableWrap .compPropsTable .compTableHeader:nth-child(2) {
+  width: 27%;
+}
+
+.openuiCompPropsTableWrap .compPropsTable .compTableHeader:nth-child(3) {
+  width: 35%;
+}
+
+.openuiCompPropsTableWrap .compPropsTable .compTableHeader:nth-child(4) {
+  width: 20%;
+}
+
+.openuiCompPropsTableWrap .compTableHeader {
+  background: color-mix(
+    in srgb,
+    var(--geist-background) 90%,
+    var(--geist-surface)
+  );
+}
+
+.openuiCompPropsTableWrap .compTableCell {
+  overflow-wrap: anywhere;
+}
+
+.openuiCompDslBlock {
+  max-height: 440px;
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--geist-border) 78%, transparent);
+  border-radius: var(--geist-radius-md);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.openuiCompContent .compTableCell {
+  line-height: 1.5;
+}
+
+@media (max-width: 1100px) {
+  .openuiCompSplit {
+    grid-template-columns: 1fr;
+  }
+
+  .openuiCompSidebar {
+    max-height: none;
+  }
+}
+
+@media (max-width: 980px) {
+  .openuiCompSplit {
+    padding: 12px 14px 28px;
+  }
+
+  .openuiCompSidebar {
+    max-height: 260px;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    border-right: 1px solid
+      color-mix(in srgb, var(--geist-border) 76%, transparent);
+    border-bottom: 1px solid
+      color-mix(in srgb, var(--geist-border) 76%, transparent);
+  }
+
+  .openuiCompContent {
+    padding-top: 2px;
+  }
+
+  .openuiCompSection {
+    padding: 14px;
+  }
+}
+
+@media (max-width: 720px) {
+  .openuiCompHeader .pageHeaderTop {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .openuiCompCategoryHeader {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .compPlaygroundSideHint {
+    margin-left: 0;
+  }
+
+  .openuiCompSection .compSectionHeader {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .openuiCompPropsTableWrap {
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  .openuiCompPropsTableWrap .compPropsTable,
+  .openuiCompPropsTableWrap .compPropsTable tbody,
+  .openuiCompPropsTableWrap .compPropsTable tr,
+  .openuiCompPropsTableWrap .compPropsTable .compTableCell {
+    display: block;
+    width: 100%;
+  }
+
+  .openuiCompPropsTableWrap .compPropsTable thead {
+    display: none;
+  }
+
+  .openuiCompPropsTableWrap .compPropsTable tr {
+    margin-bottom: 8px;
+    padding: 10px 12px;
+    border: 1px solid color-mix(in srgb, var(--geist-border) 76%, transparent);
+    border-radius: var(--geist-radius-md);
+    background: color-mix(
+      in srgb,
+      var(--geist-background) 88%,
+      var(--geist-surface)
+    );
+  }
+
+  .openuiCompPropsTableWrap .compPropsTable tr:last-child {
+    margin-bottom: 0;
+  }
+
+  .openuiCompPropsTableWrap .compPropsTable .compTableCell {
+    padding: 0;
+    border-bottom: 0;
+  }
+
+  .openuiCompPropsTableWrap .compPropsTable .compTableCell + .compTableCell {
+    margin-top: 8px;
+  }
+
+  .openuiCompPropsTableWrap .compPropsTable .compTableCell::before {
+    display: block;
+    margin-bottom: 2px;
+    color: var(--geist-secondary);
+    font-family: var(--geist-font);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    line-height: 1.3;
+    text-transform: uppercase;
+  }
+
+  .openuiCompPropsTableWrap
+    .compPropsTable
+    .compTableCell:nth-child(1)::before {
+    content: "Name";
+  }
+
+  .openuiCompPropsTableWrap
+    .compPropsTable
+    .compTableCell:nth-child(2)::before {
+    content: "Type";
+  }
+
+  .openuiCompPropsTableWrap
+    .compPropsTable
+    .compTableCell:nth-child(3)::before {
+    content: "Description";
+  }
+
+  .openuiCompPropsTableWrap
+    .compPropsTable
+    .compTableCell:nth-child(4)::before {
+    content: "Default";
+  }
+}

--- a/packages/genui/a2ui-playground/src/pages/OpenUIComponentsPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/OpenUIComponentsPage.tsx
@@ -8,7 +8,15 @@ import {
   OPENUI_COMPONENT_CATALOG,
 } from '../catalog/openui.js';
 import type { OpenUIComponentDoc } from '../catalog/openui.js';
+import { PageHeader } from '../components/PageHeader.js';
 import type { Protocol } from '../utils/protocol.js';
+
+import './ComponentsPage.css';
+
+function getOpenUICategoryLabel(categoryId: string): string {
+  return OPENUI_CATEGORIES.find((cat) => cat.id === categoryId)?.label
+    ?? categoryId;
+}
 
 // ─── Components ─────────────────────────────────────────────────────────────
 
@@ -19,7 +27,7 @@ function ComponentDetail(props: {
   const { comp, protocol } = props;
 
   return (
-    <div className='compContent'>
+    <div className='compContent openuiCompContent openuiCompDetailContent'>
       <div className='compBreadcrumb'>
         <a
           className='compBreadcrumbLink'
@@ -31,56 +39,56 @@ function ComponentDetail(props: {
         <span className='compBreadcrumbCurrent'>{comp.name}</span>
       </div>
 
-      <h2 className='compName'>{comp.name}</h2>
-      <p className='compDesc'>{comp.description}</p>
-      <div className='compCategoryBadge'>{comp.category}</div>
+      <div className='openuiCompIntro'>
+        <div className='compCategoryBadge'>
+          {getOpenUICategoryLabel(comp.category)}
+        </div>
+        <h2 className='compName'>{comp.name}</h2>
+        <p className='compDesc'>{comp.description}</p>
+      </div>
 
       {comp.props.length > 0
         ? (
-          <>
-            <h3 className='compSubheading'>Props</h3>
-            <table className='compTable'>
-              <thead>
-                <tr>
-                  <th className='compTableHeader'>Name</th>
-                  <th className='compTableHeader'>Type</th>
-                  <th className='compTableHeader'>Description</th>
-                  <th className='compTableHeader'>Default</th>
-                </tr>
-              </thead>
-              <tbody>
-                {comp.props.map((prop) => (
-                  <tr key={prop.name}>
-                    <td className='compTableCell'>{prop.name}</td>
-                    <td className='compTableCell'>{prop.type}</td>
-                    <td className='compTableCell'>{prop.description}</td>
-                    <td className='compTableCell'>{prop.default ?? '—'}</td>
+          <section className='compPropsSection compUsageSection openuiCompSection'>
+            <div className='compSectionHeader'>
+              <h3 className='compSubheading'>Props</h3>
+              <div className='compPlaygroundSideHint'>
+                {comp.props.length} fields
+              </div>
+            </div>
+            <div className='compPropsTableWrap openuiCompPropsTableWrap'>
+              <table className='compTable compPropsTable'>
+                <thead>
+                  <tr>
+                    <th className='compTableHeader'>Name</th>
+                    <th className='compTableHeader'>Type</th>
+                    <th className='compTableHeader'>Description</th>
+                    <th className='compTableHeader'>Default</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </>
+                </thead>
+                <tbody>
+                  {comp.props.map((prop) => (
+                    <tr key={prop.name}>
+                      <td className='compTableCell'>{prop.name}</td>
+                      <td className='compTableCell'>{prop.type}</td>
+                      <td className='compTableCell'>{prop.description}</td>
+                      <td className='compTableCell'>{prop.default ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
         )
         : null}
 
-      <h3 className='compSubheading'>Usage (OpenUI DSL)</h3>
-      <pre
-        style={{
-          margin: 0,
-          padding: 16,
-          fontSize: 13,
-          lineHeight: 1.6,
-          fontFamily: 'var(--geist-mono)',
-          color: 'var(--geist-code-fg)',
-          background: 'var(--geist-code-bg)',
-          borderRadius: 8,
-          overflow: 'auto',
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-        }}
-      >
-        {comp.usage}
-      </pre>
+      <section className='compUsageSection openuiCompSection'>
+        <div className='compSectionHeader compUsageSectionHeader'>
+          <h3 className='compSubheading'>Usage</h3>
+          <div className='compPlaygroundSideHint'>OpenUI DSL</div>
+        </div>
+        <pre className='compCodeBlock openuiCompDslBlock'>{comp.usage}</pre>
+      </section>
     </div>
   );
 }
@@ -89,7 +97,7 @@ function ComponentGrid(props: { protocol: Protocol }) {
   const { protocol } = props;
 
   return (
-    <div className='compContent'>
+    <div className='compContent openuiCompContent'>
       <h2 className='compName'>OpenUI Components</h2>
       <p className='compDesc'>
         Browse all supported OpenUI components by category.
@@ -102,12 +110,17 @@ function ComponentGrid(props: { protocol: Protocol }) {
         if (items.length === 0) return null;
         return (
           <div key={cat.id} className='compCategorySection'>
-            <h3 className='compCategoryTitle'>{cat.label}</h3>
+            <div className='openuiCompCategoryHeader'>
+              <h3 className='compCategoryTitle'>{cat.label}</h3>
+              <span className='openuiCompCategoryCount'>
+                {items.length} {items.length === 1 ? 'item' : 'items'}
+              </span>
+            </div>
             <div className='compGrid'>
               {items.map((comp) => (
                 <a
                   key={comp.name}
-                  className='compGridCard'
+                  className='compGridCard openuiCompGridCard'
                   href={`#/${protocol.name}/components/${comp.name}`}
                 >
                   <div className='compGridCardName'>{comp.name}</div>
@@ -149,39 +162,61 @@ export function OpenUIComponentsPage(
   }, []);
 
   return (
-    <div className='compPage'>
-      <div className='compSidebar'>
-        <a
-          className={'compSidebarAll' + (componentName ? '' : ' active')}
-          href={`#/${protocol.name}/components`}
-        >
-          All Components
-        </a>
+    <div className='compPage openuiCompPage'>
+      <div className='compCatalogPage openuiCompCatalogPage'>
+        <PageHeader
+          className='compCatalogContent openuiCompHeader'
+          title='OpenUI Components'
+          description='Browse the OpenUI DSL component catalog, prop contracts, and usage snippets.'
+          topContent={
+            <>
+              <span className='chip'>
+                {OPENUI_COMPONENT_CATALOG.length} components
+              </span>
+              <span className='chip'>
+                {OPENUI_CATEGORIES.length} categories
+              </span>
+            </>
+          }
+        />
 
-        {OPENUI_CATEGORIES.map((cat) => {
-          const items = groupedByCategory.get(cat.id);
-          if (!items) return null;
-          return (
-            <div key={cat.id} className='compSidebarGroup'>
-              <div className='compSidebarGroupLabel'>{cat.label}</div>
-              {items.map((comp) => (
-                <a
-                  key={comp.name}
-                  className={'compSidebarItem'
-                    + (componentName === comp.name ? ' active' : '')}
-                  href={`#/${protocol.name}/components/${comp.name}`}
-                >
-                  {comp.name}
-                </a>
-              ))}
-            </div>
-          );
-        })}
+        <div className='compCatalogSplit openuiCompSplit'>
+          <div className='compSidebar compCatalogSidebar openuiCompSidebar'>
+            <a
+              className={'compSidebarAll' + (componentName ? '' : ' active')}
+              href={`#/${protocol.name}/components`}
+            >
+              All Components
+            </a>
+
+            {OPENUI_CATEGORIES.map((cat) => {
+              const items = groupedByCategory.get(cat.id);
+              if (!items) return null;
+              return (
+                <div key={cat.id} className='compSidebarGroup'>
+                  <div className='compSidebarGroupLabel'>{cat.label}</div>
+                  {items.map((comp) => (
+                    <a
+                      key={comp.name}
+                      className={'compSidebarItem'
+                        + (componentName === comp.name ? ' active' : '')}
+                      href={`#/${protocol.name}/components/${comp.name}`}
+                    >
+                      {comp.name}
+                    </a>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+
+          <div className='compCatalogDetail openuiCompDetail'>
+            {selectedComp
+              ? <ComponentDetail comp={selectedComp} protocol={protocol} />
+              : <ComponentGrid protocol={protocol} />}
+          </div>
+        </div>
       </div>
-
-      {selectedComp
-        ? <ComponentDetail comp={selectedComp} protocol={protocol} />
-        : <ComponentGrid protocol={protocol} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Rework the OpenUI components page into the same catalog-style shell used by the A2UI catalog, with a page header, stable sidebar, and constrained detail content.
- Add OpenUI-specific styling for category cards, breadcrumbs, category badges, props sections, and DSL usage blocks.
- Improve narrow viewport behavior by converting the OpenUI props table into stacked field cards on small screens.

## Impact

This makes the OpenUI component catalog easier to scan on desktop and prevents the props table from crowding or overflowing on mobile widths.

## Validation

- `DPRINT_CACHE_DIR=/private/tmp/dprint-cache pnpm dprint fmt packages/genui/a2ui-playground/src/pages/OpenUIComponentsPage.tsx packages/genui/a2ui-playground/src/pages/ComponentsPage.css`
- `pnpm turbo build --filter a2ui-playground`
- Browser checked `#/openui/components` and `#/openui/components/Button` at desktop `1280x720` and mobile `390x844`; no visible horizontal overflow after the responsive table fix.

Notes: `gh auth status` reports the local `gh` token is invalid, so PR creation used the connected GitHub App. The build also emitted existing repository warnings about the ignored `pnpm` package.json field and Turborepo lockfile parsing, but completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OpenUI component catalog with enhanced styling and improved visual organization.

* **Style**
  * Updated layout and responsive design for better mobile and desktop viewing experience across multiple screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->