### PR TITLE
chore: add package support metadata across workspace

### DIFF
--- a/.changeset/package-manifest-links.md
+++ b/.changeset/package-manifest-links.md
@@ -1,0 +1,48 @@
+---
+"background-only": patch
+"@lynx-js/genui": patch
+"@lynx-js/i18next-translation-dedupe": patch
+"@lynx-js/autolink-codegen": patch
+"create-lynx-library": patch
+"@lynx-js/gesture-runtime": patch
+"@lynx-js/devtool-connector": patch
+"@lynx-js/devtool-mcp-server": patch
+"@lynx-js/docs-mcp-server": patch
+"@lynx-js/motion": patch
+"@lynx-js/react-umd": patch
+"@lynx-js/react": patch
+"@lynx-js/rspeedy": patch
+"create-rspeedy": patch
+"@lynx-js/lynx-bundle-rslib-config": patch
+"@lynx-js/config-rsbuild-plugin": patch
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+"@lynx-js/external-bundle-rsbuild-plugin": patch
+"@lynx-js/qrcode-rsbuild-plugin": patch
+"@lynx-js/react-alias-rsbuild-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"upgrade-rspeedy": patch
+"@lynx-js/websocket": patch
+"@lynx-js/tailwind-preset": patch
+"@lynx-js/kitten-lynx-test-infra": patch
+"@lynx-js/testing-environment": patch
+"@lynx-js/css-serializer": patch
+"@lynx-js/debug-metadata": patch
+"@lynx-js/use-sync-external-store": patch
+"@lynx-js/web-core": patch
+"@lynx-js/web-elements": patch
+"@lynx-js/web-explorer": patch
+"@lynx-js/web-platform-rsbuild-plugin": patch
+"@lynx-js/web-rsbuild-server-middleware": patch
+"@lynx-js/web-worker-rpc": patch
+"@lynx-js/cache-events-webpack-plugin": patch
+"@lynx-js/chunk-loading-webpack-plugin": patch
+"@lynx-js/css-extract-webpack-plugin": patch
+"@lynx-js/externals-loading-webpack-plugin": patch
+"@lynx-js/react-refresh-webpack-plugin": patch
+"@lynx-js/react-webpack-plugin": patch
+"@lynx-js/runtime-wrapper-webpack-plugin": patch
+"@lynx-js/webpack-dev-transport": patch
+"@lynx-js/webpack-runtime-globals": patch
+---
+
+Add npm homepage and issue tracker metadata to package manifests.

--- a/packages/background-only/package.json
+++ b/packages/background-only/package.json
@@ -6,6 +6,10 @@
     "react",
     "lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/background-only#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/genui/package.json
+++ b/packages/genui/package.json
@@ -2,6 +2,10 @@
   "name": "@lynx-js/genui",
   "version": "0.0.4",
   "description": "Generative UI for Lynx.",
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/genui#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/i18n/i18next-translation-dedupe/package.json
+++ b/packages/i18n/i18next-translation-dedupe/package.json
@@ -8,6 +8,10 @@
     "rspeedy",
     "rsbuild"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/i18n/i18next-translation-dedupe#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/lynx/autolink-codegen/package.json
+++ b/packages/lynx/autolink-codegen/package.json
@@ -7,6 +7,10 @@
     "Autolink",
     "codegen"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/lynx/autolink-codegen#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/lynx/create-lynx-library/package.json
+++ b/packages/lynx/create-lynx-library/package.json
@@ -7,6 +7,10 @@
     "Autolink",
     "create"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/lynx/create-lynx-library#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/lynx/gesture-runtime/package.json
+++ b/packages/lynx/gesture-runtime/package.json
@@ -2,6 +2,10 @@
   "name": "@lynx-js/gesture-runtime",
   "version": "2.1.3",
   "description": "Lynx Gesture",
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/lynx/gesture-runtime#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/mcp-servers/devtool-connector/package.json
+++ b/packages/mcp-servers/devtool-connector/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@lynx-js/devtool-connector",
   "version": "0.1.1",
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/mcp-servers/devtool-connector#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-stack.git",

--- a/packages/mcp-servers/devtool-mcp-server/package.json
+++ b/packages/mcp-servers/devtool-mcp-server/package.json
@@ -2,6 +2,10 @@
   "name": "@lynx-js/devtool-mcp-server",
   "version": "0.5.1",
   "description": "The Lynx DevTool for coding agent.",
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/mcp-servers/devtool-mcp-server#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-stack.git",

--- a/packages/mcp-servers/docs-mcp-server/package.json
+++ b/packages/mcp-servers/docs-mcp-server/package.json
@@ -2,6 +2,10 @@
   "name": "@lynx-js/docs-mcp-server",
   "version": "0.2.3",
   "description": "A MCP Server providing Lynx documentation resources for LLMs, with carefully designed prompting.",
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/mcp-servers/docs-mcp-server#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-stack.git",

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -9,6 +9,10 @@
     "motion",
     "framer-motion"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/motion#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-stack.git",

