### PR TITLE
fix(react): allow nullable ET element slots

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -14,6 +14,7 @@ import {
 import { ElementTemplateLifecycleConstant } from '../../../../src/element-template/protocol/lifecycle-constant.js';
 import { ElementTemplateUpdateOps } from '../../../../src/element-template/protocol/opcodes.js';
 import type {
+  ElementTemplateHandleSlotsCommand,
   ElementTemplateUpdateCommandStream,
   SerializedElementTemplate,
 } from '../../../../src/element-template/protocol/types.js';
@@ -344,6 +345,56 @@ describe('ElementTemplate patch stream (apply)', () => {
     resetReportedErrors();
   });
 
+  it('creates templates with nullable and sparse element slots', () => {
+    envManager.switchToMainThread();
+    elementTemplateRegistry.clear();
+    registerTemplates([
+      {
+        templateId: '_et_sparse_slot_parent',
+        compiledTemplate: {
+          kind: 'element',
+          type: 'view',
+          attributesArray: [],
+          children: [
+            { kind: 'elementSlot', type: 'slot', elementSlotIndex: 0 },
+            { kind: 'elementSlot', type: 'slot', elementSlotIndex: 1 },
+            { kind: 'elementSlot', type: 'slot', elementSlotIndex: 2 },
+          ],
+        },
+      },
+    ]);
+
+    const elementSlots: ElementTemplateHandleSlotsCommand = [];
+    elementSlots[1] = [31];
+    elementSlots[2] = null;
+
+    const createTemplateMock = globalThis.__CreateElementTemplate as unknown as {
+      mockClear: () => void;
+      mock: { calls: unknown[][] };
+    };
+    createTemplateMock.mockClear();
+
+    applyElementTemplateUpdateCommands([
+      ...createRawTextOps(31, 'child'),
+      ElementTemplateUpdateOps.createTemplate,
+      32,
+      '_et_sparse_slot_parent',
+      null,
+      [],
+      elementSlots,
+    ]);
+
+    const parentCall = createTemplateMock.mock.calls.find((call) => call[0] === '_et_sparse_slot_parent');
+    expect(parentCall).toBeDefined();
+    const childRef = elementTemplateRegistry.get(31);
+    const resolvedSlots = parentCall![3] as Array<ElementRef[] | null | undefined>;
+    expect(0 in resolvedSlots).toBe(false);
+    expect(resolvedSlots[1]).toEqual([childRef]);
+    expect(2 in resolvedSlots).toBe(false);
+    expect(elementTemplateRegistry.has(32)).toBe(true);
+    expect((globalThis.lynx as unknown as LynxWithReportErrorMock).reportError.mock.calls).toHaveLength(0);
+  });
+
   it('reports missing patch target', () => {
     const jsx = <view />;
     root.render(jsx);
@@ -373,7 +424,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       21,
       'list',
       { id: 'typed-list' },
-      [[11]],
+      [[11], null],
       {
         listChildren: [{ __etHandleRef: 12 }],
         estimatedHeight: 80,
@@ -383,7 +434,9 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(1);
     expect(mockCreateTypedElementTemplate.mock.calls[0]?.[0]).toBe('list');
     expect(mockCreateTypedElementTemplate.mock.calls[0]?.[1]).toEqual({ id: 'typed-list' });
-    expect(mockCreateTypedElementTemplate.mock.calls[0]?.[2]).toEqual([[slotChildRef]]);
+    const elementSlots = mockCreateTypedElementTemplate.mock.calls[0]?.[2] as Array<ElementRef[] | null | undefined>;
+    expect(elementSlots[0]).toEqual([slotChildRef]);
+    expect(1 in elementSlots).toBe(false);
     expect(mockCreateTypedElementTemplate.mock.calls[0]?.[3]).toBe(21);
     expect(mockCreateTypedElementTemplate.mock.calls[0]?.[4]).toEqual({
       listChildren: [optionChildRef],
@@ -450,6 +503,29 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(0);
     const reportError = (globalThis.lynx as unknown as LynxWithReportErrorMock).reportError;
     expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain('invalid handleId 0');
+    resetReportedErrors();
+  });
+
+  it('reports invalid typed create elementSlots', () => {
+    envManager.switchToMainThread();
+    elementTemplateRegistry.clear();
+    mockCreateTypedElementTemplate.mockClear();
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.createTypedElement,
+      28,
+      'list',
+      null,
+      'bad-slots' as unknown as ElementTemplateUpdateCommandStream[number],
+      null,
+    ]);
+
+    expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(0);
+    expect(elementTemplateRegistry.has(28)).toBe(false);
+    const reportError = (globalThis.lynx as unknown as LynxWithReportErrorMock).reportError;
+    expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain(
+      'elementSlots must be an array, null, or undefined',
+    );
     resetReportedErrors();
   });
 

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi.ts
@@ -77,7 +77,7 @@ export function installMockNativePapi(
     templateKey: string,
     bundleUrl: string | null | undefined,
     attributeSlots: unknown[] | null | undefined,
-    elementSlots: unknown[][] | null | undefined,
+    elementSlots: Array<unknown[] | null | undefined> | null | undefined,
     handleId: unknown,
   ) => {
     nativeLog.push(['__CreateElementTemplate', templateKey, bundleUrl, attributeSlots, elementSlots, handleId]);
@@ -122,7 +122,7 @@ export function installMockNativePapi(
   const mockCreateTypedElementTemplate = vi.fn().mockImplementation((
     type: string,
     attributes: unknown,
-    elementSlots: unknown[][] | null | undefined,
+    elementSlots: Array<unknown[] | null | undefined> | null | undefined,
     handleId: unknown,
     options: unknown,
   ) => {

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi/templateTree.ts
@@ -18,7 +18,7 @@ export interface CompiledTemplateNode {
   __compiledTemplate?: CompiledElementNode;
   __typedElementType?: string;
   __attributeSlots?: unknown[] | null;
-  __elementSlots?: unknown[][] | null;
+  __elementSlots?: Array<unknown[] | null | undefined> | null;
   __bundleUrl?: string;
   __options?: Record<string, unknown>;
 }
@@ -87,7 +87,7 @@ function applyCompiledAttributes(
 function instantiateCompiledTemplateChild(
   child: CompiledTemplateChild,
   attributeSlots: unknown[] | null | undefined,
-  elementSlots: unknown[][] | null | undefined,
+  elementSlots: Array<unknown[] | null | undefined> | null | undefined,
 ): unknown {
   if (isCompiledElementSlotNode(child)) {
     return {
@@ -103,7 +103,7 @@ function instantiateCompiledTemplateChild(
 export function instantiateCompiledTemplateNode(
   node: CompiledElementNode,
   attributeSlots: unknown[] | null | undefined,
-  elementSlots: unknown[][] | null | undefined,
+  elementSlots: Array<unknown[] | null | undefined> | null | undefined,
 ): CompiledTemplateNode {
   const instantiatedChildren: unknown[] = [];
   for (const child of node.children ?? []) {
@@ -123,7 +123,7 @@ export function instantiateCompiledTemplateNode(
 export function instantiateCompiledTemplate(
   template: unknown,
   attributeSlots: unknown[] | null | undefined,
-  elementSlots: unknown[][] | null | undefined,
+  elementSlots: Array<unknown[] | null | undefined> | null | undefined,
 ): CompiledTemplateNode {
   if (!isCompiledElementNode(template)) {
     throw new Error('ElementTemplate: __CreateElementTemplate expects the new compiled template schema.');
@@ -180,7 +180,10 @@ function rebuildTemplateInstance(root: CompiledTemplateNode): void {
   assignTemplateInstance(root, next);
 }
 
-function detachNodeFromElementSlots(elementSlots: unknown[][], node: unknown): void {
+function detachNodeFromElementSlots(
+  elementSlots: Array<unknown[] | null | undefined>,
+  node: unknown,
+): void {
   for (let slotIndex = 0; slotIndex < elementSlots.length; slotIndex += 1) {
     const children = elementSlots[slotIndex];
     if (!children) {
@@ -197,7 +200,7 @@ function detachNodeFromElementSlots(elementSlots: unknown[][], node: unknown): v
 }
 
 function insertNodeIntoElementSlot(
-  elementSlots: unknown[][],
+  elementSlots: Array<unknown[] | null | undefined>,
   elementSlotIndex: number,
   node: unknown,
   referenceNode?: unknown,
@@ -217,7 +220,7 @@ function insertNodeIntoElementSlot(
 }
 
 function removeNodeFromElementSlot(
-  elementSlots: unknown[][],
+  elementSlots: Array<unknown[] | null | undefined>,
   elementSlotIndex: number,
   node: unknown,
 ): void {
@@ -231,7 +234,7 @@ function removeNodeFromElementSlot(
 
 function commitTypedElementSlots(
   root: CompiledTemplateNode,
-  elementSlots: unknown[][],
+  elementSlots: Array<unknown[] | null | undefined>,
 ): void {
   root.__elementSlots = elementSlots;
   root.children = elementSlots[0] ?? [];
@@ -319,7 +322,7 @@ type SerializedRuntimeOptionValueForMock =
 
 interface SerializedEtNodeBaseForMock {
   attributeSlots?: SerializableValueForMock[] | null;
-  elementSlots?: SerializedEtNodeForMock[][] | null;
+  elementSlots?: Array<SerializedEtNodeForMock[] | null | undefined> | null;
   uid: number | string;
   options?: Record<string, SerializedRuntimeOptionValueForMock> | null;
 }
@@ -494,15 +497,21 @@ function normalizeAttributeSlots(
 }
 
 function serializeElementSlotsFromSlots(
-  elementSlots: unknown[][] | null | undefined,
-): SerializedEtNodeForMock[][] {
-  const serializedSlots: SerializedEtNodeForMock[][] = [];
+  elementSlots: Array<unknown[] | null | undefined> | null | undefined,
+): Array<SerializedEtNodeForMock[] | null | undefined> {
+  const serializedSlots: Array<SerializedEtNodeForMock[] | null | undefined> = [];
   if (!isUnknownArray(elementSlots)) {
     return serializedSlots;
   }
 
   for (let slotId = 0; slotId < elementSlots.length; slotId += 1) {
     const slotChildren = elementSlots[slotId];
+    if (slotChildren == null) {
+      if (slotId in elementSlots) {
+        serializedSlots[slotId] = slotChildren;
+      }
+      continue;
+    }
     if (!isUnknownArray(slotChildren)) {
       continue;
     }

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -9,7 +9,11 @@ import { backgroundElementTemplateInstanceManager } from './manager.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
 import { parseElementTemplateType } from '../protocol/template-type.js';
-import type { ElementTemplateUpdateCommandStream, SerializableValue } from '../protocol/types.js';
+import type {
+  ElementTemplateHandleSlotsCommand,
+  ElementTemplateUpdateCommandStream,
+  SerializableValue,
+} from '../protocol/types.js';
 
 function pushOp(...items: ElementTemplateUpdateCommandStream): void {
   globalCommitContext.ops.push(...items);
@@ -104,7 +108,7 @@ export class BackgroundElementTemplateInstance {
     // Walk the linked-list children once to build the slot-indexed handle list
     // for the createTemplate op. Going via `this.elementSlots` would allocate
     // the full `Instance[][]` intermediate just to throw it away here.
-    const serializedSlots: number[][] = [];
+    const serializedSlots: ElementTemplateHandleSlotsCommand = [];
     let child = this.firstChild;
     while (child) {
       (serializedSlots[child.__slotIndex] ??= []).push(child.instanceId);

--- a/packages/react/runtime/src/element-template/protocol/types.ts
+++ b/packages/react/runtime/src/element-template/protocol/types.ts
@@ -30,6 +30,12 @@ export type RuntimeTypedElementAttributes = Record<string, RuntimeAttributeSlotV
 
 export type TypedElementAttributesCommand = Record<string, SerializableValue>;
 
+export type RuntimeElementSlots = Array<ElementRef[] | null | undefined>;
+
+export type ElementTemplateHandleSlotsCommand = Array<number[] | null | undefined>;
+
+export type SerializedEtNodeSlots = Array<SerializedEtNode[] | null | undefined>;
+
 export interface ElementTemplateHandleRefCommandValue {
   __etHandleRef: number;
   [key: string]: SerializableValue;
@@ -51,7 +57,7 @@ export type SerializedRuntimeOptions = Record<string, SerializedRuntimeOptionVal
 
 export interface SerializedEtNodeBase {
   attributeSlots?: SerializableValue[] | null;
-  elementSlots?: SerializedEtNode[][] | null;
+  elementSlots?: SerializedEtNodeSlots | null;
   uid: number | string;
   options?: SerializedRuntimeOptions | null;
 }
@@ -78,7 +84,7 @@ export interface SerializedElementTemplate {
   templateKey: string;
   bundleUrl?: string;
   attributeSlots?: SerializableValue[] | null;
-  elementSlots?: SerializedElementTemplate[][] | null;
+  elementSlots?: Array<SerializedElementTemplate[] | null | undefined> | null;
   uid: number | string;
   options?: SerializedRuntimeOptions | null;
 }
@@ -89,7 +95,7 @@ export type CreateTemplateCommand = [
   templateKey: string,
   bundleUrl: string | null | undefined,
   attributeSlots: SerializableValue[] | null | undefined,
-  elementSlots: number[][] | null | undefined,
+  elementSlots: ElementTemplateHandleSlotsCommand | null | undefined,
 ];
 
 export type SetAttributeCommand = [
@@ -120,7 +126,7 @@ export type CreateTypedElementCommand = [
   handleId: number,
   type: string,
   attributes: TypedElementAttributesCommand | null | undefined,
-  elementSlots: number[][] | null | undefined,
+  elementSlots: ElementTemplateHandleSlotsCommand | null | undefined,
   options: RuntimeOptionsCommand | null | undefined,
 ];
 

--- a/packages/react/runtime/src/element-template/runtime/patch.ts
+++ b/packages/react/runtime/src/element-template/runtime/patch.ts
@@ -6,7 +6,9 @@ import { elementTemplateRegistry } from './template/registry.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
 import type { ElementTemplateUpdateOp } from '../protocol/opcodes.js';
 import type {
+  ElementTemplateHandleSlotsCommand,
   ElementTemplateUpdateCommandStream,
+  RuntimeElementSlots,
   RuntimeOptions,
   RuntimeOptionsCommand,
   SerializableValue,
@@ -28,7 +30,7 @@ export function applyElementTemplateUpdateCommands(
         const templateKey = stream[i++] as string;
         const bundleUrl = stream[i++] as string | null | undefined;
         const attributeSlots = stream[i++] as SerializableValue[] | null | undefined;
-        const elementSlots = stream[i++] as number[][] | null | undefined;
+        const elementSlots = stream[i++] as ElementTemplateHandleSlotsCommand | null | undefined;
 
         if (__DEV__) {
           const createError = validateCreateTemplatePayload(
@@ -77,7 +79,7 @@ export function applyElementTemplateUpdateCommands(
         const handleId = stream[i++] as number;
         const type = stream[i++] as string;
         const attributes = stream[i++] as TypedElementAttributesCommand | null | undefined;
-        const elementSlots = stream[i++] as number[][] | null | undefined;
+        const elementSlots = stream[i++] as ElementTemplateHandleSlotsCommand | null | undefined;
         const options = stream[i++] as RuntimeOptionsCommand | null | undefined;
 
         if (__DEV__) {
@@ -153,36 +155,47 @@ export function applyElementTemplateUpdateCommands(
 }
 
 function resolveElementSlots(
-  elementSlots: number[][] | null | undefined,
-): { hasError: boolean; value: ElementRef[][] | null } {
-  if (!Array.isArray(elementSlots)) {
+  elementSlots: ElementTemplateHandleSlotsCommand | null | undefined,
+): { hasError: boolean; value: RuntimeElementSlots | null } {
+  if (elementSlots == null) {
     return { hasError: false, value: null };
+  }
+  if (__DEV__ && !Array.isArray(elementSlots)) {
+    lynx.reportError(new Error('ElementTemplate create elementSlots must be an array, null, or undefined.'));
+    return { hasError: true, value: null };
   }
 
   let hasError = false;
-  const value = elementSlots.map((children, slotIndex) => {
-    if (!Array.isArray(children)) {
-      if (__DEV__) {
-        lynx.reportError(
-          new Error(`ElementTemplate create slot ${slotIndex} must be an array of child handles.`),
-        );
-        hasError = true;
-      }
-      return [];
+  const value: RuntimeElementSlots = [];
+  for (let slotIndex = 0; slotIndex < elementSlots.length; slotIndex += 1) {
+    const children = elementSlots[slotIndex];
+    if (children == null) {
+      continue;
+    }
+    if (__DEV__ && !Array.isArray(children)) {
+      lynx.reportError(
+        new Error(`ElementTemplate create slot ${slotIndex} must be an array of child handles, null, or undefined.`),
+      );
+      hasError = true;
+      continue;
     }
 
-    return children
-      .map((childId) => {
-        const childRef = __DEV__
-          ? resolveHandle(childId, 'child')
-          : (elementTemplateRegistry.get(childId) ?? null);
-        if (__DEV__ && childRef === null) {
+    const resolvedChildren: ElementRef[] = [];
+    for (let childIndex = 0; childIndex < children.length; childIndex += 1) {
+      const childId = children[childIndex]!;
+      const childRef = __DEV__
+        ? resolveHandle(childId, 'child')
+        : (elementTemplateRegistry.get(childId) ?? null);
+      if (childRef === null) {
+        if (__DEV__) {
           hasError = true;
         }
-        return childRef;
-      })
-      .filter((childRef): childRef is ElementRef => childRef !== null);
-  });
+        continue;
+      }
+      resolvedChildren.push(childRef);
+    }
+    value[slotIndex] = resolvedChildren;
+  }
   return { hasError, value };
 }
 
@@ -264,7 +277,7 @@ function validateCreateHandleId(handleId: number): Error | null {
 function validateCreateTemplatePayload(
   handleId: number,
   attributeSlots: SerializableValue[] | null | undefined,
-  elementSlots: number[][] | null | undefined,
+  elementSlots: ElementTemplateHandleSlotsCommand | null | undefined,
 ): Error | null {
   const handleError = validateCreateHandleId(handleId);
   if (handleError) {

--- a/packages/react/runtime/src/element-template/runtime/template/handle.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/handle.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { deleteElementTemplateNativeRef, setElementTemplateNativeRef } from './registry.js';
-import type { SerializableValue } from '../../protocol/types.js';
+import type { RuntimeElementSlots, SerializableValue } from '../../protocol/types.js';
 
 // Main-thread IFR allocates ids as consecutive negative integers.
 let nextId = -1;
@@ -18,7 +18,7 @@ export function createElementTemplateWithReservedHandle(
   templateKey: string,
   bundleUrl: string | null | undefined,
   attributeSlots: SerializableValue[] | null | undefined,
-  elementSlots: ElementRef[][] | null | undefined,
+  elementSlots: RuntimeElementSlots | null | undefined,
 ): ElementRef {
   const nativeRef = __CreateElementTemplate(
     templateKey,

--- a/packages/react/runtime/src/element-template/types.d.ts
+++ b/packages/react/runtime/src/element-template/types.d.ts
@@ -4,6 +4,7 @@
 
 import type {
   RuntimeAttributeSlotValue,
+  RuntimeElementSlots,
   RuntimeOptions,
   RuntimeTypedElementAttributes,
   SerializableValue,
@@ -21,7 +22,7 @@ declare global {
     templateKey: string,
     bundleUrl: string | null | undefined,
     attributeSlots: SerializableValue[] | null | undefined,
-    elementSlots: ElementRef[][] | null | undefined,
+    elementSlots: RuntimeElementSlots | null | undefined,
     uid: number | string,
     options?: RuntimeOptions | null,
   ): ElementRef;
@@ -29,7 +30,7 @@ declare global {
   function __CreateTypedElementTemplate(
     type: string,
     attributes: RuntimeTypedElementAttributes | null | undefined,
-    elementSlots: ElementRef[][] | null | undefined,
+    elementSlots: RuntimeElementSlots | null | undefined,
     uid: number | string,
     options?: RuntimeOptions | null,
   ): ElementRef;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved element slot handling to correctly resolve nullable and sparse slot entries.
  * Enhanced validation with clearer error messages for invalid slot configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

Element Template create payloads can contain sparse `elementSlots` arrays when background-thread serialization writes children by their slot index. After crossing the thread boundary, those sparse holes can appear as `null`. The main-thread patch resolver previously required every slot entry to be a `number[]`, so a valid empty slot could reject the whole template create and cascade into later "child handle not found" errors.

This change aligns the runtime protocol with the native behavior: a top-level slot list may be absent, and individual slot entries may be sparse, `null`, or `undefined` to mean an empty slot. The background producer can keep emitting sparse arrays instead of densifying every missing slot to `[]`, while the main-thread consumer resolves only concrete child-handle arrays.

## Runtime Contract

The internal ET create-slot shape is now:

```ts
type ElementTemplateHandleSlotsCommand = Array<number[] | null | undefined>;
```

Producer: the background ET runtime writes children into `elementSlots[slotIndex]` during template create serialization.

Consumer: the main-thread ET patch runtime resolves each `number[]` entry into native `ElementRef[]` before calling `__CreateElementTemplate` or `__CreateTypedElementTemplate`.

Nullability and ordering rules:

- `elementSlots == null` means no slot children.
- A sparse hole, `null`, or `undefined` at an inner slot index means that slot has no children.
- A `number[]` entry preserves child-handle order and is resolved through the existing element-template registry.
- Top-level non-array payloads remain invalid protocol data and still report in DEV.

## How It Works

- `protocol/types.ts`, `types.d.ts`, and `runtime/template/handle.ts` model nullable inner slot entries across the JS/native boundary.
- `background/instance.ts` keeps the sparse producer behavior so empty slots do not need to be materialized as `[]`.
- `runtime/patch.ts` treats inner `null`/holes as empty slots, keeps DEV-only protocol diagnostics for invalid internal shapes, and avoids extra production validation for this framework-internal contract.
- The native mock template tree and patch tests now cover sparse and nullable slot entries instead of only dense `number[][]` payloads.

## Boundaries

This does not add dense slot normalization on the background path, change child-handle identity, or broaden the top-level `elementSlots` contract beyond array/null/undefined. It also does not add a changeset because Element Template remains experimental and this only adjusts an internal runtime/native protocol shape.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
