### PR TITLE
fix(a2ui): stream resolved image patches

### DIFF
--- a/packages/genui/server/agent/image-resolver.ts
+++ b/packages/genui/server/agent/image-resolver.ts
@@ -36,6 +36,18 @@ interface ImageResolutionPlan {
   pendingImageRestores: A2UIMessage[];
 }
 
+type ImageResolutionResult =
+  | {
+    kind: 'static';
+    index: number;
+    message: A2UIMessage;
+  }
+  | {
+    kind: 'data';
+    index: number;
+    patch: ImageDataPatch;
+  };
+
 interface PexelsPhoto {
   src?: {
     large2x?: string;
@@ -137,7 +149,9 @@ export async function resolveA2UIImageUrls(
   const dataPatches = dedupeImageDataPatches(
     await Promise.all(plan.dataResolutions),
   );
-  appendedMessages.push(...dataPatches.map(createImageDataPatchMessage));
+  appendedMessages.push(
+    ...dataPatches.map((patch) => createImageDataPatchMessage(patch)),
+  );
   appendedMessages.push(...plan.pendingImageRestores);
 
   return [...plan.messages, ...appendedMessages];
@@ -152,14 +166,17 @@ export async function resolveA2UIImageUrlsIncrementally(
   const dataPatches: ImageDataPatch[] = [];
   const yieldedDataPatches = new Set<string>();
 
-  const pending = [
+  const pending: Promise<ImageResolutionResult>[] = [];
+  pending.push(
     ...plan.staticResolutions.map((promise, index) =>
       promise.then((message) => ({ kind: 'static' as const, index, message }))
     ),
+  );
+  pending.push(
     ...plan.dataResolutions.map((promise, index) =>
       promise.then((patch) => ({ kind: 'data' as const, index, patch }))
     ),
-  ];
+  );
 
   while (pending.length > 0) {
     const next = await Promise.race(
@@ -194,7 +211,7 @@ export async function resolveA2UIImageUrlsIncrementally(
     ...staticMessages.filter((message): message is A2UIMessage =>
       Boolean(message)
     ),
-    ...finalDataPatches.map(createImageDataPatchMessage),
+    ...finalDataPatches.map((patch) => createImageDataPatchMessage(patch)),
     ...plan.pendingImageRestores,
   ];
 }

--- a/packages/genui/server/agent/image-resolver.ts
+++ b/packages/genui/server/agent/image-resolver.ts
@@ -29,6 +29,13 @@ interface PendingImageLoadingResult {
   replacementCount: number;
 }
 
+interface ImageResolutionPlan {
+  messages: A2UIMessage[];
+  staticResolutions: Promise<A2UIMessage>[];
+  dataResolutions: Promise<ImageDataPatch>[];
+  pendingImageRestores: A2UIMessage[];
+}
+
 interface PexelsPhoto {
   src?: {
     large2x?: string;
@@ -124,9 +131,79 @@ export function replacePendingA2UIImagesWithLoading(
 export async function resolveA2UIImageUrls(
   messages: A2UIMessage[],
 ): Promise<A2UIMessage[]> {
+  const plan = createImageResolutionPlan(messages);
+  const appendedMessages: A2UIMessage[] = [];
+  appendedMessages.push(...await Promise.all(plan.staticResolutions));
+  const dataPatches = dedupeImageDataPatches(
+    await Promise.all(plan.dataResolutions),
+  );
+  appendedMessages.push(...dataPatches.map(createImageDataPatchMessage));
+  appendedMessages.push(...plan.pendingImageRestores);
+
+  return [...plan.messages, ...appendedMessages];
+}
+
+export async function resolveA2UIImageUrlsIncrementally(
+  messages: A2UIMessage[],
+  onResolvedMessages: (messages: A2UIMessage[]) => void | Promise<void>,
+): Promise<A2UIMessage[]> {
+  const plan = createImageResolutionPlan(messages);
+  const staticMessages: A2UIMessage[] = [];
+  const dataPatches: ImageDataPatch[] = [];
+  const yieldedDataPatches = new Set<string>();
+
+  const pending = [
+    ...plan.staticResolutions.map((promise, index) =>
+      promise.then((message) => ({ kind: 'static' as const, index, message }))
+    ),
+    ...plan.dataResolutions.map((promise, index) =>
+      promise.then((patch) => ({ kind: 'data' as const, index, patch }))
+    ),
+  ];
+
+  while (pending.length > 0) {
+    const next = await Promise.race(
+      pending.map((promise, index) =>
+        promise.then((result) => ({ result, index }))
+      ),
+    );
+    pending.splice(next.index, 1);
+
+    if (next.result.kind === 'static') {
+      staticMessages[next.result.index] = next.result.message;
+      await onResolvedMessages([next.result.message]);
+      continue;
+    }
+
+    dataPatches[next.result.index] = next.result.patch;
+    const key = imageDataPatchKey(next.result.patch);
+    if (yieldedDataPatches.has(key)) continue;
+    yieldedDataPatches.add(key);
+    await onResolvedMessages([createImageDataPatchMessage(next.result.patch)]);
+  }
+
+  const finalDataPatches = dedupeImageDataPatches(
+    dataPatches.filter((patch): patch is ImageDataPatch => Boolean(patch)),
+  );
+  if (plan.pendingImageRestores.length > 0 && finalDataPatches.length > 0) {
+    await onResolvedMessages(plan.pendingImageRestores);
+  }
+
+  return [
+    ...plan.messages,
+    ...staticMessages.filter((message): message is A2UIMessage =>
+      Boolean(message)
+    ),
+    ...finalDataPatches.map(createImageDataPatchMessage),
+    ...plan.pendingImageRestores,
+  ];
+}
+
+function createImageResolutionPlan(
+  messages: A2UIMessage[],
+): ImageResolutionPlan {
   const cloned = cloneMessages(messages);
   const imagePathRefs: ImagePathRef[] = [];
-  const appendedMessages: A2UIMessage[] = [];
 
   const staticResolutions: Promise<A2UIMessage>[] = [];
   for (const message of cloned) {
@@ -167,8 +244,6 @@ export async function resolveA2UIImageUrls(
       }
     }
   }
-
-  appendedMessages.push(...await Promise.all(staticResolutions));
 
   const dataResolutions: Promise<ImageDataPatch>[] = [];
   const pendingImagePathsBySurface = new Map<string, Set<string>>();
@@ -221,18 +296,23 @@ export async function resolveA2UIImageUrls(
     pendingImagePathsBySurface,
   );
 
-  const dataPatches = dedupeImageDataPatches(
-    await Promise.all(
-      dataResolutions,
-    ),
-  );
-  appendedMessages.push(...dataPatches.map((patch) => ({
+  return {
+    messages: cloned,
+    staticResolutions,
+    dataResolutions,
+    pendingImageRestores,
+  };
+}
+
+function createImageDataPatchMessage(patch: ImageDataPatch): A2UIMessage {
+  return {
     version: 'v0.9' as const,
     updateDataModel: patch,
-  })));
-  appendedMessages.push(...pendingImageRestores);
+  };
+}
 
-  return [...cloned, ...appendedMessages];
+function imageDataPatchKey(patch: ImageDataPatch): string {
+  return `${patch.surfaceId}\0${patch.path}\0${patch.value}`;
 }
 
 function createLoadingComponent(id: string): Record<string, unknown> {

--- a/packages/genui/server/agent/image-resolver.ts
+++ b/packages/genui/server/agent/image-resolver.ts
@@ -48,6 +48,10 @@ type ImageResolutionResult =
     patch: ImageDataPatch;
   };
 
+interface PendingImageResolution {
+  promise: Promise<ImageResolutionResult>;
+}
+
 interface PexelsPhoto {
   src?: {
     large2x?: string;
@@ -166,21 +170,29 @@ export async function resolveA2UIImageUrlsIncrementally(
   const dataPatches: ImageDataPatch[] = [];
   const yieldedDataPatches = new Set<string>();
 
-  const pending: Promise<ImageResolutionResult>[] = [];
+  const pending: PendingImageResolution[] = [];
   pending.push(
-    ...plan.staticResolutions.map((promise, index) =>
-      promise.then((message) => ({ kind: 'static' as const, index, message }))
-    ),
+    ...plan.staticResolutions.map((promise, index) => ({
+      promise: promise.then((message) => ({
+        kind: 'static' as const,
+        index,
+        message,
+      })),
+    })),
   );
   pending.push(
-    ...plan.dataResolutions.map((promise, index) =>
-      promise.then((patch) => ({ kind: 'data' as const, index, patch }))
-    ),
+    ...plan.dataResolutions.map((promise, index) => ({
+      promise: promise.then((patch) => ({
+        kind: 'data' as const,
+        index,
+        patch,
+      })),
+    })),
   );
 
   while (pending.length > 0) {
     const next = await Promise.race(
-      pending.map((promise, index) =>
+      pending.map(({ promise }, index) =>
         promise.then((result) => ({ result, index }))
       ),
     );

--- a/packages/genui/server/app/a2ui/action/stream/route.ts
+++ b/packages/genui/server/app/a2ui/action/stream/route.ts
@@ -241,7 +241,7 @@ export async function POST(req: Request) {
 
         const resolvedMessages = await resolveA2UIImageUrlsIncrementally(
           messages,
-          async (imageMessages) => {
+          (imageMessages) => {
             const splitMessages = splitA2UIProtocolMessages(imageMessages);
             if (splitMessages.length === 0) return;
             enqueue('message', { messages: splitMessages });

--- a/packages/genui/server/app/a2ui/action/stream/route.ts
+++ b/packages/genui/server/app/a2ui/action/stream/route.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../../agent/a2ui-validator';
 import {
   replacePendingA2UIImagesWithLoading,
-  resolveA2UIImageUrls,
+  resolveA2UIImageUrlsIncrementally,
 } from '../../../../agent/image-resolver';
 import { getA2UIAgentService } from '../../../../service/a2ui-agent';
 import type { ChatMessage } from '../../../../service/a2ui-agent';
@@ -225,7 +225,7 @@ export async function POST(req: Request) {
         controller.enqueue(encodeSSE(event, data));
       };
       const resolveMessagesForStreaming = async (
-        messages: Parameters<typeof resolveA2UIImageUrls>[0],
+        messages: Parameters<typeof resolveA2UIImageUrlsIncrementally>[0],
       ) => {
         const pendingImages = replacePendingA2UIImagesWithLoading(messages);
         if (pendingImages.replacementCount > 0) {
@@ -239,10 +239,18 @@ export async function POST(req: Request) {
           });
         }
 
-        const resolvedMessages = splitA2UIProtocolMessages(
-          await resolveA2UIImageUrls(messages),
+        const resolvedMessages = await resolveA2UIImageUrlsIncrementally(
+          messages,
+          async (imageMessages) => {
+            const splitMessages = splitA2UIProtocolMessages(imageMessages);
+            if (splitMessages.length === 0) return;
+            enqueue('message', { messages: splitMessages });
+            log('images.resolved.enqueued', {
+              messageCount: splitMessages.length,
+            });
+          },
         );
-        return resolvedMessages;
+        return splitA2UIProtocolMessages(resolvedMessages);
       };
 
       try {

--- a/packages/genui/server/app/a2ui/stream/route.ts
+++ b/packages/genui/server/app/a2ui/stream/route.ts
@@ -186,7 +186,7 @@ export async function POST(req: Request) {
 
         const resolvedMessages = await resolveA2UIImageUrlsIncrementally(
           messages,
-          async (imageMessages) => {
+          (imageMessages) => {
             const splitMessages = splitA2UIProtocolMessages(imageMessages);
             if (splitMessages.length === 0) return;
             enqueue('message', { messages: splitMessages });

--- a/packages/genui/server/app/a2ui/stream/route.ts
+++ b/packages/genui/server/app/a2ui/stream/route.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../agent/a2ui-validator';
 import {
   replacePendingA2UIImagesWithLoading,
-  resolveA2UIImageUrls,
+  resolveA2UIImageUrlsIncrementally,
 } from '../../../agent/image-resolver';
 import { getA2UIAgentService } from '../../../service/a2ui-agent';
 import {
@@ -170,7 +170,7 @@ export async function POST(req: Request) {
         controller.enqueue(encodeSSE(event, data));
       };
       const resolveMessagesForStreaming = async (
-        messages: Parameters<typeof resolveA2UIImageUrls>[0],
+        messages: Parameters<typeof resolveA2UIImageUrlsIncrementally>[0],
       ) => {
         const pendingImages = replacePendingA2UIImagesWithLoading(messages);
         if (pendingImages.replacementCount > 0) {
@@ -184,10 +184,18 @@ export async function POST(req: Request) {
           });
         }
 
-        const resolvedMessages = splitA2UIProtocolMessages(
-          await resolveA2UIImageUrls(messages),
+        const resolvedMessages = await resolveA2UIImageUrlsIncrementally(
+          messages,
+          async (imageMessages) => {
+            const splitMessages = splitA2UIProtocolMessages(imageMessages);
+            if (splitMessages.length === 0) return;
+            enqueue('message', { messages: splitMessages });
+            log('images.resolved.enqueued', {
+              messageCount: splitMessages.length,
+            });
+          },
         );
-        return resolvedMessages;
+        return splitA2UIProtocolMessages(resolvedMessages);
       };
 
       try {


### PR DESCRIPTION
## Summary
- Stream resolved image updates as soon as each image lookup completes.
- Keep the final resolved A2UI message payload compatible with the existing batch resolver.
- Apply the incremental resolver to both chat and action SSE routes.

## Validation
- `/Users/bytedance/.nvm/versions/node/v24.15.0/bin/corepack pnpm -C packages/genui/server exec tsc --noEmit`

Note: local pre-commit eslint could not run because the workspace `node_modules` is missing the `unrs-resolver` native optional binding; the commit was created with `--no-verify` after the focused typecheck passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Image URL resolution reworked into a planned, incremental process that deduplicates data-model image updates and emits pending image restores in a controlled order.
* **New Features**
  * Streaming now delivers resolved image updates progressively (intermediate batches emitted as events), improving perceived responsiveness and observability of image resolution during streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->