### PR TITLE
refactor(website): move A2UI playground from /a2ui to /genui

### DIFF
--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -46,21 +46,45 @@ jobs:
           rm -rf website/doc_build/repl
           mkdir -p website/doc_build
           cp -r packages/repl/dist website/doc_build/repl
-      - name: Build A2UI dependencies
+      - name: Build GenUI Playground dependencies
         run: |
           pnpm turbo --filter a2ui-playground^... build
-      - name: Build A2UI Lynx bundle
+      - name: Build GenUI Playground Lynx bundle
         run: |
           pnpm --filter a2ui-playground build:lynx
-      - name: Build A2UI Playground
+      - name: Build GenUI Playground
         run: |
           BASE_PATH='${{ steps.pages.outputs.base_path }}'
-          export ASSET_PREFIX="${BASE_PATH%/}/a2ui/"
+          export ASSET_PREFIX="${BASE_PATH%/}/genui/"
           pnpm --filter a2ui-playground build
-      - name: Copy A2UI Playground into website output
+      - name: Copy GenUI Playground into website output
         run: |
-          rm -rf website/doc_build/a2ui
-          cp -r packages/genui/a2ui-playground/dist website/doc_build/a2ui
+          rm -rf website/doc_build/genui website/doc_build/a2ui
+          cp -r packages/genui/a2ui-playground/dist website/doc_build/genui
+          # Legacy redirect: /a2ui -> /genui (preserves query + hash so the
+          # playground's hash-router deep links keep working). Existing
+          # /a2ui URLs out in the wild (blog posts, docs) won't break.
+          mkdir -p website/doc_build/a2ui
+          cat > website/doc_build/a2ui/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <title>Moved to /genui</title>
+              <meta http-equiv="refresh" content="0; url=/genui/" />
+              <link rel="canonical" href="/genui/" />
+              <script>
+                (function () {
+                  var dest = '/genui/' + location.search + location.hash;
+                  location.replace(dest);
+                })();
+              </script>
+            </head>
+            <body>
+              <p>The playground has moved to <a href="/genui/">/genui/</a>.</p>
+            </body>
+          </html>
+          HTML
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -754,8 +754,8 @@ const config: UserConfig = defineConfig({
       },
       {
         text: 'A2UI',
-        link: '/a2ui',
-        activeMatch: '^/(a2ui|guide/genui/a2ui)',
+        link: '/genui',
+        activeMatch: '^/(a2ui|genui|guide/genui/a2ui)',
         items: A2UI_EN_NAV_ITEMS,
       },
       {

--- a/website/sidebars/genui.ts
+++ b/website/sidebars/genui.ts
@@ -130,7 +130,7 @@ export const A2UI_EN_NAV_ITEMS = [
   },
   {
     text: 'Playground',
-    link: '/a2ui',
+    link: '/genui',
   },
 ];
 
@@ -153,7 +153,7 @@ export const A2UI_ZH_NAV_ITEMS = [
   },
   {
     text: 'Playground',
-    link: '/a2ui',
+    link: '/genui',
   },
 ];
 


### PR DESCRIPTION
## Summary

- Move the canonical playground URL from `lynx-stack.dev/a2ui/` to `lynx-stack.dev/genui/`.
- Generate a static redirect at `/a2ui/index.html` in CI that forwards to `/genui/`, preserving query string and hash fragment so the playground's hash-router deep links keep working.
- Update the rspress nav link, active-match, and the two playground links in the genui sidebar config.

The playground originally hosted only A2UI examples, but recent work (OpenUI v0.5 in #2815, expanded openui catalog and playground examples in #2849) has made `/a2ui` an inaccurate URL prefix for what is now a Generative-UI-broad playground.

## Out of scope

Package and directory names (`a2ui-playground`) are intentionally left unchanged - this PR is URL-scope only. Internal middleware paths (`/__a2ui_payload`, `/__a2ui/`) used in the dev server are also untouched.

## Test plan

- [ ] CI workflow builds successfully and uploads the artifact
- [ ] After deploy, `lynx-stack.dev/genui/` renders the playground
- [ ] After deploy, `lynx-stack.dev/a2ui/` 302-equivalents to `/genui/` via the meta-refresh + JS shim
- [ ] Deep links like `lynx-stack.dev/a2ui/#/a2ui/catalog` redirect to `lynx-stack.dev/genui/#/a2ui/catalog` (hash preserved)
- [ ] The "A2UI" nav item in the docs site still points at the right page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GenUI Playground is now available and deployed.

* **Chores**
  * Updated navigation links to direct users to GenUI Playground.
  * Added automatic redirection from legacy paths for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->