### PR TITLE
fix: A2UI bench UI judge execution

### DIFF
--- a/.github/a2ui-bench.instructions.md
+++ b/.github/a2ui-bench.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "packages/genui/server/service/a2ui-bench-*.ts,packages/genui/a2ui-playground/src/pages/BenchPage.tsx,packages/genui/server/next.config.mjs"
+---
+
+A2UI bench jobs that enable UI judge should render generated messages through the playground `render.html` URL supplied by the client or `A2UI_BENCH_PLAYGROUND_BASE_URL`, then run `@lynx-js/ui-judge` against that browser page. Do not mark judge or render metrics as skipped when their settings are enabled; surface browser, model, or preview-render configuration failures in the item errors so reports explain missing scores.
+
+When importing Midscene or UI judge from the Next server, keep `@lynx-js/ui-judge`, `@midscene/core`, `@midscene/shared`, `@midscene/web`, `@sparticuz/chromium`, and `playwright-core` in `serverExternalPackages` so Turbopack does not bundle optional Midscene debug integrations.

--- a/packages/genui/a2ui-playground/src/pages/BenchPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/BenchPage.tsx
@@ -120,8 +120,8 @@ interface BenchReport {
   };
   capabilities?: {
     agent: 'enabled';
-    renderMetrics: 'disabled' | 'skipped';
-    judge: 'disabled' | 'skipped';
+    renderMetrics: 'disabled' | 'enabled';
+    judge: 'disabled' | 'enabled';
   };
   warnings?: string[];
   groups: BenchGroup[];
@@ -400,6 +400,20 @@ function getA2UIBenchHealthEndpoint(): string {
   }
 }
 
