### PR TITLE
feat(web-core): support performance profiling APIs

### DIFF
--- a/.changeset/web-core-performance-profiling.md
+++ b/.changeset/web-core-performance-profiling.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Implement web performance profiling APIs by bridging ReactLynx `profileStart`, `profileEnd`, `profileMark`, `profileFlowId`, and `isProfileRecording` to browser User Timing entries.

--- a/.github/web-core-profiling.instructions.md
+++ b/.github/web-core-profiling.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/ts/client/background/background-apis/createPerformanceApis.ts,packages/react/runtime/src/**/profile*.ts,packages/react/runtime/src/core/hooks/react.ts"
+---
+
+When maintaining web-core profiling APIs, preserve the ReactLynx profiling contract: `profileStart(traceName, option?)` and `profileEnd()` form a stack of nested traces, `profileMark(traceName, option?)` records an instant trace, `profileFlowId()` returns monotonic nonzero IDs, and `isProfileRecording()` should reflect whether the host profiling bridge is available. On web, bridge these APIs to browser User Timing by emitting measures for start/end pairs and marks for instant events, carrying ReactLynx `TraceOption` data through User Timing `detail`.

--- a/packages/web-platform/web-core/tests/performance-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/performance-apis.spec.ts
@@ -2,16 +2,48 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  rstest,
+  test,
+} from '@rstest/core';
 import { createPerformanceApis } from '../ts/client/background/background-apis/createPerformanceApis.js';
+import { createMainThreadLynxPerformance } from '../ts/client/mainthread/createMainThreadLynxPerformance.js';
 import type { TimingSystem } from '../ts/client/background/background-apis/createTimingSystem.js';
+
+const originalPerformanceDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'performance',
+);
 
 function createTimingSystemMock(): TimingSystem {
   return {
-    markTimingInternal: vi.fn(),
+    markTimingInternal: rstest.fn(),
     pipelineIdToTimingFlags: new Map(),
-    registerGlobalEmitter: vi.fn(),
+    registerGlobalEmitter: rstest.fn(),
   };
+}
+
+function stubGlobalPerformance(performance: unknown): void {
+  Object.defineProperty(globalThis, 'performance', {
+    configurable: true,
+    value: performance,
+  });
+}
+
+function restoreGlobalPerformance(): void {
+  if (originalPerformanceDescriptor) {
+    Object.defineProperty(
+      globalThis,
+      'performance',
+      originalPerformanceDescriptor,
+    );
+  } else {
+    delete (globalThis as { performance?: Performance }).performance;
+  }
 }
 
 function clearUserTimingEntries(): void {
@@ -25,7 +57,7 @@ describe('createPerformanceApis', () => {
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    restoreGlobalPerformance();
     clearUserTimingEntries();
   });
 
@@ -87,7 +119,7 @@ describe('createPerformanceApis', () => {
   });
 
   test('degrades to no-op profiling when User Timing is unavailable', () => {
-    vi.stubGlobal('performance', {});
+    stubGlobalPerformance({});
     const performanceApis = createPerformanceApis(createTimingSystemMock());
 
     expect(performanceApis.isProfileRecording()).toBe(false);
@@ -97,5 +129,32 @@ describe('createPerformanceApis', () => {
       performanceApis.profileMark('ReactLynx::mark');
       performanceApis.profileEnd();
     }).not.toThrow();
+  });
+});
+
+describe('main-thread lynx.performance', () => {
+  beforeEach(() => {
+    clearUserTimingEntries();
+  });
+
+  afterEach(() => {
+    clearUserTimingEntries();
+  });
+
+  test('exposes profile and timing APIs to lifecycle handlers', () => {
+    const markTiming = rstest.fn();
+    const performanceApis = createMainThreadLynxPerformance(markTiming);
+
+    expect(performanceApis.profileFlowId()).toBe(1);
+    expect(() => {
+      performanceApis.profileStart('ReactLynx::patch');
+      performanceApis.profileEnd();
+    }).not.toThrow();
+
+    performanceApis._markTiming('pipeline-1', 'patchChangesStart');
+    expect(markTiming).toHaveBeenCalledWith(
+      'patchChangesStart',
+      'pipeline-1',
+    );
   });
 });

