### PR TITLE
feat: introduce OpenUI v0.5

### DIFF
--- a/.changeset/openui-v05-lang-core.md
+++ b/.changeset/openui-v05-lang-core.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": patch
+---
+
+Introduce OpenUI v0.5 rendering support and update the OpenUI language runtime dependency.

--- a/.github/openui-v05.instructions.md
+++ b/.github/openui-v05.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "packages/genui/openui/**"
+---
+
+When maintaining `packages/genui/openui`, treat OpenUI v0.5 rendering as driven by raw response text through `<OpenUiRenderer response={...}>`. Keep `<OpenUiRenderer result={...}>` only as the legacy pre-parsed/static compatibility path; v0.5 features such as `$` state declarations, `Query`, `Mutation`, and multi-step `Action` plans need the parser/evaluator runtime created by `useOpenUIState`.
+
+When changing exported OpenUI runtime APIs, refresh both API reports with `pnpm turbo api-extractor --filter @lynx-js/genui-openui -- --local` and `pnpm turbo api-extractor --filter @lynx-js/genui -- --local`, because `@lynx-js/genui` re-exports the OpenUI surface.
+
+When adding OpenUI v0.5 cases to `packages/genui/a2ui-playground`, keep raw protocol examples limited to components supported by `packages/genui/openui/src/catalog` unless the same change extends the catalog. Query and Mutation examples need matching mock tools in `packages/genui/a2ui-playground/lynx-src/openui/App.tsx` so `/render.html` previews exercise the runtime path instead of staying on default or unresolved values.

--- a/packages/genui/README.md
+++ b/packages/genui/README.md
@@ -88,21 +88,17 @@ component details.
 
 ## OpenUI
 
-OpenUI renders parsed OpenUI DSL through a configurable component library.
+OpenUI renders OpenUI Lang v0.5 responses through a configurable component
+library.
 
 ```tsx
-import {
-  OpenUiRenderer,
-  createOpenUiLibrary,
-  createStreamingParser,
-} from '@lynx-js/genui/openui';
+import { OpenUiRenderer, createOpenUiLibrary } from '@lynx-js/genui/openui';
 
 const library = createOpenUiLibrary();
-const parser = createStreamingParser(library.toJSONSchema());
-const result = parser.push('root = Stack([TextContent("Hello")])');
+const response = 'root = Stack([TextContent("Hello")])';
 
 export function OpenUIScreen() {
-  return <OpenUiRenderer result={result} library={library} />;
+  return <OpenUiRenderer response={response} library={library} />;
 }
 ```
 

--- a/packages/genui/a2ui-playground/lynx-src/openui/App.tsx
+++ b/packages/genui/a2ui-playground/lynx-src/openui/App.tsx
@@ -1,18 +1,13 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import {
-  OpenUiRenderer,
-  createOpenUiLibrary,
-  createStreamingParser,
-} from '@lynx-js/genui/openui';
-import type { ActionEvent, ParseResult } from '@lynx-js/genui/openui';
+import { OpenUiRenderer, createOpenUiLibrary } from '@lynx-js/genui/openui';
+import type { ActionEvent } from '@lynx-js/genui/openui';
 import {
   useCallback,
   useEffect,
   useGlobalProps,
   useMemo,
-  useRef,
   useState,
 } from '@lynx-js/react';
 
