### PR TITLE
fix(react): apply ET css scope to template subtree

### DIFF
--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/index.js.txt
@@ -1,6 +1,6 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 /*@jsxCSSId 1501958*/ import "./style.css?cssId=1501958";
-const _et_eb7af03baae1 = `${globDynamicComponentEntry}:${"_et_eb7af03baae1"}`;
+const _et_517e4a08d202 = `${globDynamicComponentEntry}:${"_et_517e4a08d202"}`;
 export function App() {
-    return /*#__PURE__*/ _jsx(_et_eb7af03baae1, {});
+    return /*#__PURE__*/ _jsx(_et_517e4a08d202, {});
 }

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/output.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/output.txt
@@ -1,3 +1,3 @@
 <view css-id="1501958" id="scoped">
-  <text text="Scoped Dynamic" />
+  <text css-id="1501958" text="Scoped Dynamic" />
 </view>

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/papi.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/papi.txt
@@ -9,7 +9,7 @@
   ],
   [
     "__CreateElementTemplate",
-    "_et_eb7af03baae1",
+    "_et_517e4a08d202",
     "lazy-entry",
     null,
     null,
@@ -19,7 +19,7 @@
     "__InsertNodeToElementTemplate",
     "<page />",
     0,
-    "<_et_eb7af03baae1 />",
+    "<_et_517e4a08d202 />",
     null
   ]
 ]

