### PR TITLE
ci: maximum ulimit

### DIFF
--- a/.github/lynx-stack.instructions.md
+++ b/.github/lynx-stack.instructions.md
@@ -18,7 +18,7 @@ Prefer a shared-plus-split initial chunk fixture when validating CSS merge order
 applyTo: ".github/workflows/**/*"
 ---
 
-For Playwright-related CI jobs, add ulimit -Sn 655350 directly in each job's run block before invoking Playwright commands.
+For Playwright-related CI jobs, echo the current open-file soft and hard limits, set the soft limit to the hard limit with `ulimit -Sn "$(ulimit -Hn)"`, then echo the resulting limits before invoking Playwright commands.
 
 ---
 applyTo: "packages/web-platform/web-core-e2e/**/*"

--- a/.github/ui-judge-ci.instructions.md
+++ b/.github/ui-judge-ci.instructions.md
@@ -12,7 +12,7 @@ Use the upstream build job's restored turbo cache in UI Judge CI. Do not call pa
 
 Do not add changed-file gating, GitHub API calls, or extra reusable workflow inputs for UI Judge CI. If Midscene secrets are unavailable, the UI Judge test command should write a clear skipped result and exit successfully; fork pull requests should skip the comment steps rather than requiring write permissions.
 
-Raise the soft open-file limit before running UI Judge Playwright tests in the Playwright container. The A2UI playground dev server uses rsbuild/chokidar watchers, so mirror the web-elements Playwright pattern with `ulimit -Sn 655350` before invoking `pnpm --filter @lynx-js/ui-judge test`.
+Raise the soft open-file limit before running UI Judge Playwright tests in the Playwright container. The A2UI playground dev server uses rsbuild/chokidar watchers, so mirror the web-elements Playwright pattern by echoing the current soft and hard open-file limits, running `ulimit -Sn "$(ulimit -Hn)"`, and echoing the resulting limits before invoking `pnpm --filter @lynx-js/ui-judge test`.
 
 Inject the full Midscene/OpenAI model environment into the UI Judge execution step, including `MIDSCENE_MODEL_API_KEY`, `MIDSCENE_MODEL_BASE_URL`, `MIDSCENE_MODEL_FAMILY`, `MIDSCENE_MODEL_NAME`, and `MIDSCENE_OPENAI_INIT_CONFIG_JSON`.
 

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -103,7 +103,9 @@ jobs:
       runs-on: lynx-custom-container
       is-web: true
       run: |
-        ulimit -Sn 655350
+        echo "open files limit before: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
+        ulimit -Sn "$(ulimit -Hn)"
+        echo "open files limit after: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-elements run test --reporter='github,dot,junit,html'
@@ -118,7 +120,9 @@ jobs:
       runs-on: lynx-custom-container
       is-web: true
       run: |
-        ulimit -Sn 655350
+        echo "open files limit before: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
+        ulimit -Sn "$(ulimit -Hn)"
+        echo "open files limit after: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-core-e2e run test --reporter='github,dot,junit,html'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,9 @@ jobs:
           echo "Midscene secrets are unavailable; skipping UI Judge."
           exit 0
         fi
-        ulimit -Sn 655350
+        echo "open files limit before: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
+        ulimit -Sn "$(ulimit -Hn)"
+        echo "open files limit after: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
         pnpm --filter @lynx-js/ui-judge run test:playwright
 
   ui-judge-comment:
@@ -137,7 +139,9 @@ jobs:
       runs-on: lynx-custom-container
       is-web: true
       run: |
-        ulimit -Sn 655350
+        echo "open files limit before: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
+        ulimit -Sn "$(ulimit -Hn)"
+        echo "open files limit after: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
         export NODE_OPTIONS="--max-old-space-size=32768"
         pnpm --filter @lynx-js/web-core-e2e run lh || echo "Lighthouse failed"
   playwright-web-elements:
@@ -156,7 +160,9 @@ jobs:
       codecov-flags: "e2e"
       web-report-path: "packages/web-platform/web-elements/playwright-report"
       run: |
-        ulimit -Sn 655350
+        echo "open files limit before: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
+        ulimit -Sn "$(ulimit -Hn)"
+        echo "open files limit after: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-elements run test --reporter='github,dot,junit,html' --shard=${{ matrix.shard }}/2
@@ -182,7 +188,9 @@ jobs:
         if [ "${{ matrix.render }}" = "SSR" ]; then
           export ENABLE_SSR=true
         fi
-        ulimit -Sn 655350
+        echo "open files limit before: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
+        ulimit -Sn "$(ulimit -Hn)"
+        echo "open files limit after: soft=$(ulimit -Sn), hard=$(ulimit -Hn)"
         export NODE_OPTIONS="--max-old-space-size=32768"
         export PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-report.junit.xml
         pnpm --filter @lynx-js/web-core-e2e run test --reporter='github,dot,junit,html' --shard=${{ matrix.shard }}/2


### PR DESCRIPTION
## Summary

- Echo the open-file soft and hard limits before Playwright-related CI commands.
- Raise the soft open-file limit to the current hard limit instead of using the fixed `655350` value.
- Update GitHub instructions so future CI changes follow the same pattern.

## Validation

- `rg -n "655350" .github . --glob '!node_modules'` returned no matches.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.

Full CI was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to dynamically configure system resource limits for improved test stability and reliability.

* **Documentation**
  * Enhanced CI instructions with improved resource limit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->