### PR TITLE
feat(react): ET lazy bundle loading via lynx.fetchBundle

### DIFF
--- a/.changeset/et-globdynamiccomponententry-template-type.md
+++ b/.changeset/et-globdynamiccomponententry-template-type.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+No release changes. Element Template now tags every compiled template type with the `${globDynamicComponentEntry}:` prefix (co-built lazy dynamic components carry a bundleUrl like standalone lazy bundles; the main card uses the `__Card__` sentinel, which normalizes to a null bundleUrl). Element Template support has not been published yet, so this does not need a release.

--- a/.changeset/et-lazy-bundle-fetchbundle.md
+++ b/.changeset/et-lazy-bundle-fetchbundle.md
@@ -1,10 +1,9 @@
 ---
-"@lynx-js/react-runtime": minor
-"@lynx-js/react-transform": minor
-"@lynx-js/template-webpack-plugin": minor
-"@lynx-js/react-webpack-plugin": minor
-"@lynx-js/chunk-loading-webpack-plugin": minor
-"@lynx-js/webpack-runtime-globals": minor
+"@lynx-js/react": patch
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/react-webpack-plugin": patch
+"@lynx-js/chunk-loading-webpack-plugin": patch
+"@lynx-js/webpack-runtime-globals": patch
 ---
 
 feat(react): load Element Template lazy bundles via `lynx.fetchBundle` (FetchBundle)

--- a/.changeset/et-lazy-bundle-fetchbundle.md
+++ b/.changeset/et-lazy-bundle-fetchbundle.md
@@ -1,0 +1,21 @@
+---
+"@lynx-js/react-runtime": minor
+"@lynx-js/react-transform": minor
+"@lynx-js/template-webpack-plugin": minor
+"@lynx-js/react-webpack-plugin": minor
+"@lynx-js/chunk-loading-webpack-plugin": minor
+"@lynx-js/webpack-runtime-globals": minor
+---
+
+feat(react): load Element Template lazy bundles via `lynx.fetchBundle` (FetchBundle)
+
+Element Template lazy bundles now load via `lynx.fetchBundle` + named `lynx.loadScript` sections instead of `lynx.QueryComponent`. The Snapshot path is unchanged.
+
+Per-import sync/async loading is controlled by a native import attribute:
+
+```ts
+lazy(() => import('./X', { with: { mode: 'sync' } })); // first-screen direct render
+lazy(() => import('./X', { with: { mode: 'async' } })); // background-driven (default)
+```
+
+The `mode` attribute is read at build time from the module-graph dependency's import attributes (rspack >= 2.0.3) and stamped into a per-chunk `__webpack_require__.lynx_acm` map, which the chunk-loading runtime threads into `lynx.loadLazyBundle(url, mode)`. ET lazy bundles are packaged as `customSections` (`main-thread` + `background` + `CSS`) with the element template definitions compiled into the bundle's tasm.

