### PR TITLE
fix: web css var fallback encoding

### DIFF
--- a/.changeset/web-core-css-var-fallback.md
+++ b/.changeset/web-core-css-var-fallback.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Restore CSS var fallback values when encoding web binary templates.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx-css-var-fallback.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx-css-var-fallback.spec.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { test, expect } from '@lynx-js/playwright-fixtures';
+import type { Page } from '@playwright/test';
+
+const isSSR = !!process.env['ENABLE_SSR'];
+
+const wait = async (ms: number) => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+const goto = async (page: Page, testname: string) => {
+  const url = isSSR ? `/ssr?casename=${testname}` : `/?casename=${testname}`;
+  await page.goto(url, {
+    waitUntil: 'load',
+  });
+  await page.evaluate(() => document.fonts.ready);
+  if (isSSR) await wait(300);
+};
+
+test.describe('reactlynx3 tests', () => {
+  test.describe('basic-css', () => {
+    test(
+      'basic-css-var-fallback-background-color',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        await expect(page.locator('#target')).toHaveCSS(
+          'background-color',
+          'rgb(0, 128, 0)',
+        );
+      },
+    );
+
+    test(
+      'basic-css-var-nested-fallback-background-color',
+      async ({ page }, { title }) => {
+        await goto(page, title);
+        await wait(100);
+        await expect(page.locator('#target')).toHaveCSS(
+          'background-color',
+          'rgb(0, 128, 0)',
+        );
+      },
+    );
+  });
+});

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-fallback-background-color/index.css
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-fallback-background-color/index.css
@@ -1,0 +1,5 @@
+#target {
+  width: 100px;
+  height: 100px;
+  background-color: var(--missing-bg-color, green);
+}

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-fallback-background-color/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-fallback-background-color/index.jsx
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+import './index.css';
+
+function App() {
+  return <view id='target' />;
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-nested-fallback-background-color/index.css
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-nested-fallback-background-color/index.css
@@ -1,0 +1,5 @@
+#target {
+  width: 100px;
+  height: 100px;
+  background-color: var(--missing-bg-color, var(--missing-bg-color-2, green));
+}

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-nested-fallback-background-color/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-nested-fallback-background-color/index.jsx
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+import './index.css';
+
+function App() {
+  return <view id='target' />;
+}
+
+root.render(<App></App>);

--- a/packages/web-platform/web-core/tests/encode.spec.ts
+++ b/packages/web-platform/web-core/tests/encode.spec.ts
@@ -217,6 +217,42 @@ describe('encodeCSS', () => {
     );
   });
 
+  test('should preserve fallback values in css var for background-color', () => {
+    const css = `
+      .foo {
+        background-color: var(--missing-bg-color, green);
+      }
+    `;
+    const cssMap = {
+      '1': CSS.parse(css).root,
+    };
+    const buffer = encodeCSS(cssMap);
+    const decodedString = get_style_content(
+      decode_style_info(buffer, undefined, true),
+    );
+    expect(decodedString).toContain(
+      'background-color:var(--missing-bg-color, green);',
+    );
+  });
+
+  test('should preserve nested fallback values in css var for background-color', () => {
+    const css = `
+      .foo {
+        background-color: var(--missing-bg-color, var(--missing-bg-color-2, green));
+      }
+    `;
+    const cssMap = {
+      '1': CSS.parse(css).root,
+    };
+    const buffer = encodeCSS(cssMap);
+    const decodedString = get_style_content(
+      decode_style_info(buffer, undefined, true),
+    );
+    expect(decodedString).toContain(
+      'background-color:var(--missing-bg-color, var(--missing-bg-color-2,green));',
+    );
+  });
+
   test('should handle ::placeholder selector', () => {
     const css = `
       input::placeholder {

--- a/packages/web-platform/web-core/ts/encode/encodeCSS.ts
+++ b/packages/web-platform/web-core/ts/encode/encodeCSS.ts
@@ -9,17 +9,27 @@ import {
 // @ts-ignore
 export * from '../../binary/encode/encode.js';
 
-function restoreCSSVarValue(decl: CSS.Declaration): string {
-  return decl.value.replaceAll(/\{\{(--[^}]+)\}\}/g, (_, varName: string) => {
-    const isCSSVarDecl = 'type' in decl && decl.type === 'css_var';
-
-    if (!isCSSVarDecl) {
-      return `var(${varName})`;
-    }
-
-    const fallback = decl.defaultValueMap?.[varName];
-    return fallback ? `var(${varName}, ${fallback})` : `var(${varName})`;
+function restoreCSSVarPlaceholders(
+  value: string,
+  defaultValueMap?: Record<string, string>,
+): string {
+  return value.replaceAll(/\{\{(--[^}]+)\}\}/g, (_, varName: string) => {
+    const fallback = defaultValueMap?.[varName];
+    return fallback
+      ? `var(${varName}, ${
+        restoreCSSVarPlaceholders(fallback, defaultValueMap)
+      })`
+      : `var(${varName})`;
   });
+}
+
+function restoreCSSVarValue(decl: CSS.Declaration): string {
+  const isCSSVarDecl = 'type' in decl && decl.type === 'css_var';
+
+  return restoreCSSVarPlaceholders(
+    decl.value,
+    isCSSVarDecl ? decl.defaultValueMap : undefined,
+  );
 }
 
 export function encodeCSS(


### PR DESCRIPTION
## Summary
- Restore CSS custom property fallback text before binary CSS `RawStyleInfo` encoding.
- Preserve nested fallback expressions such as `var(--a, var(--b, green))` in the new web binary template path.
- Add focused encoder coverage, e2e fixtures, and a patch changeset for `@lynx-js/web-core`.

## Root Cause
The binary template path receives CSS serializer output where `var(--token, fallback)` is represented as a `{{--token}}` placeholder plus `defaultValueMap` metadata. Encoding `decl.value` directly dropped the fallback text, so properties like `background-color` could not resolve when the custom property was missing.

## Validation
- `pnpm dprint check .changeset/web-core-css-var-fallback.md packages/web-platform/web-core/ts/encode/encodeCSS.ts packages/web-platform/web-core/tests/encode.spec.ts packages/web-platform/web-core-e2e/tests/reactlynx-css-var-fallback.spec.ts packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-fallback-background-color/index.jsx packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-fallback-background-color/index.css packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-nested-fallback-background-color/index.jsx packages/web-platform/web-core-e2e/tests/reactlynx/basic-css-var-nested-fallback-background-color/index.css`
- `pnpm turbo build`
- `pnpm --filter @lynx-js/web-core test -- tests/encode.spec.ts -t fallback`
- `pnpm turbo build --filter @lynx-js/web-core-e2e`
- `pnpm --filter @lynx-js/web-core-e2e test --grep "basic-css-var.*fallback.*background-color"` passed on Chromium/WebKit; Firefox did not launch locally because `/home/haoyang/.cache/ms-playwright/firefox-1509/firefox/lock` is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* CSS variable fallback values are now properly restored when encoding web binary templates, supporting both direct and nested fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->