--- a/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/templates.json.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/css-scope-dynamic-bundle-url/templates.json.txt
@@ -1,6 +1,6 @@
 [
   {
-    "templateId": "_et_eb7af03baae1",
+    "templateId": "_et_517e4a08d202",
     "compiledTemplate": {
       "kind": "element",
       "type": "view",
@@ -25,6 +25,11 @@
               "kind": "static",
               "key": "text",
               "value": "Scoped Dynamic"
+            },
+            {
+              "kind": "static",
+              "key": "css-id",
+              "value": 1501958
             }
           ],
           "children": []

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-transform.contract.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-transform.contract.test.ts
@@ -127,7 +127,7 @@ describe('render transform contract', () => {
     resetTemplateId();
   });
 
-  it('passes scoped css-id through ET template root attrs', async () => {
+  it('passes scoped css-id through ET template subtree attrs', async () => {
     const { code, rootRef, userTemplateIds } = await compileAndRender(
       `
       import './style.css';
@@ -135,7 +135,7 @@ describe('render transform contract', () => {
       export function App() {
         return (
           <view id="main">
-            <text>Hello</text>
+            <text className="message">Hello</text>
           </view>
         );
       }
@@ -145,17 +145,29 @@ describe('render transform contract', () => {
 
     expect(code).toContain('style.css?cssId=1460700');
 
-    expect(rootRef).toMatchObject({
+    const expectedScopedTree = {
       tag: 'view',
       attributes: {
         id: 'main',
         'css-id': 1460700,
       },
+      children: [
+        {
+          tag: 'text',
+          attributes: {
+            class: 'message',
+            text: 'Hello',
+            'css-id': 1460700,
+          },
+        },
+      ],
+    };
+
+    expect(rootRef).toMatchObject({
+      ...expectedScopedTree,
       __handleId: -1,
     });
-    expect(elementTemplateRegistry.get(-1)).toMatchObject({
-      attributes: { id: 'main', 'css-id': 1460700 },
-    });
+    expect(elementTemplateRegistry.get(-1)).toMatchObject(expectedScopedTree);
     expect(userTemplateIds).toEqual([
       expect.stringMatching(/^_et_[0-9a-f]{12}$/),
     ]);

--- a/packages/react/transform/crates/swc_plugin_element_template/extractor.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/extractor.rs
@@ -414,7 +414,7 @@ where
                 }
                 false
               }
-              "css-id" if !self.parent_element && self.has_css_id_value => {
+              "css-id" if self.has_css_id_value => {
                 HANDLER.with(|handler| {
                   handler
                     .struct_span_warn(

--- a/packages/react/transform/crates/swc_plugin_element_template/template_definition.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/template_definition.rs
@@ -74,6 +74,17 @@ where
     }))
   }
 
+  fn element_template_css_id_attribute_descriptor(&self, css_id: f64) -> Expr {
+    self.element_template_static_attribute_descriptor(
+      "css-id",
+      Expr::Lit(Lit::Num(Number {
+        span: DUMMY_SP,
+        value: css_id,
+        raw: None,
+      })),
+    )
+  }
+
   fn element_template_array_expr(&self, items: Vec<Expr>) -> Expr {
     Expr::Array(ArrayLit {
       span: DUMMY_SP,
@@ -168,21 +179,21 @@ where
             continue;
           }
 
-          out.push(self.element_template_element_node(
-            "raw-text",
-            vec![self.element_template_static_attribute_descriptor(
-              "text",
-              self.element_template_string_expr(s.as_ref()),
-            )],
-            vec![],
-          ));
+          let mut attributes = vec![self.element_template_static_attribute_descriptor(
+            "text",
+            self.element_template_string_expr(s.as_ref()),
+          )];
+          if let Some(css_id) = self.css_id_value {
+            attributes.push(self.element_template_css_id_attribute_descriptor(css_id));
+          }
+
+          out.push(self.element_template_element_node("raw-text", attributes, vec![]));
         }
-        JSXElementChild::JSXElement(el) => out.push(self.element_template_from_jsx_element_impl(
+        JSXElementChild::JSXElement(el) => out.push(self.element_template_from_jsx_element(
           el,
           dynamic_attr_slots,
           dynamic_attr_slot_cursor,
           element_slot_index,
-          false,
         )),
         JSXElementChild::JSXFragment(frag) => {
           out.extend(self.element_template_from_jsx_children(
@@ -217,23 +228,6 @@ where
     dynamic_attr_slots: &[TemplateAttributeSlot],
     dynamic_attr_slot_cursor: &mut usize,
     element_slot_index: &mut i32,
-  ) -> Expr {
-    self.element_template_from_jsx_element_impl(
-      n,
-      dynamic_attr_slots,
-      dynamic_attr_slot_cursor,
-      element_slot_index,
-      true,
-    )
-  }
-
-  fn element_template_from_jsx_element_impl(
-    &self,
-    n: &JSXElement,
-    dynamic_attr_slots: &[TemplateAttributeSlot],
-    dynamic_attr_slot_cursor: &mut usize,
-    element_slot_index: &mut i32,
-    is_template_root: bool,
   ) -> Expr {
     if is_slot_placeholder(n) {
       let idx =
@@ -371,17 +365,8 @@ where
       )
     };
 
-    if is_template_root {
-      if let Some(css_id) = self.css_id_value {
-        attribute_descriptors.push(self.element_template_static_attribute_descriptor(
-          "css-id",
-          Expr::Lit(Lit::Num(Number {
-            span: DUMMY_SP,
-            value: css_id,
-            raw: None,
-          })),
-        ));
-      }
+    if let Some(css_id) = self.css_id_value {
+      attribute_descriptors.push(self.element_template_css_id_attribute_descriptor(css_id));
     }
 
     let final_tag = tag_value.to_string_lossy().to_string();

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
@@ -59,6 +59,25 @@ fn assert_single_framework_css_id_attr(
   assert_eq!(css_id_attrs[0]["value"].as_f64(), Some(expected_css_id));
 }
 
+fn assert_css_id_override_diagnostic(diagnostics: &[String], message: &str) {
+  assert!(
+    diagnostics
+      .iter()
+      .any(|diagnostic| { diagnostic.contains("css-id") && diagnostic.contains("overridden") }),
+    "{message}, got: {diagnostics:?}"
+  );
+}
+
+fn first_user_template_json_from_templates(
+  templates: &[ElementTemplateAsset],
+) -> serde_json::Value {
+  let template = templates
+    .iter()
+    .find(|template| template.template_id != BUILTIN_RAW_TEXT_TEMPLATE_ID)
+    .expect("should collect a user template");
+  serde_json::to_value(&template.compiled_template).expect("compiled template json")
+}
+
 fn template_snapshot_json(templates: &[ElementTemplateAsset]) -> Vec<serde_json::Value> {
   templates
     .iter()
@@ -911,22 +930,40 @@ fn should_warn_and_override_direct_user_css_id_attr() {
     element_template_config(),
   );
 
-  assert!(
-    diagnostics
-      .iter()
-      .any(|message| { message.contains("css-id") && message.contains("overridden") }),
-    "expected direct css-id override diagnostic, got: {diagnostics:?}"
-  );
+  assert_css_id_override_diagnostic(&diagnostics, "expected direct css-id override diagnostic");
 
-  let template = templates
-    .iter()
-    .find(|template| template.template_id != BUILTIN_RAW_TEXT_TEMPLATE_ID)
-    .expect("should collect a user template");
-  let template = serde_json::to_value(&template.compiled_template).expect("compiled template json");
+  let template = first_user_template_json_from_templates(&templates);
   assert_single_framework_css_id_attr(
     &template,
     100.0,
     "direct user css-id should be replaced by the framework css-id",
+  );
+}
+
+#[test]
+fn should_warn_and_override_nested_direct_user_css_id_attr() {
+  let (_, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"
+      /**
+       * @jsxCSSId 100
+       */
+      <view>
+        <text css-id="user-css-id" />
+      </view>
+    "#,
+    element_template_config(),
+  );
+
+  assert_css_id_override_diagnostic(
+    &diagnostics,
+    "expected nested direct css-id override diagnostic",
+  );
+
+  let template = first_user_template_json_from_templates(&templates);
+  assert_single_framework_css_id_attr(
+    &template["children"][0],
+    100.0,
+    "nested direct user css-id should be replaced by the framework css-id",
   );
 }
 
@@ -942,25 +979,47 @@ fn should_warn_and_override_dynamic_user_css_id_attr_without_reserving_slot() {
     element_template_config(),
   );
 
-  assert!(
-    diagnostics
-      .iter()
-      .any(|message| { message.contains("css-id") && message.contains("overridden") }),
-    "expected direct css-id override diagnostic, got: {diagnostics:?}"
-  );
+  assert_css_id_override_diagnostic(&diagnostics, "expected direct css-id override diagnostic");
   assert!(
     !code.contains("attributeSlots"),
     "overridden dynamic css-id should not reserve an ET attribute slot, got: {code}"
   );
 
-  let template = templates
-    .iter()
-    .find(|template| template.template_id != BUILTIN_RAW_TEXT_TEMPLATE_ID)
-    .expect("should collect a user template");
-  let template = serde_json::to_value(&template.compiled_template).expect("compiled template json");
+  let template = first_user_template_json_from_templates(&templates);
   assert_single_framework_css_id_attr(
     &template,
     100.0,
     "dynamic user css-id should be replaced by the framework css-id",
+  );
+}
+
+#[test]
+fn should_warn_and_override_nested_dynamic_user_css_id_attr_without_reserving_slot() {
+  let (code, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"
+      /**
+       * @jsxCSSId 100
+       */
+      <view>
+        <text css-id={userCssId} />
+      </view>
+    "#,
+    element_template_config(),
+  );
+
+  assert_css_id_override_diagnostic(
+    &diagnostics,
+    "expected nested dynamic css-id override diagnostic",
+  );
+  assert!(
+    !code.contains("attributeSlots"),
+    "overridden nested dynamic css-id should not reserve an ET attribute slot, got: {code}"
+  );
+
+  let template = first_user_template_json_from_templates(&templates);
+  assert_single_framework_css_id_attr(
+    &template["children"][0],
+    100.0,
+    "nested dynamic user css-id should be replaced by the framework css-id",
   );
 }

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
@@ -128,6 +128,35 @@ fn without_whitespace(value: &str) -> String {
   value.chars().filter(|ch| !ch.is_whitespace()).collect()
 }
 
+fn assert_single_framework_css_id_attr(template: &Value, expected_css_id: f64, message: &str) {
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  let css_id_attrs = attrs
+    .iter()
+    .filter(|attr| attr["key"] == "css-id")
+    .collect::<Vec<_>>();
+  assert_eq!(css_id_attrs.len(), 1, "{message}");
+  assert_eq!(css_id_attrs[0]["kind"], "static");
+  assert_eq!(css_id_attrs[0]["value"].as_f64(), Some(expected_css_id));
+  assert!(
+    attrs.iter().all(|attr| attr["key"] != "entry-name"),
+    "{message}: element should not carry entry-name attrs",
+  );
+}
+
+fn assert_no_css_scope_attrs(template: &Value, message: &str) {
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  assert!(
+    attrs
+      .iter()
+      .all(|attr| attr["key"] != "css-id" && attr["key"] != "entry-name"),
+    "{message}",
+  );
+}
+
 fn assert_attr_plan_assignment(code: &str, expected_entries: &str, message: &str) {
   let marker = "ReactLynxInternal.__etAttrPlanMap[_et_";
   let start = code
@@ -233,14 +262,15 @@ fn should_emit_spread_attr_plan_with_ref_adapter() {
 }
 
 #[test]
-fn should_inject_root_css_scope_attr_for_element_template() {
+fn should_inject_css_scope_attr_for_element_template_subtree() {
   let (code, template) = first_user_template_json_with_code(
     r#"
       /**
        * @jsxCSSId 100
        */
-      <view>
-        <text>Hello</text>
+      <view className="task-login-card">
+        <text className="task-login-card-btn">Hello</text>
+        <text text="Explicit Text Attribute">Child Text</text>
       </view>
     "#,
     element_template_config(),
@@ -250,29 +280,32 @@ fn should_inject_root_css_scope_attr_for_element_template() {
     "element template lowering should not emit legacy cssId create metadata, got: {code}"
   );
 
-  let attrs = template["attributesArray"]
-    .as_array()
-    .expect("attributesArray");
-  let css_id_attr = attrs
-    .iter()
-    .find(|attr| attr["key"] == "css-id")
-    .expect("root element should carry framework css-id attr");
-  assert_eq!(css_id_attr["kind"], "static");
-  assert_eq!(css_id_attr["value"].as_f64(), Some(100.0));
-  assert!(
-    attrs.iter().all(|attr| attr["key"] != "entry-name"),
-    "root element should not carry entry-name attrs",
+  assert_single_framework_css_id_attr(
+    &template,
+    100.0,
+    "root element should carry framework css-id attr",
   );
 
   let children = template["children"].as_array().expect("children array");
-  let first_child_attrs = children[0]["attributesArray"]
+  assert_single_framework_css_id_attr(
+    &children[0],
+    100.0,
+    "nested text element should carry framework css-id attr",
+  );
+  assert_single_framework_css_id_attr(
+    &children[1],
+    100.0,
+    "nested text element with explicit text attr should carry framework css-id attr",
+  );
+
+  let raw_text = &children[1]["children"]
     .as_array()
-    .expect("child attributesArray");
-  assert!(
-    first_child_attrs
-      .iter()
-      .all(|attr| attr["key"] != "css-id" && attr["key"] != "entry-name"),
-    "nested static elements should not receive css scope attrs",
+    .expect("explicit text child array")[0];
+  assert_eq!(raw_text["type"], "raw-text");
+  assert_single_framework_css_id_attr(
+    raw_text,
+    100.0,
+    "inline raw-text child should carry framework css-id attr",
   );
 }
 
@@ -325,14 +358,14 @@ fn should_not_inject_css_scope_attrs_without_jsx_css_id() {
     "#,
   );
 
-  let attrs = template["attributesArray"]
-    .as_array()
-    .expect("attributesArray");
-  assert!(
-    attrs
-      .iter()
-      .all(|attr| attr["key"] != "css-id" && attr["key"] != "entry-name"),
+  assert_no_css_scope_attrs(
+    &template,
     "root element should not carry css scope attrs without @jsxCSSId",
+  );
+  let child = &template["children"].as_array().expect("children array")[0];
+  assert_no_css_scope_attrs(
+    child,
+    "nested static elements should not carry css scope attrs without @jsxCSSId",
   );
 }
 
@@ -343,7 +376,9 @@ fn should_append_framework_css_id_after_spread_attrs() {
       /**
        * @jsxCSSId 100
        */
-      <view {...props} />
+      <view {...props}>
+        <text {...childProps} />
+      </view>
     "#,
   );
 
@@ -355,6 +390,16 @@ fn should_append_framework_css_id_after_spread_attrs() {
   assert_eq!(last_attr["key"], "css-id");
   assert_eq!(last_attr["kind"], "static");
   assert_eq!(last_attr["value"].as_f64(), Some(100.0));
+
+  let child = &template["children"].as_array().expect("children array")[0];
+  let child_attrs = child["attributesArray"]
+    .as_array()
+    .expect("child attributesArray");
+  assert_eq!(child_attrs[0]["kind"], "spread");
+  let child_last_attr = child_attrs.last().expect("child should have attrs");
+  assert_eq!(child_last_attr["key"], "css-id");
+  assert_eq!(child_last_attr["kind"], "static");
+  assert_eq!(child_last_attr["value"].as_f64(), Some(100.0));
 }
 
 #[test]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS scoping to properly apply css-id attributes throughout nested element hierarchies in templates, ensuring consistent scoping beyond template roots.

* **Tests**
  * Enhanced test coverage with new helper assertions validating CSS scoping behavior across complete element template subtrees and nested child elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

ET scoped CSS now emits framework-owned `css-id` metadata for every static element in one compiled Element Template tree, not only the template root. Native consumes Template Definition attributes per element, so a root-only `css-id` left nested host nodes without the scoped stylesheet id even when their class rules were present under `@cssId`.

This PR aligns ET's generated output with Snapshot's observable subtree CSS scope behavior by making the compiler produce per-element `css-id` static attrs and by extending direct user `css-id` override handling to nested elements.

## Generated Output Contract

- Producer: `swc_plugin_element_template` when `@jsxCSSId` is present from the CSS scope transform.
- Shape: each static element node in the user compiled Template Definition receives a final static attr like `{ kind: "static", key: "css-id", value: <cssId> }`.
- Coverage: root elements, nested host elements, and inline `raw-text` nodes inside a user template tree are covered. The shared builtin raw-text template remains unchanged.
- Ordering: the framework `css-id` attr is appended after normal attrs and spread descriptors so spread-provided user values are still overridden by the framework value.
- Direct user `css-id`: statically visible direct or dynamic `css-id` attrs are warned and removed before Template Definition emission on both root and nested static elements.
- Native/PAPI shape: `__CreateElementTemplate` arguments and bundleUrl handling are unchanged; the change is inside the serialized Template Definition attrs.

## Reviewer Notes

- Start with `template_definition.rs` for the per-element attr emission and removal of the old root-only helper split.
- Read `extractor.rs` for direct user `css-id` override filtering.
- The transform tests cover subtree attr emission, spread ordering, and nested direct/dynamic user override cases.
- The render contract and `css-scope-dynamic-bundle-url` fixture show the PAPI call stays the same while the nested `text` node now carries `css-id` in the compiled template and mock native output.

## Boundaries

This does not add CSS modules support, change dynamic/lazy bundle identity, or change native Template Definition decoding. It only fixes the compiler-produced per-element metadata needed by the existing native attr consumer.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).