### PR TITLE
feat(create-rspeedy): add rspeedy-bundle-size optional skill

### DIFF
--- a/.changeset/add-rspeedy-bundle-size-skill.md
+++ b/.changeset/add-rspeedy-bundle-size-skill.md
@@ -1,0 +1,5 @@
+---
+"create-rspeedy": patch
+---
+
+Add the `rspeedy-bundle-size` skill to the optional skills users can select during project creation. It analyzes and reduces the bundle size of rspeedy/Lynx apps, sourced from `lynx-community/skills`.

--- a/packages/rspeedy/create-rspeedy/src/index.ts
+++ b/packages/rspeedy/create-rspeedy/src/index.ts
@@ -119,6 +119,11 @@ void create({
       source: 'lynx-community/skills',
       value: 'lynx-devtool',
     },
+    {
+      label: 'Rspeedy Bundle Size',
+      source: 'lynx-community/skills',
+      value: 'rspeedy-bundle-size',
+    },
   ],
   mapESLintTemplate(templateName) {
     const lang = templateName.split('-').at(-1)


### PR DESCRIPTION
## Summary

Adds the [`rspeedy-bundle-size`](https://github.com/lynx-community/skills/tree/release/skills/rspeedy-bundle-size) skill to the **optional skills** users can select during `create-rspeedy` project creation, alongside the existing "Lynx DevTool" skill.

The skill analyzes and reduces the bundle size of rspeedy/Lynx (ReactLynx) apps — a measure-first workflow for shrinking `.lynx.bundle` output.

## Changes

- `packages/rspeedy/create-rspeedy/src/index.ts` — new entry in the `extraSkills` array:
  ```ts
  {
    label: 'Rspeedy Bundle Size',
    source: 'lynx-community/skills',
    value: 'rspeedy-bundle-size',
  },
  ```
- `.changeset/` — `patch` changeset for `create-rspeedy`.

## How it works

When selected in the "Select optional skills" prompt, `create-rstack` runs:

\`\`\`bash
npx -y skills add lynx-community/skills --agent universal --yes --copy --skill rspeedy-bundle-size
\`\`\`

The `value` (`rspeedy-bundle-size`) matches both the skill directory and the `name:` field in the skill's `SKILL.md` frontmatter.

## Verification

- `pnpm build` (rslib) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added a new optional Bundle Size skill for rspeedy/Lynx applications. This community-provided feature delivers comprehensive bundle size analysis and optimization recommendations, enabling developers to easily monitor and reduce their application's bundle footprint. Optimize performance and reduce deployment sizes more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->