--- a/packages/react-umd/package.json
+++ b/packages/react-umd/package.json
@@ -9,6 +9,10 @@
     "external bundle",
     "umd"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/react-umd#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,6 +2,10 @@
   "name": "@lynx-js/react",
   "version": "0.121.2",
   "description": "ReactLynx is a framework for developing Lynx applications with familiar React.",
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/react#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -8,6 +8,10 @@
     "Lynx",
     "ReactLynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/core#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/create-rspeedy/package.json
+++ b/packages/rspeedy/create-rspeedy/package.json
@@ -9,6 +9,10 @@
     "Lynx",
     "ReactLynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/create-rspeedy#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -8,6 +8,10 @@
     "Lynx",
     "Rslib"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/lynx-bundle-rslib-config#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/plugin-config/package.json
+++ b/packages/rspeedy/plugin-config/package.json
@@ -7,6 +7,10 @@
     "Lynx",
     "Config"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/plugin-config#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/plugin-debug-metadata/package.json
+++ b/packages/rspeedy/plugin-debug-metadata/package.json
@@ -8,6 +8,10 @@
     "debug",
     "sourcemap"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/plugin-debug-metadata#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/plugin-external-bundle/package.json
+++ b/packages/rspeedy/plugin-external-bundle/package.json
@@ -8,6 +8,10 @@
     "externals",
     "bundle"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/plugin-external-bundle#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -7,6 +7,10 @@
     "Lynx",
     "ReactLynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/plugin-qrcode#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/plugin-react-alias/package.json
+++ b/packages/rspeedy/plugin-react-alias/package.json
@@ -7,6 +7,10 @@
     "Lynx",
     "ReactLynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/plugin-react-alias#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/plugin-react/package.json
+++ b/packages/rspeedy/plugin-react/package.json
@@ -7,6 +7,10 @@
     "Lynx",
     "ReactLynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/plugin-react#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/upgrade-rspeedy/package.json
+++ b/packages/rspeedy/upgrade-rspeedy/package.json
@@ -9,6 +9,10 @@
     "Rspeedy",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/upgrade-rspeedy#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/rspeedy/websocket/package.json
+++ b/packages/rspeedy/websocket/package.json
@@ -7,6 +7,10 @@
     "Lynx",
     "WebSocket"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/websocket#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -7,6 +7,10 @@
     "ReactLynx",
     "tailwindcss"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/tailwind-preset#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/testing-library/kitten-lynx/package.json
+++ b/packages/testing-library/kitten-lynx/package.json
@@ -8,6 +8,10 @@
     "android",
     "emulator"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/testing-library/kitten-lynx#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/testing-library/testing-environment/package.json
+++ b/packages/testing-library/testing-environment/package.json
@@ -7,6 +7,10 @@
     "ReactLynx",
     "testing"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/testing-library/testing-environment#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/tools/css-serializer/package.json
+++ b/packages/tools/css-serializer/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@lynx-js/css-serializer",
   "version": "0.1.6",
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/tools/css-serializer#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/tools/debug-metadata/package.json
+++ b/packages/tools/debug-metadata/package.json
@@ -8,6 +8,10 @@
     "sourcemap",
     "schema"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/tools/debug-metadata#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/use-sync-external-store/package.json
+++ b/packages/use-sync-external-store/package.json
@@ -6,6 +6,10 @@
     "react",
     "lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/use-sync-external-store#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/web-platform/web-core/package.json
+++ b/packages/web-platform/web-core/package.json
@@ -2,6 +2,10 @@
   "name": "@lynx-js/web-core",
   "version": "0.21.1",
   "description": "The Web Platform of Lynx / Lynx for Web",
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/web-platform/web-core#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/web-platform/web-elements/package.json
+++ b/packages/web-platform/web-elements/package.json
@@ -2,6 +2,10 @@
   "name": "@lynx-js/web-elements",
   "version": "0.12.4",
   "private": false,
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/web-platform/web-elements#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/web-platform/web-explorer/package.json
+++ b/packages/web-platform/web-explorer/package.json
@@ -2,6 +2,10 @@
   "name": "@lynx-js/web-explorer",
   "version": "0.0.17",
   "private": false,
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/web-platform/web-explorer#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/web-platform/web-rsbuild-plugin/package.json
+++ b/packages/web-platform/web-rsbuild-plugin/package.json
@@ -8,6 +8,10 @@
     "Lynx",
     "Web Platform"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/web-platform/web-rsbuild-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/web-platform/web-rsbuild-server-middleware/package.json
