### PR TITLE
feat: align OpenUI examples with A2UI playground

### DIFF
--- a/packages/genui/a2ui-playground/lynx-src/openui/App.tsx
+++ b/packages/genui/a2ui-playground/lynx-src/openui/App.tsx
@@ -7,7 +7,9 @@ import {
   useCallback,
   useEffect,
   useGlobalProps,
+  useLynxGlobalEventListener,
   useMemo,
+  useRef,
   useState,
 } from '@lynx-js/react';
 
@@ -15,6 +17,15 @@ import { OPENUI_SCENARIOS } from './mockData.js';
 
 const DEFAULT_CHUNK_SIZE = 8;
 const DEFAULT_STREAM_DELAY_MS = 30;
+const OPENUI_PLAYBACK_CHUNK_SIZE = 240;
+
+function chunkOpenUIResponse(rawText: string): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < rawText.length; i += OPENUI_PLAYBACK_CHUNK_SIZE) {
+    chunks.push(rawText.slice(i, i + OPENUI_PLAYBACK_CHUNK_SIZE));
+  }
+  return chunks;
+}
 
 export function App() {
   const globalProps = useGlobalProps() as Record<string, unknown> | null;
@@ -74,6 +85,16 @@ export function App() {
     return OPENUI_SCENARIOS[0].raw;
   }, [globalProps]);
 
