### PR TITLE
feat(a2ui-playground): add z template examples

### DIFF
--- a/packages/genui/a2ui-playground/rsbuild.config.ts
+++ b/packages/genui/a2ui-playground/rsbuild.config.ts
@@ -203,6 +203,10 @@ export default defineConfig({
         from: 'src/mock/a2ui-gallery/*.json',
         to: 'demos/[name][ext]',
       },
+      {
+        from: 'src/mock/z/*.json',
+        to: 'demos/[name][ext]',
+      },
     ],
   },
   server: {

--- a/packages/genui/a2ui-playground/src/demos.ts
+++ b/packages/genui/a2ui-playground/src/demos.ts
@@ -11,6 +11,7 @@ import pieChartChinaEvShare from './mock/basic/pie-chart-china-ev-share.json';
 import recs from './mock/basic/recs.json';
 import tripPlanner from './mock/basic/trip-planner.json';
 import workoutPlan from './mock/basic/workout-plan.json';
+import { Z_TEMPLATE_DEMOS } from './mock/z/z-template.js';
 
 function collectComponentNamesFromMessages(
   value: unknown,
@@ -176,9 +177,21 @@ export const EXTENDED_STATIC_DEMOS: StaticDemo[] = [
   },
 ];
 
+export const Z_STATIC_DEMOS: StaticDemo[] = Z_TEMPLATE_DEMOS.map(
+  (demo) => ({
+    id: demo.id,
+    title: demo.title,
+    description: demo.description,
+    hasStaticJson: demo.hasStaticJson,
+    tags: tagsFromMessages(demo.messages),
+    messages: demo.messages,
+  }),
+);
+
 export const STATIC_DEMOS: StaticDemo[] = [
   ...OFFICIAL_STATIC_DEMOS,
   ...EXTENDED_STATIC_DEMOS,
+  ...Z_STATIC_DEMOS,
 ];
 
 export const STATIC_DEMO_JSON_IDS = new Set(

--- a/packages/genui/a2ui-playground/src/mock/z/z-ask-human-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-ask-human-card.json
@@ -1,0 +1,213 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-ask-human-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-ask-human-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "ask-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "ask-body",
+          "component": "Column",
+          "children": [
+            "ask-title",
+            "ask-copy",
+            "ask-options",
+            "ask-skip"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "ask-title",
+          "component": "Text",
+          "text": "请选择门店",
+          "variant": "h3"
+        },
+        {
+          "id": "ask-copy",
+          "component": "Text",
+          "text": "为你找到 3 个附近候选项，确认后继续处理任务。",
+          "variant": "caption"
+        },
+        {
+          "id": "ask-options",
+          "component": "Column",
+          "children": [
+            "ask-option-1-action",
+            "ask-option-2-action",
+            "ask-option-3-action"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "ask-option-1-action",
+          "component": "Button",
+          "child": "ask-option-1-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "ask-option-1-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "ask-option-1-card",
+          "component": "Card",
+          "child": "ask-option-1-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "ask-option-1-body",
+          "component": "Row",
+          "children": [
+            "ask-option-1-text",
+            "ask-option-1-icon"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ask-option-1-text",
+          "component": "Text",
+          "text": "中关村创业大街店 · 0.6km",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ask-option-1-icon",
+          "component": "Icon",
+          "name": "arrow_forward",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "ask-option-2-action",
+          "component": "Button",
+          "child": "ask-option-2-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "ask-option-2-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "ask-option-2-card",
+          "component": "Card",
+          "child": "ask-option-2-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "ask-option-2-body",
+          "component": "Row",
+          "children": [
+            "ask-option-2-text",
+            "ask-option-2-icon"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ask-option-2-text",
+          "component": "Text",
+          "text": "北京中关村在握旗舰店 · 1.8km",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ask-option-2-icon",
+          "component": "Icon",
+          "name": "arrow_forward",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "ask-option-3-action",
+          "component": "Button",
+          "child": "ask-option-3-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "ask-option-3-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "ask-option-3-card",
+          "component": "Card",
+          "child": "ask-option-3-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "ask-option-3-body",
+          "component": "Row",
+          "children": [
+            "ask-option-3-text",
+            "ask-option-3-icon"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ask-option-3-text",
+          "component": "Text",
+          "text": "中关村城委店 · 3.5km",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ask-option-3-icon",
+          "component": "Icon",
+          "name": "arrow_forward",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "ask-skip-text",
+          "component": "Text",
+          "text": "跳过",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ask-skip",
+          "component": "Button",
+          "child": "ask-skip-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "ask-skip.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-invalid-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-invalid-card.json
@@ -1,0 +1,171 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-invalid-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-invalid-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "invalid-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "invalid-body",
+          "component": "Column",
+          "children": [
+            "invalid-titlebar",
+            "invalid-content"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "invalid-titlebar",
+          "component": "Row",
+          "children": [
+            "invalid-app",
+            "invalid-more-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "invalid-app",
+          "component": "Row",
+          "children": [
+            "invalid-app-mark",
+            "invalid-app-name"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "invalid-app-mark",
+          "component": "Icon",
+          "name": "home",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "invalid-app-name",
+          "component": "Text",
+          "text": "z 应用",
+          "variant": "caption",
+          "emphasis": "medium"
+        },
+        {
+          "id": "invalid-more",
+          "component": "Row",
+          "children": [
+            "invalid-more-text",
+            "invalid-more-icon"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "invalid-more-text",
+          "component": "Text",
+          "text": "更多",
+          "variant": "caption"
+        },
+        {
+          "id": "invalid-more-icon",
+          "component": "Icon",
+          "name": "more_vert",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "invalid-more-action",
+          "component": "Button",
+          "child": "invalid-more",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "invalid-more-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "invalid-content",
+          "component": "Button",
+          "child": "invalid-row-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "invalid-content.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "invalid-row-card",
+          "component": "Card",
+          "child": "invalid-row",
+          "variant": "filled"
+        },
+        {
+          "id": "invalid-row",
+          "component": "Row",
+          "children": [
+            "invalid-icon",
+            "invalid-copy",
+            "invalid-chevron"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "invalid-icon",
+          "component": "Icon",
+          "name": "info",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "invalid-copy",
+          "component": "Column",
+          "children": [
+            "invalid-title",
+            "invalid-desc"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "invalid-title",
+          "component": "Text",
+          "text": "任务状态已更新",
+          "variant": "h4"
+        },
+        {
+          "id": "invalid-desc",
+          "component": "Text",
+          "text": "当前卡片内容已失效，请返回查看最新状态。",
+          "variant": "caption"
+        },
+        {
+          "id": "invalid-chevron",
+          "component": "Icon",
+          "name": "arrow_forward",
+          "color": "muted",
+          "size": "md"
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-list-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-list-card.json
@@ -1,0 +1,406 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-list-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-list-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "list-card-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "list-card-body",
+          "component": "Column",
+          "children": [
+            "list-titlebar",
+            "list-items",
+            "list-view-more"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "list-titlebar",
+          "component": "Row",
+          "children": [
+            "list-app",
+            "list-more-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "list-app",
+          "component": "Row",
+          "children": [
+            "list-app-mark",
+            "list-app-name"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "list-app-mark",
+          "component": "Icon",
+          "name": "home",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "list-app-name",
+          "component": "Text",
+          "text": "z 应用",
+          "variant": "caption",
+          "emphasis": "medium"
+        },
+        {
+          "id": "list-more",
+          "component": "Row",
+          "children": [
+            "list-more-text",
+            "list-more-icon"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "list-more-text",
+          "component": "Text",
+          "text": "更多",
+          "variant": "caption"
+        },
+        {
+          "id": "list-more-icon",
+          "component": "Icon",
+          "name": "more_vert",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "list-more-action",
+          "component": "Button",
+          "child": "list-more",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "list-more-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "list-items",
+          "component": "Column",
+          "children": [
+            "list-item-1",
+            "list-item-2",
+            "list-item-3",
+            "list-item-4"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "list-item-1",
+          "component": "Card",
+          "child": "list-item-1-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "list-item-1-body",
+          "component": "Row",
+          "children": [
+            "list-item-1-media",
+            "list-item-1-copy",
+            "list-item-1-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "list-item-1-media",
+          "component": "Image",
+          "url": "https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=720&q=80",
+          "fit": "cover",
+          "variant": "smallFeature"
+        },
+        {
+          "id": "list-item-1-copy",
+          "component": "Column",
+          "children": [
+            "list-item-1-title",
+            "list-item-1-meta"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "list-item-1-title",
+          "component": "Text",
+          "text": "智能跑鞋 Pro",
+          "variant": "h4"
+        },
+        {
+          "id": "list-item-1-meta",
+          "component": "Text",
+          "text": "4199元 · 轻量缓震",
+          "variant": "caption"
+        },
+        {
+          "id": "list-item-1-action-text",
+          "component": "Text",
+          "text": "下单",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "list-item-1-action",
+          "component": "Button",
+          "child": "list-item-1-action-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "list-item-1-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "list-item-2",
+          "component": "Card",
+          "child": "list-item-2-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "list-item-2-body",
+          "component": "Row",
+          "children": [
+            "list-item-2-media",
+            "list-item-2-copy",
+            "list-item-2-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "list-item-2-media",
+          "component": "Icon",
+          "name": "star",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "list-item-2-copy",
+          "component": "Column",
+          "children": [
+            "list-item-2-title",
+            "list-item-2-meta"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "list-item-2-title",
+          "component": "Text",
+          "text": "便携咖啡杯",
+          "variant": "h4"
+        },
+        {
+          "id": "list-item-2-meta",
+          "component": "Text",
+          "text": "299元 · 保温 12 小时",
+          "variant": "caption"
+        },
+        {
+          "id": "list-item-2-action-text",
+          "component": "Text",
+          "text": "查看",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "list-item-2-action",
+          "component": "Button",
+          "child": "list-item-2-action-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "list-item-2-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "list-item-3",
+          "component": "Card",
+          "child": "list-item-3-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "list-item-3-body",
+          "component": "Row",
+          "children": [
+            "list-item-3-media",
+            "list-item-3-copy",
+            "list-item-3-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "list-item-3-media",
+          "component": "Icon",
+          "name": "location_on",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "list-item-3-copy",
+          "component": "Column",
+          "children": [
+            "list-item-3-title",
+            "list-item-3-meta"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "list-item-3-title",
+          "component": "Text",
+          "text": "城市周末套票",
+          "variant": "h4"
+        },
+        {
+          "id": "list-item-3-meta",
+          "component": "Text",
+          "text": "168元 · 含双人下午茶",
+          "variant": "caption"
+        },
+        {
+          "id": "list-item-3-action-text",
+          "component": "Text",
+          "text": "查看",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "list-item-3-action",
+          "component": "Button",
+          "child": "list-item-3-action-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "list-item-3-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "list-item-4",
+          "component": "Card",
+          "child": "list-item-4-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "list-item-4-body",
+          "component": "Row",
+          "children": [
+            "list-item-4-media",
+            "list-item-4-copy",
+            "list-item-4-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "list-item-4-media",
+          "component": "Icon",
+          "name": "star",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "list-item-4-copy",
+          "component": "Column",
+          "children": [
+            "list-item-4-title",
+            "list-item-4-meta"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "list-item-4-title",
+          "component": "Text",
+          "text": "蓝牙降噪耳机",
+          "variant": "h4"
+        },
+        {
+          "id": "list-item-4-meta",
+          "component": "Text",
+          "text": "699元 · 通勤低延迟",
+          "variant": "caption"
+        },
+        {
+          "id": "list-item-4-action-text",
+          "component": "Text",
+          "text": "查看",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "list-item-4-action",
+          "component": "Button",
+          "child": "list-item-4-action-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "list-item-4-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "list-view-more-text",
+          "component": "Text",
+          "text": "查看更多",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "list-view-more",
+          "component": "Button",
+          "child": "list-view-more-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "list-view-more.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-media-layout-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-media-layout-card.json
@@ -1,0 +1,232 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-media-layout-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-media-layout-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "media-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "media-body",
+          "component": "Column",
+          "children": [
+            "media-titlebar",
+            "media-content",
+            "media-actions"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "media-titlebar",
+          "component": "Row",
+          "children": [
+            "media-app",
+            "media-more-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "media-app",
+          "component": "Row",
+          "children": [
+            "media-app-mark",
+            "media-app-name"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "media-app-mark",
+          "component": "Icon",
+          "name": "home",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "media-app-name",
+          "component": "Text",
+          "text": "z 应用",
+          "variant": "caption",
+          "emphasis": "medium"
+        },
+        {
+          "id": "media-more",
+          "component": "Row",
+          "children": [
+            "media-more-text",
+            "media-more-icon"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "media-more-text",
+          "component": "Text",
+          "text": "更多",
+          "variant": "caption"
+        },
+        {
+          "id": "media-more-icon",
+          "component": "Icon",
+          "name": "more_vert",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "media-more-action",
+          "component": "Button",
+          "child": "media-more",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "media-more-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "media-content",
+          "component": "Row",
+          "children": [
+            "media-image",
+            "media-copy",
+            "media-extra"
+          ],
+          "align": "start",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "media-image",
+          "component": "Image",
+          "url": "https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=720&q=80",
+          "fit": "cover",
+          "variant": "smallFeature"
+        },
+        {
+          "id": "media-copy",
+          "component": "Column",
+          "children": [
+            "media-title",
+            "media-info-1",
+            "media-info-2"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "media-title",
+          "component": "Text",
+          "text": "小程序开发助手",
+          "variant": "h3"
+        },
+        {
+          "id": "media-info-1",
+          "component": "Text",
+          "text": "提供开发、构建、调试和发布能力。",
+          "variant": "caption"
+        },
+        {
+          "id": "media-info-2",
+          "component": "Text",
+          "text": "最近更新：2 分钟前",
+          "variant": "caption"
+        },
+        {
+          "id": "media-extra",
+          "component": "Card",
+          "child": "media-extra-copy",
+          "variant": "filled"
+        },
+        {
+          "id": "media-extra-copy",
+          "component": "Column",
+          "children": [
+            "media-extra-label",
+            "media-extra-value"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "media-extra-label",
+          "component": "Text",
+          "text": "状态",
+          "variant": "caption"
+        },
+        {
+          "id": "media-extra-value",
+          "component": "Text",
+          "text": "可用",
+          "variant": "h4"
+        },
+        {
+          "id": "media-actions",
+          "component": "Row",
+          "children": [
+            "media-secondary",
+            "media-primary"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "media-secondary-text",
+          "component": "Text",
+          "text": "取消",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "media-secondary",
+          "component": "Button",
+          "child": "media-secondary-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "media-secondary.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "media-primary-text",
+          "component": "Text",
+          "text": "确认",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "media-primary",
+          "component": "Button",
+          "child": "media-primary-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "media-primary.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-order-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-order-card.json
@@ -1,0 +1,453 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-order-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-order-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "order-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "order-body",
+          "component": "Column",
+          "children": [
+            "order-titlebar",
+            "order-products",
+            "order-info",
+            "order-fees",
+            "order-actions"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "order-titlebar",
+          "component": "Row",
+          "children": [
+            "order-app",
+            "order-more-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "order-app",
+          "component": "Row",
+          "children": [
+            "order-app-mark",
+            "order-app-name"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "order-app-mark",
+          "component": "Icon",
+          "name": "home",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "order-app-name",
+          "component": "Text",
+          "text": "z 应用",
+          "variant": "caption",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-more",
+          "component": "Row",
+          "children": [
+            "order-more-text",
+            "order-more-icon"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "order-more-text",
+          "component": "Text",
+          "text": "更多",
+          "variant": "caption"
+        },
+        {
+          "id": "order-more-icon",
+          "component": "Icon",
+          "name": "more_vert",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "order-more-action",
+          "component": "Button",
+          "child": "order-more",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "order-more-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "order-products",
+          "component": "Column",
+          "children": [
+            "order-product-1",
+            "order-product-2"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "order-product-1",
+          "component": "Card",
+          "child": "order-product-1-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "order-product-1-body",
+          "component": "Row",
+          "children": [
+            "order-product-1-copy",
+            "order-product-1-price"
+          ],
+          "align": "start",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "order-product-1-copy",
+          "component": "Column",
+          "children": [
+            "order-product-1-title",
+            "order-product-1-spec"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "order-product-1-title",
+          "component": "Text",
+          "text": "拿铁咖啡",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-product-1-spec",
+          "component": "Text",
+          "text": "中杯 / 少冰",
+          "variant": "caption"
+        },
+        {
+          "id": "order-product-1-price",
+          "component": "Column",
+          "children": [
+            "order-product-1-price-value",
+            "order-product-1-qty"
+          ],
+          "align": "end"
+        },
+        {
+          "id": "order-product-1-price-value",
+          "component": "Text",
+          "text": "¥5.8",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-product-1-qty",
+          "component": "Text",
+          "text": "x1",
+          "variant": "caption"
+        },
+        {
+          "id": "order-product-2",
+          "component": "Card",
+          "child": "order-product-2-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "order-product-2-body",
+          "component": "Row",
+          "children": [
+            "order-product-2-copy",
+            "order-product-2-price"
+          ],
+          "align": "start",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "order-product-2-copy",
+          "component": "Column",
+          "children": [
+            "order-product-2-title",
+            "order-product-2-spec"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "order-product-2-title",
+          "component": "Text",
+          "text": "芝士贝果",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-product-2-spec",
+          "component": "Text",
+          "text": "加热",
+          "variant": "caption"
+        },
+        {
+          "id": "order-product-2-price",
+          "component": "Column",
+          "children": [
+            "order-product-2-price-value",
+            "order-product-2-qty"
+          ],
+          "align": "end"
+        },
+        {
+          "id": "order-product-2-price-value",
+          "component": "Text",
+          "text": "¥4.0",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-product-2-qty",
+          "component": "Text",
+          "text": "x2",
+          "variant": "caption"
+        },
+        {
+          "id": "order-info",
+          "component": "Column",
+          "children": [
+            "order-info-1",
+            "order-info-2"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "order-info-1",
+          "component": "Row",
+          "children": [
+            "order-info-1-label",
+            "order-info-1-values"
+          ],
+          "align": "start",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "order-info-1-label",
+          "component": "Text",
+          "text": "取餐方式",
+          "variant": "caption"
+        },
+        {
+          "id": "order-info-1-values",
+          "component": "Column",
+          "children": [
+            "order-info-1-value",
+            "order-info-1-extra"
+          ],
+          "align": "end"
+        },
+        {
+          "id": "order-info-1-value",
+          "component": "Text",
+          "text": "到店自取",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-info-1-extra",
+          "component": "Text",
+          "text": "中关村创业大街店",
+          "variant": "caption"
+        },
+        {
+          "id": "order-info-2",
+          "component": "Row",
+          "children": [
+            "order-info-2-label",
+            "order-info-2-values"
+          ],
+          "align": "start",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "order-info-2-label",
+          "component": "Text",
+          "text": "预计时间",
+          "variant": "caption"
+        },
+        {
+          "id": "order-info-2-values",
+          "component": "Column",
+          "children": [
+            "order-info-2-value"
+          ],
+          "align": "end"
+        },
+        {
+          "id": "order-info-2-value",
+          "component": "Text",
+          "text": "今天 18:30 前",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-fees",
+          "component": "Column",
+          "children": [
+            "order-fee-1",
+            "order-fee-2",
+            "order-discount",
+            "order-total"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "order-fee-1",
+          "component": "Row",
+          "children": [
+            "order-fee-1-label",
+            "order-fee-1-value"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "order-fee-1-label",
+          "component": "Text",
+          "text": "运费",
+          "variant": "caption"
+        },
+        {
+          "id": "order-fee-1-value",
+          "component": "Text",
+          "text": "¥3.0",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-fee-2",
+          "component": "Row",
+          "children": [
+            "order-fee-2-label",
+            "order-fee-2-value"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "order-fee-2-label",
+          "component": "Text",
+          "text": "打包费",
+          "variant": "caption"
+        },
+        {
+          "id": "order-fee-2-value",
+          "component": "Text",
+          "text": "¥1.0",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-discount",
+          "component": "Text",
+          "text": "已优惠 ¥2.0",
+          "variant": "caption"
+        },
+        {
+          "id": "order-total",
+          "component": "Row",
+          "children": [
+            "order-total-label",
+            "order-total-price"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "order-total-label",
+          "component": "Text",
+          "text": "合计",
+          "variant": "h4"
+        },
+        {
+          "id": "order-total-price",
+          "component": "Text",
+          "text": "¥16.8",
+          "variant": "h2"
+        },
+        {
+          "id": "order-actions",
+          "component": "Row",
+          "children": [
+            "order-secondary",
+            "order-primary"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "order-secondary-text",
+          "component": "Text",
+          "text": "修改订单",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-secondary",
+          "component": "Button",
+          "child": "order-secondary-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "order-secondary.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "order-primary-text",
+          "component": "Text",
+          "text": "去支付",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "order-primary",
+          "component": "Button",
+          "child": "order-primary-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "order-primary.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-price-action-list-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-price-action-list-card.json
@@ -1,0 +1,383 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-price-action-list-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-price-action-list-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "price-list-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "price-list-body",
+          "component": "Column",
+          "children": [
+            "price-list-titlebar",
+            "price-list-items",
+            "price-list-footer"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "price-list-titlebar",
+          "component": "Row",
+          "children": [
+            "price-list-app",
+            "price-list-more-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "price-list-app",
+          "component": "Row",
+          "children": [
+            "price-list-app-mark",
+            "price-list-app-name"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "price-list-app-mark",
+          "component": "Icon",
+          "name": "home",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "price-list-app-name",
+          "component": "Text",
+          "text": "z 应用",
+          "variant": "caption",
+          "emphasis": "medium"
+        },
+        {
+          "id": "price-list-more",
+          "component": "Row",
+          "children": [
+            "price-list-more-text",
+            "price-list-more-icon"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "price-list-more-text",
+          "component": "Text",
+          "text": "更多",
+          "variant": "caption"
+        },
+        {
+          "id": "price-list-more-icon",
+          "component": "Icon",
+          "name": "more_vert",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "price-list-more-action",
+          "component": "Button",
+          "child": "price-list-more",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "price-list-more-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "price-list-items",
+          "component": "Column",
+          "children": [
+            "price-item-1",
+            "price-item-2",
+            "price-item-3"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "price-item-1",
+          "component": "Card",
+          "child": "price-item-1-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "price-item-1-body",
+          "component": "Row",
+          "children": [
+            "price-item-1-price-block",
+            "price-item-1-copy",
+            "price-item-1-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "price-item-1-price-block",
+          "component": "Column",
+          "children": [
+            "price-item-1-price",
+            "price-item-1-badge"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "price-item-1-price",
+          "component": "Text",
+          "text": "¥199",
+          "variant": "h3"
+        },
+        {
+          "id": "price-item-1-badge",
+          "component": "Text",
+          "text": "热门",
+          "variant": "caption"
+        },
+        {
+          "id": "price-item-1-copy",
+          "component": "Column",
+          "children": [
+            "price-item-1-line-1",
+            "price-item-1-line-2"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "price-item-1-line-1",
+          "component": "Text",
+          "text": "含 3 次上门服务",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "price-item-1-line-2",
+          "component": "Text",
+          "text": "今晚可约",
+          "variant": "caption"
+        },
+        {
+          "id": "price-item-1-action-text",
+          "component": "Text",
+          "text": "选择",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "price-item-1-action",
+          "component": "Button",
+          "child": "price-item-1-action-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "price-item-1-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "price-item-2",
+          "component": "Card",
+          "child": "price-item-2-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "price-item-2-body",
+          "component": "Row",
+          "children": [
+            "price-item-2-price-block",
+            "price-item-2-copy",
+            "price-item-2-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "price-item-2-price-block",
+          "component": "Column",
+          "children": [
+            "price-item-2-price",
+            "price-item-2-badge"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "price-item-2-price",
+          "component": "Text",
+          "text": "¥299",
+          "variant": "h3"
+        },
+        {
+          "id": "price-item-2-badge",
+          "component": "Text",
+          "text": "推荐",
+          "variant": "caption"
+        },
+        {
+          "id": "price-item-2-copy",
+          "component": "Column",
+          "children": [
+            "price-item-2-line-1",
+            "price-item-2-line-2"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "price-item-2-line-1",
+          "component": "Text",
+          "text": "含 5 次上门服务",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "price-item-2-line-2",
+          "component": "Text",
+          "text": "赠送一次保养",
+          "variant": "caption"
+        },
+        {
+          "id": "price-item-2-action-text",
+          "component": "Text",
+          "text": "选择",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "price-item-2-action",
+          "component": "Button",
+          "child": "price-item-2-action-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "price-item-2-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "price-item-3",
+          "component": "Card",
+          "child": "price-item-3-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "price-item-3-body",
+          "component": "Row",
+          "children": [
+            "price-item-3-price-block",
+            "price-item-3-copy",
+            "price-item-3-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "price-item-3-price-block",
+          "component": "Column",
+          "children": [
+            "price-item-3-price",
+            "price-item-3-badge"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "price-item-3-price",
+          "component": "Text",
+          "text": "¥499",
+          "variant": "h3"
+        },
+        {
+          "id": "price-item-3-badge",
+          "component": "Text",
+          "text": "尊享",
+          "variant": "caption"
+        },
+        {
+          "id": "price-item-3-copy",
+          "component": "Column",
+          "children": [
+            "price-item-3-line-1",
+            "price-item-3-line-2"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "price-item-3-line-1",
+          "component": "Text",
+          "text": "一年权益包",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "price-item-3-line-2",
+          "component": "Text",
+          "text": "专属客服",
+          "variant": "caption"
+        },
+        {
+          "id": "price-item-3-action-text",
+          "component": "Text",
+          "text": "选择",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "price-item-3-action",
+          "component": "Button",
+          "child": "price-item-3-action-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "price-item-3-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "price-list-footer-text",
+          "component": "Text",
+          "text": "查看全部报价",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "price-list-footer",
+          "component": "Button",
+          "child": "price-list-footer-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "price-list-footer.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-single-item-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-single-item-card.json
@@ -1,0 +1,244 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-single-item-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-single-item-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "single-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "single-body",
+          "component": "Column",
+          "children": [
+            "single-titlebar",
+            "single-product",
+            "single-actions"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "single-titlebar",
+          "component": "Row",
+          "children": [
+            "single-app",
+            "single-more-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "single-app",
+          "component": "Row",
+          "children": [
+            "single-app-mark",
+            "single-app-name"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "single-app-mark",
+          "component": "Icon",
+          "name": "home",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "single-app-name",
+          "component": "Text",
+          "text": "z 应用",
+          "variant": "caption",
+          "emphasis": "medium"
+        },
+        {
+          "id": "single-more",
+          "component": "Row",
+          "children": [
+            "single-more-text",
+            "single-more-icon"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "single-more-text",
+          "component": "Text",
+          "text": "查看更多",
+          "variant": "caption"
+        },
+        {
+          "id": "single-more-icon",
+          "component": "Icon",
+          "name": "more_vert",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "single-more-action",
+          "component": "Button",
+          "child": "single-more",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "single-more-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "single-product",
+          "component": "Row",
+          "children": [
+            "single-image",
+            "single-copy"
+          ],
+          "align": "start",
+          "justify": "start"
+        },
+        {
+          "id": "single-image",
+          "component": "Image",
+          "url": "https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=720&q=80",
+          "fit": "cover",
+          "variant": "smallFeature"
+        },
+        {
+          "id": "single-copy",
+          "component": "Column",
+          "children": [
+            "single-heading-row",
+            "single-info-1",
+            "single-info-2",
+            "single-price"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "single-heading-row",
+          "component": "Row",
+          "children": [
+            "single-heading",
+            "single-chevron"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "single-heading",
+          "component": "Text",
+          "text": "智能跑鞋 Pro",
+          "variant": "h3"
+        },
+        {
+          "id": "single-chevron",
+          "component": "Icon",
+          "name": "arrow_forward",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "single-info-1",
+          "component": "Text",
+          "text": "限时优惠 · 今日达",
+          "variant": "caption"
+        },
+        {
+          "id": "single-info-2",
+          "component": "Text",
+          "text": "运动装备 · 42 码",
+          "variant": "caption"
+        },
+        {
+          "id": "single-price",
+          "component": "Row",
+          "children": [
+            "single-price-value",
+            "single-quantity"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "single-price-value",
+          "component": "Text",
+          "text": "券后 ¥4199",
+          "variant": "h3"
+        },
+        {
+          "id": "single-quantity",
+          "component": "Text",
+          "text": "x1",
+          "variant": "caption"
+        },
+        {
+          "id": "single-actions",
+          "component": "Row",
+          "children": [
+            "single-secondary",
+            "single-primary"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "single-secondary-text",
+          "component": "Text",
+          "text": "改规格",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "single-secondary",
+          "component": "Button",
+          "child": "single-secondary-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "single-secondary.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "single-primary-text",
+          "component": "Text",
+          "text": "去下单",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "single-primary",
+          "component": "Button",
+          "child": "single-primary-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "single-primary.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-task-action-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-task-action-card.json
@@ -1,0 +1,76 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-task-action-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-task-action-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "task-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "task-body",
+          "component": "Row",
+          "children": [
+            "task-action-copy",
+            "task-action-button"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "task-action-copy",
+          "component": "Column",
+          "children": [
+            "task-action-title",
+            "task-action-desc"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "task-action-title",
+          "component": "Text",
+          "text": "任务操作",
+          "variant": "h3"
+        },
+        {
+          "id": "task-action-desc",
+          "component": "Text",
+          "text": "查看状态更新并执行下一步。",
+          "variant": "caption"
+        },
+        {
+          "id": "task-action-button-text",
+          "component": "Text",
+          "text": "操作1",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "task-action-button",
+          "component": "Button",
+          "child": "task-action-button-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "task-action-button.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-template.ts
+++ b/packages/genui/a2ui-playground/src/mock/z/z-template.ts
@@ -1,0 +1,787 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+interface A2UIComponent {
+  id: string;
+  component: string;
+  [key: string]: unknown;
+}
+
+type A2UIMessage =
+  | {
+    version: 'v0.9';
+    createSurface: {
+      surfaceId: string;
+      catalogId: string;
+    };
+  }
+  | {
+    version: 'v0.9';
+    updateComponents: {
+      surfaceId: string;
+      components: A2UIComponent[];
+    };
+  };
+
+export interface ZTemplateDemo {
+  id: string;
+  title: string;
+  description: string;
+  hasStaticJson?: boolean;
+  messages: A2UIMessage[];
+}
+
+const CATALOG_ID = 'https://a2ui.org/specification/v0_9/basic_catalog.json';
+
+const productImage =
+  'https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=720&q=80';
+const mediaImage =
+  'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=720&q=80';
+
+function text(
+  id: string,
+  value: string,
+  variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'caption' | 'body' = 'body',
+  emphasis?: 'medium' | 'strong',
+): A2UIComponent {
+  return {
+    id,
+    component: 'Text',
+    text: value,
+    variant,
+    ...(emphasis ? { emphasis } : {}),
+  };
+}
+
+function icon(
+  id: string,
+  name: string,
+  color: 'primary' | 'muted' | 'inherit' = 'muted',
+): A2UIComponent {
+  return {
+    id,
+    component: 'Icon',
+    name,
+    color,
+    size: 'md',
+  };
+}
+
+function image(
+  id: string,
+  url: string,
+  variant:
+    | 'icon'
+    | 'avatar'
+    | 'smallFeature'
+    | 'mediumFeature'
+    | 'largeFeature'
+    | 'header' = 'mediumFeature',
+): A2UIComponent {
+  return {
+    id,
+    component: 'Image',
+    url,
+    fit: 'cover',
+    variant,
+  };
+}
+
+function row(
+  id: string,
+  children: string[],
+  options: Partial<Pick<A2UIComponent, 'align' | 'justify'>> = {},
+): A2UIComponent {
+  return {
+    id,
+    component: 'Row',
+    children,
+    align: options.align ?? 'center',
+    justify: options.justify ?? 'start',
+  };
+}
+
+function column(
+  id: string,
+  children: string[],
+  align: 'start' | 'center' | 'end' | 'stretch' = 'stretch',
+): A2UIComponent {
+  return {
+    id,
+    component: 'Column',
+    children,
+    align,
+  };
+}
+
+function card(
+  id: string,
+  child: string,
+  variant: 'elevated' | 'outlined' | 'filled' | 'ghost' = 'elevated',
+): A2UIComponent {
+  return {
+    id,
+    component: 'Card',
+    child,
+    variant,
+  };
+}
+
+function button(
+  id: string,
+  label: string,
+  variant: 'primary' | 'borderless' = 'primary',
+): A2UIComponent[] {
+  return [
+    text(`${id}-text`, label, 'body', 'medium'),
+    action(id, `${id}-text`, variant),
+  ];
+}
+
+function action(
+  id: string,
+  child: string,
+  variant: 'primary' | 'borderless' = 'borderless',
+): A2UIComponent {
+  return {
+    id,
+    component: 'Button',
+    child,
+    variant,
+    action: {
+      event: {
+        name: `${id}.tap`,
+        context: {
+          templatePackage: 'z',
+          templateVersion: '0.0.35',
+        },
+      },
+    },
+  };
+}
+
+function titleBar(prefix: string, moreText = '更多'): A2UIComponent[] {
+  return [
+    row(`${prefix}-titlebar`, [
+      `${prefix}-app`,
+      `${prefix}-more-action`,
+    ], { justify: 'spaceBetween' }),
+    row(`${prefix}-app`, [
+      `${prefix}-app-mark`,
+      `${prefix}-app-name`,
+    ]),
+    icon(`${prefix}-app-mark`, 'home', 'primary'),
+    text(`${prefix}-app-name`, 'z 应用', 'caption', 'medium'),
+    row(`${prefix}-more`, [
+      `${prefix}-more-text`,
+      `${prefix}-more-icon`,
+    ]),
+    text(`${prefix}-more-text`, moreText, 'caption'),
+    icon(`${prefix}-more-icon`, 'more_vert', 'muted'),
+    action(`${prefix}-more-action`, `${prefix}-more`),
+  ];
+}
+
+function infoRow(
+  prefix: string,
+  label: string,
+  value: string,
+  extra?: string,
+): A2UIComponent[] {
+  const valueChildren = extra
+    ? [`${prefix}-value`, `${prefix}-extra`]
+    : [`${prefix}-value`];
+  return [
+    row(prefix, [
+      `${prefix}-label`,
+      `${prefix}-values`,
+    ], { justify: 'spaceBetween', align: 'start' }),
+    text(`${prefix}-label`, label, 'caption'),
+    column(`${prefix}-values`, valueChildren, 'end'),
+    text(`${prefix}-value`, value, 'body', 'medium'),
+    ...(extra ? [text(`${prefix}-extra`, extra, 'caption')] : []),
+  ];
+}
+
+function feeRow(prefix: string, label: string, value: string): A2UIComponent[] {
+  return [
+    row(prefix, [
+      `${prefix}-label`,
+      `${prefix}-value`,
+    ], { justify: 'spaceBetween' }),
+    text(`${prefix}-label`, label, 'caption'),
+    text(`${prefix}-value`, value, 'body', 'medium'),
+  ];
+}
+
+function demo(
+  id: string,
+  title: string,
+  description: string,
+  components: A2UIComponent[],
+): ZTemplateDemo {
+  const surfaceId = id;
+  return {
+    id,
+    title,
+    description,
+    messages: [
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId,
+          catalogId: CATALOG_ID,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId,
+          components,
+        },
+      },
+    ],
+  };
+}
+
+const listCard = demo(
+  'z-list-card',
+  'ListCard',
+  '0.0.35 list card template: app title bar, repeatable items, per-item actions, and view-more entry.',
+  [
+    card('root', 'list-card-body'),
+    column('list-card-body', [
+      'list-titlebar',
+      'list-items',
+      'list-view-more',
+    ]),
+    ...titleBar('list'),
+    column('list-items', [
+      'list-item-1',
+      'list-item-2',
+      'list-item-3',
+      'list-item-4',
+    ]),
+    ...[1, 2, 3, 4].flatMap((index) => {
+      const prefix = `list-item-${index}`;
+      const titles = [
+        '智能跑鞋 Pro',
+        '便携咖啡杯',
+        '城市周末套票',
+        '蓝牙降噪耳机',
+      ];
+      const prices = ['4199元', '299元', '168元', '699元'];
+      const descs = ['轻量缓震', '保温 12 小时', '含双人下午茶', '通勤低延迟'];
+      return [
+        card(prefix, `${prefix}-body`, 'outlined'),
+        row(`${prefix}-body`, [
+          `${prefix}-media`,
+          `${prefix}-copy`,
+          `${prefix}-action`,
+        ], { justify: 'spaceBetween', align: 'center' }),
+        ...(index === 1
+          ? [image(`${prefix}-media`, productImage, 'smallFeature')]
+          : [icon(`${prefix}-media`, index === 3 ? 'location_on' : 'star')]),
+        column(`${prefix}-copy`, [
+          `${prefix}-title`,
+          `${prefix}-meta`,
+        ]),
+        text(`${prefix}-title`, titles[index - 1] ?? '列表项', 'h4'),
+        text(
+          `${prefix}-meta`,
+          `${prices[index - 1]} · ${descs[index - 1]}`,
+          'caption',
+        ),
+        ...button(
+          `${prefix}-action`,
+          index === 1 ? '下单' : '查看',
+          'borderless',
+        ),
+      ];
+    }),
+    ...button('list-view-more', '查看更多'),
+  ],
+);
+
+const askHumanCard = demo(
+  'z-ask-human-card',
+  'AskHumanCard',
+  '0.0.35 ask-human template: human confirmation options plus an optional skip entry.',
+  [
+    card('root', 'ask-body'),
+    column('ask-body', [
+      'ask-title',
+      'ask-copy',
+      'ask-options',
+      'ask-skip',
+    ]),
+    text('ask-title', '请选择门店', 'h3'),
+    text(
+      'ask-copy',
+      '为你找到 3 个附近候选项，确认后继续处理任务。',
+      'caption',
+    ),
+    column('ask-options', [
+      'ask-option-1-action',
+      'ask-option-2-action',
+      'ask-option-3-action',
+    ]),
+    ...[
+      '中关村创业大街店 · 0.6km',
+      '北京中关村在握旗舰店 · 1.8km',
+      '中关村城委店 · 3.5km',
+    ].flatMap((label, index) => {
+      const id = `ask-option-${index + 1}`;
+      return [
+        action(`${id}-action`, `${id}-card`),
+        card(`${id}-card`, `${id}-body`, 'outlined'),
+        row(`${id}-body`, [
+          `${id}-text`,
+          `${id}-icon`,
+        ], { justify: 'spaceBetween' }),
+        text(`${id}-text`, label, 'body', 'medium'),
+        icon(`${id}-icon`, 'arrow_forward', 'primary'),
+      ];
+    }),
+    ...button('ask-skip', '跳过', 'borderless'),
+  ],
+);
+
+const singleItemCard = demo(
+  'z-single-item-card',
+  'SingleItemCard',
+  '0.0.35 single item template: one product or service entry with image, two info rows, price, and actions.',
+  [
+    card('root', 'single-body'),
+    column('single-body', [
+      'single-titlebar',
+      'single-product',
+      'single-actions',
+    ]),
+    ...titleBar('single', '查看更多'),
+    row('single-product', [
+      'single-image',
+      'single-copy',
+    ], { align: 'start' }),
+    image('single-image', productImage, 'smallFeature'),
+    column('single-copy', [
+      'single-heading-row',
+      'single-info-1',
+      'single-info-2',
+      'single-price',
+    ]),
+    row('single-heading-row', [
+      'single-heading',
+      'single-chevron',
+    ], { justify: 'spaceBetween' }),
+    text('single-heading', '智能跑鞋 Pro', 'h3'),
+    icon('single-chevron', 'arrow_forward'),
+    text('single-info-1', '限时优惠 · 今日达', 'caption'),
+    text('single-info-2', '运动装备 · 42 码', 'caption'),
+    row('single-price', [
+      'single-price-value',
+      'single-quantity',
+    ], { justify: 'spaceBetween' }),
+    text('single-price-value', '券后 ¥4199', 'h3'),
+    text('single-quantity', 'x1', 'caption'),
+    row('single-actions', [
+      'single-secondary',
+      'single-primary',
+    ]),
+    ...button('single-secondary', '改规格', 'borderless'),
+    ...button('single-primary', '去下单'),
+  ],
+);
+
+const mediaLayoutCard = demo(
+  'z-media-layout-card',
+  'MediaLayoutCard',
+  '0.0.35 media layout template: left media, middle title/info, right extra content, and bottom actions.',
+  [
+    card('root', 'media-body'),
+    column('media-body', [
+      'media-titlebar',
+      'media-content',
+      'media-actions',
+    ]),
+    ...titleBar('media', '更多'),
+    row('media-content', [
+      'media-image',
+      'media-copy',
+      'media-extra',
+    ], { justify: 'spaceBetween', align: 'start' }),
+    image('media-image', mediaImage, 'smallFeature'),
+    column('media-copy', [
+      'media-title',
+      'media-info-1',
+      'media-info-2',
+    ]),
+    text('media-title', '小程序开发助手', 'h3'),
+    text('media-info-1', '提供开发、构建、调试和发布能力。', 'caption'),
+    text('media-info-2', '最近更新：2 分钟前', 'caption'),
+    card('media-extra', 'media-extra-copy', 'filled'),
+    column('media-extra-copy', [
+      'media-extra-label',
+      'media-extra-value',
+    ], 'center'),
+    text('media-extra-label', '状态', 'caption'),
+    text('media-extra-value', '可用', 'h4'),
+    row('media-actions', [
+      'media-secondary',
+      'media-primary',
+    ]),
+    ...button('media-secondary', '取消', 'borderless'),
+    ...button('media-primary', '确认'),
+  ],
+);
+
+const priceActionListCard = demo(
+  'z-price-action-list-card',
+  'PriceActionListCard',
+  '0.0.35 price action list template: multiple priced offers with row actions and a footer action.',
+  [
+    card('root', 'price-list-body'),
+    column('price-list-body', [
+      'price-list-titlebar',
+      'price-list-items',
+      'price-list-footer',
+    ]),
+    ...titleBar('price-list'),
+    column('price-list-items', [
+      'price-item-1',
+      'price-item-2',
+      'price-item-3',
+    ]),
+    ...[
+      ['¥199', '热门', '含 3 次上门服务', '今晚可约'],
+      ['¥299', '推荐', '含 5 次上门服务', '赠送一次保养'],
+      ['¥499', '尊享', '一年权益包', '专属客服'],
+    ].flatMap(([price, badge, line1, line2], index) => {
+      const prefix = `price-item-${index + 1}`;
+      return [
+        card(prefix, `${prefix}-body`, 'outlined'),
+        row(`${prefix}-body`, [
+          `${prefix}-price-block`,
+          `${prefix}-copy`,
+          `${prefix}-action`,
+        ], { justify: 'spaceBetween', align: 'center' }),
+        column(`${prefix}-price-block`, [
+          `${prefix}-price`,
+          `${prefix}-badge`,
+        ]),
+        text(`${prefix}-price`, price ?? '', 'h3'),
+        text(`${prefix}-badge`, badge ?? '', 'caption'),
+        column(`${prefix}-copy`, [
+          `${prefix}-line-1`,
+          `${prefix}-line-2`,
+        ]),
+        text(`${prefix}-line-1`, line1 ?? '', 'body', 'medium'),
+        text(`${prefix}-line-2`, line2 ?? '', 'caption'),
+        ...button(`${prefix}-action`, '选择', 'borderless'),
+      ];
+    }),
+    ...button('price-list-footer', '查看全部报价'),
+  ],
+);
+
+const taskActionCard = demo(
+  'z-task-action-card',
+  'TaskActionCard',
+  '0.0.35 task action template: a single full-width task button.',
+  [
+    card('root', 'task-body'),
+    row('task-body', [
+      'task-action-copy',
+      'task-action-button',
+    ], { justify: 'spaceBetween' }),
+    column('task-action-copy', [
+      'task-action-title',
+      'task-action-desc',
+    ]),
+    text('task-action-title', '任务操作', 'h3'),
+    text('task-action-desc', '查看状态更新并执行下一步。', 'caption'),
+    ...button('task-action-button', '操作1'),
+  ],
+);
+
+const orderCard = demo(
+  'z-order-card',
+  'OrderCard',
+  '0.0.35 order card template: product summaries, order info, fees, total, and payment actions.',
+  [
+    card('root', 'order-body'),
+    column('order-body', [
+      'order-titlebar',
+      'order-products',
+      'order-info',
+      'order-fees',
+      'order-actions',
+    ]),
+    ...titleBar('order'),
+    column('order-products', [
+      'order-product-1',
+      'order-product-2',
+    ]),
+    ...[
+      ['order-product-1', '拿铁咖啡', '中杯 / 少冰', '¥5.8', 'x1'],
+      ['order-product-2', '芝士贝果', '加热', '¥4.0', 'x2'],
+    ].flatMap(([prefix, title, spec, price, quantity]) => [
+      card(prefix ?? '', `${prefix}-body`, 'outlined'),
+      row(`${prefix}-body`, [
+        `${prefix}-copy`,
+        `${prefix}-price`,
+      ], { justify: 'spaceBetween', align: 'start' }),
+      column(`${prefix}-copy`, [
+        `${prefix}-title`,
+        `${prefix}-spec`,
+      ]),
+      text(`${prefix}-title`, title ?? '', 'body', 'medium'),
+      text(`${prefix}-spec`, spec ?? '', 'caption'),
+      column(`${prefix}-price`, [
+        `${prefix}-price-value`,
+        `${prefix}-qty`,
+      ], 'end'),
+      text(`${prefix}-price-value`, price ?? '', 'body', 'medium'),
+      text(`${prefix}-qty`, quantity ?? '', 'caption'),
+    ]),
+    column('order-info', [
+      'order-info-1',
+      'order-info-2',
+    ]),
+    ...infoRow('order-info-1', '取餐方式', '到店自取', '中关村创业大街店'),
+    ...infoRow('order-info-2', '预计时间', '今天 18:30 前'),
+    column('order-fees', [
+      'order-fee-1',
+      'order-fee-2',
+      'order-discount',
+      'order-total',
+    ]),
+    ...feeRow('order-fee-1', '运费', '¥3.0'),
+    ...feeRow('order-fee-2', '打包费', '¥1.0'),
+    text('order-discount', '已优惠 ¥2.0', 'caption'),
+    row('order-total', [
+      'order-total-label',
+      'order-total-price',
+    ], { justify: 'spaceBetween' }),
+    text('order-total-label', '合计', 'h4'),
+    text('order-total-price', '¥16.8', 'h2'),
+    row('order-actions', [
+      'order-secondary',
+      'order-primary',
+    ]),
+    ...button('order-secondary', '修改订单', 'borderless'),
+    ...button('order-primary', '去支付'),
+  ],
+);
+
+const transportCard = demo(
+  'z-transport-card',
+  'TransportCard',
+  '0.0.35 transport card template: a single route with departure, arrival, transfer hint, and price.',
+  [
+    action('root', 'transport-card-body'),
+    card('transport-card-body', 'transport-body'),
+    column('transport-body', [
+      'transport-title',
+      'transport-route',
+      'transport-price-row',
+    ]),
+    text('transport-title', '北京南 - 上海虹桥', 'h3'),
+    row('transport-route', [
+      'transport-departure',
+      'transport-transfer',
+      'transport-arrival',
+    ], { justify: 'spaceBetween', align: 'center' }),
+    column('transport-departure', [
+      'transport-departure-time',
+      'transport-departure-station',
+    ], 'start'),
+    text('transport-departure-time', '08:00', 'h2'),
+    text('transport-departure-station', '北京南', 'caption'),
+    column('transport-transfer', [
+      'transport-transfer-top',
+      'transport-transfer-icon',
+      'transport-transfer-bottom',
+    ], 'center'),
+    text('transport-transfer-top', '直达', 'caption'),
+    icon('transport-transfer-icon', 'arrow_forward', 'primary'),
+    text('transport-transfer-bottom', '4小时32分', 'caption'),
+    column('transport-arrival', [
+      'transport-arrival-time',
+      'transport-arrival-station',
+    ], 'end'),
+    text('transport-arrival-time', '12:32 +1', 'h2'),
+    text('transport-arrival-station', '上海虹桥', 'caption'),
+    row('transport-price-row', [
+      'transport-seat',
+      'transport-price',
+    ], { justify: 'spaceBetween' }),
+    text('transport-seat', '二等座 · 有票', 'body', 'medium'),
+    text('transport-price', '¥553', 'h2'),
+  ],
+);
+
+const transportListCard = demo(
+  'z-transport-list-card',
+  'TransportListCard',
+  '0.0.35 transport list template: multiple route candidates plus view-more affordance.',
+  [
+    card('root', 'transport-list-body'),
+    column('transport-list-body', [
+      'transport-list-titlebar',
+      'transport-list-items',
+      'transport-list-more',
+    ]),
+    ...titleBar('transport-list'),
+    column('transport-list-items', [
+      'transport-list-item-1-action',
+      'transport-list-item-2-action',
+      'transport-list-item-3-action',
+      'transport-list-item-4-action',
+    ]),
+    ...[
+      ['11:20', '16:00 +1', '¥553', '直达'],
+      ['13:05', '18:10', '¥498', '换乘 1 次'],
+      ['15:30', '20:05', '¥628', '商务优选'],
+      ['19:10', '23:45', '¥521', '夜间班次'],
+    ].flatMap(([start, end, price, transfer], index) => {
+      const prefix = `transport-list-item-${index + 1}`;
+      return [
+        action(`${prefix}-action`, `${prefix}-card`),
+        card(`${prefix}-card`, `${prefix}-body`, 'outlined'),
+        column(`${prefix}-body`, [
+          `${prefix}-title`,
+          `${prefix}-times`,
+        ]),
+        text(`${prefix}-title`, '北京南 - 上海虹桥', 'h4'),
+        row(`${prefix}-times`, [
+          `${prefix}-depart`,
+          `${prefix}-transfer`,
+          `${prefix}-arrive`,
+          `${prefix}-price`,
+        ], { justify: 'spaceBetween' }),
+        text(`${prefix}-depart`, start ?? '', 'h3'),
+        text(`${prefix}-transfer`, transfer ?? '', 'caption'),
+        text(`${prefix}-arrive`, end ?? '', 'h3'),
+        text(`${prefix}-price`, price ?? '', 'h3'),
+      ];
+    }),
+    ...button('transport-list-more', '查看更多'),
+  ],
+);
+
+const ticketOrderCard = demo(
+  'z-ticket-order-card',
+  'TicketOrderCard',
+  '0.0.35 ticket order template: route items, passenger/order info, fees, total, and actions.',
+  [
+    card('root', 'ticket-body'),
+    column('ticket-body', [
+      'ticket-titlebar',
+      'ticket-routes',
+      'ticket-info',
+      'ticket-fees',
+      'ticket-actions',
+    ]),
+    ...titleBar('ticket'),
+    column('ticket-routes', [
+      'ticket-route-1-action',
+      'ticket-route-2-action',
+    ]),
+    ...[
+      [
+        'ticket-route-1',
+        '出发地 - 到达地',
+        '6月1日 周六 20:50-23:50 CZ0000 经济舱',
+      ],
+      [
+        'ticket-route-2',
+        '到达地 - 出发地',
+        '6月3日 周一 14:50-18:50 CZ0001 经济舱',
+      ],
+    ].flatMap(([prefix, routeTitle, routeDesc]) => [
+      action(`${prefix}-action`, `${prefix}-card`),
+      card(`${prefix}-card`, `${prefix}-body`, 'outlined'),
+      row(`${prefix}-body`, [
+        `${prefix}-copy`,
+        `${prefix}-icon`,
+      ], { justify: 'spaceBetween' }),
+      column(`${prefix}-copy`, [
+        `${prefix}-title`,
+        `${prefix}-desc`,
+      ]),
+      text(`${prefix}-title`, routeTitle ?? '', 'body', 'medium'),
+      text(`${prefix}-desc`, routeDesc ?? '', 'caption'),
+      icon(`${prefix}-icon`, 'arrow_forward'),
+    ]),
+    column('ticket-info', [
+      'ticket-info-1',
+      'ticket-info-2',
+    ]),
+    ...infoRow('ticket-info-1', '乘机人', '李雷', '身份证尾号 0823'),
+    ...infoRow('ticket-info-2', '联系电话', '138****0000'),
+    column('ticket-fees', [
+      'ticket-fee-1',
+      'ticket-fee-2',
+      'ticket-total',
+    ]),
+    ...feeRow('ticket-fee-1', '票价', '¥1064'),
+    ...feeRow('ticket-fee-2', '机建燃油', '¥440'),
+    row('ticket-total', [
+      'ticket-total-label',
+      'ticket-total-price',
+    ], { justify: 'spaceBetween' }),
+    text('ticket-total-label', '合计', 'h4'),
+    text('ticket-total-price', '¥1504', 'h2'),
+    row('ticket-actions', [
+      'ticket-secondary',
+      'ticket-primary',
+    ]),
+    ...button('ticket-secondary', '返回修改', 'borderless'),
+    ...button('ticket-primary', '确认出票'),
+  ],
+);
+
+const invalidCard = demo(
+  'z-invalid-card',
+  'InvalidCard',
+  '0.0.35 exported invalid card template: app title bar plus an expired or updated state row.',
+  [
+    card('root', 'invalid-body'),
+    column('invalid-body', [
+      'invalid-titlebar',
+      'invalid-content',
+    ]),
+    ...titleBar('invalid'),
+    action('invalid-content', 'invalid-row-card'),
+    card('invalid-row-card', 'invalid-row', 'filled'),
+    row('invalid-row', [
+      'invalid-icon',
+      'invalid-copy',
+      'invalid-chevron',
+    ], { justify: 'spaceBetween' }),
+    icon('invalid-icon', 'info', 'primary'),
+    column('invalid-copy', [
+      'invalid-title',
+      'invalid-desc',
+    ]),
+    text('invalid-title', '任务状态已更新', 'h4'),
+    text('invalid-desc', '当前卡片内容已失效，请返回查看最新状态。', 'caption'),
+    icon('invalid-chevron', 'arrow_forward'),
+  ],
+);
+
+export const Z_TEMPLATE_DEMOS: ZTemplateDemo[] = [
+  askHumanCard,
+  listCard,
+  singleItemCard,
+  mediaLayoutCard,
+  priceActionListCard,
+  taskActionCard,
+  orderCard,
+  transportCard,
+  transportListCard,
+  ticketOrderCard,
+  invalidCard,
+];

--- a/packages/genui/a2ui-playground/src/mock/z/z-ticket-order-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-ticket-order-card.json
@@ -1,0 +1,446 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-ticket-order-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-ticket-order-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "ticket-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "ticket-body",
+          "component": "Column",
+          "children": [
+            "ticket-titlebar",
+            "ticket-routes",
+            "ticket-info",
+            "ticket-fees",
+            "ticket-actions"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "ticket-titlebar",
+          "component": "Row",
+          "children": [
+            "ticket-app",
+            "ticket-more-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ticket-app",
+          "component": "Row",
+          "children": [
+            "ticket-app-mark",
+            "ticket-app-name"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "ticket-app-mark",
+          "component": "Icon",
+          "name": "home",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "ticket-app-name",
+          "component": "Text",
+          "text": "z 应用",
+          "variant": "caption",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-more",
+          "component": "Row",
+          "children": [
+            "ticket-more-text",
+            "ticket-more-icon"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "ticket-more-text",
+          "component": "Text",
+          "text": "更多",
+          "variant": "caption"
+        },
+        {
+          "id": "ticket-more-icon",
+          "component": "Icon",
+          "name": "more_vert",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "ticket-more-action",
+          "component": "Button",
+          "child": "ticket-more",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "ticket-more-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "ticket-routes",
+          "component": "Column",
+          "children": [
+            "ticket-route-1-action",
+            "ticket-route-2-action"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "ticket-route-1-action",
+          "component": "Button",
+          "child": "ticket-route-1-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "ticket-route-1-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "ticket-route-1-card",
+          "component": "Card",
+          "child": "ticket-route-1-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "ticket-route-1-body",
+          "component": "Row",
+          "children": [
+            "ticket-route-1-copy",
+            "ticket-route-1-icon"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ticket-route-1-copy",
+          "component": "Column",
+          "children": [
+            "ticket-route-1-title",
+            "ticket-route-1-desc"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "ticket-route-1-title",
+          "component": "Text",
+          "text": "出发地 - 到达地",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-route-1-desc",
+          "component": "Text",
+          "text": "6月1日 周六 20:50-23:50 CZ0000 经济舱",
+          "variant": "caption"
+        },
+        {
+          "id": "ticket-route-1-icon",
+          "component": "Icon",
+          "name": "arrow_forward",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "ticket-route-2-action",
+          "component": "Button",
+          "child": "ticket-route-2-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "ticket-route-2-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "ticket-route-2-card",
+          "component": "Card",
+          "child": "ticket-route-2-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "ticket-route-2-body",
+          "component": "Row",
+          "children": [
+            "ticket-route-2-copy",
+            "ticket-route-2-icon"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ticket-route-2-copy",
+          "component": "Column",
+          "children": [
+            "ticket-route-2-title",
+            "ticket-route-2-desc"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "ticket-route-2-title",
+          "component": "Text",
+          "text": "到达地 - 出发地",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-route-2-desc",
+          "component": "Text",
+          "text": "6月3日 周一 14:50-18:50 CZ0001 经济舱",
+          "variant": "caption"
+        },
+        {
+          "id": "ticket-route-2-icon",
+          "component": "Icon",
+          "name": "arrow_forward",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "ticket-info",
+          "component": "Column",
+          "children": [
+            "ticket-info-1",
+            "ticket-info-2"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "ticket-info-1",
+          "component": "Row",
+          "children": [
+            "ticket-info-1-label",
+            "ticket-info-1-values"
+          ],
+          "align": "start",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ticket-info-1-label",
+          "component": "Text",
+          "text": "乘机人",
+          "variant": "caption"
+        },
+        {
+          "id": "ticket-info-1-values",
+          "component": "Column",
+          "children": [
+            "ticket-info-1-value",
+            "ticket-info-1-extra"
+          ],
+          "align": "end"
+        },
+        {
+          "id": "ticket-info-1-value",
+          "component": "Text",
+          "text": "李雷",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-info-1-extra",
+          "component": "Text",
+          "text": "身份证尾号 0823",
+          "variant": "caption"
+        },
+        {
+          "id": "ticket-info-2",
+          "component": "Row",
+          "children": [
+            "ticket-info-2-label",
+            "ticket-info-2-values"
+          ],
+          "align": "start",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ticket-info-2-label",
+          "component": "Text",
+          "text": "联系电话",
+          "variant": "caption"
+        },
+        {
+          "id": "ticket-info-2-values",
+          "component": "Column",
+          "children": [
+            "ticket-info-2-value"
+          ],
+          "align": "end"
+        },
+        {
+          "id": "ticket-info-2-value",
+          "component": "Text",
+          "text": "138****0000",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-fees",
+          "component": "Column",
+          "children": [
+            "ticket-fee-1",
+            "ticket-fee-2",
+            "ticket-total"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "ticket-fee-1",
+          "component": "Row",
+          "children": [
+            "ticket-fee-1-label",
+            "ticket-fee-1-value"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ticket-fee-1-label",
+          "component": "Text",
+          "text": "票价",
+          "variant": "caption"
+        },
+        {
+          "id": "ticket-fee-1-value",
+          "component": "Text",
+          "text": "¥1064",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-fee-2",
+          "component": "Row",
+          "children": [
+            "ticket-fee-2-label",
+            "ticket-fee-2-value"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ticket-fee-2-label",
+          "component": "Text",
+          "text": "机建燃油",
+          "variant": "caption"
+        },
+        {
+          "id": "ticket-fee-2-value",
+          "component": "Text",
+          "text": "¥440",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-total",
+          "component": "Row",
+          "children": [
+            "ticket-total-label",
+            "ticket-total-price"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "ticket-total-label",
+          "component": "Text",
+          "text": "合计",
+          "variant": "h4"
+        },
+        {
+          "id": "ticket-total-price",
+          "component": "Text",
+          "text": "¥1504",
+          "variant": "h2"
+        },
+        {
+          "id": "ticket-actions",
+          "component": "Row",
+          "children": [
+            "ticket-secondary",
+            "ticket-primary"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "ticket-secondary-text",
+          "component": "Text",
+          "text": "返回修改",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-secondary",
+          "component": "Button",
+          "child": "ticket-secondary-text",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "ticket-secondary.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "ticket-primary-text",
+          "component": "Text",
+          "text": "确认出票",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "ticket-primary",
+          "component": "Button",
+          "child": "ticket-primary-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "ticket-primary.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-transport-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-transport-card.json
@@ -1,0 +1,159 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-transport-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-transport-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Button",
+          "child": "transport-card-body",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "root.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "transport-card-body",
+          "component": "Card",
+          "child": "transport-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "transport-body",
+          "component": "Column",
+          "children": [
+            "transport-title",
+            "transport-route",
+            "transport-price-row"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "transport-title",
+          "component": "Text",
+          "text": "北京南 - 上海虹桥",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-route",
+          "component": "Row",
+          "children": [
+            "transport-departure",
+            "transport-transfer",
+            "transport-arrival"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "transport-departure",
+          "component": "Column",
+          "children": [
+            "transport-departure-time",
+            "transport-departure-station"
+          ],
+          "align": "start"
+        },
+        {
+          "id": "transport-departure-time",
+          "component": "Text",
+          "text": "08:00",
+          "variant": "h2"
+        },
+        {
+          "id": "transport-departure-station",
+          "component": "Text",
+          "text": "北京南",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-transfer",
+          "component": "Column",
+          "children": [
+            "transport-transfer-top",
+            "transport-transfer-icon",
+            "transport-transfer-bottom"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "transport-transfer-top",
+          "component": "Text",
+          "text": "直达",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-transfer-icon",
+          "component": "Icon",
+          "name": "arrow_forward",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "transport-transfer-bottom",
+          "component": "Text",
+          "text": "4小时32分",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-arrival",
+          "component": "Column",
+          "children": [
+            "transport-arrival-time",
+            "transport-arrival-station"
+          ],
+          "align": "end"
+        },
+        {
+          "id": "transport-arrival-time",
+          "component": "Text",
+          "text": "12:32 +1",
+          "variant": "h2"
+        },
+        {
+          "id": "transport-arrival-station",
+          "component": "Text",
+          "text": "上海虹桥",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-price-row",
+          "component": "Row",
+          "children": [
+            "transport-seat",
+            "transport-price"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "transport-seat",
+          "component": "Text",
+          "text": "二等座 · 有票",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "transport-price",
+          "component": "Text",
+          "text": "¥553",
+          "variant": "h2"
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/mock/z/z-transport-list-card.json
+++ b/packages/genui/a2ui-playground/src/mock/z/z-transport-list-card.json
@@ -1,0 +1,426 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "z-transport-list-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "z-transport-list-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "transport-list-body",
+          "variant": "elevated"
+        },
+        {
+          "id": "transport-list-body",
+          "component": "Column",
+          "children": [
+            "transport-list-titlebar",
+            "transport-list-items",
+            "transport-list-more"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "transport-list-titlebar",
+          "component": "Row",
+          "children": [
+            "transport-list-app",
+            "transport-list-more-action"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "transport-list-app",
+          "component": "Row",
+          "children": [
+            "transport-list-app-mark",
+            "transport-list-app-name"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "transport-list-app-mark",
+          "component": "Icon",
+          "name": "home",
+          "color": "primary",
+          "size": "md"
+        },
+        {
+          "id": "transport-list-app-name",
+          "component": "Text",
+          "text": "z 应用",
+          "variant": "caption",
+          "emphasis": "medium"
+        },
+        {
+          "id": "transport-list-more",
+          "component": "Row",
+          "children": [
+            "transport-list-more-text",
+            "transport-list-more-icon"
+          ],
+          "align": "center",
+          "justify": "start"
+        },
+        {
+          "id": "transport-list-more-text",
+          "component": "Text",
+          "text": "更多",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-list-more-icon",
+          "component": "Icon",
+          "name": "more_vert",
+          "color": "muted",
+          "size": "md"
+        },
+        {
+          "id": "transport-list-more-action",
+          "component": "Button",
+          "child": "transport-list-more",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "transport-list-more-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "transport-list-items",
+          "component": "Column",
+          "children": [
+            "transport-list-item-1-action",
+            "transport-list-item-2-action",
+            "transport-list-item-3-action",
+            "transport-list-item-4-action"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "transport-list-item-1-action",
+          "component": "Button",
+          "child": "transport-list-item-1-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "transport-list-item-1-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "transport-list-item-1-card",
+          "component": "Card",
+          "child": "transport-list-item-1-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "transport-list-item-1-body",
+          "component": "Column",
+          "children": [
+            "transport-list-item-1-title",
+            "transport-list-item-1-times"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "transport-list-item-1-title",
+          "component": "Text",
+          "text": "北京南 - 上海虹桥",
+          "variant": "h4"
+        },
+        {
+          "id": "transport-list-item-1-times",
+          "component": "Row",
+          "children": [
+            "transport-list-item-1-depart",
+            "transport-list-item-1-transfer",
+            "transport-list-item-1-arrive",
+            "transport-list-item-1-price"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "transport-list-item-1-depart",
+          "component": "Text",
+          "text": "11:20",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-1-transfer",
+          "component": "Text",
+          "text": "直达",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-list-item-1-arrive",
+          "component": "Text",
+          "text": "16:00 +1",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-1-price",
+          "component": "Text",
+          "text": "¥553",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-2-action",
+          "component": "Button",
+          "child": "transport-list-item-2-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "transport-list-item-2-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "transport-list-item-2-card",
+          "component": "Card",
+          "child": "transport-list-item-2-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "transport-list-item-2-body",
+          "component": "Column",
+          "children": [
+            "transport-list-item-2-title",
+            "transport-list-item-2-times"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "transport-list-item-2-title",
+          "component": "Text",
+          "text": "北京南 - 上海虹桥",
+          "variant": "h4"
+        },
+        {
+          "id": "transport-list-item-2-times",
+          "component": "Row",
+          "children": [
+            "transport-list-item-2-depart",
+            "transport-list-item-2-transfer",
+            "transport-list-item-2-arrive",
+            "transport-list-item-2-price"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "transport-list-item-2-depart",
+          "component": "Text",
+          "text": "13:05",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-2-transfer",
+          "component": "Text",
+          "text": "换乘 1 次",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-list-item-2-arrive",
+          "component": "Text",
+          "text": "18:10",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-2-price",
+          "component": "Text",
+          "text": "¥498",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-3-action",
+          "component": "Button",
+          "child": "transport-list-item-3-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "transport-list-item-3-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "transport-list-item-3-card",
+          "component": "Card",
+          "child": "transport-list-item-3-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "transport-list-item-3-body",
+          "component": "Column",
+          "children": [
+            "transport-list-item-3-title",
+            "transport-list-item-3-times"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "transport-list-item-3-title",
+          "component": "Text",
+          "text": "北京南 - 上海虹桥",
+          "variant": "h4"
+        },
+        {
+          "id": "transport-list-item-3-times",
+          "component": "Row",
+          "children": [
+            "transport-list-item-3-depart",
+            "transport-list-item-3-transfer",
+            "transport-list-item-3-arrive",
+            "transport-list-item-3-price"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "transport-list-item-3-depart",
+          "component": "Text",
+          "text": "15:30",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-3-transfer",
+          "component": "Text",
+          "text": "商务优选",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-list-item-3-arrive",
+          "component": "Text",
+          "text": "20:05",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-3-price",
+          "component": "Text",
+          "text": "¥628",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-4-action",
+          "component": "Button",
+          "child": "transport-list-item-4-card",
+          "variant": "borderless",
+          "action": {
+            "event": {
+              "name": "transport-list-item-4-action.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        },
+        {
+          "id": "transport-list-item-4-card",
+          "component": "Card",
+          "child": "transport-list-item-4-body",
+          "variant": "outlined"
+        },
+        {
+          "id": "transport-list-item-4-body",
+          "component": "Column",
+          "children": [
+            "transport-list-item-4-title",
+            "transport-list-item-4-times"
+          ],
+          "align": "stretch"
+        },
+        {
+          "id": "transport-list-item-4-title",
+          "component": "Text",
+          "text": "北京南 - 上海虹桥",
+          "variant": "h4"
+        },
+        {
+          "id": "transport-list-item-4-times",
+          "component": "Row",
+          "children": [
+            "transport-list-item-4-depart",
+            "transport-list-item-4-transfer",
+            "transport-list-item-4-arrive",
+            "transport-list-item-4-price"
+          ],
+          "align": "center",
+          "justify": "spaceBetween"
+        },
+        {
+          "id": "transport-list-item-4-depart",
+          "component": "Text",
+          "text": "19:10",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-4-transfer",
+          "component": "Text",
+          "text": "夜间班次",
+          "variant": "caption"
+        },
+        {
+          "id": "transport-list-item-4-arrive",
+          "component": "Text",
+          "text": "23:45",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-item-4-price",
+          "component": "Text",
+          "text": "¥521",
+          "variant": "h3"
+        },
+        {
+          "id": "transport-list-more-text",
+          "component": "Text",
+          "text": "查看更多",
+          "variant": "body",
+          "emphasis": "medium"
+        },
+        {
+          "id": "transport-list-more",
+          "component": "Button",
+          "child": "transport-list-more-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "transport-list-more.tap",
+              "context": {
+                "templatePackage": "z",
+                "templateVersion": "0.0.35"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/genui/a2ui-playground/src/pages/DemosListPage.tsx
+++ b/packages/genui/a2ui-playground/src/pages/DemosListPage.tsx
@@ -17,6 +17,7 @@ import {
   EXTENDED_STATIC_DEMOS,
   OFFICIAL_STATIC_DEMOS,
   STATIC_DEMO_JSON_IDS,
+  Z_STATIC_DEMOS,
 } from '../demos.js';
 import { DEFAULT_A2UI_DEMO_URL } from '../utils/demoUrl.js';
 import type { Protocol } from '../utils/protocol.js';
@@ -30,11 +31,13 @@ interface ExampleScenario {
 }
 
 const EXTENDED_EXAMPLES: ExampleScenario[] = [...EXTENDED_STATIC_DEMOS];
+const Z_EXAMPLES: ExampleScenario[] = [...Z_STATIC_DEMOS];
 const OFFICIAL_EXAMPLES: ExampleScenario[] = [...OFFICIAL_STATIC_DEMOS];
 const DYNAMIC_EXAMPLES: ExampleScenario[] = [...DYNAMIC_PRESETS];
 const ALL_EXAMPLES: ExampleScenario[] = [
   ...EXTENDED_EXAMPLES,
   ...OFFICIAL_EXAMPLES,
+  ...Z_EXAMPLES,
   ...DYNAMIC_EXAMPLES,
 ];
 
@@ -136,6 +139,24 @@ export function DemosListPage(
                   scenario={scenario}
                   previewUrl={previewUrls.get(scenario.id)}
                   badge='From A2UI Gallery'
+                  onOpen={handleOpenExample}
+                  onKeyDown={handleCardKeyDown}
+                />
+              ))}
+            </div>
+          </section>
+          <section className='exampleSection'>
+            <div className='exampleSectionHeader'>
+              <h2 className='exampleSectionTitle'>z</h2>
+              <span className='chip'>{Z_EXAMPLES.length}</span>
+            </div>
+            <div className='exampleGrid'>
+              {Z_EXAMPLES.map((scenario) => (
+                <ExamplePreviewCard
+                  key={scenario.id}
+                  scenario={scenario}
+                  previewUrl={previewUrls.get(scenario.id)}
+                  badge='z 0.0.35'
                   onOpen={handleOpenExample}
                   onKeyDown={handleCardKeyDown}
                 />


### PR DESCRIPTION
## Summary
- add a z section to the A2UI examples list with 11 template scenarios
- register z scenarios as static demos and copy generated z JSON payloads into dist/demos

## Verification
- pnpm turbo build --filter=a2ui-playground
- browser use: opened all 11 z cases directly and confirmed they render via ?demo=z-* without waiting for streamed components


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Z" demo section to the playground featuring multiple UI template examples, including product orders, transportation options, ticket bookings, pricing lists, and various card layouts for common e-commerce and service scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->