--- a/examples/react-et-lazy-bundle/src/App.tsx
+++ b/examples/react-et-lazy-bundle/src/App.tsx
@@ -47,7 +47,9 @@ function delayedImport<T>(
 const BasicLazy = lazy(() =>
   delayedImport(() => import('./LazyComponent.js'), 80)
 );
-const FirstScreenLazy = lazy(() => import('./LazyFirstScreenContent.js'));
+const FirstScreenLazy = lazy(() =>
+  import('./LazyFirstScreenContent.js', { with: { mode: 'sync' } })
+);
 const NestedLazy = lazy(() =>
   delayedImport(() => import('./LazyNestedContent.js'), 160)
 );

--- a/packages/react/runtime/__test__/element-template/lynx/lazy-bundle-fetchbundle.test.ts
+++ b/packages/react/runtime/__test__/element-template/lynx/lazy-bundle-fetchbundle.test.ts
@@ -1,0 +1,282 @@
+import type { ComponentType } from 'preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadLazyBundle } from '../../../src/element-template/lynx/lazy-bundle.js';
+import { ElementTemplateEnvManager } from '../test-utils/debug/envManager.js';
+
+interface LazyExports {
+  default: ComponentType<Record<string, never>>;
+  data?: string;
+}
+
+interface FetchResponse {
+  code: number;
+  url: string;
+}
+
+type FetchBundle = (url: string, options?: unknown) => {
+  wait: (timeout: number) => FetchResponse | undefined;
+  then: (onResolve: (response: FetchResponse | undefined) => void) => void;
+};
+type LoadScript = <T>(section: string, options: { bundleName: string }) => T;
+
+type LynxWithFetch = typeof lynx & {
+  fetchBundle?: FetchBundle;
+  loadScript?: LoadScript;
+};
+
+const envManager = new ElementTemplateEnvManager();
+const TestComponent = (() => null) as ComponentType<Record<string, never>>;
+
+function makeExports(data: string): LazyExports {
+  return { default: TestComponent, data };
+}
+
+// A `fetchBundle` whose handler resolves synchronously (the bundle is already
+// in the native cache), mirroring the real FetchBundle behavior.
+function syncFetch(response: FetchResponse | undefined): FetchBundle {
+  return vi.fn(() => ({
+    wait: () => response,
+    then: (onResolve) => onResolve(response),
+  }));
+}
+
+const l = () => lynx as LynxWithFetch;
+
+describe('element-template loadLazyBundle (FetchBundle)', () => {
+  let originalFetchBundle: FetchBundle | undefined;
+  let originalLoadScript: LoadScript | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envManager.resetEnv('background');
+    originalFetchBundle = l().fetchBundle;
+    originalLoadScript = l().loadScript;
+  });
+
+  afterEach(() => {
+    l().fetchBundle = originalFetchBundle;
+    l().loadScript = originalLoadScript;
+    envManager.resetEnv('background');
+  });
+
+  // --- main thread ---
+
+  it('main thread async mode stays pending (background-driven)', async () => {
+    envManager.resetEnv('main');
+    const fetchBundle = syncFetch({ code: 0, url: 'u' });
+    l().fetchBundle = fetchBundle;
+
+    const promise = loadLazyBundle<LazyExports>('entry', 'async');
+    let settled = false;
+    void promise.then(() => (settled = true), () => (settled = true));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(fetchBundle).not.toHaveBeenCalled();
+  });
+
+  it('main thread sync mode loads the main-thread section synchronously', () => {
+    envManager.resetEnv('main');
+    l().fetchBundle = syncFetch({ code: 0, url: 'resolved-url' });
+    const loadScript = vi.fn(() => makeExports('mt')) as unknown as LoadScript;
+    l().loadScript = loadScript;
+
+    const promise = loadLazyBundle<LazyExports>('entry', 'sync');
+
+    expect(loadScript).toHaveBeenCalledWith('main-thread', {
+      bundleName: 'resolved-url',
+    });
+    let fulfilled = false;
+    void promise.then((exports) => {
+      expect(exports.data).toBe('mt');
+      fulfilled = true;
+    });
+    expect(fulfilled).toBe(true);
+  });
+
+  it('main thread sync mode stays pending when fetchBundle throws', async () => {
+    envManager.resetEnv('main');
+    l().fetchBundle = vi.fn(() => {
+      throw new Error('fetch failed');
+    }) as unknown as FetchBundle;
+
+    await expectPending(loadLazyBundle<LazyExports>('entry', 'sync'));
+  });
+
+  it('main thread sync mode stays pending on a failed response', async () => {
+    envManager.resetEnv('main');
+    l().fetchBundle = syncFetch({ code: 1, url: 'u' });
+    await expectPending(loadLazyBundle<LazyExports>('entry', 'sync'));
+  });
+
+  it('main thread sync mode stays pending when the response is missing', async () => {
+    envManager.resetEnv('main');
+    l().fetchBundle = syncFetch(undefined);
+    await expectPending(loadLazyBundle<LazyExports>('entry', 'sync'));
+  });
+
+  it('main thread sync mode stays pending when loadScript throws', async () => {
+    envManager.resetEnv('main');
+    l().fetchBundle = syncFetch({ code: 0, url: 'u' });
+    l().loadScript = (() => {
+      throw new Error('eval failed');
+    }) as unknown as LoadScript;
+    await expectPending(loadLazyBundle<LazyExports>('entry', 'sync'));
+  });
+
+  // --- background, sync mode ---
+
+  it('background sync mode loads the background section synchronously', () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = syncFetch({ code: 0, url: 'bg-url' });
+    const loadScript = vi.fn(() => makeExports('bg')) as unknown as LoadScript;
+    l().loadScript = loadScript;
+
+    const promise = loadLazyBundle<LazyExports>('entry', 'sync');
+    expect(loadScript).toHaveBeenCalledWith('background', { bundleName: 'bg-url' });
+    let fulfilled = false;
+    void promise.then((exports) => {
+      expect(exports.data).toBe('bg');
+      fulfilled = true;
+    });
+    expect(fulfilled).toBe(true);
+  });
+
+  it('background sync mode rejects when fetchBundle throws (Error)', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = vi.fn(() => {
+      throw new Error('boom');
+    }) as unknown as FetchBundle;
+    await expect(loadLazyBundle<LazyExports>('entry', 'sync')).rejects.toThrow('boom');
+  });
+
+  it('background sync mode rejects when fetchBundle throws (non-Error)', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = vi.fn(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'string failure';
+    }) as unknown as FetchBundle;
+    await expect(loadLazyBundle<LazyExports>('entry', 'sync')).rejects.toThrow(
+      'string failure',
+    );
+  });
+
+  it('background sync mode rejects with cause on a failed response', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = syncFetch({ code: 1, url: 'u' });
+    await expect(
+      loadLazyBundle<LazyExports>('entry', 'sync').catch(
+        (error: Error & { cause?: unknown }) => {
+          expect(error.cause).toBe('{"code":1,"url":"u"}');
+          throw error;
+        },
+      ),
+    ).rejects.toThrow('Lazy bundle load failed, schema: entry');
+  });
+
+  it('background sync mode rejects when loadScript throws (Error)', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = syncFetch({ code: 0, url: 'u' });
+    l().loadScript = (() => {
+      throw new Error('eval failed');
+    }) as unknown as LoadScript;
+    await expect(loadLazyBundle<LazyExports>('entry', 'sync')).rejects.toThrow(
+      'eval failed',
+    );
+  });
+
+  it('background sync mode rejects when loadScript throws (non-Error)', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = syncFetch({ code: 0, url: 'u' });
+    l().loadScript = (() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'sync eval string';
+    }) as unknown as LoadScript;
+    await expect(loadLazyBundle<LazyExports>('entry', 'sync')).rejects.toThrow(
+      'sync eval string',
+    );
+  });
+
+  // --- background, async mode (default) ---
+
+  it('background async mode resolves the background section', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = syncFetch({ code: 0, url: 'bg-url' });
+    l().loadScript = vi.fn(() => makeExports('async')) as unknown as LoadScript;
+
+    await expect(loadLazyBundle<LazyExports>('entry')).resolves.toMatchObject({
+      data: 'async',
+    });
+  });
+
+  it('background async mode rejects when fetchBundle throws (non-Error)', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = vi.fn(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'async string failure';
+    }) as unknown as FetchBundle;
+    await expect(loadLazyBundle<LazyExports>('entry', 'async')).rejects.toThrow(
+      'async string failure',
+    );
+  });
+
+  it('background async mode rejects when fetchBundle throws (Error)', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = vi.fn(() => {
+      throw new Error('async boom');
+    }) as unknown as FetchBundle;
+    await expect(loadLazyBundle<LazyExports>('entry', 'async')).rejects.toThrow(
+      'async boom',
+    );
+  });
+
+  it('background async mode rejects with cause on a failed response', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = syncFetch({ code: 1, url: 'u' });
+    await expect(
+      loadLazyBundle<LazyExports>('entry', 'async').catch(
+        (error: Error & { cause?: unknown }) => {
+          expect(error.cause).toBe('{"code":1,"url":"u"}');
+          throw error;
+        },
+      ),
+    ).rejects.toThrow('Lazy bundle load failed, schema: entry');
+  });
+
+  it('background async mode rejects when loadScript throws (Error)', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = syncFetch({ code: 0, url: 'u' });
+    l().loadScript = (() => {
+      throw new Error('async eval failed');
+    }) as unknown as LoadScript;
+    await expect(loadLazyBundle<LazyExports>('entry', 'async')).rejects.toThrow(
+      'async eval failed',
+    );
+  });
+
+  it('background async mode rejects when loadScript throws (non-Error)', async () => {
+    envManager.resetEnv('background');
+    l().fetchBundle = syncFetch({ code: 0, url: 'u' });
+    l().loadScript = (() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'async eval string';
+    }) as unknown as LoadScript;
+    await expect(loadLazyBundle<LazyExports>('entry', 'async')).rejects.toThrow(
+      'async eval string',
+    );
+  });
+
+  it('throws in unsupported execution environments', () => {
+    envManager.resetEnv('background');
+    globalThis.__JS__ = false;
+    globalThis.__MAIN_THREAD__ = false;
+    expect(() => loadLazyBundle<LazyExports>('entry', 'sync')).toThrow('unreachable');
+  });
+});
+
+async function expectPending(promise: Promise<unknown>): Promise<void> {
+  let settled = false;
+  void promise.then(() => (settled = true), () => (settled = true));
+  await Promise.resolve();
+  expect(settled).toBe(false);
+}