+  const instant = useMemo(() => {
+    const value = globalProps?.instant;
+    return value === true || value === '1' || value === 1;
+  }, [globalProps]);
+
+  const playbackMode = useMemo(() => {
+    const value = globalProps?.playbackMode;
+    return value === true || value === '1' || value === 1;
+  }, [globalProps]);
+
   // Speed multiplier from globalProps (e.g. ?speed=2)
   const streamDelay = useMemo(() => {
     const raw = globalProps?.speed;
@@ -88,6 +109,35 @@ export function App() {
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
+  const [playbackTargetCount, setPlaybackTargetCount] = useState(0);
+  const playbackPausedRef = useRef(false);
+  const playbackChunks = useMemo(() => chunkOpenUIResponse(rawText), [rawText]);
+
+  useEffect(() => {
+    setPlaybackTargetCount(0);
+    playbackPausedRef.current = false;
+  }, [playbackMode, rawText]);
+
+  useLynxGlobalEventListener(
+    'A2UI_PLAYBACK_CONTROL',
+    (action: unknown) => {
+      playbackPausedRef.current = action === 'pause';
+    },
+  );
+
+  useLynxGlobalEventListener(
+    'A2UI_PLAYBACK_PROGRESS',
+    (payload: unknown) => {
+      if (!playbackMode) return;
+      if (!payload || typeof payload !== 'object') return;
+      const next = (payload as { deliveredCount?: unknown }).deliveredCount;
+      const nextCount = typeof next === 'number'
+        ? next
+        : (typeof next === 'string' ? Number(next) : Number.NaN);
+      if (!Number.isFinite(nextCount) || nextCount < 0) return;
+      setPlaybackTargetCount(Math.floor(nextCount));
+    },
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -95,6 +145,25 @@ export function App() {
     setIsStreaming(true);
     setError('');
     setResponse('');
+
+    if (instant) {
+      setResponse(rawText);
+      setIsStreaming(false);
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    if (playbackMode) {
+      const next = playbackChunks.slice(0, playbackTargetCount).join('');
+      setResponse(next);
+      setIsStreaming(playbackTargetCount < playbackChunks.length);
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
 
     let offset = 0;
 
@@ -125,7 +194,15 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [openUiLibrary, rawText, streamDelay]);
+  }, [
+    instant,
+    openUiLibrary,
+    playbackChunks,
+    playbackMode,
+    playbackTargetCount,
+    rawText,
+    streamDelay,
+  ]);
 
   const onOpenUiAction = useCallback((_event: ActionEvent) => {
     // noop for now

--- a/packages/genui/a2ui-playground/src/App.tsx
+++ b/packages/genui/a2ui-playground/src/App.tsx
@@ -17,6 +17,7 @@ import { ComponentsPage } from './pages/ComponentsPage.js';
 import { DemosListPage } from './pages/DemosListPage.js';
 import { DemosPage } from './pages/DemosPage.js';
 import { OpenUIComponentsPage } from './pages/OpenUIComponentsPage.js';
+import { OpenUIDemosListPage } from './pages/OpenUIDemosListPage.js';
 import { OpenUIDemosPage } from './pages/OpenUIDemosPage.js';
 import type { Protocol, ProtocolName } from './utils/protocol.js';
 import { DEFAULT_PROTOCOL, PROTOCOLS, getProtocol } from './utils/protocol.js';
@@ -213,7 +214,20 @@ export function App() {
             />
           );
         default:
-          return <OpenUIDemosPage key='openui-examples' protocol={protocol} />;
+          return route.demoId
+            ? (
+              <OpenUIDemosPage
+                key='openui-examples-detail'
+                protocol={protocol}
+                demoId={route.demoId}
+              />
+            )
+            : (
+              <OpenUIDemosListPage
+                key='openui-examples-index'
+                protocol={protocol}
+              />
+            );
       }
     }
 

--- a/packages/genui/a2ui-playground/src/components/ExamplePreviewCard.tsx
+++ b/packages/genui/a2ui-playground/src/components/ExamplePreviewCard.tsx
@@ -1,0 +1,198 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent, RefObject } from 'react';
+
+import { PreviewViewport } from './PreviewViewport.js';
+import { MountQueueProvider, useQueuedMount } from '../hooks/useMountQueue.js';
+import { PRIORITY } from '../utils/mountQueue.js';
+import type { Priority } from '../utils/mountQueue.js';
+
+const ROOT_MARGIN = '50% 0px';
+const RENDER_READY_TIMEOUT_MS = 5000;
+
+export const EXAMPLE_PREVIEW_MAX_CONCURRENT = 4;
+
+export interface ExamplePreviewScenario {
+  id: string;
+  title: string;
+}
+
+export { MountQueueProvider as ExamplePreviewQueueProvider };
+
+function useViewportPriority(
+  ref: RefObject<Element | null>,
+): Priority {
+  const [priority, setPriority] = useState<Priority>(PRIORITY.OFFSCREEN);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setPriority(PRIORITY.IN_VIEW);
+      return;
+    }
+    const inViewObserver = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry?.isIntersecting) {
+          setPriority(PRIORITY.IN_VIEW);
+        } else {
+          // Outside the viewport: defer to the near-viewport observer below.
+          setPriority((cur) => cur === PRIORITY.IN_VIEW ? PRIORITY.NEAR : cur);
+        }
+      },
+      { rootMargin: '0px' },
+    );
+    const nearObserver = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        setPriority((cur) => {
+          if (entry?.isIntersecting) {
+            return cur === PRIORITY.IN_VIEW ? cur : PRIORITY.NEAR;
+          }
+          return PRIORITY.OFFSCREEN;
+        });
+      },
+      { rootMargin: ROOT_MARGIN },
+    );
+    inViewObserver.observe(el);
+    nearObserver.observe(el);
+    return () => {
+      inViewObserver.disconnect();
+      nearObserver.disconnect();
+    };
+  }, [ref]);
+  return priority;
+}
+
+function CardPreviewLoading(props: { title: string; revealed: boolean }) {
+  return (
+    <div className='cardPreviewLoading' data-revealed={props.revealed}>
+      <div className='cardPreviewLoadingTitle'>{props.title}</div>
+      <div className='cardPreviewLoadingDots' aria-hidden='true'>
+        <span />
+        <span />
+        <span />
+      </div>
+    </div>
+  );
+}
+
+export function ExamplePreviewCard(props: {
+  scenario: ExamplePreviewScenario;
+  previewUrl: string | undefined;
+  badge?: string;
+  onOpen: (id: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>, id: string) => void;
+}) {
+  const { badge, onKeyDown, onOpen, previewUrl, scenario } = props;
+  const cardRef = useRef<HTMLDivElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const readyRef = useRef(false);
+  const previewUrlRef = useRef(previewUrl);
+  const timerRef = useRef<number | null>(null);
+  const priority = useViewportPriority(cardRef);
+  const { armed, markReady } = useQueuedMount(scenario.id, priority);
+  const [rendered, setRendered] = useState(false);
+
+  const releaseSlot = useCallback(() => {
+    if (readyRef.current) return;
+    readyRef.current = true;
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    markReady();
+  }, [markReady]);
+
+  const handleRenderReady = useCallback(() => {
+    setRendered(true);
+    releaseSlot();
+  }, [releaseSlot]);
+
+  // When previewUrl changes (e.g. theme toggle rebuilds the URL), cover the
+  // stale frame until the next boot reports readiness.
+  useEffect(() => {
+    previewUrlRef.current = previewUrl;
+    readyRef.current = false;
+    setRendered(false);
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, [previewUrl]);
+
+  useEffect(() => {
+    if (!armed) return;
+    const handler = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      if (e.origin !== window.location.origin) return;
+      const data = e.data as { type?: string } | null;
+      if (data && data.type === 'A2UI_RENDER_READY') {
+        handleRenderReady();
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [armed, handleRenderReady]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleIframeLoad = useCallback(() => {
+    if (readyRef.current) return;
+    if (timerRef.current !== null) return;
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      releaseSlot();
+    }, RENDER_READY_TIMEOUT_MS);
+  }, [releaseSlot]);
+
+  return (
+    <div
+      ref={cardRef}
+      className='exampleCard'
+      onClick={() => onOpen(scenario.id)}
+      onKeyDown={(event) => onKeyDown(event, scenario.id)}
+      role='button'
+      tabIndex={0}
+    >
+      <div className='exampleCardPreview'>
+        <div
+          className='exampleCardPreviewWindow'
+          style={{ position: 'relative' }}
+        >
+          <PreviewViewport
+            src={armed ? previewUrl : undefined}
+            iframeTitle={`${scenario.title} preview`}
+            emptyTitle={scenario.title}
+            displayMode='full'
+            iframeRef={iframeRef}
+            onLoad={handleIframeLoad}
+          />
+          {armed
+            ? (
+              <CardPreviewLoading
+                title={scenario.title}
+                revealed={rendered}
+              />
+            )
+            : null}
+        </div>
+      </div>
+      <div className='exampleCardBody'>
+        <div className='exampleCardTop'>
+          <div className='exampleCardTitle'>{scenario.title}</div>
+          {badge ? <span className='exampleCardBadge'>{badge}</span> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/a2ui-playground/src/components/PreviewPanel.tsx
@@ -27,7 +27,7 @@ import { useMediaQuery } from '../hooks/useMediaQuery.js';
 import { copyToClipboard } from '../utils/clipboard.js';
 import { DEFAULT_A2UI_DEMO_URL } from '../utils/demoUrl.js';
 import type { Protocol } from '../utils/protocol.js';
-import { buildRenderUrl } from '../utils/renderUrl.js';
+import { buildOpenUIRenderUrl, buildRenderUrl } from '../utils/renderUrl.js';
 
 declare const __A2UI_PLAYGROUND_CLIENT_PAYLOAD_STORE__: boolean;
 
@@ -91,6 +91,7 @@ interface A2UIPreviewSource {
 interface OpenUIPreviewSource {
   kind: 'openui';
   rawText: string;
+  playbackMode?: boolean;
 }
 
 interface PlaceholderPreviewSource {
@@ -234,21 +235,6 @@ function useRspeedyDevUrl(): string {
     };
   }, []);
   return url;
-}
-
-function buildOpenUIRenderUrl(
-  rawText: string,
-  baseUrl: string,
-  speed: number,
-): string {
-  const url = new URL('render.html', baseUrl);
-  url.searchParams.set('protocol', 'openui');
-  url.searchParams.set('demoUrl', './openui.web.js');
-  url.searchParams.set('rawText', rawText);
-  if (speed !== 1) {
-    url.searchParams.set('speed', String(speed));
-  }
-  return url.toString();
 }
 
 function absoluteUrl(url: string, origin: string): string {
@@ -750,12 +736,15 @@ export function PreviewPanel(props: PreviewPanelProps) {
       return;
     }
 
-    const url = buildOpenUIRenderUrl(previewSource.rawText, baseUrl, speed);
-    const shareUrl = buildOpenUIRenderUrl(
-      previewSource.rawText,
-      shareBaseUrl,
+    const url = buildOpenUIRenderUrl({
+      rawText: previewSource.rawText,
       speed,
-    );
+      playbackMode: previewSource.playbackMode,
+    }, baseUrl);
+    const shareUrl = buildOpenUIRenderUrl({
+      rawText: previewSource.rawText,
+      speed,
+    }, shareBaseUrl);
     setRenderUrl(url);
     setRenderShareUrl(shareUrl);
 
@@ -796,23 +785,15 @@ export function PreviewPanel(props: PreviewPanelProps) {
           }
           setLynxDevUrl(u.toString());
 
-          const r = new URL('render.html', baseUrl);
-          r.searchParams.set('protocol', 'openui');
-          r.searchParams.set('demoUrl', './openui.web.js');
-          r.searchParams.set('rawTextUrl', rawTextUrlAbs);
-          if (speed !== 1) {
-            r.searchParams.set('speed', String(speed));
-          }
-          setRenderUrl(r.toString());
-
-          const s = new URL('render.html', shareBaseUrl);
-          s.searchParams.set('protocol', 'openui');
-          s.searchParams.set('demoUrl', './openui.web.js');
-          s.searchParams.set('rawTextUrl', rawTextUrlAbs);
-          if (speed !== 1) {
-            s.searchParams.set('speed', String(speed));
-          }
-          setRenderShareUrl(s.toString());
+          setRenderUrl(buildOpenUIRenderUrl({
+            rawTextUrl: rawTextUrlAbs,
+            speed,
+            playbackMode: previewSource.playbackMode,
+          }, baseUrl));
+          setRenderShareUrl(buildOpenUIRenderUrl({
+            rawTextUrl: rawTextUrlAbs,
+            speed,
+          }, shareBaseUrl));
         }
       } catch {
         // Keep the inline URLs above if shortening is unavailable.

--- a/packages/genui/a2ui-playground/src/mock/openui-scenarios.ts
+++ b/packages/genui/a2ui-playground/src/mock/openui-scenarios.ts
@@ -71,7 +71,7 @@ const OPENUI_SCENARIO_SCHEMA: LibraryJSONSchema = {
 
 const openUiScenarioParser = createParser(OPENUI_SCENARIO_SCHEMA, 'Stack');
 
-function parseScenario(raw: string): string {
+export function parseOpenUIScenarioRaw(raw: string): string {
   return JSON.stringify(openUiScenarioParser.parse(raw), null, 2);
 }
 
@@ -727,21 +727,21 @@ entBtn = Buttons([Button("Contact Sales", Action([@ToAssistant("Contact sales fo
     title: 'Query Weather',
     badge: 'v0.5',
     raw: V05_QUERY_WEATHER_RAW,
-    parsed: parseScenario(V05_QUERY_WEATHER_RAW),
+    parsed: parseOpenUIScenarioRaw(V05_QUERY_WEATHER_RAW),
   },
   {
     id: 'v05-mutation-action',
     title: 'Mutation Action',
     badge: 'v0.5',
     raw: V05_MUTATION_ACTION_RAW,
-    parsed: parseScenario(V05_MUTATION_ACTION_RAW),
+    parsed: parseOpenUIScenarioRaw(V05_MUTATION_ACTION_RAW),
   },
   {
     id: 'v05-stateful-picker',
     title: 'Stateful Picker',
     badge: 'v0.5',
     raw: V05_STATEFUL_PICKER_RAW,
-    parsed: parseScenario(V05_STATEFUL_PICKER_RAW),
+    parsed: parseOpenUIScenarioRaw(V05_STATEFUL_PICKER_RAW),
   },
   {
     id: 'recipe-card',

--- a/packages/genui/a2ui-playground/src/pages/DemosListPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosListPage.tsx
@@ -1,28 +1,25 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { KeyboardEvent, RefObject } from 'react';
+import { useCallback, useMemo } from 'react';
+import type { KeyboardEvent } from 'react';
 
 import './DemosPage.css';
 
+import {
+  EXAMPLE_PREVIEW_MAX_CONCURRENT,
+  ExamplePreviewCard,
+  ExamplePreviewQueueProvider,
+} from '../components/ExamplePreviewCard.js';
 import { PageHeader } from '../components/PageHeader.js';
-import { PreviewViewport } from '../components/PreviewViewport.js';
 import {
   DYNAMIC_PRESETS,
   EXTENDED_STATIC_DEMOS,
   OFFICIAL_STATIC_DEMOS,
 } from '../demos.js';
-import { MountQueueProvider, useQueuedMount } from '../hooks/useMountQueue.js';
 import { DEFAULT_A2UI_DEMO_URL } from '../utils/demoUrl.js';
-import { PRIORITY } from '../utils/mountQueue.js';
-import type { Priority } from '../utils/mountQueue.js';
 import type { Protocol } from '../utils/protocol.js';
 import { buildRenderUrl } from '../utils/renderUrl.js';
-
-const MAX_CONCURRENT = 4;
-const ROOT_MARGIN = '50% 0px';
-const RENDER_READY_TIMEOUT_MS = 5000;
 
 interface ExampleScenario {
   id: string;
@@ -43,196 +40,6 @@ const ALL_EXAMPLES: ExampleScenario[] = [
 const STATIC_DEMO_IDS = new Set(
   [...OFFICIAL_STATIC_DEMOS, ...EXTENDED_STATIC_DEMOS].map((d) => d.id),
 );
-
-function useViewportPriority(
-  ref: RefObject<Element | null>,
-): Priority {
-  const [priority, setPriority] = useState<Priority>(PRIORITY.OFFSCREEN);
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    if (typeof IntersectionObserver === 'undefined') {
-      setPriority(PRIORITY.IN_VIEW);
-      return;
-    }
-    const inViewObserver = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        if (entry?.isIntersecting) {
-          setPriority(PRIORITY.IN_VIEW);
-        } else {
-          // Outside the viewport: defer to the near-viewport observer below.
-          setPriority((cur) => cur === PRIORITY.IN_VIEW ? PRIORITY.NEAR : cur);
-        }
-      },
-      { rootMargin: '0px' },
-    );
-    const nearObserver = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        setPriority((cur) => {
-          if (entry?.isIntersecting) {
-            return cur === PRIORITY.IN_VIEW ? cur : PRIORITY.NEAR;
-          }
-          return PRIORITY.OFFSCREEN;
-        });
-      },
-      { rootMargin: ROOT_MARGIN },
-    );
-    inViewObserver.observe(el);
-    nearObserver.observe(el);
-    return () => {
-      inViewObserver.disconnect();
-      nearObserver.disconnect();
-    };
-  }, [ref]);
-  return priority;
-}
-
-interface ExampleCardProps {
-  scenario: ExampleScenario;
-  previewUrl: string | undefined;
-  badge?: string;
-  onOpen: (id: string) => void;
-  onKeyDown: (event: KeyboardEvent<HTMLDivElement>, id: string) => void;
-}
-
-function CardPreviewLoading(props: { title: string; revealed: boolean }) {
-  return (
-    <div className='cardPreviewLoading' data-revealed={props.revealed}>
-      <div className='cardPreviewLoadingTitle'>{props.title}</div>
-      <div className='cardPreviewLoadingDots' aria-hidden='true'>
-        <span />
-        <span />
-        <span />
-      </div>
-    </div>
-  );
-}
-
-function ExampleCard(props: ExampleCardProps) {
-  const { badge, onKeyDown, onOpen, previewUrl, scenario } = props;
-  const cardRef = useRef<HTMLDivElement>(null);
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const readyRef = useRef(false);
-  const timerRef = useRef<number | null>(null);
-  const priority = useViewportPriority(cardRef);
-  const { armed, markReady } = useQueuedMount(scenario.id, priority);
-  const [rendered, setRendered] = useState(false);
-
-  // Free the queue slot. Does NOT reveal the iframe — that's the
-  // RENDER_READY path's job. If we never hear from the iframe (web-core
-  // race, broken bundle, etc.), the loading overlay stays put so the
-  // user never sees a blank-white iframe peeking through.
-  const releaseSlot = useCallback(() => {
-    if (readyRef.current) return;
-    readyRef.current = true;
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-    markReady();
-  }, [markReady]);
-
-  const handleRenderReady = useCallback(() => {
-    setRendered(true);
-    releaseSlot();
-  }, [releaseSlot]);
-
-  // When previewUrl changes (e.g. theme toggle rebuilds the URL with a
-  // new `?theme=` param), drop the rendered state so the loading overlay
-  // covers the iframe again until the new boot finishes — otherwise the
-  // user sees the old frame, then a white flash, then the new one.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: previewUrl is intentionally a reset trigger; the effect body only resets local refs.
-  useEffect(() => {
-    readyRef.current = false;
-    setRendered(false);
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, [previewUrl]);
-
-  // Listen for the iframe's A2UI_RENDER_READY postMessage. Stays
-  // attached even after the safety timeout, so a slow-but-eventually
-  // working iframe still gets its overlay faded out when it finishes.
-  useEffect(() => {
-    if (!armed) return;
-    const handler = (e: MessageEvent) => {
-      if (e.source !== iframeRef.current?.contentWindow) return;
-      if (e.origin !== window.location.origin) return;
-      const data = e.data as { type?: string } | null;
-      if (data && data.type === 'A2UI_RENDER_READY') {
-        handleRenderReady();
-      }
-    };
-    window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
-  }, [armed, handleRenderReady]);
-
-  // Cleanup the safety timer if the card unmounts before it fires.
-  useEffect(() => {
-    return () => {
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-    };
-  }, []);
-
-  const handleIframeLoad = useCallback(() => {
-    if (readyRef.current) return;
-    if (timerRef.current !== null) return;
-    // Safety timeout: if A2UI_RENDER_READY never arrives, release the
-    // slot so the queue can advance. We do NOT set rendered=true here —
-    // the overlay stays on top so a failed iframe never shows blank.
-    timerRef.current = window.setTimeout(() => {
-      timerRef.current = null;
-      releaseSlot();
-    }, RENDER_READY_TIMEOUT_MS);
-  }, [releaseSlot]);
-
-  return (
-    <div
-      ref={cardRef}
-      className='exampleCard'
-      onClick={() => onOpen(scenario.id)}
-      onKeyDown={(event) => onKeyDown(event, scenario.id)}
-      role='button'
-      tabIndex={0}
-    >
-      <div className='exampleCardPreview'>
-        <div
-          className='exampleCardPreviewWindow'
-          style={{ position: 'relative' }}
-        >
-          <PreviewViewport
-            src={armed ? previewUrl : undefined}
-            iframeTitle={`${scenario.title} preview`}
-            emptyTitle={scenario.title}
-            displayMode='full'
-            iframeRef={iframeRef}
-            onLoad={handleIframeLoad}
-          />
-          {armed
-            ? (
-              <CardPreviewLoading
-                title={scenario.title}
-                revealed={rendered}
-              />
-            )
-            : null}
-        </div>
-      </div>
-      <div className='exampleCardBody'>
-        <div className='exampleCardTop'>
-          <div className='exampleCardTitle'>{scenario.title}</div>
-          {badge ? <span className='exampleCardBadge'>{badge}</span> : null}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export function DemosListPage(
   props: { protocol: Protocol; theme: 'light' | 'dark' },
@@ -280,8 +87,8 @@ export function DemosListPage(
   );
 
   return (
-    <MountQueueProvider
-      maxConcurrent={MAX_CONCURRENT}
+    <ExamplePreviewQueueProvider
+      maxConcurrent={EXAMPLE_PREVIEW_MAX_CONCURRENT}
       resetKey={`${protocol.name}|${theme}`}
     >
       <div className='examplePage'>
@@ -303,7 +110,7 @@ export function DemosListPage(
             </div>
             <div className='exampleGrid exampleGridFlow'>
               {EXTENDED_EXAMPLES.map((scenario) => (
-                <ExampleCard
+                <ExamplePreviewCard
                   key={scenario.id}
                   scenario={scenario}
                   previewUrl={previewUrls.get(scenario.id)}
@@ -327,7 +134,7 @@ export function DemosListPage(
             </div>
             <div className='exampleGrid'>
               {OFFICIAL_EXAMPLES.map((scenario) => (
-                <ExampleCard
+                <ExamplePreviewCard
                   key={scenario.id}
                   scenario={scenario}
                   previewUrl={previewUrls.get(scenario.id)}
@@ -340,6 +147,6 @@ export function DemosListPage(
           </section>
         </div>
       </div>
-    </MountQueueProvider>
+    </ExamplePreviewQueueProvider>
   );
 }

--- a/packages/genui/a2ui-playground/src/pages/DemosPage.css
+++ b/packages/genui/a2ui-playground/src/pages/DemosPage.css
@@ -137,6 +137,10 @@
   box-shadow: none;
 }
 
+.exampleCardPreviewWindow iframe {
+  pointer-events: none;
+}
+
 .exampleCardPreviewFrame {
   width: 100%;
   height: 100%;
@@ -452,6 +456,41 @@
 
 /* toolbarBtn / toolbarBtn.primary: replaced by <Button variant="ghost"|"primary"
    size="sm" ...>. */
+
+.openuiCodeToolbar {
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  min-width: 0;
+}
+
+.openuiCodeTitle {
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.openuiCodeTitleText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.openuiCodeViewSwitch {
+  width: 118px;
+  margin-left: 4px;
+}
+
+.openuiCodeViewSwitch .previewModeBtn {
+  flex: 1;
+  min-width: 0;
+  text-align: center;
+}
+
+.openuiToolbarActions {
+  flex-shrink: 0;
+  gap: 2px;
+}
 
 .codeEditor {
   flex: 1;
@@ -1112,5 +1151,19 @@
   .codePanelTitle {
     white-space: nowrap;
     font-size: 12px;
+  }
+
+  .openuiCodeToolbar {
+    gap: 6px;
+    padding: 6px 8px;
+  }
+
+  .openuiCodeViewSwitch .previewModeBtn {
+    padding: 2px 8px;
+    font-size: 11px;
+  }
+
+  .openuiCodeTitleText {
+    display: none;
   }
 }

--- a/packages/genui/a2ui-playground/src/pages/OpenUIDemosListPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/OpenUIDemosListPage.tsx
@@ -1,0 +1,92 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useCallback, useMemo } from 'react';
+import type { KeyboardEvent } from 'react';
+
+import './DemosPage.css';
+
+import {
+  EXAMPLE_PREVIEW_MAX_CONCURRENT,
+  ExamplePreviewCard,
+  ExamplePreviewQueueProvider,
+} from '../components/ExamplePreviewCard.js';
+import { PageHeader } from '../components/PageHeader.js';
+import { OPENUI_SCENARIOS } from '../mock/openui-scenarios.js';
+import type { Protocol } from '../utils/protocol.js';
+import { buildOpenUIRenderUrl } from '../utils/renderUrl.js';
+
+export function OpenUIDemosListPage(props: { protocol: Protocol }) {
+  const { protocol } = props;
+  const baseUrl = window.location.href.replace(/#.*$/, '');
+
+  const previewUrls = useMemo(
+    () =>
+      new Map(
+        OPENUI_SCENARIOS.map((scenario) => [
+          scenario.id,
+          buildOpenUIRenderUrl({
+            rawText: scenario.raw,
+            instant: true,
+          }, baseUrl),
+        ]),
+      ),
+    [baseUrl],
+  );
+
+  const handleOpenExample = useCallback(
+    (id: string) => {
+      window.location.hash = `#/${protocol.name}/examples/${id}`;
+    },
+    [protocol.name],
+  );
+
+  const handleCardKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>, id: string) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      handleOpenExample(id);
+    },
+    [handleOpenExample],
+  );
+
+  return (
+    <ExamplePreviewQueueProvider
+      maxConcurrent={EXAMPLE_PREVIEW_MAX_CONCURRENT}
+      resetKey={protocol.name}
+    >
+      <div className='examplePage'>
+        <PageHeader
+          className='examplePageHeader'
+          titleClassName='examplePageHeaderTitle'
+          descriptionClassName='examplePageHeaderDesc'
+          title='OpenUI Showcase'
+          description='Explore OpenUI Lang examples rendered through the Lynx preview runtime.'
+          topContent={
+            <span className='chip'>{OPENUI_SCENARIOS.length} examples</span>
+          }
+        />
+        <div className='exampleColumns'>
+          <section className='exampleSection'>
+            <div className='exampleSectionHeader'>
+              <h2 className='exampleSectionTitle'>Examples</h2>
+              <span className='chip'>{OPENUI_SCENARIOS.length}</span>
+            </div>
+            <div className='exampleGrid exampleGridFlow'>
+              {OPENUI_SCENARIOS.map((scenario) => (
+                <ExamplePreviewCard
+                  key={scenario.id}
+                  scenario={scenario}
+                  previewUrl={previewUrls.get(scenario.id)}
+                  badge={scenario.badge}
+                  onOpen={handleOpenExample}
+                  onKeyDown={handleCardKeyDown}
+                />
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </ExamplePreviewQueueProvider>
+  );
+}

--- a/packages/genui/a2ui-playground/src/pages/OpenUIDemosPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/OpenUIDemosPage.tsx
@@ -1,43 +1,101 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import CodeMirror from '@uiw/react-codemirror';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
 
 import './DemosPage.css';
 
 import { Button } from '../components/Button.js';
-import { Play } from '../components/Icon.js';
+import { ChevronLeft, Pause, Play, RotateCcw, X } from '../components/Icon.js';
+import { MobileTabBar } from '../components/MobileTabBar.js';
+import type { MobilePaneTab } from '../components/MobileTabBar.js';
 import { PanelResizeHandle } from '../components/PanelResizeHandle.js';
 import { PreviewPanel } from '../components/PreviewPanel.js';
 import { PreviewViewport } from '../components/PreviewViewport.js';
 import { useResizablePanels } from '../hooks/useResizablePanels.js';
-import { OPENUI_SCENARIOS } from '../mock/openui-scenarios.js';
+import {
+  OPENUI_SCENARIOS,
+  parseOpenUIScenarioRaw,
+} from '../mock/openui-scenarios.js';
+import type { OpenUIScenario } from '../mock/openui-scenarios.js';
 import type { Protocol } from '../utils/protocol.js';
-
-type CodeView = 'raw' | 'parsed';
-
-const DESKTOP_PREVIEW_MIN_WIDTH = 320;
-const DESKTOP_CODE_MIN_WIDTH = 360;
-const COMPACT_CODE_MIN_HEIGHT = 220;
-const COMPACT_PREVIEW_MIN_HEIGHT = 320;
-const RESIZE_BREAKPOINT = 980;
 
 interface PreviewInput {
   rawText: string;
 }
 
-export function OpenUIDemosPage(_props: { protocol: Protocol }) {
-  const [codeView, setCodeView] = useState<CodeView>('raw');
+type PlayState = 'idle' | 'playing' | 'paused' | 'done';
+type PlaybackProgressStatus = 'idle' | 'streaming' | 'paused' | 'done';
+type CodeView = 'raw' | 'parsed';
+
+const DESKTOP_PREVIEW_MIN_WIDTH = 360;
+const DESKTOP_CODE_MIN_WIDTH = 360;
+const COMPACT_CODE_MIN_HEIGHT = 220;
+const COMPACT_PREVIEW_MIN_HEIGHT = 320;
+const RESIZE_BREAKPOINT = 980;
+
+const PLAYBACK_PANEL_IDLE_HEIGHT = 48;
+const PLAYBACK_PANEL_MIN_HEIGHT_ACTIVE = 200;
+const PLAYBACK_PANEL_ACTIVE_RATIO = 0.66;
+const PLAYBACK_PANEL_MAX_RATIO = 0.85;
+const OPENUI_PLAYBACK_CHUNK_SIZE = 240;
+
+function findScenarioById(id?: string): OpenUIScenario | undefined {
+  if (!id) return undefined;
+  return OPENUI_SCENARIOS.find((scenario) => scenario.id === id);
+}
+
+function chunkOpenUI(rawText: string): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < rawText.length; i += OPENUI_PLAYBACK_CHUNK_SIZE) {
+    chunks.push(rawText.slice(i, i + OPENUI_PLAYBACK_CHUNK_SIZE));
+  }
+  return chunks;
+}
+
+function formatChunk(chunk: string): string {
+  return chunk;
+}
+
+export function OpenUIDemosPage(props: {
+  protocol: Protocol;
+  demoId?: string;
+}) {
+  const { protocol, demoId } = props;
+  const initialScenario = findScenarioById(demoId) ?? OPENUI_SCENARIOS[0];
+
   const [scenarioId, setScenarioId] = useState<string>(
-    OPENUI_SCENARIOS[0]?.id ?? '',
+    initialScenario?.id ?? '',
   );
-  const [customRawText, setCustomRawText] = useState('');
+  const [customRawText, setCustomRawText] = useState<string>(
+    initialScenario?.raw ?? '',
+  );
   const [error, setError] = useState('');
   const [previewRenderKey, setPreviewRenderKey] = useState(0);
-  const [previewInput, setPreviewInput] = useState<PreviewInput | null>(() => {
-    const initialScenario = OPENUI_SCENARIOS[0];
-    return initialScenario ? { rawText: initialScenario.raw } : null;
-  });
+  const [activeMobileTab, setActiveMobileTab] = useState<MobilePaneTab>('edit');
+  const [codeView, setCodeView] = useState<CodeView>('raw');
+  const [previewInput, setPreviewInput] = useState<PreviewInput | null>(() =>
+    initialScenario ? { rawText: initialScenario.raw } : null
+  );
+
+  const [playState, setPlayState] = useState<PlayState>('idle');
+  const [playbackSpeed, setPlaybackSpeed] = useState(1);
+  const [deliveredCount, setDeliveredCount] = useState(0);
+  const [playbackPanelHeight, setPlaybackPanelHeight] = useState(
+    PLAYBACK_PANEL_IDLE_HEIGHT,
+  );
+  const [isPlaybackResizing, setIsPlaybackResizing] = useState(false);
+  const [playbackChunksSource, setPlaybackChunksSource] = useState<string[]>(
+    [],
+  );
+
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const streamTimerRef = useRef<number | null>(null);
+  const lastSentDeliveredRef = useRef(-1);
+  const codePanelInnerRef = useRef<HTMLDivElement | null>(null);
+  const playbackResizeStopRef = useRef<(() => void) | null>(null);
 
   const {
     containerRef: pageRef,
@@ -55,68 +113,404 @@ export function OpenUIDemosPage(_props: { protocol: Protocol }) {
     desktopPrimaryMinSize: DESKTOP_CODE_MIN_WIDTH,
     desktopSecondaryMinSize: DESKTOP_PREVIEW_MIN_WIDTH,
     initialPrimarySize: 320,
-    initialSecondarySize: 420,
+    initialSecondarySize: 480,
   });
 
   const currentScenario = useMemo(
-    () =>
-      OPENUI_SCENARIOS.find((s) => s.id === scenarioId)
-        ?? OPENUI_SCENARIOS[0],
+    () => findScenarioById(scenarioId) ?? OPENUI_SCENARIOS[0],
     [scenarioId],
   );
 
-  useEffect(() => {
-    if (currentScenario) {
-      setCustomRawText(currentScenario.raw);
-      setPreviewInput({ rawText: currentScenario.raw });
+  const parsedJson = useMemo(() => {
+    if (!customRawText.trim()) return '';
+    if (currentScenario && customRawText === currentScenario.raw) {
+      return currentScenario.parsed;
     }
-  }, [currentScenario]);
+
+    try {
+      return parseOpenUIScenarioRaw(customRawText);
+    } catch (err) {
+      return `Unable to parse OpenUI DSL:\n${String(err)}`;
+    }
+  }, [currentScenario, customRawText]);
+
+  const isPlaybackActive = playState !== 'idle';
+  const isPlaying = playState === 'playing';
+  const isPaused = playState === 'paused';
+  const isDone = playState === 'done';
+
+  const stopStreamTimer = useCallback(() => {
+    if (streamTimerRef.current !== null) {
+      window.clearTimeout(streamTimerRef.current);
+      streamTimerRef.current = null;
+    }
+  }, []);
+
+  const resetPlayback = useCallback(() => {
+    stopStreamTimer();
+    setPlayState('idle');
+    setDeliveredCount(0);
+    setPlaybackChunksSource([]);
+    lastSentDeliveredRef.current = -1;
+  }, [stopStreamTimer]);
+
+  useEffect(() => () => stopStreamTimer(), [stopStreamTimer]);
+
+  useEffect(() => {
+    if (isPlaybackActive) {
+      const containerHeight = codePanelInnerRef.current?.getBoundingClientRect()
+        .height;
+      const target = containerHeight
+        ? Math.max(
+          PLAYBACK_PANEL_MIN_HEIGHT_ACTIVE,
+          Math.round(containerHeight * PLAYBACK_PANEL_ACTIVE_RATIO),
+        )
+        : PLAYBACK_PANEL_MIN_HEIGHT_ACTIVE;
+      setPlaybackPanelHeight(target);
+      return;
+    }
+
+    setPlaybackPanelHeight(PLAYBACK_PANEL_IDLE_HEIGHT);
+  }, [isPlaybackActive]);
+
+  useEffect(() => {
+    const nextScenario = findScenarioById(demoId) ?? OPENUI_SCENARIOS[0];
+    if (!nextScenario) return;
+    setScenarioId(nextScenario.id);
+    setCustomRawText(nextScenario.raw);
+    setError('');
+    setPreviewInput({ rawText: nextScenario.raw });
+    if (streamTimerRef.current !== null) {
+      window.clearTimeout(streamTimerRef.current);
+      streamTimerRef.current = null;
+    }
+    setPlayState('idle');
+    setDeliveredCount(0);
+    setPlaybackChunksSource([]);
+    lastSentDeliveredRef.current = -1;
+  }, [demoId]);
 
   const previewSource = useMemo(() => {
     if (!previewInput) return undefined;
     return {
       kind: 'openui' as const,
       rawText: previewInput.rawText,
+      playbackMode: isPlaybackActive,
     };
-  }, [previewInput]);
+  }, [isPlaybackActive, previewInput]);
 
-  const handleSelectScenario = useCallback((id: string) => {
-    setScenarioId(id);
-  }, []);
+  const handleSelectScenario = useCallback(
+    (id: string) => {
+      window.location.hash = `#/${protocol.name}/examples/${id}`;
+      setScenarioId(id);
+      setError('');
+      const scenario = findScenarioById(id);
+      if (scenario) {
+        setCustomRawText(scenario.raw);
+        setPreviewInput({ rawText: scenario.raw });
+      }
+      resetPlayback();
+    },
+    [protocol.name, resetPlayback],
+  );
 
-  const handleRender = useCallback(() => {
+  const handleBackToExamples = useCallback(() => {
+    window.location.hash = `#/${protocol.name}/examples`;
+  }, [protocol.name]);
+
+  const commitRawText = useCallback((): string | null => {
     if (!customRawText.trim()) {
       setError('Raw output is empty.');
-      return;
+      return null;
     }
+
     setError('');
     setPreviewInput({ rawText: customRawText });
-    setPreviewRenderKey((value) => value + 1);
+    return customRawText;
   }, [customRawText]);
+
+  const handleRender = useCallback(() => {
+    const committed = commitRawText();
+    if (!committed) return;
+    resetPlayback();
+    setPreviewRenderKey((value) => value + 1);
+  }, [commitRawText, resetPlayback]);
+
+  const handleFillExample = useCallback(() => {
+    setError('');
+    if (currentScenario) {
+      setCustomRawText(currentScenario.raw);
+      setPreviewInput({ rawText: currentScenario.raw });
+    }
+    resetPlayback();
+  }, [currentScenario, resetPlayback]);
+
+  const handleClear = useCallback(() => {
+    setCustomRawText('');
+    setPreviewInput(null);
+    setError('');
+    resetPlayback();
+  }, [resetPlayback]);
+
+  const sendPlaybackProgress = useCallback((
+    delivered: number,
+    total: number,
+    status: PlaybackProgressStatus,
+  ) => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    win.postMessage(
+      {
+        type: 'A2UI_PLAYBACK_PROGRESS',
+        data: {
+          deliveredCount: delivered,
+          totalCount: total,
+          status,
+        },
+      },
+      '*',
+    );
+  }, []);
+
+  const sendPlaybackControl = useCallback((action: 'pause' | 'resume') => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    win.postMessage({ type: 'A2UI_PLAYBACK_CONTROL', action }, '*');
+  }, []);
+
+  const handlePlay = useCallback(() => {
+    const committed = commitRawText();
+    if (!committed) return;
+
+    const nextChunks = chunkOpenUI(committed);
+    if (nextChunks.length === 0) {
+      setError('Nothing to play: raw output is empty.');
+      return;
+    }
+
+    stopStreamTimer();
+    setPlaybackChunksSource(nextChunks);
+    setDeliveredCount(0);
+    lastSentDeliveredRef.current = -1;
+    setPlayState('playing');
+    setPreviewRenderKey((value) => value + 1);
+  }, [commitRawText, stopStreamTimer]);
+
+  const handlePause = useCallback(() => {
+    if (!isPlaying) return;
+    stopStreamTimer();
+    setPlayState('paused');
+    sendPlaybackControl('pause');
+  }, [isPlaying, sendPlaybackControl, stopStreamTimer]);
+
+  const handleResume = useCallback(() => {
+    if (!isPaused) return;
+    setPlayState('playing');
+    sendPlaybackControl('resume');
+  }, [isPaused, sendPlaybackControl]);
+
+  const handleRestart = useCallback(() => {
+    handlePlay();
+  }, [handlePlay]);
+
+  useEffect(() => {
+    if (playState !== 'playing') {
+      stopStreamTimer();
+      return;
+    }
+    if (deliveredCount >= playbackChunksSource.length) {
+      stopStreamTimer();
+      setPlayState('done');
+      return;
+    }
+
+    const intervalMs = Math.max(
+      120,
+      Math.round(800 / Math.max(playbackSpeed, 0.25)),
+    );
+    streamTimerRef.current = window.setTimeout(() => {
+      setDeliveredCount((count) =>
+        Math.min(count + 1, playbackChunksSource.length)
+      );
+    }, intervalMs);
+
+    return stopStreamTimer;
+  }, [
+    deliveredCount,
+    playState,
+    playbackChunksSource.length,
+    playbackSpeed,
+    stopStreamTimer,
+  ]);
+
+  useEffect(() => {
+    if (!isPlaybackActive) return;
+    if (lastSentDeliveredRef.current === deliveredCount) return;
+    lastSentDeliveredRef.current = deliveredCount;
+    const status: PlaybackProgressStatus = isDone
+      ? 'done'
+      : (isPaused ? 'paused' : 'streaming');
+    sendPlaybackProgress(deliveredCount, playbackChunksSource.length, status);
+  }, [
+    deliveredCount,
+    isDone,
+    isPaused,
+    isPlaybackActive,
+    playbackChunksSource.length,
+    sendPlaybackProgress,
+  ]);
+
+  const handleIframeLoad = useCallback(() => {
+    lastSentDeliveredRef.current = -1;
+    if (!isPlaybackActive) return;
+    const status: PlaybackProgressStatus = isDone
+      ? 'done'
+      : (isPaused ? 'paused' : 'streaming');
+    sendPlaybackProgress(deliveredCount, playbackChunksSource.length, status);
+    if (isPaused) sendPlaybackControl('pause');
+  }, [
+    deliveredCount,
+    isDone,
+    isPaused,
+    isPlaybackActive,
+    playbackChunksSource.length,
+    sendPlaybackControl,
+    sendPlaybackProgress,
+  ]);
+
+  const handlePlaybackResizeStart = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      playbackResizeStopRef.current?.();
+
+      const container = codePanelInnerRef.current;
+      const startY = event.clientY;
+      const startHeight = playbackPanelHeight;
+      const minHeight = isPlaybackActive
+        ? PLAYBACK_PANEL_MIN_HEIGHT_ACTIVE
+        : PLAYBACK_PANEL_IDLE_HEIGHT;
+
+      setIsPlaybackResizing(true);
+      document.body.dataset.panelResize = 'horizontal';
+
+      const onMove = (moveEvent: PointerEvent) => {
+        const delta = moveEvent.clientY - startY;
+        let next = startHeight + delta;
+        const containerHeight = container?.getBoundingClientRect().height
+          ?? Number.POSITIVE_INFINITY;
+        const max = Math.max(
+          minHeight,
+          containerHeight * PLAYBACK_PANEL_MAX_RATIO,
+        );
+        if (next < minHeight) next = minHeight;
+        if (next > max) next = max;
+        setPlaybackPanelHeight(next);
+      };
+
+      const stop = () => {
+        setIsPlaybackResizing(false);
+        delete document.body.dataset.panelResize;
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', stop);
+        window.removeEventListener('pointercancel', stop);
+        playbackResizeStopRef.current = null;
+      };
+
+      playbackResizeStopRef.current = stop;
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', stop);
+      window.addEventListener('pointercancel', stop);
+    },
+    [isPlaybackActive, playbackPanelHeight],
+  );
+
+  useEffect(() => () => playbackResizeStopRef.current?.(), []);
+
+  const playbackPanelStyle = useMemo<CSSProperties>(() => {
+    return { height: `${playbackPanelHeight}px` };
+  }, [playbackPanelHeight]);
+
+  const playbackChunks = playbackChunksSource.slice(
+    0,
+    Math.max(0, deliveredCount),
+  );
+  const playbackTotal = playbackChunksSource.length;
+  const playbackProgressRatio = playbackTotal === 0
+    ? 0
+    : Math.min(deliveredCount, playbackTotal) / playbackTotal;
+
+  const playbackPrimaryButton = isPlaying
+    ? (
+      <Button
+        variant='primary'
+        size='sm'
+        iconBefore={Pause}
+        onClick={handlePause}
+        title='Pause playback'
+      >
+        Pause
+      </Button>
+    )
+    : (isPaused
+      ? (
+        <Button
+          variant='primary'
+          size='sm'
+          iconBefore={Play}
+          onClick={handleResume}
+          title='Resume playback'
+        >
+          Resume
+        </Button>
+      )
+      : (
+        <Button
+          variant='primary'
+          size='sm'
+          iconBefore={Play}
+          onClick={handlePlay}
+          title='Start playback'
+        >
+          Play
+        </Button>
+      ));
 
   return (
     <div
       ref={pageRef}
       className={isPanelResizing ? 'demosPage resizing' : 'demosPage'}
+      data-active-tab={activeMobileTab}
     >
       <aside className='sidebar'>
+        <div className='sidebarTopNav'>
+          <Button
+            variant='secondary'
+            size='md'
+            responsiveIconOnly
+            iconBefore={ChevronLeft}
+            onClick={handleBackToExamples}
+            aria-label='Back to Examples'
+          >
+            Back to Examples
+          </Button>
+        </div>
         <div className='sidebarSection'>
           <div className='sidebarHeading'>Scenarios</div>
           <div className='scenarioList'>
-            {OPENUI_SCENARIOS.map((s) => (
+            {OPENUI_SCENARIOS.map((scenario) => (
               <button
-                key={s.id}
+                key={scenario.id}
                 type='button'
                 className={[
                   'scenarioItem',
-                  s.id === scenarioId ? 'active' : '',
-                  s.badge ? 'hasBadge' : '',
+                  scenario.id === scenarioId ? 'active' : '',
+                  scenario.badge ? 'hasBadge' : '',
                 ].filter(Boolean).join(' ')}
-                onClick={() => handleSelectScenario(s.id)}
+                onClick={() => handleSelectScenario(scenario.id)}
               >
-                <span className='scenarioName'>{s.title}</span>
-                {s.badge
-                  ? <span className='scenarioBadge'>{s.badge}</span>
+                <span className='scenarioName'>{scenario.title}</span>
+                {scenario.badge
+                  ? <span className='scenarioBadge'>{scenario.badge}</span>
                   : null}
               </button>
             ))}
@@ -124,103 +518,241 @@ export function OpenUIDemosPage(_props: { protocol: Protocol }) {
         </div>
       </aside>
 
-      <div className='codePanel' style={codePanelStyle}>
-        <div className='codePanelToolbar'>
-          <div className='codePanelTitle'>
-            OpenUI Output
-          </div>
-          <div className='spacer' />
-          <div className='previewModeSwitch'>
-            <button
-              type='button'
-              className={codeView === 'raw'
-                ? 'previewModeBtn active'
-                : 'previewModeBtn'}
-              onClick={() => setCodeView('raw')}
-            >
-              Raw Output
-            </button>
-            <button
-              type='button'
-              className={codeView === 'parsed'
-                ? 'previewModeBtn active'
-                : 'previewModeBtn'}
-              onClick={() => setCodeView('parsed')}
-            >
-              Parsed JSON
-            </button>
-          </div>
-          <div className='toolbarActions'>
-            <Button
-              variant='primary'
-              size='sm'
-              iconBefore={Play}
-              onClick={handleRender}
-            >
-              Render
-            </Button>
-          </div>
-        </div>
-        <div className='codeEditor' style={{ flex: 1, overflow: 'auto' }}>
-          {currentScenario
-            ? (
-              <pre
-                style={{
-                  margin: 0,
-                  padding: 16,
-                  fontSize: 13,
-                  lineHeight: 1.6,
-                  fontFamily: 'var(--geist-mono)',
-                  color: 'var(--geist-code-fg)',
-                  background: 'var(--geist-code-bg)',
-                  height: '100%',
-                  overflow: 'auto',
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-word',
-                }}
-              >
-                {codeView === 'raw'
-                  ? currentScenario.raw
-                  : currentScenario.parsed}
-              </pre>
-            )
-            : (
-              <div
-                className='previewEmpty'
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  flex: 1,
-                }}
-              >
-                <div>Select a scenario</div>
+      <div
+        className={isPlaybackResizing ? 'codePanel resizing' : 'codePanel'}
+        style={codePanelStyle}
+      >
+        <div className='codePanelInner' ref={codePanelInnerRef}>
+          <section
+            className={isPlaybackActive
+              ? 'playbackSection top active'
+              : 'playbackSection top idle'}
+            style={playbackPanelStyle}
+            aria-label='Playback'
+          >
+            <header className='playbackSectionHeader'>
+              <span className='playbackSectionTitle'>Playback</span>
+              <span className='sectionBadge'>LLM stream</span>
+              {isPlaybackActive
+                ? (
+                  <span
+                    className={isDone
+                      ? 'playbackStateDot done'
+                      : (isPaused
+                        ? 'playbackStateDot paused'
+                        : 'playbackStateDot live')}
+                    aria-hidden='true'
+                  />
+                )
+                : (
+                  <span className='playbackIdleHint'>
+                    <Play size={11} strokeWidth={2.25} aria-hidden='true' />
+                    Replay payload chunk by chunk
+                  </span>
+                )}
+              <div className='spacer' />
+              <div className='playbackHeaderControls'>
+                {isPlaybackActive
+                  ? (
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      iconOnly
+                      iconBefore={RotateCcw}
+                      onClick={handleRestart}
+                      title='Restart playback'
+                      aria-label='Restart playback'
+                    />
+                  )
+                  : null}
+                {playbackPrimaryButton}
               </div>
-            )}
+            </header>
+
+            {isPlaybackActive
+              ? (
+                <>
+                  <div className='playbackProgressTrack active'>
+                    <div
+                      className='playbackProgressFill'
+                      style={{
+                        width: `${Math.round(playbackProgressRatio * 100)}%`,
+                      }}
+                    />
+                    <span className='playbackProgressLabel'>
+                      {Math.min(deliveredCount, playbackTotal)}
+                      {' / '}
+                      {playbackTotal} chunks
+                      {isDone
+                        ? ' - complete'
+                        : (isPaused
+                          ? ' - paused'
+                          : ' - streaming...')}
+                    </span>
+                  </div>
+
+                  <div className='playbackStream'>
+                    {playbackChunks.length > 0
+                      ? playbackChunks.map((chunk, index) => {
+                        const isLatest = index === deliveredCount - 1;
+                        return (
+                          <div
+                            key={index}
+                            className={isLatest && isPlaying
+                              ? 'playbackChunk live'
+                              : 'playbackChunk'}
+                          >
+                            <div className='playbackChunkHeader'>
+                              <span className='playbackChunkIndex'>
+                                #{index + 1}
+                              </span>
+                              {isLatest && isPlaying
+                                ? (
+                                  <span className='playbackChunkLiveTag'>
+                                    live
+                                  </span>
+                                )
+                                : null}
+                            </div>
+                            <pre className='playbackChunkJson'>
+                              {formatChunk(chunk)}
+                            </pre>
+                          </div>
+                        );
+                      })
+                      : (
+                        <div className='playbackEmpty subtle'>
+                          Streaming...
+                        </div>
+                      )}
+                  </div>
+                </>
+              )
+              : null}
+          </section>
+
+          <div
+            className={isPlaybackResizing
+              ? 'playbackSplitter active'
+              : 'playbackSplitter'}
+            role='separator'
+            aria-orientation='horizontal'
+            aria-label='Resize Playback and OpenUI output panels'
+            title='Drag to resize'
+            onPointerDown={handlePlaybackResizeStart}
+          >
+            <span className='playbackSplitterGrip' aria-hidden='true' />
+          </div>
+
+          <div className='codePanelEditorSection'>
+            <div className='codePanelToolbar openuiCodeToolbar'>
+              <div className='codePanelTitle openuiCodeTitle'>
+                <span className='openuiCodeTitleText'>OpenUI Output</span>
+              </div>
+              <div className='previewModeSwitch openuiCodeViewSwitch'>
+                <button
+                  type='button'
+                  className={codeView === 'raw'
+                    ? 'previewModeBtn active'
+                    : 'previewModeBtn'}
+                  onClick={() => setCodeView('raw')}
+                  title='Raw Output'
+                >
+                  Raw
+                </button>
+                <button
+                  type='button'
+                  className={codeView === 'parsed'
+                    ? 'previewModeBtn active'
+                    : 'previewModeBtn'}
+                  onClick={() => setCodeView('parsed')}
+                  title='Parsed JSON'
+                >
+                  JSON
+                </button>
+              </div>
+              <div className='spacer' />
+              <div className='toolbarActions openuiToolbarActions'>
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  iconOnly
+                  iconBefore={RotateCcw}
+                  onClick={handleFillExample}
+                  title='Reset to example'
+                  aria-label='Reset to example'
+                />
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  iconOnly
+                  iconBefore={X}
+                  onClick={handleClear}
+                  title='Clear editor'
+                  aria-label='Clear editor'
+                />
+                <Button
+                  variant='primary'
+                  size='sm'
+                  iconBefore={Play}
+                  onClick={handleRender}
+                >
+                  Render
+                </Button>
+              </div>
+            </div>
+            <CodeMirror
+              key={codeView}
+              className='codeEditor'
+              value={codeView === 'raw' ? customRawText : parsedJson}
+              onChange={codeView === 'raw' ? setCustomRawText : undefined}
+              editable={codeView === 'raw'}
+              theme='dark'
+              basicSetup={{
+                lineNumbers: false,
+                foldGutter: false,
+                bracketMatching: true,
+                closeBrackets: true,
+                autocompletion: true,
+              }}
+            />
+            {error ? <div className='codeError'>{error}</div> : null}
+          </div>
         </div>
-        {error ? <div className='codeError'>{error}</div> : null}
       </div>
 
       <PanelResizeHandle
         isActive={isPanelResizing}
         isCompactLayout={isCompactLayout}
-        ariaLabel='Resize examples and preview panels'
+        ariaLabel='Resize OpenUI output and preview panels'
         onPointerDown={handlePanelResizeStart}
       />
 
-      <PreviewPanel
-        className='previewPanel'
-        style={previewPanelStyle}
-        title='Lynx Preview'
-        showPreviewModeSwitch
-        previewSource={previewSource}
-      >
-        <PreviewViewport
-          key={previewRenderKey}
-          emptyTitle='Select a scenario to preview'
-          emptySubTitle='Lynx rendering will appear here'
-        />
-      </PreviewPanel>
+      <div className='examplesPreviewWrap' style={previewPanelStyle}>
+        <PreviewPanel
+          className='previewPanel examplesPreviewPanel'
+          title='Lynx Preview'
+          showPreviewModeSwitch
+          speed={playbackSpeed}
+          onSpeedChange={setPlaybackSpeed}
+          previewSource={previewSource}
+        >
+          <PreviewViewport
+            key={previewRenderKey}
+            iframeRef={iframeRef}
+            onLoad={handleIframeLoad}
+            retainPreviousFrame
+            emptyTitle='Select a scenario to preview'
+            emptySubTitle='Lynx rendering will appear here'
+          />
+        </PreviewPanel>
+      </div>
+
+      <MobileTabBar
+        activeTab={activeMobileTab}
+        onChange={setActiveMobileTab}
+        editLabel='Code'
+      />
     </div>
   );
 }

--- a/packages/genui/a2ui-playground/src/render.tsx
+++ b/packages/genui/a2ui-playground/src/render.tsx
@@ -546,6 +546,32 @@ function Render() {
   }, []);
 
   useEffect(() => {
+    const rawTextUrl = initData?.rawTextUrl;
+    if (!rawTextUrl) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await window.fetch(rawTextUrl);
+        if (!res.ok || cancelled) return;
+        const rawText = await res.text();
+        if (!cancelled) {
+          setInitData((prev) =>
+            prev && prev.rawTextUrl === rawTextUrl
+              ? { ...prev, rawText }
+              : prev
+          );
+        }
+      } catch {
+        // ignore; the Lynx app will keep its fallback scenario
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [initData?.rawTextUrl]);
+
+  useEffect(() => {
     const lynxView = lynxViewRef.current;
     if (!lynxView) return;
 

--- a/packages/genui/a2ui-playground/src/utils/renderUrl.ts
+++ b/packages/genui/a2ui-playground/src/utils/renderUrl.ts
@@ -32,6 +32,14 @@ export interface RenderInit {
   playbackMode?: boolean;
 }
 
+export interface OpenUIRenderInit {
+  rawText?: string;
+  rawTextUrl?: string;
+  speed?: number;
+  instant?: boolean;
+  playbackMode?: boolean;
+}
+
 function buildRenderInitData(init: RenderInit): Record<string, unknown> {
   const initData: Record<string, unknown> = {
     protocol: init.protocol.name,
@@ -109,6 +117,35 @@ export function buildRenderUrl(init: RenderInit, baseUrl: string): string {
 
   if (init.liveAction) {
     url.searchParams.set('liveAction', '1');
+  }
+
+  if (init.playbackMode) {
+    url.searchParams.set('playbackMode', '1');
+  }
+
+  return url.toString();
+}
+
+export function buildOpenUIRenderUrl(
+  init: OpenUIRenderInit,
+  baseUrl: string,
+): string {
+  const url = new URL('render.html', baseUrl);
+  url.searchParams.set('protocol', 'openui');
+  url.searchParams.set('demoUrl', './openui.web.js');
+
+  if (init.rawTextUrl) {
+    url.searchParams.set('rawTextUrl', init.rawTextUrl);
+  } else if (init.rawText !== undefined) {
+    url.searchParams.set('rawText', init.rawText);
+  }
+
+  if (init.speed !== undefined && init.speed !== 1) {
+    url.searchParams.set('speed', String(init.speed));
+  }
+
+  if (init.instant) {
+    url.searchParams.set('instant', '1');
   }
 
   if (init.playbackMode) {


### PR DESCRIPTION
## Summary

- Add an OpenUI examples index that reuses the A2UI example card layout.
- Align the OpenUI example detail page with the A2UI detail experience, including inline playback, editable/raw and parsed JSON views, resizable preview layout, and mobile tabs.
- Add OpenUI preview playback support through render URLs and the OpenUI Lynx runtime.

## Validation

- `pnpm dprint fmt ...`
- `pnpm biome lint --write --no-errors-on-unmatched --files-ignore-unknown=true packages/genui/a2ui-playground/src/components/ExamplePreviewCard.tsx`
- `pnpm turbo build --filter=a2ui-playground`
- Browser checks on `http://localhost:3001/#/openui/examples/v05-query-weather` at desktop and mobile widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenUI playback modes: instant playback and progressive streaming with play/pause/resume/restart controls
  * Example gallery with interactive preview cards and smart loading
  * Code editor with raw and parsed JSON view toggle
  * Adjustable playback speed control
  * Deep-linking support to individual examples
  * Persistent scenario sidebar for quick navigation

* **Improvements**
  * Enhanced mobile responsiveness with responsive toolbar and tab layout
  * Preview progress tracking and visual feedback
  * Back-to-Examples navigation button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->