### PR TITLE
test(react): cover keyed host replacement

### DIFF
--- a/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
+++ b/packages/react/testing-library/src/__tests__/dom-reuse.test.jsx
@@ -1367,6 +1367,58 @@ describe('should reuse dom', () => {
     }
   });
 
+  it('keyed host replacement updates content without crashing during snapshot patch apply', () => {
+    // https://github.com/lynx-family/lynx-stack/issues/2435
+    vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
+    vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
+
+    const App = () => {
+      const [tab, setTab] = useState('a');
+
+      return (
+        <view>
+          <text
+            data-testid='toggle'
+            bindtap={() => setTab(prev => prev === 'a' ? 'b' : 'a')}
+          >
+            toggle tab: {tab}
+          </text>
+
+          <view key={tab}>
+            {tab === 'a'
+              ? (
+                <view>
+                  <text>A content</text>
+                </view>
+              )
+              : (
+                <view>
+                  <text>B content</text>
+                </view>
+              )}
+          </view>
+        </view>
+      );
+    };
+
+    const { getByTestId, queryByText } = render(<App />);
+
+    expect(queryByText('A content')).toBeInTheDocument();
+    expect(queryByText('B content')).not.toBeInTheDocument();
+
+    expect(() => fireEvent.tap(getByTestId('toggle'))).not.toThrow();
+
+    expect(queryByText('A content')).not.toBeInTheDocument();
+    expect(queryByText('B content')).toBeInTheDocument();
+    expect(getByTestId('toggle')).toHaveTextContent('toggle tab: b');
+
+    expect(() => fireEvent.tap(getByTestId('toggle'))).not.toThrow();
+
+    expect(queryByText('A content')).toBeInTheDocument();
+    expect(queryByText('B content')).not.toBeInTheDocument();
+    expect(getByTestId('toggle')).toHaveTextContent('toggle tab: a');
+  });
+
   it('slot 1 component hooks state must be preserved when slot 0 type changes', () => {
     vi.spyOn(lynxTestingEnv.backgroundThread.lynxCoreInject.tt, 'OnLifecycleEvent');
     vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');

--- a/packages/react/testing-library/src/__tests__/list.test.jsx
+++ b/packages/react/testing-library/src/__tests__/list.test.jsx
@@ -970,3 +970,46 @@ describe('list - deferred <list-item/> should render as normal', () => {
     expect(JSON.parse(callLepusMethodCalls[0][1]['data']).patchList[0].snapshotPatch.length).toBe(0);
   });
 });
+
+test('should replace a keyed list in a dynamic slot without corrupting the slot index', async () => {
+  // https://github.com/lynx-family/lynx-stack/issues/2273
+  let setListKey;
+  const Comp = () => {
+    const [listKey, _setListKey] = useState('before');
+    setListKey = _setListKey;
+
+    return (
+      <view>
+        <text>header</text>
+        <list key={listKey} custom-list-name='list-container'>
+          <list-item item-key='bottom' estimated-height-px={20}>
+            <text>{listKey}</text>
+          </list-item>
+        </list>
+        <text>footer</text>
+      </view>
+    );
+  };
+
+  const { container } = render(<Comp />);
+  const initialList = container.querySelector('list');
+
+  expect(initialList).not.toBeNull();
+  expect(() => {
+    act(() => {
+      setListKey('after');
+    });
+  }).not.toThrow();
+
+  const nextList = container.querySelector('list');
+  expect(nextList).not.toBe(initialList);
+
+  const uid = elementTree.enterListItemAtIndex(nextList, 0);
+  await uid;
+
+  expect(container.querySelectorAll('view > wrapper > list')).toHaveLength(1);
+  expect(nextList.getAttribute('custom-list-name')).toBe('list-container');
+  expect(nextList.querySelector('list-item').getAttribute('item-key')).toBe('bottom');
+  expect(nextList.querySelector('list-item').getAttribute('estimated-height-px')).toBe('20');
+  expect(container.textContent).toBe('headerafterfooter');
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes #2273 #2435

## Summary by CodeRabbit

* **Tests**
  * Added test verifying keyed view swapping via a toggle, ensuring content updates and toggle state reflect across transitions without errors.
  * Added test verifying replacement of a keyed list inside a dynamic slot, ensuring the list node is replaced cleanly, slot integrity is preserved, and list/item attributes and combined content remain correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
