### PR TITLE
feat(debug-metadata): rename tos_key to metadata_key, add --header/-H to remap CLI

### DIFF
--- a/.changeset/debug-metadata-remap-cli-headers.md
+++ b/.changeset/debug-metadata-remap-cli-headers.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/debug-metadata": minor
+---
+
+Add a repeatable `--header`/`-H` option to the `debug-metadata remap` CLI so extra HTTP headers (e.g. `-H "authorization: Bearer xxx"`) are forwarded when fetching a `debugMetadataUrl` from an auth-gated endpoint.

--- a/packages/rspeedy/plugin-debug-metadata/test/source-mapping-url-rewriter.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/source-mapping-url-rewriter.test.ts
@@ -223,7 +223,7 @@ describe('rewriteSourceMappingURLToAbsolute', () => {
 
 describe('rewriteSourceMappingURL', () => {
   const CUSTOM_URL =
-    'https://gateway.example/raw?tos_key=abc123&field=source-map&path=foo.js.map'
+    'https://gateway.example/raw?metadata_key=abc123&field=source-map&path=foo.js.map'
 
   test('substitutes the caller URL verbatim into a `//#` directive', () => {
     const before = wrap('//# sourceMappingURL=foo.js.map')

--- a/packages/tools/debug-metadata/src/cli.ts
+++ b/packages/tools/debug-metadata/src/cli.ts
@@ -44,8 +44,8 @@ function resolveRef(ref: string, baseFile: string): string {
 
 /**
  * Parse a single `--header` value of the form "name: value". The first ":"
- * separates name from value (so values may contain ":"). The header name is
- * trimmed and lowercased; the value is trimmed but otherwise preserved.
+ * separates name from value (so values may contain ":"). The header name and
+ * value are both trimmed; casing is otherwise preserved.
  *
  * @internal
  */

--- a/packages/tools/debug-metadata/src/cli.ts
+++ b/packages/tools/debug-metadata/src/cli.ts
@@ -5,12 +5,13 @@
 
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type { DebugMetadataAsset } from './types.js';
 import { assertUiNode, remapUiTree } from './ui-remap.js';
 
 const USAGE =
-  `Usage: debug-metadata remap --ui <input.json> [--output <output.json>]
+  `Usage: debug-metadata remap --ui <input.json> [--output <output.json>] [--header <name: value>]...
 
 Reverse-resolve a Lynx UI node tree dumped by the engine. Every node that
 carries a "nodeIndex" and a "debugMetadataUrl" is annotated with its source
@@ -18,7 +19,14 @@ location ("repo", "source", "line", "column"); all other fields — and nodes
 that cannot be resolved — pass through unchanged.
 
 A node's "debugMetadataUrl" may be an http(s) URL or a path relative to the
-input file. Output is written to --output when given, otherwise to stdout.`;
+input file. Output is written to --output when given, otherwise to stdout.
+
+Options:
+  --ui, -i <input.json>           Path to the UI tree JSON dumped by the engine.
+  --output, -o <output.json>      Write remapped tree here instead of stdout.
+  --header, -H <name: value>      Extra HTTP header for fetching debugMetadataUrl
+                                  (repeatable; e.g. -H "authorization: Bearer xxx"
+                                  for endpoints that require auth).`;
 
 function isHttpUrl(value: string): boolean {
   return /^https?:\/\//.test(value);
@@ -34,13 +42,36 @@ function resolveRef(ref: string, baseFile: string): string {
   return path.resolve(path.dirname(baseFile), ref);
 }
 
+/**
+ * Parse a single `--header` value of the form "name: value". The first ":"
+ * separates name from value (so values may contain ":"). The header name is
+ * trimmed and lowercased; the value is trimmed but otherwise preserved.
+ *
+ * @internal
+ */
+export function parseHeader(raw: string): [string, string] {
+  const idx = raw.indexOf(':');
+  if (idx < 0) {
+    throw new Error(
+      `Invalid --header value (expected "name: value"): ${raw}`,
+    );
+  }
+  const name = raw.slice(0, idx).trim();
+  const value = raw.slice(idx + 1).trim();
+  if (name === '') {
+    throw new Error(`Invalid --header value (empty name): ${raw}`);
+  }
+  return [name, value];
+}
+
 function createLoader(
   inputPath: string,
+  headers: Record<string, string>,
 ): (debugMetadataUrl: string) => Promise<DebugMetadataAsset> {
   return async (debugMetadataUrl) => {
     const ref = resolveRef(debugMetadataUrl, inputPath);
     if (isHttpUrl(ref)) {
-      const response = await fetch(ref);
+      const response = await fetch(ref, { headers });
       if (!response.ok) {
         throw new Error(
           `Failed to fetch ${ref}: ${response.status} ${response.statusText}`,
@@ -55,10 +86,12 @@ function createLoader(
 interface RemapArgs {
   ui?: string;
   output?: string;
+  headers: Record<string, string>;
 }
 
-function parseRemapArgs(argv: string[]): RemapArgs {
-  const args: RemapArgs = {};
+/** @internal */
+export function parseRemapArgs(argv: string[]): RemapArgs {
+  const args: RemapArgs = { headers: {} };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     const requireValue = (): string => {
@@ -77,6 +110,12 @@ function parseRemapArgs(argv: string[]): RemapArgs {
       case '-o':
         args.output = requireValue();
         break;
+      case '--header':
+      case '-H': {
+        const [name, value] = parseHeader(requireValue());
+        args.headers[name] = value;
+        break;
+      }
       default:
         throw new Error(`Unknown argument: ${arg ?? ''}`);
     }
@@ -94,7 +133,10 @@ async function runRemap(argv: string[]): Promise<void> {
   const root: unknown = JSON.parse(await readFile(inputPath, 'utf8'));
   assertUiNode(root);
 
-  const remapped = await remapUiTree(root, createLoader(inputPath));
+  const remapped = await remapUiTree(
+    root,
+    createLoader(inputPath, args.headers),
+  );
   const serialized = `${JSON.stringify(remapped, null, 2)}\n`;
 
   if (args.output === undefined) {
@@ -122,10 +164,19 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error: unknown) => {
-  const message = error instanceof Error
-    ? (error.stack ?? error.message)
-    : String(error);
-  process.stderr.write(`${message}\n`);
-  process.exitCode = 1;
-});
+// Only run main() when this file is invoked as the CLI entry point — avoids
+// kicking off argv parsing when imported from tests. Use fileURLToPath +
+// path.resolve so the comparison handles Windows separators, drive-letter
+// casing, and percent-encoded characters in the file:// URL.
+if (
+  process.argv[1] !== undefined
+  && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error
+      ? (error.stack ?? error.message)
+      : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/tools/debug-metadata/test/cli.test.ts
+++ b/packages/tools/debug-metadata/test/cli.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from 'vitest';
+
+import { parseHeader, parseRemapArgs } from '../src/cli.js';
+
+describe('parseHeader', () => {
+  test('splits "name: value" on the first colon', () => {
+    expect(parseHeader('internal-token: abc')).toEqual([
+      'internal-token',
+      'abc',
+    ]);
+  });
+
+  test('preserves colons inside the value', () => {
+    expect(parseHeader('referer: https://example.com:8443/path')).toEqual([
+      'referer',
+      'https://example.com:8443/path',
+    ]);
+  });
+
+  test('trims surrounding whitespace from name and value', () => {
+    expect(parseHeader('  Authorization  :   Bearer abc  ')).toEqual([
+      'Authorization',
+      'Bearer abc',
+    ]);
+  });
+
+  test('rejects values without a colon', () => {
+    expect(() => parseHeader('no-colon')).toThrow(/expected "name: value"/);
+  });
+
+  test('rejects empty header name', () => {
+    expect(() => parseHeader(': value')).toThrow(/empty name/);
+  });
+
+  test('accepts empty value', () => {
+    expect(parseHeader('x-empty:')).toEqual(['x-empty', '']);
+  });
+});
+
+describe('parseRemapArgs', () => {
+  test('parses --ui and --output', () => {
+    const args = parseRemapArgs(['--ui', 'in.json', '--output', 'out.json']);
+    expect(args.ui).toBe('in.json');
+    expect(args.output).toBe('out.json');
+    expect(args.headers).toEqual({});
+  });
+
+  test('accepts -i and -o short flags', () => {
+    const args = parseRemapArgs(['-i', 'in.json', '-o', 'out.json']);
+    expect(args.ui).toBe('in.json');
+    expect(args.output).toBe('out.json');
+  });
+
+  test('collects repeated --header values', () => {
+    const args = parseRemapArgs([
+      '--ui',
+      'in.json',
+      '--header',
+      'internal-token: abc',
+      '--header',
+      'authorization: Bearer xyz',
+    ]);
+    expect(args.headers).toEqual({
+      'internal-token': 'abc',
+      'authorization': 'Bearer xyz',
+    });
+  });
+
+  test('accepts -H short flag for headers', () => {
+    const args = parseRemapArgs([
+      '-i',
+      'in.json',
+      '-H',
+      'internal-token: abc',
+      '-H',
+      'accept: application/json',
+    ]);
+    expect(args.headers).toEqual({
+      'internal-token': 'abc',
+      'accept': 'application/json',
+    });
+  });
+
+  test('later --header for the same name wins', () => {
+    const args = parseRemapArgs([
+      '-i',
+      'in.json',
+      '-H',
+      'internal-token: old',
+      '-H',
+      'internal-token: new',
+    ]);
+    expect(args.headers).toEqual({ 'internal-token': 'new' });
+  });
+
+  test('rejects unknown arguments', () => {
+    expect(() => parseRemapArgs(['--mystery', 'x'])).toThrow(
+      /Unknown argument/,
+    );
+  });
+
+  test('rejects --header without a value', () => {
+    expect(() => parseRemapArgs(['--ui', 'in.json', '--header'])).toThrow(
+      /Missing value/,
+    );
+  });
+
+  test('rejects malformed --header value', () => {
+    expect(() => parseRemapArgs(['--ui', 'in.json', '--header', 'no-colon']))
+      .toThrow(/expected "name: value"/);
+  });
+});


### PR DESCRIPTION
Two changes that go together because both touch `@lynx-js/debug-metadata`'s remap surface:

1. **Rename test fixture** `tos_key` → `metadata_key` (matches an IDL rename on the backend; no logic change).

2. **Add `--header` / `-H` to `debug-metadata remap`** so callers can forward auth headers when fetching `debugMetadataUrl`. If the endpoint that backs `debugMetadataUrl` requires auth, the CLI cannot reach it without this flag.

   ```bash
   debug-metadata remap --ui dump.json \\
     -H 'internal-token: $TOKEN' \\
     -H 'authorization: Bearer $JWT'
   ```

   Repeatable; `name: value` (first colon splits, so values may contain colons). Headers are passed verbatim to `fetch()`; local file refs ignore them. New `test/cli.test.ts` covers `--header`/`-H`, repeated flags, malformed values, and the existing `--ui`/`--output`/`-i`/`-o` paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI remap accepts repeatable --header/-H flags (validated, later values override) and passes headers when fetching metadata.
  * CLI no longer runs argument parsing when imported, preventing side effects.

* **Tests**
  * Updated source-mapping URL test fixture.
  * Added tests for header parsing and remap argument handling (repeats, overrides, validation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->