### PR TITLE
feat(genui): expand openui catalog and playground examples

### DIFF
--- a/.changeset/openui-catalog-playground.md
+++ b/.changeset/openui-catalog-playground.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": minor
+---
+
+Expand the OpenUI catalog with more layout, media, modal, tabs, text, and picker components, and add richer playground examples that showcase the new component set.

--- a/.changeset/openui-catalog-playground.md
+++ b/.changeset/openui-catalog-playground.md
@@ -1,5 +1,5 @@
 ---
-"@lynx-js/genui": minor
+"@lynx-js/genui": patch
 ---
 
 Expand the OpenUI catalog with more layout, media, modal, tabs, text, and picker components, and add richer playground examples that showcase the new component set.

--- a/.github/openui-v05.instructions.md
+++ b/.github/openui-v05.instructions.md
@@ -9,3 +9,5 @@ When changing exported OpenUI runtime APIs, refresh both API reports with `pnpm 
 When adding OpenUI v0.5 cases to `packages/genui/a2ui-playground`, keep raw protocol examples limited to components supported by `packages/genui/openui/src/catalog` unless the same change extends the catalog. Query and Mutation examples need matching mock tools in `packages/genui/a2ui-playground/lynx-src/openui/App.tsx` so `/render.html` previews exercise the runtime path instead of staying on default or unresolved values.
 
 When exposing OpenUI prompt generation for server-side agents, keep prompt-only component libraries headless: mirror the ReactLynx component names and Zod schemas but use null renderers so Node routes can build system prompts without importing ReactLynx or Lynx UI runtime modules.
+
+When adding a built-in component under `packages/genui/openui/src/catalog`, update `src/catalog/index.ts`, the `DEFAULT_COMPONENTS` and `DEFAULT_COMPONENT_GROUPS` arrays in `src/core/createLibrary.tsx`, and `src/core/renderer.css` in the same change. Otherwise the component may be importable but absent from the default OpenUI library or render without its intended Lynx styles.

--- a/packages/genui/a2ui-playground/lynx-src/openui/mockData.ts
+++ b/packages/genui/a2ui-playground/lynx-src/openui/mockData.ts
@@ -8,7 +8,46 @@ export interface OpenUIScenario {
   raw: string;
 }
 
+const NEW_LAYOUT_SHOWCASE_RAW =
+  `root = Column([hero, layoutCard, listCard], "start", "stretch", "m")
+hero = Card([Text("Layout Showcase", "h2"), Text("Row, Column, List and Divider compose a compact planning view.", "body")], "card", "column", false, "s", "start", "start")
+layoutCard = Card([CardHeader("Release Roadmap", "Row and Column primitives"), statusRow, Divider("horizontal"), milestoneColumn], "card", "column", false, "m", "stretch", "start")
+statusRow = Row([Text("Design", "h5"), Tag("In review"), Icon("arrow_forward", "sm", "muted"), Text("Build", "h5"), Tag("Active"), Icon("arrow_forward", "sm", "muted"), Text("Launch", "h5")], "between", "center", "s", true)
+milestoneColumn = Column([Text("1. API shape finalized", "body"), Text("2. Playground coverage added", "body"), Text("3. Browser verification complete", "body")], "start", "stretch", "s")
+listCard = Card([CardHeader("Checklist", "Tap each item to update local state"), List([CheckBox("Document usage snippets", true), CheckBox("Verify tabs and modal interactions", false), CheckBox("Confirm media placeholders render", false)], "vertical", "stretch", "s", true)], "sunk", "column", false, "m", "stretch", "start")`;
+
+const NEW_INTERACTIVE_CONTROLS_RAW = `$plan = "Pro"
+root = Column([header, tabs, modalLauncher], "start", "stretch", "m")
+header = Card([Text("Interactive Controls", "h2"), Text("Tabs, ChoicePicker, DateTimeInput and Modal in one flow.", "body")], "card", "column", false, "s", "start", "start")
+tabs = Tabs([{ value: "plan", title: "Plan", child: planCard }, { value: "schedule", title: "Schedule", child: scheduleCard }])
+planCard = Card([CardHeader("Plan", "ChoicePicker updates local visual state"), ChoicePicker("Tier", ["Free", "Pro", "Team"], $plan, "card", "chips", true), Buttons([Button("Set Free", Action([@Set($plan, "Free")]), "secondary"), Button("Set Team", Action([@Set($plan, "Team")]), "primary")])], "sunk", "column", false, "m", "stretch", "start")
+scheduleCard = Card([CardHeader("Schedule", "DateTimeInput displays date and time constraints"), DateTimeInput("2026-06-16T09:30:00", true, true, "2026-06-01", "2026-06-30", "Launch window")], "sunk", "column", false, "m", "stretch", "start")
+modalContent = Card([Text("Confirmation", "h3"), Text("The modal renders arbitrary OpenUI content.", "body"), Button("Looks good", Action([@ToAssistant("Confirmed modal content")]), "primary")], "card", "column", false, "m", "stretch", "start")
+modalLauncher = Modal(Button("Open confirmation", Action([@ToAssistant("Opened confirmation modal")]), "secondary"), modalContent, "Review details")`;
+
+const NEW_MEDIA_CARDS_RAW =
+  `root = Column([header, mediaTabs], "start", "stretch", "m")
+header = Card([Text("Media Cards", "h2"), Text("AudioPlayer and Video provide lightweight media attachment surfaces.", "body")], "card", "column", false, "s", "start", "start")
+mediaTabs = Tabs([{ value: "audio", title: "Audio", child: audioCard }, { value: "video", title: "Video", child: videoCard }])
+audioCard = Card([CardHeader("Podcast Preview", "AudioPlayer placeholder"), AudioPlayer("https://example.com/openui-weekly.mp3", "OpenUI Weekly - catalog additions"), Row([Icon("pause", "sm", "muted"), Text("12 min episode", "caption"), Tag("Transcript ready")], "start", "center", "s", true)], "card", "column", false, "m", "stretch", "start")
+videoCard = Card([CardHeader("Launch Walkthrough", "Video placeholder"), Video("https://example.com/openui-launch.mp4", "OpenUI component walkthrough"), List([Text("Covers layout primitives", "body"), Text("Shows tabs and modal", "body"), Text("Highlights media cards", "body")], "vertical", "stretch", "xs", true)], "card", "column", false, "m", "stretch", "start")`;
+
 export const OPENUI_SCENARIOS: OpenUIScenario[] = [
+  {
+    id: 'new-layout-showcase',
+    title: 'New Layout Showcase',
+    raw: NEW_LAYOUT_SHOWCASE_RAW,
+  },
+  {
+    id: 'new-interactive-controls',
+    title: 'New Interactive Controls',
+    raw: NEW_INTERACTIVE_CONTROLS_RAW,
+  },
+  {
+    id: 'new-media-cards',
+    title: 'New Media Cards',
+    raw: NEW_MEDIA_CARDS_RAW,
+  },
   {
     id: 'pricing-cards',
     title: 'Pricing Cards',

--- a/packages/genui/a2ui-playground/src/catalog/openui.ts
+++ b/packages/genui/a2ui-playground/src/catalog/openui.ts
@@ -22,6 +22,7 @@ export const OPENUI_CATEGORIES = [
   { id: 'content', label: 'Content' },
   { id: 'buttons', label: 'Buttons' },
   { id: 'data-display', label: 'Data Display' },
+  { id: 'overlays', label: 'Overlays' },
   { id: 'inputs', label: 'Inputs' },
 ] as const;
 
@@ -61,6 +62,102 @@ export const OPENUI_COMPONENT_CATALOG: OpenUIComponentDoc[] = [
     usage: `root = Stack([title, subtitle], "column", false, "l")
 title = TextContent("Hello World", "large-heavy")
 subtitle = TextContent("A simple stack example")`,
+  },
+  {
+    name: 'Row',
+    category: 'layout',
+    description: 'Horizontal flex layout container.',
+    props: [
+      { name: 'children', type: 'any[]', description: 'Child elements.' },
+      {
+        name: 'justify',
+        type: '"start" | "center" | "end" | "between" | "around" | "evenly"',
+        description: 'Main-axis alignment.',
+        default: '"start"',
+      },
+      {
+        name: 'align',
+        type: '"start" | "center" | "end" | "stretch"',
+        description: 'Cross-axis alignment.',
+        default: '"center"',
+      },
+      {
+        name: 'gap',
+        type: '"none" | "xs" | "s" | "m" | "l" | "xl"',
+        description: 'Gap between children.',
+        default: '"m"',
+      },
+      { name: 'wrap', type: 'boolean', description: 'Enable flex-wrap.' },
+    ],
+    usage:
+      `root = Row([Text("Design", "h5"), Tag("Active"), Icon("arrow_forward", "sm", "muted")], "start", "center", "s", true)`,
+  },
+  {
+    name: 'Column',
+    category: 'layout',
+    description: 'Vertical flex layout container.',
+    props: [
+      { name: 'children', type: 'any[]', description: 'Child elements.' },
+      {
+        name: 'justify',
+        type: '"start" | "center" | "end" | "between" | "around" | "evenly"',
+        description: 'Main-axis alignment.',
+        default: '"start"',
+      },
+      {
+        name: 'align',
+        type: '"start" | "center" | "end" | "stretch"',
+        description: 'Cross-axis alignment.',
+        default: '"stretch"',
+      },
+      {
+        name: 'gap',
+        type: '"none" | "xs" | "s" | "m" | "l" | "xl"',
+        description: 'Gap between children.',
+        default: '"m"',
+      },
+    ],
+    usage:
+      `root = Column([Text("Step 1", "body"), Text("Step 2", "body")], "start", "stretch", "s")`,
+  },
+  {
+    name: 'List',
+    category: 'layout',
+    description:
+      'List container for repeated children with optional item dividers.',
+    props: [
+      { name: 'children', type: 'any[]', description: 'Child elements.' },
+      {
+        name: 'items',
+        type: 'any[]',
+        description: 'Alias for children when list data is provided as items.',
+      },
+      {
+        name: 'direction',
+        type: '"vertical" | "horizontal"',
+        description: 'List direction.',
+        default: '"vertical"',
+      },
+      {
+        name: 'align',
+        type: '"start" | "center" | "end" | "stretch"',
+        description: 'Cross-axis alignment.',
+        default: '"stretch"',
+      },
+      {
+        name: 'gap',
+        type: '"none" | "xs" | "s" | "m" | "l" | "xl"',
+        description: 'Gap between items.',
+        default: '"m"',
+      },
+      {
+        name: 'divider',
+        type: 'boolean',
+        description: 'Render dividers between items.',
+      },
+    ],
+    usage:
+      `root = List([Text("First", "body"), Text("Second", "body"), Text("Third", "body")], "vertical", "stretch", "s", true)`,
   },
   {
     name: 'Card',
@@ -116,6 +213,26 @@ content = TextContent("Card body text goes here.")`,
     usage: `root = Stack([Card([CardHeader("Main Title", "Subtitle text")])])`,
   },
   {
+    name: 'Text',
+    category: 'content',
+    description: 'Plain text with display variants.',
+    props: [
+      {
+        name: 'text',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Text to display.',
+      },
+      {
+        name: 'variant',
+        type: '"h1" | "h2" | "h3" | "h4" | "h5" | "caption" | "body"',
+        description: 'Text display variant.',
+        default: '"body"',
+      },
+    ],
+    usage:
+      `root = Column([Text("Launch Plan", "h2"), Text("Updated today", "caption")], "start", "stretch", "s")`,
+  },
+  {
     name: 'TextContent',
     category: 'content',
     description: 'Text content with optional size.',
@@ -144,6 +261,21 @@ t3 = TextContent("Large heavy text", "large-heavy")`,
     props: [],
     usage:
       `root = Stack([TextContent("Above"), Separator(), TextContent("Below")])`,
+  },
+  {
+    name: 'Divider',
+    category: 'content',
+    description: 'Horizontal or vertical divider.',
+    props: [
+      {
+        name: 'axis',
+        type: '"horizontal" | "vertical"',
+        description: 'Divider orientation.',
+        default: '"horizontal"',
+      },
+    ],
+    usage:
+      `root = Column([Text("Above", "body"), Divider("horizontal"), Text("Below", "body")], "start", "stretch", "s")`,
   },
   {
     name: 'Button',
@@ -256,6 +388,44 @@ feature = Image("https://example.com/hero.png", "contain", "largeFeature")`,
 row = Stack([Icon("check", "md", "primary"), Icon("close", "lg", "muted")], "row", false, "s")`,
   },
   {
+    name: 'Video',
+    category: 'data-display',
+    description: 'Video attachment placeholder with title and URL.',
+    props: [
+      {
+        name: 'url',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Video URL.',
+      },
+      {
+        name: 'title',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Optional video title.',
+      },
+    ],
+    usage:
+      `root = Card([CardHeader("Walkthrough"), Video("https://example.com/demo.mp4", "Product walkthrough")])`,
+  },
+  {
+    name: 'AudioPlayer',
+    category: 'data-display',
+    description: 'Audio attachment placeholder with description and URL.',
+    props: [
+      {
+        name: 'url',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Audio URL.',
+      },
+      {
+        name: 'description',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Optional audio description.',
+      },
+    ],
+    usage:
+      `root = Card([CardHeader("Podcast"), AudioPlayer("https://example.com/episode.mp3", "Episode preview")])`,
+  },
+  {
     name: 'Loading',
     category: 'data-display',
     description: 'Skeleton placeholder while content loads.',
@@ -271,10 +441,61 @@ row = Stack([Icon("check", "md", "primary"), Icon("close", "lg", "muted")], "row
       `root = Stack([Loading("inline"), Loading("block")], "column", false, "m")`,
   },
   {
+    name: 'Tabs',
+    category: 'overlays',
+    description: 'Tabbed content switcher with per-tab child content.',
+    props: [
+      {
+        name: 'tabs',
+        type: '{ value: string; title: string; child: any }[]',
+        description: 'Tab definitions with a stable value, title, and child.',
+      },
+      {
+        name: 'value',
+        type: 'string',
+        description: 'Initially selected tab value.',
+      },
+    ],
+    usage:
+      `root = Tabs([{ value: "summary", title: "Summary", child: summary }, { value: "details", title: "Details", child: details }])
+summary = Card([Text("Summary", "h3")])
+details = Card([Text("Details", "h3")])`,
+  },
+  {
+    name: 'Modal',
+    category: 'overlays',
+    description: 'Tap-triggered modal container with custom content.',
+    props: [
+      {
+        name: 'trigger',
+        type: 'any',
+        description: 'Trigger element, usually a Button.',
+      },
+      {
+        name: 'content',
+        type: 'any',
+        description: 'Modal body content.',
+      },
+      {
+        name: 'title',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Optional modal title.',
+      },
+      {
+        name: 'closeOnAction',
+        type: 'boolean',
+        description: 'Close the modal after an action inside the body fires.',
+        default: 'true',
+      },
+    ],
+    usage:
+      `root = Modal(Button("Open details", Action([@ToAssistant("open")]), "secondary"), Card([Text("Modal body", "body")]), "Details")`,
+  },
+  {
     name: 'CheckBox',
     category: 'inputs',
     description:
-      'Toggleable checkbox. Tap fires the action; visual state is controlled by the caller.',
+      'Toggleable checkbox. Tap the row to update local visual state and fire the action.',
     props: [
       { name: 'label', type: 'string', description: 'Checkbox label text.' },
       {
@@ -322,6 +543,49 @@ box2 = CheckBox("Subscribe to updates", false, Action([@ToAssistant("Subscribe")
     ],
     usage: `root = Stack([rg])
 rg = RadioGroup(["Small", "Medium", "Large"], "Medium", "row", Action([@ToAssistant("size")]))`,
+  },
+  {
+    name: 'ChoicePicker',
+    category: 'inputs',
+    description:
+      'Choice picker rendered as selectable chips, list items, or a dropdown-like field.',
+    props: [
+      {
+        name: 'label',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Optional picker label.',
+      },
+      {
+        name: 'options',
+        type:
+          '(string | number | boolean | { path: string })[] | string | { path: string }',
+        description: 'Picker options.',
+      },
+      {
+        name: 'value',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Selected option.',
+      },
+      {
+        name: 'variant',
+        type: '"default" | "card"',
+        description: 'Visual variant.',
+        default: '"default"',
+      },
+      {
+        name: 'displayStyle',
+        type: '"list" | "chips" | "dropdown"',
+        description: 'Option layout style.',
+        default: '"chips"',
+      },
+      {
+        name: 'filterable',
+        type: 'boolean | { path: string }',
+        description: 'Whether the picker is filterable.',
+      },
+    ],
+    usage:
+      `root = ChoicePicker("Tier", ["Free", "Pro", "Team"], "Pro", "card", "chips", true)`,
   },
   {
     name: 'Slider',
@@ -390,5 +654,45 @@ s2 = Slider("Brightness", 0, 100, 75, 5, Action([@ToAssistant("brightness")]))`,
 tf1 = TextField("Email", "user@example.com", "shortText", "", Action([@ToAssistant("email")]))
 tf2 = TextField("Age", "30", "number", "", Action([@ToAssistant("age")]))
 tf3 = TextField("Notes", "Hello", "longText", "", Action([@ToAssistant("notes")]))`,
+  },
+  {
+    name: 'DateTimeInput',
+    category: 'inputs',
+    description:
+      'Date/time value display with optional label, min/max, and enabled date/time hints.',
+    props: [
+      {
+        name: 'value',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Current date/time value.',
+      },
+      {
+        name: 'enableDate',
+        type: 'boolean | { path: string }',
+        description: 'Whether date selection is enabled.',
+      },
+      {
+        name: 'enableTime',
+        type: 'boolean | { path: string }',
+        description: 'Whether time selection is enabled.',
+      },
+      {
+        name: 'min',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Optional minimum value.',
+      },
+      {
+        name: 'max',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Optional maximum value.',
+      },
+      {
+        name: 'label',
+        type: 'string | number | boolean | { path: string }',
+        description: 'Optional field label.',
+      },
+    ],
+    usage:
+      `root = DateTimeInput("2026-06-16T09:30:00", true, true, "2026-06-01", "2026-06-30", "Launch window")`,
   },
 ];

--- a/packages/genui/a2ui-playground/src/mock/openui-scenarios.ts
+++ b/packages/genui/a2ui-playground/src/mock/openui-scenarios.ts
@@ -25,6 +25,35 @@ const OPENUI_SCENARIO_SCHEMA: LibraryJSONSchema = {
       },
       required: ['children'],
     },
+    Row: {
+      properties: {
+        children: {},
+        justify: {},
+        align: {},
+        gap: {},
+        wrap: {},
+      },
+      required: ['children'],
+    },
+    Column: {
+      properties: {
+        children: {},
+        justify: {},
+        align: {},
+        gap: {},
+      },
+      required: ['children'],
+    },
+    List: {
+      properties: {
+        children: {},
+        items: {},
+        direction: {},
+        align: {},
+        gap: {},
+        divider: {},
+      },
+    },
     Card: {
       properties: {
         children: {},
@@ -41,12 +70,19 @@ const OPENUI_SCENARIO_SCHEMA: LibraryJSONSchema = {
       properties: { title: {}, subtitle: {} },
       required: ['title'],
     },
+    Text: {
+      properties: { text: {}, variant: {} },
+      required: ['text'],
+    },
     TextContent: {
       properties: { text: {}, size: {} },
       required: ['text'],
     },
     Separator: {
       properties: { orientation: {}, decorative: {} },
+    },
+    Divider: {
+      properties: { axis: {} },
     },
     Button: {
       properties: {
@@ -65,6 +101,85 @@ const OPENUI_SCENARIO_SCHEMA: LibraryJSONSchema = {
     Tag: {
       properties: { text: {} },
       required: ['text'],
+    },
+    Image: {
+      properties: { url: {}, fit: {}, variant: {} },
+      required: ['url'],
+    },
+    Icon: {
+      properties: { name: {}, size: {}, color: {} },
+      required: ['name'],
+    },
+    Video: {
+      properties: { url: {}, title: {} },
+      required: ['url'],
+    },
+    AudioPlayer: {
+      properties: { url: {}, description: {} },
+      required: ['url'],
+    },
+    Loading: {
+      properties: { variant: {} },
+    },
+    Tabs: {
+      properties: { tabs: {}, value: {} },
+      required: ['tabs'],
+    },
+    Modal: {
+      properties: { trigger: {}, content: {}, title: {} },
+      required: ['trigger', 'content'],
+    },
+    CheckBox: {
+      properties: { label: {}, value: {}, action: {}, name: {} },
+      required: ['label'],
+    },
+    RadioGroup: {
+      properties: { items: {}, value: {}, usageHint: {}, action: {}, name: {} },
+      required: ['items'],
+    },
+    ChoicePicker: {
+      properties: {
+        label: {},
+        options: {},
+        value: {},
+        variant: {},
+        displayStyle: {},
+        filterable: {},
+      },
+      required: ['options'],
+    },
+    Slider: {
+      properties: {
+        label: {},
+        min: {},
+        max: {},
+        value: {},
+        step: {},
+        action: {},
+        name: {},
+      },
+    },
+    TextField: {
+      properties: {
+        label: {},
+        value: {},
+        variant: {},
+        validationRegexp: {},
+        action: {},
+        name: {},
+      },
+      required: ['label'],
+    },
+    DateTimeInput: {
+      properties: {
+        value: {},
+        enableDate: {},
+        enableTime: {},
+        min: {},
+        max: {},
+        label: {},
+      },
+      required: ['value'],
     },
   },
 };
@@ -109,7 +224,49 @@ teamCard = Card([Tag($plan == "Team" ? "Selected" : "Option"), TextContent("Team
 billingCard = Card([CardHeader("Billing", "@Set changes $billing without a server"), Buttons([Button("Monthly", Action([@Set($billing, "Monthly")]), $billing == "Monthly" ? "primary" : "secondary"), Button("Annual", Action([@Set($billing, "Annual")]), $billing == "Annual" ? "primary" : "secondary")])], "clear", "column", false, "s", "stretch", "start")
 actionRow = Buttons([Button("Reset Picker", Action([@Reset($plan, $billing)]), "tertiary"), Button("Open v0.5 Spec", Action([@OpenUrl("https://www.openui.com/docs/openui-lang/specification-v05")]), "secondary")])`;
 
+const NEW_LAYOUT_SHOWCASE_RAW =
+  `root = Column([hero, layoutCard, listCard], "start", "stretch", "m")
+hero = Card([Text("Layout Showcase", "h2"), Text("Row, Column, List and Divider compose a compact planning view.", "body")], "card", "column", false, "s", "start", "start")
+layoutCard = Card([CardHeader("Release Roadmap", "Row and Column primitives"), statusRow, Divider("horizontal"), milestoneColumn], "card", "column", false, "m", "stretch", "start")
+statusRow = Row([Text("Design", "h5"), Tag("In review"), Icon("arrow_forward", "sm", "muted"), Text("Build", "h5"), Tag("Active"), Icon("arrow_forward", "sm", "muted"), Text("Launch", "h5")], "between", "center", "s", true)
+milestoneColumn = Column([Text("1. API shape finalized", "body"), Text("2. Playground coverage added", "body"), Text("3. Browser verification complete", "body")], "start", "stretch", "s")
+listCard = Card([CardHeader("Checklist", "Tap each item to update local state"), List([CheckBox("Document usage snippets", true), CheckBox("Verify tabs and modal interactions", false), CheckBox("Confirm media placeholders render", false)], "vertical", "stretch", "s", true)], "sunk", "column", false, "m", "stretch", "start")`;
+
+const NEW_INTERACTIVE_CONTROLS_RAW = `$plan = "Pro"
+root = Column([header, tabs, modalLauncher], "start", "stretch", "m")
+header = Card([Text("Interactive Controls", "h2"), Text("Tabs, ChoicePicker, DateTimeInput and Modal in one flow.", "body")], "card", "column", false, "s", "start", "start")
+tabs = Tabs([{ value: "plan", title: "Plan", child: planCard }, { value: "schedule", title: "Schedule", child: scheduleCard }])
+planCard = Card([CardHeader("Plan", "ChoicePicker updates local visual state"), ChoicePicker("Tier", ["Free", "Pro", "Team"], $plan, "card", "chips", true), Buttons([Button("Set Free", Action([@Set($plan, "Free")]), "secondary"), Button("Set Team", Action([@Set($plan, "Team")]), "primary")])], "sunk", "column", false, "m", "stretch", "start")
+scheduleCard = Card([CardHeader("Schedule", "DateTimeInput displays date and time constraints"), DateTimeInput("2026-06-16T09:30:00", true, true, "2026-06-01", "2026-06-30", "Launch window")], "sunk", "column", false, "m", "stretch", "start")
+modalContent = Card([Text("Confirmation", "h3"), Text("The modal renders arbitrary OpenUI content.", "body"), Button("Looks good", Action([@ToAssistant("Confirmed modal content")]), "primary")], "card", "column", false, "m", "stretch", "start")
+modalLauncher = Modal(Button("Open confirmation", Action([@ToAssistant("Opened confirmation modal")]), "secondary"), modalContent, "Review details")`;
+
+const NEW_MEDIA_CARDS_RAW =
+  `root = Column([header, mediaTabs], "start", "stretch", "m")
+header = Card([Text("Media Cards", "h2"), Text("AudioPlayer and Video provide lightweight media attachment surfaces.", "body")], "card", "column", false, "s", "start", "start")
+mediaTabs = Tabs([{ value: "audio", title: "Audio", child: audioCard }, { value: "video", title: "Video", child: videoCard }])
+audioCard = Card([CardHeader("Podcast Preview", "AudioPlayer placeholder"), AudioPlayer("https://example.com/openui-weekly.mp3", "OpenUI Weekly - catalog additions"), Row([Icon("pause", "sm", "muted"), Text("12 min episode", "caption"), Tag("Transcript ready")], "start", "center", "s", true)], "card", "column", false, "m", "stretch", "start")
+videoCard = Card([CardHeader("Launch Walkthrough", "Video placeholder"), Video("https://example.com/openui-launch.mp4", "OpenUI component walkthrough"), List([Text("Covers layout primitives", "body"), Text("Shows tabs and modal", "body"), Text("Highlights media cards", "body")], "vertical", "stretch", "xs", true)], "card", "column", false, "m", "stretch", "start")`;
+
 export const OPENUI_SCENARIOS: OpenUIScenario[] = [
+  {
+    id: 'new-layout-showcase',
+    title: 'New Layout Showcase',
+    raw: NEW_LAYOUT_SHOWCASE_RAW,
+    parsed: parseOpenUIScenarioRaw(NEW_LAYOUT_SHOWCASE_RAW),
+  },
+  {
+    id: 'new-interactive-controls',
+    title: 'New Interactive Controls',
+    raw: NEW_INTERACTIVE_CONTROLS_RAW,
+    parsed: parseOpenUIScenarioRaw(NEW_INTERACTIVE_CONTROLS_RAW),
+  },
+  {
+    id: 'new-media-cards',
+    title: 'New Media Cards',
+    raw: NEW_MEDIA_CARDS_RAW,
+    parsed: parseOpenUIScenarioRaw(NEW_MEDIA_CARDS_RAW),
+  },
   {
     id: 'pricing-cards',
     title: 'Pricing Cards',

--- a/packages/genui/openui/README.md
+++ b/packages/genui/openui/README.md
@@ -14,8 +14,10 @@ This package includes:
   `Action([@...])` steps.
 - `createParser` / `createStreamingParser`: parse OpenUI DSL text
   (functional notation) into a renderable AST.
-- `catalog/*`: built-in component renderers (Stack, Card, CardHeader,
-  TextContent, Separator, Button, Buttons, Tag).
+- `catalog/*`: built-in component renderers (Stack, Row, Column, List, Card,
+  CardHeader, Text, TextContent, Separator, Divider, Button, Buttons, Tag,
+  Image, Icon, Video, AudioPlayer, Loading, Tabs, Modal, CheckBox,
+  RadioGroup, ChoicePicker, Slider, TextField, DateTimeInput).
 
 ## Exports
 

--- a/packages/genui/openui/src/catalog/AudioPlayer/index.tsx
+++ b/packages/genui/openui/src/catalog/AudioPlayer/index.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { defineComponent } from '../../core/library.jsx';
+import { stringLikeSchema, stringifyValue } from '../utils.js';
+
+export const AudioPlayer = defineComponent({
+  name: 'AudioPlayer',
+  props: z.object({
+    url: stringLikeSchema,
+    description: stringLikeSchema.optional(),
+  }),
+  description: 'Audio attachment placeholder with URL and description.',
+  component: ({ props }) => {
+    const description = stringifyValue(props.description);
+    const url = stringifyValue(props.url);
+
+    return (
+      <view className='OpenUIAudio'>
+        <view className='OpenUIAudioIcon'>
+          <text className='OpenUIAudioIconText'>music_note</text>
+        </view>
+        <view className='OpenUIAudioContent'>
+          <text className='OpenUIAudioTitle'>{description || 'Audio'}</text>
+          {url ? <text className='OpenUIAudioUrl'>{url}</text> : null}
+        </view>
+      </view>
+    );
+  },
+});

--- a/packages/genui/openui/src/catalog/CheckBox/index.tsx
+++ b/packages/genui/openui/src/catalog/CheckBox/index.tsx
@@ -5,12 +5,12 @@ import type { ActionPlan } from '@openuidev/lang-core';
 import { BuiltinActionType } from '@openuidev/lang-core';
 import { z } from 'zod/v4';
 
-import { Checkbox, CheckboxIndicator } from '@lynx-js/lynx-ui';
 import { useEffect, useRef, useState } from '@lynx-js/react';
 
 import {
   useFormName,
   useGetFieldValue,
+  useIsStreaming,
   useSetDefaultValue,
   useSetFieldValue,
   useTriggerAction,
@@ -36,6 +36,7 @@ export const CheckBox = defineComponent({
   component: ({ props }) => {
     const triggerAction = useTriggerAction();
     const formName = useFormName();
+    const isStreaming = useIsStreaming();
     const getFieldValue = useGetFieldValue();
     const setFieldValue = useSetFieldValue();
     const [checked, setChecked] = useState<boolean>(props.value === true);
@@ -70,7 +71,7 @@ export const CheckBox = defineComponent({
       if (props.name) {
         setFieldValue(formName, 'CheckBox', props.name, next, true);
       }
-      if (!props.action) return;
+      if (isStreaming || !props.action) return;
       if ('steps' in props.action) {
         void triggerAction(props.label, formName, props.action as ActionPlan);
         return;
@@ -88,19 +89,23 @@ export const CheckBox = defineComponent({
         params: actionParams,
       });
     };
+    const onToggle = () => onChange(!checked);
 
     return (
-      <view className='OpenUICheckBoxRow'>
-        <Checkbox
-          checked={checked}
-          onChange={onChange}
-          className='OpenUICheckBoxInput'
+      <view
+        className='OpenUICheckBoxRow'
+        {...(isStreaming ? {} : ({ bindtap: onToggle }))}
+      >
+        <view
+          className={checked
+            ? 'OpenUICheckBoxInput ui-checked'
+            : 'OpenUICheckBoxInput'}
         >
-          <CheckboxIndicator>
-            <text>✓</text>
-          </CheckboxIndicator>
-        </Checkbox>
-        <text className='OpenUICheckBoxLabel'>{props.label}</text>
+          {checked ? <text className='OpenUICheckBoxMark'>✓</text> : null}
+        </view>
+        <view className='OpenUICheckBoxLabelHitbox'>
+          <text className='OpenUICheckBoxLabel'>{props.label}</text>
+        </view>
       </view>
     );
   },

--- a/packages/genui/openui/src/catalog/ChoicePicker/index.tsx
+++ b/packages/genui/openui/src/catalog/ChoicePicker/index.tsx
@@ -1,0 +1,106 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { useEffect, useRef, useState } from '@lynx-js/react';
+
+import { useIsStreaming } from '../../core/context.jsx';
+import { defineComponent } from '../../core/library.jsx';
+import {
+  booleanLikeSchema,
+  booleanValue,
+  isPathBinding,
+  stringLikeSchema,
+  stringifyValue,
+} from '../utils.js';
+
+const choicePickerPropsSchema = z.object({
+  label: stringLikeSchema.optional(),
+  options: z.union([z.array(stringLikeSchema), stringLikeSchema]),
+  value: stringLikeSchema.optional(),
+  variant: z.enum(['default', 'card']).optional(),
+  displayStyle: z.enum(['list', 'chips', 'dropdown']).optional(),
+  filterable: booleanLikeSchema.optional(),
+});
+
+type ChoicePickerProps = z.infer<typeof choicePickerPropsSchema>;
+
+function ChoicePickerRenderer({ props }: { props: ChoicePickerProps }) {
+  const isStreaming = useIsStreaming();
+  const initialSelected = stringifyValue(props.value);
+  const [selected, setSelected] = useState(initialSelected);
+  const dirtyRef = useRef(false);
+  const options = Array.isArray(props.options)
+    ? props.options
+    : [props.options];
+  const displayStyle = props.displayStyle ?? 'chips';
+  const variant = props.variant ?? 'default';
+  const filterable = booleanValue(props.filterable);
+
+  useEffect(() => {
+    if (!dirtyRef.current) {
+      setSelected(stringifyValue(props.value));
+    }
+  }, [props.value]);
+
+  const onSelect = (next: string) => {
+    dirtyRef.current = true;
+    setSelected(next);
+  };
+
+  return (
+    <view
+      className={`OpenUIChoicePicker OpenUIChoicePicker-${displayStyle} OpenUIChoicePicker-${variant}`}
+    >
+      {props.label
+        ? (
+          <text className='OpenUIChoicePickerLabel'>
+            {stringifyValue(props.label)}
+          </text>
+        )
+        : null}
+      {isPathBinding(props.options)
+        ? (
+          <text className='OpenUIChoicePickerHint'>
+            {`options: {path: ${props.options.path}}`}
+          </text>
+        )
+        : null}
+      {filterable === null || filterable === undefined
+        ? null
+        : (
+          <text className='OpenUIChoicePickerHint'>
+            {`filterable: ${filterable ? 'true' : 'false'}`}
+          </text>
+        )}
+      <view className='OpenUIChoicePickerOptions'>
+        {options.map((option, index) => {
+          const value = stringifyValue(option);
+          const active = value === selected;
+          return (
+            <view
+              key={`${value}-${index}`}
+              className={active
+                ? 'OpenUIChoiceItem OpenUIChoiceItemSelected'
+                : 'OpenUIChoiceItem'}
+              {...(isStreaming || !value
+                ? {}
+                : ({ bindtap: () => onSelect(value) }))}
+            >
+              <text className='OpenUIChoiceItemText'>{value}</text>
+            </view>
+          );
+        })}
+      </view>
+    </view>
+  );
+}
+
+export const ChoicePicker = defineComponent({
+  name: 'ChoicePicker',
+  props: choicePickerPropsSchema,
+  description:
+    'Choice picker rendered as selectable chips, list items, or a dropdown-like field.',
+  component: ChoicePickerRenderer,
+});

--- a/packages/genui/openui/src/catalog/Column/index.tsx
+++ b/packages/genui/openui/src/catalog/Column/index.tsx
@@ -1,0 +1,53 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { defineComponent } from '../../core/library.jsx';
+import {
+  GAP_CLASS,
+  asArray,
+  getAlignClass,
+  getJustifyClass,
+} from '../utils.js';
+
+const columnPropsSchema = z.object({
+  children: z.array(z.any()),
+  justify: z.enum([
+    'start',
+    'center',
+    'end',
+    'between',
+    'around',
+    'evenly',
+    'spaceBetween',
+    'spaceAround',
+    'spaceEvenly',
+    'stretch',
+  ]).optional(),
+  align: z.enum(['start', 'center', 'end', 'stretch']).optional(),
+  gap: z.enum(['none', 'xs', 's', 'm', 'l', 'xl']).optional(),
+});
+
+export const Column = defineComponent({
+  name: 'Column',
+  props: columnPropsSchema,
+  description: 'Vertical flex layout container.',
+  component: ({ props, renderNode }) => {
+    const gap = props.gap ?? 'm';
+    const className = [
+      'OpenUIColumn',
+      'OpenUIStack',
+      'OpenUIStackColumn',
+      GAP_CLASS[gap] ?? GAP_CLASS['m'],
+      getAlignClass(props.align ?? 'stretch'),
+      getJustifyClass(props.justify ?? 'start'),
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <view className={className}>{renderNode(asArray(props.children))}</view>
+    );
+  },
+});

--- a/packages/genui/openui/src/catalog/DateTimeInput/index.tsx
+++ b/packages/genui/openui/src/catalog/DateTimeInput/index.tsx
@@ -1,0 +1,63 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { defineComponent } from '../../core/library.jsx';
+import {
+  booleanLikeSchema,
+  booleanValue,
+  stringLikeSchema,
+  stringifyValue,
+} from '../utils.js';
+
+const dateTimeInputPropsSchema = z.object({
+  value: stringLikeSchema,
+  enableDate: booleanLikeSchema.optional(),
+  enableTime: booleanLikeSchema.optional(),
+  min: stringLikeSchema.optional(),
+  max: stringLikeSchema.optional(),
+  label: stringLikeSchema.optional(),
+});
+
+export const DateTimeInput = defineComponent({
+  name: 'DateTimeInput',
+  props: dateTimeInputPropsSchema,
+  description:
+    'Date/time value display with optional label, min/max, and enabled date/time hints.',
+  component: ({ props }) => {
+    const enableDate = booleanValue(props.enableDate);
+    const enableTime = booleanValue(props.enableTime);
+    const min = stringifyValue(props.min);
+    const max = stringifyValue(props.max);
+
+    return (
+      <view className='OpenUIDateTimeInput'>
+        {props.label
+          ? (
+            <text className='OpenUIDateTimeLabel'>
+              {stringifyValue(props.label)}
+            </text>
+          )
+          : null}
+        <text className='OpenUIDateTimeValue'>
+          {stringifyValue(props.value)}
+        </text>
+        <text className='OpenUIDateTimeHint'>
+          {`enableDate=${
+            enableDate === null ? '-' : (enableDate ? 'true' : 'false')
+          }, enableTime=${
+            enableTime === null ? '-' : (enableTime ? 'true' : 'false')
+          }`}
+        </text>
+        {min || max
+          ? (
+            <text className='OpenUIDateTimeHint'>
+              {`min=${min || '-'}, max=${max || '-'}`}
+            </text>
+          )
+          : null}
+      </view>
+    );
+  },
+});

--- a/packages/genui/openui/src/catalog/Divider/index.tsx
+++ b/packages/genui/openui/src/catalog/Divider/index.tsx
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { defineComponent } from '../../core/library.jsx';
+
+export const Divider = defineComponent({
+  name: 'Divider',
+  props: z.object({
+    axis: z.enum(['horizontal', 'vertical']).optional(),
+  }),
+  description: 'Horizontal or vertical divider.',
+  component: ({ props }) => {
+    const axis = props.axis === 'vertical' ? 'Vertical' : 'Horizontal';
+    return <view className={`OpenUIDivider OpenUIDivider${axis}`} />;
+  },
+});

--- a/packages/genui/openui/src/catalog/List/index.tsx
+++ b/packages/genui/openui/src/catalog/List/index.tsx
@@ -1,0 +1,79 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { Fragment } from '@lynx-js/react';
+import type { ReactNode } from '@lynx-js/react';
+
+import { defineComponent } from '../../core/library.jsx';
+import {
+  GAP_CLASS,
+  asArray,
+  getAlignClass,
+  isTemplateChildren,
+  templateChildrenSchema,
+} from '../utils.js';
+
+const listChildrenSchema = z.union([z.array(z.any()), templateChildrenSchema]);
+
+const listPropsSchema = z.object({
+  children: listChildrenSchema.optional(),
+  items: listChildrenSchema.optional(),
+  direction: z.enum(['vertical', 'horizontal']).optional(),
+  align: z.enum(['start', 'center', 'end', 'stretch']).optional(),
+  gap: z.enum(['none', 'xs', 's', 'm', 'l', 'xl']).optional(),
+  divider: z.boolean().optional(),
+});
+
+function renderTemplateHint(children: { componentId: string; path: string }) {
+  return (
+    <view className='OpenUIList'>
+      <text className='OpenUIListTemplateHint'>
+        {`TemplateChildren(componentId=${children.componentId}, path=${children.path})`}
+      </text>
+    </view>
+  );
+}
+
+export const List = defineComponent({
+  name: 'List',
+  props: listPropsSchema,
+  description:
+    'List container for repeated children. Supports vertical or horizontal layout.',
+  component: ({ props, renderNode }) => {
+    const children = props.children ?? props.items ?? [];
+
+    if (isTemplateChildren(children)) {
+      return renderTemplateHint(children);
+    }
+
+    const direction = props.direction ?? 'vertical';
+    const gap = props.gap ?? 'm';
+    const items = asArray(children);
+    const dividerClassName = direction === 'horizontal'
+      ? 'OpenUIListDivider OpenUIListDividerVertical'
+      : 'OpenUIListDivider OpenUIListDividerHorizontal';
+    const className = [
+      'OpenUIList',
+      direction === 'horizontal' ? 'OpenUIStackRow' : 'OpenUIStackColumn',
+      GAP_CLASS[gap] ?? GAP_CLASS['m'],
+      getAlignClass(props.align ?? 'stretch'),
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <view className={className}>
+        {items.map((item: unknown, index: number): ReactNode => (
+          <Fragment key={index}>
+            {props.divider && index > 0
+              ? <view className={dividerClassName} />
+              : null}
+            {renderNode(item)}
+          </Fragment>
+        ))}
+      </view>
+    );
+  },
+});

--- a/packages/genui/openui/src/catalog/Modal/index.tsx
+++ b/packages/genui/openui/src/catalog/Modal/index.tsx
@@ -1,0 +1,112 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { useMemo, useState } from '@lynx-js/react';
+import type { ReactNode } from '@lynx-js/react';
+
+import {
+  OpenUIContext,
+  useIsStreaming,
+  useOpenUI,
+} from '../../core/context.jsx';
+import { defineComponent } from '../../core/library.jsx';
+import { stringLikeSchema, stringifyValue } from '../utils.js';
+
+const modalPropsSchema = z.object({
+  trigger: z.any(),
+  content: z.any(),
+  title: stringLikeSchema.optional(),
+  closeOnAction: z.boolean().optional(),
+});
+
+type ModalProps = z.infer<typeof modalPropsSchema>;
+
+function ModalRenderer(
+  { props, renderNode }: {
+    props: ModalProps;
+    renderNode: (v: unknown) => ReactNode;
+  },
+) {
+  const [open, setOpen] = useState(false);
+  const openUi = useOpenUI();
+  const isStreaming = useIsStreaming();
+  const closeOnAction = props.closeOnAction ?? true;
+  const onOpen = () => setOpen(true);
+  const onClose = () => setOpen(false);
+  const triggerContext = useMemo(
+    () => ({
+      ...openUi,
+      triggerAction: async (
+        ...args: Parameters<typeof openUi.triggerAction>
+      ) => {
+        await openUi.triggerAction(...args);
+        setOpen(true);
+      },
+    }),
+    [openUi],
+  );
+  const contentContext = useMemo(
+    () => ({
+      ...openUi,
+      triggerAction: async (
+        ...args: Parameters<typeof openUi.triggerAction>
+      ) => {
+        await openUi.triggerAction(...args);
+        if (closeOnAction) {
+          setOpen(false);
+        }
+      },
+    }),
+    [openUi, closeOnAction],
+  );
+
+  return (
+    <view className='OpenUIModal'>
+      <OpenUIContext.Provider value={triggerContext}>
+        <view
+          className='OpenUIModalTrigger'
+          {...(isStreaming ? {} : ({ bindtap: onOpen }))}
+        >
+          {renderNode(props.trigger)}
+        </view>
+      </OpenUIContext.Provider>
+      {open
+        ? (
+          <view className='OpenUIModalMask'>
+            <view className='OpenUIModalContent'>
+              <view className='OpenUIModalHeader'>
+                {props.title
+                  ? (
+                    <text className='OpenUIModalTitle'>
+                      {stringifyValue(props.title)}
+                    </text>
+                  )
+                  : null}
+                <view
+                  className='OpenUIModalClose'
+                  {...(isStreaming ? {} : ({ bindtap: onClose }))}
+                >
+                  <text className='OpenUIModalCloseText'>x</text>
+                </view>
+              </view>
+              <OpenUIContext.Provider value={contentContext}>
+                <view className='OpenUIModalBody'>
+                  {renderNode(props.content)}
+                </view>
+              </OpenUIContext.Provider>
+            </view>
+          </view>
+        )
+        : null}
+    </view>
+  );
+}
+
+export const Modal = defineComponent({
+  name: 'Modal',
+  props: modalPropsSchema,
+  description: 'Tap-triggered modal container with custom content.',
+  component: ModalRenderer,
+});

--- a/packages/genui/openui/src/catalog/Row/index.tsx
+++ b/packages/genui/openui/src/catalog/Row/index.tsx
@@ -1,0 +1,55 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { defineComponent } from '../../core/library.jsx';
+import {
+  GAP_CLASS,
+  asArray,
+  getAlignClass,
+  getJustifyClass,
+} from '../utils.js';
+
+const rowPropsSchema = z.object({
+  children: z.array(z.any()),
+  justify: z.enum([
+    'start',
+    'center',
+    'end',
+    'between',
+    'around',
+    'evenly',
+    'spaceBetween',
+    'spaceAround',
+    'spaceEvenly',
+    'stretch',
+  ]).optional(),
+  align: z.enum(['start', 'center', 'end', 'stretch']).optional(),
+  gap: z.enum(['none', 'xs', 's', 'm', 'l', 'xl']).optional(),
+  wrap: z.boolean().optional(),
+});
+
+export const Row = defineComponent({
+  name: 'Row',
+  props: rowPropsSchema,
+  description: 'Horizontal flex layout container.',
+  component: ({ props, renderNode }) => {
+    const gap = props.gap ?? 'm';
+    const className = [
+      'OpenUIRow',
+      'OpenUIStack',
+      'OpenUIStackRow',
+      props.wrap ? 'OpenUIStackWrap' : '',
+      GAP_CLASS[gap] ?? GAP_CLASS['m'],
+      getAlignClass(props.align ?? 'center'),
+      getJustifyClass(props.justify ?? 'start'),
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <view className={className}>{renderNode(asArray(props.children))}</view>
+    );
+  },
+});

--- a/packages/genui/openui/src/catalog/Tabs/index.tsx
+++ b/packages/genui/openui/src/catalog/Tabs/index.tsx
@@ -1,0 +1,88 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { useEffect, useRef, useState } from '@lynx-js/react';
+import type { ReactNode } from '@lynx-js/react';
+
+import { useIsStreaming } from '../../core/context.jsx';
+import { defineComponent } from '../../core/library.jsx';
+import { stringLikeSchema, stringifyValue } from '../utils.js';
+
+const tabSchema = z.object({
+  value: z.string(),
+  title: stringLikeSchema,
+  child: z.any(),
+});
+
+const tabsPropsSchema = z.object({
+  tabs: z.array(tabSchema),
+  value: z.string().optional(),
+});
+
+type TabsProps = z.infer<typeof tabsPropsSchema>;
+
+function TabsRenderer(
+  { props, renderNode }: {
+    props: TabsProps;
+    renderNode: (v: unknown) => ReactNode;
+  },
+) {
+  const isStreaming = useIsStreaming();
+  const firstValue = props.tabs[0]?.value ?? '';
+  const [active, setActive] = useState(props.value ?? firstValue);
+  const dirtyRef = useRef(false);
+
+  useEffect(() => {
+    if (!dirtyRef.current) {
+      setActive(props.value ?? firstValue);
+    }
+  }, [firstValue, props.value]);
+
+  if (!props.tabs.length) return null;
+
+  const activeTab = props.tabs.find((tab) => tab.value === active)
+    ?? props.tabs[0];
+
+  const onSelect = (value: string) => {
+    dirtyRef.current = true;
+    setActive(value);
+  };
+
+  return (
+    <view className='OpenUITabs'>
+      <view className='OpenUITabList'>
+        {props.tabs.map((tab) => {
+          const selected = tab.value === activeTab?.value;
+          return (
+            <view
+              key={tab.value}
+              className={selected
+                ? 'OpenUITabTrigger OpenUITabTriggerActive'
+                : 'OpenUITabTrigger OpenUITabTriggerInactive'}
+              {...(isStreaming
+                ? {}
+                : ({ bindtap: () => onSelect(tab.value) }))}
+            >
+              <text className='OpenUITabTriggerText'>
+                {stringifyValue(tab.title) || tab.value}
+              </text>
+            </view>
+          );
+        })}
+      </view>
+      <view className='OpenUITabBody'>
+        {activeTab ? renderNode(activeTab.child) : null}
+      </view>
+    </view>
+  );
+}
+
+export const Tabs = defineComponent({
+  name: 'Tabs',
+  props: tabsPropsSchema,
+  description:
+    'Tabbed content switcher. Each tab has value, title, and child content.',
+  component: TabsRenderer,
+});

--- a/packages/genui/openui/src/catalog/Text/index.tsx
+++ b/packages/genui/openui/src/catalog/Text/index.tsx
@@ -1,0 +1,53 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { defineComponent } from '../../core/library.jsx';
+import { stringLikeSchema, stringifyValue } from '../utils.js';
+
+const textVariants = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'caption',
+  'body',
+] as const;
+
+function getVariantClass(variant: typeof textVariants[number]): string {
+  switch (variant) {
+    case 'h1':
+      return 'OpenUITextH1';
+    case 'h2':
+      return 'OpenUITextH2';
+    case 'h3':
+      return 'OpenUITextH3';
+    case 'h4':
+      return 'OpenUITextH4';
+    case 'h5':
+      return 'OpenUITextH5';
+    case 'caption':
+      return 'OpenUITextCaption';
+    default:
+      return 'OpenUITextBody';
+  }
+}
+
+export const Text = defineComponent({
+  name: 'Text',
+  props: z.object({
+    text: stringLikeSchema,
+    variant: z.enum(textVariants).optional(),
+  }),
+  description: 'Plain text with display variants.',
+  component: ({ props }) => {
+    const variant = props.variant ?? 'body';
+    return (
+      <text className={`OpenUIText ${getVariantClass(variant)}`}>
+        {stringifyValue(props.text)}
+      </text>
+    );
+  },
+});

--- a/packages/genui/openui/src/catalog/Video/index.tsx
+++ b/packages/genui/openui/src/catalog/Video/index.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
+import { defineComponent } from '../../core/library.jsx';
+import { stringLikeSchema, stringifyValue } from '../utils.js';
+
+export const Video = defineComponent({
+  name: 'Video',
+  props: z.object({
+    url: stringLikeSchema,
+    title: stringLikeSchema.optional(),
+  }),
+  description: 'Video attachment placeholder with URL.',
+  component: ({ props }) => {
+    const title = stringifyValue(props.title) || 'Video';
+    const url = stringifyValue(props.url);
+
+    return (
+      <view className='OpenUIVideo'>
+        <view className='OpenUIVideoPoster'>
+          <text className='OpenUIVideoPlay'>play_arrow</text>
+        </view>
+        <view className='OpenUIVideoMeta'>
+          <text className='OpenUIVideoTitle'>{title}</text>
+          {url ? <text className='OpenUIVideoUrl'>{url}</text> : null}
+        </view>
+      </view>
+    );
+  },
+});

--- a/packages/genui/openui/src/catalog/index.ts
+++ b/packages/genui/openui/src/catalog/index.ts
@@ -1,17 +1,28 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+export { AudioPlayer } from './AudioPlayer/index.jsx';
 export { Button, Buttons } from './Button/index.jsx';
 export { Card } from './Card/index.jsx';
 export { CardHeader } from './CardHeader/index.jsx';
 export { CheckBox } from './CheckBox/index.jsx';
+export { ChoicePicker } from './ChoicePicker/index.jsx';
+export { Column } from './Column/index.jsx';
+export { DateTimeInput } from './DateTimeInput/index.jsx';
+export { Divider } from './Divider/index.jsx';
 export { Icon } from './Icon/index.jsx';
 export { Image } from './Image/index.jsx';
+export { List } from './List/index.jsx';
 export { Loading } from './Loading/index.jsx';
+export { Modal } from './Modal/index.jsx';
 export { RadioGroup } from './RadioGroup/index.jsx';
+export { Row } from './Row/index.jsx';
 export { Separator } from './Separator/index.jsx';
 export { Slider } from './Slider/index.jsx';
 export { Stack } from './Stack/index.jsx';
+export { Tabs } from './Tabs/index.jsx';
 export { Tag } from './Tag/index.jsx';
+export { Text } from './Text/index.jsx';
 export { TextContent } from './TextContent/index.jsx';
 export { TextField } from './TextField/index.jsx';
+export { Video } from './Video/index.jsx';

--- a/packages/genui/openui/src/catalog/utils.ts
+++ b/packages/genui/openui/src/catalog/utils.ts
@@ -1,6 +1,8 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { z } from 'zod/v4';
+
 export const GAP_CLASS: Record<string, string> = {
   none: 'OpenUIGapNone',
   xs: 'OpenUIGapXs',
@@ -13,4 +15,112 @@ export const GAP_CLASS: Record<string, string> = {
 export function asArray<T>(value: T | T[] | null | undefined): T[] {
   if (value === null || value === undefined) return [];
   return Array.isArray(value) ? value : [value];
+}
+
+export const pathBindingSchema = z.object({
+  path: z.string(),
+});
+
+export const stringLikeSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  pathBindingSchema,
+]);
+
+export const booleanLikeSchema = z.union([
+  z.boolean(),
+  pathBindingSchema,
+]);
+
+export const templateChildrenSchema = z.object({
+  componentId: z.string(),
+  path: z.string(),
+});
+
+export type StringLike = z.infer<typeof stringLikeSchema>;
+
+export function isPathBinding(value: unknown): value is { path: string } {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && typeof (value as { path?: unknown }).path === 'string'
+  );
+}
+
+export function isTemplateChildren(
+  value: unknown,
+): value is { componentId: string; path: string } {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && typeof (value as { componentId?: unknown }).componentId === 'string'
+    && typeof (value as { path?: unknown }).path === 'string'
+  );
+}
+
+export function stringifyValue(value: unknown): string {
+  if (isPathBinding(value)) return `{path: ${value.path}}`;
+  if (
+    typeof value === 'string' || typeof value === 'number'
+    || typeof value === 'boolean'
+  ) {
+    return String(value);
+  }
+  return '';
+}
+
+export function booleanValue(value: unknown): boolean | null {
+  if (typeof value === 'boolean') return value;
+  return null;
+}
+
+export function getAlignClass(
+  align: 'start' | 'center' | 'end' | 'stretch' | undefined,
+): string {
+  switch (align) {
+    case 'start':
+      return 'OpenUIAlignStart';
+    case 'center':
+      return 'OpenUIAlignCenter';
+    case 'end':
+      return 'OpenUIAlignEnd';
+    default:
+      return 'OpenUIAlignStretch';
+  }
+}
+
+export function getJustifyClass(
+  justify:
+    | 'start'
+    | 'center'
+    | 'end'
+    | 'between'
+    | 'around'
+    | 'evenly'
+    | 'spaceBetween'
+    | 'spaceAround'
+    | 'spaceEvenly'
+    | 'stretch'
+    | undefined,
+): string {
+  switch (justify) {
+    case 'center':
+      return 'OpenUIJustifyCenter';
+    case 'end':
+      return 'OpenUIJustifyEnd';
+    case 'between':
+    case 'spaceBetween':
+      return 'OpenUIJustifyBetween';
+    case 'around':
+    case 'spaceAround':
+      return 'OpenUIJustifyAround';
+    case 'evenly':
+    case 'spaceEvenly':
+      return 'OpenUIJustifyEvenly';
+    case 'stretch':
+      return 'OpenUIJustifyStretch';
+    default:
+      return 'OpenUIJustifyStart';
+  }
 }

--- a/packages/genui/openui/src/core/createLibrary.tsx
+++ b/packages/genui/openui/src/core/createLibrary.tsx
@@ -19,33 +19,62 @@ export interface CreateOpenUiLibraryOptions {
 
 const DEFAULT_COMPONENTS: DefinedComponent<any>[] = [
   c.Stack,
+  c.Row,
+  c.Column,
+  c.List,
   c.Card,
   c.CardHeader,
+  c.Text,
   c.TextContent,
   c.Separator,
+  c.Divider,
   c.Button,
   c.Buttons,
   c.Tag,
   c.Image,
   c.Icon,
+  c.Video,
+  c.AudioPlayer,
   c.Loading,
+  c.Tabs,
+  c.Modal,
   c.CheckBox,
   c.RadioGroup,
+  c.ChoicePicker,
   c.Slider,
   c.TextField,
+  c.DateTimeInput,
 ];
 
 const DEFAULT_COMPONENT_GROUPS: ComponentGroup[] = [
-  { name: 'Layout', components: ['Stack'] },
+  { name: 'Layout', components: ['Stack', 'Row', 'Column', 'List'] },
   {
     name: 'Content',
-    components: ['Card', 'CardHeader', 'TextContent', 'Separator'],
+    components: [
+      'Card',
+      'CardHeader',
+      'Text',
+      'TextContent',
+      'Separator',
+      'Divider',
+    ],
   },
   { name: 'Buttons', components: ['Button', 'Buttons'] },
-  { name: 'Data Display', components: ['Tag', 'Image', 'Icon', 'Loading'] },
+  {
+    name: 'Data Display',
+    components: ['Tag', 'Image', 'Icon', 'Video', 'AudioPlayer', 'Loading'],
+  },
+  { name: 'Overlays', components: ['Tabs', 'Modal'] },
   {
     name: 'Inputs',
-    components: ['CheckBox', 'RadioGroup', 'Slider', 'TextField'],
+    components: [
+      'CheckBox',
+      'RadioGroup',
+      'ChoicePicker',
+      'Slider',
+      'TextField',
+      'DateTimeInput',
+    ],
   },
 ];
 

--- a/packages/genui/openui/src/core/renderer.css
+++ b/packages/genui/openui/src/core/renderer.css
@@ -117,6 +117,18 @@
   justify-content: space-between;
 }
 
+.OpenUIJustifyAround {
+  justify-content: space-around;
+}
+
+.OpenUIJustifyEvenly {
+  justify-content: space-evenly;
+}
+
+.OpenUIJustifyStretch {
+  justify-content: stretch;
+}
+
 /* ===== Card ===== */
 .OpenUICard {
   width: 100%;
@@ -480,6 +492,8 @@
 
 /* ===== CheckBox ===== */
 .OpenUICheckBoxRow {
+  width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -507,6 +521,24 @@
 .OpenUICheckBoxInput.ui-checked {
   background-color: rgba(59, 130, 246, 1);
   border-color: rgba(59, 130, 246, 1);
+}
+
+.OpenUICheckBoxMark {
+  color: #ffffff;
+  font-size: 24rpx;
+  line-height: 1;
+  font-weight: 800;
+  opacity: 0;
+}
+
+.OpenUICheckBoxInput.ui-checked .OpenUICheckBoxMark {
+  opacity: 1;
+}
+
+.OpenUICheckBoxLabelHitbox {
+  flex: 1;
+  min-width: 0;
+  padding: 4rpx 0;
 }
 
 .dark .OpenUICheckBoxInput {
@@ -795,4 +827,516 @@
 
 .dark .OpenUITextFieldError {
   color: rgba(248, 113, 113, 1);
+}
+
+/* ===== Row / Column / List ===== */
+.OpenUIRow,
+.OpenUIColumn,
+.OpenUIList {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+}
+
+.OpenUIListTemplateHint {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 22rpx;
+  line-height: 32rpx;
+}
+
+.OpenUIListDivider {
+  flex-shrink: 0;
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.OpenUIListDividerHorizontal {
+  width: 100%;
+  height: 1rpx;
+}
+
+.OpenUIListDividerVertical {
+  width: 1rpx;
+  min-height: 36rpx;
+  align-self: stretch;
+}
+
+.dark .OpenUIListTemplateHint {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.dark .OpenUIListDivider {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+/* ===== Text ===== */
+.OpenUIText {
+  color: rgba(0, 0, 0, 0.84);
+  line-height: 1.4;
+}
+
+.OpenUITextH1 {
+  font-size: 40rpx;
+  font-weight: 800;
+}
+
+.OpenUITextH2 {
+  font-size: 36rpx;
+  font-weight: 780;
+}
+
+.OpenUITextH3 {
+  font-size: 32rpx;
+  font-weight: 720;
+}
+
+.OpenUITextH4 {
+  font-size: 30rpx;
+  font-weight: 680;
+}
+
+.OpenUITextH5 {
+  font-size: 28rpx;
+  font-weight: 640;
+}
+
+.OpenUITextCaption {
+  color: rgba(0, 0, 0, 0.5);
+  font-size: 22rpx;
+}
+
+.OpenUITextBody {
+  font-size: 26rpx;
+}
+
+.dark .OpenUIText {
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.dark .OpenUITextCaption {
+  color: rgba(255, 255, 255, 0.58);
+}
+
+/* ===== Divider ===== */
+.OpenUIDivider {
+  flex-shrink: 0;
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+.OpenUIDividerHorizontal {
+  width: 100%;
+  height: 1rpx;
+}
+
+.OpenUIDividerVertical {
+  width: 1rpx;
+  min-height: 48rpx;
+  align-self: stretch;
+}
+
+.dark .OpenUIDivider {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+/* ===== Tabs ===== */
+.OpenUITabs {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+}
+
+.OpenUITabList {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8rpx;
+  padding-bottom: 4rpx;
+}
+
+.OpenUITabTrigger {
+  padding: 9rpx 14rpx;
+  border-radius: 999rpx;
+  border-width: 1rpx;
+  border-style: solid;
+}
+
+.OpenUITabTriggerActive {
+  background-color: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.28);
+}
+
+.OpenUITabTriggerInactive {
+  background-color: rgba(0, 0, 0, 0.035);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+.OpenUITabTriggerText {
+  color: rgba(0, 0, 0, 0.82);
+  font-size: 24rpx;
+  font-weight: 650;
+}
+
+.OpenUITabBody {
+  width: 100%;
+  min-width: 0;
+}
+
+.dark .OpenUITabTriggerActive {
+  background-color: rgba(96, 165, 250, 0.2);
+  border-color: rgba(96, 165, 250, 0.32);
+}
+
+.dark .OpenUITabTriggerInactive {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.dark .OpenUITabTriggerText {
+  color: rgba(255, 255, 255, 0.88);
+}
+
+/* ===== ChoicePicker ===== */
+.OpenUIChoicePicker {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10rpx;
+}
+
+.OpenUIChoicePickerLabel {
+  color: rgba(0, 0, 0, 0.58);
+  font-size: 26rpx;
+  font-weight: 650;
+  line-height: 1.5;
+}
+
+.OpenUIChoicePickerHint {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 22rpx;
+  line-height: 1.4;
+}
+
+.OpenUIChoicePickerOptions {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 10rpx;
+}
+
+.OpenUIChoicePicker-list .OpenUIChoicePickerOptions,
+.OpenUIChoicePicker-dropdown .OpenUIChoicePickerOptions {
+  flex-direction: column;
+}
+
+.OpenUIChoiceItem {
+  padding: 10rpx 14rpx;
+  border-radius: 12rpx;
+  border-width: 1rpx;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.035);
+}
+
+.OpenUIChoicePicker-card .OpenUIChoiceItem {
+  border-radius: 16rpx;
+  padding: 14rpx 16rpx;
+}
+
+.OpenUIChoiceItemSelected {
+  border-color: rgba(59, 130, 246, 0.42);
+  background-color: rgba(59, 130, 246, 0.12);
+}
+
+.OpenUIChoiceItemText {
+  color: rgba(0, 0, 0, 0.82);
+  font-size: 24rpx;
+  font-weight: 560;
+}
+
+.dark .OpenUIChoicePickerLabel {
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.dark .OpenUIChoicePickerHint {
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.dark .OpenUIChoiceItem {
+  border-color: rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.dark .OpenUIChoiceItemSelected {
+  border-color: rgba(96, 165, 250, 0.36);
+  background-color: rgba(96, 165, 250, 0.18);
+}
+
+.dark .OpenUIChoiceItemText {
+  color: rgba(255, 255, 255, 0.88);
+}
+
+/* ===== Modal ===== */
+.OpenUIModal {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10rpx;
+}
+
+.OpenUIModalTrigger {
+  width: 100%;
+}
+
+.OpenUIModalMask {
+  width: 100%;
+  min-width: 0;
+  padding: 10rpx 0 0;
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-start;
+}
+
+.OpenUIModalContent {
+  width: 100%;
+  min-width: 0;
+  padding: 16rpx;
+  border-radius: 16rpx;
+  border-width: 1rpx;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.08);
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 14rpx;
+}
+
+.OpenUIModalHeader {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12rpx;
+}
+
+.OpenUIModalTitle {
+  min-width: 0;
+  color: rgba(0, 0, 0, 0.88);
+  font-size: 28rpx;
+  font-weight: 700;
+}
+
+.OpenUIModalClose {
+  width: 40rpx;
+  height: 40rpx;
+  border-radius: 999rpx;
+  background-color: rgba(0, 0, 0, 0.05);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.OpenUIModalCloseText {
+  color: rgba(0, 0, 0, 0.72);
+  font-size: 24rpx;
+  font-weight: 700;
+}
+
+.OpenUIModalBody {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+}
+
+.dark .OpenUIModalMask {
+  background-color: transparent;
+}
+
+.dark .OpenUIModalContent {
+  background-color: #171717;
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.dark .OpenUIModalTitle {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.dark .OpenUIModalClose {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.dark .OpenUIModalCloseText {
+  color: rgba(255, 255, 255, 0.86);
+}
+
+/* ===== DateTimeInput ===== */
+.OpenUIDateTimeInput {
+  width: 100%;
+  min-width: 0;
+  padding: 14rpx 16rpx;
+  border-radius: 14rpx;
+  border-width: 1rpx;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(0, 0, 0, 0.025);
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+}
+
+.OpenUIDateTimeLabel {
+  color: rgba(0, 0, 0, 0.55);
+  font-size: 24rpx;
+  font-weight: 650;
+}
+
+.OpenUIDateTimeValue {
+  color: rgba(0, 0, 0, 0.88);
+  font-size: 28rpx;
+  font-weight: 650;
+}
+
+.OpenUIDateTimeHint {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 22rpx;
+  line-height: 1.4;
+}
+
+.dark .OpenUIDateTimeInput {
+  border-color: rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.dark .OpenUIDateTimeLabel {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.dark .OpenUIDateTimeValue {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.dark .OpenUIDateTimeHint {
+  color: rgba(255, 255, 255, 0.48);
+}
+
+/* ===== Media ===== */
+.OpenUIAudio,
+.OpenUIVideo {
+  width: 100%;
+  min-width: 0;
+  border-radius: 16rpx;
+  border-width: 1rpx;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.08);
+  background-color: rgba(0, 0, 0, 0.025);
+}
+
+.OpenUIAudio {
+  padding: 14rpx;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12rpx;
+}
+
+.OpenUIAudioIcon {
+  width: 44rpx;
+  height: 44rpx;
+  border-radius: 999rpx;
+  background-color: rgba(59, 130, 246, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.OpenUIAudioIconText {
+  font-family: "Material Icons Round";
+  color: rgba(59, 130, 246, 1);
+  font-size: 28rpx;
+  line-height: 1;
+}
+
+.OpenUIAudioContent,
+.OpenUIVideoMeta {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4rpx;
+}
+
+.OpenUIAudioTitle,
+.OpenUIVideoTitle {
+  color: rgba(0, 0, 0, 0.86);
+  font-size: 26rpx;
+  font-weight: 650;
+}
+
+.OpenUIAudioUrl,
+.OpenUIVideoUrl {
+  color: rgba(0, 0, 0, 0.48);
+  font-size: 22rpx;
+  line-height: 1.4;
+}
+
+.OpenUIVideo {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.OpenUIVideoPoster {
+  width: 100%;
+  height: 180rpx;
+  background-color: rgba(15, 23, 42, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.OpenUIVideoPlay {
+  font-family: "Material Icons Round";
+  color: rgba(15, 23, 42, 0.62);
+  font-size: 56rpx;
+  line-height: 1;
+}
+
+.OpenUIVideoMeta {
+  padding: 14rpx;
+}
+
+.dark .OpenUIAudio,
+.dark .OpenUIVideo {
+  border-color: rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.dark .OpenUIAudioIcon {
+  background-color: rgba(96, 165, 250, 0.2);
+}
+
+.dark .OpenUIAudioIconText {
+  color: rgba(96, 165, 250, 1);
+}
+
+.dark .OpenUIAudioTitle,
+.dark .OpenUIVideoTitle {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.dark .OpenUIAudioUrl,
+.dark .OpenUIVideoUrl {
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.dark .OpenUIVideoPoster {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.dark .OpenUIVideoPlay {
+  color: rgba(255, 255, 255, 0.72);
 }


### PR DESCRIPTION
## Summary
- add a larger OpenUI catalog surface, including layout, media, modal, tabs, text, and picker components
- expand the OpenUI playground docs and scenarios with new showcase examples
- remove the `New` badge from the new OpenUI example cards in the examples list

## Why
- the OpenUI catalog in `packages/genui/openui` was missing several components already implemented in the reference app
- the playground needed richer examples so the new catalog entries are easier to inspect and demo
- the examples list no longer needs the temporary `New` marker once these demos are part of the standard showcase set

## Validation
- `pnpm exec dprint check ...`
- `git diff --check`
- `pnpm turbo build --filter a2ui-playground --filter @lynx-js/genui-openui`
- verified in the in-app browser that the OpenUI examples list no longer shows the `New` badge

## Notes
- leaving this as a draft to keep a little room for final polish and follow-up verification on the newer interactive examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 11 new OpenUI catalog components: Row, Column, List, Text, Divider, Video, AudioPlayer, Tabs, Modal, ChoicePicker, and DateTimeInput
  * Introduced a new **Overlays** category
  * Expanded the interactive playground with three new example scenarios
* **Bug Fixes**
  * Improved streaming behavior for interactive components (e.g., checkbox/tabs now avoid action/selection changes while streaming)
* **Documentation**
  * Updated catalog documentation, examples, and supported component set
<!-- end of auto-generated comment: release notes by coderabbit.ai -->