### PR TITLE
fix(react): refresh withInitDataInState state on a main-thread re-render

### DIFF
--- a/.changeset/fix-with-init-data-in-state-main-thread.md
+++ b/.changeset/fix-with-init-data-in-state-main-thread.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix `withInitDataInState` not refreshing the component state on a main-thread re-render.
+
+`withInitDataInState` injected `lynx.__initData` into the class component's state only in the constructor, and its `onDataChanged` listener was active on the background thread only. On the main thread the component instance is reused across an `updatePage` re-render (the constructor never re-runs), so the injected state stayed frozen at the data from the first render. This surfaces whenever the main thread re-renders the screen itself before hydration (an `updatePage` while `firstScreenSyncTiming` is `'jsReady'`). The HOC now re-reads `lynx.__initData` on every render via `getDerivedStateFromProps`, composing with — and not overriding — the wrapped component's own `getDerivedStateFromProps`.

--- a/packages/react/runtime/__test__/snapshot/lifecycle/updateData.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/updateData.test.jsx
@@ -918,6 +918,113 @@ describe('triggerDataUpdated when jsReady is enabled', () => {
       `);
     }
   });
+
+  /**
+   * Reproduces the `withInitDataInState` main-thread staleness bug.
+   *
+   * `withInitDataInState` injects `lynx.__initData` into the class component's state only in
+   * the constructor, and its `onDataChanged` listener is gated to the background thread. On
+   * the main thread, `renderToString` reuses the same class instance across an `updatePage`
+   * re-render (the constructor never re-runs), so the state stays frozen at the data injected
+   * on first mount. When the main thread re-renders before hydration (an `updatePage` while
+   * `__FIRST_SCREEN_SYNC_TIMING__` is `'jsReady'`), the stale state surfaces as a stale render.
+   */
+  it('should refresh withInitDataInState state on a main-thread updatePage re-render', async function() {
+    class App extends Component {
+      render() {
+        // reads from state (what `withInitDataInState` injects), like real pages do
+        return <text>{this.state.msg}</text>;
+      }
+    }
+
+    const Comp = withInitDataInState(App);
+
+    // first screen renders cache data into the injected state (jsReady mode: not synced yet)
+    {
+      __root.__jsx = <Comp />;
+      renderPage({ msg: 'cache' });
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <text>
+            <raw-text
+              text="cache"
+            />
+          </text>
+        </page>
+      `);
+    }
+
+    // the second render: the main thread re-renders with real data via `updatePage` before hydration.
+    // The injected state must refresh to the new data — otherwise the render is stale.
+    {
+      updatePage({ msg: 'real' });
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <text>
+            <raw-text
+              text="real"
+            />
+          </text>
+        </page>
+      `);
+    }
+  });
+
+  /**
+   * Verifies that `withInitDataInState` composes with — and does not drop — the wrapped
+   * component's own `getDerivedStateFromProps` on the main thread. The wrapped
+   * `getDerivedStateFromProps` keeps running on each `updatePage` re-render and sees the
+   * freshened `initData`, while the injected `initData` itself is also refreshed.
+   */
+  it('should keep the wrapped getDerivedStateFromProps working on a main-thread updatePage re-render', async function() {
+    class App extends Component {
+      static getDerivedStateFromProps(props, state) {
+        // derives from the injected initData in state, proving it sees the fresh data
+        return { upper: state.msg?.toUpperCase() };
+      }
+
+      render() {
+        return <text>{`${this.state.msg}|${this.state.upper}`}</text>;
+      }
+    }
+
+    const Comp = withInitDataInState(App);
+
+    {
+      __root.__jsx = <Comp />;
+      renderPage({ msg: 'cache' });
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <text>
+            <raw-text
+              text="cache|CACHE"
+            />
+          </text>
+        </page>
+      `);
+    }
+
+    {
+      updatePage({ msg: 'real' });
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <text>
+            <raw-text
+              text="real|REAL"
+            />
+          </text>
+        </page>
+      `);
+    }
+  });
 });
 
 describe('flush pending `renderComponent` before hydrate', () => {

--- a/packages/react/runtime/src/core/initData.ts
+++ b/packages/react/runtime/src/core/initData.ts
@@ -147,5 +147,24 @@ export function withInitDataInState<P, S>(App: ComponentClass<P, S>): ComponentC
     }
   }
 
+  // Installed on the main thread only. There, `renderToString` reuses this component
+  // instance across an `updatePage` re-render (the constructor never re-runs) and there
+  // is no `onDataChanged` listener, so the constructor's one-time `initData` injection
+  // goes stale; refresh it on every render, mirroring how `useInitData` re-reads
+  // `lynx.__initData`. It is not installed on the background thread because defining
+  // `getDerivedStateFromProps` at all would disable the wrapped component's legacy
+  // `componentWillMount` / `componentWillReceiveProps` lifecycles — and the background
+  // path already refreshes the state via its `onDataChanged` listener.
+  if (__LEPUS__) {
+    (C as ComponentClass<P, S>).getDerivedStateFromProps = (props: P, state: S): Partial<S> => {
+      const base = { ...state, ...lynx.__initData } as S;
+      // Compose with the wrapped component's own (or inherited) `getDerivedStateFromProps`
+      // — passing it the freshened `initData` and letting its derived values win, matching
+      // how it runs (and wins) on the background thread.
+      const derived = App.getDerivedStateFromProps?.(props, base) ?? null;
+      return { ...base, ...derived } as Partial<S>;
+    };
+  }
+
   return C;
 }


### PR DESCRIPTION
## Summary

`withInitDataInState` injected `lynx.__initData` into the wrapped class component's state **only in the constructor**, and its `onDataChanged` listener is gated to the background thread. On the main thread, `renderToString` reuses the same class instance across an `updatePage` re-render (the constructor never re-runs), so the injected state stayed **frozen at the data from first mount**.

This surfaces whenever the main thread re-renders the screen itself **before hydration** — an `updatePage` while `firstScreenSyncTiming` is `'jsReady'` (the background thread hasn't taken over yet). The page renders with stale `initData`.

`useInitData()` is unaffected because hooks re-read `lynx.__initData` on every render; only the class-component HOC went stale.

## Fix

Add a `getDerivedStateFromProps` to the HOC that, on the main thread (`__LEPUS__`), re-reads `lynx.__initData` every render — mirroring how `useInitData` behaves. It **composes with** the wrapped component's own `getDerivedStateFromProps` via `super`:

- passes the freshened `initData` in as the base state, and
- lets the wrapped component's derived result win,

matching how that hook runs last (and wins) on the background thread. The background-thread path is unchanged.

## Tests

Two tests in `updateData.test.jsx` (in `'jsReady'` mode, reproducing the pre-hydration main-thread re-render):

1. `withInitDataInState` state refreshes from `cache` → `real` across an `updatePage` re-render. Verified to fail before the fix (renders stale `cache`).
2. A wrapped `getDerivedStateFromProps` keeps running and sees the freshened `initData` (`cache|CACHE` → `real|REAL`).

> Split out of #2826 — this fix is independent of the `firstScreenSyncTiming: 'manual'` feature there (the bug also reproduces in `'jsReady'` mode before hydration).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `withInitDataInState` so `lynx.__initData` refreshes correctly on main-thread re-renders (including render-to-string reuse), preventing stale UI before hydration.
  * Updated behavior to merge refreshed init-data state with any wrapped component `getDerivedStateFromProps` output, ensuring derived state remains intact.
* **Tests**
  * Added new test cases covering the main-thread staleness scenario and validating both refreshed init-data rendering and proper derived-state coexistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->