--- a/packages/web-platform/web-core/tests/performance-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/performance-apis.spec.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createPerformanceApis } from '../ts/client/background/background-apis/createPerformanceApis.js';
+import type { TimingSystem } from '../ts/client/background/background-apis/createTimingSystem.js';
+
+function createTimingSystemMock(): TimingSystem {
+  return {
+    markTimingInternal: vi.fn(),
+    pipelineIdToTimingFlags: new Map(),
+    registerGlobalEmitter: vi.fn(),
+  };
+}
+
+function clearUserTimingEntries(): void {
+  globalThis.performance?.clearMarks?.();
+  globalThis.performance?.clearMeasures?.();
+}
+
+describe('createPerformanceApis', () => {
+  beforeEach(() => {
+    clearUserTimingEntries();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearUserTimingEntries();
+  });
+
+  test('bridges profile traces and marks to browser User Timing entries', () => {
+    const performanceApis = createPerformanceApis(createTimingSystemMock());
+
+    const outerOption = {
+      flowId: performanceApis.profileFlowId(),
+      args: {
+        componentName: 'App',
+      },
+    };
+    const markOption = {
+      flowId: performanceApis.profileFlowId(),
+    };
+
+    expect(performanceApis.isProfileRecording()).toBe(true);
+    expect(markOption.flowId).toBe(2);
+
+    performanceApis.profileStart('ReactLynx::outer', outerOption);
+    performanceApis.profileMark('ReactLynx::mark', markOption);
+    performanceApis.profileStart('ReactLynx::inner');
+    performanceApis.profileEnd();
+    performanceApis.profileEnd();
+
+    const markEntries = performance.getEntriesByName(
+      'ReactLynx::mark',
+      'mark',
+    ) as PerformanceMark[];
+    expect(markEntries).toHaveLength(1);
+    expect(markEntries[0]!.detail).toEqual(markOption);
+
+    const innerMeasures = performance.getEntriesByName(
+      'ReactLynx::inner',
+      'measure',
+    );
+    expect(innerMeasures).toHaveLength(1);
+    expect(innerMeasures[0]!.duration).toBeGreaterThanOrEqual(0);
+
+    const outerMeasures = performance.getEntriesByName(
+      'ReactLynx::outer',
+      'measure',
+    ) as PerformanceMeasure[];
+    expect(outerMeasures).toHaveLength(1);
+    expect(outerMeasures[0]!.duration).toBeGreaterThanOrEqual(
+      innerMeasures[0]!.duration,
+    );
+    expect(outerMeasures[0]!.detail).toEqual(outerOption);
+
+    expect(performance.getEntriesByType('mark').map(entry => entry.name))
+      .not.toContain('lynx.profile:0:start:ReactLynx::outer');
+  });
+
+  test('ignores unmatched profileEnd calls', () => {
+    const performanceApis = createPerformanceApis(createTimingSystemMock());
+
+    expect(() => performanceApis.profileEnd()).not.toThrow();
+    expect(performance.getEntriesByType('measure')).toHaveLength(0);
+  });
+
+  test('degrades to no-op profiling when User Timing is unavailable', () => {
+    vi.stubGlobal('performance', {});
+    const performanceApis = createPerformanceApis(createTimingSystemMock());
+
+    expect(performanceApis.isProfileRecording()).toBe(false);
+    expect(performanceApis.profileFlowId()).toBe(1);
+    expect(() => {
+      performanceApis.profileStart('ReactLynx::trace');
+      performanceApis.profileMark('ReactLynx::mark');
+      performanceApis.profileEnd();
+    }).not.toThrow();
+  });
+});

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createPerformanceApis.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createPerformanceApis.ts
@@ -5,6 +5,83 @@
 import type { NativeApp } from '../../../types/index.js';
 import type { TimingSystem } from './createTimingSystem.js';
 
