### PR TITLE
feat(react): tag ET template types with globDynamicComponentEntry

### DIFF
--- a/.changeset/et-globdynamiccomponententry-template-type.md
+++ b/.changeset/et-globdynamiccomponententry-template-type.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+No release changes. Element Template now tags every compiled template type with the `${globDynamicComponentEntry}:` prefix (co-built lazy dynamic components carry a bundleUrl like standalone lazy bundles; the main card uses the `__Card__` sentinel, which normalizes to a null bundleUrl). Element Template support has not been published yet, so this does not need a release.

--- a/packages/react/runtime/__test__/element-template/fixtures/background/render/constructs-shadow-tree/output.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/render/constructs-shadow-tree/output.txt
@@ -1,7 +1,7 @@
 Object {
   "isRootInstance": true,
   "tree": "<root>
-  <_et_8aa39ef57bf1 />
+  <__Card__:_et_8aa39ef57bf1 />
 </root>
 ",
 }

--- a/packages/react/runtime/__test__/element-template/fixtures/background/render/supports-slot-component-materiality/output.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/render/supports-slot-component-materiality/output.txt
@@ -1,13 +1,13 @@
 Object {
   "tree": "<root>
-  <_et_d7c09654e316>
-    <_et_d7c09654e316>
-      <_et_1d658c77caa0 />
-    </_et_d7c09654e316>
-    <_et_d7c09654e316>
-      <_et_f4df0f2dba8f />
-    </_et_d7c09654e316>
-  </_et_d7c09654e316>
+  <__Card__:_et_d7c09654e316>
+    <__Card__:_et_d7c09654e316>
+      <__Card__:_et_1d658c77caa0 />
+    </__Card__:_et_d7c09654e316>
+    <__Card__:_et_d7c09654e316>
+      <__Card__:_et_f4df0f2dba8f />
+    </__Card__:_et_d7c09654e316>
+  </__Card__:_et_d7c09654e316>
 </root>
 ",
 }