+++ b/packages/web-platform/web-rsbuild-server-middleware/package.json
@@ -4,6 +4,10 @@
   "private": false,
   "description": "a dev server middleware for rsbuild to serve Lynx Web Platform shell project",
   "keywords": [],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/web-platform/web-rsbuild-server-middleware#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lynx-family/lynx-stack.git",

--- a/packages/web-platform/web-worker-rpc/package.json
+++ b/packages/web-platform/web-worker-rpc/package.json
@@ -4,6 +4,10 @@
   "private": false,
   "description": "",
   "keywords": [],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/web-platform/web-worker-rpc#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/cache-events-webpack-plugin/package.json
+++ b/packages/webpack/cache-events-webpack-plugin/package.json
@@ -6,6 +6,10 @@
     "webpack",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/cache-events-webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/chunk-loading-webpack-plugin/package.json
+++ b/packages/webpack/chunk-loading-webpack-plugin/package.json
@@ -7,6 +7,10 @@
     "webpack",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/chunk-loading-webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/css-extract-webpack-plugin/package.json
+++ b/packages/webpack/css-extract-webpack-plugin/package.json
@@ -6,6 +6,10 @@
     "webpack",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/css-extract-webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/externals-loading-webpack-plugin/package.json
+++ b/packages/webpack/externals-loading-webpack-plugin/package.json
@@ -6,6 +6,10 @@
     "webpack",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/externals-loading-webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/react-refresh-webpack-plugin/package.json
+++ b/packages/webpack/react-refresh-webpack-plugin/package.json
@@ -6,6 +6,10 @@
     "webpack",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/react-refresh-webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/react-webpack-plugin/package.json
+++ b/packages/webpack/react-webpack-plugin/package.json
@@ -7,6 +7,10 @@
     "Lynx",
     "ReactLynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/react-webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/runtime-wrapper-webpack-plugin/package.json
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/package.json
@@ -6,6 +6,10 @@
     "webpack",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/runtime-wrapper-webpack-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/webpack-dev-transport/package.json
+++ b/packages/webpack/webpack-dev-transport/package.json
@@ -6,6 +6,10 @@
     "webpack",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/webpack-dev-transport#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",

--- a/packages/webpack/webpack-runtime-globals/package.json
+++ b/packages/webpack/webpack-runtime-globals/package.json
@@ -6,6 +6,10 @@
     "webpack",
     "Lynx"
   ],
+  "homepage": "https://github.com/lynx-family/lynx-stack/tree/main/packages/webpack/webpack-runtime-globals#readme",
+  "bugs": {
+    "url": "https://github.com/lynx-family/lynx-stack/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynx-stack.git",


### PR DESCRIPTION
## Summary

- add the published package homepage for `@lynx-js/debug-metadata-rsbuild-plugin`
- add the package bug tracker URL pointing to the Lynx Stack issues page
- leave runtime code, dependencies, exports, and versions unchanged

The current stable and canary npm metadata expose the repository but do not expose `homepage` or `bugs`, so this fills in the standard npm package support links.

## Validation

- `node -e "const p=require('./packages/rspeedy/plugin-debug-metadata/package.json'); if(p.homepage!=='https://github.com/lynx-family/lynx-stack/tree/main/packages/rspeedy/plugin-debug-metadata#readme') throw new Error('bad homepage'); if(p.bugs?.url!=='https://github.com/lynx-family/lynx-stack/issues') throw new Error('bad bugs'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs,repository:p.repository},null,2));"`
- `npm view @lynx-js/debug-metadata-rsbuild-plugin@0.1.0 name version repository homepage bugs license --json`
- `npm view @lynx-js/debug-metadata-rsbuild-plugin-canary name version repository homepage bugs license --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec tsc --build packages/tools/debug-metadata/tsconfig.build.json packages/webpack/template-webpack-plugin/tsconfig.build.json packages/rspeedy/plugin-debug-metadata/tsconfig.build.json --pretty false`
- `pnpm --filter @lynx-js/debug-metadata-rsbuild-plugin build`
- `pnpm --filter @lynx-js/debug-metadata-rsbuild-plugin test`
- `npm pack --dry-run --ignore-scripts --json ./packages/rspeedy/plugin-debug-metadata`
- `pnpm exec sort-package-json --check packages/rspeedy/plugin-debug-metadata/package.json`
- `pnpm exec dprint check packages/rspeedy/plugin-debug-metadata/package.json`
- `git diff --check`
- `pnpm changeset status --since=upstream/main --output .changeset-status.json` returned no changesets/releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated npm package metadata across multiple packages to include a `homepage` link and a `bugs` (issue tracker) URL.
  * Added a changeset instruction to keep npm homepage/issue-tracker metadata consistent in future releases, improving discoverability and making it easier to find and report issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->