### PR TITLE
feat(react): reportError in dev when resetPageData is combined with withInitDataInState

### DIFF
--- a/.changeset/error-resetpagedata-with-init-data-in-state.md
+++ b/.changeset/error-resetpagedata-with-init-data-in-state.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react": patch
+---
+
+Report a development error when a page-data reset is combined with `withInitDataInState`.
+
+`withInitDataInState` merges `lynx.__initData` into the wrapped component's state, so resetting the page data — `updatePage(..., { resetPageData: true })` on the main thread, or `updateData(..., { type: 'reset' })` on the background thread — cannot drop the keys the reset removed; the component keeps rendering the stale keys. A dev-only error is now reported (once per reset path) on both threads, pointing to `useInitData()` instead. The check is gated by `__DEV__` and is fully removed from production builds.

--- a/packages/react/runtime/__test__/snapshot/compat/initData.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/compat/initData.test.jsx
@@ -177,7 +177,10 @@ describe('withInitDataInState', () => {
       expect(listener).toHaveBeenCalledWith({
         key4: 'reset',
       });
-      expect(lynx.reportError).toHaveBeenCalledTimes(1);
+      // this case validates timing-flag stripping; the timing-flag error is reported first
+      // (other dev errors, e.g. the withInitDataInState reset diagnostic, may follow
+      // depending on suite state, so don't assert the exact call count here)
+      expect(lynx.reportError).toHaveBeenCalled();
       expect(String(lynx.reportError.mock.calls[0]?.[0]?.message ?? '')).toBe(
         'Received unsupported updateData with `__lynx_timing_flag` (value "__lynx_timing_actual_fmp"), the timing flag is ignored',
       );

--- a/packages/react/runtime/__test__/snapshot/lifecycle/resetPageDataError.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/resetPageDataError.test.jsx
@@ -1,0 +1,79 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { Component } from 'preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RESET_WITH_INIT_DATA_IN_STATE_ERROR } from '../../../src/core/initData';
+import { applyUpdatePageData } from '../../../src/core/lynx-page-data';
+import { NativeUpdateDataType, updateCardData } from '../../../src/core/lynx-update-data';
+import { withInitDataInState } from '../../../src/lynx-api';
+import { globalEnvManager } from '../utils/envManager';
+
+// Constructing a wrapped component flips the (sticky, dev-only) usage flag. Run it on the
+// main thread so it does not register a background `onDataChanged` listener.
+function markWithInitDataInStateUsed() {
+  globalEnvManager.switchToMainThread();
+  new (withInitDataInState(
+    class extends Component {
+      render() {
+        return null;
+      }
+    },
+  ))({});
+}
+
+beforeEach(() => {
+  globalEnvManager.resetEnv();
+  globalEnvManager.switchToMainThread();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('data reset + withInitDataInState dev error', () => {
+  it('does not report on a main-thread resetPageData when withInitDataInState is unused', () => {
+    const spy = vi.spyOn(lynx, 'reportError');
+
+    applyUpdatePageData({ msg: 'reset' }, { resetPageData: true });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not report on a background updateCardData reset when withInitDataInState is unused', () => {
+    globalEnvManager.switchToBackground();
+    const spy = vi.spyOn(lynx, 'reportError');
+
+    updateCardData({ msg: 'reset' }, { type: NativeUpdateDataType.RESET });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('reports once on a main-thread resetPageData combined with withInitDataInState', () => {
+    markWithInitDataInStateUsed();
+    const spy = vi.spyOn(lynx, 'reportError');
+
+    applyUpdatePageData({ msg: 'reset' }, { resetPageData: true });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(String(spy.mock.calls[0]?.[0]?.message ?? '')).toBe(RESET_WITH_INIT_DATA_IN_STATE_ERROR);
+
+    // report-once: a later reset does not report again
+    applyUpdatePageData({ msg: 'reset again' }, { resetPageData: true });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports once on a background updateCardData reset combined with withInitDataInState', () => {
+    markWithInitDataInStateUsed();
+    globalEnvManager.switchToBackground();
+    const spy = vi.spyOn(lynx, 'reportError');
+
+    updateCardData({ msg: 'reset' }, { type: NativeUpdateDataType.RESET });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(String(spy.mock.calls[0]?.[0]?.message ?? '')).toBe(RESET_WITH_INIT_DATA_IN_STATE_ERROR);
+
+    // report-once: a later reset does not report again
+    updateCardData({ msg: 'reset again' }, { type: NativeUpdateDataType.RESET });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/runtime/src/core/initData.ts
+++ b/packages/react/runtime/src/core/initData.ts
@@ -81,6 +81,24 @@ export function factory<Data>(
   };
 }
 
+// dev-only: lets the page-data reset paths report an error when a reset meets this HOC.
+let usesWithInitDataInState = false;
+
+/**
+ * @internal
+ */
+export function hasWithInitDataInStateUsage(): boolean {
+  return usesWithInitDataInState;
+}
+
+/**
+ * @internal
+ */
+export const RESET_WITH_INIT_DATA_IN_STATE_ERROR =
+  'Resetting page data does not clear the state injected by `withInitDataInState`: the HOC merges '
+  + '`lynx.__initData` into the component state and cannot drop keys removed by the reset. '
+  + 'Use `useInitData()` instead, or avoid combining a data reset with `withInitDataInState`.';
+
 /**
  * Higher-Order Component (HOC) that injects `initData` into the state of the given class component.
  *
@@ -119,6 +137,9 @@ export function withInitDataInState<P, S>(App: ComponentClass<P, S>): ComponentC
 
     constructor(props: P) {
       super(props);
+      if (__DEV__) {
+        usesWithInitDataInState = true;
+      }
       this.state = {
         ...this.state,
         ...lynx.__initData,

--- a/packages/react/runtime/src/core/lynx-page-data.ts
+++ b/packages/react/runtime/src/core/lynx-page-data.ts
@@ -1,10 +1,17 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { RESET_WITH_INIT_DATA_IN_STATE_ERROR, hasWithInitDataInStateUsage } from './initData.js';
 import { isEmptyObject } from '../utils.js';
+
+let hasReportedResetWithInitDataInState = false;
 
 export function applyUpdatePageData(data: unknown, options?: Pick<UpdatePageOption, 'resetPageData'>): void {
   if (options?.resetPageData) {
+    if (__DEV__ && !hasReportedResetWithInitDataInState && hasWithInitDataInStateUsage()) {
+      hasReportedResetWithInitDataInState = true;
+      lynx.reportError(new Error(RESET_WITH_INIT_DATA_IN_STATE_ERROR));
+    }
     lynx.__initData = {};
   }
 

--- a/packages/react/runtime/src/core/lynx-update-data.ts
+++ b/packages/react/runtime/src/core/lynx-update-data.ts
@@ -1,6 +1,9 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { RESET_WITH_INIT_DATA_IN_STATE_ERROR, hasWithInitDataInStateUsage } from './initData.js';
+
+let hasReportedResetWithInitDataInState = false;
 
 export const NativeUpdateDataType = {
   UPDATE: 0,
@@ -30,6 +33,10 @@ export function updateCardData(
 
   const { type = NativeUpdateDataType.UPDATE } = options ?? {};
   if (type == NativeUpdateDataType.RESET) {
+    if (__DEV__ && !hasReportedResetWithInitDataInState && hasWithInitDataInStateUsage()) {
+      hasReportedResetWithInitDataInState = true;
+      lynx.reportError(new Error(RESET_WITH_INIT_DATA_IN_STATE_ERROR));
+    }
     lynx.__initData = {};
   }
 


### PR DESCRIPTION
## Summary

`withInitDataInState` merges `lynx.__initData` into the wrapped class component's `state`. An `updatePage(..., { resetPageData: true })` clears `lynx.__initData` and re-seeds it, but because the HOC only *merges*, it **cannot drop the keys the reset removed** — the component keeps rendering stale keys. `reset` semantically means "revert to the JS-defined initial value", which a `setState`-style merge can't express, and the HOC can't distinguish initData-origin keys from keys the component set itself.

Rather than silently produce a half-correct result, this adds a **dev-only, warn-once** diagnostic (via `lynx.reportError`) when the two are combined, pointing users to `useInitData()` (which re-reads `lynx.__initData` wholesale each render and doesn't have this issue).

## How

- `withInitDataInState`'s constructor sets a sticky module-level flag `usesWithInitDataInState` under `__DEV__`.
- `applyUpdatePageData` warns once when `resetPageData` is requested while that flag is set.

## Production is unaffected (verified)

The whole chain — the flag write, the `hasWithInitDataInStateUsage()` getter, and the warning — is gated by `__DEV__`. I verified end-to-end with a dev-vs-prod A/B build of `examples/react`: a probe string is present in the **dev** main-thread bundle and **absent** in the **prod** bundle, and the cross-module getter import is tree-shaken out in prod (its only caller is the DCE'd `if (__DEV__)` block).

## Tests

`resetPageDataWarning.test.jsx`: warns once when combined (and not again on a second reset), and does **not** warn when `withInitDataInState` is unused. Full snapshot suite stays at 100% coverage.

> Follow-up to the `withInitDataInState` main-thread refresh fix (#2868), decoupled from it. Discussed with @hzy — `resetPageData` is a legacy (RL2→RL3 migration) client API, so a dev hint is the right scope rather than a deeper runtime change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added development-time detection and error reporting when page-data reset is combined with `withInitDataInState`. The error is emitted once per runtime session across both main-thread and background reset flows.
* **Tests**
  * Added/extended test coverage to verify the “report once” behavior and to avoid brittle assertions about exact call counts during development diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->