### PR TITLE
fix(rspeedy): type entry dependOn and cssLoader modules

### DIFF
--- a/.changeset/rspeedy-config-options.md
+++ b/.changeset/rspeedy-config-options.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Add Rspeedy config types for `entry.dependOn` and `cssLoader.modules`.

--- a/packages/rspeedy/core/etc/rspeedy.api.md
+++ b/packages/rspeedy/core/etc/rspeedy.api.md
@@ -131,7 +131,7 @@ export interface CssExtractRspackPluginOptions {
 // @public
 export interface CssLoader {
     importLoaders?: 0 | 1 | 2 | undefined;
-    modules?: boolean | CssLoaderModules | undefined;
+    modules?: boolean | 'local' | 'global' | 'pure' | 'icss' | CssLoaderModules | undefined;
 }
 
 // @public
@@ -199,6 +199,7 @@ export type Entry = string | string[] | Record<string, string | string[] | Entry
 
 // @public
 export interface EntryDescription {
+    dependOn?: string | string[] | undefined;
     import?: string | string[] | undefined;
     publicPath?: string | undefined;
 }

--- a/packages/rspeedy/core/src/config/source/entry.ts
+++ b/packages/rspeedy/core/src/config/source/entry.ts
@@ -20,6 +20,11 @@ export interface EntryDescription {
    */
   import?: string | string[] | undefined
 
+  /**
+   * The entry points that the current entry depends on. They must be loaded before this entry is loaded.
+   */
+  dependOn?: string | string[] | undefined
+
   // TODO(doc): inherit from `output.publicPath`.
   /**
    * This is an important option when using on-demand-loading or loading external resources like images, files, etc. If an incorrect value is specified you'll receive 404 errors while loading these resources.

--- a/packages/rspeedy/core/src/config/tools/css-loader.ts
+++ b/packages/rspeedy/core/src/config/tools/css-loader.ts
@@ -75,7 +75,14 @@ export interface CssLoader {
    * })
    * ```
    */
-  modules?: boolean | CssLoaderModules | undefined
+  modules?:
+    | boolean
+    | 'local'
+    | 'global'
+    | 'pure'
+    | 'icss'
+    | CssLoaderModules
+    | undefined
 }
 
 /**

--- a/packages/rspeedy/core/test/config/rsbuild.test.ts
+++ b/packages/rspeedy/core/test/config/rsbuild.test.ts
@@ -297,6 +297,27 @@ describe('Config - toRsBuildConfig', () => {
       `)
     })
 
+    test('transform entry description with string dependency', () => {
+      const rsbuildConfig = toRsbuildConfig({
+        source: {
+          entry: {
+            main: {
+              dependOn: 'vendor',
+              import: './src/index.js',
+            },
+          },
+        },
+      })
+      expect(rsbuildConfig.source?.entry).toMatchInlineSnapshot(`
+        {
+          "main": {
+            "dependOn": "vendor",
+            "import": "./src/index.js",
+          },
+        }
+      `)
+    })
+
     test('transform single entry in entry description format without import', () => {
       const rsbuildConfig = toRsbuildConfig({
         source: {

--- a/packages/rspeedy/core/test/config/rsbuild.test.ts
+++ b/packages/rspeedy/core/test/config/rsbuild.test.ts
@@ -274,6 +274,29 @@ describe('Config - toRsBuildConfig', () => {
       `)
     })
 
+    test('transform entry description with dependencies', () => {
+      const rsbuildConfig = toRsbuildConfig({
+        source: {
+          entry: {
+            main: {
+              dependOn: ['vendor'],
+              import: './src/index.js',
+            },
+          },
+        },
+      })
+      expect(rsbuildConfig.source?.entry).toMatchInlineSnapshot(`
+        {
+          "main": {
+            "dependOn": [
+              "vendor",
+            ],
+            "import": "./src/index.js",
+          },
+        }
+      `)
+    })
+
     test('transform single entry in entry description format without import', () => {
       const rsbuildConfig = toRsbuildConfig({
         source: {

--- a/packages/rspeedy/core/test/config/source/entry.test-d.ts
+++ b/packages/rspeedy/core/test/config/source/entry.test-d.ts
@@ -59,6 +59,24 @@ describe('Config - source.entry', () => {
     assertType<Source>({
       entry: {
         main: {
+          import: 'src/index.js',
+          dependOn: 'vendor',
+        },
+      },
+    })
+
+    assertType<Source>({
+      entry: {
+        main: {
+          import: 'src/index.js',
+          dependOn: ['vendor', 'runtime'],
+        },
+      },
+    })
+
+    assertType<Source>({
+      entry: {
+        main: {
           publicPath: 'https://example.com/',
         },
       },

--- a/packages/rspeedy/core/test/config/tools/tools.test-d.ts
+++ b/packages/rspeedy/core/test/config/tools/tools.test-d.ts
@@ -160,6 +160,30 @@ describe('Config - Tools', () => {
         importLoaders: 2,
       },
     })
+
+    assertType<Tools>({
+      cssLoader: {
+        modules: 'local',
+      },
+    })
+
+    assertType<Tools>({
+      cssLoader: {
+        modules: 'global',
+      },
+    })
+
+    assertType<Tools>({
+      cssLoader: {
+        modules: 'pure',
+      },
+    })
+
+    assertType<Tools>({
+      cssLoader: {
+        modules: 'icss',
+      },
+    })
   })
 
   test('tools.rsdoctor', () => {

--- a/packages/rspeedy/core/test/config/validate.test.ts
+++ b/packages/rspeedy/core/test/config/validate.test.ts
@@ -2730,6 +2730,24 @@ describe('Config Validation', () => {
 
         {
           cssLoader: {
+            modules: 'global',
+          },
+        },
+
+        {
+          cssLoader: {
+            modules: 'pure',
+          },
+        },
+
+        {
+          cssLoader: {
+            modules: 'icss',
+          },
+        },
+
+        {
+          cssLoader: {
             modules: {
               auto: true,
             },

--- a/packages/rspeedy/core/test/config/validate.test.ts
+++ b/packages/rspeedy/core/test/config/validate.test.ts
@@ -305,8 +305,13 @@ describe('Config Validation', () => {
           bar: {
             import: ['src'],
           },
+          qux: {
+            import: ['src'],
+            dependOn: ['foo'],
+          },
           baz: {
             publicPath: 'https://example.com/',
+            dependOn: 'foo',
           },
         },
       ]
@@ -2714,6 +2719,12 @@ describe('Config Validation', () => {
         {
           cssLoader: {
             modules: true,
+          },
+        },
+
+        {
+          cssLoader: {
+            modules: 'local',
           },
         },
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entry configurations now support a `dependOn` option to declare which entry points must be loaded before the current entry.
  * CSS loader `modules` now also accepts string values (`'local'`, `'global'`, `'pure'`, `'icss'`) in addition to the existing boolean/object forms.
* **Tests**
  * Added and extended type and config conversion coverage to validate `dependOn` behavior and the expanded `modules` options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
