### PR TITLE
feat(react-webpack-plugin): enable unify fixed behavior for ET

### DIFF
--- a/.changeset/et-unify-fixed-page-config-no-release.md
+++ b/.changeset/et-unify-fixed-page-config-no-release.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Add no release changes for the Element Template unify fixed page config default because Element Template support has not been published yet.

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -509,6 +509,8 @@ class ReactWebpackPlugin {
               );
             }
 
+            args.encodeData.sourceContent.config['enableUnifyFixedBehavior'] =
+              true;
             args.encodeData.elementTemplate = elementTemplates;
             return args;
           },

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/basic/rspack.config.js
@@ -38,6 +38,10 @@ export default {
             if (!args.encodeData.elementTemplate) {
               throw new Error('elementTemplate should exist');
             }
+            expect(
+              args.encodeData.sourceContent.config.enableUnifyFixedBehavior,
+            )
+              .toBe(true);
             const userTemplateIds = Object.keys(args.encodeData.elementTemplate)
               .filter(id => id !== '_et_builtin_raw_text');
             expect(userTemplateIds).toHaveLength(1);


### PR DESCRIPTION
## Overview

Element Template bundles now opt into Lynx's unified fixed-position behavior by default during ReactLynx template encoding. The React webpack plugin already owns ET-specific encode-time metadata, so this change adds the page config in the existing ET-only `beforeEncode` hook instead of requiring app or example configs to set it manually.

## Generated Page Config Contract

`@lynx-js/react-webpack-plugin` is the producer for this ET default. When `experimental_useElementTemplate` is enabled, its `beforeEncode` hook now writes:

```js
sourceContent.config.enableUnifyFixedBehavior = true
```

`@lynx-js/template-webpack-plugin` remains the generic encode data producer, and the web encoder continues to build final `pageConfig` from `compilerOptions + sourceContent.config`. This keeps the new default scoped to standard ReactLynx ET bundles while preserving the existing `elementTemplate` asset merge contract.

## Reviewer Notes

- Start with `packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts` to review the ET-only hook and ordering.
- Then read `packages/webpack/react-webpack-plugin/test/cases/element-template/basic/rspack.config.js`, which now asserts the config is present while keeping the existing ET template asset assertions active.
- `.changeset/et-unify-fixed-page-config-no-release.md` is an empty changeset because ET support has not been published yet.

## Boundaries

- Non-ET / Snapshot bundles are not changed.
- The generic template webpack plugin defaults are not changed.
- REPL raw template output is intentionally not covered by this PR.
- No public option or opt-out is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated element template configuration handling to enforce unified fixed page behavior during encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
