### PR TITLE
fix: add kitten lynx turbo config

### DIFF
--- a/.changeset/kitten-lynx-turbo-config.md
+++ b/.changeset/kitten-lynx-turbo-config.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/kitten-lynx-test-infra": patch
+---
+
+Add a package-level Turbo build configuration and include `CHANGELOG.md` in the published files.

--- a/packages/testing-library/kitten-lynx/package.json
+++ b/packages/testing-library/kitten-lynx/package.json
@@ -28,7 +28,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "rslib build",

--- a/packages/testing-library/kitten-lynx/turbo.json
+++ b/packages/testing-library/kitten-lynx/turbo.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "src/**",
+        "package.json",
+        "rslib.config.ts",
+        "tsconfig.json"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a package-level Turbo configuration for `@lynx-js/kitten-lynx-test-infra`.
- Include `CHANGELOG.md` in the package `files` list, matching nearby publishable packages.

## Impact

This makes the package build cacheable through Turbo with explicit build inputs and `dist/**` outputs, and ensures the package changelog is included when published.

## Validation

- `pnpm dprint check packages/testing-library/kitten-lynx/package.json packages/testing-library/kitten-lynx/turbo.json --incremental=false`
- `pnpm turbo build --filter @lynx-js/kitten-lynx-test-infra --dry`

Note: Turbo dry run still reports the existing `pnpm-lock.yaml` patchedDependencies parsing warning for `@napi-rs/cli@2.18.4`; the command exits successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated package distribution configuration to include changelog documentation in published releases
* Implemented build pipeline enhancements to optimize consistency and reliability during package builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->