### PR TITLE
feat(react): support ET scoped CSS native metadata

### DIFF
--- a/packages/react/runtime/__test__/element-template/fixtures/background/instance/ops/emits-bundle-url-in-create-template/case.ts
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/instance/ops/emits-bundle-url-in-create-template/case.ts
@@ -1,0 +1,11 @@
+import { BackgroundElementTemplateInstance, globalCommitContext, runCase } from '../../_shared.js';
+
+export function run() {
+  return runCase(() => {
+    const instance = new BackgroundElementTemplateInstance('dynamic-entry:_et_foo');
+
+    instance.emitCreate();
+
+    return globalCommitContext.ops;
+  });
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/background/instance/ops/emits-bundle-url-in-create-template/output.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/instance/ops/emits-bundle-url-in-create-template/output.txt
@@ -1,0 +1,8 @@
+Array [
+  1,
+  1,
+  "_et_foo",
+  "dynamic-entry",
+  Array [],
+  Array [],
+]

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/fixture.config.json
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/fixture.config.json
@@ -1,0 +1,5 @@
+{
+  "cssScope": "all",
+  "isDynamicComponent": true,
+  "dynamicComponentEntry": "lazy-entry"
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/index.js.txt
@@ -1,0 +1,6 @@
+import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+/*@jsxCSSId 1501958*/ import "./style.css?cssId=1501958";
+const _et_eb7af03baae1 = `${globDynamicComponentEntry}:${"_et_eb7af03baae1"}`;
+export function App() {
+    return /*#__PURE__*/ _jsx(_et_eb7af03baae1, {});
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/index.tsx
@@ -1,0 +1,9 @@
+import './style.css';
+
+export function App() {
+  return (
+    <view id='scoped'>
+      <text>Scoped Dynamic</text>
+    </view>
+  );
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/output.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/output.txt
@@ -1,0 +1,3 @@
+<view css-id="1501958" id="scoped">
+  <text text="Scoped Dynamic" />
+</view>

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/papi.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/papi.txt
@@ -1,0 +1,25 @@
+[
+  [
+    "__CreateTypedElementTemplate",
+    "page",
+    null,
+    null,
+    "0",
+    null
+  ],
+  [
+    "__CreateElementTemplate",
+    "_et_eb7af03baae1",
+    "lazy-entry",
+    null,
+    null,
+    -1
+  ],
+  [
+    "__InsertNodeToElementTemplate",
+    "<page />",
+    0,
+    "<_et_eb7af03baae1 />",
+    null
+  ]
+]

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/templates.json.txt
@@ -1,0 +1,52 @@
+[
+  {
+    "templateId": "_et_eb7af03baae1",
+    "compiledTemplate": {
+      "kind": "element",
+      "type": "view",
+      "attributesArray": [
+        {
+          "kind": "static",
+          "key": "id",
+          "value": "scoped"
+        },
+        {
+          "kind": "static",
+          "key": "css-id",
+          "value": 1501958
+        }
+      ],
+      "children": [
+        {
+          "kind": "element",
+          "type": "text",
+          "attributesArray": [
+            {
+              "kind": "static",
+              "key": "text",
+              "value": "Scoped Dynamic"
+            }
+          ],
+          "children": []
+        }
+      ]
+    },
+    "sourceFile": "index.tsx"
+  },
+  {
+    "templateId": "_et_builtin_raw_text",
+    "compiledTemplate": {
+      "kind": "element",
+      "type": "raw-text",
+      "attributesArray": [
+        {
+          "kind": "slot",
+          "key": "text",
+          "attrSlotIndex": 0
+        }
+      ],
+      "children": []
+    },
+    "sourceFile": "<builtin>"
+  }
+]

--- a/packages/react/runtime/__test__/element-template/fixtures/render/opcodes-into-element-template/passes-bundle-url-to-native-create/case.ts
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/opcodes-into-element-template/passes-bundle-url-to-native-create/case.ts
@@ -1,0 +1,20 @@
+import { __OpBegin, __OpEnd, renderOpcodesIntoElementTemplate, runCase } from '../_shared.js';
+
+export function run() {
+  return runCase(({ root, nativeLog }) => {
+    const opcodes = [
+      __OpBegin,
+      { type: 'dynamic-entry:_et_foo', props: {} },
+      __OpEnd,
+    ];
+
+    const { rootRefs } = renderOpcodesIntoElementTemplate(opcodes);
+    rootRefs.forEach(rootRef => __InsertNodeToElementTemplate(root as FiberElement, 0, rootRef, null));
+
+    return {
+      files: {
+        'native-log.txt': nativeLog,
+      },
+    };
+  });
+}

--- a/packages/react/runtime/__test__/element-template/fixtures/render/opcodes-into-element-template/passes-bundle-url-to-native-create/native-log.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/opcodes-into-element-template/passes-bundle-url-to-native-create/native-log.txt
@@ -1,0 +1,25 @@
+Array [
+  Array [
+    "__CreateTypedElementTemplate",
+    "page",
+    null,
+    null,
+    "0",
+    null,
+  ],
+  Array [
+    "__CreateElementTemplate",
+    "_et_foo",
+    "dynamic-entry",
+    null,
+    null,
+    -1,
+  ],
+  Array [
+    "__InsertNodeToElementTemplate",
+    "<page />",
+    0,
+    "<_et_foo />",
+    null,
+  ],
+]

--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -45,6 +45,7 @@ function createHydrationChild(
   templateKey: string,
   options: {
     attributeSlots?: unknown[] | null;
+    bundleUrl?: string;
     elementSlots?: SerializedElementTemplate[][] | null;
   } = {},
 ): SerializedElementTemplate {
@@ -609,6 +610,25 @@ describe('hydrate', () => {
     expect(backgroundElementTemplateInstanceManager.get(-11)).toBe(entryA);
     expect(backgroundElementTemplateInstanceManager.get(-12)).toBe(entryB);
     expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+  });
+
+  it('ignores native main-bundle sentinel urls during hydrate', () => {
+    const root = new BackgroundElementTemplateInstance('_et_root');
+    const child = new BackgroundElementTemplateInstance('_et_child');
+    root.appendChild(child);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, '_et_root', {
+        bundleUrl: '__Card__',
+        elementSlots: [[createHydrationChild(-2, '_et_child', { bundleUrl: '__Card__' })]],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([]);
+    expect((globalThis as { __LYNX_REPORT_ERROR_CALLS?: Error[] }).__LYNX_REPORT_ERROR_CALLS).toEqual([]);
+    expect(backgroundElementTemplateInstanceManager.get(root.instanceId)).toBe(root);
+    expect(backgroundElementTemplateInstanceManager.get(-2)).toBe(child);
   });
 
   it('keeps hydrated handles for later background attribute updates', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -20,6 +20,7 @@ function createHydrationTemplate(
   templateKey: string,
   options: {
     attributeSlots?: unknown[] | null;
+    bundleUrl?: string;
     elementSlots?: SerializedElementTemplate[][] | null;
   } = {},
 ): SerializedElementTemplate {
@@ -29,6 +30,9 @@ function createHydrationTemplate(
   };
   if ('attributeSlots' in options) {
     serialized.attributeSlots = options.attributeSlots as SerializedElementTemplate['attributeSlots'];
+  }
+  if (options.bundleUrl !== undefined) {
+    serialized.bundleUrl = options.bundleUrl;
   }
   if ('elementSlots' in options) {
     serialized.elementSlots = options.elementSlots as SerializedElementTemplate['elementSlots'];
@@ -568,6 +572,43 @@ describe('hydrate', () => {
     ]);
     expect(root.elementSlots[0]).toEqual([slot0Item]);
     expect(root.elementSlots[1]).toEqual([slot1Item]);
+  });
+
+  it('matches same local template ids by bundleUrl during hydrate', () => {
+    const root = new BackgroundElementTemplateInstance('root');
+
+    const entryB = new BackgroundElementTemplateInstance('entry-b:_et_same', ['B']);
+    const entryA = new BackgroundElementTemplateInstance('entry-a:_et_same', ['A']);
+    root.appendChild(entryB);
+    root.appendChild(entryA);
+
+    const stream = hydrate(
+      createHydrationTemplate(root.instanceId, 'root', {
+        elementSlots: [[
+          createHydrationChild(-11, '_et_same', {
+            attributeSlots: ['A'],
+            bundleUrl: 'entry-a',
+          }),
+          createHydrationChild(-12, '_et_same', {
+            attributeSlots: ['B'],
+            bundleUrl: 'entry-b',
+          }),
+        ]],
+      }),
+      root,
+    );
+
+    expect(stream).toEqual([
+      ElementTemplateUpdateOps.insertNode,
+      root.instanceId,
+      0,
+      entryA.instanceId,
+      0,
+    ]);
+    expect(root.elementSlots[0]).toEqual([entryB, entryA]);
+    expect(backgroundElementTemplateInstanceManager.get(-11)).toBe(entryA);
+    expect(backgroundElementTemplateInstanceManager.get(-12)).toBe(entryB);
+    expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
   });
 
   it('keeps hydrated handles for later background attribute updates', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -761,6 +761,26 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(createTemplateMock.mock.calls[0]?.[2]).toEqual([null, 'x']);
   });
 
+  it('passes bundleUrl from createTemplate patch to native create', () => {
+    envManager.switchToMainThread();
+    const createTemplateMock = globalThis.__CreateElementTemplate as unknown as {
+      mockClear: () => void;
+      mock: { calls: unknown[][] };
+    };
+    createTemplateMock.mockClear();
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.createTemplate,
+      9,
+      '_et_builtin_raw_text',
+      'dynamic-entry',
+      ['x'],
+      [],
+    ]);
+
+    expect(createTemplateMock.mock.calls[0]?.[1]).toBe('dynamic-entry');
+  });
+
   it('drops unresolved element slot children without reporting in prod mode', () => {
     envManager.switchToMainThread();
     const originalDev = globalThis.__DEV__;

--- a/packages/react/runtime/__test__/element-template/runtime/protocol/template-type.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/protocol/template-type.test.ts
@@ -28,4 +28,13 @@ describe('element template type protocol', () => {
       'https://example.com/main.lynx.bundle:_et_a',
     );
   });
+
+  it('keeps an empty bundle url distinct from a page-local template', () => {
+    expect(parseElementTemplateType(':_et_a')).toEqual({
+      templateKey: '_et_a',
+      bundleUrl: '',
+    });
+    expect(elementTemplateIdentityKey('_et_a', '')).toBe(':_et_a');
+    expect(elementTemplateIdentityKey('_et_a', null)).toBe('_et_a');
+  });
 });

--- a/packages/react/runtime/__test__/element-template/runtime/protocol/template-type.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/protocol/template-type.test.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, it } from 'vitest';
+
+import {
+  elementTemplateIdentityKey,
+  parseElementTemplateType,
+} from '../../../../src/element-template/protocol/template-type.js';
+
+describe('element template type protocol', () => {
+  it('keeps local template ids unchanged', () => {
+    expect(parseElementTemplateType('_et_a')).toEqual({
+      templateKey: '_et_a',
+      bundleUrl: null,
+    });
+  });
+
+  it('splits dynamic bundle entry from local template id at the final delimiter', () => {
+    expect(parseElementTemplateType('https://example.com/main.lynx.bundle:_et_a')).toEqual({
+      templateKey: '_et_a',
+      bundleUrl: 'https://example.com/main.lynx.bundle',
+    });
+  });
+
+  it('rebuilds the runtime identity key from serialized native fields', () => {
+    expect(elementTemplateIdentityKey('_et_a', 'https://example.com/main.lynx.bundle')).toBe(
+      'https://example.com/main.lynx.bundle:_et_a',
+    );
+  });
+});

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
@@ -128,6 +128,26 @@ describe('renderOpcodesIntoElementTemplate', () => {
     expect(addEvent).not.toHaveBeenCalled();
   });
 
+  it('prepares attr plan slots when the opcode omits attributeSlots', () => {
+    const rootRef = { kind: 'root-ref' };
+    createElementTemplate.mockReturnValue(rootRef);
+    __etAttrPlanMap._et_event = [0, adaptEventAttrSlot];
+
+    renderOpcodesIntoElementTemplate([
+      __OpBegin,
+      { type: '_et_event' },
+      __OpEnd,
+    ]);
+
+    expect(createElementTemplate).toHaveBeenCalledWith(
+      '_et_event',
+      null,
+      [null],
+      null,
+      -1,
+    );
+  });
+
   it('prepares direct ref values before native create', () => {
     const rootRef = { kind: 'root-ref' };
     const ref = vi.fn();

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-transform.contract.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-transform.contract.test.ts
@@ -17,11 +17,13 @@ import { installMockNativePapi, lastMock } from '../../test-utils/mock/mockNativ
 
 interface CompileOptions {
   isDynamicComponent?: boolean;
+  cssScopeAll?: boolean;
 }
 
 interface RenderResult {
   rootRef: ElementRef;
   userTemplateIds: string[];
+  code: string;
 }
 
 function findUserTemplateCreateLog(): unknown[] | undefined {
@@ -32,28 +34,12 @@ function findUserTemplateCreateLog(): unknown[] | undefined {
   ) as unknown[];
 }
 
-function registerCompiledTemplates(
-  result: TransformNodiffOutput,
-  entryName: string | undefined,
-): void {
+function registerCompiledTemplates(result: TransformNodiffOutput): void {
   const templates = result.elementTemplates ?? [];
 
   clearTemplates();
   registerBuiltinRawTextTemplate();
   registerTemplates(templates);
-
-  if (!entryName) {
-    return;
-  }
-
-  registerTemplates(
-    templates
-      .filter(template => template.templateId !== '_et_builtin_raw_text')
-      .map(template => ({
-        ...template,
-        templateId: `${entryName}:${template.templateId}`,
-      })),
-  );
 }
 
 async function compileAndRender(
@@ -70,16 +56,12 @@ async function compileAndRender(
     globalThis.__MAIN_THREAD__ = true;
     globalThis.__BACKGROUND__ = false;
 
-    const entryName = options.isDynamicComponent
-      ? String(globalThis.globDynamicComponentEntry)
-      : undefined;
-
     const result = await transformReactLynx(source, {
       mode: 'test',
       pluginName: 'runtime-transform-contract',
       filename: 'source.tsx',
       sourcemap: false,
-      cssScope: false,
+      cssScope: options.cssScopeAll ? { mode: 'all', filename: 'source.tsx' } : false,
       elementTemplate: {
         preserveJsx: false,
         runtimePkg: '@lynx-js/react/element-template/internal',
@@ -96,10 +78,15 @@ async function compileAndRender(
       refresh: false,
     }) as TransformNodiffOutput;
 
-    let outputCode = result.code;
+    const transformedCode = result.code;
+    let outputCode = transformedCode;
     outputCode = outputCode.replace(/from ["']react\/jsx-runtime["']/g, 'from "@lynx-js/react/jsx-runtime"');
+    outputCode = outputCode.replace(
+      /\/\*@jsxCSSId \d+\*\/ import ["'][^"']+\.(?:css|scss|sass|less)\?cssId=\d+["'];\n?/g,
+      '',
+    );
 
-    registerCompiledTemplates(result, entryName);
+    registerCompiledTemplates(result);
 
     fs.writeFileSync(tempImportPath, outputCode);
     const module = (await import(`${pathToFileURL(tempImportPath).href}?t=${Date.now()}`)) as {
@@ -117,6 +104,7 @@ async function compileAndRender(
       userTemplateIds: (result.elementTemplates ?? [])
         .map(template => template.templateId)
         .filter(templateId => templateId !== '_et_builtin_raw_text'),
+      code: transformedCode,
     };
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -139,11 +127,11 @@ describe('render transform contract', () => {
     resetTemplateId();
   });
 
-  it('does not pass legacy css-id metadata through ET create', async () => {
-    const { rootRef, userTemplateIds } = await compileAndRender(`
-      /**
-       * @jsxCSSId 100
-       */
+  it('passes scoped css-id through ET template root attrs', async () => {
+    const { code, rootRef, userTemplateIds } = await compileAndRender(
+      `
+      import './style.css';
+
       export function App() {
         return (
           <view id="main">
@@ -151,17 +139,22 @@ describe('render transform contract', () => {
           </view>
         );
       }
-    `);
+    `,
+      { cssScopeAll: true },
+    );
+
+    expect(code).toContain('style.css?cssId=1460700');
 
     expect(rootRef).toMatchObject({
       tag: 'view',
       attributes: {
         id: 'main',
+        'css-id': 1460700,
       },
       __handleId: -1,
     });
     expect(elementTemplateRegistry.get(-1)).toMatchObject({
-      attributes: { id: 'main' },
+      attributes: { id: 'main', 'css-id': 1460700 },
     });
     expect(userTemplateIds).toEqual([
       expect.stringMatching(/^_et_[0-9a-f]{12}$/),
@@ -176,7 +169,7 @@ describe('render transform contract', () => {
     ]);
   });
 
-  it('does not pass legacy entry-name metadata through ET create for dynamic component output', async () => {
+  it('passes dynamic component entry through ET bundleUrl create parameter', async () => {
     vi.stubGlobal('globDynamicComponentEntry', 'lazy-entry');
 
     const { rootRef, userTemplateIds } = await compileAndRender(
@@ -210,8 +203,8 @@ describe('render transform contract', () => {
     expect(userTemplateIds[0]).not.toContain(':');
     expect(findUserTemplateCreateLog()).toEqual([
       '__CreateElementTemplate',
-      expect.stringMatching(/^lazy-entry:_et_[0-9a-f]{12}$/),
-      null,
+      expect.stringMatching(/^_et_[0-9a-f]{12}$/),
+      'lazy-entry',
       null,
       null,
       -1,

--- a/packages/react/runtime/__test__/element-template/test-utils/debug/renderFixtureRunner.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/debug/renderFixtureRunner.ts
@@ -204,6 +204,8 @@ async function runCompiledRenderFixture(options: {
 
     let outputCode = result.code ?? '';
     outputCode = outputCode.replace(/from ["']react\/jsx-runtime["']/g, 'from "@lynx-js/react/jsx-runtime"');
+    // The transform keeps `/*@jsxCSSId 1*/ import "x.css?cssId=1";` in
+    // compiled output; strip it only for dynamic import execution.
     const importableCode = outputCode.replace(
       /\/\*@jsxCSSId \d+\*\/ import ["'][^"']+\.(?:css|scss|sass|less)\?cssId=\d+["'];\n?/g,
       '',

--- a/packages/react/runtime/__test__/element-template/test-utils/debug/renderFixtureRunner.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/debug/renderFixtureRunner.ts
@@ -23,6 +23,7 @@ import { serializeToJSX } from './serializer.js';
 
 declare global {
   var __USE_ELEMENT_TEMPLATE__: boolean | undefined;
+  var globDynamicComponentEntry: string | undefined;
 }
 
 interface RootNode {
@@ -33,6 +34,12 @@ interface RootNode {
 interface TransformResult {
   code?: string;
   elementTemplates?: unknown[];
+}
+
+interface CompiledRenderFixtureConfig {
+  cssScope: false | 'all';
+  isDynamicComponent: boolean;
+  dynamicComponentEntry?: string;
 }
 
 interface RegisteredTemplateFixture {
@@ -129,6 +136,8 @@ async function runCompiledRenderFixture(options: {
   const expectedPath = path.join(fixtureDir, 'output.txt');
   const papiPath = path.join(fixtureDir, 'papi.txt');
   const tempImportPath = path.join(tempDir, 'temp_actual.js');
+  const fixtureConfig = readCompiledRenderFixtureConfig(fixtureDir, fixtureName);
+  const previousGlobDynamicComponentEntry = globalThis.globDynamicComponentEntry;
 
   if (!fs.existsSync(sourcePath)) {
     throw new Error(`Source file missing for fixture "${fixtureName}"`);
@@ -164,6 +173,9 @@ async function runCompiledRenderFixture(options: {
   const nativeLog = installed.nativeLog as unknown[];
   const cleanup = installed.cleanup;
   const root = __CreateTypedElementTemplate('page', null, null, '0', null) as unknown as RootNode;
+  if (fixtureConfig.dynamicComponentEntry !== undefined) {
+    globalThis.globDynamicComponentEntry = fixtureConfig.dynamicComponentEntry;
+  }
 
   try {
     const code = fs.readFileSync(sourcePath, 'utf8');
@@ -173,12 +185,13 @@ async function runCompiledRenderFixture(options: {
       pluginName: 'test-plugin',
       filename: 'index.tsx',
       sourcemap: false,
-      cssScope: false,
+      cssScope: fixtureConfig.cssScope === 'all' ? { mode: 'all', filename: 'index.tsx' } : false,
       elementTemplate: {
         preserveJsx: false,
         runtimePkg: '@lynx-js/react/element-template/internal',
         filename: 'index.tsx',
         target: 'LEPUS',
+        isDynamicComponent: fixtureConfig.isDynamicComponent,
       },
       shake: false,
       compat: true,
@@ -191,6 +204,10 @@ async function runCompiledRenderFixture(options: {
 
     let outputCode = result.code ?? '';
     outputCode = outputCode.replace(/from ["']react\/jsx-runtime["']/g, 'from "@lynx-js/react/jsx-runtime"');
+    const importableCode = outputCode.replace(
+      /\/\*@jsxCSSId \d+\*\/ import ["'][^"']+\.(?:css|scss|sass|less)\?cssId=\d+["'];\n?/g,
+      '',
+    );
 
     const outputTemplates = result.elementTemplates ? JSON.stringify(result.elementTemplates, null, 2) : '';
 
@@ -220,15 +237,14 @@ async function runCompiledRenderFixture(options: {
     }
 
     if (update && outputTemplates) {
-      registerBuiltinRawTextTemplate();
-      registerTemplates(JSON.parse(outputTemplates) as RegisteredTemplateFixture[]);
+      registerCompiledRenderTemplates(outputTemplates);
     } else if (fs.existsSync(templatesPath)) {
-      registerBuiltinRawTextTemplate();
-      const templates = JSON.parse(fs.readFileSync(templatesPath, 'utf8')) as RegisteredTemplateFixture[];
-      registerTemplates(templates);
+      registerCompiledRenderTemplates(
+        fs.readFileSync(templatesPath, 'utf8'),
+      );
     }
 
-    fs.writeFileSync(tempImportPath, outputCode);
+    fs.writeFileSync(tempImportPath, importableCode);
     try {
       const module = (await import(`${pathToFileURL(tempImportPath).href}?t=${Date.now()}`)) as { App: unknown };
       const vnode = { type: module.App, props: {}, key: null, ref: null };
@@ -264,7 +280,54 @@ async function runCompiledRenderFixture(options: {
     clearEtAttrPlanMap();
     cleanup();
     globalThis.__USE_ELEMENT_TEMPLATE__ = undefined;
+    if (previousGlobDynamicComponentEntry === undefined) {
+      delete globalThis.globDynamicComponentEntry;
+    } else {
+      globalThis.globDynamicComponentEntry = previousGlobDynamicComponentEntry;
+    }
   }
+}
+
+function readCompiledRenderFixtureConfig(
+  fixtureDir: string,
+  fixtureName: string,
+): CompiledRenderFixtureConfig {
+  const configPath = path.join(fixtureDir, 'fixture.config.json');
+  if (!fs.existsSync(configPath)) {
+    return {
+      cssScope: false,
+      isDynamicComponent: false,
+    };
+  }
+
+  const rawConfig = JSON.parse(fs.readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+  const cssScope = rawConfig['cssScope'] ?? false;
+  if (cssScope !== false && cssScope !== 'all') {
+    throw new Error(`Unsupported cssScope for fixture "${fixtureName}": ${String(cssScope)}`);
+  }
+
+  const isDynamicComponent = rawConfig['isDynamicComponent'] === true;
+  const dynamicComponentEntry = rawConfig['dynamicComponentEntry'];
+  if (dynamicComponentEntry !== undefined && typeof dynamicComponentEntry !== 'string') {
+    throw new Error(`dynamicComponentEntry must be a string for fixture "${fixtureName}".`);
+  }
+  if (isDynamicComponent && dynamicComponentEntry === undefined) {
+    throw new Error(`Dynamic component fixture "${fixtureName}" must set dynamicComponentEntry.`);
+  }
+
+  return {
+    cssScope,
+    isDynamicComponent,
+    dynamicComponentEntry,
+  };
+}
+
+function registerCompiledRenderTemplates(
+  serializedTemplates: string,
+): void {
+  registerBuiltinRawTextTemplate();
+  const templates = JSON.parse(serializedTemplates) as RegisteredTemplateFixture[];
+  registerTemplates(templates);
 }
 
 function normalizeCaseFixtureResult(result: unknown): CaseFixtureResult {

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi.ts
@@ -102,6 +102,13 @@ export function installMockNativePapi(
       writable: true,
       configurable: true,
     });
+    if (typeof bundleUrl === 'string') {
+      Object.defineProperty(element, '__bundleUrl', {
+        value: bundleUrl,
+        writable: true,
+        configurable: true,
+      });
+    }
     if (typeof handleId === 'number') {
       Object.defineProperty(element, '__handleId', {
         value: handleId,

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.test.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.test.ts
@@ -99,6 +99,31 @@ describe('mock native template tree spread slots', () => {
     });
   });
 
+  it('serializes compiled node bundleUrl when native create stored one', () => {
+    const root = {
+      templateId: '_et_test',
+      attributes: {},
+      children: [],
+      __handleId: 1,
+      __compiledTemplate: {
+        kind: 'element',
+        type: 'view',
+        attributesArray: [],
+        children: [],
+      },
+      __attributeSlots: null,
+      __bundleUrl: 'dynamic-entry',
+    } satisfies CompiledTemplateNode;
+
+    expect(serializeTemplateInstance(root)).toEqual({
+      templateKey: '_et_test',
+      bundleUrl: 'dynamic-entry',
+      attributeSlots: [],
+      elementSlots: [],
+      uid: 1,
+    });
+  });
+
   it('moves typed children between element slots instead of duplicating them', () => {
     const child = { tag: 'view' };
     const root = {

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.ts
@@ -19,6 +19,7 @@ export interface CompiledTemplateNode {
   __typedElementType?: string;
   __attributeSlots?: unknown[] | null;
   __elementSlots?: unknown[][] | null;
+  __bundleUrl?: string;
   __options?: Record<string, unknown>;
 }
 
@@ -575,8 +576,10 @@ function serializeTemplateNode(
   }
 
   const templateId = root['templateId'];
+  const bundleUrl = root['__bundleUrl'];
   return {
     templateKey: templateId === '_et_builtin_raw_text' ? '_et_builtin_raw_text' : String(templateId),
+    ...(typeof bundleUrl === 'string' ? { bundleUrl } : {}),
     attributeSlots: templateId === '_et_builtin_raw_text'
       ? [String((isRecord(root['attributes']) ? root['attributes']?.['text'] : '') ?? '')]
       : normalizeAttributeSlots(root['__attributeSlots']),

--- a/packages/react/runtime/src/element-template/background/hydrate.ts
+++ b/packages/react/runtime/src/element-template/background/hydrate.ts
@@ -20,6 +20,8 @@ import type {
   SerializedElementTemplate,
 } from '../protocol/types.js';
 
+const MAIN_BUNDLE_URL_SENTINEL = '__Card__';
+
 export function hydrate(
   serialized: SerializedElementTemplate,
   instance: BackgroundElementTemplateInstance,
@@ -69,7 +71,9 @@ function hydrateMatchingChildrenAndDiffSlot(
 
   for (let i = 0; i < serializedChildren.length; i += 1) {
     const node = serializedChildren[i]!;
-    const identityKey = elementTemplateIdentityKey(node.templateKey, node.bundleUrl);
+    const identityKey = node.bundleUrl === MAIN_BUNDLE_URL_SENTINEL
+      ? node.templateKey
+      : elementTemplateIdentityKey(node.templateKey, node.bundleUrl);
     (serializedByIdentityKey[identityKey] ??= []).push([node, i]);
   }
 
@@ -116,7 +120,7 @@ function hydrateInstance(
   instance: BackgroundElementTemplateInstance,
 ): boolean {
   const nativeTemplate = parseElementTemplateType(instance.type);
-  const serializedBundleUrl = serialized.bundleUrl ?? null;
+  const serializedBundleUrl = normalizeSerializedBundleUrl(serialized.bundleUrl);
   if (
     serialized.templateKey !== nativeTemplate.templateKey
     || serializedBundleUrl !== nativeTemplate.bundleUrl
@@ -161,6 +165,10 @@ function hydrateInstance(
     }
   }
   return true;
+}
+
+function normalizeSerializedBundleUrl(bundleUrl: string | undefined): string | null {
+  return bundleUrl === undefined || bundleUrl === MAIN_BUNDLE_URL_SENTINEL ? null : bundleUrl;
 }
 
 function hydrateElementSlot(

--- a/packages/react/runtime/src/element-template/background/hydrate.ts
+++ b/packages/react/runtime/src/element-template/background/hydrate.ts
@@ -13,6 +13,7 @@ import { backgroundElementTemplateInstanceManager } from './manager.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
 import { hydrationMap } from '../hydration-map.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
+import { elementTemplateIdentityKey, parseElementTemplateType } from '../protocol/template-type.js';
 import type {
   ElementTemplateUpdateCommandStream,
   SerializableValue,
@@ -63,22 +64,24 @@ function hydrateMatchingChildrenAndDiffSlot(
     removals: [],
     moves: {},
   };
-  const serializedByTemplateKey: Record<string, [SerializedElementTemplate, number][]> = {};
-  const serializedCursorByTemplateKey: Record<string, number> = {};
+  const serializedByIdentityKey: Record<string, [SerializedElementTemplate, number][]> = {};
+  const serializedCursorByIdentityKey: Record<string, number> = {};
 
   for (let i = 0; i < serializedChildren.length; i += 1) {
     const node = serializedChildren[i]!;
-    (serializedByTemplateKey[node.templateKey] ??= []).push([node, i]);
+    const identityKey = elementTemplateIdentityKey(node.templateKey, node.bundleUrl);
+    (serializedByIdentityKey[identityKey] ??= []).push([node, i]);
   }
 
   for (let i = 0; i < backgroundChildren.length; i += 1) {
     const backgroundChild = backgroundChildren[i]!;
-    const serializedCandidates = serializedByTemplateKey[backgroundChild.type];
-    const candidateCursor = serializedCursorByTemplateKey[backgroundChild.type] ?? 0;
+    const identityKey = backgroundChild.type;
+    const serializedCandidates = serializedByIdentityKey[identityKey];
+    const candidateCursor = serializedCursorByIdentityKey[identityKey] ?? 0;
     const matchedSerialized = serializedCandidates?.[candidateCursor];
 
     if (matchedSerialized) {
-      serializedCursorByTemplateKey[backgroundChild.type] = candidateCursor + 1;
+      serializedCursorByIdentityKey[identityKey] = candidateCursor + 1;
       const oldIndex = matchedSerialized[1];
       if (!hydrateInstance(matchedSerialized[0], backgroundChild)) {
         return null;
@@ -96,9 +99,9 @@ function hydrateMatchingChildrenAndDiffSlot(
     }
   }
 
-  for (const key in serializedByTemplateKey) {
-    const candidates = serializedByTemplateKey[key]!;
-    const candidateCursor = serializedCursorByTemplateKey[key] ?? 0;
+  for (const key in serializedByIdentityKey) {
+    const candidates = serializedByIdentityKey[key]!;
+    const candidateCursor = serializedCursorByIdentityKey[key] ?? 0;
     for (let i = candidateCursor; i < candidates.length; i += 1) {
       result.removals.push(candidates[i]![1]);
       result.hasChanges = true;
@@ -112,11 +115,18 @@ function hydrateInstance(
   serialized: SerializedElementTemplate,
   instance: BackgroundElementTemplateInstance,
 ): boolean {
-  if (serialized.templateKey !== instance.type) {
+  const nativeTemplate = parseElementTemplateType(instance.type);
+  const serializedBundleUrl = serialized.bundleUrl ?? null;
+  if (
+    serialized.templateKey !== nativeTemplate.templateKey
+    || serializedBundleUrl !== nativeTemplate.bundleUrl
+  ) {
     if (__DEV__) {
       lynx.reportError(
         new Error(
-          `ElementTemplate hydrate key mismatch: main='${serialized.templateKey}' background='${instance.type}'.`,
+          `ElementTemplate hydrate key mismatch: main='${
+            elementTemplateIdentityKey(serialized.templateKey, serializedBundleUrl)
+          }' background='${instance.type}'.`,
         ),
       );
     }

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -8,6 +8,7 @@ import { isElementTemplateHydrated } from './commit-hook.js';
 import { backgroundElementTemplateInstanceManager } from './manager.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
+import { parseElementTemplateType } from '../protocol/template-type.js';
 import type { ElementTemplateUpdateCommandStream, SerializableValue } from '../protocol/types.js';
 
 function pushOp(...items: ElementTemplateUpdateCommandStream): void {
@@ -109,12 +110,13 @@ export class BackgroundElementTemplateInstance {
       (serializedSlots[child.__slotIndex] ??= []).push(child.instanceId);
       child = child.nextSibling;
     }
+    const nativeTemplate = parseElementTemplateType(this.type);
 
     pushOp(
       ElementTemplateUpdateOps.createTemplate,
       this.instanceId,
-      this.type,
-      null,
+      nativeTemplate.templateKey,
+      nativeTemplate.bundleUrl,
       this.attributeSlots,
       serializedSlots,
     );

--- a/packages/react/runtime/src/element-template/protocol/template-type.ts
+++ b/packages/react/runtime/src/element-template/protocol/template-type.ts
@@ -25,5 +25,5 @@ export function elementTemplateIdentityKey(
   templateKey: string,
   bundleUrl: string | null | undefined,
 ): string {
-  return bundleUrl ? `${bundleUrl}:${templateKey}` : templateKey;
+  return bundleUrl == null ? templateKey : `${bundleUrl}:${templateKey}`;
 }

--- a/packages/react/runtime/src/element-template/protocol/template-type.ts
+++ b/packages/react/runtime/src/element-template/protocol/template-type.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export interface ParsedElementTemplateType {
+  templateKey: string;
+  bundleUrl: string | null;
+}
+
+export function parseElementTemplateType(type: string): ParsedElementTemplateType {
+  const delimiter = type.lastIndexOf(':');
+  if (delimiter < 0) {
+    return {
+      templateKey: type,
+      bundleUrl: null,
+    };
+  }
+  return {
+    templateKey: type.slice(delimiter + 1),
+    bundleUrl: type.slice(0, delimiter),
+  };
+}
+
+export function elementTemplateIdentityKey(
+  templateKey: string,
+  bundleUrl: string | null | undefined,
+): string {
+  return bundleUrl ? `${bundleUrl}:${templateKey}` : templateKey;
+}

--- a/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { __OpAttr, __OpBegin, __OpEnd, __OpSlot, __OpText } from './render-to-opcodes.js';
+import { parseElementTemplateType } from '../../protocol/template-type.js';
 import type { SerializableValue } from '../../protocol/types.js';
 import { __etAttrPlanMap } from '../template/attr-slot-plan.js';
 import type { EtAttrAdapter } from '../template/attr-slot-plan.js';
@@ -14,35 +15,11 @@ export interface MainThreadCreateResult {
   rootRefs: ElementRef[];
 }
 
-function appendChildToParent(
-  parentTemplateKey: string | null | undefined,
-  parentActiveElementSlot: ElementRef[] | undefined,
-  rootRefs: ElementRef[],
-  elementRef: ElementRef,
-): void {
-  /* v8 ignore start -- stackTop is always rooted with `null`, never `undefined`. */
-  if (parentTemplateKey === undefined) {
-    return;
-  }
-  /* v8 ignore end */
-
-  if (parentTemplateKey === null) {
-    rootRefs.push(elementRef);
-    return;
-  }
-
-  if (!parentActiveElementSlot) {
-    throw new Error(`Template '${parentTemplateKey}' received a child outside of any element slot.`);
-  }
-
-  parentActiveElementSlot.push(elementRef);
-}
-
 export function renderOpcodesIntoElementTemplate(
   opcodes: unknown[],
 ): MainThreadCreateResult {
   const rootRefs: ElementRef[] = [];
-  const templateKeyStack: Array<string | null> = [null];
+  const typeStack: Array<string | null> = [null];
   const attributeSlotsStack: Array<SerializableValue[] | undefined> = [undefined];
   const elementSlotsStack: Array<Array<Array<ElementRef>> | undefined> = [undefined];
   const activeElementSlotStack: Array<ElementRef[] | undefined> = [undefined];
@@ -54,7 +31,7 @@ export function renderOpcodesIntoElementTemplate(
       case __OpBegin: {
         const vnode = opcodes[i + 1] as { type: string };
         stackTop += 1;
-        templateKeyStack[stackTop] = vnode.type;
+        typeStack[stackTop] = vnode.type;
         attributeSlotsStack[stackTop] = undefined;
         elementSlotsStack[stackTop] = undefined;
         activeElementSlotStack[stackTop] = undefined;
@@ -66,44 +43,28 @@ export function renderOpcodesIntoElementTemplate(
           throw new Error('Instruction mismatch: Popped root frame at __OpEnd');
         }
 
-        const templateKey = templateKeyStack[stackTop];
+        const type = typeStack[stackTop];
         const attributeSlots = attributeSlotsStack[stackTop];
         const elementSlots = elementSlotsStack[stackTop];
         stackTop -= 1;
 
-        // If templateKey is null, it means we popped the root frame?
-        // But __OpEnd should pair with __OpBegin.
-        // The Root frame is manually pushed and has no __OpBegin.
-        // So we should never pop the Root frame via __OpEnd unless there's an extra End.
-        if (templateKey === null) {
-          // This should effectively not happen if opcodes are balanced?
-          // Actually, if we are at root, and opcode has __OpEnd, it implies we are closing a component.
-          // The structure is: Root -> [Begin ... End] -> Root.
-          // Wait, if opcodes list ends, loop finishes.
-          // __OpEnd corresponds to a component.
-          // So if we pop, we must get a valid component frame.
+        if (type === null) {
+          // Balanced opcodes never close the synthetic root frame.
           /* v8 ignore start -- the synthetic root frame cannot be popped by balanced opcodes. */
           throw new Error('Instruction mismatch: Popped root frame at __OpEnd');
           /* v8 ignore end */
         }
-        const concreteTemplateKey = templateKey!;
+        const concreteType = type!;
+        const nativeTemplate = parseElementTemplateType(concreteType);
 
-        const parentTemplateKey = templateKeyStack[stackTop];
+        const parentType = stackTop === 0 ? null : typeStack[stackTop]!;
         const parentActiveElementSlot = activeElementSlotStack[stackTop];
 
-        const attrPlan = __etAttrPlanMap[concreteTemplateKey];
+        const attrPlan = __etAttrPlanMap[concreteType];
         const handleId = reserveElementTemplateId();
-        let elementRef: ElementRef;
-        if (attrPlan === undefined) {
-          elementRef = createElementTemplateWithReservedHandle(
-            handleId,
-            concreteTemplateKey,
-            null,
-            attributeSlots ?? null,
-            elementSlots ?? null,
-          );
-        } else {
-          const preparedAttributeSlots = attributeSlots?.slice() ?? [];
+        let preparedAttributeSlots = attributeSlots ?? null;
+        if (attrPlan !== undefined) {
+          preparedAttributeSlots = attributeSlots?.slice() ?? [];
           for (let planIndex = 0; planIndex < attrPlan.length; planIndex += 2) {
             const attrSlotIndex = attrPlan[planIndex] as number;
             const adapter = attrPlan[planIndex + 1] as EtAttrAdapter;
@@ -113,15 +74,21 @@ export function renderOpcodesIntoElementTemplate(
               preparedAttributeSlots[attrSlotIndex],
             );
           }
-          elementRef = createElementTemplateWithReservedHandle(
-            handleId,
-            concreteTemplateKey,
-            null,
-            preparedAttributeSlots,
-            elementSlots ?? null,
-          );
         }
-        appendChildToParent(parentTemplateKey, parentActiveElementSlot, rootRefs, elementRef);
+        const elementRef = createElementTemplateWithReservedHandle(
+          handleId,
+          nativeTemplate.templateKey,
+          nativeTemplate.bundleUrl,
+          preparedAttributeSlots,
+          elementSlots ?? null,
+        );
+        if (parentType === null) {
+          rootRefs.push(elementRef);
+        } else if (parentActiveElementSlot) {
+          parentActiveElementSlot.push(elementRef);
+        } else {
+          throw new Error(`Template '${parentType}' received a child outside of any element slot.`);
+        }
 
         i += 1;
         break;
@@ -153,13 +120,13 @@ export function renderOpcodesIntoElementTemplate(
           [String(text)],
           [],
         );
-        const parentTemplateKey = templateKeyStack[stackTop];
-        if (parentTemplateKey === null) {
+        const parentType = stackTop === 0 ? null : typeStack[stackTop]!;
+        if (parentType === null) {
           rootRefs.push(textRef);
         } else {
           const activeElementSlot = activeElementSlotStack[stackTop];
           if (!activeElementSlot) {
-            throw new Error(`Template '${parentTemplateKey}' received a text child outside of any element slot.`);
+            throw new Error(`Template '${parentType}' received a text child outside of any element slot.`);
           }
           activeElementSlot.push(textRef);
         }
@@ -167,9 +134,6 @@ export function renderOpcodesIntoElementTemplate(
         break;
       }
       default:
-        // Unknown opcode, maybe skip? or throw?
-        // renderToString loop increments manually.
-        // If we hit here, something is desync.
         throw new Error(`Unknown opcode: ${opcode as string | number}`);
     }
   }

--- a/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
@@ -48,12 +48,6 @@ export function renderOpcodesIntoElementTemplate(
         const elementSlots = elementSlotsStack[stackTop];
         stackTop -= 1;
 
-        if (type === null) {
-          // Balanced opcodes never close the synthetic root frame.
-          /* v8 ignore start -- the synthetic root frame cannot be popped by balanced opcodes. */
-          throw new Error('Instruction mismatch: Popped root frame at __OpEnd');
-          /* v8 ignore end */
-        }
         const concreteType = type!;
         const nativeTemplate = parseElementTemplateType(concreteType);
 

--- a/packages/react/transform/crates/swc_plugin_element_template/extractor.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/extractor.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use std::collections::HashSet;
 
 use swc_core::{
-  common::{util::take::Take, DUMMY_SP},
+  common::{errors::HANDLER, util::take::Take, Spanned, DUMMY_SP},
   ecma::{
     ast::{JSXExpr, *},
     utils::is_literal,
@@ -90,13 +90,14 @@ where
   pub(super) key: Option<JSXAttrValue>,
   attr_slot_counter: i32,
   element_slot_counter: i32,
+  has_css_id_value: bool,
 }
 
 impl<'a, V> ElementTemplateExtractor<'a, V>
 where
   V: VisitMut,
 {
-  pub(super) fn new(dynamic_part_visitor: &'a mut V) -> Self {
+  pub(super) fn new(dynamic_part_visitor: &'a mut V, has_css_id_value: bool) -> Self {
     Self {
       parent_element: false,
       dynamic_attrs: vec![],
@@ -106,6 +107,7 @@ where
       key: None,
       attr_slot_counter: 0,
       element_slot_counter: 0,
+      has_css_id_value,
     }
   }
 
@@ -410,6 +412,17 @@ where
                 if !self.parent_element {
                   self.key = value.take();
                 }
+                false
+              }
+              "css-id" if !self.parent_element && self.has_css_id_value => {
+                HANDLER.with(|handler| {
+                  handler
+                    .struct_span_warn(
+                      name.span(),
+                      "css-id is overridden by Element Template CSS scope metadata",
+                    )
+                    .emit()
+                });
                 false
               }
               _ => true,

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -228,13 +228,16 @@ where
               continue;
             }
             match value.parse::<f64>() {
-              Ok(css_id) => {
+              Ok(css_id) if css_id.is_finite() => {
                 self.css_id_value = Some(css_id);
               }
-              Err(_) => {
+              Ok(_) | Err(_) => {
                 HANDLER.with(|handler| {
                   handler
-                    .struct_span_err(span, &format!("@jsxCSSId must be numeric, got `{value}`"))
+                    .struct_span_err(
+                      span,
+                      &format!("@jsxCSSId must be a finite number, got `{value}`"),
+                    )
                     .emit()
                 });
               }

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -144,6 +144,7 @@ where
   template_identity_collision_guard: TemplateIdentityCollisionGuard,
   current_template_defs: Vec<ModuleItem>,
   comments: Option<C>,
+  css_id_value: Option<f64>,
 }
 
 impl<C> JSXTransformer<C>
@@ -198,10 +199,11 @@ where
       template_identity_collision_guard: TemplateIdentityCollisionGuard::default(),
       current_template_defs: vec![],
       comments,
+      css_id_value: None,
     }
   }
 
-  fn validate_directives(&self, span: Span) {
+  fn parse_directives(&mut self, span: Span) {
     self.comments.with_leading(span.lo, |comments| {
       for cmt in comments {
         if cmt.kind != CommentKind::Block {
@@ -218,21 +220,23 @@ where
           }
 
           let mut words = line.split_whitespace();
-          loop {
-            let pragma = words.next();
-            if pragma.is_none() {
-              break;
+          while let Some(pragma) = words.next() {
+            let Some(value) = words.next() else {
+              continue;
+            };
+            if pragma != "@jsxCSSId" {
+              continue;
             }
-            let val = words.next();
-            if let Some("@jsxCSSId") = pragma {
-              if let Some(css_id) = val {
-                if css_id.parse::<f64>().is_err() {
-                  HANDLER.with(|handler| {
-                    handler
-                      .struct_span_err(span, &format!("@jsxCSSId must be numeric, got `{css_id}`"))
-                      .emit()
-                  });
-                }
+            match value.parse::<f64>() {
+              Ok(css_id) => {
+                self.css_id_value = Some(css_id);
+              }
+              Err(_) => {
+                HANDLER.with(|handler| {
+                  handler
+                    .struct_span_err(span, &format!("@jsxCSSId must be numeric, got `{value}`"))
+                    .emit()
+                });
               }
             }
           }
@@ -281,7 +285,8 @@ where
       dynamic_attr_slots,
       dynamic_children,
     } = {
-      let mut extractor = ElementTemplateExtractor::new(self);
+      let has_css_id_value = self.css_id_value.is_some();
+      let mut extractor = ElementTemplateExtractor::new(self, has_css_id_value);
 
       node.visit_mut_with(&mut extractor);
       extractor.into_extracted_template_parts()
@@ -451,9 +456,6 @@ where
         self.current_template_defs.push(attr_plan_def);
       }
 
-      // TODO(element-template): reintroduce cssId/entryName metadata once the
-      // runtime/native contract grows a dedicated replacement channel.
-
       if let Some(element_templates) = &self.element_templates {
         element_templates.borrow_mut().push(ElementTemplateAsset {
           template_id: template_uid.clone(),
@@ -498,10 +500,10 @@ where
   }
 
   fn visit_mut_module(&mut self, n: &mut Module) {
-    self.validate_directives(n.span);
+    self.parse_directives(n.span);
     for item in &n.body {
       let span = item.span();
-      self.validate_directives(span);
+      self.parse_directives(span);
     }
 
     n.visit_mut_children_with(self);

--- a/packages/react/transform/crates/swc_plugin_element_template/template_definition.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/template_definition.rs
@@ -182,6 +182,7 @@ where
           dynamic_attr_slots,
           dynamic_attr_slot_cursor,
           element_slot_index,
+          false,
         )),
         JSXElementChild::JSXFragment(frag) => {
           out.extend(self.element_template_from_jsx_children(
@@ -222,6 +223,7 @@ where
       dynamic_attr_slots,
       dynamic_attr_slot_cursor,
       element_slot_index,
+      true,
     )
   }
 
@@ -231,6 +233,7 @@ where
     dynamic_attr_slots: &[TemplateAttributeSlot],
     dynamic_attr_slot_cursor: &mut usize,
     element_slot_index: &mut i32,
+    is_template_root: bool,
   ) -> Expr {
     if is_slot_placeholder(n) {
       let idx =
@@ -367,6 +370,19 @@ where
         element_slot_index,
       )
     };
+
+    if is_template_root {
+      if let Some(css_id) = self.css_id_value {
+        attribute_descriptors.push(self.element_template_static_attribute_descriptor(
+          "css-id",
+          Expr::Lit(Lit::Num(Number {
+            span: DUMMY_SP,
+            value: css_id,
+            raw: None,
+          })),
+        ));
+      }
+    }
 
     let final_tag = tag_value.to_string_lossy().to_string();
     self.element_template_element_node(&final_tag, attribute_descriptors, children)

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
@@ -874,8 +874,28 @@ fn should_report_invalid_jsx_css_id_as_diagnostic() {
   assert!(
     diagnostics
       .iter()
-      .any(|message| message == "@jsxCSSId must be numeric, got `abc`"),
+      .any(|message| message == "@jsxCSSId must be a finite number, got `abc`"),
     "expected invalid @jsxCSSId diagnostic, got: {diagnostics:?}"
+  );
+}
+
+#[test]
+fn should_report_non_finite_jsx_css_id_as_diagnostic() {
+  let (_, _, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"
+      /**
+       * @jsxCSSId NaN
+       */
+      <view>Invalid Css Id</view>
+    "#,
+    element_template_config(),
+  );
+
+  assert!(
+    diagnostics
+      .iter()
+      .any(|message| message == "@jsxCSSId must be a finite number, got `NaN`"),
+    "expected non-finite @jsxCSSId diagnostic, got: {diagnostics:?}"
   );
 }
 

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
@@ -42,6 +42,23 @@ fn assert_has_single_builtin_raw_text_template(templates: &[ElementTemplateAsset
   );
 }
 
+fn assert_single_framework_css_id_attr(
+  template: &serde_json::Value,
+  expected_css_id: f64,
+  message: &str,
+) {
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  let css_id_attrs = attrs
+    .iter()
+    .filter(|attr| attr["key"] == "css-id")
+    .collect::<Vec<_>>();
+  assert_eq!(css_id_attrs.len(), 1, "{message}");
+  assert_eq!(css_id_attrs[0]["kind"], "static");
+  assert_eq!(css_id_attrs[0]["value"].as_f64(), Some(expected_css_id));
+}
+
 fn template_snapshot_json(templates: &[ElementTemplateAsset]) -> Vec<serde_json::Value> {
   templates
     .iter()
@@ -701,6 +718,8 @@ fn should_collect_element_templates_for_dynamic_component_in_element_template_mo
   assert_has_single_builtin_raw_text_template(&templates);
   assert!(!code.contains("__elementTemplateMap"));
   assert!(code.contains("globDynamicComponentEntry"));
+  assert!(!code.contains("templateKey"));
+  assert!(!code.contains("bundleUrl"));
 
   for template in templates {
     assert!(template.template_id.starts_with("_et_"));
@@ -857,5 +876,71 @@ fn should_report_invalid_jsx_css_id_as_diagnostic() {
       .iter()
       .any(|message| message == "@jsxCSSId must be numeric, got `abc`"),
     "expected invalid @jsxCSSId diagnostic, got: {diagnostics:?}"
+  );
+}
+
+#[test]
+fn should_warn_and_override_direct_user_css_id_attr() {
+  let (_, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"
+      /**
+       * @jsxCSSId 100
+       */
+      <view css-id="user-css-id" />
+    "#,
+    element_template_config(),
+  );
+
+  assert!(
+    diagnostics
+      .iter()
+      .any(|message| { message.contains("css-id") && message.contains("overridden") }),
+    "expected direct css-id override diagnostic, got: {diagnostics:?}"
+  );
+
+  let template = templates
+    .iter()
+    .find(|template| template.template_id != BUILTIN_RAW_TEXT_TEMPLATE_ID)
+    .expect("should collect a user template");
+  let template = serde_json::to_value(&template.compiled_template).expect("compiled template json");
+  assert_single_framework_css_id_attr(
+    &template,
+    100.0,
+    "direct user css-id should be replaced by the framework css-id",
+  );
+}
+
+#[test]
+fn should_warn_and_override_dynamic_user_css_id_attr_without_reserving_slot() {
+  let (code, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"
+      /**
+       * @jsxCSSId 100
+       */
+      <view css-id={userCssId} />
+    "#,
+    element_template_config(),
+  );
+
+  assert!(
+    diagnostics
+      .iter()
+      .any(|message| { message.contains("css-id") && message.contains("overridden") }),
+    "expected direct css-id override diagnostic, got: {diagnostics:?}"
+  );
+  assert!(
+    !code.contains("attributeSlots"),
+    "overridden dynamic css-id should not reserve an ET attribute slot, got: {code}"
+  );
+
+  let template = templates
+    .iter()
+    .find(|template| template.template_id != BUILTIN_RAW_TEXT_TEMPLATE_ID)
+    .expect("should collect a user template");
+  let template = serde_json::to_value(&template.compiled_template).expect("compiled template json");
+  assert_single_framework_css_id_attr(
+    &template,
+    100.0,
+    "dynamic user css-id should be replaced by the framework css-id",
   );
 }

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
@@ -233,7 +233,7 @@ fn should_emit_spread_attr_plan_with_ref_adapter() {
 }
 
 #[test]
-fn should_not_inject_root_css_scope_attrs_for_element_template() {
+fn should_inject_root_css_scope_attr_for_element_template() {
   let (code, template) = first_user_template_json_with_code(
     r#"
       /**
@@ -253,11 +253,15 @@ fn should_not_inject_root_css_scope_attrs_for_element_template() {
   let attrs = template["attributesArray"]
     .as_array()
     .expect("attributesArray");
+  let css_id_attr = attrs
+    .iter()
+    .find(|attr| attr["key"] == "css-id")
+    .expect("root element should carry framework css-id attr");
+  assert_eq!(css_id_attr["kind"], "static");
+  assert_eq!(css_id_attr["value"].as_f64(), Some(100.0));
   assert!(
-    attrs
-      .iter()
-      .all(|attr| attr["key"] != "css-id" && attr["key"] != "entry-name"),
-    "root element should no longer carry css scope attrs once metadata moves to options",
+    attrs.iter().all(|attr| attr["key"] != "entry-name"),
+    "root element should not carry entry-name attrs",
   );
 
   let children = template["children"].as_array().expect("children array");
@@ -270,6 +274,87 @@ fn should_not_inject_root_css_scope_attrs_for_element_template() {
       .all(|attr| attr["key"] != "css-id" && attr["key"] != "entry-name"),
     "nested static elements should not receive css scope attrs",
   );
+}
+
+#[test]
+fn should_inject_css_scope_attr_for_each_user_template_root() {
+  let templates = transform_to_templates(
+    r#"
+      /**
+       * @jsxCSSId 100
+       */
+      const first = <view />;
+      const second = <image />;
+    "#,
+    element_template_config(),
+  );
+
+  let user_templates = templates
+    .into_iter()
+    .filter(|template| template.template_id != BUILTIN_RAW_TEXT_TEMPLATE_ID)
+    .map(|template| {
+      serde_json::to_value(template.compiled_template).expect("compiled template to json")
+    })
+    .collect::<Vec<_>>();
+  assert_eq!(
+    user_templates.len(),
+    2,
+    "should collect both user template roots"
+  );
+
+  for template in user_templates {
+    let attrs = template["attributesArray"]
+      .as_array()
+      .expect("attributesArray");
+    assert!(
+      attrs.iter().any(|attr| {
+        attr["key"] == "css-id" && attr["kind"] == "static" && attr["value"].as_f64() == Some(100.0)
+      }),
+      "user template root should carry framework css-id attr: {template:?}",
+    );
+  }
+}
+
+#[test]
+fn should_not_inject_css_scope_attrs_without_jsx_css_id() {
+  let template = first_user_template_json(
+    r#"
+      <view>
+        <text>Hello</text>
+      </view>
+    "#,
+  );
+
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  assert!(
+    attrs
+      .iter()
+      .all(|attr| attr["key"] != "css-id" && attr["key"] != "entry-name"),
+    "root element should not carry css scope attrs without @jsxCSSId",
+  );
+}
+
+#[test]
+fn should_append_framework_css_id_after_spread_attrs() {
+  let template = first_user_template_json(
+    r#"
+      /**
+       * @jsxCSSId 100
+       */
+      <view {...props} />
+    "#,
+  );
+
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  assert_eq!(attrs[0]["kind"], "spread");
+  let last_attr = attrs.last().expect("root should have attrs");
+  assert_eq!(last_attr["key"], "css-id");
+  assert_eq!(last_attr["kind"], "static");
+  assert_eq!(last_attr["value"].as_f64(), Some(100.0));
 }
 
 #[test]
@@ -344,7 +429,7 @@ fn should_preserve_text_children_when_text_attr_may_come_from_spread() {
 }
 
 #[test]
-fn should_not_inject_root_entry_name_attr_for_dynamic_component_element_template() {
+fn should_inject_css_id_without_entry_name_attr_for_dynamic_component_element_template() {
   let (code, template) = first_user_template_json_with_code(
     r#"
       /**
@@ -365,10 +450,14 @@ fn should_not_inject_root_entry_name_attr_for_dynamic_component_element_template
     .as_array()
     .expect("attributesArray");
   assert!(
-    attrs
-      .iter()
-      .all(|attr| attr["key"] != "entry-name" && attr["key"] != "css-id"),
-    "dynamic component root should no longer encode css scope metadata in attrs",
+    attrs.iter().any(|attr| {
+      attr["key"] == "css-id" && attr["kind"] == "static" && attr["value"].as_f64() == Some(100.0)
+    }),
+    "dynamic component root should carry framework css-id attr",
+  );
+  assert!(
+    attrs.iter().all(|attr| attr["key"] != "entry-name"),
+    "dynamic component root should not encode entry metadata in attrs",
   );
 }
 

--- a/packages/webpack/react-webpack-plugin/test/loader-options.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/loader-options.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { getBackgroundTransformOptions } from '../src/loaders/options.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function createLoaderContext(options: Record<string, unknown>) {
+  return {
+    getOptions: () => options,
+    hot: false,
+    resourcePath: path.resolve(__dirname, 'fixture.tsx'),
+    rootContext: __dirname,
+    sourceMap: false,
+  };
+}
+
+describe('loader options', () => {
+  it('uses ET backend with all CSS scoped when enableRemoveCSSScope is false', () => {
+    const context = createLoaderContext({
+      enableRemoveCSSScope: false,
+      experimental_useElementTemplate: true,
+    });
+
+    const backgroundOptions = getBackgroundTransformOptions.call(
+      context,
+      undefined,
+    );
+
+    expect(backgroundOptions.cssScope).toMatchObject({
+      mode: 'all',
+      filename: 'fixture.tsx',
+    });
+    expect(backgroundOptions.snapshot).toBe(false);
+    expect(backgroundOptions.elementTemplate).toMatchObject({
+      runtimePkg: '@lynx-js/react/element-template',
+      target: 'JS',
+    });
+  });
+});


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic bundle URLs are now preserved and used when creating and matching element templates, improving template identity and hydration accuracy.
  * JSX-level CSS scope directive injects framework CSS-id into root templates for consistent scoping.

* **Tests**
  * Expanded coverage for dynamic bundle URL handling, CSS scoping, identity matching, and serialization.

* **Chores**
  * Fixture runner and mocks enhanced to support per-fixture config and dynamic component entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

Element Template currently drops the scoped CSS metadata that Snapshot can carry when `enableRemoveCSSScope: false` keeps CSS ids in the compiled CSS. This PR lets ET preserve that native-visible metadata without adding extra JSX props or background-state fields.

The compiler now reads `@jsxCSSId`, injects a framework-owned `css-id` static attribute into template-root Template Definitions, and encodes dynamic-component bundle identity in the ET `type`. The runtime keeps storing only that `type`, then splits it at the native create/hydrate boundary to pass the local template id and optional bundle URL separately.

## Runtime / Generated Output Contract

- Producer: `swc_plugin_element_template` parses `@jsxCSSId` and, only when present, appends a root-level static `{ kind: "static", key: "css-id", value: <number> }` descriptor for each user template. Direct user `css-id` is warned and overwritten; spread `css-id` is not statically diagnosable, but the framework descriptor is appended after spreads so it wins. No default `css-id: 0` descriptor is emitted.
- Dynamic identity: dynamic component template references are emitted as `${globDynamicComponentEntry}:${templateId}`. The background and main-thread ET runtime keep this single `type` string in memory.
- Native boundary: `parseElementTemplateType(type)` splits on the final `:`. Native create receives `templateKey` as the local template id and `bundleUrl` as the prefix, or `null` for page-local templates and built-in raw text.
- Hydration identity: matching uses `elementTemplateIdentityKey(templateKey, bundleUrl)` so two bundles can reuse a local template id without colliding.

## How It Works

1. The webpack loader preserves `enableRemoveCSSScope: false` as `cssScope.mode = "all"` while still selecting the ET backend.
2. The ET SWC transform records `@jsxCSSId`, injects root CSS descriptors into Template Definition assets, and keeps dynamic component type constants entry-prefixed.
3. Runtime render opcodes and background `emitCreate` parse `type` only when talking to native, passing `bundleUrl` through `__CreateElementTemplate` and create-template ops.
4. Hydration compares serialized `{ templateKey, bundleUrl }` against the parsed background type before rebinding handles.

## Reviewer Notes

- Start with `packages/react/transform/crates/swc_plugin_element_template/lib.rs`, `extractor.rs`, and `template_definition.rs` for the compiler-side contract.
- Read `packages/react/runtime/src/element-template/protocol/template-type.ts`, `runtime/render/render-opcodes.ts`, `background/instance.ts`, and `background/hydrate.ts` for the runtime/native boundary.
- The render fixtures under `packages/react/runtime/__test__/element-template/fixtures/render/` show both generated Template Definition `css-id` output and PAPI calls with `bundleUrl`.
- `packages/webpack/react-webpack-plugin/test/loader-options.test.ts` covers the loader option path from `enableRemoveCSSScope: false` into ET transform options.

## Boundaries

- ET does not add `entry-name`, JSX `templateKey`, JSX `bundleUrl`, or default `css-id: 0` attributes.
- The runtime does not keep a separate `bundleUrl` field on ET instances; `type` remains the stored identity and is split only at protocol boundaries.
- Spread-provided `css-id` values are intentionally not diagnosed at compile time, but descriptor ordering still makes the framework value win.
- This keeps the behavior scoped to the unpublished Element Template path and does not change released non-ET package behavior.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required: unpublished Element Template path, no package dependency metadata changes).
