### PR TITLE
feat(a2ui-playground): persist and reuse the conversation share link

### DIFF
--- a/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/AIChatPage.tsx
@@ -25,7 +25,10 @@ import type { StaticDemo } from '../demos.js';
 import { useConversation } from '../hooks/useConversation.js';
 import type { ModelChatMessage } from '../hooks/useConversation.js';
 import { useResizablePanels } from '../hooks/useResizablePanels.js';
-import { loadConversation } from '../storage/conversationRepo.js';
+import {
+  loadConversation,
+  saveConversationSharePayload,
+} from '../storage/conversationRepo.js';
 import {
   isSharedConversationDoc,
   serializeConversation,
@@ -2154,8 +2157,25 @@ export function AIChatPage(
           showCopyToast(false);
           return;
         }
-        const doc = serializeConversation(record, protocol.name);
-        const conversationUrl = await publishConversation(doc);
+        // Reuse the link already published for this conversation while it is
+        // unchanged, so repeated shares — including after a page reload — copy
+        // the same link instead of uploading a fresh copy (and minting a new
+        // URL) each time. `meta.updatedAt` bumps on every turn or rename, and a
+        // new turn rewrites the snapshot and drops the cached payload.
+        const cached = record.snapshot?.sharePayload;
+        let conversationUrl: string | undefined;
+        if (cached && cached.updatedAt === record.meta.updatedAt) {
+          conversationUrl = cached.url;
+        }
+        if (!conversationUrl) {
+          const doc = serializeConversation(record, protocol.name);
+          conversationUrl = await publishConversation(doc);
+          await saveConversationSharePayload(
+            id,
+            conversationUrl,
+            record.meta.updatedAt,
+          );
+        }
         const link = buildConversationShareUrl(
           conversationUrl,
           baseUrl,

--- a/packages/genui/a2ui-playground/src/storage/conversationRepo.ts
+++ b/packages/genui/a2ui-playground/src/storage/conversationRepo.ts
@@ -132,6 +132,27 @@ export async function saveConversationMessages(
   await tx.done;
 }
 
+/**
+ * Persist the durable URL of the published share document on the conversation
+ * snapshot, paired with the `meta.updatedAt` it was generated for. Touches only
+ * the snapshot's share field (not `meta.updatedAt`), so it does not invalidate
+ * itself; a later turn rewrites the snapshot and drops it.
+ */
+export async function saveConversationSharePayload(
+  conversationId: string,
+  url: string,
+  updatedAt: number,
+): Promise<void> {
+  const db = await getDB();
+  const tx = db.transaction('snapshots', 'readwrite');
+  const store = tx.objectStore('snapshots');
+  const snapshot = await store.get(conversationId);
+  if (snapshot) {
+    await store.put({ ...snapshot, sharePayload: { url, updatedAt } });
+  }
+  await tx.done;
+}
+
 export function previewTextFromSharedMessages(
   messages: SharedConversationDoc['messages'],
 ): string {

--- a/packages/genui/a2ui-playground/src/storage/types.ts
+++ b/packages/genui/a2ui-playground/src/storage/types.ts
@@ -41,6 +41,13 @@ export interface DataModelSnapshot {
   previewMessages?: unknown[];
   previewPayloadUrls?: PreviewPayloadUrls;
   updatedAt: number;
+  /**
+   * Durable URL of the most recently published "share whole conversation"
+   * document, paired with the `meta.updatedAt` it was generated for. Lets
+   * repeated shares (including after a page reload) reuse the same link until
+   * the conversation changes.
+   */
+  sharePayload?: { url: string; updatedAt: number };
 }
 
 export interface MetaRecord {


### PR DESCRIPTION
Sharing a conversation uploads the serialized document and builds an import link. Because each upload uses a fresh random storage path, every Share click — and every share after a page reload — minted a different link for the same, unchanged conversation.

Persist the published document URL on the conversation's IndexedDB snapshot, paired with the meta.updatedAt it was generated for, and reuse it while the conversation is unchanged. Repeated shares (within a session and across reloads) now copy the same link; a new turn or rename bumps updatedAt (and a turn also rewrites the snapshot), so the link refreshes exactly when the shared content changes.

- types.ts: DataModelSnapshot.sharePayload { url, updatedAt }
- conversationRepo.ts: saveConversationSharePayload()
- AIChatPage.tsx: shareConversation reuses the persisted URL, or uploads and persists a fresh one

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation sharing efficiency. When sharing a conversation multiple times without making changes, the system now reuses the previously published share link instead of creating a duplicate. This reduces unnecessary processing and ensures consistent share URLs for unchanged conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