@@ -24,6 +19,51 @@ const DEFAULT_STREAM_DELAY_MS = 30;
 export function App() {
   const globalProps = useGlobalProps() as Record<string, unknown> | null;
   const openUiLibrary = useMemo(() => createOpenUiLibrary(), []);
+  const openUiToolProvider = useMemo<
+    Record<string, (args: Record<string, unknown>) => unknown>
+  >(() => ({
+    get_weather(args) {
+      const city = typeof args.city === 'string' ? args.city : 'Seattle';
+      if (city === 'San Francisco') {
+        return {
+          city,
+          temp: 64,
+          condition: 'Fog clearing',
+          high: 68,
+          low: 55,
+          humidity: '72%',
+          wind: '11 mph',
+          updated: 'mocked just now',
+          alerts: ['Marine layer expected this evening.'],
+        };
+      }
+      return {
+        city: 'Seattle',
+        temp: 71,
+        condition: 'Partly cloudy',
+        high: 76,
+        low: 58,
+        humidity: '61%',
+        wind: '8 mph',
+        updated: 'mocked just now',
+        alerts: [],
+      };
+    },
+    get_release_queue() {
+      return {
+        count: 3,
+        next: 'Ship OpenUI v0.5 playground cases',
+        owner: 'GenUI',
+      };
+    },
+    save_release_note(args) {
+      return {
+        ok: true,
+        id: 'release-note-openui-v05',
+        saved: args,
+      };
+    },
+  }), []);
 
   // Read rawText from globalProps; fall back to hardcoded mock data.
   const rawText = useMemo(() => {
@@ -44,24 +84,17 @@ export function App() {
     return DEFAULT_STREAM_DELAY_MS / speed;
   }, [globalProps]);
 
-  const [parseResult, setParseResult] = useState<ParseResult | null>(null);
+  const [response, setResponse] = useState<string>('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
-  const streamParserRef = useRef<
-    ReturnType<typeof createStreamingParser> | null
-  >(null);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setIsStreaming(true);
     setError('');
-    setParseResult(null);
-
-    const schema = openUiLibrary.toJSONSchema();
-    const streamParser = createStreamingParser(schema);
-    streamParserRef.current = streamParser;
+    setResponse('');
 
     let offset = 0;
 
@@ -75,8 +108,7 @@ export function App() {
       try {
         const chunk = rawText.slice(offset, offset + DEFAULT_CHUNK_SIZE);
         offset += DEFAULT_CHUNK_SIZE;
-        const result = streamParser.push(chunk);
-        setParseResult(result);
+        setResponse((prev) => prev + chunk);
         setLoading(false);
       } catch (e) {
         setError(String(e));
@@ -92,7 +124,6 @@ export function App() {
 
     return () => {
       cancelled = true;
-      streamParserRef.current = null;
     };
   }, [openUiLibrary, rawText, streamDelay]);
 
@@ -118,12 +149,13 @@ export function App() {
         )
         : null}
 
-      {parseResult?.root
+      {response
         ? (
           <scroll-view scroll-y style={{ height: '100%', width: '100%' }}>
             <OpenUiRenderer
-              result={parseResult}
+              response={response}
               library={openUiLibrary}
+              toolProvider={openUiToolProvider}
               onAction={onOpenUiAction}
               isStreaming={isStreaming}
             />

--- a/packages/genui/a2ui-playground/package.json
+++ b/packages/genui/a2ui-playground/package.json
@@ -20,6 +20,7 @@
     "@lynx-js/react": "workspace:*",
     "@lynx-js/web-core": "workspace:*",
     "@lynx-js/web-elements": "workspace:*",
+    "@openuidev/lang-core": "^0.2.5",
     "@uiw/react-codemirror": "^4.25.9",
     "idb": "^8.0.3",
     "lucide-react": "^0.575.0",

--- a/packages/genui/a2ui-playground/src/App.tsx
+++ b/packages/genui/a2ui-playground/src/App.tsx
@@ -19,7 +19,7 @@ import { DemosPage } from './pages/DemosPage.js';
 import { OpenUIComponentsPage } from './pages/OpenUIComponentsPage.js';
 import { OpenUIDemosPage } from './pages/OpenUIDemosPage.js';
 import type { Protocol, ProtocolName } from './utils/protocol.js';
-import { DEFAULT_PROTOCOL, getProtocol } from './utils/protocol.js';
+import { DEFAULT_PROTOCOL, PROTOCOLS, getProtocol } from './utils/protocol.js';
 
 const LYNX_LIGHT_LOGO =
   'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-dark-logo.svg';
@@ -267,8 +267,8 @@ export function App() {
         value={protocol.name}
         onChange={(e) => handleProtocolSelect(e.target.value as ProtocolName)}
       >
-        <option value='a2ui'>A2UI v0.9</option>
-        <option value='openui'>OpenUI v0.1</option>
+        <option value='a2ui'>A2UI v{PROTOCOLS.a2ui.version}</option>
+        <option value='openui'>OpenUI v{PROTOCOLS.openui.version}</option>
       </select>
     </div>
   );

--- a/packages/genui/a2ui-playground/src/mock/openui-scenarios.ts
+++ b/packages/genui/a2ui-playground/src/mock/openui-scenarios.ts
@@ -1,13 +1,113 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { createParser } from '@openuidev/lang-core';
+import type { LibraryJSONSchema } from '@openuidev/lang-core';
 
 export interface OpenUIScenario {
   id: string;
   title: string;
+  badge?: string;
   raw: string;
   parsed: string;
 }
+
+const OPENUI_SCENARIO_SCHEMA: LibraryJSONSchema = {
+  $defs: {
+    Stack: {
+      properties: {
+        children: {},
+        direction: {},
+        wrap: {},
+        gap: {},
+        align: {},
+        justify: {},
+      },
+      required: ['children'],
+    },
+    Card: {
+      properties: {
+        children: {},
+        variant: {},
+        direction: {},
+        wrap: {},
+        gap: {},
+        align: {},
+        justify: {},
+      },
+      required: ['children'],
+    },
+    CardHeader: {
+      properties: { title: {}, subtitle: {} },
+      required: ['title'],
+    },
+    TextContent: {
+      properties: { text: {}, size: {} },
+      required: ['text'],
+    },
+    Separator: {
+      properties: { orientation: {}, decorative: {} },
+    },
+    Button: {
+      properties: {
+        label: {},
+        action: {},
+        variant: {},
+        type: {},
+        size: {},
+      },
+      required: ['label'],
+    },
+    Buttons: {
+      properties: { buttons: {} },
+      required: ['buttons'],
+    },
+    Tag: {
+      properties: { text: {} },
+      required: ['text'],
+    },
+  },
+};
+
+const openUiScenarioParser = createParser(OPENUI_SCENARIO_SCHEMA, 'Stack');
+
+function parseScenario(raw: string): string {
+  return JSON.stringify(openUiScenarioParser.parse(raw), null, 2);
+}
+
+const V05_QUERY_WEATHER_RAW = `$city = "Seattle"
+weather = Query("get_weather", { city: $city }, { city: "Loading", temp: "--", condition: "Loading", high: "--", low: "--", humidity: "--", wind: "--", updated: "waiting", alerts: [] })
+root = Stack([hero, metrics, alerts, actions], "column", false, "m", "stretch", "start")
+hero = Card([CardHeader("Live Weather Query", "Query() hydrates this card from a mock tool"), cityLine, tempLine, updatedLine], "card", "column", false, "s", "start", "start")
+cityLine = TextContent(weather.city + " · " + weather.condition, "large-heavy")
+tempLine = TextContent(weather.temp + "°F", "large-heavy")
+updatedLine = TextContent("Updated: " + weather.updated, "small")
+metrics = Stack([highCard, lowCard, humidityCard, windCard], "row", true, "s", "stretch", "start")
+highCard = Card([TextContent("High", "small"), TextContent(weather.high + "°", "large-heavy")], "sunk", "column", false, "xs", "center", "center")
+lowCard = Card([TextContent("Low", "small"), TextContent(weather.low + "°", "large-heavy")], "sunk", "column", false, "xs", "center", "center")
+humidityCard = Card([TextContent("Humidity", "small"), TextContent(weather.humidity, "large-heavy")], "sunk", "column", false, "xs", "center", "center")
+windCard = Card([TextContent("Wind", "small"), TextContent(weather.wind, "large-heavy")], "sunk", "column", false, "xs", "center", "center")
+alerts = Card([CardHeader("Alerts", "Uses @Count() over query data"), TextContent("Active alerts: " + @Count(weather.alerts), "default"), TextContent(@Count(weather.alerts) == 0 ? "No advisories right now." : weather.alerts[0], "small")], "clear", "column", false, "s", "start", "start")
+actions = Buttons([Button("Refresh Query", Action([@Run(weather), @ToAssistant("Refresh weather for " + $city)]), "primary"), Button("Use San Francisco", Action([@Set($city, "San Francisco"), @Run(weather)]), "secondary"), Button("Reset City", Action([@Reset($city), @Run(weather)]), "tertiary")])`;
+
+const V05_MUTATION_ACTION_RAW = `$status = "Draft"
+queue = Query("get_release_queue", {}, { count: 0, next: "Loading release queue", owner: "GenUI" })
+saveResult = Mutation("save_release_note", { title: queue.next, status: $status })
+root = Stack([overview, queueCard, actionCard], "column", false, "m", "stretch", "start")
+overview = Card([CardHeader("Release Note Mutation", "Mutation() + multi-step ActionPlan"), TextContent("Status: " + $status, "large-heavy"), TextContent("Owner: " + queue.owner, "small")], "card", "column", false, "s", "start", "start")
+queueCard = Card([CardHeader("Queue Snapshot", "Loaded with Query()"), TextContent("Next item: " + queue.next), TextContent("Open items: " + queue.count, "small")], "sunk", "column", false, "s", "start", "start")
+actionCard = Card([CardHeader("Actions", "@Set, @Run, @Reset, and @ToAssistant in one plan"), Buttons([Button("Mark Ready", Action([@Set($status, "Ready to ship")]), "secondary"), Button("Save Note", Action([@Set($status, "Saving..."), @Run(saveResult), @Set($status, "Saved"), @ToAssistant("Saved release note: " + queue.next)]), "primary"), Button("Reset", Action([@Reset($status)]), "tertiary")])], "card", "column", false, "m", "stretch", "start")`;
+
+const V05_STATEFUL_PICKER_RAW = `$plan = "Pro"
+$billing = "Monthly"
+root = Stack([summaryCard, planCards, billingCard, actionRow], "column", false, "m", "stretch", "start")
+summaryCard = Card([CardHeader("Stateful Plan Picker", "Local $variables drive computed text"), TextContent("Selected: " + $plan + " · " + $billing, "large-heavy"), TextContent($billing == "Annual" ? "Annual billing includes two months free." : "Switch to annual for savings.", "small")], "card", "column", false, "s", "start", "start")
+planCards = Stack([freeCard, proCard, teamCard], "row", true, "s", "stretch", "start")
+freeCard = Card([Tag($plan == "Free" ? "Selected" : "Option"), TextContent("Free", "large-heavy"), TextContent("For experiments", "small"), Button("Choose Free", Action([@Set($plan, "Free")]), "secondary")], "sunk", "column", false, "s", "start", "start")
+proCard = Card([Tag($plan == "Pro" ? "Selected" : "Option"), TextContent("Pro", "large-heavy"), TextContent("For shipped apps", "small"), Button("Choose Pro", Action([@Set($plan, "Pro")]), "primary")], "sunk", "column", false, "s", "start", "start")
+teamCard = Card([Tag($plan == "Team" ? "Selected" : "Option"), TextContent("Team", "large-heavy"), TextContent("For collaboration", "small"), Button("Choose Team", Action([@Set($plan, "Team")]), "secondary")], "sunk", "column", false, "s", "start", "start")
+billingCard = Card([CardHeader("Billing", "@Set changes $billing without a server"), Buttons([Button("Monthly", Action([@Set($billing, "Monthly")]), $billing == "Monthly" ? "primary" : "secondary"), Button("Annual", Action([@Set($billing, "Annual")]), $billing == "Annual" ? "primary" : "secondary")])], "clear", "column", false, "s", "stretch", "start")
+actionRow = Buttons([Button("Reset Picker", Action([@Reset($plan, $billing)]), "tertiary"), Button("Open v0.5 Spec", Action([@OpenUrl("https://www.openui.com/docs/openui-lang/specification-v05")]), "secondary")])`;
 
 export const OPENUI_SCENARIOS: OpenUIScenario[] = [
   {
@@ -621,6 +721,27 @@ entBtn = Buttons([Button("Contact Sales", Action([@ToAssistant("Contact sales fo
       null,
       2,
     ),
+  },
+  {
+    id: 'v05-query-weather',
+    title: 'Query Weather',
+    badge: 'v0.5',
+    raw: V05_QUERY_WEATHER_RAW,
+    parsed: parseScenario(V05_QUERY_WEATHER_RAW),
+  },
+  {
+    id: 'v05-mutation-action',
+    title: 'Mutation Action',
+    badge: 'v0.5',
+    raw: V05_MUTATION_ACTION_RAW,
+    parsed: parseScenario(V05_MUTATION_ACTION_RAW),
+  },
+  {
+    id: 'v05-stateful-picker',
+    title: 'Stateful Picker',
+    badge: 'v0.5',
+    raw: V05_STATEFUL_PICKER_RAW,
+    parsed: parseScenario(V05_STATEFUL_PICKER_RAW),
   },
   {
     id: 'recipe-card',

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.css
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.css
@@ -308,6 +308,7 @@
 }
 
 .scenarioItem {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -323,6 +324,10 @@
     border-color var(--geist-transition),
     color var(--geist-transition);
   width: 100%;
+}
+
+.scenarioItem.hasBadge {
+  padding-right: 56px;
 }
 
 .scenarioItem:hover {
@@ -346,6 +351,20 @@
   font-size: 14px;
   font-weight: 500;
   color: var(--geist-foreground);
+}
+
+.scenarioBadge {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  padding: 1px 5px;
+  border: 1px solid var(--geist-border);
+  border-radius: 4px;
+  background: var(--geist-background);
+  color: var(--geist-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
 }
 
 .scenarioTags {
@@ -1059,12 +1078,21 @@
     border-radius: 999px;
     border-color: var(--geist-border);
   }
+  .scenarioItem.hasBadge {
+    padding-right: 12px;
+  }
   .scenarioItem .scenarioDesc {
     display: none;
   }
   .scenarioItem .scenarioName {
     white-space: nowrap;
     font-size: 12px;
+  }
+  .scenarioBadge {
+    position: static;
+    flex: 0 0 auto;
+    margin-left: 4px;
+    font-size: 9px;
   }
 
   /* Tighter toolbar so title + Reset/Clear/Render all stay on one row

--- a/packages/genui/a2ui-playground/src/pages/OpenUIDemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/OpenUIDemosPage.tsx
@@ -107,12 +107,17 @@ export function OpenUIDemosPage(_props: { protocol: Protocol }) {
               <button
                 key={s.id}
                 type='button'
-                className={s.id === scenarioId
-                  ? 'scenarioItem active'
-                  : 'scenarioItem'}
+                className={[
+                  'scenarioItem',
+                  s.id === scenarioId ? 'active' : '',
+                  s.badge ? 'hasBadge' : '',
+                ].filter(Boolean).join(' ')}
                 onClick={() => handleSelectScenario(s.id)}
               >
                 <span className='scenarioName'>{s.title}</span>
+                {s.badge
+                  ? <span className='scenarioBadge'>{s.badge}</span>
+                  : null}
               </button>
             ))}
           </div>

--- a/packages/genui/a2ui-playground/src/utils/protocol.ts
+++ b/packages/genui/a2ui-playground/src/utils/protocol.ts
@@ -11,7 +11,7 @@ export interface Protocol {
 
 export const PROTOCOLS: Record<ProtocolName, Protocol> = {
   a2ui: { name: 'a2ui', version: '0.9' },
-  openui: { name: 'openui', version: '0.1' },
+  openui: { name: 'openui', version: '0.5' },
 };
 
 export const DEFAULT_PROTOCOL: Protocol = PROTOCOLS.a2ui;

--- a/packages/genui/etc/genui.api.md
+++ b/packages/genui/etc/genui.api.md
@@ -5,24 +5,58 @@
 ```ts
 
 import type { $ZodObject } from 'zod/v4/core';
+import { ACTION_STEPS } from '@openuidev/lang-core';
 import { ActionEvent } from '@openuidev/lang-core';
+import { ActionPlan } from '@openuidev/lang-core';
+import { ActionStep } from '@openuidev/lang-core';
+import { BuiltinActionType } from '@openuidev/lang-core';
+import { builtInValidators } from '@openuidev/lang-core';
 import { ComponentGroup } from '@openuidev/lang-core';
+import { ComponentPromptSpec } from '@openuidev/lang-core';
 import type { ComponentRenderProps as ComponentRenderProps_2 } from '@openuidev/lang-core';
 import type { ComponentType } from '@lynx-js/react';
+import { Context } from 'react';
 import { createParser } from '@openuidev/lang-core';
 import { createStreamingParser } from '@openuidev/lang-core';
 import type { DefinedComponent as DefinedComponent_2 } from '@openuidev/lang-core';
+import { ElementNode } from '@openuidev/lang-core';
+import { EvaluationContext } from '@openuidev/lang-core';
+import { extractToolResult } from '@openuidev/lang-core';
+import { generatePrompt } from '@openuidev/lang-core';
+import type { InferStateFieldValue } from '@openuidev/lang-core';
+import { isReactiveAssign } from '@openuidev/lang-core';
+import { isReactiveSchema } from '@openuidev/lang-core';
 import { JSX as JSX_2 } from '@lynx-js/react';
 import type { Library as Library_2 } from '@openuidev/lang-core';
 import type { LibraryDefinition as LibraryDefinition_2 } from '@openuidev/lang-core';
 import { LibraryJSONSchema } from '@openuidev/lang-core';
+import { McpClientLike } from '@openuidev/lang-core';
 import { MemoExoticComponent } from 'react';
+import { mergeStatements } from '@openuidev/lang-core';
+import { OpenUIError } from '@openuidev/lang-core';
+import { ParsedRule } from '@openuidev/lang-core';
 import { ParseResult } from '@openuidev/lang-core';
+import { parseRules } from '@openuidev/lang-core';
+import { parseStructuredRules } from '@openuidev/lang-core';
 import type { ProjectReflection } from 'typedoc';
+import { PromptOptions } from '@openuidev/lang-core';
+import { PromptSpec } from '@openuidev/lang-core';
+import type { default as React_2 } from 'react';
+import { ReactiveAssign } from '@openuidev/lang-core';
 import { ReactNode } from '@lynx-js/react';
 import type { Signal } from '@preact/signals';
+import { StateField } from '@openuidev/lang-core';
+import type { Store } from '@openuidev/lang-core';
 import { StreamParser } from '@openuidev/lang-core';
+import { SubComponentOf } from '@openuidev/lang-core';
+import { tagSchemaId } from '@openuidev/lang-core';
+import { ToolDescriptor } from '@openuidev/lang-core';
+import { ToolNotFoundError } from '@openuidev/lang-core';
+import { ToolProvider } from '@openuidev/lang-core';
+import { ToolSpec } from '@openuidev/lang-core';
 import type * as v0_9 from '@a2ui/web_core/v0_9';
+import { validate } from '@openuidev/lang-core';
+import { ValidatorFn } from '@openuidev/lang-core';
 import type { z } from 'zod/v4';
 
 // Warning: (ae-forgotten-export) The symbol "A2UIImpl" needs to be exported by the entry point index.d.ts
@@ -183,7 +217,11 @@ export interface A2UIProps {
     }) => ReactNode;
 }
 
+export { ACTION_STEPS }
+
 export { ActionEvent }
+
+export { ActionPlan }
 
 // Warning: (ae-missing-release-tag) "ActionProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -196,6 +234,8 @@ export interface ActionProps {
     // (undocumented)
     surfaceId: string;
 }
+
+export { ActionStep }
 
 // Warning: (ae-missing-release-tag) "BASIC_CATALOG" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -237,6 +277,10 @@ export interface BuildSystemPromptOptions {
     catalog?: A2UIPromptCatalog;
 }
 
+export { BuiltinActionType }
+
+export { builtInValidators }
+
 // Warning: (ae-missing-release-tag) "CatalogArtifacts" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -277,6 +321,8 @@ export type ComponentInstance = v0_9.AnyComponent & {
         path: string;
     };
 };
+
+export { ComponentPromptSpec }
 
 // Warning: (ae-missing-release-tag) "ComponentRenderer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -366,6 +412,10 @@ export function defineComponent<T extends $ZodObject>(config: {
 //
 // @public (undocumented)
 export type DefinedComponent<T extends $ZodObject = $ZodObject> = DefinedComponent_2<T, ComponentRenderer<z.infer<T>>>;
+
+export { ElementNode }
+
+export { EvaluationContext }
 
 // Warning: (ae-missing-release-tag) "executeFunctionCall" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -478,10 +528,42 @@ export interface ExtractedJsonSchema {
     type?: string;
 }
 
+export { extractToolResult }
+
 // Warning: (ae-missing-release-tag) "findCatalogSourceFiles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function findCatalogSourceFiles(inputPath: string): string[];
+
+// Warning: (ae-missing-release-tag) "FormNameContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const FormNameContext: Context<string | undefined>;
+
+// Warning: (ae-missing-release-tag) "FormValidationContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const FormValidationContext: Context<FormValidationContextValue | null>;
+
+// Warning: (ae-missing-release-tag) "FormValidationContextValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface FormValidationContextValue {
+    // (undocumented)
+    clearFieldError: (name: string) => void;
+    // (undocumented)
+    errors: Record<string, string | undefined>;
+    // (undocumented)
+    getFieldError: (name: string) => string | undefined;
+    // (undocumented)
+    registerField: (name: string, rules: ParsedRule[], getValue: () => unknown) => void;
+    // (undocumented)
+    unregisterField: (name: string) => void;
+    // (undocumented)
+    validateField: (name: string, value: unknown, rules: ParsedRule[]) => boolean;
+    // (undocumented)
+    validateForm: () => boolean;
+}
 
 // Warning: (ae-missing-release-tag) "FunctionCallContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -553,6 +635,8 @@ export class FunctionRegistry {
 // @public (undocumented)
 export const functionRegistry: FunctionRegistry;
 
+export { generatePrompt }
+
 // Warning: (ae-missing-release-tag) "GenericComponentProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -581,6 +665,10 @@ export function isDataBinding(value: unknown): value is v0_9.DataBinding;
 // @public (undocumented)
 export function isFunctionCall(value: unknown): value is v0_9.FunctionCall;
 
+export { isReactiveAssign }
+
+export { isReactiveSchema }
+
 // Warning: (ae-missing-release-tag) "Library" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -592,6 +680,10 @@ export type Library = Library_2<ComponentRenderer<any>>;
 export type LibraryDefinition = LibraryDefinition_2<ComponentRenderer<any>>;
 
 export { LibraryJSONSchema }
+
+export { McpClientLike }
+
+export { mergeStatements }
 
 // Warning: (ae-missing-release-tag) "MessageProcessor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -645,17 +737,86 @@ export const NodeRenderer: typeof NodeRendererImpl;
 // @public
 export function normalizePayloadToMessages(payload: unknown): ServerToClientMessage[];
 
+// Warning: (ae-missing-release-tag) "OpenUIContextValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface OpenUIContextValue {
+    evaluationContext: EvaluationContext;
+    getFieldValue: (formName: string | undefined, name: string) => any;
+    isQueryLoading: boolean;
+    isStreaming: boolean;
+    library: Library_2;
+    renderNode: (value: unknown) => ReactNode;
+    reportError?: (error: OpenUIError) => void;
+    setFieldValue: (formName: string | undefined, componentType: string | undefined, name: string, value: unknown, shouldTriggerSaveCallback?: boolean) => void;
+    store: Store;
+    triggerAction: (userMessage: string, formName?: string, action?: ActionPlan | {
+        type?: string;
+        params?: Record<string, any>;
+        url?: string;
+        context?: string;
+    }) => void | Promise<void>;
+}
+
+export { OpenUIError }
+
 // Warning: (ae-missing-release-tag) "OpenUiRenderer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function OpenUiRenderer(props: {
+export function OpenUiRenderer(props: OpenUiRendererProps): JSX_2.Element;
+
+// Warning: (ae-missing-release-tag) "OpenUiRendererParsedProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface OpenUiRendererParsedProps {
+    // (undocumented)
+    isStreaming?: boolean;
+    // (undocumented)
+    library: Library;
+    // (undocumented)
+    onAction?: (event: ActionEvent) => void;
     result: ParseResult | null;
+}
+
+// Warning: (ae-missing-release-tag) "OpenUiRendererProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type OpenUiRendererProps = OpenUiRendererRuntimeProps | OpenUiRendererParsedProps;
+
+// Warning: (ae-missing-release-tag) "OpenUiRendererRuntimeProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface OpenUiRendererRuntimeProps {
+    initialState?: Record<string, unknown>;
+    isStreaming?: boolean;
     library: Library;
     onAction?: (event: ActionEvent) => void;
-    isStreaming?: boolean;
-}): JSX_2.Element | null;
+    onError?: (errors: OpenUIError[]) => void;
+    onParseResult?: (result: ParseResult | null) => void;
+    onStateUpdate?: (state: Record<string, unknown>) => void;
+    queryLoader?: ReactNode;
+    response: string | null;
+    toolProvider?: ToolProviderInput;
+}
+
+// Warning: (ae-missing-release-tag) "OpenUIState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface OpenUIState {
+    // (undocumented)
+    contextValue: OpenUIContextValue;
+    isQueryLoading: boolean;
+    parseResult: ParseResult | null;
+    result: ParseResult | null;
+}
+
+export { ParsedRule }
 
 export { ParseResult }
+
+export { parseRules }
+
+export { parseStructuredRules }
 
 // Warning: (ae-missing-release-tag) "prepareMessagesForProcessing" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -664,6 +825,10 @@ export function prepareMessagesForProcessing(rawMessages: ServerToClientMessage[
     messages: ServerToClientMessage[];
     hasComponentUpdate: boolean;
 };
+
+export { PromptOptions }
+
+export { PromptSpec }
 
 // Warning: (ae-missing-release-tag) "Resource" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -693,6 +858,13 @@ export interface RawResource<T = unknown> {
     // (undocumented)
     readonly value: T | undefined;
 }
+
+// Warning: (ae-missing-release-tag) "reactive" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function reactive<T extends z.ZodType>(schema: T): z.ZodType<StateField<z.infer<T>>>;
+
+export { ReactiveAssign }
 
 // Warning: (ae-missing-release-tag) "ReadA2UICatalogDirectoryOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -791,7 +963,11 @@ export class SignalStore {
     }[]): void;
 }
 
+export { StateField }
+
 export { StreamParser }
+
+export { SubComponentOf }
 
 // Warning: (ae-missing-release-tag) "Surface" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -818,6 +994,21 @@ export interface Surface {
 //
 // @public (undocumented)
 export type SurfaceId = string;
+
+export { tagSchemaId }
+
+export { ToolDescriptor }
+
+export { ToolNotFoundError }
+
+export { ToolProvider }
+
+// Warning: (ae-missing-release-tag) "ToolProviderInput" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ToolProviderInput = Record<string, (args: Record<string, unknown>) => unknown> | McpClientLike | null;
+
+export { ToolSpec }
 
 // Warning: (ae-missing-release-tag) "TypeDocComment" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -973,10 +1164,65 @@ export function useChecks(options: {
     firstFailureMessage: string | undefined;
 };
 
+// Warning: (ae-missing-release-tag) "useCreateFormValidation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useCreateFormValidation(): FormValidationContextValue;
+
 // Warning: (ae-missing-release-tag) "useDataBinding" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function useDataBinding<T = unknown>(dynamicValue: unknown, surface: Surface | undefined, dataContextPath?: string, fallbackValue?: T): [T | undefined, (newValue: T) => void, string | undefined];
+
+// Warning: (ae-missing-release-tag) "useFormValidation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useFormValidation(): FormValidationContextValue | null;
+
+// Warning: (ae-missing-release-tag) "useGetFieldValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useGetFieldValue(): (formName: string | undefined, name: string) => any;
+
+// Warning: (ae-missing-release-tag) "useIsQueryLoading" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useIsQueryLoading(): boolean;
+
+// Warning: (ae-missing-release-tag) "useIsStreaming" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useIsStreaming(): boolean;
+
+// Warning: (ae-missing-release-tag) "useOpenUI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useOpenUI(): OpenUIContextValue;
+
+// Warning: (ae-missing-release-tag) "useOpenUIState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useOpenUIState(input: UseOpenUIStateOptions, renderDeep: (value: unknown) => React_2.ReactNode): OpenUIState;
+
+// Warning: (ae-missing-release-tag) "UseOpenUIStateOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface UseOpenUIStateOptions {
+    // (undocumented)
+    initialState?: Record<string, unknown>;
+    // (undocumented)
+    isStreaming: boolean;
+    // (undocumented)
+    library: Library;
+    // (undocumented)
+    onAction?: (event: ActionEvent) => void;
+    onError?: (errors: OpenUIError[]) => void;
+    // (undocumented)
+    onStateUpdate?: (state: Record<string, unknown>) => void;
+    // (undocumented)
+    response: string | null;
+    toolProvider?: ToolProvider | null;
+}
 
 // Warning: (ae-missing-release-tag) "UserActionPayload" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -994,10 +1240,51 @@ export interface UserActionPayload {
     timestamp: string;
 }
 
+// Warning: (ae-missing-release-tag) "useRenderNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useRenderNode(): (value: unknown) => ReactNode;
+
 // Warning: (ae-missing-release-tag) "useResolvedProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function useResolvedProps(properties: Record<string, unknown>, surface: Surface | undefined, dataContextPath?: string, processor?: MessageProcessor, functions?: readonly CatalogFunctionEntry[]): readonly [Record<string, unknown>, (key: string, value: unknown) => void];
+
+// Warning: (ae-missing-release-tag) "useSetDefaultValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useSetDefaultValue(input: {
+    formName?: string;
+    componentType?: string;
+    name: string;
+    existingValue: unknown;
+    defaultValue: unknown;
+    shouldTriggerSaveCallback?: boolean;
+}): void;
+
+// Warning: (ae-missing-release-tag) "useSetFieldValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useSetFieldValue(): (formName: string | undefined, componentType: string | undefined, name: string, value: unknown, shouldTriggerSaveCallback?: boolean) => void;
+
+// Warning: (ae-missing-release-tag) "useStateField" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useStateField<T = unknown>(name: string, value?: T): StateField<InferStateFieldValue<T>>;
+
+// Warning: (ae-missing-release-tag) "useTriggerAction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useTriggerAction(): (userMessage: string, formName?: string, action?: ActionPlan | {
+    type?: string;
+    params?: Record<string, any>;
+    url?: string;
+    context?: string;
+}) => void | Promise<void>;
+
+export { validate }
+
+export { ValidatorFn }
 
 // Warning: (ae-missing-release-tag) "writeCatalogArtifacts" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/genui/openui/README.md
+++ b/packages/genui/openui/README.md
@@ -9,7 +9,9 @@ This package includes:
 - `createOpenUiLibrary`: factory that builds an OpenUI `Library` instance
   with built-in components, fully customizable via options.
 - `defineComponent`: define custom components with Zod-validated props.
-- `OpenUiRenderer`: ReactLynx component that renders a parsed OpenUI tree.
+- `OpenUiRenderer`: ReactLynx component that parses and renders OpenUI Lang
+  v0.5 responses, including `$variables`, `Query()`, `Mutation()`, and
+  `Action([@...])` steps.
 - `createParser` / `createStreamingParser`: parse OpenUI DSL text
   (functional notation) into a renderable AST.
 - `catalog/*`: built-in component renderers (Stack, Card, CardHeader,
@@ -34,48 +36,28 @@ pnpm add @lynx-js/genui
 
 ## Quick Start
 
-1. Create a library and get its JSON Schema.
-2. Create a streaming parser from the schema.
-3. Feed OpenUI DSL text (chunks or full) into the parser.
-4. Render the parse result with `<OpenUiRenderer>`.
+1. Create a library.
+2. Pass raw OpenUI Lang text to `<OpenUiRenderer response={...}>`.
+3. Handle actions from `@ToAssistant()` / `@OpenUrl()` with `onAction`.
 
 ```tsx
-import {
-  createOpenUiLibrary,
-  createStreamingParser,
-  OpenUiRenderer,
-} from '@lynx-js/genui/openui';
-import type { ParseResult } from '@lynx-js/genui/openui';
-import { useEffect, useMemo, useState } from '@lynx-js/react';
+import { createOpenUiLibrary, OpenUiRenderer } from '@lynx-js/genui/openui';
+import { useMemo } from '@lynx-js/react';
 
-const library = createOpenUiLibrary();
-const schema = library.toJSONSchema();
-
-export function App() {
-  const [result, setResult] = useState<ParseResult | null>(null);
-
-  useEffect(() => {
-    const parser = createStreamingParser(schema);
-
-    // OpenUI DSL uses functional notation:
-    const rawText = `
+const rawText = `
 root = Stack([header, card], "column", "l", "center")
 header = TextContent("Hello OpenUI", "large-heavy")
 card = Card([content, btn], "card")
 content = TextContent("Welcome to OpenUI")
 btn = Buttons([Button("Get Started", Action([@ToAssistant("clicked")]), "primary")])
-    `.trim();
+`.trim();
 
-    // Feed the entire text (or stream it chunk by chunk)
-    const parsed = parser.push(rawText);
-    setResult(parsed);
-  }, []);
-
-  if (!result?.root) return null;
+export function App() {
+  const library = useMemo(() => createOpenUiLibrary(), []);
 
   return (
     <OpenUiRenderer
-      result={result}
+      response={rawText}
       library={library}
       onAction={(event) => {
         console.log('Action:', event.humanFriendlyMessage);
@@ -91,28 +73,21 @@ For real-time streaming scenarios (e.g., LLM output), feed chunks
 incrementally:
 
 ```tsx
-import {
-  createOpenUiLibrary,
-  createStreamingParser,
-  OpenUiRenderer,
-} from '@lynx-js/genui/openui';
-import type { ParseResult } from '@lynx-js/genui/openui';
-import { useEffect, useMemo, useRef, useState } from '@lynx-js/react';
+import { createOpenUiLibrary, OpenUiRenderer } from '@lynx-js/genui/openui';
+import { useEffect, useMemo, useState } from '@lynx-js/react';
 
 const CHUNK_SIZE = 8;
 const STREAM_DELAY_MS = 30;
 
 export function StreamingApp({ rawText }: { rawText: string }) {
   const library = useMemo(() => createOpenUiLibrary(), []);
-  const [result, setResult] = useState<ParseResult | null>(null);
+  const [response, setResponse] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     setIsStreaming(true);
-
-    const schema = library.toJSONSchema();
-    const parser = createStreamingParser(schema);
+    setResponse('');
     let offset = 0;
 
     const tick = () => {
@@ -122,7 +97,7 @@ export function StreamingApp({ rawText }: { rawText: string }) {
       }
       const chunk = rawText.slice(offset, offset + CHUNK_SIZE);
       offset += CHUNK_SIZE;
-      setResult(parser.push(chunk));
+      setResponse((prev) => prev + chunk);
       setTimeout(tick, STREAM_DELAY_MS);
     };
 
@@ -132,17 +107,46 @@ export function StreamingApp({ rawText }: { rawText: string }) {
     };
   }, [library, rawText]);
 
-  if (!result?.root) return null;
-
   return (
     <OpenUiRenderer
-      result={result}
+      response={response}
       library={library}
       isStreaming={isStreaming}
     />
   );
 }
 ```
+
+## v0.5 Runtime
+
+Use the `response` renderer entry point for v0.5 features:
+
+```tsx
+const ui = `
+$title = ""
+data = Query("list_items", { search: $title }, { rows: [] })
+save = Mutation("save_item", { title: $title })
+root = Stack([
+  TextContent("Rows: " + @Count(data.rows)),
+  Button("Save", Action([@Run(save), @Run(data), @Reset($title)]))
+])
+`.trim();
+
+<OpenUiRenderer
+  response={ui}
+  library={library}
+  toolProvider={{
+    list_items: async (args) => ({ rows: [] }),
+    save_item: async (args) => ({ ok: true }),
+  }}
+  onStateUpdate={(state) => persist(state)}
+  initialState={{ $title: 'Draft' }}
+/>;
+```
+
+`OpenUiRenderer` still accepts `result={parseResult}` for legacy/static
+callers, but `Query()`, `Mutation()`, `$variables`, and runtime expression
+evaluation require the raw `response` path.
 
 ## Customizing the Library
 

--- a/packages/genui/openui/etc/genui-openui.api.md
+++ b/packages/genui/openui/etc/genui-openui.api.md
@@ -5,24 +5,70 @@
 ```ts
 
 import type { $ZodObject } from 'zod/v4/core';
+import { ACTION_STEPS } from '@openuidev/lang-core';
 import { ActionEvent } from '@openuidev/lang-core';
+import { ActionPlan } from '@openuidev/lang-core';
+import { ActionStep } from '@openuidev/lang-core';
+import { BuiltinActionType } from '@openuidev/lang-core';
+import { builtInValidators } from '@openuidev/lang-core';
 import { ComponentGroup } from '@openuidev/lang-core';
+import { ComponentPromptSpec } from '@openuidev/lang-core';
 import type { ComponentRenderProps as ComponentRenderProps_2 } from '@openuidev/lang-core';
+import { Context } from 'react';
 import { createParser } from '@openuidev/lang-core';
 import { createStreamingParser } from '@openuidev/lang-core';
 import type { DefinedComponent as DefinedComponent_2 } from '@openuidev/lang-core';
+import { ElementNode } from '@openuidev/lang-core';
+import { EvaluationContext } from '@openuidev/lang-core';
+import { extractToolResult } from '@openuidev/lang-core';
+import { generatePrompt } from '@openuidev/lang-core';
+import type { InferStateFieldValue } from '@openuidev/lang-core';
+import { isReactiveAssign } from '@openuidev/lang-core';
+import { isReactiveSchema } from '@openuidev/lang-core';
 import { JSX as JSX_2 } from '@lynx-js/react';
 import type { Library as Library_2 } from '@openuidev/lang-core';
 import type { LibraryDefinition as LibraryDefinition_2 } from '@openuidev/lang-core';
 import { LibraryJSONSchema } from '@openuidev/lang-core';
+import { McpClientLike } from '@openuidev/lang-core';
+import { mergeStatements } from '@openuidev/lang-core';
+import { OpenUIError } from '@openuidev/lang-core';
+import { ParsedRule } from '@openuidev/lang-core';
 import { ParseResult } from '@openuidev/lang-core';
+import { parseRules } from '@openuidev/lang-core';
+import { parseStructuredRules } from '@openuidev/lang-core';
+import { PromptOptions } from '@openuidev/lang-core';
+import { PromptSpec } from '@openuidev/lang-core';
+import type { default as React_2 } from 'react';
+import { ReactiveAssign } from '@openuidev/lang-core';
 import type { ReactNode } from '@lynx-js/react';
+import { StateField } from '@openuidev/lang-core';
+import type { Store } from '@openuidev/lang-core';
 import { StreamParser } from '@openuidev/lang-core';
+import { SubComponentOf } from '@openuidev/lang-core';
+import { tagSchemaId } from '@openuidev/lang-core';
+import { ToolDescriptor } from '@openuidev/lang-core';
+import { ToolNotFoundError } from '@openuidev/lang-core';
+import { ToolProvider } from '@openuidev/lang-core';
+import { ToolSpec } from '@openuidev/lang-core';
+import { validate } from '@openuidev/lang-core';
+import { ValidatorFn } from '@openuidev/lang-core';
 import type { z } from 'zod/v4';
+
+export { ACTION_STEPS }
 
 export { ActionEvent }
 
+export { ActionPlan }
+
+export { ActionStep }
+
+export { BuiltinActionType }
+
+export { builtInValidators }
+
 export { ComponentGroup }
+
+export { ComponentPromptSpec }
 
 // Warning: (ae-missing-release-tag) "ComponentRenderer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -70,6 +116,48 @@ export function defineComponent<T extends $ZodObject>(config: {
 // @public (undocumented)
 export type DefinedComponent<T extends $ZodObject = $ZodObject> = DefinedComponent_2<T, ComponentRenderer<z.infer<T>>>;
 
+export { ElementNode }
+
+export { EvaluationContext }
+
+export { extractToolResult }
+
+// Warning: (ae-missing-release-tag) "FormNameContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const FormNameContext: Context<string | undefined>;
+
+// Warning: (ae-missing-release-tag) "FormValidationContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const FormValidationContext: Context<FormValidationContextValue | null>;
+
+// Warning: (ae-missing-release-tag) "FormValidationContextValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface FormValidationContextValue {
+    // (undocumented)
+    clearFieldError: (name: string) => void;
+    // (undocumented)
+    errors: Record<string, string | undefined>;
+    // (undocumented)
+    getFieldError: (name: string) => string | undefined;
+    // (undocumented)
+    registerField: (name: string, rules: ParsedRule[], getValue: () => unknown) => void;
+    // (undocumented)
+    unregisterField: (name: string) => void;
+    // (undocumented)
+    validateField: (name: string, value: unknown, rules: ParsedRule[]) => boolean;
+    // (undocumented)
+    validateForm: () => boolean;
+}
+
+export { generatePrompt }
+
+export { isReactiveAssign }
+
+export { isReactiveSchema }
+
 // Warning: (ae-missing-release-tag) "Library" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -82,19 +170,218 @@ export type LibraryDefinition = LibraryDefinition_2<ComponentRenderer<any>>;
 
 export { LibraryJSONSchema }
 
+export { McpClientLike }
+
+export { mergeStatements }
+
+// Warning: (ae-missing-release-tag) "OpenUIContextValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface OpenUIContextValue {
+    evaluationContext: EvaluationContext;
+    getFieldValue: (formName: string | undefined, name: string) => any;
+    isQueryLoading: boolean;
+    isStreaming: boolean;
+    library: Library_2;
+    renderNode: (value: unknown) => ReactNode;
+    reportError?: (error: OpenUIError) => void;
+    setFieldValue: (formName: string | undefined, componentType: string | undefined, name: string, value: unknown, shouldTriggerSaveCallback?: boolean) => void;
+    store: Store;
+    triggerAction: (userMessage: string, formName?: string, action?: ActionPlan | {
+        type?: string;
+        params?: Record<string, any>;
+        url?: string;
+        context?: string;
+    }) => void | Promise<void>;
+}
+
+export { OpenUIError }
+
 // Warning: (ae-missing-release-tag) "OpenUiRenderer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function OpenUiRenderer(props: {
+export function OpenUiRenderer(props: OpenUiRendererProps): JSX_2.Element;
+
+// Warning: (ae-missing-release-tag) "OpenUiRendererParsedProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface OpenUiRendererParsedProps {
+    // (undocumented)
+    isStreaming?: boolean;
+    // (undocumented)
+    library: Library;
+    // (undocumented)
+    onAction?: (event: ActionEvent) => void;
     result: ParseResult | null;
+}
+
+// Warning: (ae-missing-release-tag) "OpenUiRendererProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type OpenUiRendererProps = OpenUiRendererRuntimeProps | OpenUiRendererParsedProps;
+
+// Warning: (ae-missing-release-tag) "OpenUiRendererRuntimeProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface OpenUiRendererRuntimeProps {
+    initialState?: Record<string, unknown>;
+    isStreaming?: boolean;
     library: Library;
     onAction?: (event: ActionEvent) => void;
-    isStreaming?: boolean;
-}): JSX_2.Element | null;
+    onError?: (errors: OpenUIError[]) => void;
+    onParseResult?: (result: ParseResult | null) => void;
+    onStateUpdate?: (state: Record<string, unknown>) => void;
+    queryLoader?: ReactNode;
+    response: string | null;
+    toolProvider?: ToolProviderInput;
+}
+
+// Warning: (ae-missing-release-tag) "OpenUIState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface OpenUIState {
+    // (undocumented)
+    contextValue: OpenUIContextValue;
+    isQueryLoading: boolean;
+    parseResult: ParseResult | null;
+    result: ParseResult | null;
+}
+
+export { ParsedRule }
 
 export { ParseResult }
 
+export { parseRules }
+
+export { parseStructuredRules }
+
+export { PromptOptions }
+
+export { PromptSpec }
+
+// Warning: (ae-missing-release-tag) "reactive" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function reactive<T extends z.ZodType>(schema: T): z.ZodType<StateField<z.infer<T>>>;
+
+export { ReactiveAssign }
+
+export { StateField }
+
 export { StreamParser }
+
+export { SubComponentOf }
+
+export { tagSchemaId }
+
+export { ToolDescriptor }
+
+export { ToolNotFoundError }
+
+export { ToolProvider }
+
+// Warning: (ae-missing-release-tag) "ToolProviderInput" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ToolProviderInput = Record<string, (args: Record<string, unknown>) => unknown> | McpClientLike | null;
+
+export { ToolSpec }
+
+// Warning: (ae-missing-release-tag) "useCreateFormValidation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useCreateFormValidation(): FormValidationContextValue;
+
+// Warning: (ae-missing-release-tag) "useFormValidation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useFormValidation(): FormValidationContextValue | null;
+
+// Warning: (ae-missing-release-tag) "useGetFieldValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useGetFieldValue(): (formName: string | undefined, name: string) => any;
+
+// Warning: (ae-missing-release-tag) "useIsQueryLoading" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useIsQueryLoading(): boolean;
+
+// Warning: (ae-missing-release-tag) "useIsStreaming" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useIsStreaming(): boolean;
+
+// Warning: (ae-missing-release-tag) "useOpenUI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useOpenUI(): OpenUIContextValue;
+
+// Warning: (ae-missing-release-tag) "useOpenUIState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useOpenUIState(input: UseOpenUIStateOptions, renderDeep: (value: unknown) => React_2.ReactNode): OpenUIState;
+
+// Warning: (ae-missing-release-tag) "UseOpenUIStateOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface UseOpenUIStateOptions {
+    // (undocumented)
+    initialState?: Record<string, unknown>;
+    // (undocumented)
+    isStreaming: boolean;
+    // (undocumented)
+    library: Library;
+    // (undocumented)
+    onAction?: (event: ActionEvent) => void;
+    onError?: (errors: OpenUIError[]) => void;
+    // (undocumented)
+    onStateUpdate?: (state: Record<string, unknown>) => void;
+    // (undocumented)
+    response: string | null;
+    toolProvider?: ToolProvider | null;
+}
+
+// Warning: (ae-missing-release-tag) "useRenderNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useRenderNode(): (value: unknown) => ReactNode;
+
+// Warning: (ae-missing-release-tag) "useSetDefaultValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useSetDefaultValue(input: {
+    formName?: string;
+    componentType?: string;
+    name: string;
+    existingValue: unknown;
+    defaultValue: unknown;
+    shouldTriggerSaveCallback?: boolean;
+}): void;
+
+// Warning: (ae-missing-release-tag) "useSetFieldValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useSetFieldValue(): (formName: string | undefined, componentType: string | undefined, name: string, value: unknown, shouldTriggerSaveCallback?: boolean) => void;
+
+// Warning: (ae-missing-release-tag) "useStateField" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useStateField<T = unknown>(name: string, value?: T): StateField<InferStateFieldValue<T>>;
+
+// Warning: (ae-missing-release-tag) "useTriggerAction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useTriggerAction(): (userMessage: string, formName?: string, action?: ActionPlan | {
+    type?: string;
+    params?: Record<string, any>;
+    url?: string;
+    context?: string;
+}) => void | Promise<void>;
+
+export { validate }
+
+export { ValidatorFn }
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/genui/openui/package.json
+++ b/packages/genui/openui/package.json
@@ -31,7 +31,7 @@
     "build:api": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@openuidev/lang-core": "^0.2.4",
+    "@openuidev/lang-core": "^0.2.5",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/genui/openui/src/catalog/Button/index.tsx
+++ b/packages/genui/openui/src/catalog/Button/index.tsx
@@ -2,7 +2,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { ActionPlan } from '@openuidev/lang-core';
 import { ACTION_STEPS, BuiltinActionType } from '@openuidev/lang-core';
 import { z } from 'zod/v4';
 
@@ -16,6 +15,7 @@ import {
 import { useFormValidation } from '../../core/hooks/index.js';
 import { defineComponent } from '../../core/library.jsx';
 import { actionPropSchema } from '../Action/index.jsx';
+import type { ActionLike } from '../Action/index.jsx';
 import { asArray } from '../utils.js';
 
 const CONTINUE_CONVERSATION_ACTION = String(
@@ -25,7 +25,7 @@ const OPEN_URL_ACTION = String(BuiltinActionType.OpenUrl);
 
 const buttonPropsSchema = z.object({
   label: z.string(),
-  action: actionPropSchema,
+  action: actionPropSchema.optional(),
   variant: z.enum(['primary', 'secondary', 'tertiary']).optional(),
   type: z.enum(['normal', 'destructive']).optional(),
   size: z.enum(['extra-small', 'small', 'medium', 'large']).optional(),
@@ -41,7 +41,7 @@ function ButtonRenderer({ props }: { props: ButtonProps }) {
 
   const label = String(props.label ?? '');
   const variant = props.variant ?? 'primary';
-  const action = props.action;
+  const action = props.action as ActionLike | undefined;
 
   let className = 'OpenUIButton OpenUIButtonPrimary';
   if (variant === 'secondary') {
@@ -51,27 +51,27 @@ function ButtonRenderer({ props }: { props: ButtonProps }) {
   }
 
   const onTap = () => {
-    if ('steps' in action) {
-      if (
-        formValidation
-        && variant === 'primary'
-        && action.steps.some((step) => step.type === ACTION_STEPS.ToAssistant)
-      ) {
+    const legacyAction = action && !('steps' in action) ? action : undefined;
+    const actionType = legacyAction?.type ?? CONTINUE_CONVERSATION_ACTION;
+
+    if (formValidation && variant === 'primary') {
+      if (action && 'steps' in action) {
+        const needsValidation = action.steps.some((step) =>
+          step.type === ACTION_STEPS.ToAssistant
+          || (
+            step.type === ACTION_STEPS.Run && step.refType === 'mutation'
+          )
+        );
+        if (needsValidation && !formValidation.validateForm()) return;
+      } else if (actionType === CONTINUE_CONVERSATION_ACTION) {
         const valid = formValidation.validateForm();
         if (!valid) return;
       }
-      void triggerAction(label, formName, action as ActionPlan);
-      return;
     }
-    const legacyAction = action;
-    const actionType = legacyAction?.type ?? CONTINUE_CONVERSATION_ACTION;
 
-    if (
-      formValidation && variant === 'primary'
-      && actionType === CONTINUE_CONVERSATION_ACTION
-    ) {
-      const valid = formValidation.validateForm();
-      if (!valid) return;
+    if (action && 'steps' in action) {
+      void triggerAction(label, formName, action);
+      return;
     }
 
     const actionParams = actionType === OPEN_URL_ACTION

--- a/packages/genui/openui/src/core/context.tsx
+++ b/packages/genui/openui/src/core/context.tsx
@@ -24,18 +24,26 @@ export interface OpenUIContextValue {
   /**
    * Trigger an action. Accepts either:
    * - ActionPlan (v0.5): runs steps sequentially (Run, Set, ToAssistant, OpenUrl)
-   * - Legacy action config (v0.1): { type?: string, params?: Record<string, any> }
+   * - Legacy action config (v0.1): object with optional type and params.
    * - Nothing: fires ContinueConversation with the label
    */
   triggerAction: (
     userMessage: string,
     formName?: string,
     // biome-ignore lint/suspicious/noExplicitAny: form values are dynamically typed
-    action?: ActionPlan | { type?: string; params?: Record<string, any> },
+    action?: ActionPlan | {
+      type?: string;
+      params?: Record<string, any>;
+      url?: string;
+      context?: string;
+    },
   ) => void | Promise<void>;
 
   /** Whether the LLM is currently streaming content. */
   isStreaming: boolean;
+
+  /** Whether any Query is currently fetching data. */
+  isQueryLoading: boolean;
 
   /** Get a field value. Top-level for $bindings, nested under formName for form fields. */
   // biome-ignore lint/suspicious/noExplicitAny: form values are dynamically typed
@@ -44,11 +52,11 @@ export interface OpenUIContextValue {
   /**
    * Set a form field value.
    *
-   * @param formName  The form's name prop
-   * @param componentType  The component type (e.g. "Input", "Select") — optional
-   * @param name  The field's name prop
-   * @param value  The new value
-   * @param shouldTriggerSaveCallback  When true, persists state via onStateUpdate.
+   * @param formName - The form's name prop.
+   * @param componentType - The component type (e.g. "Input", "Select").
+   * @param name - The field's name prop.
+   * @param value - The new value.
+   * @param shouldTriggerSaveCallback - When true, persists state via onStateUpdate.
    *   Text inputs should pass `false` on change and `true` on blur.
    *   Discrete inputs (Select, RadioGroup, etc.) should always pass `true`.
    */
@@ -111,6 +119,13 @@ export function useIsStreaming() {
 }
 
 /**
+ * Whether any Query is currently fetching data.
+ */
+export function useIsQueryLoading() {
+  return useOpenUI().isQueryLoading;
+}
+
+/**
  * Get a form field value from the form state context.
  *
  * @example
@@ -158,7 +173,7 @@ export function useFormName(): string | undefined {
  * `defaultChecked` prop. It is a no-op during streaming so that LLM
  * prop changes don't fight with partial state.
  *
- * @param shouldTriggerSaveCallback — defaults to `false` (only local state, no message persistence)
+ * @param shouldTriggerSaveCallback - Defaults to `false` (only local state, no message persistence).
  */
 export function useSetDefaultValue({
   formName,

--- a/packages/genui/openui/src/core/hooks/index.ts
+++ b/packages/genui/openui/src/core/hooks/index.ts
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 export { useOpenUIState } from './useOpenUIState.js';
 export type { OpenUIState, UseOpenUIStateOptions } from './useOpenUIState.js';
+export { useStateField } from './useStateField.js';
 
 export {
   FormValidationContext,

--- a/packages/genui/openui/src/core/hooks/useOpenUIState.ts
+++ b/packages/genui/openui/src/core/hooks/useOpenUIState.ts
@@ -460,6 +460,8 @@ export function useOpenUIState(
     renderErrorsRef.current.push(error);
   }, []);
 
+  const isQueryLoading = querySnapshot.__openui_loading.length > 0;
+
   // ─── Context value ───
   const contextValue = useMemo<OpenUIContextValue>(
     () => ({
@@ -467,6 +469,7 @@ export function useOpenUIState(
       renderNode: renderDeep,
       triggerAction,
       isStreaming,
+      isQueryLoading,
       getFieldValue,
       setFieldValue,
       store,
@@ -477,6 +480,7 @@ export function useOpenUIState(
       library,
       renderDeep,
       isStreaming,
+      isQueryLoading,
       triggerAction,
       getFieldValue,
       setFieldValue,
@@ -515,8 +519,6 @@ export function useOpenUIState(
       return result;
     }
   }, [result, evaluationContext, library, store, storeSnapshot, querySnapshot]);
-
-  const isQueryLoading = querySnapshot.__openui_loading.length > 0;
 
   // ─── Collect and fire onError ───
   const lastErrorKeyRef = useRef<string>('');

--- a/packages/genui/openui/src/core/index.ts
+++ b/packages/genui/openui/src/core/index.ts
@@ -1,17 +1,73 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-export { createParser, createStreamingParser } from '@openuidev/lang-core';
+export {
+  ACTION_STEPS,
+  BuiltinActionType,
+  ToolNotFoundError,
+  builtInValidators,
+  createParser,
+  createStreamingParser,
+  extractToolResult,
+  generatePrompt,
+  isReactiveAssign,
+  mergeStatements,
+  parseRules,
+  parseStructuredRules,
+  tagSchemaId,
+  validate,
+} from '@openuidev/lang-core';
 
 export type {
   ActionEvent,
+  ActionPlan,
+  ActionStep,
+  ComponentPromptSpec,
+  ElementNode,
+  EvaluationContext,
   LibraryJSONSchema,
+  McpClientLike,
+  OpenUIError,
   ParseResult,
+  ParsedRule,
+  PromptOptions,
+  PromptSpec,
+  ReactiveAssign,
+  StateField,
   StreamParser,
+  SubComponentOf,
+  ToolDescriptor,
+  ToolProvider,
+  ToolSpec,
+  ValidatorFn,
 } from '@openuidev/lang-core';
 
 export { createOpenUiLibrary } from './createLibrary.jsx';
 export type { CreateOpenUiLibraryOptions } from './createLibrary.jsx';
+export {
+  FormNameContext,
+  useGetFieldValue,
+  useIsQueryLoading,
+  useIsStreaming,
+  useOpenUI,
+  useRenderNode,
+  useSetDefaultValue,
+  useSetFieldValue,
+  useTriggerAction,
+} from './context.jsx';
+export type { OpenUIContextValue } from './context.jsx';
+export {
+  FormValidationContext,
+  useCreateFormValidation,
+  useFormValidation,
+  useOpenUIState,
+  useStateField,
+} from './hooks/index.js';
+export type {
+  FormValidationContextValue,
+  OpenUIState,
+  UseOpenUIStateOptions,
+} from './hooks/index.js';
 export type {
   ComponentGroup,
   ComponentRenderer,
@@ -21,4 +77,11 @@ export type {
   LibraryDefinition,
 } from './library.jsx';
 export { defineComponent } from './library.jsx';
+export { isReactiveSchema, reactive } from './runtime/index.js';
 export { OpenUiRenderer } from './renderer.jsx';
+export type {
+  OpenUiRendererParsedProps,
+  OpenUiRendererProps,
+  OpenUiRendererRuntimeProps,
+  ToolProviderInput,
+} from './renderer.jsx';

--- a/packages/genui/openui/src/core/renderer.css
+++ b/packages/genui/openui/src/core/renderer.css
@@ -5,6 +5,42 @@
     format("truetype");
 }
 
+/* ===== Renderer ===== */
+.OpenUIRenderer {
+  width: 100%;
+  position: relative;
+}
+
+.OpenUIRendererContent {
+  width: 100%;
+  opacity: 1;
+}
+
+.OpenUIRendererContentLoading {
+  opacity: 0.72;
+}
+
+.OpenUIQueryLoader {
+  position: absolute;
+  top: 8rpx;
+  right: 8rpx;
+  width: 18rpx;
+  height: 18rpx;
+  border-radius: 999rpx;
+  background-color: rgba(59, 130, 246, 0.16);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.OpenUIQueryLoaderDot {
+  width: 8rpx;
+  height: 8rpx;
+  border-radius: 999rpx;
+  background-color: rgba(59, 130, 246, 0.72);
+}
+
 /* ===== Stack ===== */
 .OpenUIStack {
   width: 100%;

--- a/packages/genui/openui/src/core/renderer.tsx
+++ b/packages/genui/openui/src/core/renderer.tsx
@@ -6,10 +6,19 @@ import type {
   ActionPlan,
   ElementNode,
   EvaluationContext,
+  McpClientLike,
+  OpenUIError,
   ParseResult,
   Store,
+  ToolProvider,
 } from '@openuidev/lang-core';
-import { ACTION_STEPS, BuiltinActionType } from '@openuidev/lang-core';
+import {
+  ACTION_STEPS,
+  BuiltinActionType,
+  ToolNotFoundError,
+  createStore,
+  extractToolResult,
+} from '@openuidev/lang-core';
 
 import {
   Fragment,
@@ -19,13 +28,55 @@ import {
   useRef,
   useState,
 } from '@lynx-js/react';
+import type { ReactNode } from '@lynx-js/react';
 
-import { OpenUIContext } from './context.jsx';
-import type { Library, RenderOutput } from './library.jsx';
+import { OpenUIContext, useOpenUI, useRenderNode } from './context.jsx';
+import { useOpenUIState } from './hooks/useOpenUIState.js';
+import type { ComponentRenderer, Library, RenderOutput } from './library.jsx';
 import { keyFrom } from './utils.js';
 import type { LegacyActionConfig } from '../catalog/Action/index.jsx';
 
 export type { Library, RenderOutput };
+
+export type ToolProviderInput =
+  | Record<string, (args: Record<string, unknown>) => unknown>
+  | McpClientLike
+  | null;
+
+export interface OpenUiRendererRuntimeProps {
+  /** Raw openui-lang response text. This enables v0.5 runtime features. */
+  response: string | null;
+  /** Component library from createOpenUiLibrary(). */
+  library: Library;
+  /** Whether the LLM is still streaming; disables interactions while true. */
+  isStreaming?: boolean;
+  /** Callback when a component triggers a host action. */
+  onAction?: (event: ActionEvent) => void;
+  /** Called whenever $variables or form state changes. */
+  onStateUpdate?: (state: Record<string, unknown>) => void;
+  /** Initial persisted state. $-prefixed keys hydrate reactive bindings. */
+  initialState?: Record<string, unknown>;
+  /** Called whenever the raw parse result changes. */
+  onParseResult?: (result: ParseResult | null) => void;
+  /** Tool provider for Query()/Mutation(): function map or MCP client. */
+  toolProvider?: ToolProviderInput;
+  /** Custom loading node shown while Query() calls are in flight. */
+  queryLoader?: ReactNode;
+  /** Structured parser/runtime/query errors for correction loops. */
+  onError?: (errors: OpenUIError[]) => void;
+}
+
+export interface OpenUiRendererParsedProps {
+  /** Pre-parsed result. Kept for v0.1/static-render compatibility. */
+  result: ParseResult | null;
+  library: Library;
+  onAction?: (event: ActionEvent) => void;
+  isStreaming?: boolean;
+}
+
+export type OpenUiRendererProps =
+  | OpenUiRendererRuntimeProps
+  | OpenUiRendererParsedProps;
 
 interface FieldEntry {
   value: unknown;
@@ -85,11 +136,7 @@ function getFieldEntry(
   return formValue[name];
 }
 
-function renderValue(
-  value: unknown,
-  library: Library,
-  onAction?: (event: ActionEvent) => void,
-): RenderOutput {
+function renderDeep(value: unknown): ReactNode {
   if (value === null || value === undefined) return null;
 
   if (
@@ -102,63 +149,168 @@ function renderValue(
   if (Array.isArray(value)) {
     return value.map((v, i) => (
       <Fragment key={keyFrom(v, i)}>
-        {renderValue(v, library, onAction)}
+        {renderDeep(v)}
       </Fragment>
     ));
   }
 
   if (isElementNode(value)) {
     const stableKey = value.statementId ?? keyFrom(value);
-    return (
-      <RenderNode
-        key={stableKey}
-        stableKey={stableKey}
-        node={value}
-        library={library}
-        {...(onAction ? { onAction } : {})}
-      />
-    );
+    return <RenderNode key={stableKey} node={value} />;
   }
 
   return null;
 }
 
-function RenderNode(
-  props: {
-    key?: string;
-    stableKey?: string;
-    node: ElementNode;
-    library: Library;
-    onAction?: (event: ActionEvent) => void;
-  },
-) {
-  const { stableKey, node, library, onAction } = props;
-  const Comp = library.components[node.typeName]?.component;
+function RenderNode({ node }: { node: ElementNode }) {
+  const { library, reportError } = useOpenUI();
+  const Comp = library.components[node.typeName]?.component as
+    | ComponentRenderer<any>
+    | undefined;
 
   if (!Comp) return null;
 
-  const renderNode = (value: unknown) => renderValue(value, library, onAction);
+  try {
+    return <RenderNodeInner el={node} Comp={Comp} />;
+  } catch (error) {
+    reportError?.({
+      source: 'runtime',
+      code: 'render-error',
+      component: node.typeName,
+      message: `Component ${node.typeName} render failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    });
+    return null;
+  }
+}
 
+function RenderNodeInner(
+  { el, Comp }: {
+    el: ElementNode;
+    Comp: ComponentRenderer<any>;
+  },
+) {
+  const renderNode = useRenderNode();
   return (
     <Comp
-      key={stableKey}
-      props={node.props}
+      props={el.props}
       renderNode={renderNode}
-      {...(onAction ? { onAction } : {})}
+      {...(el.statementId ? { statementId: el.statementId } : {})}
     />
   );
 }
 
-export function OpenUiRenderer(props: {
-  result: ParseResult | null;
-  library: Library;
-  onAction?: (event: ActionEvent) => void;
-  isStreaming?: boolean;
-}) {
-  const { result, library, onAction, isStreaming = false } = props;
+function DefaultQueryLoader() {
+  return (
+    <view className='OpenUIQueryLoader'>
+      <view className='OpenUIQueryLoaderDot' />
+    </view>
+  );
+}
+
+function RuntimeOpenUiRenderer(
+  {
+    response,
+    library,
+    isStreaming = false,
+    onAction,
+    onStateUpdate,
+    initialState,
+    onParseResult,
+    toolProvider,
+    queryLoader,
+    onError,
+  }: OpenUiRendererRuntimeProps,
+) {
+  const onParseResultRef = useRef(onParseResult);
+  onParseResultRef.current = onParseResult;
+
+  const toolProviderInputRef = useRef(toolProvider);
+  toolProviderInputRef.current = toolProvider;
+
+  const stableToolProvider = useRef<ToolProvider>({
+    async callTool(
+      toolName: string,
+      args: Record<string, unknown>,
+    ): Promise<unknown> {
+      const current = toolProviderInputRef.current ?? null;
+      if (current === null) {
+        throw new Error('[openui] toolProvider is null');
+      }
+
+      if (typeof (current as McpClientLike).callTool === 'function') {
+        const result = await (current as McpClientLike).callTool({
+          name: toolName,
+          arguments: args,
+        });
+        return extractToolResult(result);
+      }
+
+      const map = current as Record<
+        string,
+        (a: Record<string, unknown>) => unknown
+      >;
+      const fn = map[toolName];
+      if (!fn) throw new ToolNotFoundError(toolName, Object.keys(map));
+      return await fn(args);
+    },
+  });
+  const resolvedToolProvider =
+    toolProvider !== null && toolProvider !== undefined
+      ? stableToolProvider.current
+      : null;
+
+  const stateOptions = {
+    response,
+    library,
+    isStreaming,
+    toolProvider: resolvedToolProvider,
+    ...(onAction ? { onAction } : {}),
+    ...(onStateUpdate ? { onStateUpdate } : {}),
+    ...(initialState ? { initialState } : {}),
+    ...(onError ? { onError } : {}),
+  };
+
+  const { result, parseResult, contextValue, isQueryLoading } = useOpenUIState(
+    stateOptions,
+    renderDeep,
+  );
+
+  useEffect(() => {
+    onParseResultRef.current?.(parseResult);
+  }, [parseResult]);
+
+  if (!result?.root) return null;
+
+  return (
+    <OpenUIContext.Provider value={contextValue}>
+      <view className='OpenUIRenderer'>
+        {isQueryLoading ? (queryLoader ?? <DefaultQueryLoader />) : null}
+        <view
+          className={isQueryLoading
+            ? 'OpenUIRendererContent OpenUIRendererContentLoading'
+            : 'OpenUIRendererContent'}
+        >
+          <RenderNode node={result.root} />
+        </view>
+      </view>
+    </OpenUIContext.Provider>
+  );
+}
+
+function ParsedOpenUiRenderer(
+  {
+    result,
+    library,
+    onAction,
+    isStreaming = false,
+  }: OpenUiRendererParsedProps,
+) {
   const [formState, setFormState] = useState<FormState>({});
   const formStateRef = useRef(formState);
   const onActionRef = useRef(onAction);
+  const store = useMemo<Store>(() => createStore(), []);
 
   useEffect(() => {
     formStateRef.current = formState;
@@ -167,6 +319,10 @@ export function OpenUiRenderer(props: {
   useEffect(() => {
     onActionRef.current = onAction;
   }, [onAction]);
+
+  useEffect(() => {
+    return () => store.dispose();
+  }, [store]);
 
   const getFieldValue = useCallback(
     (formName: string | undefined, name: string) => {
@@ -194,12 +350,13 @@ export function OpenUiRenderer(props: {
         };
       } else {
         newState[name] = createFieldEntry(value, componentType);
+        store.set(name, value);
       }
 
       setFormState(newState);
       formStateRef.current = newState;
     },
-    [formStateRef, setFormState],
+    [formStateRef, setFormState, store],
   );
 
   const triggerAction = useCallback(
@@ -269,7 +426,9 @@ export function OpenUiRenderer(props: {
           : undefined;
       const actionType = legacyAction?.type
         ?? BuiltinActionType.ContinueConversation;
-      const actionParams = legacyAction?.params ?? {};
+      const actionParams = { ...(legacyAction?.params ?? {}) };
+      if (legacyAction?.url) actionParams['url'] = legacyAction.url;
+      if (legacyAction?.context) actionParams['context'] = legacyAction.context;
 
       let relevantState: Record<string, unknown> | undefined;
       const formValue = formName ? currentState[formName] : undefined;
@@ -290,28 +449,34 @@ export function OpenUiRenderer(props: {
     [formStateRef, onActionRef],
   );
 
-  const renderNode = useCallback(
-    (value: unknown) => renderValue(value, library, onAction),
-    [library, onAction],
+  const evaluationContext = useMemo<EvaluationContext>(
+    () => ({
+      getState: (name: string) => getFieldValue(undefined, name),
+      resolveRef: () => undefined,
+    }),
+    [getFieldValue],
   );
+
   const contextValue = useMemo(
     () => ({
       library,
-      renderNode,
+      renderNode: renderDeep,
       triggerAction,
       isStreaming,
+      isQueryLoading: false,
       getFieldValue,
       setFieldValue,
-      store: {} as Store,
-      evaluationContext: {} as EvaluationContext,
+      store,
+      evaluationContext,
     }),
     [
       library,
-      renderNode,
       triggerAction,
       isStreaming,
       getFieldValue,
       setFieldValue,
+      store,
+      evaluationContext,
     ],
   );
 
@@ -319,11 +484,14 @@ export function OpenUiRenderer(props: {
 
   return (
     <OpenUIContext.Provider value={contextValue}>
-      <RenderNode
-        node={result.root}
-        library={library}
-        {...(onAction ? { onAction } : {})}
-      />
+      <RenderNode node={result.root} />
     </OpenUIContext.Provider>
   );
+}
+
+export function OpenUiRenderer(props: OpenUiRendererProps) {
+  if ('response' in props) {
+    return <RuntimeOpenUiRenderer {...props} />;
+  }
+  return <ParsedOpenUiRenderer {...props} />;
 }

--- a/packages/genui/openui/src/core/runtime/index.ts
+++ b/packages/genui/openui/src/core/runtime/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+export { isReactiveSchema, reactive } from './reactive.js';

--- a/packages/genui/openui/src/core/runtime/reactive.ts
+++ b/packages/genui/openui/src/core/runtime/reactive.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { StateField } from '@openuidev/lang-core';
+import { markReactive } from '@openuidev/lang-core';
+import type { z } from 'zod/v4';
+
+export { isReactiveSchema } from '@openuidev/lang-core';
+
+/**
+ * Mark a schema prop as reactive so runtime evaluation can preserve $bindings.
+ */
+export function reactive<T extends z.ZodType>(
+  schema: T,
+): z.ZodType<StateField<z.infer<T>>> {
+  markReactive(schema);
+  return schema as unknown as z.ZodType<StateField<z.infer<T>>>;
+}

--- a/packages/genui/package.json
+++ b/packages/genui/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@a2ui/web_core": "0.9.1",
-    "@openuidev/lang-core": "^0.2.4",
+    "@openuidev/lang-core": "^0.2.5",
     "@preact/signals": "^2.5.1",
     "typedoc": "^0.28.19",
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,8 +606,8 @@ importers:
         specifier: ^3.133.0
         version: 3.133.0(@lynx-js/react@packages+react)(@lynx-js/types@3.7.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
       '@openuidev/lang-core':
-        specifier: ^0.2.4
-        version: 0.2.4(@modelcontextprotocol/sdk@1.25.2(hono@4.12.12)(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.2.5
+        version: 0.2.5(@modelcontextprotocol/sdk@1.25.2(hono@4.12.12)(zod@3.25.76))(zod@3.25.76)
       '@preact/signals':
         specifier: ^2.5.1
         version: 2.5.1(preact@10.29.1)
@@ -719,6 +719,9 @@ importers:
       '@lynx-js/web-elements':
         specifier: workspace:*
         version: link:../../web-platform/web-elements
+      '@openuidev/lang-core':
+        specifier: ^0.2.5
+        version: 0.2.5(@modelcontextprotocol/sdk@1.25.2(hono@4.12.12)(zod@4.4.3))(zod@4.4.3)
       '@uiw/react-codemirror':
         specifier: ^4.25.9
         version: 4.25.9(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.41.1)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -809,8 +812,8 @@ importers:
   packages/genui/openui:
     dependencies:
       '@openuidev/lang-core':
-        specifier: ^0.2.4
-        version: 0.2.4(@modelcontextprotocol/sdk@1.25.2(hono@4.12.12)(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.2.5
+        version: 0.2.5(@modelcontextprotocol/sdk@1.25.2(hono@4.12.12)(zod@3.25.76))(zod@3.25.76)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -4659,8 +4662,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@openuidev/lang-core@0.2.4':
-    resolution: {integrity: sha512-HfY5nb6kAEWjdHL+3pBjw2TLc7TWwVMllaKtTY9itncJJjiPA0dj7mEJmcDpoMJ+NWPv+UbhWhOkmUtqpGOwDQ==}
+  '@openuidev/lang-core@0.2.5':
+    resolution: {integrity: sha512-cL01txOXWeDdOJY83F8R0QR7F1FPEsuUFft/8uRYiaN8LozKySNonc1g5nhreYKjcQ2YvvyvwHZn/AQZCaFtDQ==}
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
       zod: ^3.25.0 || ^4.0.0
@@ -15290,11 +15293,17 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@openuidev/lang-core@0.2.4(@modelcontextprotocol/sdk@1.25.2(hono@4.12.12)(zod@3.25.76))(zod@3.25.76)':
+  '@openuidev/lang-core@0.2.5(@modelcontextprotocol/sdk@1.25.2(hono@4.12.12)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.25.2(hono@4.12.12)(zod@3.25.76)
+
+  '@openuidev/lang-core@0.2.5(@modelcontextprotocol/sdk@1.25.2(hono@4.12.12)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.12.12)(zod@4.4.3)
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true


### PR DESCRIPTION
## Summary

- add OpenUI v0.5 runtime rendering through raw `response` text, including state declarations, Query, Mutation, and multi-step Action plans
- wire playground OpenUI previews to the runtime path with mock tools and add v0.5-specific scenarios
- update OpenUI docs, dependency versions, API reports, and project instructions for v0.5 maintenance

## Validation

- `pnpm dprint fmt ...`
- `pnpm eslint --cache --fix --no-warn-ignored --flag v10_config_lookup_from_file packages/genui/openui/src/core/renderer.tsx`
- `pnpm turbo build --filter @lynx-js/genui-openui`
- `pnpm turbo api-extractor --filter @lynx-js/genui-openui -- --local`
- `pnpm turbo api-extractor --filter @lynx-js/genui -- --local`
- `pnpm turbo build --filter a2ui-playground`
- verified `http://localhost:3000/#/openui` shows the new cases without `v0.5` title prefixes and with `v0.5` badges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added OpenUI v0.5 rendering support with streaming and tool provider integration
- Added new v0.5 scenario examples to the playground demonstrating queries, mutations, and actions
- Expanded public API with new hooks for form validation, state management, and query handling

**Updates**
- Updated OpenUI runtime dependency to v0.2.5
- Enhanced playground UI with v0.5 scenario badges and improved mobile layout
- Updated documentation with v0.5 usage examples and best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->