### PR TITLE
fix(a2ui): validate list template bindings

### DIFF
--- a/.github/a2ui-server-agent.instructions.md
+++ b/.github/a2ui-server-agent.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "packages/genui/server/agent/**"
+---
+
+When prompting or validating A2UI template children, follow the v0.9 collection scope rules: the container uses an absolute collection path such as `{ "path": "/items", "componentId": "itemRow" }`, while bindings inside the template component tree use relative item paths such as `{ "path": "name" }`. Do not generate or accept wildcard item bindings like `{ "path": "/items/*/name" }`; `*` appears only in validator-internal flattened data-model coverage.
+
+For repeated text values, model collection items as objects such as `{ "label": "Alpha" }` and bind the field with `{ "path": "label" }`. Do not use primitive arrays together with `{ "path": "." }`, because the current renderer does not resolve `.` as the current item.
+
+Do not conflate repeating data with the `List` component. Prefer `Column` template children for ordinary vertical repeated content and `Row` template children for ordinary horizontal repeated content. Reserve `List` for repeated content that needs a scrollable container.

--- a/packages/genui/server/agent/a2ui-catalog.ts
+++ b/packages/genui/server/agent/a2ui-catalog.ts
@@ -111,19 +111,22 @@ const COMPONENT_SUMMARIES: Record<string, string> = {
   CheckBox: 'Boolean checkbox with a label and optional validation checks.',
   ChoicePicker:
     'Single- or multi-select choice picker with checkbox and chip display styles.',
-  Column: 'Vertical layout container.',
+  Column:
+    'Vertical layout container. Preferred for ordinary non-scrollable repeated content using template children.',
   DateTimeInput:
     'Date and/or time input with a calendar panel. Without outputFormat, date-enabled inputs write YYYY-MM-DD.',
   Divider: 'Horizontal or vertical separator line.',
   Icon: 'Display an icon by name.',
   Image: 'Display an image by URL.',
   LineChart: 'Display one or more numeric line series over shared labels.',
-  List: 'Repeating layout container, commonly bound to a data path.',
+  List:
+    'Scrollable repeating layout container. Use when repeated content needs scrolling; otherwise prefer Column or Row template children.',
   Loading: 'Animated progress indicator for pending content.',
   Modal:
     'Modal dialog with a trigger component and a content component. The trigger opens the modal locally when tapped.',
   RadioGroup: 'Single-choice selector for a list of string options.',
-  Row: 'Horizontal layout container.',
+  Row:
+    'Horizontal layout container. Preferred for ordinary non-scrollable repeated content using template children.',
   Slider: 'Numeric slider with an optional label and validation checks.',
   Tabs: 'Tabbed container; each tab references a child component id.',
   Text:

--- a/packages/genui/server/agent/a2ui-examples.ts
+++ b/packages/genui/server/agent/a2ui-examples.ts
@@ -78,7 +78,7 @@ export const BASIC_CATALOG_EXAMPLES: A2UIExample[] = [
   },
   {
     name: 'dynamic-list',
-    user: 'Show three trip ideas as a compact list.',
+    user: 'Show three trip ideas as a compact vertical group.',
     messages: [
       {
         version: 'v0.9',
@@ -110,7 +110,7 @@ export const BASIC_CATALOG_EXAMPLES: A2UIExample[] = [
             {
               id: 'root',
               component: 'Column',
-              children: ['title', 'trip-list'],
+              children: ['title', 'trip-items'],
             },
             {
               id: 'title',
@@ -119,9 +119,8 @@ export const BASIC_CATALOG_EXAMPLES: A2UIExample[] = [
               variant: 'h2',
             },
             {
-              id: 'trip-list',
-              component: 'List',
-              direction: 'vertical',
+              id: 'trip-items',
+              component: 'Column',
               children: { path: '/items', componentId: 'trip-row' },
             },
             {
@@ -139,13 +138,13 @@ export const BASIC_CATALOG_EXAMPLES: A2UIExample[] = [
             {
               id: 'trip-name',
               component: 'Text',
-              text: { path: '/items/*/name' },
+              text: { path: 'name' },
               variant: 'h3',
             },
             {
               id: 'trip-detail',
               component: 'Text',
-              text: { path: '/items/*/detail' },
+              text: { path: 'detail' },
               variant: 'body',
             },
           ],

--- a/packages/genui/server/agent/a2ui-prompt.ts
+++ b/packages/genui/server/agent/a2ui-prompt.ts
@@ -69,16 +69,37 @@ and exactly ONE of the following keys:
     }
 - The component with id "root" is the entry point of the tree.
 - Layout containers (Row / Column / List) take "children": ["id1", "id2", ...].
-  To repeat from the data model, use "children":
+  To repeat from the data model, any of these containers can use "children":
     { "path": "/items", "componentId": "itemRow" }
+  Prefer Column for ordinary vertical repeated content and Row for ordinary
+  horizontal repeated content. Use List only when the repeated content should
+  be scrollable.
 - Card uses "child": "id".  Modal uses "trigger" + "content".  Tabs uses an
   array of {title, child}.
 
 ## Data binding
 - Static text:  "text": "Hello"
 - Bound text:   "text": { "path": "/user/name" }
-- Bound list children:
+- Bound repeating children:
     "children": { "path": "/items", "componentId": "itemRow" }
+- Inside the template component tree for a bound repeating container, bind item
+  fields with relative paths that match the object fields in each data-model
+  item. Example
+  data model:
+    { "items": [{ "item": "Alpha" }, { "item": "Beta" }] }
+  paired with:
+    "children": { "path": "/items", "componentId": "itemRow" }
+    "text": { "path": "item" }
+  If each array item is { "name": "Alpha" }, use { "path": "name" } instead.
+  For repeated text values, still use object items such as
+    { "items": [{ "label": "Alpha" }, { "label": "Beta" }] }
+  and bind with { "path": "label" }. Do NOT use primitive arrays like
+  { "items": ["Alpha", "Beta"] } with { "path": "." }; this renderer does not
+  resolve "." as the current item.
+  Template collection data MUST be an array of objects. If the source values
+  are plain strings, wrap them as objects before binding.
+  Do NOT use wildcard paths like "/items/*/item"; collection scope makes the
+  current item the base path automatically.
 - Use updateDataModel messages to populate values at those paths.
 - DynamicString/DynamicNumber/DynamicBoolean props accept either a literal value
   or { "path": "/json/pointer" }. If you bind a prop to a path, create the
@@ -115,6 +136,15 @@ function buildHardRules(catalogId: string): string {
    updateComponents message that contains components reading those paths. After
    createSurface, either send a literal root/skeleton updateComponents first, or
    send updateDataModel first when the first visible components use bindings.
+   In template children, use relative paths from the current item, for example
+   { "path": "item" }, never absolute wildcard paths like "/items/*/item".
+   Do not use { "path": "." }; for repeated primitive text values, model the
+   data as objects such as [{ "label": "Alpha" }] and bind "label".
+   Any data-model array used by template children MUST contain objects; never
+   bind template children to an array of strings/numbers/booleans.
+   Do not use List merely because data is repeated. Prefer Column/Row
+   template children for non-scrollable repeated content; reserve List for
+   scrollable collections.
 7. For a fresh non-action response, the first updateComponents message MUST
    contain exactly one component with id "root".
 8. Use property-based component discriminators: "component": "Text", not

--- a/packages/genui/server/agent/a2ui-validator.ts
+++ b/packages/genui/server/agent/a2ui-validator.ts
@@ -318,6 +318,7 @@ export function validateA2UIOutput(
   const componentsBySurface = new Map<string, Map<string, A2UIComponent>>();
   const allPaths: { surfaceId: string; path: string }[] = [];
   const providedPaths: { surfaceId: string; path: string }[] = [];
+  const templatePaths: { surfaceId: string; path: string }[] = [];
 
   for (
     const [surfaceId, dataModel] of Object.entries(
@@ -366,7 +367,28 @@ export function validateA2UIOutput(
         const componentPaths: string[] = [];
         collectPaths(comp, componentPaths);
         for (const path of componentPaths) {
+          if (isCurrentItemPath(path)) {
+            errors.push(
+              `Path "${path}" in component "${comp.id}" is not supported; use object array items and bind a relative field path like "label" inside template children.`,
+            );
+            continue;
+          }
+          if (hasWildcardSegment(path)) {
+            errors.push(
+              `Path "${path}" in component "${comp.id}" uses "*", but A2UI collection item bindings must use relative paths like "item" inside template children.`,
+            );
+            continue;
+          }
           allPaths.push({ surfaceId: sId, path });
+        }
+        for (const path of collectTemplatePaths(comp)) {
+          if (!path.startsWith('/')) {
+            errors.push(
+              `Template collection path "${path}" in component "${comp.id}" on surface "${sId}" must be absolute and start with "/".`,
+            );
+            continue;
+          }
+          templatePaths.push({ surfaceId: sId, path });
         }
       }
       componentsBySurface.set(sId, bucket);
@@ -432,8 +454,11 @@ export function validateA2UIOutput(
   for (const referenced of allPaths) {
     const providedSet = providedBySurface.get(referenced.surfaceId)
       ?? new Set<string>();
+    const surfaceTemplatePaths = templatePaths
+      .filter((template) => template.surfaceId === referenced.surfaceId)
+      .map((template) => template.path);
     const hasMatch = [...providedSet].some((provided) =>
-      isPathCovered(referenced.path, provided)
+      isPathReferenceCovered(referenced.path, provided, surfaceTemplatePaths)
     );
     if (!hasMatch) {
       errors.push(
@@ -447,6 +472,23 @@ export function validateA2UIOutput(
     messages: errors.length === 0 ? messages : [],
     errors,
   };
+}
+
+function isPathReferenceCovered(
+  referencedPath: string,
+  providedPath: string,
+  templatePaths: string[],
+): boolean {
+  if (referencedPath.startsWith('/')) {
+    return isPathCovered(referencedPath, providedPath);
+  }
+
+  for (const templatePath of templatePaths) {
+    const scopedPath = joinPath(templatePath, '*', referencedPath);
+    if (isPathCovered(scopedPath, providedPath)) return true;
+  }
+
+  return isPathCovered(referencedPath, providedPath);
 }
 
 function isPathCovered(referencedPath: string, providedPath: string): boolean {
@@ -482,6 +524,19 @@ function normalizePathSegments(path: string): string[] {
   return path.split('/').filter(Boolean);
 }
 
+function hasWildcardSegment(path: string): boolean {
+  return normalizePathSegments(path).includes('*');
+}
+
+function isCurrentItemPath(path: string): boolean {
+  return path === '.';
+}
+
+function joinPath(...parts: string[]): string {
+  const segments = parts.flatMap((part) => normalizePathSegments(part));
+  return `/${segments.join('/')}`;
+}
+
 function collectPaths(node: unknown, acc: string[]): void {
   if (!isRecord(node) && !Array.isArray(node)) return;
   if (Array.isArray(node)) {
@@ -494,6 +549,22 @@ function collectPaths(node: unknown, acc: string[]): void {
     return;
   }
   for (const value of Object.values(record)) collectPaths(value, acc);
+}
+
+function collectTemplatePaths(comp: A2UIComponent): string[] {
+  const children = comp.children;
+  if (!isRecord(children)) return [];
+
+  const paths: string[] = [];
+  const directPath = children.path;
+  if (typeof directPath === 'string') paths.push(directPath);
+
+  const template = children.template;
+  if (isRecord(template) && typeof template.path === 'string') {
+    paths.push(template.path);
+  }
+
+  return paths;
 }
 
 function collectChildRefs(comp: A2UIComponent): string[] {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded catalog guidance with richer advice on choosing Column/Row vs List and handling repeated content; clarified template-child binding rules and prohibitions.

* **Infrastructure**
  * Strengthened validation and error reporting for template/data bindings, rejecting ambiguous or wildcard/relative misuse and improving coverage checks.

* **Examples**
  * Updated dynamic-list example to use compact vertical grouping and relative item bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
