### PR TITLE
feat(genui): add a2ui final-state snapshot export

### DIFF
--- a/.github/a2ui-snapshot.instructions.md
+++ b/.github/a2ui-snapshot.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/genui/a2ui/src/snapshot/**"
+---
+
+For A2UI final-state compaction, model the message stream as an operation log and replay it into a dedicated snapshot state machine before serializing compact messages. Do not trim the original message array in place; update ordering, template expansion, data bindings, and deleted surfaces can make local pruning incorrect.

--- a/packages/genui/a2ui/docs/overview.md
+++ b/packages/genui/a2ui/docs/overview.md
@@ -80,6 +80,27 @@ the renderer does not care. The rest of this page explains what happens
 between `store.push(...)` and the rendered surface. For install details and
 optional theme tokens, see the [README](../README.md).
 
+## Compact final-state messages
+
+Use `compactA2UIMessagesToSnapshot` when you need the final UI state, not the
+full streaming history. The helper runs the A2UI messages through a snapshot
+state machine, removes unreachable components and data paths, and returns a
+new message array that can be rendered or shared like any other A2UI payload.
+
+```ts
+import { compactA2UIMessagesToSnapshot } from '@lynx-js/genui/a2ui/snapshot';
+import { createMessageStore } from '@lynx-js/genui/a2ui';
+
+const snapshot = compactA2UIMessagesToSnapshot(messages);
+const store = createMessageStore({ initialMessages: snapshot.messages });
+```
+
+Use `snapshot.messages` for final-state previews, shared URLs, QR payloads,
+thumbnail rendering, and benchmark final renders. Keep the original messages
+for playback or any UI that needs to show the stream chunk by chunk.
+`snapshot.metadata` is for diagnostics and tests; it does not affect
+rendering.
+
 ## The mental model
 
 If you have written React, the shift is small but important:

--- a/packages/genui/a2ui/package.json
+++ b/packages/genui/a2ui/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/store/index.d.ts",
       "default": "./dist/store/index.js"
     },
+    "./snapshot": {
+      "types": "./dist/snapshot/index.d.ts",
+      "default": "./dist/snapshot/index.js"
+    },
     "./catalog": {
       "types": "./dist/catalog/index.d.ts",
       "default": "./dist/catalog/index.js"

--- a/packages/genui/a2ui/src/snapshot/index.ts
+++ b/packages/genui/a2ui/src/snapshot/index.ts
@@ -1,0 +1,648 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type {
+  ComponentInstance,
+  ServerToClientMessage,
+} from '../store/types.js';
+
+export interface CompactA2UISnapshotSurfaceMetadata {
+  surfaceId: string;
+  componentCount: number;
+  droppedComponentCount: number;
+  dataPathCount: number;
+  hasRoot: boolean;
+}
+
+export interface CompactA2UISnapshotMetadata {
+  originalMessageCount: number;
+  compactedMessageCount: number;
+  activeSurfaceCount: number;
+  retainedComponentCount: number;
+  droppedComponentCount: number;
+  retainedDataPathCount: number;
+  surfaces: CompactA2UISnapshotSurfaceMetadata[];
+}
+
+export interface CompactA2UISnapshotResult {
+  messages: ServerToClientMessage[];
+  metadata: CompactA2UISnapshotMetadata;
+}
+
+interface SnapshotTemplateInfo {
+  componentId: string;
+  path: string;
+}
+
+interface SnapshotSurfaceState {
+  surfaceId: string;
+  catalogId?: string;
+  theme?: Readonly<Record<string, unknown>>;
+  sendDataModel?: boolean;
+  rootComponentId: string | null;
+  components: Map<string, ComponentInstance>;
+  templates: Map<string, SnapshotTemplateInfo>;
+  dataModel: Map<string, unknown>;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+const CHILD_REFERENCE_FIELDS = [
+  'child',
+  'trigger',
+  'content',
+  'entryPointChild',
+  'contentChild',
+] as const;
+
+function isObject(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function cloneJson<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function normalizePath(path: string): string {
+  if (path === '') return '/';
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+function resolveBindingPath(path: string, dataContextPath?: string): string {
+  if (!path) return path;
+  const bindingPath = path.startsWith('./') ? path.substring(2) : path;
+  if (bindingPath.startsWith('/')) return bindingPath;
+  const context = dataContextPath?.endsWith('/')
+    ? dataContextPath.slice(0, -1)
+    : dataContextPath;
+  return context ? `${context}/${bindingPath}` : `/${bindingPath}`;
+}
+
+function flattenValue(
+  value: unknown,
+  basePath: string,
+  updates: Array<{ path: string; value: unknown }>,
+): void {
+  const normalizedBase = basePath === '' ? '/' : normalizePath(basePath);
+
+  if (Array.isArray(value)) {
+    updates.push({ path: normalizedBase, value });
+    value.forEach((item, index) => {
+      const childPath = normalizedBase === '/'
+        ? `/${index}`
+        : `${normalizedBase}/${index}`;
+      if (isObject(item) || Array.isArray(item)) {
+        updates.push({ path: childPath, value: item });
+        flattenValue(item, childPath, updates);
+      } else {
+        updates.push({ path: childPath, value: String(item) });
+      }
+    });
+    return;
+  }
+
+  if (isObject(value)) {
+    updates.push({ path: normalizedBase, value });
+    for (const [key, item] of Object.entries(value)) {
+      const childPath = normalizedBase === '/'
+        ? `/${key}`
+        : `${normalizedBase}/${key}`;
+      if (isObject(item) || Array.isArray(item)) {
+        updates.push({ path: childPath, value: item });
+        flattenValue(item, childPath, updates);
+      } else {
+        updates.push({ path: childPath, value: String(item) });
+      }
+    }
+    return;
+  }
+
+  updates.push({ path: normalizedBase, value: String(value) });
+}
+
+function createSurfaceState(surfaceId: string): SnapshotSurfaceState {
+  return {
+    surfaceId,
+    rootComponentId: null,
+    components: new Map(),
+    templates: new Map(),
+    dataModel: new Map(),
+  };
+}
+
+function getTemplateInfo(
+  component: ComponentInstance,
+  dataContextPath: string | undefined,
+): SnapshotTemplateInfo | null {
+  const children = (component as JsonRecord)['children'];
+  if (!isObject(children)) return null;
+  const componentId = children['componentId'];
+  const path = children['path'];
+  if (typeof componentId !== 'string' || typeof path !== 'string') {
+    return null;
+  }
+  return {
+    componentId,
+    path: resolveBindingPath(path, dataContextPath),
+  };
+}
+
+function readDataValue(surface: SnapshotSurfaceState, path: string): unknown {
+  const raw = surface.dataModel.get(path);
+  if (raw === undefined || raw === null) return raw;
+  if (typeof raw !== 'string') return raw;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return raw;
+  }
+}
+
+function rewriteStringField(
+  component: JsonRecord,
+  field: string,
+  resolveChild: (childId: string) => string | null,
+): void {
+  const childId = component[field];
+  if (typeof childId !== 'string') return;
+  const nextId = resolveChild(childId);
+  if (nextId) component[field] = nextId;
+}
+
+function cloneComponentTree(
+  surface: SnapshotSurfaceState,
+  originalId: string,
+  newIdSuffix: string,
+  dataContextPath: string,
+  clonedRefs = new Map<string, string | null>(),
+): string | null {
+  if (clonedRefs.has(originalId)) return clonedRefs.get(originalId) ?? null;
+
+  const original = surface.components.get(originalId);
+  if (!original) {
+    clonedRefs.set(originalId, null);
+    return null;
+  }
+
+  const newId = `${originalId}${newIdSuffix}`;
+  clonedRefs.set(originalId, newId);
+
+  const cloned = cloneJson(original);
+  (cloned as JsonRecord)['id'] = newId;
+  cloned.dataContextPath = dataContextPath;
+  surface.components.set(newId, cloned);
+
+  const originalTemplate = surface.templates.get(originalId);
+  if (originalTemplate) {
+    surface.templates.set(newId, { ...originalTemplate });
+  } else {
+    surface.templates.delete(newId);
+  }
+
+  const clonedRecord = cloned as JsonRecord;
+  const resolveChild = (childId: string): string | null =>
+    cloneComponentTree(
+      surface,
+      childId,
+      newIdSuffix,
+      dataContextPath,
+      clonedRefs,
+    );
+
+  if (Array.isArray(clonedRecord['children'])) {
+    const nextChildren: string[] = [];
+    for (const childId of clonedRecord['children']) {
+      if (typeof childId !== 'string') continue;
+      const nextId = resolveChild(childId);
+      if (nextId) nextChildren.push(nextId);
+    }
+    clonedRecord['children'] = nextChildren;
+  }
+
+  for (const field of CHILD_REFERENCE_FIELDS) {
+    rewriteStringField(clonedRecord, field, resolveChild);
+  }
+
+  if (Array.isArray(clonedRecord['tabs'])) {
+    clonedRecord['tabs'] = clonedRecord['tabs'].map((tab) => {
+      if (!isObject(tab)) return tab;
+      const childId = tab['child'];
+      if (typeof childId !== 'string') return tab;
+      const nextId = resolveChild(childId);
+      return nextId ? { ...tab, child: nextId } : tab;
+    });
+  }
+
+  return newId;
+}
+
+function comparePaths(a: string, b: string): number {
+  const depthA = a === '/' ? 0 : a.split('/').length;
+  const depthB = b === '/' ? 0 : b.split('/').length;
+  return depthA === depthB ? a.localeCompare(b) : depthA - depthB;
+}
+
+function addKnownChildReferences(
+  component: JsonRecord,
+  out: Set<string>,
+): void {
+  const children = component['children'];
+  if (Array.isArray(children)) {
+    for (const childId of children) {
+      if (typeof childId === 'string') out.add(childId);
+    }
+  }
+
+  for (const field of CHILD_REFERENCE_FIELDS) {
+    const childId = component[field];
+    if (typeof childId === 'string') out.add(childId);
+  }
+
+  const tabs = component['tabs'];
+  if (Array.isArray(tabs)) {
+    for (const tab of tabs) {
+      if (isObject(tab) && typeof tab['child'] === 'string') {
+        out.add(tab['child']);
+      }
+    }
+  }
+}
+
+function scanStringReferences(
+  value: unknown,
+  knownIds: Set<string>,
+  out: Set<string>,
+): void {
+  if (typeof value === 'string') {
+    if (knownIds.has(value)) out.add(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) scanStringReferences(item, knownIds, out);
+    return;
+  }
+  if (!isObject(value)) return;
+  for (const item of Object.values(value)) {
+    scanStringReferences(item, knownIds, out);
+  }
+}
+
+function collectChildReferences(
+  component: ComponentInstance,
+  knownIds: Set<string>,
+): string[] {
+  const refs = new Set<string>();
+  const record = component as JsonRecord;
+  addKnownChildReferences(record, refs);
+  scanStringReferences(record, knownIds, refs);
+  return [...refs].filter(id => id !== component.id);
+}
+
+function collectReachableComponents(
+  surface: SnapshotSurfaceState,
+): ComponentInstance[] {
+  const rootId = surface.rootComponentId;
+  if (!rootId || !surface.components.has(rootId)) return [];
+
+  const knownIds = new Set(surface.components.keys());
+  const visited = new Set<string>();
+  const ordered: ComponentInstance[] = [];
+
+  const visit = (componentId: string) => {
+    if (visited.has(componentId)) return;
+    const component = surface.components.get(componentId);
+    if (!component) return;
+    visited.add(componentId);
+    ordered.push(component);
+    for (const childId of collectChildReferences(component, knownIds)) {
+      visit(childId);
+    }
+  };
+
+  visit(rootId);
+  return ordered;
+}
+
+function collectDataPaths(
+  value: unknown,
+  dataContextPath: string | undefined,
+  out: Set<string>,
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectDataPaths(item, dataContextPath, out);
+    return;
+  }
+
+  if (!isObject(value)) return;
+
+  if (typeof value['path'] === 'string') {
+    const path = resolveBindingPath(value['path'], dataContextPath);
+    if (path) out.add(normalizePath(path));
+  }
+
+  for (const item of Object.values(value)) {
+    collectDataPaths(item, dataContextPath, out);
+  }
+}
+
+function stripInternalComponentState(
+  component: ComponentInstance,
+): ComponentInstance {
+  const out = cloneJson(component) as ComponentInstance & JsonRecord;
+  delete out['__template'];
+  return out;
+}
+
+function createSurfaceMessage(
+  surface: SnapshotSurfaceState,
+): ServerToClientMessage {
+  const createSurface: JsonRecord = {
+    surfaceId: surface.surfaceId,
+  };
+  if (surface.catalogId !== undefined) {
+    createSurface['catalogId'] = surface.catalogId;
+  }
+  if (surface.theme !== undefined) {
+    createSurface['theme'] = cloneJson(surface.theme);
+  }
+  if (surface.sendDataModel !== undefined) {
+    createSurface['sendDataModel'] = surface.sendDataModel;
+  }
+  return {
+    version: 'v0.9',
+    createSurface,
+  } as ServerToClientMessage;
+}
+
+function createDataMessage(
+  surfaceId: string,
+  path: string,
+  value: unknown,
+): ServerToClientMessage {
+  const updateDataModel: JsonRecord = {
+    surfaceId,
+    value: cloneJson(value),
+  };
+  if (path !== '/') updateDataModel['path'] = path;
+  return {
+    version: 'v0.9',
+    updateDataModel,
+  } as ServerToClientMessage;
+}
+
+function createComponentsMessage(
+  surfaceId: string,
+  components: ComponentInstance[],
+): ServerToClientMessage {
+  return {
+    version: 'v0.9',
+    updateComponents: {
+      surfaceId,
+      components: components.map(stripInternalComponentState),
+    },
+  } as ServerToClientMessage;
+}
+
+class A2UISnapshotMachine {
+  private surfaces = new Map<string, SnapshotSurfaceState>();
+
+  applyAll(messages: readonly ServerToClientMessage[]): void {
+    for (const message of messages) this.apply(message);
+  }
+
+  apply(message: ServerToClientMessage): void {
+    if ('createSurface' in message && message.createSurface) {
+      this.applyCreateSurface(message);
+    }
+    if ('updateComponents' in message && message.updateComponents) {
+      this.applyUpdateComponents(message);
+    }
+    if ('updateDataModel' in message && message.updateDataModel) {
+      this.applyUpdateDataModel(message);
+    }
+    if ('deleteSurface' in message && message.deleteSurface) {
+      this.applyDeleteSurface(message);
+    }
+  }
+
+  serialize(originalMessageCount: number): CompactA2UISnapshotResult {
+    const messages: ServerToClientMessage[] = [];
+    const surfaces: CompactA2UISnapshotSurfaceMetadata[] = [];
+    let retainedComponentCount = 0;
+    let droppedComponentCount = 0;
+    let retainedDataPathCount = 0;
+
+    for (const surface of this.surfaces.values()) {
+      const reachableComponents = collectReachableComponents(surface);
+      const retainedPaths = new Set<string>();
+      for (const component of reachableComponents) {
+        collectDataPaths(component, component.dataContextPath, retainedPaths);
+      }
+      const retainedExistingPaths = [...retainedPaths]
+        .filter(path => surface.dataModel.has(path))
+        .sort(comparePaths);
+      const droppedForSurface = Math.max(
+        0,
+        surface.components.size - reachableComponents.length,
+      );
+
+      messages.push(createSurfaceMessage(surface));
+      for (const path of retainedExistingPaths) {
+        messages.push(createDataMessage(
+          surface.surfaceId,
+          path,
+          surface.dataModel.get(path),
+        ));
+      }
+      if (reachableComponents.length > 0) {
+        messages.push(createComponentsMessage(
+          surface.surfaceId,
+          reachableComponents,
+        ));
+      }
+
+      retainedComponentCount += reachableComponents.length;
+      droppedComponentCount += droppedForSurface;
+      retainedDataPathCount += retainedExistingPaths.length;
+      surfaces.push({
+        surfaceId: surface.surfaceId,
+        componentCount: reachableComponents.length,
+        droppedComponentCount: droppedForSurface,
+        dataPathCount: retainedExistingPaths.length,
+        hasRoot: Boolean(
+          surface.rootComponentId
+            && surface.components.has(surface.rootComponentId),
+        ),
+      });
+    }
+
+    return {
+      messages,
+      metadata: {
+        originalMessageCount,
+        compactedMessageCount: messages.length,
+        activeSurfaceCount: this.surfaces.size,
+        retainedComponentCount,
+        droppedComponentCount,
+        retainedDataPathCount,
+        surfaces,
+      },
+    };
+  }
+
+  private getOrCreateSurface(surfaceId: string): SnapshotSurfaceState {
+    let surface = this.surfaces.get(surfaceId);
+    if (!surface) {
+      surface = createSurfaceState(surfaceId);
+      this.surfaces.set(surfaceId, surface);
+    }
+    return surface;
+  }
+
+  private applyCreateSurface(message: ServerToClientMessage): void {
+    const createSurface =
+      (message as { createSurface?: unknown }).createSurface;
+    if (!isObject(createSurface)) return;
+    const surfaceId = createSurface['surfaceId'];
+    if (typeof surfaceId !== 'string' || surfaceId.length === 0) return;
+
+    const surface = this.getOrCreateSurface(surfaceId);
+    if (typeof createSurface['catalogId'] === 'string') {
+      surface.catalogId = createSurface['catalogId'];
+    }
+    if (isObject(createSurface['theme'])) {
+      surface.theme = cloneJson(createSurface['theme']);
+    }
+    if (typeof createSurface['sendDataModel'] === 'boolean') {
+      surface.sendDataModel = createSurface['sendDataModel'];
+    }
+  }
+
+  private applyUpdateComponents(message: ServerToClientMessage): void {
+    const updateComponents =
+      (message as { updateComponents?: unknown }).updateComponents;
+    if (!isObject(updateComponents)) return;
+    const surfaceId = updateComponents['surfaceId'];
+    const components = updateComponents['components'];
+    if (typeof surfaceId !== 'string' || !Array.isArray(components)) return;
+
+    const surface = this.getOrCreateSurface(surfaceId);
+    let firstUpdatedId: string | null = null;
+
+    for (const rawComponent of components) {
+      if (!isObject(rawComponent) || typeof rawComponent['id'] !== 'string') {
+        continue;
+      }
+      const id = rawComponent['id'];
+      firstUpdatedId ??= id;
+
+      const existing = surface.components.get(id);
+      const instance = cloneJson(rawComponent) as ComponentInstance;
+      if (existing?.dataContextPath !== undefined) {
+        instance.dataContextPath = existing.dataContextPath;
+      }
+
+      surface.components.set(id, instance);
+
+      const template = getTemplateInfo(instance, instance.dataContextPath);
+      if (template) {
+        surface.templates.set(id, template);
+      } else {
+        surface.templates.delete(id);
+      }
+
+      if (id === 'root') {
+        surface.rootComponentId = 'root';
+      }
+    }
+
+    if (!surface.rootComponentId) {
+      if (surface.components.has('root')) {
+        surface.rootComponentId = 'root';
+      } else {
+        surface.rootComponentId = firstUpdatedId;
+      }
+    }
+  }
+
+  private applyUpdateDataModel(message: ServerToClientMessage): void {
+    const updateDataModel =
+      (message as { updateDataModel?: unknown }).updateDataModel;
+    if (!isObject(updateDataModel)) return;
+    const surfaceId = updateDataModel['surfaceId'];
+    if (typeof surfaceId !== 'string') return;
+
+    const surface = this.getOrCreateSurface(surfaceId);
+    const path = updateDataModel['path'];
+    const value = updateDataModel['value'];
+    const updates: Array<{ path: string; value: unknown }> = [];
+
+    if (value !== undefined) {
+      const basePath = typeof path === 'string' && path !== ''
+        ? normalizePath(path)
+        : '/';
+      flattenValue(value, basePath, updates);
+    } else if (typeof path === 'string' && path !== '') {
+      updates.push({ path: normalizePath(path), value: '' });
+    }
+
+    for (const update of updates) {
+      surface.dataModel.set(update.path, cloneJson(update.value));
+    }
+    if (updates.length > 0) this.expandTemplates(surface);
+  }
+
+  private applyDeleteSurface(message: ServerToClientMessage): void {
+    const deleteSurface =
+      (message as { deleteSurface?: unknown }).deleteSurface;
+    if (!isObject(deleteSurface)) return;
+    const surfaceId = deleteSurface['surfaceId'];
+    if (typeof surfaceId === 'string') this.surfaces.delete(surfaceId);
+  }
+
+  private expandTemplates(surface: SnapshotSurfaceState): void {
+    for (const [componentId, template] of Array.from(surface.templates)) {
+      const component = surface.components.get(componentId);
+      if (!component) {
+        surface.templates.delete(componentId);
+        continue;
+      }
+
+      const rawData = readDataValue(surface, template.path);
+      const explicitChildren: string[] = [];
+
+      if (Array.isArray(rawData)) {
+        rawData.forEach((_, index) => {
+          const clonedId = cloneComponentTree(
+            surface,
+            template.componentId,
+            `:${index}`,
+            `${template.path}/${index}`,
+          );
+          if (clonedId) explicitChildren.push(clonedId);
+        });
+      } else if (isObject(rawData)) {
+        for (const key of Object.keys(rawData)) {
+          const clonedId = cloneComponentTree(
+            surface,
+            template.componentId,
+            `:${key}`,
+            `${template.path}/${key}`,
+          );
+          if (clonedId) explicitChildren.push(clonedId);
+        }
+      }
+
+      (component as JsonRecord)['children'] = explicitChildren;
+    }
+  }
+}
+
+export function compactA2UIMessagesToSnapshot(
+  messages: readonly ServerToClientMessage[],
+): CompactA2UISnapshotResult {
+  const machine = new A2UISnapshotMachine();
+  machine.applyAll(messages);
+  return machine.serialize(messages.length);
+}

--- a/packages/genui/a2ui/src/snapshot/index.ts
+++ b/packages/genui/a2ui/src/snapshot/index.ts
@@ -224,8 +224,9 @@ function cloneComponentTree(
     rewriteStringField(clonedRecord, field, resolveChild);
   }
 
-  if (Array.isArray(clonedRecord['tabs'])) {
-    clonedRecord['tabs'] = clonedRecord['tabs'].map((tab) => {
+  const tabs = clonedRecord['tabs'];
+  if (Array.isArray(tabs)) {
+    clonedRecord['tabs'] = tabs.map((tab: unknown): unknown => {
       if (!isObject(tab)) return tab;
       const childId = tab['child'];
       if (typeof childId !== 'string') return tab;
@@ -350,7 +351,7 @@ function stripInternalComponentState(
   component: ComponentInstance,
 ): ComponentInstance {
   const out = cloneJson(component) as ComponentInstance & JsonRecord;
-  delete out['__template'];
+  delete out.__template;
   return out;
 }
 
@@ -399,7 +400,9 @@ function createComponentsMessage(
     version: 'v0.9',
     updateComponents: {
       surfaceId,
-      components: components.map(stripInternalComponentState),
+      components: components.map(component =>
+        stripInternalComponentState(component)
+      ),
     },
   } as ServerToClientMessage;
 }

--- a/packages/genui/a2ui/src/snapshot/index.ts
+++ b/packages/genui/a2ui/src/snapshot/index.ts
@@ -79,6 +79,17 @@ function resolveBindingPath(path: string, dataContextPath?: string): string {
   return context ? `${context}/${bindingPath}` : `/${bindingPath}`;
 }
 
+function joinDataContextPath(
+  basePath: string,
+  segment: string | number,
+): string {
+  const normalizedBase = normalizePath(basePath);
+  const base = normalizedBase === '/'
+    ? ''
+    : normalizedBase.replace(/\/+$/, '');
+  return `${base}/${segment}`;
+}
+
 function flattenValue(
   value: unknown,
   basePath: string,
@@ -621,7 +632,7 @@ class A2UISnapshotMachine {
             surface,
             template.componentId,
             `:${index}`,
-            `${template.path}/${index}`,
+            joinDataContextPath(template.path, index),
           );
           if (clonedId) explicitChildren.push(clonedId);
         });
@@ -631,7 +642,7 @@ class A2UISnapshotMachine {
             surface,
             template.componentId,
             `:${key}`,
-            `${template.path}/${key}`,
+            joinDataContextPath(template.path, key),
           );
           if (clonedId) explicitChildren.push(clonedId);
         }

--- a/packages/genui/a2ui/test/snapshot.test.ts
+++ b/packages/genui/a2ui/test/snapshot.test.ts
@@ -4,43 +4,111 @@
 import { describe, expect, test } from '@rstest/core';
 
 import { compactA2UIMessagesToSnapshot } from '../src/snapshot/index.js';
-import type {
-  ComponentInstance,
-  ServerToClientMessage,
-} from '../src/store/types.js';
+import type { ServerToClientMessage } from '../src/store/types.js';
 
-function componentMessages(
-  result: ReturnType<typeof compactA2UIMessagesToSnapshot>,
-) {
-  return result.messages.filter((message) =>
-    'updateComponents' in message && message.updateComponents
-  );
+type SnapshotResult = ReturnType<typeof compactA2UIMessagesToSnapshot>;
+type SnapshotComponent = Record<string, unknown> & {
+  id?: string;
+  dataContextPath?: string;
+};
+
+interface ComponentUpdate {
+  components: SnapshotComponent[];
 }
 
-function components(result: ReturnType<typeof compactA2UIMessagesToSnapshot>) {
-  return componentMessages(result).flatMap((message) =>
-    (message.updateComponents?.components ?? []) as ComponentInstance[]
-  );
+interface DataUpdate {
+  path?: string;
+  value?: unknown;
+}
+
+interface DataMessage {
+  updateDataModel: DataUpdate;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getComponentUpdate(
+  message: ServerToClientMessage,
+): ComponentUpdate | null {
+  const updateComponents =
+    (message as { updateComponents?: unknown }).updateComponents;
+  if (!isRecord(updateComponents)) return null;
+
+  const rawComponents = updateComponents['components'];
+  if (!Array.isArray(rawComponents)) return null;
+
+  const components: SnapshotComponent[] = [];
+  for (const rawComponent of rawComponents) {
+    if (isRecord(rawComponent)) components.push(rawComponent);
+  }
+  return { components };
+}
+
+function getDataUpdate(message: ServerToClientMessage): DataUpdate | null {
+  const updateDataModel =
+    (message as { updateDataModel?: unknown }).updateDataModel;
+  if (!isRecord(updateDataModel)) return null;
+
+  const path = updateDataModel['path'];
+  return {
+    ...(typeof path === 'string' ? { path } : {}),
+    value: updateDataModel['value'],
+  };
+}
+
+function componentMessages(
+  result: SnapshotResult,
+): ComponentUpdate[] {
+  const out: ComponentUpdate[] = [];
+  for (const message of result.messages) {
+    const update = getComponentUpdate(message);
+    if (update) out.push(update);
+  }
+  return out;
+}
+
+function components(result: SnapshotResult): SnapshotComponent[] {
+  const out: SnapshotComponent[] = [];
+  for (const update of componentMessages(result)) {
+    out.push(...update.components);
+  }
+  return out;
 }
 
 function componentIds(
-  result: ReturnType<typeof compactA2UIMessagesToSnapshot>,
+  result: SnapshotResult,
 ) {
   return components(result).map(component => component.id);
 }
 
 function dataMessages(
-  result: ReturnType<typeof compactA2UIMessagesToSnapshot>,
-) {
-  return result.messages.filter((message) =>
-    'updateDataModel' in message && message.updateDataModel
-  );
+  result: SnapshotResult,
+): DataMessage[] {
+  const out: DataMessage[] = [];
+  for (const message of result.messages) {
+    const updateDataModel = getDataUpdate(message);
+    if (updateDataModel) out.push({ updateDataModel });
+  }
+  return out;
 }
 
-function dataPaths(result: ReturnType<typeof compactA2UIMessagesToSnapshot>) {
-  return dataMessages(result).map((message) =>
-    message.updateDataModel?.path ?? '/'
-  );
+function dataPaths(result: SnapshotResult): string[] {
+  const out: string[] = [];
+  for (const message of dataMessages(result)) {
+    const { path } = message.updateDataModel;
+    out.push(typeof path === 'string' ? path : '/');
+  }
+  return out;
+}
+
+function dataValues(result: SnapshotResult): unknown[] {
+  const out: unknown[] = [];
+  for (const message of dataMessages(result)) {
+    out.push(message.updateDataModel.value);
+  }
+  return out;
 }
 
 describe('compactA2UIMessagesToSnapshot', () => {
@@ -324,8 +392,7 @@ describe('compactA2UIMessagesToSnapshot', () => {
     ] as ServerToClientMessage[]);
 
     expect(dataPaths(result)).toEqual(['/items/0/name']);
-    expect(dataMessages(result).map(message => message.updateDataModel?.value))
-      .toEqual(['Apple']);
+    expect(dataValues(result)).toEqual(['Apple']);
   });
 
   test('keeps a generated component data context when it is replaced', () => {

--- a/packages/genui/a2ui/test/snapshot.test.ts
+++ b/packages/genui/a2ui/test/snapshot.test.ts
@@ -1,0 +1,528 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { compactA2UIMessagesToSnapshot } from '../src/snapshot/index.js';
+import type {
+  ComponentInstance,
+  ServerToClientMessage,
+} from '../src/store/types.js';
+
+function componentMessages(
+  result: ReturnType<typeof compactA2UIMessagesToSnapshot>,
+) {
+  return result.messages.filter((message) =>
+    'updateComponents' in message && message.updateComponents
+  );
+}
+
+function components(result: ReturnType<typeof compactA2UIMessagesToSnapshot>) {
+  return componentMessages(result).flatMap((message) =>
+    (message.updateComponents?.components ?? []) as ComponentInstance[]
+  );
+}
+
+function componentIds(
+  result: ReturnType<typeof compactA2UIMessagesToSnapshot>,
+) {
+  return components(result).map(component => component.id);
+}
+
+function dataMessages(
+  result: ReturnType<typeof compactA2UIMessagesToSnapshot>,
+) {
+  return result.messages.filter((message) =>
+    'updateDataModel' in message && message.updateDataModel
+  );
+}
+
+function dataPaths(result: ReturnType<typeof compactA2UIMessagesToSnapshot>) {
+  return dataMessages(result).map((message) =>
+    message.updateDataModel?.path ?? '/'
+  );
+}
+
+describe('compactA2UIMessagesToSnapshot', () => {
+  test('drops components removed from the final reachable tree', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: ['keep', 'remove-me'],
+            },
+            { id: 'keep', component: 'Text', text: { path: '/title' } },
+            {
+              id: 'remove-me',
+              component: 'Text',
+              text: { path: '/unused' },
+            },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: { title: 'Visible', unused: 'Gone' },
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            { id: 'root', component: 'Column', children: ['keep'] },
+          ],
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(componentIds(result)).toEqual(['root', 'keep']);
+    expect(dataPaths(result)).toEqual(['/title']);
+    expect(result.metadata).toMatchObject({
+      originalMessageCount: 4,
+      compactedMessageCount: 3,
+      activeSurfaceCount: 1,
+      retainedComponentCount: 2,
+      droppedComponentCount: 1,
+      retainedDataPathCount: 1,
+      surfaces: [
+        {
+          surfaceId: 's1',
+          componentCount: 2,
+          droppedComponentCount: 1,
+          dataPathCount: 1,
+          hasRoot: true,
+        },
+      ],
+    });
+  });
+
+  test('keeps the final replacement for an updated component', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            { id: 'root', component: 'Text', text: 'First' },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            { id: 'root', component: 'Text', text: 'Final' },
+          ],
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(components(result)).toEqual([
+      { id: 'root', component: 'Text', text: 'Final' },
+    ]);
+  });
+
+  test('preserves createSurface metadata and omits passthrough fields', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 's1',
+          catalogId: 'test',
+          theme: { color: 'blue' },
+          sendDataModel: true,
+          passthrough: 'drop',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [{ id: 'root', component: 'Text', text: 'Ready' }],
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(result.messages[0]).toEqual({
+      version: 'v0.9',
+      createSurface: {
+        surfaceId: 's1',
+        catalogId: 'test',
+        theme: { color: 'blue' },
+        sendDataModel: true,
+      },
+    });
+  });
+
+  test('omits deleted surfaces', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 'gone', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gone',
+          components: [{ id: 'root', component: 'Text', text: 'Gone' }],
+        },
+      },
+      {
+        version: 'v0.9',
+        deleteSurface: { surfaceId: 'gone' },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(result.messages).toEqual([]);
+    expect(result.metadata.activeSurfaceCount).toBe(0);
+  });
+
+  test('serializes final dynamic children with data contexts', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: { componentId: 'item', path: '/items' },
+            },
+            { id: 'item', component: 'Text', text: { path: 'name' } },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: { items: [{ name: 'Apple' }, { name: 'Banana' }] },
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    const nextComponents = components(result);
+    expect(nextComponents).toEqual([
+      {
+        id: 'root',
+        component: 'Column',
+        children: ['item:0', 'item:1'],
+      },
+      {
+        id: 'item:0',
+        component: 'Text',
+        text: { path: 'name' },
+        dataContextPath: '/items/0',
+      },
+      {
+        id: 'item:1',
+        component: 'Text',
+        text: { path: 'name' },
+        dataContextPath: '/items/1',
+      },
+    ]);
+    expect(
+      nextComponents.some(component => '__template' in component),
+    ).toBe(false);
+    expect(dataPaths(result)).toEqual(['/items/0/name', '/items/1/name']);
+  });
+
+  test('drops stale dynamic children when the final data is empty', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: { componentId: 'item', path: '/items' },
+            },
+            { id: 'item', component: 'Text', text: { path: 'name' } },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: { items: [{ name: 'Apple' }, { name: 'Banana' }] },
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          path: '/items',
+          value: [],
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(components(result)).toEqual([
+      { id: 'root', component: 'Column', children: [] },
+    ]);
+    expect(componentIds(result)).not.toContain('item:0');
+    expect(componentIds(result)).not.toContain('item:1');
+    expect(dataPaths(result)).toEqual([]);
+  });
+
+  test('resolves dot-relative bindings against generated data contexts', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: { componentId: 'item', path: '/items' },
+            },
+            { id: 'item', component: 'Text', text: { path: './name' } },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: { items: [{ name: 'Apple' }] },
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(dataPaths(result)).toEqual(['/items/0/name']);
+    expect(dataMessages(result).map(message => message.updateDataModel?.value))
+      .toEqual(['Apple']);
+  });
+
+  test('keeps a generated component data context when it is replaced', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: { componentId: 'item', path: '/items' },
+            },
+            { id: 'item', component: 'Text', text: { path: 'name' } },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: { items: [{ name: 'Apple' }] },
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'item:0',
+              component: 'Text',
+              text: { path: 'name' },
+              color: 'green',
+            },
+          ],
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(components(result)).toEqual([
+      {
+        id: 'root',
+        component: 'Column',
+        children: ['item:0'],
+      },
+      {
+        id: 'item:0',
+        component: 'Text',
+        text: { path: 'name' },
+        color: 'green',
+        dataContextPath: '/items/0',
+      },
+    ]);
+    expect(dataPaths(result)).toEqual(['/items/0/name']);
+  });
+
+  test('retains data paths referenced by actions, checks, and function args', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            { id: 'root', component: 'Column', children: ['button'] },
+            {
+              id: 'button',
+              component: 'Button',
+              child: 'label',
+              action: {
+                event: {
+                  name: 'buy',
+                  context: { productId: { path: '/product/id' } },
+                },
+              },
+              checks: [{ condition: { path: '/product/valid' } }],
+              isValid: {
+                call: 'isPositive',
+                args: { value: { path: '/product/count' } },
+              },
+            },
+            { id: 'label', component: 'Text', text: 'Buy' },
+            { id: 'unused', component: 'Text', text: { path: '/unused' } },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: {
+            product: { id: 'sku-1', valid: true, count: 3 },
+            unused: 'drop',
+          },
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(dataPaths(result)).toEqual([
+      '/product/count',
+      '/product/id',
+      '/product/valid',
+    ]);
+    expect(componentIds(result)).not.toContain('unused');
+  });
+
+  test('retains custom child references on unknown components', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'root',
+              component: 'CustomShell',
+              slots: { main: 'custom-child' },
+            },
+            {
+              id: 'custom-child',
+              component: 'Text',
+              text: { path: '/title' },
+            },
+            {
+              id: 'orphan',
+              component: 'Text',
+              text: { path: '/unused' },
+            },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: { title: 'Visible', unused: 'Gone' },
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(componentIds(result)).toEqual(['root', 'custom-child']);
+    expect(dataPaths(result)).toEqual(['/title']);
+  });
+
+  test('is stable when compacting compacted messages again', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: ['keep', 'remove-me'],
+            },
+            { id: 'keep', component: 'Text', text: { path: '/title' } },
+            { id: 'remove-me', component: 'Text', text: 'drop' },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: { title: 'Stable' },
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            { id: 'root', component: 'Column', children: ['keep'] },
+          ],
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    const next = compactA2UIMessagesToSnapshot(result.messages);
+    expect(next.messages).toEqual(result.messages);
+  });
+});

--- a/packages/genui/a2ui/test/snapshot.test.ts
+++ b/packages/genui/a2ui/test/snapshot.test.ts
@@ -317,6 +317,57 @@ describe('compactA2UIMessagesToSnapshot', () => {
     expect(dataPaths(result)).toEqual(['/items/0/name', '/items/1/name']);
   });
 
+  test('normalizes root-bound dynamic children data contexts', () => {
+    const result = compactA2UIMessagesToSnapshot([
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId: 's1', catalogId: 'test' },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: { componentId: 'item', path: '/' },
+            },
+            { id: 'item', component: 'Text', text: { path: 'name' } },
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 's1',
+          value: [{ name: 'Alpha' }, { name: 'Beta' }],
+        },
+      },
+    ] as ServerToClientMessage[]);
+
+    expect(components(result)).toEqual([
+      {
+        id: 'root',
+        component: 'Column',
+        children: ['item:0', 'item:1'],
+      },
+      {
+        id: 'item:0',
+        component: 'Text',
+        text: { path: 'name' },
+        dataContextPath: '/0',
+      },
+      {
+        id: 'item:1',
+        component: 'Text',
+        text: { path: 'name' },
+        dataContextPath: '/1',
+      },
+    ]);
+    expect(dataPaths(result)).toEqual(['/0/name', '/1/name']);
+  });
+
   test('drops stale dynamic children when the final data is empty', () => {
     const result = compactA2UIMessagesToSnapshot([
       {

--- a/packages/genui/package.json
+++ b/packages/genui/package.json
@@ -30,6 +30,10 @@
       "types": "./a2ui/dist/store/index.d.ts",
       "default": "./a2ui/dist/store/index.js"
     },
+    "./a2ui/snapshot": {
+      "types": "./a2ui/dist/snapshot/index.d.ts",
+      "default": "./a2ui/dist/snapshot/index.js"
+    },
     "./a2ui/catalog": {
       "types": "./a2ui/dist/catalog/index.d.ts",
       "default": "./a2ui/dist/catalog/index.js"


### PR DESCRIPTION
## Summary

- Add `@lynx-js/genui-a2ui/snapshot` and `@lynx-js/genui/a2ui/snapshot` exports for final-state A2UI compaction.
- Replay normalized A2UI messages through `A2UISnapshotMachine`, then serialize active surfaces into compact final-state messages plus metadata.
- Preserve renderer-facing behavior for component replacement, dynamic children expansion, data contexts, data-path retention, and deleted surfaces.
- Document `result.messages` as the render/share payload and `metadata` as diagnostic/test-only data.

## Why

A2UI playback should keep the original operation log, but final-state preview/share/benchmark payloads do not need superseded updates or components that were later removed. Replaying into a snapshot state avoids unsafe local pruning and rebuilds the payload from the actual final state.

## Validation

- `pnpm exec rstest --project genui/a2ui test/snapshot.test.ts`
- `pnpm exec tsc --project packages/genui/a2ui/tsconfig.build.json --noEmit`
- `DPRINT_CACHE_DIR=/private/tmp/codex-dprint-cache pnpm exec dprint check packages/genui/a2ui/src/snapshot/index.ts packages/genui/a2ui/test/snapshot.test.ts packages/genui/a2ui/docs/overview.md .github/a2ui-snapshot.instructions.md packages/genui/a2ui/package.json packages/genui/package.json`
- `pnpm turbo build --filter @lynx-js/genui-a2ui`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added A2UI snapshot compaction that converts server-to-client streaming messages into a smaller compact final-state representation.

* **Documentation**
  * Added a new guide section explaining how final-state message compaction works, including examples and what metadata is intended for.

* **Tests**
  * Added comprehensive coverage to verify reachability, data bindings, template-driven children, and idempotence.

* **Packaging**
  * Exposed the new snapshot compaction API via added package subpath exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->