### PR TITLE
ci(benchx): enable CodSpeed walltime mode

### DIFF
--- a/packages/lynx/benchx_cli/scripts/build_unix.sh
+++ b/packages/lynx/benchx_cli/scripts/build_unix.sh
@@ -13,7 +13,7 @@ if [ ! -f "package.json" ] || ! grep -q '"name": "benchx_cli"' package.json; the
   exit 1
 fi
 
-LOCKED_VERSION="benchx_cli-202603021542"
+LOCKED_VERSION="benchx_cli-202606120920"
 
 # Check if binary is up to date
 if [ -f "./dist/bin/benchx_cli" ] && [ -f "./dist/bin/benchx_cli.version" ]; then


### PR DESCRIPTION
## Summary

Enables CodSpeed **walltime** benchmarking next to the existing simulation run:

1. Bumps `LOCKED_VERSION` (`packages/lynx/benchx_cli/scripts/build_unix.sh`) to **`benchx_cli-202606120920`**, which adds a walltime instrument ([lynx-community/benchx_cli#2](https://github.com/lynx-community/benchx_cli/pull/2)). The previous binary only had valgrind/callgrind paths, so `--mode walltime` produced no native data.
2. Adds a `Run benchmark (walltime)` step to `workflow-bench.yml` so CodSpeed reports real-world timings alongside the deterministic instruction counts. Job timeout bumped 30→45m for the second pass.

## Behaviour

- **Simulation / perfetto unchanged** — the binary's non-walltime path is the same run loop; verified the released artifact builds on Linux x86_64 + Darwin arm64 and reproduces existing behaviour.
- Under `--mode walltime` the binary writes `results/<pid>.json` in CodSpeed's walltime format (matching `@codspeed/core`'s schema + quantile/IQR/3σ math), with a mode-aware loop: ~100 rounds/uri, one warmup sample dropped, sample cap + early-stop so internally-looping harnesses (tinybench) don't record millions of rounds.
- **No bench-script changes** — the shared `bench:*` scripts work for both modes via the binary's mode-aware default.

## Validation

Reproduced the `pnpm bench` chain with the released binary under `CODSPEED_RUNNER_MODE=walltime`: 71 benchmarks, all schema-valid; heavy end-to-end ops ~9.4% CV. Note: this runs on the shared `lynx-ubuntu-24.04-xlarge` runner, so walltime numbers will be noisier than on a dedicated host — #2793 explores moving the bench job to a `physical-exclusive` runner to tighten that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build tooling to pull a newer benchmarking CLI artifact so builds use the latest release.
  * Updated CI benchmark workflow: increased job timeout and split benchmark execution into separate simulation and walltime runs; the walltime run now uses a sampler profiler for more reliable measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->