--- a/packages/react/runtime/__test__/element-template/lynx/lazy-bundle-fetchbundle.test.ts
+++ b/packages/react/runtime/__test__/element-template/lynx/lazy-bundle-fetchbundle.test.ts
@@ -62,9 +62,30 @@ describe('element-template loadLazyBundle (FetchBundle)', () => {
 
   // --- main thread ---
 
-  it('main thread async mode stays pending (background-driven)', async () => {
+  it('main thread async mode stays pending but warms the cache', async () => {
     envManager.resetEnv('main');
     const fetchBundle = syncFetch({ code: 0, url: 'u' });
+    l().fetchBundle = fetchBundle;
+    const loadScript = vi.fn(() => makeExports('mt')) as unknown as LoadScript;
+    l().loadScript = loadScript;
+
+    const promise = loadLazyBundle<LazyExports>('entry', 'async');
+    let settled = false;
+    void promise.then(() => (settled = true), () => (settled = true));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    // The main thread fires fetchBundle (fire-and-forget) to warm the native
+    // cache so the background path waits less...
+    expect(fetchBundle).toHaveBeenCalledWith('entry', {});
+    // ...but does no rendering here.
+    expect(loadScript).not.toHaveBeenCalled();
+  });
+
+  it('main thread async mode swallows a fetchBundle throw and stays pending', async () => {
+    envManager.resetEnv('main');
+    const fetchBundle = vi.fn(() => {
+      throw new Error('fetchBundle unavailable');
+    }) as unknown as FetchBundle;
     l().fetchBundle = fetchBundle;
 
     const promise = loadLazyBundle<LazyExports>('entry', 'async');
@@ -72,7 +93,7 @@ describe('element-template loadLazyBundle (FetchBundle)', () => {
     void promise.then(() => (settled = true), () => (settled = true));
     await Promise.resolve();
     expect(settled).toBe(false);
-    expect(fetchBundle).not.toHaveBeenCalled();
+    expect(fetchBundle).toHaveBeenCalledWith('entry', {});
   });
 
   it('main thread sync mode loads the main-thread section synchronously', () => {

--- a/packages/react/runtime/src/core/lynx/lazy-bundle.ts
+++ b/packages/react/runtime/src/core/lynx/lazy-bundle.ts
@@ -4,8 +4,8 @@
 
 /**
  * To make code below works
- * const App1 = lazy(() => import("./x").then(({App1}) => ({default: App1})))
- * const App2 = lazy(() => import("./x").then(({App2}) => ({default: App2})))
+ * const App1 = lazy(() => import("./components.jsx").then(({App1}) => ({default: App1})))
+ * const App2 = lazy(() => import("./components.jsx").then(({App2}) => ({default: App2})))
  * @internal
  */
 export const makeSyncThen = function<T>(result: T): Promise<T>['then'] {
@@ -27,7 +27,7 @@ export const makeSyncThen = function<T>(result: T): Promise<T>['then'] {
 
       if (ret && typeof (ret as PromiseLike<TR1>).then === 'function' /* `thenable` object */) {
         // lazy(() =>
-        //   import("./x").then(() => new Promise(...))
+        //   import("./components.jsx").then(() => new Promise(...))
         // )
         // Calling `then` and passing a callback is standard behavior
         // but in Lepus runtime the callback will never be called
@@ -37,7 +37,7 @@ export const makeSyncThen = function<T>(result: T): Promise<T>['then'] {
         // TODO(hongzhiyuan.hzy): Avoid warning that cannot be turned-off, so the warning is commented
         // lynx.reportError(
         //   new Error(
-        //     'You returned a Promise in promise-chain of lazy-bundle import (eg. `import("./x").then(() => new Promise(...))`), which will cause related Component unavailable at first-screen, '
+        //     'You returned a Promise in promise-chain of lazy-bundle import (eg. `import("./components.jsx").then(() => new Promise(...))`), which will cause related Component unavailable at first-screen, '
         //   ),
         //   { level: "warning" }
         // );

--- a/packages/react/runtime/src/element-template/internal.ts
+++ b/packages/react/runtime/src/element-template/internal.ts
@@ -47,7 +47,10 @@ export { wrapWithLynxComponent } from '../core/compat/lynxComponent.js';
 //   loadLazyBundle,
 // );
 
-export { loadLazyBundle } from '../core/lynx/lazy-bundle.js';
+// Element Template loads lazy bundles via `lynx.fetchBundle` (FetchBundle),
+// not `lynx.QueryComponent`. This is the ET-only loader; Snapshot keeps the
+// shared `core/lynx/lazy-bundle.js` one via `src/internal.ts`.
+export { loadLazyBundle } from './lynx/lazy-bundle.js';
 
 // TODO(ET MTS): add MTRef hydrate semantics in follow-up tracks.
 export { transformToWorklet } from './runtime/template/main-thread-background-function.js';

--- a/packages/react/runtime/src/element-template/lynx/lazy-bundle.ts
+++ b/packages/react/runtime/src/element-template/lynx/lazy-bundle.ts
@@ -122,10 +122,10 @@ export const loadLazyBundle: <
             reject(e instanceof Error ? e : new Error(String(e)));
             return;
           }
-          // No `rLynxPrepareLazyBundleMTS` round-trip is needed (unlike
-          // Snapshot): once `fetchBundle` resolves, the native cache holds the
-          // bundle, so any `__CreateElementTemplate` patch the background thread
-          // emits next resolves its template on the main thread.
+          // No `processEvalResult` round-trip is needed (unlike the
+          // QueryComponent path): once `fetchBundle` resolves, the native cache
+          // holds the bundle, so any `__CreateElementTemplate` patch the
+          // background thread emits next resolves its template on the main thread.
           resolve(result);
         });
       });

--- a/packages/react/runtime/src/element-template/lynx/lazy-bundle.ts
+++ b/packages/react/runtime/src/element-template/lynx/lazy-bundle.ts
@@ -37,8 +37,13 @@ export const loadLazyBundle: <
     if (__MAIN_THREAD__) {
       // `async`: the lazy subtree is rendered on the background thread and
       // materialized on the main thread from native templates, so the main
-      // thread runs no JS here.
+      // thread renders nothing here — but we still fire the fetch (ignoring
+      // the result) to warm the native bundle cache so the background `async`
+      // path waits less.
       if (mode !== 'sync') {
+        try {
+          lynx.fetchBundle(source, {});
+        } catch {}
         return new Promise(() => {});
       }
       // `sync` (first-screen direct render): the main thread must run the lazy
@@ -56,9 +61,12 @@ export const loadLazyBundle: <
       }
       let result: T;
       try {
-        result = lynx.loadScript!<T>(SECTION_MAIN_THREAD, {
+        const oldGlobalDynamicComponentEntry = globalThis.globDynamicComponentEntry;
+        globalThis.globDynamicComponentEntry = response.url;
+        result = lynx.loadScript<T>(SECTION_MAIN_THREAD, {
           bundleName: response.url,
         });
+        globalThis.globDynamicComponentEntry = oldGlobalDynamicComponentEntry;
       } catch {
         return new Promise(() => {});
       }
@@ -82,9 +90,12 @@ export const loadLazyBundle: <
         }
         let result: T;
         try {
-          result = lynx.loadScript!<T>(SECTION_BACKGROUND, {
+          const oldGlobalDynamicComponentEntry = globalThis.globDynamicComponentEntry;
+          globalThis.globDynamicComponentEntry = response.url;
+          result = lynx.loadScript<T>(SECTION_BACKGROUND, {
             bundleName: response.url,
           });
+          globalThis.globDynamicComponentEntry = oldGlobalDynamicComponentEntry;
         } catch (e) {
           return Promise.reject(e instanceof Error ? e : new Error(String(e)));
         }
@@ -115,9 +126,12 @@ export const loadLazyBundle: <
           }
           let result: T;
           try {
-            result = lynx.loadScript!<T>(SECTION_BACKGROUND, {
+            const oldGlobalDynamicComponentEntry = globalThis.globDynamicComponentEntry;
+            globalThis.globDynamicComponentEntry = response.url;
+            result = lynx.loadScript<T>(SECTION_BACKGROUND, {
               bundleName: response.url,
             });
+            globalThis.globDynamicComponentEntry = oldGlobalDynamicComponentEntry;
           } catch (e) {
             reject(e instanceof Error ? e : new Error(String(e)));
             return;

--- a/packages/react/runtime/src/element-template/lynx/lazy-bundle.ts
+++ b/packages/react/runtime/src/element-template/lynx/lazy-bundle.ts
@@ -1,0 +1,138 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { makeSyncThen } from '../../core/lynx/lazy-bundle.js';
+
+// Element Template lazy bundles are fetched via `lynx.fetchBundle` and each
+// section is run via `lynx.loadScript`. ET template definitions are compiled
+// into the bundle's `tasm.json`, so native materializes the templates (by
+// content-hashed `templateKey`) from the fetched Lynx.bundle — the main thread
+// only needs the `main-thread` section for `sync` first-screen direct render
+// (to produce the first-screen elements); `async` is background-driven.
+const SECTION_MAIN_THREAD = 'main-thread';
+const SECTION_BACKGROUND = 'background';
+
+// `mode: 'sync'` blocks first-screen on the fetch; `wait()` needs a timeout.
+const LYNX_LAZY_SYNC_TIMEOUT_SECONDS = 5;
+
+export type LazyBundleMode = 'sync' | 'async';
+
+/**
+ * Load an Element Template lazy bundle via `lynx.fetchBundle`. Designed to be
+ * used with `lazy`. The `mode` is threaded in by the chunk-loading runtime from
+ * the `import(..., { with: { mode } })` import attribute (see `lynx_acm`).
+ * @param source - where the lazy bundle Lynx.bundle locates
+ * @param mode - `'sync'` (first-screen blocking) or `'async'` (default)
+ * @public
+ */
+export const loadLazyBundle: <
+  T extends { default: React.ComponentType<any> },
+>(source: string, mode?: LazyBundleMode) => Promise<T> = /*#__PURE__*/ (() => {
+  lynx.loadLazyBundle = loadLazyBundle;
+
+  function loadLazyBundle<
+    T extends { default: React.ComponentType<any> },
+  >(source: string, mode?: LazyBundleMode): Promise<T> {
+    if (__MAIN_THREAD__) {
+      // `async`: the lazy subtree is rendered on the background thread and
+      // materialized on the main thread from native templates, so the main
+      // thread runs no JS here.
+      if (mode !== 'sync') {
+        return new Promise(() => {});
+      }
+      // `sync` (first-screen direct render): the main thread must run the lazy
+      // bundle's `main-thread` section to produce the first-screen elements.
+      let response;
+      try {
+        response = lynx.fetchBundle(source, {}).wait(
+          LYNX_LAZY_SYNC_TIMEOUT_SECONDS,
+        );
+      } catch {
+        return new Promise(() => {});
+      }
+      if (!response || response.code !== 0) {
+        return new Promise(() => {});
+      }
+      let result: T;
+      try {
+        result = lynx.loadScript!<T>(SECTION_MAIN_THREAD, {
+          bundleName: response.url,
+        });
+      } catch {
+        return new Promise(() => {});
+      }
+      const r: Promise<T> = Promise.resolve(result);
+      r.then = makeSyncThen(result);
+      return r;
+    } else if (__JS__) {
+      if (mode === 'sync') {
+        let response;
+        try {
+          response = lynx.fetchBundle(source, {}).wait(
+            LYNX_LAZY_SYNC_TIMEOUT_SECONDS,
+          );
+        } catch (e) {
+          return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+        }
+        if (!response || response.code !== 0) {
+          const e = new Error('Lazy bundle load failed, schema: ' + source);
+          e.cause = JSON.stringify(response);
+          return Promise.reject(e);
+        }
+        let result: T;
+        try {
+          result = lynx.loadScript!<T>(SECTION_BACKGROUND, {
+            bundleName: response.url,
+          });
+        } catch (e) {
+          return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+        }
+        const r: Promise<T> = Promise.resolve(result);
+        r.then = makeSyncThen(result);
+        return r;
+      }
+
+      // async (default)
+      return new Promise<T>((resolve, reject) => {
+        // The upstream `ResponseHandler.then` type is a placeholder stub; it is
+        // a callback at runtime, so type it locally.
+        let handler: {
+          then(onResolve: (response: { code: number; url: string }) => void): void;
+        };
+        try {
+          handler = lynx.fetchBundle(source, {}) as unknown as typeof handler;
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+          return;
+        }
+        handler.then((response) => {
+          if (!response || response.code !== 0) {
+            const e = new Error('Lazy bundle load failed, schema: ' + source);
+            e.cause = JSON.stringify(response);
+            reject(e);
+            return;
+          }
+          let result: T;
+          try {
+            result = lynx.loadScript!<T>(SECTION_BACKGROUND, {
+              bundleName: response.url,
+            });
+          } catch (e) {
+            reject(e instanceof Error ? e : new Error(String(e)));
+            return;
+          }
+          // No `rLynxPrepareLazyBundleMTS` round-trip is needed (unlike
+          // Snapshot): once `fetchBundle` resolves, the native cache holds the
+          // bundle, so any `__CreateElementTemplate` patch the background thread
+          // emits next resolves its template on the main thread.
+          resolve(result);
+        });
+      });
+    }
+
+    throw new Error('unreachable');
+  }
+
+  return loadLazyBundle;
+})();

--- a/packages/react/runtime/src/element-template/types.d.ts
+++ b/packages/react/runtime/src/element-template/types.d.ts
@@ -18,6 +18,14 @@ declare global {
 
   const __USE_ELEMENT_TEMPLATE__: boolean;
 
+  /**
+   * The lazy bundle's entry URL. The FetchBundle loader sets this before
+   * running a lazy bundle's `loadScript` so the bundle wrapper resolves its
+   * own element templates instead of falling back to the main card
+   * (`__Card__`).
+   */
+  var globDynamicComponentEntry: string | undefined;
+
   function __CreateElementTemplate(
     templateKey: string,
     bundleUrl: string | null | undefined,

--- a/packages/react/runtime/types/types.d.ts
+++ b/packages/react/runtime/types/types.d.ts
@@ -291,7 +291,17 @@ declare module '@lynx-js/types/background' {
     getNativeLynx(): NativeLynx;
     reportError(e: Error): void;
     QueryComponent?(source: string, callback: (result: any) => void): void;
-    loadLazyBundle?<T extends { default: React.ComponentType<any> }>(source: string): Promise<T>;
+    loadLazyBundle?<T extends { default: React.ComponentType<any> }>(
+      source: string,
+      mode?: 'sync' | 'async',
+    ): Promise<T>;
+
+    /**
+     * Evaluate a named section of a bundle already loaded via
+     * {@link fetchBundle} and return its `module.exports`.
+     * @since 3.8
+     */
+    loadScript?<T>(section: string, options: { bundleName: string }): T;
 
     /**
      * @since 2.14

--- a/packages/react/transform/__test__/fixture.spec.js
+++ b/packages/react/transform/__test__/fixture.spec.js
@@ -1328,6 +1328,65 @@ describe('dynamic import', () => {
         ]
       `);
   });
+  it('lazy bundle mode option', async () => {
+    const result = await transformReactLynx(
+      `\
+(async function () {
+  await import("./index.js", { with: { mode: "sync" } });
+  await import("./index.js", { with: { mode: "async" } });
+  await import("https://www/a.js", { with: { mode: "async" } });
+  await import("./index.js", { with: { type: "component", mode: "sync" } });
+})();
+`,
+      {
+        pluginName: '',
+        filename: '',
+        sourcemap: false,
+        parserConfig: {
+          tsx: true,
+        },
+        cssScope: false,
+        jsx: false,
+        directiveDCE: false,
+        defineDCE: false,
+        shake: false,
+        compat: false,
+        worklet: false,
+        refresh: false,
+      },
+    );
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "import 'data:text/javascript;charset=utf-8,import { loadLazyBundle } from "@lynx-js/react/internal";lynx.loadLazyBundle = loadLazyBundle;';
+      import "@lynx-js/react/experimental/lazy/import";
+      import { __dynamicImport } from "@lynx-js/react/internal";
+      (async function() {
+          await import(/*webpackChunkName: "./index.js-"*/ "./index.js", {
+              with: {
+                  mode: "sync"
+              }
+          });
+          await import(/*webpackChunkName: "./index.js-"*/ "./index.js", {
+              with: {
+                  mode: "async"
+              }
+          });
+          await __dynamicImport("https://www/a.js", {
+              with: {
+                  mode: "async"
+              }
+          });
+          await import(/*webpackChunkName: "./index.js-"*/ "./index.js", {
+              with: {
+                  type: "component",
+                  mode: "sync"
+              }
+          });
+      })();
+      "
+    `);
+    expect(result.errors).toMatchInlineSnapshot(`[]`);
+  });
 });
 
 describe('define dce', () => {

--- a/packages/react/transform/crates/swc_plugin_dynamic_import/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_dynamic_import/lib.rs
@@ -346,6 +346,12 @@ mod tests {
       await import("https://www/a.js", { with: { type: "component" } });
       await import(url, { with: { type: "component" } });
       await import(url+"?v=1.0", { with: { type: "component" } });
+
+      await import("./index.js", { with: { mode: "sync" } });
+      await import("./index.js", { with: { mode: "async" } });
+      await import("ftp://www/a.js", { with: { mode: "sync" } });
+      await import("https://www/a.js", { with: { mode: "async" } });
+      await import("./index.js", { with: { type: "component", mode: "sync" } });
     })();
     "#
   );

--- a/packages/react/transform/crates/swc_plugin_dynamic_import/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_dynamic_import/lib.rs
@@ -115,6 +115,24 @@ fn is_import_call_with_type(call_expr: &CallExpr) -> (bool, bool, Value) {
   }
 }
 
+fn import_call_has_with_key(call_expr: &CallExpr, key: &str) -> bool {
+  match &call_expr.callee {
+    Callee::Import(_) if call_expr.args.len() >= 2 => match &*call_expr.args[1].expr {
+      Expr::Object(object) => {
+        let (is_lit, _) = calc_literal_cost(object, false);
+        if is_lit {
+          let with = jsonify(Expr::Object(object.clone()));
+          with.pointer(&format!("/with/{key}")).is_some()
+        } else {
+          false
+        }
+      }
+      _ => false,
+    },
+    _ => false,
+  }
+}
+
 fn create_import_decl(name: &str) -> ModuleItem {
   ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
     span: DUMMY_SP,
@@ -168,6 +186,10 @@ where
 
     let (is_import_call_lit, is_import_call_str_lit, str_lit) = is_import_call_str_lit(call_expr);
     let (has_option, is_import_call_with_type, _with_type) = is_import_call_with_type(call_expr);
+    // FetchBundle lazy bundles accept `{ with: { mode: 'sync' | 'async' } }`
+    // (read at build time via the dependency's import attributes), so a `mode`
+    // option is valid on its own without `type`.
+    let is_import_call_with_mode = import_call_has_with_key(call_expr, "mode");
 
     // TODO: reject dynamic import without `{ with: { type: "component" } }`
 
@@ -194,7 +216,7 @@ where
       || str_lit.starts_with("//");
 
     if is_import_call_str_lit && !is_explicitly_external {
-      if has_option && !is_import_call_with_type {
+      if has_option && !is_import_call_with_type && !is_import_call_with_mode {
         HANDLER.with(|handler| {
           handler
             .struct_span_err(

--- a/packages/react/transform/crates/swc_plugin_dynamic_import/tests/__swc_snapshots__/lib.rs/should_transform_import_call.js
+++ b/packages/react/transform/crates/swc_plugin_dynamic_import/tests/__swc_snapshots__/lib.rs/should_transform_import_call.js
@@ -32,4 +32,30 @@ import { __dynamicImport } from "@lynx-js/react/internal";
             type: "component"
         }
     });
+    await import(/*webpackChunkName: "./index.js-test"*/ "./index.js", {
+        with: {
+            mode: "sync"
+        }
+    });
+    await import(/*webpackChunkName: "./index.js-test"*/ "./index.js", {
+        with: {
+            mode: "async"
+        }
+    });
+    await import(/*webpackChunkName: "ftp://www/a.js-test"*/ "ftp://www/a.js", {
+        with: {
+            mode: "sync"
+        }
+    });
+    await __dynamicImport("https://www/a.js", {
+        with: {
+            mode: "async"
+        }
+    });
+    await import(/*webpackChunkName: "./index.js-test"*/ "./index.js", {
+        with: {
+            type: "component",
+            mode: "sync"
+        }
+    });
 })();

--- a/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
@@ -32,6 +32,7 @@ export default function() {
               const promise = lynx.loadLazyBundle(
                 $RuntimeGlobals_publicPath$
                   + $RuntimeGlobals_lynxAsyncChunkIds$[chunkId],
+                $RuntimeGlobals_lynxAsyncChunkMode$[chunkId],
               ).then((exports) => {
                 installChunk(exports);
                 return exports;

--- a/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
@@ -32,7 +32,11 @@ export default function() {
               const promise = lynx.loadLazyBundle(
                 $RuntimeGlobals_publicPath$
                   + $RuntimeGlobals_lynxAsyncChunkIds$[chunkId],
-                $RuntimeGlobals_lynxAsyncChunkMode$[chunkId],
+                // `lynx_acm` may be absent (e.g. a build that emits `lynx_aci`
+                // without the mode map); the loader treats a missing mode as
+                // `async`.
+                $RuntimeGlobals_lynxAsyncChunkMode$
+                  && $RuntimeGlobals_lynxAsyncChunkMode$[chunkId],
               ).then((exports) => {
                 installChunk(exports);
                 return exports;

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -511,15 +511,26 @@ class ReactWebpackPlugin {
                     continue;
                   }
 
+                  // Element Template loads lazy bundles via `lynx.fetchBundle`
+                  // + `lynx.loadScript`, which evaluate the section and read its
+                  // returned `module.exports`. So the wrapper must self-execute
+                  // and bake the entry, unlike the QueryComponent form where the
+                  // host calls the function with `globDynamicComponentEntry`.
+                  const isFetchBundle =
+                    options.experimental_useElementTemplate === true;
                   compilation.updateAsset(
                     file,
                     old =>
                       new ConcatSource(
-                        `(function (globDynamicComponentEntry) {\n`,
+                        isFetchBundle
+                          ? `(function () {\n  var globDynamicComponentEntry = '__Card__';\n`
+                          : `(function (globDynamicComponentEntry) {\n`,
                         `  const module = { exports: {} }\n`,
                         `  const exports = module.exports;\n`,
                         old,
-                        `\n  ;return module.exports\n})`,
+                        isFetchBundle
+                          ? `\n  ;return module.exports\n})()`
+                          : `\n  ;return module.exports\n})`,
                       ),
                   );
                 }

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -523,7 +523,7 @@ class ReactWebpackPlugin {
                     old =>
                       new ConcatSource(
                         isFetchBundle
-                          ? `(function () {\n  var globDynamicComponentEntry = '__Card__';\n`
+                          ? `(function () {\n  var globDynamicComponentEntry = globalThis.globDynamicComponentEntry || '__Card__';\n`
                           : `(function (globDynamicComponentEntry) {\n`,
                         `  const module = { exports: {} }\n`,
                         `  const exports = module.exports;\n`,

--- a/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
+++ b/packages/webpack/template-webpack-plugin/etc/template-webpack-plugin.api.md
@@ -33,7 +33,8 @@ export interface EncodeOptions {
     // (undocumented)
     customSections: Record<string, {
         type?: 'lazy';
-        content: string | Record<string, unknown>;
+        encoding?: 'JsBytecode' | 'CSS';
+        content: string | Record<string, unknown> | undefined;
     }>;
     elementTemplate?: Record<string, unknown>;
     // (undocumented)
@@ -41,9 +42,9 @@ export interface EncodeOptions {
         root: string | undefined;
         lepusChunk: Record<string, string>;
         filename: string | undefined;
-    };
+    } | undefined;
     // (undocumented)
-    manifest: Record<string, string | undefined>;
+    manifest?: Record<string, string | undefined> | undefined;
 }
 
 // @public
@@ -192,6 +193,6 @@ export class WebEncodePlugin {
 
 // Warnings were encountered during analysis:
 //
-// lib/LynxTemplatePlugin.d.ts:72:9 - (ae-forgotten-export) The symbol "EncodeRawData" needs to be exported by the entry point index.d.ts
+// lib/LynxTemplatePlugin.d.ts:73:9 - (ae-forgotten-export) The symbol "EncodeRawData" needs to be exported by the entry point index.d.ts
 
 ```

--- a/packages/webpack/template-webpack-plugin/src/LynxAsyncChunksRuntimeModule.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxAsyncChunksRuntimeModule.ts
@@ -2,13 +2,69 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { RuntimeModule } from '@rspack/core';
+import type { Compilation, Module, RuntimeModule } from '@rspack/core';
 
 import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
 
 type LynxAsyncChunksRuntimeModule = new(
   getChunkName: (chunkName: string) => string,
 ) => RuntimeModule;
+
+type ChunkGraph = Compilation['chunkGraph'];
+type AsyncDependenciesBlock = Module['blocks'][number];
+
+const LAZY_BUNDLE_MODE_ATTRIBUTE = 'mode';
+
+// Building the `chunk.id -> mode` map walks the whole module graph, so memoize
+// it per compilation: `generate()` runs once per runtime chunk and the result
+// is identical for all of them.
+const modeCache = new WeakMap<
+  Compilation,
+  Map<string | number, string>
+>();
+
+function collectLazyBundleModes(
+  compilation: Compilation,
+  chunkGraph: ChunkGraph,
+): Map<string | number, string> {
+  const cached = modeCache.get(compilation);
+  if (cached) {
+    return cached;
+  }
+
+  const modeByChunkId = new Map<string | number, string>();
+  const visitBlock = (block: AsyncDependenciesBlock): void => {
+    for (const dependency of block.dependencies) {
+      // `import(..., { with: { mode } })` surfaces here as a dependency import
+      // attribute (rspack >= 2.0.3, web-infra-dev/rspack#13947).
+      const mode = dependency.attributes?.[LAZY_BUNDLE_MODE_ATTRIBUTE];
+      if (mode === undefined) {
+        continue;
+      }
+      const chunkGroup = chunkGraph.getBlockChunkGroup(block);
+      if (chunkGroup === null) {
+        continue;
+      }
+      for (const chunk of chunkGroup.chunks) {
+        if (chunk.id !== undefined) {
+          modeByChunkId.set(chunk.id, mode);
+        }
+      }
+    }
+    for (const nested of block.blocks) {
+      visitBlock(nested);
+    }
+  };
+
+  for (const module of compilation.modules) {
+    for (const block of module.blocks) {
+      visitBlock(block);
+    }
+  }
+
+  modeCache.set(compilation, modeByChunkId);
+  return modeByChunkId;
+}
 
 export function createLynxAsyncChunksRuntimeModule(
   webpack: typeof import('@rspack/core').rspack,
@@ -27,29 +83,45 @@ export function createLynxAsyncChunksRuntimeModule(
       const chunk = this.chunk!;
       const compilation = this.compilation!;
 
-      return `// lynx async chunks ids
-${RuntimeGlobals.lynxAsyncChunkIds} = {${
-        Array.from(chunk.getAllAsyncChunks())
-          .filter(c => c.name !== null && c.name !== undefined)
-          .map(c => {
-            const filename = this.getChunkName(c.name!);
+      const modeByChunkId = collectLazyBundleModes(
+        compilation,
+        this.chunkGraph!,
+      );
 
-            // Modified from https://github.com/webpack/webpack/blob/11449f02175f055a4540d76aa4478958c4cb297e/lib/runtime/GetChunkFilenameRuntimeModule.js#L154-L157
-            // Rspack currently ignores `hashWithLength` (also missing from its
-            // `PathData` type, hence the cast); kept for when it gains support.
-            const pathData = {
-              hash: `" + ${webpack.RuntimeGlobals.getFullHash}() + "`,
-              hashWithLength: (length: number) =>
-                `" + ${webpack.RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
-              // TODO: support [contenthash]
-            } as Parameters<typeof compilation.getPath>[1];
-            const chunkPath = compilation.getPath(filename, pathData);
+      const asyncChunks = Array.from(chunk.getAllAsyncChunks())
+        .filter(c => c.name !== null && c.name !== undefined);
 
-            return [c.id, chunkPath];
-          })
+      const ids = asyncChunks
+        .map(c => {
+          const filename = this.getChunkName(c.name!);
+
+          // Modified from https://github.com/webpack/webpack/blob/11449f02175f055a4540d76aa4478958c4cb297e/lib/runtime/GetChunkFilenameRuntimeModule.js#L154-L157
+          // Rspack currently ignores `hashWithLength` (also missing from its
+          // `PathData` type, hence the cast); kept for when it gains support.
+          const pathData = {
+            hash: `" + ${webpack.RuntimeGlobals.getFullHash}() + "`,
+            hashWithLength: (length: number) =>
+              `" + ${webpack.RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
+            // TODO: support [contenthash]
+          } as Parameters<typeof compilation.getPath>[1];
+          const chunkPath = compilation.getPath(filename, pathData);
+
           // Do not use `JSON.stringify` on `chunkPath`, it may contains `+` which will be treated as string concatenation.
-          .map(([id, path]) => `${JSON.stringify(id)}: "${path}"`).join(',\n')
-      }}`;
+          return `${JSON.stringify(c.id)}: "${chunkPath}"`;
+        })
+        .join(',\n');
+
+      const modes = asyncChunks
+        .filter(c => modeByChunkId.has(c.id!))
+        .map(c =>
+          `${JSON.stringify(c.id)}: ${JSON.stringify(modeByChunkId.get(c.id!))}`
+        )
+        .join(',\n');
+
+      return `// lynx async chunks ids
+${RuntimeGlobals.lynxAsyncChunkIds} = {${ids}}
+// lynx async chunks modes
+${RuntimeGlobals.lynxAsyncChunkMode} = {${modes}}`;
     }
   };
 }

--- a/packages/webpack/template-webpack-plugin/src/LynxAsyncChunksRuntimeModule.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxAsyncChunksRuntimeModule.ts
@@ -2,7 +2,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { Compilation, Module, RuntimeModule } from '@rspack/core';
+import type {
+  AsyncDependenciesBlock,
+  Compilation,
+  RuntimeModule,
+} from '@rspack/core';
 
 import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
 
@@ -11,7 +15,6 @@ type LynxAsyncChunksRuntimeModule = new(
 ) => RuntimeModule;
 
 type ChunkGraph = Compilation['chunkGraph'];
-type AsyncDependenciesBlock = Module['blocks'][number];
 
 const LAZY_BUNDLE_MODE_ATTRIBUTE = 'mode';
 

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -35,17 +35,18 @@ export type OriginManifest = Record<string, {
  * @public
  */
 export interface EncodeOptions {
-  manifest: Record<string, string | undefined>;
+  manifest?: Record<string, string | undefined> | undefined;
   compilerOptions: Record<string, string | boolean>;
   lepusCode: {
     root: string | undefined;
     lepusChunk: Record<string, string>;
     filename: string | undefined;
-  };
+  } | undefined;
   // `customSections` option only takes effect on Lynx >= 2.16.
   customSections: Record<string, {
     type?: 'lazy';
-    content: string | Record<string, unknown>;
+    encoding?: 'JsBytecode' | 'CSS';
+    content: string | Record<string, unknown> | undefined;
   }>;
   /**
    * Element template data used by encoders that support element template output.
@@ -331,6 +332,7 @@ interface EncodeRawData {
   // `customSections` option only takes effect on Lynx >= 2.16.
   customSections: Record<string, {
     type?: 'lazy';
+    encoding?: 'JsBytecode' | 'CSS';
     content: string | Record<string, unknown>;
   }>;
   sourceContent: {
@@ -468,6 +470,16 @@ export class LynxTemplatePlugin {
       Object.assign({}, LynxTemplatePlugin.defaultOptions, this.options),
     );
   }
+}
+
+const SECTION_MAIN_THREAD = 'main-thread';
+const SECTION_BACKGROUND = 'background';
+const SECTION_CSS = 'CSS';
+
+interface CustomSectionEntry {
+  type?: 'lazy';
+  encoding?: 'JsBytecode' | 'CSS';
+  content: string | Record<string, unknown>;
 }
 
 class LynxTemplatePluginImpl {
@@ -691,6 +703,62 @@ class LynxTemplatePluginImpl {
     return asyncChunkGroups;
   }
 
+  // Split an Element Template lazy bundle's payloads into the named sections
+  // that `lynx.loadScript` addresses at runtime: `main-thread` (for `sync`
+  // first-screen direct render), `background`, and `CSS`. The element template
+  // definitions stay in `elementTemplate` (compiled into the bundle's tasm).
+  #buildLazyBundleFetchBundleSections(
+    mainThreadAsset: Asset | undefined,
+    manifest: Record<string, string>,
+    cssAssets: Asset[],
+    enableBytecode: boolean,
+  ): {
+    sections: Record<string, CustomSectionEntry>;
+    remainingManifest: Record<string, string>;
+  } {
+    const { cssPlugins, enableCSSSelector } = this.#options;
+    const sections: Record<string, CustomSectionEntry> = {};
+
+    if (mainThreadAsset) {
+      sections[SECTION_MAIN_THREAD] = {
+        ...(enableBytecode ? { encoding: 'JsBytecode' as const } : {}),
+        content: mainThreadAsset.source.source().toString(),
+      };
+    }
+
+    const remainingManifest: Record<string, string> = {};
+    let entryChunk: [string, string] | undefined;
+    for (const [name, content] of Object.entries(manifest)) {
+      if (name === '/app-service.js') {
+        continue;
+      }
+      if (!entryChunk) {
+        entryChunk = [name, content];
+        continue;
+      }
+      remainingManifest[name] = content;
+    }
+
+    if (entryChunk) {
+      sections[SECTION_BACKGROUND] = { content: entryChunk[1] };
+    }
+
+    const firstCss = cssAssets[0];
+    if (firstCss) {
+      const ruleList = cssChunksToMap(
+        [firstCss.source.source().toString()],
+        cssPlugins,
+        enableCSSSelector,
+      ).cssMap[0] ?? [];
+      sections[SECTION_CSS] = {
+        encoding: 'CSS',
+        content: { ruleList },
+      };
+    }
+
+    return { sections, remainingManifest };
+  }
+
   #getAsyncFilenameTemplate(filename: string) {
     return this.#options.lazyBundleFilename.replace(
       /\[name\]/,
@@ -881,22 +949,51 @@ class LynxTemplatePluginImpl {
 
     const { lepusCode, css } = encodeData;
 
+    const lepusChunk = Object.fromEntries(
+      lepusCode.chunks.map(asset => {
+        return [asset.name, asset.source.source().toString()];
+      }),
+    );
+
+    // Element Template lazy bundles load via `lynx.fetchBundle` + named
+    // `lynx.loadScript` sections (FetchBundle) instead of QueryComponent, so
+    // split the main-thread / background / CSS payloads into `customSections`.
+    // `encodeData.elementTemplate` is only set for ET builds.
+    const isFetchBundleLazy = isAsync
+      && encodeData.elementTemplate !== undefined;
+    // Default to bytecode for the lazy main-thread section. Skip in dev or when
+    // DEBUG matches rspeedy so the source stays debuggable.
+    const enableLazyBundleBytecode = isFetchBundleLazy && !isDev && !isDebug();
+    const fetchBundleSplit = isFetchBundleLazy
+      ? this.#buildLazyBundleFetchBundleSections(
+        lepusCode.root,
+        encodeData.manifest,
+        encodeData.css.chunks,
+        enableLazyBundleBytecode,
+      )
+      : null;
+
     const resolvedEncodeOptions: EncodeOptions = {
       ...encodeData,
       css: {
         ...css,
+        cssMap: fetchBundleSplit ? {} : css.cssMap,
+        cssSource: fetchBundleSplit ? {} : css.cssSource,
         chunks: undefined,
         contentMap: undefined,
       },
-      lepusCode: {
+      lepusCode: fetchBundleSplit ? undefined : {
         // TODO: support multiple lepus chunks
         root: lepusCode.root?.source.source().toString(),
-        lepusChunk: Object.fromEntries(
-          lepusCode.chunks.map(asset => {
-            return [asset.name, asset.source.source().toString()];
-          }),
-        ),
+        lepusChunk,
         filename: lepusCode.filename,
+      },
+      manifest: fetchBundleSplit
+        ? fetchBundleSplit.remainingManifest
+        : encodeData.manifest,
+      customSections: {
+        ...encodeData.customSections,
+        ...(fetchBundleSplit ? fetchBundleSplit.sections : {}),
       },
     };
 
@@ -912,7 +1009,7 @@ class LynxTemplatePluginImpl {
           JSON.stringify(resolvedEncodeOptions, null, 2),
         ),
       );
-      Object.entries(resolvedEncodeOptions.lepusCode.lepusChunk).forEach(
+      Object.entries(lepusChunk).forEach(
         ([name, content]) => {
           compilation.emitAsset(
             path.posix.format({

--- a/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
@@ -95,11 +95,13 @@ export class WebEncodePlugin {
             cardType: encodeOptions['cardType'] as string,
             appType: encodeOptions['appType'] as string,
             pageConfig: encodeOptions['pageConfig'] as Record<string, unknown>,
-            lepusCode: {
-              // flatten the lepusCode to a single object
-              ...encodeOptions.lepusCode.lepusChunk,
-              root: encodeOptions.lepusCode.root!,
-            },
+            lepusCode: encodeOptions.lepusCode
+              ? {
+                // flatten the lepusCode to a single object
+                ...encodeOptions.lepusCode.lepusChunk,
+                root: encodeOptions.lepusCode.root!,
+              }
+              : {},
             customSections: encodeOptions.customSections ?? {},
           };
           if (encodeOptions.elementTemplate !== undefined) {

--- a/packages/webpack/webpack-runtime-globals/etc/webpack-runtime-globals.api.md
+++ b/packages/webpack/webpack-runtime-globals/etc/webpack-runtime-globals.api.md
@@ -7,6 +7,7 @@
 // @public
 export const RuntimeGlobals: {
     readonly lynxAsyncChunkIds: "__webpack_require__.lynx_aci";
+    readonly lynxAsyncChunkMode: "__webpack_require__.lynx_acm";
     readonly lynxChunkEntries: "lynx.__chunk_entries__";
     readonly lynxProcessEvalResult: "globalThis.processEvalResult";
     readonly lynxCacheEventsSetupList: "__webpack_require__.lynx_ce.setupList";

--- a/packages/webpack/webpack-runtime-globals/src/RuntimeGlobals.ts
+++ b/packages/webpack/webpack-runtime-globals/src/RuntimeGlobals.ts
@@ -14,6 +14,13 @@ export const RuntimeGlobals = {
   lynxAsyncChunkIds: '__webpack_require__.lynx_aci',
 
   /**
+   * A map from `chunk.id` to the lazy-bundle loading mode (`'sync'` | `'async'`)
+   * derived from the `import(..., { with: { mode } })` import attribute.
+   * Only async chunks carrying a `mode` attribute appear here.
+   */
+  lynxAsyncChunkMode: '__webpack_require__.lynx_acm',
+
+  /**
    * A map from `chunk.id` to entryName of the chunk.
    */
   lynxChunkEntries: 'lynx.__chunk_entries__',


### PR DESCRIPTION
## Overview

Element Template lazy bundles now load via `lynx.fetchBundle` + named `lynx.loadScript` sections (FetchBundle) instead of `lynx.QueryComponent`. This is the ET counterpart to the Snapshot FetchBundle work in #2584 — the two paths are independent and do not interfere (the Snapshot path is unchanged).

## Per-import sync/async mode (native import attribute)

```ts
lazy(() => import('./X', { with: { mode: 'sync' } }))   // first-screen direct render (loads main-thread section)
lazy(() => import('./X', { with: { mode: 'async' } }))  // background-driven (default)
```

Now that rspack exposes dependency import attributes (web-infra-dev/rspack#13947, in @rspack/core >= 2.0.3), `mode` is read at **build time** from the module-graph dependency — no swc runtime wrapper / no global side-channel:

- `LynxAsyncChunksRuntimeModule` walks `module.blocks → dependency.attributes.mode` (+ `getBlockChunkGroup`) and emits a per-chunk `__webpack_require__.lynx_acm` map alongside `lynx_aci`.
- The chunk-loading runtime threads it through: `lynx.loadLazyBundle(url, lynx_acm[chunkId])`.
- The swc plugin keeps the native `import(..., { with: { mode } })` intact (validation relaxed to accept a `mode`-only option).

## Runtime loader

`@lynx-js/react/element-template/internal` now exports an ET FetchBundle `loadLazyBundle(source, mode)`:
- **sync** (first-screen direct render): main thread `loadScript('main-thread')`; background `loadScript('background')`.
- **async** (default): background-only `fetchBundle().then → loadScript('background')`. No `prepareLazyBundleMTS` round-trip — once the bundle is fetched, native holds it for any `__CreateElementTemplate` patch.

ET template definitions are content-hash-unique, so no `bundleUrl` threading is needed.

## Packaging

ET lazy bundles are emitted as `customSections` (`main-thread` + `background` + `CSS`), with element template definitions compiled into the bundle's tasm. Gated on `isAsync && elementTemplate present`, so non-ET (Snapshot) output is unchanged. The MT chunk wrapper switches to the self-executing FetchBundle form for ET.

## Verification

- ✅ End-to-end build of `examples/react-et-lazy-bundle`: `lynx_acm = {669: "sync"}`, `loadLazyBundle(p+lynx_aci[t], lynx_acm[t])`, lazy tasm `customSections: ["main-thread","background","CSS"]` with `elementTemplate` preserved, self-executing wrapper.
- ✅ swc cargo tests (4/4), ET runtime suite (no new regressions; the 23 failing tests are pre-existing on `main`).
- ⏳ On-device runtime verification (LynxExplorer 3.8+) — pending.

## Notes / follow-ups

- `@lynx-js/types`: this PR uses a local type augmentation for `loadScript` / `ResponseHandler.then`; a proper bump (as in #2584) can replace it.
- Nice-to-have: dedicated ET-loader unit tests + a swc snapshot test for `mode`.

## Checklist

- [x] Changeset added.
- [ ] On-device verification.
