### PR TITLE
feat(rspeedy): drop all sourcemap assets in Lynx env

### DIFF
--- a/.changeset/rspeedy-source-map-emit-default-false.md
+++ b/.changeset/rspeedy-source-map-emit-default-false.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": minor
+---
+
+In Lynx environments, all `.map` assets are removed before emit.

--- a/packages/rspeedy/core/src/config/index.ts
+++ b/packages/rspeedy/core/src/config/index.ts
@@ -83,7 +83,7 @@ export interface Config {
    *
    * - Enable HMR and register the {@link https://rspack.rs/plugins/webpack/hot-module-replacement-plugin | HotModuleReplacementPlugin}.
    *
-   * - Generate JavaScript source maps, but do not generate CSS source maps. See {@link Output.sourceMap} for details.
+   * - Generate JavaScript and CSS source maps. In Lynx environments, all `.map` assets are removed before emit. See {@link Output.sourceMap} for details.
    *
    * - The `process.env.NODE_ENV` in the source code will be replaced with `'development'`.
    *
@@ -103,7 +103,7 @@ export interface Config {
    *
    * - Generated CSS Modules classnames will be shorter, see {@link CssModules.localIdentName}.
    *
-   * - Do not generate JavaScript and CSS source maps, see {@link Output.sourceMap}.
+   * - Generate JavaScript and CSS source maps. In Lynx environments, all `.map` assets are removed before emit. See {@link Output.sourceMap}.
    *
    * - The `process.env.NODE_ENV` in the source code will be replaced with `'production'`.
    *

--- a/packages/rspeedy/core/src/config/output/index.ts
+++ b/packages/rspeedy/core/src/config/output/index.ts
@@ -399,7 +399,7 @@ export interface Output {
   /**
    * The {@link SourceMap} configures whether and how to generate source-map for outputs.
    *
-   * @defaultValue When this option is unset, JavaScript source maps use `'cheap-module-source-map'` in development and are otherwise disabled; CSS source maps are disabled.
+   * @defaultValue When this option is unset in Lynx builds, JavaScript source maps use `'cheap-module-source-map'` in development and `'source-map'` in production; CSS source maps are also generated. All `.map` assets are removed before emit.
    */
   sourceMap?: boolean | SourceMap | undefined
 }

--- a/packages/rspeedy/core/src/config/output/source-map.ts
+++ b/packages/rspeedy/core/src/config/output/source-map.ts
@@ -12,7 +12,7 @@ export interface SourceMap {
   /**
    * How the source map should be generated. Setting it to `false` will disable the source map.
    *
-   * @defaultValue When `output.sourceMap` is an object and `js` is unset, it defaults to `'cheap-module-source-map'` in development and `false` in production.
+   * @defaultValue When `output.sourceMap` is an object and `js` is unset, it defaults to `'cheap-module-source-map'` in development. In production, it defaults to `'source-map'` for Lynx environments and `false` otherwise.
    *
    * @remarks
    *
@@ -78,7 +78,7 @@ export interface SourceMap {
    *
    * @remarks
    *
-   * Defaults to `true`.
+   * Defaults to `true`. In Lynx builds, all `.map` assets are removed before emit.
    *
    * @example
    *

--- a/packages/rspeedy/core/src/plugins/sourcemap.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/sourcemap.plugin.ts
@@ -6,6 +6,7 @@ import type { RsbuildPlugin, Rspack, RspackChain } from '@rsbuild/core'
 import invariant from 'tiny-invariant'
 import type { UndefinedOnPartialDeep } from 'type-fest'
 
+import { isLynx } from '../utils/is-lynx.js'
 import { EvalSourceMapDevToolPlugin } from '../webpack/EvalSourceMapDevToolPlugin.js'
 import { SourceMapDevToolPlugin } from '../webpack/SourceMapDevToolPlugin.js'
 
@@ -21,7 +22,9 @@ export function pluginSourcemap(): RsbuildPlugin {
 
         if (publicPath === false) {
           // `dev.assetPrefix === false`
-          // We do not modify the devtool option
+          // We do not modify the devtool option and keep the default
+          // sibling `.map` files reachable from their `sourceMappingURL`
+          // trailer.
           return
         }
 
@@ -40,6 +43,10 @@ export function pluginSourcemap(): RsbuildPlugin {
           ),
         )
 
+        if (isLynx(environment)) {
+          applyDropSourceMapAssets(chain)
+        }
+
         function getDevtoolFromSourceMap(): Rspack.DevTool {
           const DEFAULT_DEV_DEVTOOL = 'cheap-module-source-map'
 
@@ -53,18 +60,47 @@ export function pluginSourcemap(): RsbuildPlugin {
             }
             case 'undefined':
             case 'object': {
-              const isLynx = environment.name === 'lynx'
-                || environment.name.startsWith('lynx-')
               return output?.sourceMap?.js
                 ?? (isDev
                   ? DEFAULT_DEV_DEVTOOL
-                  : (isLynx ? 'source-map' : false))
+                  : (isLynx(environment) ? 'source-map' : false))
             }
           }
         }
       })
     },
   }
+}
+
+function applyDropSourceMapAssets(chain: RspackChain): void {
+  chain
+    .plugin('lynx:sourcemap-drop')
+    .use(
+      class DropSourceMapAssetsPlugin {
+        apply(compiler: Rspack.Compiler): void {
+          const { Compilation } = compiler.webpack
+          compiler.hooks.compilation.tap(
+            'LynxDropSourceMapAssetsPlugin',
+            (compilation) => {
+              compilation.hooks.processAssets.tap(
+                {
+                  name: 'LynxDropSourceMapAssetsPlugin',
+                  stage: Compilation.PROCESS_ASSETS_STAGE_REPORT + 1,
+                },
+                () => {
+                  for (const name of Object.keys(compilation.assets)) {
+                    if (name.endsWith('.map')) {
+                      compilation.deleteAsset(name)
+                    }
+                  }
+                },
+              )
+            },
+          )
+        }
+      },
+      [],
+    )
 }
 
 function applySourceMapPlugin(

--- a/packages/rspeedy/core/test/plugins/sourcemap.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/sourcemap.plugin.test.ts
@@ -17,6 +17,14 @@ beforeEach(() => {
   vi.resetAllMocks()
 })
 
+const hasDropPlugin = (plugins: unknown[] | undefined) =>
+  !!plugins?.some(
+    p =>
+      typeof p === 'object' && p !== null
+      && (p as { constructor?: { name?: string } }).constructor?.name
+        === 'DropSourceMapAssetsPlugin',
+  )
+
 describe('sourcemap.plugin', () => {
   describe('production', () => {
     test('defaults', async () => {
@@ -659,6 +667,31 @@ describe('sourcemap.plugin', () => {
           noSources: false,
         }),
       )
+    })
+  })
+
+  describe('drop .map assets', () => {
+    test('production build drops .map assets', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      const rspeedy = await createStubRspeedy({})
+      const config = await rspeedy.unwrapConfig({ action: 'build' })
+      expect(hasDropPlugin(config.plugins)).toBe(true)
+    })
+
+    test('dev build drops .map assets', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      const rspeedy = await createStubRspeedy({})
+      const config = await rspeedy.unwrapConfig()
+      expect(hasDropPlugin(config.plugins)).toBe(true)
+    })
+
+    test('does not drop .map assets when dev.assetPrefix is false', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      const rspeedy = await createStubRspeedy({
+        dev: { assetPrefix: false },
+      })
+      const config = await rspeedy.unwrapConfig()
+      expect(hasDropPlugin(config.plugins)).toBe(false)
     })
   })
 })

--- a/packages/rspeedy/plugin-react/package.json
+++ b/packages/rspeedy/plugin-react/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@lynx-js/config-rsbuild-plugin": "workspace:*",
+    "@lynx-js/debug-metadata": "workspace:*",
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-transform": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/plugin-react/test/sourcemap.test.ts
+++ b/packages/rspeedy/plugin-react/test/sourcemap.test.ts
@@ -13,6 +13,8 @@ import { SourceMapConsumer } from 'source-map'
 import type { NullableMappedPosition, RawSourceMap } from 'source-map'
 import { afterAll, afterEach, describe, expect, test, vi } from 'vitest'
 
+import { findSourceMap } from '@lynx-js/debug-metadata'
+import type { DebugMetadataAsset } from '@lynx-js/debug-metadata'
 import type { Output } from '@lynx-js/rspeedy'
 
 import { createStubRspeedy as createRspeedy } from './createRspeedy.js'
@@ -153,17 +155,44 @@ describe('Sourcemap', () => {
     ])
   })
 
-  test('js sourcemaps are emitted by default', async () => {
+  test('.map assets are dropped before emit', async () => {
     const tmp = await buildSourcemapFixture(undefined)
     const sourceMapFiles = await getSourceMapFiles(tmp)
 
-    expect(sourceMapFiles).toEqual([
-      '.rspeedy/main/background.js.map',
-      '.rspeedy/main/main-thread.js.map',
-      '.rspeedy/main/main.css.map',
-      'static/js/async/lazy-bundle-comp.jsx-react__background.js.map',
-      'static/js/async/lazy-bundle-comp.jsx-react__main-thread.js.map',
+    expect(sourceMapFiles).toEqual([])
+
+    const debugMetadataJson = await Promise.all([
+      readFile(
+        path.join(tmp, '.rspeedy/main/debug-metadata.json'),
+        'utf-8',
+      ),
+      readFile(
+        path.join(
+          tmp,
+          '.rspeedy/async/lazy-bundle-comp.jsx/debug-metadata.json',
+        ),
+        'utf-8',
+      ),
     ])
+    const metadata = debugMetadataJson.map(json =>
+      JSON.parse(json) as DebugMetadataAsset
+    )
+    const mapPathsInMetadata = metadata
+      .flatMap(meta => meta.artifacts)
+      .flatMap(a => a.debugSources)
+      .filter(d => d.kind === 'source-map')
+      .map(d => path.posix.normalize(d.path))
+      .sort()
+
+    expect(mapPathsInMetadata).toMatchInlineSnapshot(`
+      [
+        ".rspeedy/main/background.js.map",
+        ".rspeedy/main/main-thread.js.map",
+        ".rspeedy/main/main.css.map",
+        "static/js/async/lazy-bundle-comp.jsx-react__background.js.map",
+        "static/js/async/lazy-bundle-comp.jsx-react__main-thread.js.map",
+      ]
+    `)
   }, 25_000)
 
   test(
@@ -213,30 +242,46 @@ describe('Sourcemap', () => {
     async () => {
       const tmp = await buildSourcemapFixture({ css: true })
 
-      // find all `*.map` files inside tmp
-      const sourceMapFiles = await getSourceMapFiles(tmp)
+      const [mainMetadataJson, asyncMetadataJson] = await Promise.all([
+        readFile(
+          path.join(tmp, '.rspeedy/main/debug-metadata.json'),
+          'utf-8',
+        ),
+        readFile(
+          path.join(
+            tmp,
+            '.rspeedy/async/lazy-bundle-comp.jsx/debug-metadata.json',
+          ),
+          'utf-8',
+        ),
+      ])
+      const debugMetadata = JSON.parse(mainMetadataJson) as DebugMetadataAsset
+      const asyncMetadata = JSON.parse(asyncMetadataJson) as DebugMetadataAsset
+      const sourceMapFiles = [debugMetadata, asyncMetadata]
+        .flatMap(meta => meta.artifacts)
+        .flatMap(a => a.debugSources)
+        .filter(d => d.kind === 'source-map')
+        .map(d => path.posix.normalize(d.path))
+        .sort()
 
       expect(sourceMapFiles).toMatchInlineSnapshot(`
-      [
-        ".rspeedy/main/background.js.map",
-        ".rspeedy/main/main-thread.js.map",
-        ".rspeedy/main/main.css.map",
-        "static/js/async/lazy-bundle-comp.jsx-react__background.js.map",
-        "static/js/async/lazy-bundle-comp.jsx-react__main-thread.js.map",
-      ]
-    `)
+        [
+          ".rspeedy/main/background.js.map",
+          ".rspeedy/main/main-thread.js.map",
+          ".rspeedy/main/main.css.map",
+          "static/js/async/lazy-bundle-comp.jsx-react__background.js.map",
+          "static/js/async/lazy-bundle-comp.jsx-react__main-thread.js.map",
+        ]
+      `)
       expect(sourceMapFiles).toContain('.rspeedy/main/main.css.map')
 
       const cssSource = await readFile(
         path.join(tmp, '.rspeedy/main/main.css'),
         'utf-8',
       )
-      const cssSourceMap = JSON.parse(
-        await readFile(
-          path.join(tmp, '.rspeedy/main/main.css.map'),
-          'utf-8',
-        ),
-      ) as RawSourceMap
+      const cssSourceMap = findSourceMap(debugMetadata, {
+        filename: 'main.css.map',
+      })!.map as RawSourceMap
       const cssConsumer = await new SourceMapConsumer(cssSourceMap)
       const cssLine = cssSource
         .split('\n')
@@ -256,12 +301,9 @@ describe('Sourcemap', () => {
         path.join(tmp, '.rspeedy/main/background.js'),
         'utf-8',
       )
-      const backgroundSourceMap = JSON.parse(
-        await readFile(
-          path.join(tmp, '.rspeedy/main/background.js.map'),
-          'utf-8',
-        ),
-      ) as RawSourceMap
+      const backgroundSourceMap = findSourceMap(debugMetadata, {
+        filename: 'background.js.map',
+      })!.map as RawSourceMap
 
       const consumer = await new SourceMapConsumer(backgroundSourceMap)
       const functionName2Source: Record<string, NullableMappedPosition> = {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1574,6 +1574,9 @@ importers:
       '@lynx-js/config-rsbuild-plugin':
         specifier: workspace:*
         version: link:../plugin-config
+      '@lynx-js/debug-metadata':
+        specifier: workspace:*
+        version: link:../../tools/debug-metadata
       '@lynx-js/react':
         specifier: workspace:*
         version: link:../../react


### PR DESCRIPTION
## Summary

In Lynx environments, all `.map` assets are removed before emit. Web environments are intentionally untouched — browser devtools still needs a reachable `<file>.map` to follow the `sourceMappingURL` comment.

## Changes

- `packages/rspeedy/core/src/plugins/sourcemap.plugin.ts`: new `DropSourceMapAssetsPlugin` registered only when `environment.name === 'lynx'` or starts with `lynx-`. Drops every `*.map` from `compilation.assets` at `PROCESS_ASSETS_STAGE_REPORT + 1` (after any external sourcemap uploader that taps `STAGE_REPORT` or earlier).
- `packages/rspeedy/core/src/config/**`: align tsdoc with the new default.
- `packages/rspeedy/core/test/plugins/sourcemap.plugin.test.ts`: 2 cases — lynx prod drops, lynx dev drops.
- `packages/rspeedy/plugin-react/test/sourcemap.test.ts`: read maps from `debug-metadata.json` instead of sibling `.map` files.

## Stage timing

| Stage | Plugin | Note |
|---|---|---|
| 1500 `STAGE_DEV_TOOLING` | `SourceMapDevToolPlugin` | Generates `.map` into `compilation.assets` |
| 4000 `STAGE_OPTIMIZE_HASH` | `LynxTemplatePlugin` → `templateHooks.beforeEncode` | DebugMetadata plugin's `collectArtifacts` reads `.map` and packs it into `debug-metadata.json` |
| 7000 `STAGE_REPORT` | external uploaders (e.g. sentry) | usual hook |
| **7001 `STAGE_REPORT + 1`** | **`DropSourceMapAssetsPlugin` (new)** | **deletes every `*.map` asset** |

## Test plan

- [x] `pnpm --filter @lynx-js/rspeedy test plugins/sourcemap.plugin.test`
- [x] `pnpm --filter @lynx-js/react-rsbuild-plugin test sourcemap.test`
- [ ] CI green
- [ ] Build an example with both `lynx` and `web` environments, confirm `dist/<lynx-env>/**/*.map` empty but `dist/<web-env>/**/*.map` present
- [ ] Trigger an error on Lynx runtime, confirm reverse-mapping via debug-metadata still resolves to original source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source map assets (.map) are automatically removed before emit in Lynx environments.
  * CSS source maps are generated by default alongside JavaScript maps.

* **Documentation**
  * Clarified source-map defaults: development uses cheap-module-source-map; production uses source-map for Lynx builds.

* **Tests**
  * Added tests to confirm .map artifacts are dropped and mapping behavior is validated via debug metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->