### PR TITLE
feat(plugin-qrcode): add shortcut to switch dev server host in QR code

### DIFF
--- a/.changeset/qrcode-switch-host.md
+++ b/.changeset/qrcode-switch-host.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/qrcode-rsbuild-plugin": minor
+---
+
+Add a `Switch host` shortcut (press `i` in the terminal) to switch the dev server host shown in the QR code between the available network interfaces (e.g. Wi-Fi or VPN addresses), useful when the default IP picked by Rspeedy is not reachable from your device.

--- a/packages/rspeedy/plugin-qrcode/README.md
+++ b/packages/rspeedy/plugin-qrcode/README.md
@@ -80,6 +80,14 @@ export default defineConfig({
 })
 ```
 
+## Shortcuts
+
+While the dev server is running, the following keys are available in the terminal:
+
+- `r`: Switch between entries.
+- `a`: Switch between schemas.
+- `i`: Switch the dev server host shown in the QR code between the available network interfaces (useful when the default IP is not reachable from your device).
+
 ## Documentation
 
 Visit [Lynx Website](https://lynxjs.org/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcode.html) to view the full documentation.

--- a/packages/rspeedy/plugin-qrcode/src/generateDevUrls.ts
+++ b/packages/rspeedy/plugin-qrcode/src/generateDevUrls.ts
@@ -12,6 +12,7 @@ export default function generateDevUrls(
   entry: string,
   schemaFn: CustomizedSchemaFn,
   port: number,
+  host?: string,
 ): Record<string, string> {
   const { dev: { assetPrefix } } = api.getNormalizedConfig()
   const { config } = api.useExposed<ExposedAPI>(
@@ -34,11 +35,18 @@ export default function generateDevUrls(
     ? bundle({ lazyBundle: false, entryName: entry, platform: 'lynx' })
     : bundle) ?? defaultFilename
 
+  // <port> is supported in `dev.assetPrefix`, we should replace it with the real port
+  let base = assetPrefix.replaceAll('<port>', String(port))
+  if (host !== undefined) {
+    const baseURL = new URL(base)
+    baseURL.hostname = host
+    base = baseURL.toString()
+  }
+
   const customSchema = schemaFn(
     new URL(
       name.replace('[name]', entry).replace('[platform]', 'lynx'),
-      // <port> is supported in `dev.assetPrefix`, we should replace it with the real port
-      assetPrefix.replaceAll('<port>', String(port)),
+      base,
     ).toString(),
   )
 

--- a/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
+++ b/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
@@ -104,6 +104,7 @@ async function loop(
 
   let currentEntry = options.entries[0]!
   let currentSchema = Object.keys(devUrls)[0]!
+  let currentHost: string | undefined
 
   while (!isCancel(value)) {
     const name = await selectKey({
@@ -111,6 +112,7 @@ async function loop(
       options: [
         { value: 'r', label: 'Switch entries' },
         { value: 'a', label: 'Switch schema' },
+        { value: 'i', label: 'Switch host' },
         { value: 'h', label: 'Help' },
         ...Object.values(options.customShortcuts ?? {}),
         { value: 'q', label: 'Quit' },
@@ -137,6 +139,7 @@ async function loop(
             entry,
             options.schema,
             options.port,
+            currentHost,
           )[currentSchema]!,
         })),
         initialValue: currentEntry,
@@ -152,6 +155,7 @@ async function loop(
         currentEntry,
         options.schema,
         options.port,
+        currentHost,
       )
       const selection = await selectFn(Object.keys(devUrls).length)({
         message: 'Select schema',
@@ -166,6 +170,28 @@ async function loop(
         break
       }
       currentSchema = selection
+      value = getCurrentUrl()
+    } else if (name === 'i') {
+      const hosts = await getAvailableHosts()
+      const selection = await selectFn(hosts.length)({
+        message: 'Select host',
+        options: hosts.map(({ address, interfaceName }) => ({
+          value: address,
+          label: address,
+          hint: `${interfaceName} — ${generateDevUrls(
+            options.api,
+            currentEntry,
+            options.schema,
+            options.port,
+            address,
+          )[currentSchema]!}`,
+        })),
+        initialValue: currentHost ?? hosts[0]?.address,
+      })
+      if (isCancel(selection)) {
+        break
+      }
+      currentHost = selection
       value = getCurrentUrl()
     } else if (options.customShortcuts?.[name]) {
       await options.customShortcuts[name].action?.()
@@ -189,7 +215,27 @@ async function loop(
       currentEntry,
       options.schema,
       options.port,
+      currentHost,
     )[currentSchema]!
+  }
+
+  async function getAvailableHosts(): Promise<
+    { address: string, interfaceName: string }[]
+  > {
+    const { networkInterfaces } = await import('node:os')
+    const hosts: { address: string, interfaceName: string }[] = []
+    for (
+      const [interfaceName, networks] of Object.entries(networkInterfaces())
+    ) {
+      for (const network of networks ?? []) {
+        // Skip loopback addresses: the QR code is scanned by another device,
+        // which cannot reach the loopback interface of this machine.
+        if (network.family === 'IPv4' && !network.internal) {
+          hosts.push({ address: network.address, interfaceName })
+        }
+      }
+    }
+    return hosts
   }
 
   function exit(code?: number) {

--- a/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
+++ b/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
@@ -93,7 +93,7 @@ async function loop(
   devUrls: Record<string, string>,
 ) {
   const [
-    { autocomplete, select, selectKey, isCancel, cancel },
+    { autocomplete, select, selectKey, isCancel, cancel, log },
     { default: showQRCode },
   ] = await Promise.all([
     import('@clack/prompts'),
@@ -172,7 +172,23 @@ async function loop(
       currentSchema = selection
       value = getCurrentUrl()
     } else if (name === 'i') {
+      // When the dev server is bound to a specific address, other
+      // addresses are not reachable, so there is nothing to switch to.
+      const boundHost = options.api.getNormalizedConfig().server?.host
+      if (
+        boundHost !== undefined && boundHost !== '0.0.0.0'
+        && boundHost !== '::'
+      ) {
+        log.warn(
+          `The dev server is bound to ${boundHost} (server.host), other addresses are not reachable.`,
+        )
+        continue
+      }
       const hosts = await getAvailableHosts()
+      if (hosts.length === 0) {
+        log.warn('No non-internal IPv4 addresses found.')
+        continue
+      }
       const selection = await selectFn(hosts.length)({
         message: 'Select host',
         options: hosts.map(({ address, interfaceName }) => ({

--- a/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
@@ -8,6 +8,22 @@ import { registerConsoleShortcuts } from '../src/shortcuts.js'
 
 vi.mock('@clack/prompts')
 
+vi.mock('node:os', async (importOriginal) => ({
+  ...await importOriginal<typeof import('node:os')>(),
+  networkInterfaces: () => ({
+    lo0: [
+      { address: '127.0.0.1', family: 'IPv4', internal: true },
+    ],
+    en0: [
+      { address: '10.0.0.1', family: 'IPv4', internal: false },
+      { address: 'fe80::1', family: 'IPv6', internal: false },
+    ],
+    en1: [
+      { address: '192.168.1.2', family: 'IPv4', internal: false },
+    ],
+  }),
+}))
+
 describe('PluginQRCode - CLI Shortcuts', () => {
   const mockedRsbuildAPI = {
     getNormalizedConfig: vi.fn().mockReturnValue({
@@ -164,6 +180,50 @@ describe('PluginQRCode - CLI Shortcuts', () => {
     expect(onPrint).toBeCalledTimes(2)
 
     expect(onOpen).toBeCalledTimes(1)
+    unregister()
+  })
+
+  test('switch host', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.clearAllMocks()
+    const onPrint = vi.fn()
+
+    const { selectKey, select, isCancel } = await import('@clack/prompts')
+    let i = 0
+    vi.mocked(selectKey).mockImplementation(() => {
+      i++
+      if (i === 1) {
+        return Promise.resolve('i')
+      } else if (i === 2) {
+        return new Promise(vi.fn())
+      }
+      expect.fail('should not call selectKey 3 times')
+    })
+    vi.mocked(select).mockResolvedValue('10.0.0.1')
+    vi.mocked(isCancel).mockReturnValue(false)
+
+    const unregister = await registerConsoleShortcuts({
+      api: mockedRsbuildAPI,
+      entries: ['foo'],
+      schema: i => i,
+      port: 3000,
+      onPrint,
+    })
+
+    expect(onPrint).toBeCalledWith('https://example.com/foo.lynx.bundle')
+    await expect.poll(() => selectKey).toBeCalledTimes(2)
+
+    expect(select).toBeCalledWith(expect.objectContaining({
+      message: 'Select host',
+      options: [
+        expect.objectContaining({ value: '10.0.0.1' }),
+        expect.objectContaining({ value: '192.168.1.2' }),
+      ],
+    }))
+    expect(onPrint).toBeCalledTimes(2)
+    expect(onPrint).toHaveBeenLastCalledWith(
+      'https://10.0.0.1/foo.lynx.bundle',
+    )
     unregister()
   })
 })

--- a/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
@@ -8,20 +8,11 @@ import { registerConsoleShortcuts } from '../src/shortcuts.js'
 
 vi.mock('@clack/prompts')
 
+const networkInterfacesMock = vi.hoisted(() => vi.fn())
+
 vi.mock('node:os', async (importOriginal) => ({
   ...await importOriginal<typeof import('node:os')>(),
-  networkInterfaces: () => ({
-    lo0: [
-      { address: '127.0.0.1', family: 'IPv4', internal: true },
-    ],
-    en0: [
-      { address: '10.0.0.1', family: 'IPv4', internal: false },
-      { address: 'fe80::1', family: 'IPv6', internal: false },
-    ],
-    en1: [
-      { address: '192.168.1.2', family: 'IPv4', internal: false },
-    ],
-  }),
+  networkInterfaces: networkInterfacesMock,
 }))
 
 describe('PluginQRCode - CLI Shortcuts', () => {
@@ -35,6 +26,19 @@ describe('PluginQRCode - CLI Shortcuts', () => {
   } as unknown as RsbuildPluginAPI
 
   beforeEach(() => {
+    networkInterfacesMock.mockReturnValue({
+      lo0: [
+        { address: '127.0.0.1', family: 'IPv4', internal: true },
+      ],
+      en0: [
+        { address: '10.0.0.1', family: 'IPv4', internal: false },
+        { address: 'fe80::1', family: 'IPv6', internal: false },
+      ],
+      en1: [
+        { address: '192.168.1.2', family: 'IPv4', internal: false },
+      ],
+    })
+
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       configurable: true,
@@ -224,6 +228,92 @@ describe('PluginQRCode - CLI Shortcuts', () => {
     expect(onPrint).toHaveBeenLastCalledWith(
       'https://10.0.0.1/foo.lynx.bundle',
     )
+    unregister()
+  })
+
+  test('switch host with no available hosts', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.clearAllMocks()
+    networkInterfacesMock.mockReturnValue({
+      lo0: [
+        { address: '127.0.0.1', family: 'IPv4', internal: true },
+      ],
+    })
+    const onPrint = vi.fn()
+
+    const { selectKey, select, isCancel, log } = await import('@clack/prompts')
+    let i = 0
+    vi.mocked(selectKey).mockImplementation(() => {
+      i++
+      if (i === 1) {
+        return Promise.resolve('i')
+      } else if (i === 2) {
+        return new Promise(vi.fn())
+      }
+      expect.fail('should not call selectKey 3 times')
+    })
+    vi.mocked(isCancel).mockReturnValue(false)
+
+    const unregister = await registerConsoleShortcuts({
+      api: mockedRsbuildAPI,
+      entries: ['foo'],
+      schema: i => i,
+      port: 3000,
+      onPrint,
+    })
+
+    await expect.poll(() => selectKey).toBeCalledTimes(2)
+
+    expect(select).not.toBeCalled()
+    expect(log.warn).toBeCalledWith('No non-internal IPv4 addresses found.')
+    // Only the initial print, no re-print after the aborted switch
+    expect(onPrint).toBeCalledTimes(1)
+    unregister()
+  })
+
+  test('switch host is unavailable when server.host is bound', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.clearAllMocks()
+    const onPrint = vi.fn()
+
+    const boundRsbuildAPI = {
+      getNormalizedConfig: vi.fn().mockReturnValue({
+        dev: { assetPrefix: 'https://example.com/' },
+        server: { host: '127.0.0.1' },
+      }),
+      useExposed: vi.fn().mockReturnValue({
+        config: { filename: '[name].[platform].bundle' },
+      }),
+    } as unknown as RsbuildPluginAPI
+
+    const { selectKey, select, isCancel, log } = await import('@clack/prompts')
+    let i = 0
+    vi.mocked(selectKey).mockImplementation(() => {
+      i++
+      if (i === 1) {
+        return Promise.resolve('i')
+      } else if (i === 2) {
+        return new Promise(vi.fn())
+      }
+      expect.fail('should not call selectKey 3 times')
+    })
+    vi.mocked(isCancel).mockReturnValue(false)
+
+    const unregister = await registerConsoleShortcuts({
+      api: boundRsbuildAPI,
+      entries: ['foo'],
+      schema: i => i,
+      port: 3000,
+      onPrint,
+    })
+
+    await expect.poll(() => selectKey).toBeCalledTimes(2)
+
+    expect(select).not.toBeCalled()
+    expect(log.warn).toBeCalledWith(
+      'The dev server is bound to 127.0.0.1 (server.host), other addresses are not reachable.',
+    )
+    expect(onPrint).toBeCalledTimes(1)
     unregister()
   })
 })


### PR DESCRIPTION
Rspeedy picks a single network interface IP when normalizing `dev.assetPrefix` (via `findIp('v4')`), so the QR code always shows that one address — even when the machine has multiple network interfaces (e.g. Wi-Fi + VPN) and the chosen one happens to be unreachable from the scanning device. Tools like `http-server` and `rsbuild dev` print all network addresses; this PR brings an equivalent escape hatch to the QR code plugin.

## What's changed

- Add a new console shortcut: press `i` (**Switch host**) to pick one of the machine's non-internal IPv4 addresses. The QR code URL is regenerated with the selected host, and each option's hint shows the interface name along with the resulting URL for easy comparison.
- The selected host persists across subsequent entry (`r`) and schema (`a`) switches.
- Loopback addresses are excluded from the list: the QR code is scanned by another device, which cannot reach the loopback interface of this machine.
- Default behavior is unchanged — the initial QR code still uses the host from `dev.assetPrefix` until you explicitly switch.

## Known limitation (intentionally out of scope)

URLs baked into the compiled bundles at build time (e.g. the `//# sourceMappingURL=...` trailer rewritten by `plugin-debug-metadata`, and the HMR websocket host) still point at the original `dev.assetPrefix` host after switching. Making those follow the selected host would require serve-time rewriting in rspeedy core, which we decided not to pursue for now.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Switch host" keyboard shortcut (i) to cycle dev-server hosts shown in the QR code; preserves selected host when switching entries or schema variants.
  * Documented keyboard shortcuts to switch entries (r) and schema variants (a).

* **Documentation**
  * Updated README Shortcuts section with the new host-switching and existing shortcuts.

* **Tests**
  * Added tests covering host-selection flows, warnings, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->