### PR TITLE
chore: clean up genui 0.0.3 changesets

### DIFF
--- a/.changeset/a2ui-full-catalog-json.md
+++ b/.changeset/a2ui-full-catalog-json.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Publish a full A2UI catalog JSON artifact at `a2ui/dist/catalog/catalog.json`.

--- a/.changeset/dirty-nails-rhyme.md
+++ b/.changeset/dirty-nails-rhyme.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Add `genui a2ui create --project-name` command to create an a2ui project based on default template

--- a/.changeset/eager-days-try.md
+++ b/.changeset/eager-days-try.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-fix: resolve import error

--- a/.changeset/fruity-months-add.md
+++ b/.changeset/fruity-months-add.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Refactor genui cli to use typescript.

--- a/.changeset/openui-playground-styles.md
+++ b/.changeset/openui-playground-styles.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Restore OpenUI renderer styling in the A2UI playground by preserving ReactLynx JSX through the OpenUI build and bundling the renderer stylesheet with the OpenUI preview entry.

--- a/.changeset/openui-v05-lang-core.md
+++ b/.changeset/openui-v05-lang-core.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Introduce OpenUI v0.5 rendering support and update the OpenUI language runtime dependency.

--- a/.github/manual-release-cleanup.instructions.md
+++ b/.github/manual-release-cleanup.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "{packages/**/package.json,.changeset/**}"
+---
+
+When a package has already been published manually outside the Changesets GitHub Action, keep the package version aligned with the published npm version and delete the changeset files that were consumed by that manual release. Do not leave those changesets in the tree, because the next automated release will treat them as new changes and bump the package again. A GitHub Release entry also requires a corresponding tag/release to be created separately; deleting changesets in a follow-up PR will not backfill a GitHub Release.

--- a/packages/genui/package.json
+++ b/packages/genui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/genui",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Generative UI for Lynx.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Keep `@lynx-js/genui` aligned with the manually published npm version `0.0.3`.
- Remove the six consumed `@lynx-js/genui` patch changesets so the next automated release does not bump them again.
- Add a short repo instruction for future manual-release cleanup.

## Release follow-up

`npm view @lynx-js/genui version time --json` confirms `0.0.3` was published on `2026-06-11T08:13:32Z`. GitHub currently has no `@lynx-js/genui@0.0.3` release, and the corresponding tag is also missing (`gh release view` returned `release not found`; the GitHub refs API returned 404 for `refs/tags/@lynx-js/genui@0.0.3`).

That means this PR can clean up the repository state, but it will not backfill GitHub Releases automatically. If we want the release page to show this package version, create a GitHub tag/release separately for `@lynx-js/genui@0.0.3` with notes from the removed changesets.

## Validation

- `pnpm dprint fmt`
- `CI=1 pnpm changeset status --since=origin/main --output .changeset-status.json` -> `releases: []`, `changesets: []` (with existing qrcode/rspeedy dependency warning)
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenUI v0.5 rendering support.

* **Refactor**
  * genui CLI refactored to use TypeScript.

* **Chores**
  * Added release cleanup documentation for manual releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->