+function getA2UIPlaygroundBaseUrl(): string {
+  const url = new URL(window.location.href);
+  url.hash = '';
+  url.search = '';
+  if (!url.pathname.endsWith('/')) {
+    const parts = url.pathname.split('/');
+    const last = parts[parts.length - 1] ?? '';
+    url.pathname = last.includes('.')
+      ? url.pathname.replace(/[^/]*$/u, '')
+      : `${url.pathname}/`;
+  }
+  return url.toString();
+}
+
 function canForwardApiKeyToEndpoint(raw: string): boolean {
   try {
     const endpoint = new URL(raw, window.location.origin);
@@ -624,7 +638,7 @@ function getRunMetaText(
 }
 
 function formatReportJudgeMetric(report: BenchReport | null): string {
-  if (report?.capabilities?.judge === 'skipped') return 'skipped';
+  if (report?.capabilities?.judge === 'disabled') return 'off';
   if (!report || report.summaries.length === 0) return 'n/a';
   return `${
     average(report.summaries.map((item) => item.avgJudgeScore)).toFixed(1)
@@ -636,8 +650,9 @@ function formatSummaryJudgeMetric(
   settings: BenchSettings,
   summary: BenchGroupSummary,
 ): string {
-  if (report.capabilities?.judge === 'skipped') return 'skipped';
-  if (!settings.judgeEnabled) return 'off';
+  if (!settings.judgeEnabled || report.capabilities?.judge === 'disabled') {
+    return 'off';
+  }
   return `${summary.avgJudgeScore.toFixed(1)}/5`;
 }
 
@@ -884,6 +899,9 @@ export function BenchPage() {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
+            playground: {
+              baseUrl: getA2UIPlaygroundBaseUrl(),
+            },
             provider: providerConfigured
               ? filterProviderForEndpoint(env, jobsEndpoint)
               : {},

--- a/packages/genui/server/next.config.mjs
+++ b/packages/genui/server/next.config.mjs
@@ -4,7 +4,15 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  serverExternalPackages: ['@mastra/core'],
+  serverExternalPackages: [
+    '@mastra/core',
+    '@lynx-js/ui-judge',
+    '@midscene/core',
+    '@midscene/shared',
+    '@midscene/web',
+    '@sparticuz/chromium',
+    'playwright-core',
+  ],
 };
 
 export default nextConfig;

--- a/packages/genui/server/package.json
+++ b/packages/genui/server/package.json
@@ -11,8 +11,11 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.63",
     "@aws-sdk/client-s3": "^3.1053.0",
+    "@lynx-js/ui-judge": "workspace:*",
     "@mastra/core": "1.13.2",
+    "@sparticuz/chromium": "^149.0.0",
     "next": "16.2.6",
+    "playwright-core": "^1.58.2",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "zod": "^3.25.76"

--- a/packages/genui/server/service/a2ui-bench-preview.ts
+++ b/packages/genui/server/service/a2ui-bench-preview.ts
@@ -1,0 +1,614 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createServer as createHttpServer } from 'node:http';
+
+import type { Browser, LaunchOptions } from 'playwright-core';
+
+import type { BenchJobRequest, BenchScenarioRequest } from './a2ui-bench-types';
+import type { A2UIMessage } from '../agent/a2ui-validator';
+
+interface BenchPreviewOptions {
+  messages: A2UIMessage[];
+  request: BenchJobRequest;
+  runId: string;
+  scenario: BenchScenarioRequest;
+}
+
+interface BenchPreviewResult {
+  errors: string[];
+  fmpMs: number;
+  judgeScore: number;
+  renderMs: number;
+  ttiMs: number;
+}
+
+interface PreviewMetricBag {
+  fcp?: unknown;
+  fmp?: unknown;
+  render?: unknown;
+  tti?: unknown;
+}
+
+interface JudgeEnv {
+  apiKey?: string;
+  baseURL?: string;
+  model?: string;
+}
+
+interface JudgeProxy {
+  baseUrl: string;
+  close: () => Promise<void>;
+}
+
+const DEFAULT_PLAYGROUND_BASE_URL = 'https://lynx-stack.dev/a2ui/';
+const DEFAULT_JUDGE_TIMEOUT_MS = 120_000;
+const PREVIEW_WIDTH = 450;
+const PREVIEW_HEIGHT = 970;
+const IFRAME_WIDTH = 430;
+const IFRAME_HEIGHT = 932;
+const JUDGE_ENV_KEYS = [
+  'MIDSCENE_MODEL_API_KEY',
+  'MIDSCENE_MODEL_BASE_URL',
+  'MIDSCENE_MODEL_NAME',
+  'MIDSCENE_MODEL_TIMEOUT',
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+] as const;
+
+let browserPromise: Promise<Browser> | null = null;
+let judgeQueue: Promise<void> = Promise.resolve();
+
+const noop = () => undefined;
+
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, 'utf8')
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/u, '');
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isDevHost(hostname: string): boolean {
+  return hostname === 'localhost'
+    || hostname === '127.0.0.1'
+    || hostname === '0.0.0.0'
+    || hostname.startsWith('10.')
+    || hostname.startsWith('192.168.')
+    || /^172\.(?:1[6-9]|2\d|3[01])\./u.test(hostname);
+}
+
+function normalizeBaseUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    url.hash = '';
+    url.search = '';
+    if (!url.pathname.endsWith('/')) {
+      url.pathname = `${url.pathname}/`;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isTrustedPlaygroundBaseUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    if (url.username || url.password) return false;
+    if (url.origin === 'https://lynx-stack.dev') return true;
+    if (process.env.A2UI_BENCH_PLAYGROUND_BASE_URL) {
+      const configured = new URL(process.env.A2UI_BENCH_PLAYGROUND_BASE_URL);
+      if (url.origin === configured.origin) return true;
+    }
+    if (process.env.NODE_ENV !== 'production') {
+      return url.protocol === 'http:' && isDevHost(url.hostname);
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function resolvePlaygroundBaseUrl(request: BenchJobRequest): string {
+  const configured = process.env.A2UI_BENCH_PLAYGROUND_BASE_URL;
+  if (configured) {
+    const normalized = normalizeBaseUrl(configured);
+    if (normalized) return normalized;
+  }
+
+  const requested = request.playground?.baseUrl;
+  if (requested && isTrustedPlaygroundBaseUrl(requested)) {
+    const normalized = normalizeBaseUrl(requested);
+    if (normalized) return normalized;
+  }
+
+  return DEFAULT_PLAYGROUND_BASE_URL;
+}
+
+function buildRenderUrl(baseUrl: string, metricId: string): string {
+  const url = new URL('render.html', baseUrl);
+  url.searchParams.set('protocol', 'a2ui');
+  url.searchParams.set('demoUrl', './a2ui.web.js');
+  url.searchParams.set('theme', 'light');
+  url.searchParams.set('speed', '0');
+  url.searchParams.set('instant', '1');
+  url.searchParams.set('liveAction', '1');
+  url.searchParams.set('previewMetricId', metricId);
+  url.searchParams.set('messages', base64UrlEncode(JSON.stringify([])));
+  return url.toString();
+}
+
+function readMetric(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.round(value))
+    : 0;
+}
+
+function normalizeOpenAIBaseUrl(raw: string): string {
+  try {
+    const url = new URL(raw);
+    url.pathname = url.pathname
+      .replace(/\/chat\/completions\/?$/u, '')
+      .replace(/\/responses\/?$/u, '');
+    return url.toString().replace(/\/$/u, '');
+  } catch {
+    return raw;
+  }
+}
+
+function usesQueryAkAuth(endpoint: string): boolean {
+  try {
+    return /\/crawl\/?$/u.test(new URL(endpoint).pathname);
+  } catch {
+    return false;
+  }
+}
+
+function shouldProxyJudgeBaseUrl(raw: string): boolean {
+  return usesQueryAkAuth(raw);
+}
+
+function resolveJudgeEnv(request: BenchJobRequest): JudgeEnv {
+  const apiKey = process.env.A2UI_BENCH_JUDGE_API_KEY
+    ?? process.env.MIDSCENE_MODEL_API_KEY
+    ?? request.provider.apiKey
+    ?? process.env.OPENAI_API_KEY;
+  const baseURL = process.env.A2UI_BENCH_JUDGE_BASE_URL
+    ?? process.env.MIDSCENE_MODEL_BASE_URL
+    ?? request.provider.baseURL
+    ?? process.env.OPENAI_BASE_URL;
+  const model = process.env.A2UI_BENCH_JUDGE_MODEL
+    ?? process.env.JUDGE_MODEL
+    ?? process.env.MIDSCENE_MODEL_NAME
+    ?? request.provider.model
+    ?? process.env.OPENAI_MODEL;
+  return { apiKey, baseURL, model };
+}
+
+function getMissingJudgeEnv(env: JudgeEnv): string[] {
+  const missing: string[] = [];
+  if (!env.apiKey) missing.push('MIDSCENE_MODEL_API_KEY');
+  if (!env.baseURL) missing.push('MIDSCENE_MODEL_BASE_URL');
+  if (!env.model) missing.push('MIDSCENE_MODEL_NAME');
+  return missing;
+}
+
+async function readRequestBody(req: import('node:http').IncomingMessage) {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of req as AsyncIterable<Uint8Array | string>) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function startJudgeModelProxy(
+  endpoint: string,
+  apiKey: string,
+): Promise<JudgeProxy> {
+  const server = createHttpServer((req, res) => {
+    void (async () => {
+      if (req.method !== 'POST' || !req.url?.endsWith('/chat/completions')) {
+        res.statusCode = 404;
+        res.end('not found');
+        return;
+      }
+
+      const body = await readRequestBody(req);
+      const url = new URL(endpoint);
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (usesQueryAkAuth(endpoint)) {
+        url.searchParams.set('ak', apiKey);
+      } else {
+        headers.Authorization = `Bearer ${apiKey}`;
+      }
+
+      const upstream = await fetch(url, {
+        body,
+        headers,
+        method: 'POST',
+      });
+      const responseText = await upstream.text();
+      res.statusCode = upstream.status;
+      res.setHeader(
+        'Content-Type',
+        upstream.headers.get('content-type') ?? 'application/json',
+      );
+      res.end(responseText);
+    })().catch((error: unknown) => {
+      res.statusCode = 502;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        error: {
+          message: toErrorMessage(error),
+          type: 'a2ui_bench_judge_proxy_error',
+        },
+      }));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Failed to allocate a local ui-judge model proxy port.');
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+async function resolveJudgeRuntimeEnv(
+  env: JudgeEnv,
+): Promise<{ env: Required<JudgeEnv>; proxy?: JudgeProxy }> {
+  const missing = getMissingJudgeEnv(env);
+  if (missing.length > 0) {
+    throw new Error(
+      `ui-judge is enabled but missing judge model config: ${
+        missing.join(', ')
+      }.`,
+    );
+  }
+
+  const { apiKey, baseURL, model } = env;
+  if (!apiKey || !baseURL || !model) {
+    throw new Error('ui-judge model config failed normalization.');
+  }
+
+  const resolved: Required<JudgeEnv> = {
+    apiKey,
+    baseURL,
+    model,
+  };
+
+  if (!shouldProxyJudgeBaseUrl(resolved.baseURL)) {
+    return {
+      env: {
+        ...resolved,
+        baseURL: normalizeOpenAIBaseUrl(resolved.baseURL),
+      },
+    };
+  }
+
+  const proxy = await startJudgeModelProxy(resolved.baseURL, resolved.apiKey);
+  return {
+    env: {
+      ...resolved,
+      baseURL: proxy.baseUrl,
+    },
+    proxy,
+  };
+}
+
+function setEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+async function withSerializedJudgeEnv<T>(
+  env: Required<JudgeEnv>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  let release: () => void = noop;
+  const previous = judgeQueue.catch(noop);
+  judgeQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+
+  const saved = new Map<string, string | undefined>();
+  for (const key of JUDGE_ENV_KEYS) {
+    saved.set(key, process.env[key]);
+  }
+
+  try {
+    process.env.MIDSCENE_MODEL_API_KEY = env.apiKey;
+    process.env.MIDSCENE_MODEL_BASE_URL = env.baseURL;
+    process.env.MIDSCENE_MODEL_NAME = env.model;
+    process.env.MIDSCENE_MODEL_TIMEOUT ??= String(DEFAULT_JUDGE_TIMEOUT_MS);
+    process.env.OPENAI_API_KEY = env.apiKey;
+    process.env.OPENAI_BASE_URL = env.baseURL;
+    return await fn();
+  } finally {
+    for (const key of JUDGE_ENV_KEYS) {
+      setEnvValue(key, saved.get(key));
+    }
+    release();
+  }
+}
+
+function isServerlessRuntime(): boolean {
+  return Boolean(
+    process.env.VERCEL
+      ?? process.env.AWS_LAMBDA_FUNCTION_NAME
+      ?? process.env.AWS_EXECUTION_ENV,
+  );
+}
+
+async function resolveChromiumLaunchOptions(): Promise<LaunchOptions> {
+  const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+    ?? process.env.CHROME_EXECUTABLE_PATH
+    ?? process.env.CHROMIUM_EXECUTABLE_PATH;
+  if (executablePath) {
+    return {
+      args: ['--disable-dev-shm-usage', '--no-sandbox'],
+      executablePath,
+      headless: true,
+    };
+  }
+
+  if (!isServerlessRuntime()) {
+    return { headless: true };
+  }
+
+  const mod = await import('@sparticuz/chromium');
+  const chromium = mod.default;
+  const serverlessExecutablePath = await chromium.executablePath();
+  return {
+    args: [...chromium.args, '--disable-dev-shm-usage'],
+    executablePath: serverlessExecutablePath,
+    headless: true,
+  };
+}
+
+async function launchBenchBrowser(): Promise<Browser> {
+  const { chromium } = await import('playwright-core');
+  const launchOptions = await resolveChromiumLaunchOptions();
+  return await chromium.launch(launchOptions);
+}
+
+async function getBenchBrowser(): Promise<Browser> {
+  browserPromise ??= launchBenchBrowser().catch((error: unknown) => {
+    browserPromise = null;
+    throw error;
+  });
+
+  const browser = await browserPromise;
+  if (!browser.isConnected()) {
+    browserPromise = null;
+    return await getBenchBrowser();
+  }
+  return browser;
+}
+
+async function renderMessagesInPreview(
+  options: BenchPreviewOptions,
+): Promise<{
+  metrics: PreviewMetricBag;
+  page: Awaited<ReturnType<Browser['newPage']>>;
+}> {
+  const browser = await getBenchBrowser();
+  const page = await browser.newPage({
+    deviceScaleFactor: 1,
+    viewport: { height: PREVIEW_HEIGHT, width: PREVIEW_WIDTH },
+  });
+  const renderUrl = buildRenderUrl(
+    resolvePlaygroundBaseUrl(options.request),
+    `bench-${options.runId}`,
+  );
+
+  try {
+    await page.setContent(
+      `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    html, body { margin: 0; padding: 0; background: #f4f5f7; }
+    .shell { width: ${PREVIEW_WIDTH}px; min-height: ${PREVIEW_HEIGHT}px; display: flex; align-items: center; justify-content: center; }
+    iframe { width: ${IFRAME_WIDTH}px; height: ${IFRAME_HEIGHT}px; border: 0; background: white; box-shadow: 0 0 0 1px rgba(0,0,0,.08); }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <iframe id="preview" title="A2UI preview"></iframe>
+  </div>
+</body>
+</html>`,
+      { waitUntil: 'load' },
+    );
+
+    const metrics = await page.evaluate(
+      ({ id, messages, src }) => {
+        return new Promise<PreviewMetricBag>((resolve) => {
+          const iframe = document.getElementById(
+            'preview',
+          ) as HTMLIFrameElement | null;
+          const metricBag: PreviewMetricBag = {};
+          if (!iframe) {
+            resolve(metricBag);
+            return;
+          }
+
+          let posted = false;
+          let settleTimer = 0;
+
+          const settleSoon = (delay = 800) => {
+            window.clearTimeout(settleTimer);
+            settleTimer = window.setTimeout(() => {
+              resolve(metricBag);
+            }, delay);
+          };
+
+          const postMessages = () => {
+            if (posted) return;
+            posted = true;
+            const targetOrigin = new URL(src).origin;
+            const post = () => {
+              iframe.contentWindow?.postMessage(
+                { messages, type: 'A2UI_LIVE_MESSAGES' },
+                targetOrigin,
+              );
+            };
+            post();
+            for (const delay of [120, 320, 800]) {
+              window.setTimeout(post, delay);
+            }
+          };
+
+          window.addEventListener('message', (event) => {
+            const data = event.data as Record<string, unknown> | null;
+            if (!data || typeof data !== 'object') return;
+            if (data.type === 'A2UI_RENDER_READY') {
+              postMessages();
+              settleSoon(3500);
+              return;
+            }
+            if (data.type !== 'A2UI_PREVIEW_METRIC') return;
+            if (data.metricId !== id) return;
+            const metric = data.metric;
+            if (
+              metric === 'fcp' || metric === 'fmp' || metric === 'render'
+              || metric === 'tti'
+            ) {
+              metricBag[metric] = data.value;
+            }
+            if (metric === 'tti') {
+              settleSoon(500);
+            } else {
+              settleSoon(1800);
+            }
+          });
+
+          iframe.src = src;
+          window.setTimeout(postMessages, 800);
+          window.setTimeout(() => resolve(metricBag), 12_000);
+        });
+      },
+      {
+        id: `bench-${options.runId}`,
+        messages: options.messages,
+        src: renderUrl,
+      },
+    );
+
+    await page.waitForTimeout(1000);
+    return { metrics, page };
+  } catch (error) {
+    await page.close().catch(noop);
+    throw error;
+  }
+}
+
+async function runJudge(
+  page: Awaited<ReturnType<Browser['newPage']>>,
+  options: BenchPreviewOptions,
+): Promise<number> {
+  const { judgePage } = await import('@lynx-js/ui-judge');
+  const runtime = await resolveJudgeRuntimeEnv(
+    resolveJudgeEnv(options.request),
+  );
+  try {
+    const result = await withSerializedJudgeEnv(runtime.env, () =>
+      judgePage({
+        dimension: 'visual-correctness',
+        page,
+        reference: options.scenario.prompt,
+        steps: options.scenario.judgeSteps,
+        task: options.scenario.judgeTask ?? options.scenario.prompt,
+        timeoutMs: Number(
+          process.env.A2UI_BENCH_JUDGE_TIMEOUT_MS
+            ?? process.env.JUDGE_TIMEOUT_MS
+            ?? DEFAULT_JUDGE_TIMEOUT_MS,
+        ),
+      }));
+    if (result.error) {
+      throw new Error(result.error.message);
+    }
+    return result.score;
+  } finally {
+    await runtime.proxy?.close().catch(noop);
+  }
+}
+
+export async function runBenchPreview(
+  options: BenchPreviewOptions,
+): Promise<BenchPreviewResult> {
+  const shouldRender = options.request.settings.renderMetricsEnabled
+    || options.request.settings.judgeEnabled;
+  if (!shouldRender || options.messages.length === 0) {
+    return {
+      errors: [],
+      fmpMs: 0,
+      judgeScore: 0,
+      renderMs: 0,
+      ttiMs: 0,
+    };
+  }
+
+  const errors: string[] = [];
+  let page: Awaited<ReturnType<Browser['newPage']>> | undefined;
+
+  try {
+    const rendered = await renderMessagesInPreview(options);
+    page = rendered.page;
+
+    let judgeScore = 0;
+    if (options.request.settings.judgeEnabled) {
+      try {
+        judgeScore = await runJudge(page, options);
+      } catch (error) {
+        errors.push(`ui-judge failed: ${toErrorMessage(error)}`);
+      }
+    }
+
+    return {
+      errors,
+      fmpMs: readMetric(rendered.metrics.fmp),
+      judgeScore,
+      renderMs: readMetric(rendered.metrics.render),
+      ttiMs: readMetric(rendered.metrics.tti),
+    };
+  } catch (error) {
+    return {
+      errors: [`preview render failed: ${toErrorMessage(error)}`],
+      fmpMs: 0,
+      judgeScore: 0,
+      renderMs: 0,
+      ttiMs: 0,
+    };
+  } finally {
+    await page?.close().catch(noop);
+  }
+}

--- a/packages/genui/server/service/a2ui-bench-request.ts
+++ b/packages/genui/server/service/a2ui-bench-request.ts
@@ -175,6 +175,14 @@ function normalizeScenarios(value: unknown): BenchScenarioRequest[] {
     .filter((item): item is BenchScenarioRequest => item !== null);
 }
 
+function normalizePlayground(
+  value: unknown,
+): BenchJobRequest['playground'] {
+  if (!isRecord(value)) return undefined;
+  const baseUrl = readOptionalString(value.baseUrl, 500);
+  return baseUrl ? { baseUrl } : undefined;
+}
+
 export function normalizeBenchJobRequest(
   value: unknown,
   options: { clientOverrideAccepted: boolean },
@@ -246,10 +254,13 @@ export function normalizeBenchJobRequest(
     );
   }
 
+  const playground = normalizePlayground(value.playground);
+
   return {
     ok: true,
     request: {
       provider,
+      ...(playground ? { playground } : {}),
       settings,
       groups,
       scenarios,

--- a/packages/genui/server/service/a2ui-bench-runner.ts
+++ b/packages/genui/server/service/a2ui-bench-runner.ts
@@ -5,6 +5,7 @@
 import { getA2UIAgentService } from './a2ui-agent';
 import type { ChatMessage } from './a2ui-agent';
 import { resolveBenchCatalog } from './a2ui-bench-catalog';
+import { runBenchPreview } from './a2ui-bench-preview';
 import { getBenchJobStore } from './a2ui-bench-store';
 import type {
   BenchCatalogLabel,
@@ -184,6 +185,15 @@ async function runOne(
     emitRunPhase(jobId, item, 'validate');
     const agentMs = performance.now() - startedAt;
     const outputChars = result.text.length;
+    const preview = result.ok
+      ? await runBenchPreviewForItem(jobId, request, item, result.messages)
+      : {
+        errors: [],
+        fmpMs: 0,
+        judgeScore: 0,
+        renderMs: 0,
+        ttiMs: 0,
+      };
     return {
       id: runId,
       groupId: item.group.id,
@@ -198,14 +208,14 @@ async function runOne(
       catalog: catalogLabel,
       tokens: parseTotalTokens(result.usage),
       agentMs: Math.round(agentMs),
-      fmpMs: 0,
-      ttiMs: 0,
-      renderMs: 0,
+      fmpMs: preview.fmpMs,
+      ttiMs: preview.ttiMs,
+      renderMs: preview.renderMs,
       attempts: result.attempts,
-      judgeScore: 0,
+      judgeScore: preview.judgeScore,
       messageCount: result.messages.length,
       outputChars,
-      errors: result.errors,
+      errors: [...result.errors, ...preview.errors],
       finishReason: result.finishReason,
       usage: result.usage,
       messages: result.messages,
@@ -239,6 +249,51 @@ async function runOne(
       error: message,
     };
   }
+}
+
+async function runBenchPreviewForItem(
+  jobId: string,
+  request: BenchJobRequest,
+  item: BenchRunItem,
+  messages: BenchRunResult['messages'],
+) {
+  if (!messages || messages.length === 0) {
+    return {
+      errors: [],
+      fmpMs: 0,
+      judgeScore: 0,
+      renderMs: 0,
+      ttiMs: 0,
+    };
+  }
+
+  if (
+    !request.settings.renderMetricsEnabled && !request.settings.judgeEnabled
+  ) {
+    return {
+      errors: [],
+      fmpMs: 0,
+      judgeScore: 0,
+      renderMs: 0,
+      ttiMs: 0,
+    };
+  }
+
+  emitRunPhase(
+    jobId,
+    item,
+    request.settings.renderMetricsEnabled ? 'render' : 'judge',
+  );
+  const preview = await runBenchPreview({
+    messages,
+    request,
+    runId: `${item.group.id}-${item.scenario.id}-${item.repeatIndex}`,
+    scenario: item.scenario,
+  });
+  if (request.settings.judgeEnabled) {
+    emitRunPhase(jobId, item, 'judge');
+  }
+  return preview;
 }
 
 function summarizeGroup(
@@ -321,9 +376,9 @@ function buildReport(
     capabilities: {
       agent: 'enabled',
       renderMetrics: request.settings.renderMetricsEnabled
-        ? 'skipped'
+        ? 'enabled'
         : 'disabled',
-      judge: request.settings.judgeEnabled ? 'skipped' : 'disabled',
+      judge: request.settings.judgeEnabled ? 'enabled' : 'disabled',
     },
     warnings,
     groups: request.groups,

--- a/packages/genui/server/service/a2ui-bench-types.ts
+++ b/packages/genui/server/service/a2ui-bench-types.ts
@@ -32,6 +32,10 @@ export interface BenchProviderConfig {
   api?: 'chat' | 'responses';
 }
 
+export interface BenchPlaygroundConfig {
+  baseUrl?: string;
+}
+
 export interface BenchSettings {
   repeats: number;
   parallelism: number;
@@ -66,6 +70,7 @@ export interface BenchScenarioRequest {
 
 export interface BenchJobRequest {
   provider: BenchProviderConfig;
+  playground?: BenchPlaygroundConfig;
   settings: BenchSettings;
   groups: BenchGroupRequest[];
   scenarios: BenchScenarioRequest[];
@@ -152,8 +157,8 @@ export interface BenchReport {
   };
   capabilities: {
     agent: 'enabled';
-    renderMetrics: 'disabled' | 'skipped';
-    judge: 'disabled' | 'skipped';
+    renderMetrics: 'disabled' | 'enabled';
+    judge: 'disabled' | 'enabled';
   };
   warnings: string[];
   groups: BenchGroupRequest[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,12 +839,21 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1053.0
         version: 3.1053.0
+      '@lynx-js/ui-judge':
+        specifier: workspace:*
+        version: link:../ui-judge
       '@mastra/core':
         specifier: 1.13.2
         version: 1.13.2(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.10)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.10)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@3.25.76))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@3.25.76)
+      '@sparticuz/chromium':
+        specifier: ^149.0.0
+        version: 149.0.0
       next:
         specifier: 16.2.6
         version: 16.2.6(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+      playwright-core:
+        specifier: ^1.58.2
+        version: 1.58.2
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -5685,6 +5694,10 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@sparticuz/chromium@149.0.0':
+    resolution: {integrity: sha512-2NECBVKlUA9xIUXb4fT8OoGKdAJs+I2tNYscO8FwcxCKCWA7FmpPI0fdVxGJoIJglrFZYn+4YEJqChq4rdrxQg==}
+    engines: {node: ^22.17.0 || >=24.0.0}
 
   '@standard-community/standard-json@0.3.5':
     resolution: {integrity: sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA==}
@@ -16591,6 +16604,14 @@ snapshots:
       tslib: 2.8.1
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@sparticuz/chromium@149.0.0':
+    dependencies:
+      tar-fs: 3.1.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.10)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
     dependencies:


### PR DESCRIPTION
## Summary

- Run A2UI bench outputs through the deployed playground preview and execute `@lynx-js/ui-judge` when judge is enabled.
- Send the current playground base URL from the bench page so the server can render the same deployed `render.html` entry.
- Add server-side Playwright/Chromium support for preview rendering, keep ui-judge/Midscene packages external in Next, and report judge/render capabilities as enabled or disabled instead of silently skipped.
- Add A2UI bench instructions for future agent work.

## Root Cause

The bench UI defaulted `judgeEnabled` to true, but the server runner never invoked UI judge. It returned a `judgeScore` of 0 and built reports with `capabilities.judge = skipped`, so "run with defaults" appeared to omit UI judge even after deployment.

## Validation

- `pnpm dprint fmt .github/a2ui-bench.instructions.md packages/genui/server/service/a2ui-bench-preview.ts packages/genui/server/service/a2ui-bench-runner.ts packages/genui/server/service/a2ui-bench-request.ts packages/genui/server/service/a2ui-bench-types.ts packages/genui/server/next.config.mjs packages/genui/a2ui-playground/src/pages/BenchPage.tsx packages/genui/server/package.json pnpm-lock.yaml`
- `pnpm eslint --cache --fix --no-warn-ignored --flag v10_config_lookup_from_file packages/genui/server/service/a2ui-bench-preview.ts`
- `pnpm biome lint --write --no-errors-on-unmatched --files-ignore-unknown=true packages/genui/server/service/a2ui-bench-preview.ts`
- `git diff --check`
- `pnpm turbo build --filter a2ui-server`
- `pnpm turbo build --filter a2ui-playground`

Note: Turbo still prints the repository's existing `pnpm-lock.yaml` patchedDependencies parse warning, but both targeted builds completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark preview rendering that loads UI in a browser environment for testing
  * Integrated automated UI judging to assess visual correctness against reference implementations
  * Introduced performance metrics tracking including First Meaningful Paint, Time-to-Interactive, and render duration

* **Chores**
  * Updated dependencies and Next.js configuration to support benchmark preview and judging capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->