--- a/packages/react/runtime/__test__/element-template/fixtures/render/child-siblings/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/child-siblings/index.js.txt
@@ -1,7 +1,7 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
-const _et_1d658c77caa0 = "_et_1d658c77caa0";
-const _et_f4df0f2dba8f = "_et_f4df0f2dba8f";
-const _et_d7c09654e316 = "_et_d7c09654e316";
+const _et_1d658c77caa0 = `${globDynamicComponentEntry}:${"_et_1d658c77caa0"}`;
+const _et_f4df0f2dba8f = `${globDynamicComponentEntry}:${"_et_f4df0f2dba8f"}`;
+const _et_d7c09654e316 = `${globDynamicComponentEntry}:${"_et_d7c09654e316"}`;
 export function App() {
     return /*#__PURE__*/ _jsx(_et_d7c09654e316, {
         $0: [

--- a/packages/react/runtime/__test__/element-template/fixtures/render/component-slot-content/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/component-slot-content/index.js.txt
@@ -1,12 +1,12 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
-const _et_04020ede3da7 = "_et_04020ede3da7";
+const _et_04020ede3da7 = `${globDynamicComponentEntry}:${"_et_04020ede3da7"}`;
 function CustomComponent(props) {
     return /*#__PURE__*/ _jsx(_et_04020ede3da7, {
         $0: props.children
     });
 }
-const _et_d33ba201dffe = "_et_d33ba201dffe";
-const _et_d7c09654e316 = "_et_d7c09654e316";
+const _et_d33ba201dffe = `${globDynamicComponentEntry}:${"_et_d33ba201dffe"}`;
+const _et_d7c09654e316 = `${globDynamicComponentEntry}:${"_et_d7c09654e316"}`;
 export function App() {
     return /*#__PURE__*/ _jsx(_et_d7c09654e316, {
         $0: /*#__PURE__*/ _jsx(CustomComponent, {

--- a/packages/react/runtime/__test__/element-template/fixtures/render/component/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/component/index.js.txt
@@ -1,5 +1,5 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
-const _et_d24f9e2c7533 = "_et_d24f9e2c7533";
+const _et_d24f9e2c7533 = `${globDynamicComponentEntry}:${"_et_d24f9e2c7533"}`;
 export function App() {
     const x = null;
     const y = 2;

--- a/packages/react/runtime/__test__/element-template/fixtures/render/mapped-view-children/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/mapped-view-children/index.js.txt
@@ -1,6 +1,6 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
-const _et_602071c91d92 = "_et_602071c91d92";
-const _et_d7c09654e316 = "_et_d7c09654e316";
+const _et_602071c91d92 = `${globDynamicComponentEntry}:${"_et_602071c91d92"}`;
+const _et_d7c09654e316 = `${globDynamicComponentEntry}:${"_et_d7c09654e316"}`;
 export function App() {
     const items = [
         'A',

--- a/packages/react/runtime/__test__/element-template/fixtures/render/mixed-children/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/mixed-children/index.js.txt
@@ -1,6 +1,6 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import { Component } from '@lynx-js/react';
-const _et_14b97eb313a1 = "_et_14b97eb313a1";
+const _et_14b97eb313a1 = `${globDynamicComponentEntry}:${"_et_14b97eb313a1"}`;
 export class App extends Component {
     render() {
         const leading = 'A';

--- a/packages/react/runtime/__test__/element-template/fixtures/render/multiple-text/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/multiple-text/index.js.txt
@@ -1,7 +1,7 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import { Component } from '@lynx-js/react';
-const _et_dd10eca65d68 = "_et_dd10eca65d68";
-const _et_6306a5a2decc = "_et_6306a5a2decc";
+const _et_dd10eca65d68 = `${globDynamicComponentEntry}:${"_et_dd10eca65d68"}`;
+const _et_6306a5a2decc = `${globDynamicComponentEntry}:${"_et_6306a5a2decc"}`;
 export class App extends Component {
     render() {
         const items = [

--- a/packages/react/runtime/__test__/element-template/fixtures/render/nested-templates/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/nested-templates/index.js.txt
@@ -1,6 +1,6 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import { Component } from '@lynx-js/react';
-const _et_d7c09654e316 = "_et_d7c09654e316";
+const _et_d7c09654e316 = `${globDynamicComponentEntry}:${"_et_d7c09654e316"}`;
 class Inner extends Component {
     render() {
         return /*#__PURE__*/ _jsx(_et_d7c09654e316, {

--- a/packages/react/runtime/__test__/element-template/fixtures/render/react-example/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/react-example/index.js.txt
@@ -4,9 +4,9 @@ import { useCallback, useEffect, useState } from '@lynx-js/react';
 const arrow = './assets/arrow.png';
 const lynxLogo = './assets/lynx-logo.png';
 const reactLynxLogo = './assets/react-logo.png';
-const _et_b89c02b1874f = "_et_b89c02b1874f";
-const _et_a51110b9901e = "_et_a51110b9901e";
-const _et_3a121f15a890 = "_et_3a121f15a890";
+const _et_b89c02b1874f = `${globDynamicComponentEntry}:${"_et_b89c02b1874f"}`;
+const _et_a51110b9901e = `${globDynamicComponentEntry}:${"_et_a51110b9901e"}`;
+const _et_3a121f15a890 = `${globDynamicComponentEntry}:${"_et_3a121f15a890"}`;
 ReactLynxInternal.__etAttrPlanMap[_et_3a121f15a890] = [
     0,
     ReactLynxInternal.adaptEventAttrSlot

--- a/packages/react/runtime/__test__/element-template/fixtures/render/sparse-element-slot/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/sparse-element-slot/index.js.txt
@@ -1,7 +1,7 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
-const _et_01c4a5c2b24f = "_et_01c4a5c2b24f";
-const _et_dd10eca65d68 = "_et_dd10eca65d68";
-const _et_192834fffc79 = "_et_192834fffc79";
+const _et_01c4a5c2b24f = `${globDynamicComponentEntry}:${"_et_01c4a5c2b24f"}`;
+const _et_dd10eca65d68 = `${globDynamicComponentEntry}:${"_et_dd10eca65d68"}`;
+const _et_192834fffc79 = `${globDynamicComponentEntry}:${"_et_192834fffc79"}`;
 export function App({ showHeader = false, items = [
     'body'
 ] }) {

--- a/packages/react/runtime/__test__/element-template/fixtures/render/template-dedupe/index.js.txt
+++ b/packages/react/runtime/__test__/element-template/fixtures/render/template-dedupe/index.js.txt
@@ -1,6 +1,6 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import { Component } from '@lynx-js/react';
-const _et_eed499fe6178 = "_et_eed499fe6178";
+const _et_eed499fe6178 = `${globDynamicComponentEntry}:${"_et_eed499fe6178"}`;
 function PrimaryRow({ label }) {
     return /*#__PURE__*/ _jsx(_et_eed499fe6178, {
         $0: label
@@ -11,7 +11,7 @@ function SecondaryRow({ label }) {
         $0: label
     });
 }
-const _et_d7c09654e316 = "_et_d7c09654e316";
+const _et_d7c09654e316 = `${globDynamicComponentEntry}:${"_et_d7c09654e316"}`;
 export class App extends Component {
     render() {
         return /*#__PURE__*/ _jsx(_et_d7c09654e316, {

--- a/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/event/compiled-fixtures.test.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../../../../src/element-template/native/patch-listener.js';
 import { ElementTemplateLifecycleConstant } from '../../../../../src/element-template/protocol/lifecycle-constant.js';
 import { ElementTemplateUpdateOps } from '../../../../../src/element-template/protocol/opcodes.js';
+import { parseElementTemplateType } from '../../../../../src/element-template/protocol/template-type.js';
 import type {
   ElementTemplateUpdateCommandStream,
   ElementTemplateUpdateCommitContext,
@@ -131,11 +132,12 @@ function collectRecursiveCreateCommandStream(
       commands.push(...collectRecursiveCreateCommandStream(child));
     }
   }
+  const nativeTemplate = parseElementTemplateType(instance.type);
   commands.push(
     ElementTemplateUpdateOps.createTemplate,
     instance.instanceId,
-    instance.type,
-    null,
+    nativeTemplate.templateKey,
+    nativeTemplate.bundleUrl,
     instance.attributeSlots,
     instance.elementSlots.map(children => (children ?? []).map(child => child.instanceId)),
   );
@@ -515,8 +517,11 @@ describe('Compiled direct event background updates', () => {
 
     const { loadLepusChunk } = installRealWorkletRuntime();
     const { backgroundModule, mainModule } = await loadCompiledMainThreadRunOnBackgroundEventFixture();
+    // Real main bundles define `globDynamicComponentEntry` as the `__Card__`
+    // sentinel via the webpack banner, so the compiled main thread forwards it
+    // to the worklet runtime loader (matching production for the main card).
     expect(loadLepusChunk).toHaveBeenCalledWith('worklet-runtime', {
-      dynamicComponentEntry: undefined,
+      dynamicComponentEntry: '__Card__',
       chunkType: 0,
     });
     const onReport = vi.fn((label: string) => `reported:${label}`);

--- a/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/update/compiled-fixtures.test.tsx
@@ -22,6 +22,7 @@ import type {
   ElementTemplateUpdateCommandStream,
   ElementTemplateUpdateCommitContext,
 } from '../../../../../src/element-template/protocol/types.js';
+import { parseElementTemplateType } from '../../../../../src/element-template/protocol/template-type.js';
 import { parseElementTemplateUpdateEventPayload } from '../../../../../src/element-template/protocol/update-event.js';
 import { clearEtAttrPlanMap } from '../../../../../src/element-template/runtime/template/attr-slot-plan.js';
 import { __root } from '../../../../../src/element-template/runtime/page/root-instance.js';
@@ -78,11 +79,12 @@ function collectRecursiveCreateCommandStream(
       commands.push(...collectRecursiveCreateCommandStream(child));
     }
   }
+  const nativeTemplate = parseElementTemplateType(instance.type);
   commands.push(
     ElementTemplateUpdateOps.createTemplate,
     instance.instanceId,
-    instance.type,
-    null,
+    nativeTemplate.templateKey,
+    nativeTemplate.bundleUrl,
     instance.attributeSlots,
     instance.elementSlots.map(children => (children ?? []).map(child => child.instanceId)),
   );

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -317,7 +317,9 @@ describe('ElementTemplate patch stream (apply)', () => {
   it('records main-thread dynamic attr state after createTemplate PAPI succeeds', () => {
     const handleId = 107;
     const ctx = { _wkltId: 'created' };
-    __etAttrPlanMap.view = [0, adaptMTEventAttrSlot];
+    // The transform keys the attr plan by the full `${entry}:${key}` tag; the
+    // main card uses the `__Card__` sentinel (normalized from a null bundleUrl).
+    __etAttrPlanMap['__Card__:view'] = [0, adaptMTEventAttrSlot];
     registerTemplates([{
       templateId: 'view',
       compiledTemplate: {

--- a/packages/react/runtime/__test__/element-template/runtime/template/element-template-handle.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/template/element-template-handle.test.ts
@@ -79,7 +79,9 @@ describe('ElementTemplateHandle', () => {
   it('records main-thread dynamic attr state after reserved-handle create succeeds', () => {
     const id = reserveElementTemplateId();
     const ctx = { _wkltId: 'tap' };
-    __etAttrPlanMap._et_test = [0, adaptMTEventAttrSlot];
+    // The transform keys the attr plan by the full `${entry}:${key}` tag; the
+    // main card uses the `__Card__` sentinel (normalized from a null bundleUrl).
+    __etAttrPlanMap['__Card__:_et_test'] = [0, adaptMTEventAttrSlot];
     createElementTemplateWithReservedHandle(
       id,
       '_et_test',

--- a/packages/react/runtime/__test__/element-template/test-utils/setup.js
+++ b/packages/react/runtime/__test__/element-template/test-utils/setup.js
@@ -53,6 +53,12 @@ beforeEach(() => {
   installMockNativePapi();
   installThreadContexts();
 
+  // Compiled main-thread templates reference `globDynamicComponentEntry`
+  // (Element Template always tags template types with it). Real builds define
+  // it via the banner/wrapper; reset it here so a fixture that mutates it for a
+  // dynamic component does not leak an undefined value into later tests.
+  globalThis.globDynamicComponentEntry = '__Card__';
+
   resetPerformanceMocks();
 });
 

--- a/packages/react/runtime/src/element-template/background/hydrate.ts
+++ b/packages/react/runtime/src/element-template/background/hydrate.ts
@@ -13,7 +13,7 @@ import { backgroundElementTemplateInstanceManager } from './manager.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
 import { hydrationMap } from '../hydration-map.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
-import { elementTemplateIdentityKey } from '../protocol/template-type.js';
+import { elementTemplateIdentityKey, parseElementTemplateType } from '../protocol/template-type.js';
 import type {
   SerializableValue,
   SerializedCompiledNode,
@@ -83,7 +83,14 @@ function hydrateMatchingChildrenAndDiffSlot(
 
   for (let i = 0; i < backgroundChildren.length; i += 1) {
     const backgroundChild = backgroundChildren[i]!;
-    const backgroundKey = backgroundChild.type;
+    // Normalize the background instance's full `${entry}:${key}` type tag to the
+    // same native identity the serialized side uses (sentinel folded to the main
+    // card), so main-card nodes match regardless of the `__Card__` prefix.
+    const parsedBackgroundType = parseElementTemplateType(backgroundChild.type);
+    const backgroundKey = elementTemplateIdentityKey(
+      parsedBackgroundType.templateKey,
+      parsedBackgroundType.bundleUrl,
+    );
     const serializedCandidates = serializedByNodeKey[backgroundKey];
     const candidateCursor = serializedCursorByNodeKey[backgroundKey] ?? 0;
     const matchedSerialized = serializedCandidates?.[candidateCursor];

--- a/packages/react/runtime/src/element-template/protocol/template-type.ts
+++ b/packages/react/runtime/src/element-template/protocol/template-type.ts
@@ -7,6 +7,13 @@ export interface ParsedElementTemplateType {
   bundleUrl: string | null;
 }
 
+/**
+ * The `globDynamicComponentEntry` value baked into main-bundle templates. It
+ * denotes "the main card", which is equivalent to having no `bundleUrl`, so it
+ * normalizes to `null` everywhere the template type is parsed.
+ */
+export const MAIN_BUNDLE_URL_SENTINEL = '__Card__';
+
 export function parseElementTemplateType(type: string): ParsedElementTemplateType {
   const delimiter = type.lastIndexOf(':');
   if (delimiter < 0) {
@@ -15,15 +22,35 @@ export function parseElementTemplateType(type: string): ParsedElementTemplateTyp
       bundleUrl: null,
     };
   }
+  const bundleUrl = type.slice(0, delimiter);
   return {
     templateKey: type.slice(delimiter + 1),
-    bundleUrl: type.slice(0, delimiter),
+    bundleUrl: bundleUrl === MAIN_BUNDLE_URL_SENTINEL ? null : bundleUrl,
   };
 }
 
+/**
+ * The native identity for a template: the bundle-scoped key the main-thread
+ * registers it under. The main card has no bundle, so its sentinel is stripped
+ * to a bare `templateKey` (preserving native behavior); lazy bundles keep their
+ * `${bundleUrl}:${templateKey}` form.
+ */
 export function elementTemplateIdentityKey(
   templateKey: string,
   bundleUrl: string | null | undefined,
 ): string {
   return bundleUrl == null ? templateKey : `${bundleUrl}:${templateKey}`;
+}
+
+/**
+ * The full `${globDynamicComponentEntry}:${templateKey}` tag the transform bakes
+ * into compiled templates and uses as the `__etAttrPlanMap` key. It always keeps
+ * the `__Card__` sentinel for the main card (unlike {@link elementTemplateIdentityKey},
+ * which strips it). Inverse of {@link parseElementTemplateType}.
+ */
+export function elementTemplateTypeTag(
+  templateKey: string,
+  bundleUrl: string | null | undefined,
+): string {
+  return `${bundleUrl ?? MAIN_BUNDLE_URL_SENTINEL}:${templateKey}`;
 }

--- a/packages/react/runtime/src/element-template/runtime/patch.ts
+++ b/packages/react/runtime/src/element-template/runtime/patch.ts
@@ -21,7 +21,11 @@ import type { ETListFlushResult, ETListUpdateItem } from './list/list.js';
 import { elementTemplateRegistry } from './template/registry.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
 import type { ElementTemplateUpdateOp } from '../protocol/opcodes.js';
-import { elementTemplateIdentityKey } from '../protocol/template-type.js';
+import {
+  elementTemplateIdentityKey,
+  elementTemplateTypeTag,
+  parseElementTemplateType,
+} from '../protocol/template-type.js';
 import type {
   ElementTemplateHandleSlotsCommand,
   ElementTemplateUpdateCommandStream,
@@ -88,7 +92,7 @@ export function applyElementTemplateUpdateCommands(
           elementTemplateRegistry.set(handleId, nativeRef);
           initializeMainThreadDynamicAttrSlots(
             handleId,
-            elementTemplateIdentityKey(templateKey, bundleUrl),
+            elementTemplateTypeTag(templateKey, bundleUrl),
             nativeAttributeSlots,
           );
         }
@@ -408,10 +412,14 @@ function resolveTypedListItem(
   if (ref === null) {
     return null;
   }
+  // `item.type` is the full `${globDynamicComponentEntry}:${key}` tag; the
+  // native list identifies items by the same identity key the templates were
+  // registered under (see the `createTemplate` op above), so normalize it.
+  const nativeTemplate = parseElementTemplateType(item.type);
   return {
     uid: item.__etHandleRef,
     ref,
-    templateKey: item.type,
+    templateKey: elementTemplateIdentityKey(nativeTemplate.templateKey, nativeTemplate.bundleUrl),
     platformInfo: item.platformInfo,
   };
 }

--- a/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { __OpAttr, __OpBegin, __OpEnd, __OpSlot, __OpText } from './render-to-opcodes.js';
-import { parseElementTemplateType } from '../../protocol/template-type.js';
+import { elementTemplateIdentityKey, parseElementTemplateType } from '../../protocol/template-type.js';
 import type { RuntimeTypedElementAttributes, SerializableValue } from '../../protocol/types.js';
 import {
   composeElementTemplateListAttributes,
@@ -169,7 +169,10 @@ export function renderOpcodesIntoElementTemplate(
         );
         if (listItemPlatformInfo !== undefined) {
           registerElementTemplateListItem(handleId, elementRef, {
-            templateKey: concreteType,
+            // The native list identifies items by the same identity the template
+            // was registered under (sentinel stripped for the main card), so the
+            // update path (`resolveTypedListItem`) stays consistent with it.
+            templateKey: elementTemplateIdentityKey(nativeTemplate.templateKey, nativeTemplate.bundleUrl),
             platformInfo: listItemPlatformInfo,
           });
         }

--- a/packages/react/runtime/src/element-template/runtime/template/handle.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/handle.ts
@@ -7,7 +7,7 @@ import {
   initializeMainThreadDynamicAttrSlots,
 } from './main-thread-dynamic-attr-state.js';
 import { deleteElementTemplateNativeRef, setElementTemplateNativeRef } from './registry.js';
-import { elementTemplateIdentityKey } from '../../protocol/template-type.js';
+import { elementTemplateTypeTag } from '../../protocol/template-type.js';
 import type {
   RuntimeElementSlots,
   RuntimeOptions,
@@ -41,7 +41,7 @@ export function createElementTemplateWithReservedHandle(
     setElementTemplateNativeRef(handleId, nativeRef);
     initializeMainThreadDynamicAttrSlots(
       handleId,
-      elementTemplateIdentityKey(templateKey, bundleUrl),
+      elementTemplateTypeTag(templateKey, bundleUrl),
       attributeSlots,
     );
   }

--- a/packages/react/transform/__test__/fixture.spec.js
+++ b/packages/react/transform/__test__/fixture.spec.js
@@ -283,8 +283,8 @@ describe('element template', () => {
     expect(result.elementTemplates?.some(template => template.compiledTemplate.type === 'list-item')).toBe(true);
     expect(result.code).toMatchInlineSnapshot(`
       "import { jsx as _jsx } from "react/jsx-runtime";
-      const _et_4f796f70cdd7 = "_et_4f796f70cdd7";
-      const _et_b8da8bac988e = "_et_b8da8bac988e";
+      const _et_4f796f70cdd7 = \`\${globDynamicComponentEntry}:\${"_et_4f796f70cdd7"}\`;
+      const _et_b8da8bac988e = \`\${globDynamicComponentEntry}:\${"_et_b8da8bac988e"}\`;
       /*#__PURE__*/ _jsx("list", {
           attributes: {
               "id": listId,

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -562,10 +562,10 @@ where
     };
     let template_uid = template_identity.template_id.clone();
 
-    let mut entry_template_uid = quote!("$template_uid" as Expr, template_uid: Expr = Expr::Lit(Lit::Str(template_uid.clone().into())));
-    if matches!(self.cfg.is_dynamic_component, Some(true)) {
-      entry_template_uid = quote!("`${globDynamicComponentEntry}:${$template_uid}`" as Expr, template_uid: Expr = Expr::Lit(Lit::Str(template_uid.clone().into())));
-    }
+    // Always keep the `globDynamicComponentEntry` prefix
+    // since __CreateElementTemplate needs to know the bundle URL of lazy
+    // bundle.
+    let entry_template_uid = quote!("`${globDynamicComponentEntry}:${$template_uid}`" as Expr, template_uid: Expr = Expr::Lit(Lit::Str(template_uid.clone().into())));
 
     if is_new_template {
       let entry_template_uid_def = ModuleItem::Stmt(quote!(

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_generate_attribute_slots_for_dynamic_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_generate_attribute_slots_for_dynamic_attributes.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_d5a51fb4f19d = \"_et_d5a51fb4f19d\";\n<_et_d5a51fb4f19d attributeSlots={[\n    dynamicId,\n    value\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_d5a51fb4f19d = `${globDynamicComponentEntry}:${\"_et_d5a51fb4f19d\"}`;\n<_et_d5a51fb4f19d attributeSlots={[\n    dynamicId,\n    value\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_d5a51fb4f19d",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_background_conditional_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_background_conditional_attributes.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_7fa05c65429d = \"_et_7fa05c65429d\";\nfunction App() {\n    const attrs = __BACKGROUND__ ? {\n        0: {\n            id: 'b'\n        },\n        2: {\n            data: 'extra'\n        }\n    } : {\n        0: {\n            id: 'a'\n        },\n        1: {\n            title: 'main'\n        }\n    };\n    return (<_et_7fa05c65429d attributeSlots={[\n        attrs,\n        attrs\n    ]}/>);\n}\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_7fa05c65429d = `${globDynamicComponentEntry}:${\"_et_7fa05c65429d\"}`;\nfunction App() {\n    const attrs = __BACKGROUND__ ? {\n        0: {\n            id: 'b'\n        },\n        2: {\n            data: 'extra'\n        }\n    } : {\n        0: {\n            id: 'a'\n        },\n        1: {\n            title: 'main'\n        }\n    };\n    return (<_et_7fa05c65429d attributeSlots={[\n        attrs,\n        attrs\n    ]}/>);\n}\n",
   "templates": [
     {
       "template_id": "_et_7fa05c65429d",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_boolean_and_number_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_boolean_and_number_attributes.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_30f1eb7cba92 = \"_et_30f1eb7cba92\";\n<_et_30f1eb7cba92/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_30f1eb7cba92 = `${globDynamicComponentEntry}:${\"_et_30f1eb7cba92\"}`;\n<_et_30f1eb7cba92/>;\n",
   "templates": [
     {
       "template_id": "_et_30f1eb7cba92",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_complex_text_structure.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_complex_text_structure.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_47f338e2f09c = \"_et_47f338e2f09c\";\n<_et_47f338e2f09c/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_47f338e2f09c = `${globDynamicComponentEntry}:${\"_et_47f338e2f09c\"}`;\n<_et_47f338e2f09c/>;\n",
   "templates": [
     {
       "template_id": "_et_47f338e2f09c",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_dataset_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_dataset_attributes.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_18716c005f6f = \"_et_18716c005f6f\";\n<_et_18716c005f6f/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_18716c005f6f = `${globDynamicComponentEntry}:${\"_et_18716c005f6f\"}`;\n<_et_18716c005f6f/>;\n",
   "templates": [
     {
       "template_id": "_et_18716c005f6f",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_deeply_nested_user_components.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_deeply_nested_user_components.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_efe140538def = \"_et_efe140538def\";\nconst _et_d7c09654e316 = \"_et_d7c09654e316\";\n<_et_d7c09654e316 $0={<Outer title={title}>\n        <Middle enabled={enabled}>\n          <Inner count={count}>\n            <_et_efe140538def/>\n          </Inner>\n        </Middle>\n      </Outer>}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_efe140538def = `${globDynamicComponentEntry}:${\"_et_efe140538def\"}`;\nconst _et_d7c09654e316 = `${globDynamicComponentEntry}:${\"_et_d7c09654e316\"}`;\n<_et_d7c09654e316 $0={<Outer title={title}>\n        <Middle enabled={enabled}>\n          <Inner count={count}>\n            <_et_efe140538def/>\n          </Inner>\n        </Middle>\n      </Outer>}/>;\n",
   "templates": [
     {
       "template_id": "_et_efe140538def",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_dynamic_class_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_dynamic_class_attributes.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_512af556d201 = \"_et_512af556d201\";\n<_et_512af556d201 attributeSlots={[\n    dynamicClass\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_512af556d201 = `${globDynamicComponentEntry}:${\"_et_512af556d201\"}`;\n<_et_512af556d201 attributeSlots={[\n    dynamicClass\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_512af556d201",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_js.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_22fa50e6e3b9 = \"_et_22fa50e6e3b9\";\nReactLynxInternal.__etAttrPlanMap[_et_22fa50e6e3b9] = [\n    0,\n    ReactLynxInternal.adaptEventAttrSlot,\n    1,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_22fa50e6e3b9 attributeSlots={[\n    handleTap,\n    handleTouch\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_22fa50e6e3b9 = `${globDynamicComponentEntry}:${\"_et_22fa50e6e3b9\"}`;\nReactLynxInternal.__etAttrPlanMap[_et_22fa50e6e3b9] = [\n    0,\n    ReactLynxInternal.adaptEventAttrSlot,\n    1,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_22fa50e6e3b9 attributeSlots={[\n    handleTap,\n    handleTouch\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_22fa50e6e3b9",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_events_lepus.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_22fa50e6e3b9 = \"_et_22fa50e6e3b9\";\nReactLynxInternal.__etAttrPlanMap[_et_22fa50e6e3b9] = [\n    0,\n    ReactLynxInternal.adaptEventAttrSlot,\n    1,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_22fa50e6e3b9 attributeSlots={[\n    1,\n    1\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_22fa50e6e3b9 = `${globDynamicComponentEntry}:${\"_et_22fa50e6e3b9\"}`;\nReactLynxInternal.__etAttrPlanMap[_et_22fa50e6e3b9] = [\n    0,\n    ReactLynxInternal.adaptEventAttrSlot,\n    1,\n    ReactLynxInternal.adaptEventAttrSlot\n];\n<_et_22fa50e6e3b9 attributeSlots={[\n    1,\n    1\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_22fa50e6e3b9",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_id_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_id_attributes.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_ea6d5e931fea = \"_et_ea6d5e931fea\";\n<_et_ea6d5e931fea attributeSlots={[\n    dynamicId\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_ea6d5e931fea = `${globDynamicComponentEntry}:${\"_et_ea6d5e931fea\"}`;\n<_et_ea6d5e931fea attributeSlots={[\n    dynamicId\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_ea6d5e931fea",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_inline_styles.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_inline_styles.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_ada2059ce2a3 = \"_et_ada2059ce2a3\";\n<_et_ada2059ce2a3 attributeSlots={[\n    {\n        color: dynamicColor\n    }\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_ada2059ce2a3 = `${globDynamicComponentEntry}:${\"_et_ada2059ce2a3\"}`;\n<_et_ada2059ce2a3 attributeSlots={[\n    {\n        color: dynamicColor\n    }\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_ada2059ce2a3",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_js.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_dd10eca65d68 = \"_et_dd10eca65d68\";\nconst _et_ed9291f1e955 = \"_et_ed9291f1e955\";\n<_et_ed9291f1e955 $0={items} $1={items.map((item)=><_et_dd10eca65d68 $0={item}/>)}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_dd10eca65d68 = `${globDynamicComponentEntry}:${\"_et_dd10eca65d68\"}`;\nconst _et_ed9291f1e955 = `${globDynamicComponentEntry}:${\"_et_ed9291f1e955\"}`;\n<_et_ed9291f1e955 $0={items} $1={items.map((item)=><_et_dd10eca65d68 $0={item}/>)}/>;\n",
   "templates": [
     {
       "template_id": "_et_dd10eca65d68",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_interpolated_text_with_siblings_lepus.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_dd10eca65d68 = \"_et_dd10eca65d68\";\nconst _et_ed9291f1e955 = \"_et_ed9291f1e955\";\n<_et_ed9291f1e955 $0={items} $1={items.map((item)=><_et_dd10eca65d68 $0={item}/>)}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_dd10eca65d68 = `${globDynamicComponentEntry}:${\"_et_dd10eca65d68\"}`;\nconst _et_ed9291f1e955 = `${globDynamicComponentEntry}:${\"_et_ed9291f1e955\"}`;\n<_et_ed9291f1e955 $0={items} $1={items.map((item)=><_et_dd10eca65d68 $0={item}/>)}/>;\n",
   "templates": [
     {
       "template_id": "_et_dd10eca65d68",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_mixed_content.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_mixed_content.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_beb3a71c96f6 = \"_et_beb3a71c96f6\";\n<_et_beb3a71c96f6 $0={dynamicPart}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_beb3a71c96f6 = `${globDynamicComponentEntry}:${\"_et_beb3a71c96f6\"}`;\n<_et_beb3a71c96f6 $0={dynamicPart}/>;\n",
   "templates": [
     {
       "template_id": "_et_beb3a71c96f6",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_nested_structure_and_dynamic_content.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_nested_structure_and_dynamic_content.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_dd10eca65d68 = \"_et_dd10eca65d68\";\nconst _et_f2aabcaaedd9 = \"_et_f2aabcaaedd9\";\nconst _et_9a26fdfe48b4 = \"_et_9a26fdfe48b4\";\n<_et_9a26fdfe48b4 $0={items.map((item)=><_et_dd10eca65d68 $0={item}/>)} $1={showCopyright && <_et_f2aabcaaedd9/>}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_dd10eca65d68 = `${globDynamicComponentEntry}:${\"_et_dd10eca65d68\"}`;\nconst _et_f2aabcaaedd9 = `${globDynamicComponentEntry}:${\"_et_f2aabcaaedd9\"}`;\nconst _et_9a26fdfe48b4 = `${globDynamicComponentEntry}:${\"_et_9a26fdfe48b4\"}`;\n<_et_9a26fdfe48b4 $0={items.map((item)=><_et_dd10eca65d68 $0={item}/>)} $1={showCopyright && <_et_f2aabcaaedd9/>}/>;\n",
   "templates": [
     {
       "template_id": "_et_dd10eca65d68",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_js.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_js.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_c5232cf7d7c7 = \"_et_c5232cf7d7c7\";\nReactLynxInternal.__etAttrPlanMap[_et_c5232cf7d7c7] = [\n    0,\n    ReactLynxInternal.adaptRefAttrSlot\n];\n<_et_c5232cf7d7c7 attributeSlots={[\n    viewRef\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_c5232cf7d7c7 = `${globDynamicComponentEntry}:${\"_et_c5232cf7d7c7\"}`;\nReactLynxInternal.__etAttrPlanMap[_et_c5232cf7d7c7] = [\n    0,\n    ReactLynxInternal.adaptRefAttrSlot\n];\n<_et_c5232cf7d7c7 attributeSlots={[\n    viewRef\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_c5232cf7d7c7",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_refs_lepus.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_c5232cf7d7c7 = \"_et_c5232cf7d7c7\";\nReactLynxInternal.__etAttrPlanMap[_et_c5232cf7d7c7] = [\n    0,\n    ReactLynxInternal.adaptRefAttrSlot\n];\n<_et_c5232cf7d7c7 attributeSlots={[\n    1\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_c5232cf7d7c7 = `${globDynamicComponentEntry}:${\"_et_c5232cf7d7c7\"}`;\nReactLynxInternal.__etAttrPlanMap[_et_c5232cf7d7c7] = [\n    0,\n    ReactLynxInternal.adaptRefAttrSlot\n];\n<_et_c5232cf7d7c7 attributeSlots={[\n    1\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_c5232cf7d7c7",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_sibling_user_components.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_sibling_user_components.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_1d658c77caa0 = \"_et_1d658c77caa0\";\nconst _et_f4df0f2dba8f = \"_et_f4df0f2dba8f\";\nconst _et_d7c09654e316 = \"_et_d7c09654e316\";\n<_et_d7c09654e316 $0={[\n    <Component>\n        <_et_1d658c77caa0/>\n      </Component>,\n    <Component>\n        <_et_f4df0f2dba8f/>\n      </Component>\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_1d658c77caa0 = `${globDynamicComponentEntry}:${\"_et_1d658c77caa0\"}`;\nconst _et_f4df0f2dba8f = `${globDynamicComponentEntry}:${\"_et_f4df0f2dba8f\"}`;\nconst _et_d7c09654e316 = `${globDynamicComponentEntry}:${\"_et_d7c09654e316\"}`;\n<_et_d7c09654e316 $0={[\n    <Component>\n        <_et_1d658c77caa0/>\n      </Component>,\n    <Component>\n        <_et_f4df0f2dba8f/>\n      </Component>\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_1d658c77caa0",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_spread_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_spread_attributes.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_9982b477067b = \"_et_9982b477067b\";\nReactLynxInternal.__etAttrPlanMap[_et_9982b477067b] = [\n    0,\n    ReactLynxInternal.adaptSpreadAttrSlot\n];\n<_et_9982b477067b attributeSlots={[\n    props\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_9982b477067b = `${globDynamicComponentEntry}:${\"_et_9982b477067b\"}`;\nReactLynxInternal.__etAttrPlanMap[_et_9982b477067b] = [\n    0,\n    ReactLynxInternal.adaptSpreadAttrSlot\n];\n<_et_9982b477067b attributeSlots={[\n    props\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_9982b477067b",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_user_component.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_handle_user_component.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_b2f62f2ab913 = \"_et_b2f62f2ab913\";\nconst _et_d7c09654e316 = \"_et_d7c09654e316\";\n<_et_d7c09654e316 $0={<Component id={1}>\n        <_et_b2f62f2ab913/>\n      </Component>}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_b2f62f2ab913 = `${globDynamicComponentEntry}:${\"_et_b2f62f2ab913\"}`;\nconst _et_d7c09654e316 = `${globDynamicComponentEntry}:${\"_et_d7c09654e316\"}`;\n<_et_d7c09654e316 $0={<Component id={1}>\n        <_et_b2f62f2ab913/>\n      </Component>}/>;\n",
   "templates": [
     {
       "template_id": "_et_b2f62f2ab913",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_isolate_arrays_with_element_slot_placeholder.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_isolate_arrays_with_element_slot_placeholder.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_009a4e5e88d7 = \"_et_009a4e5e88d7\";\n<_et_009a4e5e88d7 $0={[\n    \"a\",\n    \"b\"\n]} $1={[\n    \"c\",\n    \"d\"\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_009a4e5e88d7 = `${globDynamicComponentEntry}:${\"_et_009a4e5e88d7\"}`;\n<_et_009a4e5e88d7 $0={[\n    \"a\",\n    \"b\"\n]} $1={[\n    \"c\",\n    \"d\"\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_009a4e5e88d7",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_keep_code_and_template_attribute_slots_in_sync_for_spread.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_keep_code_and_template_attribute_slots_in_sync_for_spread.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_8f7efeb63f22 = \"_et_8f7efeb63f22\";\nReactLynxInternal.__etAttrPlanMap[_et_8f7efeb63f22] = [\n    1,\n    ReactLynxInternal.adaptSpreadAttrSlot,\n    2,\n    ReactLynxInternal.adaptEventAttrSlot,\n    3,\n    ReactLynxInternal.adaptRefAttrSlot\n];\n<_et_8f7efeb63f22 attributeSlots={[\n    dynamicId,\n    props,\n    1,\n    1\n]}/>;\n",
+  "code": "import * as ReactLynxInternal from \"@lynx-js/react/internal\";\nimport * as ReactLynx from \"@lynx-js/react\";\nconst _et_8f7efeb63f22 = `${globDynamicComponentEntry}:${\"_et_8f7efeb63f22\"}`;\nReactLynxInternal.__etAttrPlanMap[_et_8f7efeb63f22] = [\n    1,\n    ReactLynxInternal.adaptSpreadAttrSlot,\n    2,\n    ReactLynxInternal.adaptEventAttrSlot,\n    3,\n    ReactLynxInternal.adaptRefAttrSlot\n];\n<_et_8f7efeb63f22 attributeSlots={[\n    dynamicId,\n    props,\n    1,\n    1\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_8f7efeb63f22",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_output_element_template_simple_lepus.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_output_element_template_simple_lepus.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_3fb8e0b93073 = \"_et_3fb8e0b93073\";\n<_et_3fb8e0b93073/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_3fb8e0b93073 = `${globDynamicComponentEntry}:${\"_et_3fb8e0b93073\"}`;\n<_et_3fb8e0b93073/>;\n",
   "templates": [
     {
       "template_id": "_et_3fb8e0b93073",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_output_template_with_static_attributes.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_output_template_with_static_attributes.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_f47c3e863a57 = \"_et_f47c3e863a57\";\n<_et_f47c3e863a57/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_f47c3e863a57 = `${globDynamicComponentEntry}:${\"_et_f47c3e863a57\"}`;\n<_et_f47c3e863a57/>;\n",
   "templates": [
     {
       "template_id": "_et_f47c3e863a57",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_verify_template_structure_complex.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_verify_template_structure_complex.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_afd0a7c03a98 = \"_et_afd0a7c03a98\";\n<_et_afd0a7c03a98 attributeSlots={[\n    dynamicId,\n    url\n]}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_afd0a7c03a98 = `${globDynamicComponentEntry}:${\"_et_afd0a7c03a98\"}`;\n<_et_afd0a7c03a98 attributeSlots={[\n    dynamicId,\n    url\n]}/>;\n",
   "templates": [
     {
       "template_id": "_et_afd0a7c03a98",

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_verify_text_attribute_and_child_text_slots.snap
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/__combined_snapshots__/should_verify_text_attribute_and_child_text_slots.snap
@@ -3,7 +3,7 @@ source: packages/react/transform/crates/swc_plugin_element_template/tests/elemen
 expression: "serde_json::json!({\n    \"code\": code, \"templates\": template_snapshot_json(&templates),\n})"
 ---
 {
-  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_12543240e29f = \"_et_12543240e29f\";\n<_et_12543240e29f attributeSlots={[\n    dynamicText\n]} $0={dynamicText2}/>;\n",
+  "code": "import * as ReactLynx from \"@lynx-js/react\";\nconst _et_12543240e29f = `${globDynamicComponentEntry}:${\"_et_12543240e29f\"}`;\n<_et_12543240e29f attributeSlots={[\n    dynamicText\n]} $0={dynamicText2}/>;\n",
   "templates": [
     {
       "template_id": "_et_12543240e29f",


### PR DESCRIPTION
## What

Element Template now **always** tags compiled template types with the `${globDynamicComponentEntry}:${templateKey}` prefix. This makes **co-built lazy dynamic components** (`lazy(() => import())`) carry a `bundleUrl` in their template type, exactly like standalone lazy bundles already do.

The **main card** resolves `globDynamicComponentEntry` to the `__Card__` sentinel (provided by the webpack banner / dynamic-import chunk wrapper). The runtime normalizes `__Card__` back to a `null` bundleUrl, so **every native-observable value for the main card is identical to before this change** (bare `templateKey`, null `bundleUrl`, bare keyed-list item type).

## Why

Previously the prefix was gated on `experimental_isLazyBundle`, so only the standalone lazy-bundle producer emitted it. Co-built lazy components fell back to a bare template type and could not be distinguished by bundle. Tagging unconditionally (in the element-template SWC transform, **not** via the `isDynamicComponent` loader flag — that flag carries broader semantics) gives co-built lazy components the same per-bundle identity.

## Runtime keying made consistent

Under the always-prefixed type there are two distinct key kinds, kept separate by two small helpers in `protocol/template-type.ts`:

| Key | Main card | Used for |
| --- | --- | --- |
| `elementTemplateTypeTag` | `__Card__:_et_xxx` (sentinel kept) | `__etAttrPlanMap` lookups — the full tag the transform registers (`handle.ts`, `patch.ts` create op; render path already used the raw `concreteType`) |
| `elementTemplateIdentityKey` | `_et_xxx` (sentinel stripped) | native identity / keyed-list item type (`render-opcodes`, `resolveTypedListItem`); hydrate matching normalizes both sides to this |

Only the `__CreateElementTemplate` PAPI splits the type back into `templateKey` + `bundleUrl`.

## Tests

- ET suite **690/690**, full runtime suite green, `tsc` clean, `cargo test -p swc_plugin_element_template` green.
- Regenerated cargo snapshots + runtime fixtures. Verified **no `__Card__` leaks into any native-op fixture** — it appears only in background-tree debug serializations (which legitimately show the instance's full `this.type`).

## Changeset

No-release: Element Template is not published yet (empty-frontmatter changeset, matching the prior ET PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for element template rendering and attribute handling.

* **Chores**
  * Internal refactoring of template identification and normalization infrastructure to ensure consistent handling of compiled template types across runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->