### PR TITLE
ci: consume private package changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -33,7 +33,7 @@
   "updateInternalDependencies": "patch",
   "privatePackages": {
     "tag": false,
-    "version": false
+    "version": true
   },
   "ignore": [
     "@lynx-js/example-react",

--- a/.github/changeset-ci.instructions.md
+++ b/.github/changeset-ci.instructions.md
@@ -1,7 +1,11 @@
 ---
-applyTo: ".github/workflows/test.yml"
+applyTo: ".github/workflows/test.yml,.github/workflows/deploy-main.yml,.github/scripts/check-*changeset*.cjs"
 ---
 
 When validating changesets in CI, use `pnpm changeset status --since=origin/main --output <file>` and consume the JSON in a script for stable checks (for example, blocking `major` bumps) instead of parsing CLI text output.
 
 When validating changeset Markdown files in CI, run `node .github/scripts/check-no-heading-changeset.cjs .changeset-status.json` so the script resolves files from `changeset status` output, and fail the job if any listed changeset file contains H1 (`#`), H2 (`##`) or H3 (`###`) headings.
+
+Keep `privatePackages.version` enabled in `.changeset/config.json` so private package changesets are consumed by `pnpm changeset version`; leave `privatePackages.tag` disabled so private packages do not get release tags.
+
+After CI runs `pnpm changeset version`, run `node .github/scripts/check-no-leftover-changesets.cjs` before any snapshot/canary rewrite or publish step. The check should fail if `.changeset/*.md` files remain, because leftover changesets usually mean Changesets skipped an ignored or non-versioned package.

--- a/.github/scripts/check-no-leftover-changesets.cjs
+++ b/.github/scripts/check-no-leftover-changesets.cjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+const { readdirSync } = require('node:fs');
+
+function findLeftoverChangesets(changesetDir = '.changeset') {
+  return readdirSync(changesetDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => name.endsWith('.md') && name !== 'README.md')
+    .sort();
+}
+
+function main() {
+  const changesetDir = process.argv[2] || '.changeset';
+  const leftovers = findLeftoverChangesets(changesetDir);
+
+  if (leftovers.length === 0) {
+    process.stdout.write('No leftover changeset files found.\n');
+    return;
+  }
+
+  process.stderr.write(
+    '\nThe following changeset files were left after `pnpm changeset version`:\n\n',
+  );
+  for (const file of leftovers) {
+    process.stderr.write(`  - ${file}\n`);
+  }
+  process.stderr.write(
+    '\nMake sure every package named in these changesets is versioned by Changesets, or delete changesets for packages that should not be versioned.\n',
+  );
+
+  throw new Error(`${leftovers.length} leftover changeset file(s) found.`);
+}
+
+module.exports = { findLeftoverChangesets };
+
+if (require.main === module) {
+  main();
+}

--- a/.github/scripts/check-no-leftover-changesets.test.cjs
+++ b/.github/scripts/check-no-leftover-changesets.test.cjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+const assert = require('node:assert/strict');
+const { mkdtempSync, mkdirSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const test = require('node:test');
+
+const { findLeftoverChangesets } = require(
+  './check-no-leftover-changesets.cjs',
+);
+
+function withChangesetDir(files, run) {
+  const dir = mkdtempSync(join(tmpdir(), 'leftover-changeset-check-'));
+  const changesetDir = join(dir, '.changeset');
+  mkdirSync(changesetDir, { recursive: true });
+
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(changesetDir, name), content, 'utf8');
+  }
+
+  try {
+    run(changesetDir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('passes when no unreleased changeset markdown files remain', () => {
+  withChangesetDir(
+    {
+      'config.json': '{}\n',
+      'README.md': '# Changesets\n',
+    },
+    (changesetDir) => {
+      assert.deepEqual(findLeftoverChangesets(changesetDir), []);
+    },
+  );
+});
+
+test('reports unreleased changeset markdown files left after versioning', () => {
+  withChangesetDir(
+    {
+      'config.json': '{}\n',
+      'README.md': '# Changesets\n',
+      'private-package.md':
+        '---\n"private-pkg": patch\n---\n\nPrivate change.\n',
+    },
+    (changesetDir) => {
+      assert.deepEqual(findLeftoverChangesets(changesetDir), [
+        'private-package.md',
+      ]);
+    },
+  );
+});

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -227,6 +227,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm changeset version --snapshot canary
+          node .github/scripts/check-no-leftover-changesets.cjs
           node packages/tools/canary-release/snapshot.js
       - name: publish canary packages
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,6 +239,7 @@ jobs:
         pnpm dlx @pnpm/registry-mock@4 &
         printf '\n//localhost:4873/:_authToken="this-is-a-fake-token"\n' >> ~/.npmrc
         pnpm changeset version --snapshot regression
+        node .github/scripts/check-no-leftover-changesets.cjs
         node packages/tools/canary-release/snapshot.js
         pnpm --recursive publish --no-git-checks --access public --registry=http://localhost:4873
         cd `mktemp -d`


### PR DESCRIPTION
## Summary

- Enable Changesets to version private packages while still avoiding private package tags.
- Add a CI helper that fails when `.changeset/*.md` files remain after `pnpm changeset version`.
- Run the leftover changeset check in snapshot publish smoke tests and canary publish versioning.

## Test Plan

- `node --test .github/scripts/check-no-leftover-changesets.test.cjs .github/scripts/check-no-heading-changeset.test.cjs`
- `pnpm dprint check`
- `pnpm biome check`
- `pnpm changeset status --since=upstream/main --output .changeset-status.json`
- Temp worktree verification: private `a2ui-playground` changeset is consumed by `pnpm changeset version --snapshot verify`
- `pnpm turbo build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced changeset configuration to enable versioning for private packages.
  * Improved CI/CD validation workflows with automated checks for changeset integrity and leftover file detection.
  * Added safeguards to enforce deterministic validation during release processes.

* **Tests**
  * Added test coverage for changeset validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->