### PR TITLE
feat(react): add ET list e2e example

### DIFF
--- a/examples/react-et-list/lynx.config.js
+++ b/examples/react-et-list/lynx.config.js
@@ -1,0 +1,26 @@
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx({
+      experimental_useElementTemplate: true,
+    }),
+    pluginQRCode({
+      schema(url) {
+        // We use `?fullscreen=true` to open the page in LynxExplorer in full screen mode
+        return `${url}?fullscreen=true`;
+      },
+    }),
+  ],
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  performance: {
+    profile: enableBundleAnalysis,
+  },
+});

--- a/examples/react-et-list/package.json
+++ b/examples/react-et-list/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@lynx-js/example-react-et-list",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "@lynx-js/react": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
+    "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/types": "3.7.0",
+    "@types/react": "^18.3.28"
+  }
+}

--- a/examples/react-et-list/src/App.css
+++ b/examples/react-et-list/src/App.css
@@ -1,0 +1,86 @@
+:root {
+  background-color: #111318;
+}
+
+.Page {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #111318;
+  padding: 20px;
+}
+
+.Header {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 12px;
+}
+
+.Title {
+  color: #fff;
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.Status {
+  color: #d4d8df;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.Actions {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 12px;
+}
+
+.Action {
+  height: 40px;
+  padding-left: 12px;
+  padding-right: 12px;
+  margin-right: 8px;
+  background-color: #2f6fed;
+  justify-content: center;
+}
+
+.ActionText {
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.Feed {
+  width: 100%;
+  height: 620px;
+  background-color: #1e232b;
+}
+
+.FeedItem {
+  width: 100%;
+  height: 96px;
+  background-color: #f4d35e;
+  border-width: 3px;
+  border-color: #2b8a3e;
+  justify-content: center;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.ItemBody {
+  display: flex;
+  flex-direction: column;
+}
+
+.ItemTitle {
+  color: #101318;
+  font-size: 22px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.ItemMeta {
+  color: #3d424a;
+  font-size: 13px;
+}

--- a/examples/react-et-list/src/App.css
+++ b/examples/react-et-list/src/App.css
@@ -5,10 +5,53 @@
 .Page {
   width: 100vw;
   height: 100vh;
+  background-color: #111318;
+  padding: 18px;
+}
+
+.Shell {
   display: flex;
   flex-direction: column;
-  background-color: #111318;
-  padding: 20px;
+}
+
+.AppTitle {
+  color: #ffffff;
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.Tabs {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 14px;
+}
+
+.Tab {
+  height: 38px;
+  padding-left: 14px;
+  padding-right: 14px;
+  margin-right: 8px;
+  background-color: #242a33;
+  justify-content: center;
+  border-width: 1px;
+  border-color: #3b4655;
+}
+
+.TabActive {
+  background-color: #2f6fed;
+  border-color: #82a9ff;
+}
+
+.TabText {
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.Scenario {
+  display: flex;
+  flex-direction: column;
 }
 
 .Header {
@@ -18,8 +61,8 @@
 }
 
 .Title {
-  color: #fff;
-  font-size: 24px;
+  color: #ffffff;
+  font-size: 21px;
   font-weight: 700;
   margin-bottom: 8px;
 }
@@ -46,26 +89,45 @@
 }
 
 .ActionText {
-  color: #fff;
+  color: #ffffff;
   font-size: 13px;
   font-weight: 600;
 }
 
 .Feed {
   width: 100%;
-  height: 620px;
+  height: 570px;
   background-color: #1e232b;
+}
+
+.CompactFeed {
+  height: 430px;
 }
 
 .FeedItem {
   width: 100%;
   height: 96px;
-  background-color: #f4d35e;
   border-width: 3px;
-  border-color: #2b8a3e;
+  border-color: #19202a;
   justify-content: center;
   padding-left: 16px;
   padding-right: 16px;
+}
+
+.FeedItem-warm {
+  background-color: #f4d35e;
+}
+
+.FeedItem-cool {
+  background-color: #8ecae6;
+}
+
+.FeedItem-mint {
+  background-color: #95d5b2;
+}
+
+.FeedItem-rose {
+  background-color: #ffafcc;
 }
 
 .ItemBody {
@@ -75,12 +137,26 @@
 
 .ItemTitle {
   color: #101318;
-  font-size: 22px;
+  font-size: 21px;
   font-weight: 700;
   margin-bottom: 4px;
 }
 
 .ItemMeta {
-  color: #3d424a;
+  color: #303741;
   font-size: 13px;
+}
+
+.EmptyState {
+  width: 100%;
+  height: 220px;
+  background-color: #202732;
+  align-items: center;
+  justify-content: center;
+}
+
+.EmptyText {
+  color: #d4d8df;
+  font-size: 18px;
+  font-weight: 600;
 }

--- a/examples/react-et-list/src/App.tsx
+++ b/examples/react-et-list/src/App.tsx
@@ -2,12 +2,153 @@ import { useCallback, useRef, useState } from '@lynx-js/react';
 
 import './App.css';
 
-const initialItems = Array.from({ length: 3 }, (_, index) => index + 1);
+type Scenario = 'basic' | 'single-render' | 'recreate';
 
-export function App() {
-  const [items, setItems] = useState(initialItems);
+interface ListCaseItem {
+  id: string;
+  title: string;
+  meta: string;
+  tone: 'warm' | 'cool' | 'mint' | 'rose';
+}
+
+const SCENARIOS: Array<{ id: Scenario; label: string }> = [
+  { id: 'basic', label: 'Basic' },
+  { id: 'single-render', label: 'Single Render' },
+  { id: 'recreate', label: 'Recreate' },
+];
+
+const basicItemCount = 24;
+const initialBasicItems = Array.from(
+  { length: basicItemCount },
+  (_, index) => createBasicItem(index),
+);
+
+const singleRenderInitialItems: ListCaseItem[] = [
+  createLetterItem('A', 'warm'),
+  createLetterItem('B', 'cool'),
+  createLetterItem('C', 'mint'),
+  createLetterItem('D', 'rose'),
+  createLetterItem('E', 'warm'),
+];
+
+const singleRenderNextItems: ListCaseItem[] = [
+  createLetterItem('X', 'rose'),
+  createLetterItem('C', 'mint'),
+  createLetterItem('A', 'warm'),
+  createLetterItem('E', 'cool'),
+  createLetterItem('Y', 'mint'),
+];
+
+function createBasicItem(index: number): ListCaseItem {
+  const tones: ListCaseItem['tone'][] = ['warm', 'cool', 'mint', 'rose'];
+  const tone = tones[index % tones.length] ?? 'warm';
+  return {
+    id: `basic-${index}`,
+    title: `Item ${index}`,
+    meta: `key=basic-${index} reuse=basic-row`,
+    tone,
+  };
+}
+
+function createLetterItem(
+  letter: string,
+  tone: ListCaseItem['tone'],
+): ListCaseItem {
+  return {
+    id: `letter-${letter}`,
+    title: letter,
+    meta: `key=${letter}`,
+    tone,
+  };
+}
+
+function createRecreateItems(version: number): ListCaseItem[] {
+  return Array.from({ length: 8 }, (_, index) => ({
+    id: `holder-${version}-${index}`,
+    title: `Holder ${version} / Item ${index}`,
+    meta: `key=v${version}-${index} reuse=holder-${version}`,
+    tone: index % 2 === 0 ? 'mint' : 'cool',
+  }));
+}
+
+function Action({
+  label,
+  onTap,
+}: {
+  label: string;
+  onTap: () => void;
+}) {
+  return (
+    <view className='Action' bindtap={onTap}>
+      <text className='ActionText'>{label}</text>
+    </view>
+  );
+}
+
+function ScenarioTabs({
+  current,
+  onChange,
+}: {
+  current: Scenario;
+  onChange: (scenario: Scenario) => void;
+}) {
+  const selectScenario = useCallback((scenario: Scenario) => {
+    'background-only';
+    onChange(scenario);
+  }, [onChange]);
+
+  return (
+    <view className='Tabs'>
+      {SCENARIOS.map((scenario) => (
+        <view
+          key={scenario.id}
+          className={current === scenario.id ? 'Tab TabActive' : 'Tab'}
+          bindtap={() => selectScenario(scenario.id)}
+        >
+          <text className='TabText'>{scenario.label}</text>
+        </view>
+      ))}
+    </view>
+  );
+}
+
+function ListRow({
+  item,
+  index,
+  reuseIdentifier,
+  onTap,
+  bindFirstRef,
+}: {
+  item: ListCaseItem;
+  index: number;
+  reuseIdentifier: string;
+  onTap: (item: ListCaseItem) => void;
+  bindFirstRef?: (node: unknown) => void;
+}) {
+  return (
+    <list-item
+      item-key={item.id}
+      key={item.id}
+      reuse-identifier={reuseIdentifier}
+      className={`FeedItem FeedItem-${item.tone}`}
+      bindtap={() => onTap(item)}
+    >
+      <view
+        className='ItemBody'
+        {...(index === 0 && bindFirstRef ? { ref: bindFirstRef } : {})}
+      >
+        <text className='ItemTitle'>{item.title}</text>
+        <text className='ItemMeta'>{item.meta} index={index}</text>
+      </view>
+    </list-item>
+  );
+}
+
+function BasicScenario() {
+  const [items, setItems] = useState(initialBasicItems);
   const [selected, setSelected] = useState('none');
   const [firstItemRefStatus, setFirstItemRefStatus] = useState('pending');
+  const [nextBasicIndex, setNextBasicIndex] = useState(basicItemCount);
   const firstItemRef = useRef<unknown>(null);
 
   const bindFirstItemRef = useCallback((node: unknown) => {
@@ -16,9 +157,9 @@ export function App() {
     setFirstItemRefStatus(node ? 'attached' : 'detached');
   }, []);
 
-  const handleItemTap = useCallback((item: number) => {
+  const handleItemTap = useCallback((item: ListCaseItem) => {
     'background-only';
-    setSelected(`item ${item}`);
+    setSelected(item.id);
   }, []);
 
   const moveLastToFront = useCallback(() => {
@@ -39,65 +180,197 @@ export function App() {
 
   const appendItem = useCallback(() => {
     'background-only';
-    setItems(prevItems => {
-      const next = (prevItems.reduce((max, item) =>
-        Math.max(max, item), 0) || 0) + 1;
-      return [...prevItems, next];
-    });
+    setItems(prevItems => [...prevItems, createBasicItem(nextBasicIndex)]);
+    setNextBasicIndex(prevIndex => prevIndex + 1);
+  }, [nextBasicIndex]);
+
+  const resetItems = useCallback(() => {
+    'background-only';
+    setItems(initialBasicItems);
+    setSelected('none');
+    setFirstItemRefStatus('pending');
+    setNextBasicIndex(basicItemCount);
   }, []);
 
   return (
-    <view className='Page'>
+    <view className='Scenario'>
       <view className='Header'>
-        <text className='Title'>ET List Manual Test</text>
+        <text className='Title'>ET List Basic</text>
         <text className='Status'>selected: {selected}</text>
         <text className='Status'>first item ref: {firstItemRefStatus}</text>
         <text className='Status'>count: {items.length}</text>
       </view>
 
       <view className='Actions'>
-        <view className='Action' bindtap={moveLastToFront}>
-          <text className='ActionText'>Move Last To Front</text>
-        </view>
-        <view className='Action' bindtap={removeFirst}>
-          <text className='ActionText'>Remove First</text>
-        </view>
-        <view className='Action' bindtap={appendItem}>
-          <text className='ActionText'>Append</text>
-        </view>
+        <Action label='Move Last To Front' onTap={moveLastToFront} />
+        <Action label='Remove First' onTap={removeFirst} />
+        <Action label='Append' onTap={appendItem} />
+        <Action label='Reset' onTap={resetItems} />
       </view>
 
-      <list
-        list-type='single'
-        className='Feed'
-        style={{ width: '100%', height: '620px', backgroundColor: '#1e232b' }}
-      >
+      <list list-type='single' className='Feed'>
         {items.map((item, index) => (
-          <list-item
-            item-key={`${item}`}
-            key={item}
-            {...(index === 0 ? { ref: bindFirstItemRef } : {})}
-            reuse-identifier='manual-list-item'
-            className='FeedItem'
-            style={{
-              width: '100%',
-              height: '96px',
-              backgroundColor: '#f4d35e',
-              borderWidth: '3px',
-              borderColor: '#2b8a3e',
-              justifyContent: 'center',
-              paddingLeft: '16px',
-              paddingRight: '16px',
-            }}
-            bindtap={() => handleItemTap(item)}
-          >
-            <view className='ItemBody'>
-              <text className='ItemTitle'>Item {item}</text>
-              <text className='ItemMeta'>key={item} index={index}</text>
-            </view>
-          </list-item>
+          <ListRow
+            key={item.id}
+            item={item}
+            index={index}
+            reuseIdentifier='basic-row'
+            onTap={handleItemTap}
+            bindFirstRef={bindFirstItemRef}
+          />
         ))}
       </list>
+    </view>
+  );
+}
+
+function SingleRenderScenario() {
+  const [items, setItems] = useState(singleRenderInitialItems);
+  const [phase, setPhase] = useState('initial');
+  const [selected, setSelected] = useState('none');
+
+  const handleItemTap = useCallback((item: ListCaseItem) => {
+    'background-only';
+    setSelected(item.id);
+  }, []);
+
+  const applyUpdate = useCallback(() => {
+    'background-only';
+    setItems(singleRenderNextItems);
+    setPhase('updated');
+    setSelected('none');
+  }, []);
+
+  const resetUpdate = useCallback(() => {
+    'background-only';
+    setItems(singleRenderInitialItems);
+    setPhase('initial');
+    setSelected('none');
+  }, []);
+
+  return (
+    <view className='Scenario'>
+      <view className='Header'>
+        <text className='Title'>ET List Single Render</text>
+        <text className='Status'>
+          order: {items.map(item => item.title).join(', ')}
+        </text>
+        <text className='Status'>phase: {phase}</text>
+        <text className='Status'>selected: {selected}</text>
+      </view>
+
+      <view className='Actions'>
+        <Action label='Apply X,C,A,E,Y' onTap={applyUpdate} />
+        <Action label='Reset A,B,C,D,E' onTap={resetUpdate} />
+      </view>
+
+      <list list-type='single' className='Feed CompactFeed'>
+        {items.map((item, index) => (
+          <ListRow
+            key={item.id}
+            item={item}
+            index={index}
+            reuseIdentifier='single-render-row'
+            onTap={handleItemTap}
+          />
+        ))}
+      </list>
+    </view>
+  );
+}
+
+function RecreateScenario() {
+  const [visible, setVisible] = useState(true);
+  const [holderVersion, setHolderVersion] = useState(1);
+  const [selected, setSelected] = useState('none');
+  const [firstItemRefStatus, setFirstItemRefStatus] = useState('pending');
+  const firstItemRef = useRef<unknown>(null);
+
+  const items = createRecreateItems(holderVersion);
+
+  const bindFirstItemRef = useCallback((node: unknown) => {
+    'background-only';
+    firstItemRef.current = node;
+    setFirstItemRefStatus(
+      node ? `attached:v${holderVersion}` : `detached:v${holderVersion}`,
+    );
+  }, [holderVersion]);
+
+  const handleItemTap = useCallback((item: ListCaseItem) => {
+    'background-only';
+    setSelected(item.id);
+  }, []);
+
+  const hideList = useCallback(() => {
+    'background-only';
+    setVisible(false);
+    setSelected('none');
+    setFirstItemRefStatus('detached');
+  }, []);
+
+  const recreateList = useCallback(() => {
+    'background-only';
+    setHolderVersion(prevVersion => prevVersion + 1);
+    setVisible(true);
+    setSelected('none');
+    setFirstItemRefStatus('pending');
+  }, []);
+
+  return (
+    <view className='Scenario'>
+      <view className='Header'>
+        <text className='Title'>ET List Recreate</text>
+        <text className='Status'>holder: {holderVersion}</text>
+        <text className='Status'>selected: {selected}</text>
+        <text className='Status'>first item ref: {firstItemRefStatus}</text>
+      </view>
+
+      <view className='Actions'>
+        <Action label='Unmount List' onTap={hideList} />
+        <Action label='Recreate List' onTap={recreateList} />
+      </view>
+
+      {visible
+        ? (
+          <list list-type='single' className='Feed CompactFeed'>
+            {items.map((item, index) => (
+              <ListRow
+                key={item.id}
+                item={item}
+                index={index}
+                reuseIdentifier={`holder-${holderVersion}`}
+                onTap={handleItemTap}
+                bindFirstRef={bindFirstItemRef}
+              />
+            ))}
+          </list>
+        )
+        : (
+          <view className='EmptyState'>
+            <text className='EmptyText'>list unmounted</text>
+          </view>
+        )}
+    </view>
+  );
+}
+
+export function App() {
+  const [scenario, setScenario] = useState<Scenario>('basic');
+
+  const selectScenario = useCallback((nextScenario: Scenario) => {
+    'background-only';
+    setScenario(nextScenario);
+  }, []);
+
+  return (
+    <view className='Page'>
+      <view className='Shell'>
+        <text className='AppTitle'>ET List E2E Examples</text>
+        <ScenarioTabs current={scenario} onChange={selectScenario} />
+        {scenario === 'basic' ? <BasicScenario /> : null}
+        {scenario === 'single-render' ? <SingleRenderScenario /> : null}
+        {scenario === 'recreate' ? <RecreateScenario /> : null}
+      </view>
     </view>
   );
 }

--- a/examples/react-et-list/src/App.tsx
+++ b/examples/react-et-list/src/App.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useRef, useState } from '@lynx-js/react';
+
+import './App.css';
+
+const initialItems = Array.from({ length: 3 }, (_, index) => index + 1);
+
+export function App() {
+  const [items, setItems] = useState(initialItems);
+  const [selected, setSelected] = useState('none');
+  const [firstItemRefStatus, setFirstItemRefStatus] = useState('pending');
+  const firstItemRef = useRef<unknown>(null);
+
+  const bindFirstItemRef = useCallback((node: unknown) => {
+    'background-only';
+    firstItemRef.current = node;
+    setFirstItemRefStatus(node ? 'attached' : 'detached');
+  }, []);
+
+  const handleItemTap = useCallback((item: number) => {
+    'background-only';
+    setSelected(`item ${item}`);
+  }, []);
+
+  const moveLastToFront = useCallback(() => {
+    'background-only';
+    setItems(prevItems => {
+      const last = prevItems[prevItems.length - 1];
+      if (last === undefined) {
+        return prevItems;
+      }
+      return [last, ...prevItems.slice(0, -1)];
+    });
+  }, []);
+
+  const removeFirst = useCallback(() => {
+    'background-only';
+    setItems(prevItems => prevItems.slice(1));
+  }, []);
+
+  const appendItem = useCallback(() => {
+    'background-only';
+    setItems(prevItems => {
+      const next = (prevItems.reduce((max, item) =>
+        Math.max(max, item), 0) || 0) + 1;
+      return [...prevItems, next];
+    });
+  }, []);
+
+  return (
+    <view className='Page'>
+      <view className='Header'>
+        <text className='Title'>ET List Manual Test</text>
+        <text className='Status'>selected: {selected}</text>
+        <text className='Status'>first item ref: {firstItemRefStatus}</text>
+        <text className='Status'>count: {items.length}</text>
+      </view>
+
+      <view className='Actions'>
+        <view className='Action' bindtap={moveLastToFront}>
+          <text className='ActionText'>Move Last To Front</text>
+        </view>
+        <view className='Action' bindtap={removeFirst}>
+          <text className='ActionText'>Remove First</text>
+        </view>
+        <view className='Action' bindtap={appendItem}>
+          <text className='ActionText'>Append</text>
+        </view>
+      </view>
+
+      <list
+        list-type='single'
+        className='Feed'
+        style={{ width: '100%', height: '620px', backgroundColor: '#1e232b' }}
+      >
+        {items.map((item, index) => (
+          <list-item
+            item-key={`${item}`}
+            key={item}
+            {...(index === 0 ? { ref: bindFirstItemRef } : {})}
+            reuse-identifier='manual-list-item'
+            className='FeedItem'
+            style={{
+              width: '100%',
+              height: '96px',
+              backgroundColor: '#f4d35e',
+              borderWidth: '3px',
+              borderColor: '#2b8a3e',
+              justifyContent: 'center',
+              paddingLeft: '16px',
+              paddingRight: '16px',
+            }}
+            bindtap={() => handleItemTap(item)}
+          >
+            <view className='ItemBody'>
+              <text className='ItemTitle'>Item {item}</text>
+              <text className='ItemMeta'>key={item} index={index}</text>
+            </view>
+          </list-item>
+        ))}
+      </list>
+    </view>
+  );
+}

--- a/examples/react-et-list/src/index.tsx
+++ b/examples/react-et-list/src/index.tsx
@@ -1,0 +1,11 @@
+import { root } from '@lynx-js/react';
+
+import { App } from './App.jsx';
+
+root.render(
+  <App />,
+);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/react-et-list/src/rspeedy-env.d.ts
+++ b/examples/react-et-list/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/react-et-list/tsconfig.json
+++ b/examples/react-et-list/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+    "noEmit": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedDeclarations": false,
+  },
+  "include": ["src", "lynx.config.js"],
+  "references": [
+    { "path": "../../packages/react/tsconfig.json" },
+    { "path": "../../packages/rspeedy/core/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-qrcode/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-react/tsconfig.build.json" },
+  ],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,28 @@ importers:
         specifier: ^18.3.28
         version: 18.3.28
 
+  examples/react-et-list:
+    dependencies:
+      '@lynx-js/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-qrcode
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      '@lynx-js/types':
+        specifier: 3.7.0
+        version: 3.7.0
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+
   examples/react-et-mtf:
     dependencies:
       '@lynx-js/react':


### PR DESCRIPTION
## Overview

Adds a focused Element Template list example under `examples/react-et-list`. The example ports the archived ET list native E2E scenarios into the current `lynx-stack` example layout so list behavior can be exercised through the public `@lynx-js/*` workspace packages instead of the older demo workspace.

## Key Points

- Enables Element Template directly in `lynx.config.js` and keeps the example aligned with the existing ET example setup.
- Covers the archived list verification scenarios as selectable pages: basic scroll / reuse / item interaction, single-render insert / remove / reorder, and list holder teardown / recreate.
- Exercises stable `key` / `item-key`, `reuse-identifier`, first-item callback ref attachment state, item tap feedback, same-list move, list unmount, and fresh holder creation.
- Adds the private workspace importer for `@lynx-js/example-react-et-list` to `pnpm-lock.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new React example demonstrating ET List usage with three interactive scenarios: basic list operations (move, remove, append), single-render reordering, and dynamic list recreation with tab-based scenario selection.
* **Enhancements**
  * Added example-specific styling for the scenario UI, list items, and empty states.
* **Chores**
  * Introduced example project configuration, build/dev setup, and TypeScript environment typings for the new example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