+type ProfileTraceOption = unknown;
+
+interface ProfileTimingContext {
+  traceName: string;
+  startMarkName: string;
+  option?: ProfileTraceOption;
+}
+
+function getUserTimingPerformance(): Performance | undefined {
+  const browserPerformance = globalThis.performance;
+  if (
+    !browserPerformance
+    || typeof browserPerformance.mark !== 'function'
+    || typeof browserPerformance.measure !== 'function'
+  ) {
+    return undefined;
+  }
+  return browserPerformance;
+}
+
+function markUserTiming(
+  markName: string,
+  option?: ProfileTraceOption,
+): boolean {
+  const browserPerformance = getUserTimingPerformance();
+  if (!browserPerformance) {
+    return false;
+  }
+  try {
+    if (option === undefined) {
+      browserPerformance.mark(markName);
+    } else {
+      try {
+        browserPerformance.mark(markName, { detail: option });
+      } catch {
+        browserPerformance.mark(markName);
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function measureUserTiming(
+  traceName: string,
+  startMarkName: string,
+  endMarkName: string,
+  option?: ProfileTraceOption,
+): void {
+  const browserPerformance = getUserTimingPerformance();
+  if (!browserPerformance) {
+    return;
+  }
+  if (option === undefined) {
+    try {
+      browserPerformance.measure(traceName, startMarkName, endMarkName);
+    } catch {
+      // Do nothing.
+    }
+  } else {
+    try {
+      browserPerformance.measure(traceName, {
+        start: startMarkName,
+        end: endMarkName,
+        detail: option,
+      });
+    } catch {
+      try {
+        browserPerformance.measure(traceName, startMarkName, endMarkName);
+      } catch {
+        // Do nothing.
+      }
+    }
+  }
+}
+
 export function createPerformanceApis(timingSystem: TimingSystem): Pick<
   NativeApp,
   | 'generatePipelineOptions'
@@ -18,6 +95,9 @@ export function createPerformanceApis(timingSystem: TimingSystem): Pick<
   | 'isProfileRecording'
 > {
   let inc = 0;
+  let profileFlowIdInc = 0;
+  let profileMarkInc = 0;
+  const profileTimingStack: ProfileTimingContext[] = [];
   const performanceApis = {
     generatePipelineOptions: () => {
       const newPipelineId = `_pipeline_` + (inc++);
@@ -45,22 +125,53 @@ export function createPerformanceApis(timingSystem: TimingSystem): Pick<
       const timingFlags = timingSystem.pipelineIdToTimingFlags.get(pipelineId)!;
       timingFlags.push(timingFlag);
     },
-    profileStart: () => {
-      console.error('NYI: profileStart. This is an issue of lynx-core.');
+    profileStart: (
+      traceName: string,
+      option?: ProfileTraceOption,
+    ): void => {
+      const id = profileMarkInc++;
+      const startMarkName = `lynx.profile:${id}:start:${traceName}`;
+      if (markUserTiming(startMarkName, option)) {
+        profileTimingStack.push({ traceName, startMarkName, option });
+      }
     },
-    profileEnd: () => {
-      console.error('NYI: profileEnd. This is an issue of lynx-core.');
+    profileEnd: (): void => {
+      const profileTimingContext = profileTimingStack.pop();
+      if (!profileTimingContext) {
+        return;
+      }
+
+      const id = profileMarkInc++;
+      const endMarkName =
+        `lynx.profile:${id}:end:${profileTimingContext.traceName}`;
+      if (!markUserTiming(endMarkName, profileTimingContext.option)) {
+        getUserTimingPerformance()?.clearMarks?.(
+          profileTimingContext.startMarkName,
+        );
+        return;
+      }
+      measureUserTiming(
+        profileTimingContext.traceName,
+        profileTimingContext.startMarkName,
+        endMarkName,
+        profileTimingContext.option,
+      );
+
+      const browserPerformance = getUserTimingPerformance();
+      browserPerformance?.clearMarks?.(profileTimingContext.startMarkName);
+      browserPerformance?.clearMarks?.(endMarkName);
     },
-    profileMark: () => {
-      console.error('NYI: profileMark. This is an issue of lynx-core.');
+    profileMark: (
+      traceName: string,
+      option?: ProfileTraceOption,
+    ): void => {
+      markUserTiming(traceName, option);
     },
-    profileFlowId: () => {
-      console.error('NYI: profileFlowId. This is an issue of lynx-core.');
-      return 0;
+    profileFlowId: (): number => {
+      return ++profileFlowIdInc;
     },
-    isProfileRecording: () => {
-      console.error('NYI: isProfileRecording. This is an issue of lynx-core.');
-      return false;
+    isProfileRecording: (): boolean => {
+      return getUserTimingPerformance() !== undefined;
     },
   };
   return performanceApis;

--- a/packages/web-platform/web-core/ts/client/mainthread/createMainThreadGlobalAPIs.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/createMainThreadGlobalAPIs.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../types/index.js';
 import { templateManager } from './TemplateManager.js';
 import { type LynxViewInstance } from './LynxViewInstance.js';
+import { createMainThreadLynxPerformance } from './createMainThreadLynxPerformance.js';
 
 function createMainThreadLynx(
   lynxViewInstance: LynxViewInstance,
@@ -21,6 +22,11 @@ function createMainThreadLynx(
   const setIntervalBrowserImpl = setInterval;
   const clearIntervalBrowserImpl = clearInterval;
   return {
+    performance: createMainThreadLynxPerformance(
+      lynxViewInstance.backgroundThread.markTiming.bind(
+        lynxViewInstance.backgroundThread,
+      ),
+    ),
     getJSContext() {
       return lynxViewInstance.backgroundThread.jsContext;
     },

--- a/packages/web-platform/web-core/ts/client/mainthread/createMainThreadLynxPerformance.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/createMainThreadLynxPerformance.ts
@@ -1,0 +1,165 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { LynxPerformance } from '../../types/index.js';
+
+type ProfileTraceOption = unknown;
+
+interface ProfileTimingContext {
+  traceName: string;
+  startMarkName: string;
+  option?: ProfileTraceOption;
+}
+
+type MarkTiming = (
+  timingKey: string,
+  pipelineId?: string,
+  timeStamp?: number,
+) => void;
+
+function getUserTimingPerformance(): Performance | undefined {
+  const browserPerformance = globalThis.performance;
+  if (
+    !browserPerformance
+    || typeof browserPerformance.mark !== 'function'
+    || typeof browserPerformance.measure !== 'function'
+  ) {
+    return undefined;
+  }
+  return browserPerformance;
+}
+
+function markUserTiming(
+  markName: string,
+  option?: ProfileTraceOption,
+): boolean {
+  const browserPerformance = getUserTimingPerformance();
+  if (!browserPerformance) {
+    return false;
+  }
+  try {
+    if (option === undefined) {
+      browserPerformance.mark(markName);
+    } else {
+      try {
+        browserPerformance.mark(markName, { detail: option });
+      } catch {
+        browserPerformance.mark(markName);
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function measureUserTiming(
+  traceName: string,
+  startMarkName: string,
+  endMarkName: string,
+  option?: ProfileTraceOption,
+): void {
+  const browserPerformance = getUserTimingPerformance();
+  if (!browserPerformance) {
+    return;
+  }
+  if (option === undefined) {
+    try {
+      browserPerformance.measure(traceName, startMarkName, endMarkName);
+    } catch {
+      // Do nothing.
+    }
+  } else {
+    try {
+      browserPerformance.measure(traceName, {
+        start: startMarkName,
+        end: endMarkName,
+        detail: option,
+      });
+    } catch {
+      try {
+        browserPerformance.measure(traceName, startMarkName, endMarkName);
+      } catch {
+        // Do nothing.
+      }
+    }
+  }
+}
+
+export function createMainThreadLynxPerformance(
+  markTiming: MarkTiming,
+): LynxPerformance {
+  let pipelineIdInc = 0;
+  let profileFlowIdInc = 0;
+  let profileMarkInc = 0;
+  const profileTimingStack: ProfileTimingContext[] = [];
+  return {
+    _generatePipelineOptions: () => {
+      return {
+        pipelineID: `_pipeline_mts_` + (pipelineIdInc++),
+        needTimestamps: false,
+      };
+    },
+    _onPipelineStart: () => {
+      // Do nothing.
+    },
+    _bindPipelineIdWithTimingFlag: () => {
+      // Timing flags are posted by the element flush path on the web main thread.
+    },
+    _markTiming: (
+      pipelineId: string,
+      timingKey: string,
+    ): void => {
+      markTiming(timingKey, pipelineId);
+    },
+    profileStart: (
+      traceName: string,
+      option?: ProfileTraceOption,
+    ): void => {
+      const id = profileMarkInc++;
+      const startMarkName = `lynx.profile:${id}:start:${traceName}`;
+      if (markUserTiming(startMarkName, option)) {
+        profileTimingStack.push({ traceName, startMarkName, option });
+      }
+    },
+    profileEnd: (): void => {
+      const profileTimingContext = profileTimingStack.pop();
+      if (!profileTimingContext) {
+        return;
+      }
+
+      const id = profileMarkInc++;
+      const endMarkName =
+        `lynx.profile:${id}:end:${profileTimingContext.traceName}`;
+      if (!markUserTiming(endMarkName, profileTimingContext.option)) {
+        getUserTimingPerformance()?.clearMarks?.(
+          profileTimingContext.startMarkName,
+        );
+        return;
+      }
+      measureUserTiming(
+        profileTimingContext.traceName,
+        profileTimingContext.startMarkName,
+        endMarkName,
+        profileTimingContext.option,
+      );
+
+      const browserPerformance = getUserTimingPerformance();
+      browserPerformance?.clearMarks?.(profileTimingContext.startMarkName);
+      browserPerformance?.clearMarks?.(endMarkName);
+    },
+    profileMark: (
+      traceName: string,
+      option?: ProfileTraceOption,
+    ): void => {
+      markUserTiming(traceName, option);
+    },
+    profileFlowId: (): number => {
+      return ++profileFlowIdInc;
+    },
+    isProfileRecording: (): boolean => {
+      return getUserTimingPerformance() !== undefined;
+    },
+  };
+}

--- a/packages/web-platform/web-core/ts/server/createServerLynx.ts
+++ b/packages/web-platform/web-core/ts/server/createServerLynx.ts
@@ -11,7 +11,22 @@ export function createServerLynx(
   globalProps: Cloneable,
   customSections: Record<string, Cloneable>,
 ): MainThreadLynx {
+  let pipelineIdInc = 0;
   return {
+    performance: {
+      _generatePipelineOptions: () => ({
+        pipelineID: `_pipeline_ssr_` + (pipelineIdInc++),
+        needTimestamps: false,
+      }),
+      _onPipelineStart: () => {},
+      _bindPipelineIdWithTimingFlag: () => {},
+      _markTiming: () => {},
+      profileStart: () => {},
+      profileEnd: () => {},
+      profileMark: () => {},
+      profileFlowId: () => 0,
+      isProfileRecording: () => false,
+    },
     getJSContext() {
       // Return a basic mock for SSR
       return {} as any;

--- a/packages/web-platform/web-core/ts/types/MainThreadLynx.ts
+++ b/packages/web-platform/web-core/ts/types/MainThreadLynx.ts
@@ -6,7 +6,9 @@
 import type { Cloneable } from './Cloneable.js';
 import type { ExternalBundleLynxAPIs } from './ExternalBundle.js';
 import type { LynxContextEventTarget } from './LynxContextEventTarget.js';
+import type { LynxPerformance } from './NativeApp.js';
 export interface MainThreadLynx extends ExternalBundleLynxAPIs {
+  performance: LynxPerformance;
   getJSContext: () => LynxContextEventTarget;
   requestAnimationFrame: (cb: () => void) => number;
   cancelAnimationFrame: (handler: number) => void;

--- a/packages/web-platform/web-core/ts/types/NativeApp.ts
+++ b/packages/web-platform/web-core/ts/types/NativeApp.ts
@@ -43,6 +43,24 @@ export type NativeLynx = {
   getCustomSection(key: string): Promise<CloneableObject>;
 };
 
+export type LynxPerformance = {
+  _generatePipelineOptions: () => PerformancePipelineOptions;
+  _onPipelineStart: (
+    pipeline_id: string,
+    options?: PerformancePipelineOptions & Record<string, unknown>,
+  ) => void;
+  _bindPipelineIdWithTimingFlag: (
+    pipeline_id: string,
+    timing_flag: string,
+  ) => void;
+  _markTiming: (pipeline_id: string, timing_key: string) => void;
+  profileStart: (traceName: string, option?: unknown) => void;
+  profileEnd: () => void;
+  profileMark: (traceName: string, option?: unknown) => void;
+  profileFlowId: () => number;
+  isProfileRecording: () => boolean;
+};
+
 export type NativeTTObject = {
   lynx: NativeLynx;
   OnLifecycleEvent: (...args: unknown[]) => void;

--- a/packages/web-platform/web-core/ts/types/NativeApp.ts
+++ b/packages/web-platform/web-core/ts/types/NativeApp.ts
@@ -166,7 +166,7 @@ export interface NativeApp {
   /***
    * Support from Lynx 3.0
    */
-  profileMark: () => void;
+  profileMark: (traceName: string, option?: unknown) => void;
 
   /**
    * Support from Lynx 3.0


### PR DESCRIPTION
## Summary

- Bridge web-core profileStart/profileEnd/profileMark/profileFlowId/isProfileRecording to browser User Timing APIs.
- Preserve ReactLynx trace options in User Timing detail and keep nested traces stack-based.
- Add focused web-core tests and a scoped project instruction note for future profiling work.

## Validation

- pnpm turbo build
- pnpm --filter @lynx-js/web-core test -- tests/performance-apis.spec.ts
- pnpm dprint check .github/web-core-profiling.instructions.md packages/web-platform/web-core/ts/client/background/background-apis/createPerformanceApis.ts packages/web-platform/web-core/ts/types/NativeApp.ts packages/web-platform/web-core/tests/performance-apis.spec.ts
- pnpm eslint --config packages/web-platform/web-core/eslint.config.js packages/web-platform/web-core/ts/client/background/background-apis/createPerformanceApis.ts packages/web-platform/web-core/ts/types/NativeApp.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added web-core performance profiling that bridges Lynx profiling calls to browser User Timing measures and marks.
  * Supports nested `profileStart/profileEnd`, instant `profileMark`, flow IDs, and recording-state detection.
  * Exposed performance capability on main-thread Lynx, with SSR mock support for `performance`.
* **Bug Fixes**
  * Profiling now safely degrades when User Timing isn’t available (no throws; predictable flow/recording behavior).
* **Tests**
  * Added automated coverage for bridging behavior, detail propagation, nesting, and fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->