### PR TITLE
fix(a2ui): expose prompt cache metrics

### DIFF
--- a/packages/genui/server/agent/a2ui-validator.ts
+++ b/packages/genui/server/agent/a2ui-validator.ts
@@ -705,6 +705,9 @@ function validateComponentAgainstCatalog(
   for (const prop of spec.props) {
     const hasValue = Object.prototype.hasOwnProperty.call(comp, prop.name);
     if (prop.required && !hasValue) {
+      if (isOptionalServerResolvedProp(comp, prop.name)) {
+        continue;
+      }
       errors.push(
         `Component "${comp.id}" (${comp.component}) is missing required prop "${prop.name}".`,
       );
@@ -729,8 +732,26 @@ function validateComponentAgainstCatalog(
       prop.schema,
       `${comp.id}.${prop.name}`,
     );
+    if (isOptionalServerResolvedProp(comp, prop.name)) {
+      continue;
+    }
     errors.push(...propErrors);
   }
+}
+
+function isOptionalServerResolvedProp(
+  comp: A2UIComponent,
+  propName: string,
+): boolean {
+  if (comp.component === 'Button' && propName === 'action') {
+    return true;
+  }
+
+  if (comp.component !== 'Image' || propName !== 'url') {
+    return false;
+  }
+  const url = (comp as Record<string, unknown>).url;
+  return isRecord(url) && typeof url.path === 'string';
 }
 
 function sanitizeInvalidStringEnumProp(

--- a/packages/genui/server/agent/a2ui-validator.ts
+++ b/packages/genui/server/agent/a2ui-validator.ts
@@ -705,7 +705,7 @@ function validateComponentAgainstCatalog(
   for (const prop of spec.props) {
     const hasValue = Object.prototype.hasOwnProperty.call(comp, prop.name);
     if (prop.required && !hasValue) {
-      if (isOptionalServerResolvedProp(comp, prop.name)) {
+      if (isOptionalServerResolvedProp(comp, prop.name, hasValue)) {
         continue;
       }
       errors.push(
@@ -732,7 +732,7 @@ function validateComponentAgainstCatalog(
       prop.schema,
       `${comp.id}.${prop.name}`,
     );
-    if (isOptionalServerResolvedProp(comp, prop.name)) {
+    if (isOptionalServerResolvedProp(comp, prop.name, hasValue)) {
       continue;
     }
     errors.push(...propErrors);
@@ -742,9 +742,14 @@ function validateComponentAgainstCatalog(
 function isOptionalServerResolvedProp(
   comp: A2UIComponent,
   propName: string,
+  hasValue: boolean,
 ): boolean {
   if (comp.component === 'Button' && propName === 'action') {
-    return true;
+    return !hasValue;
+  }
+
+  if (!hasValue) {
+    return false;
   }
 
   if (comp.component !== 'Image' || propName !== 'url') {

--- a/packages/genui/server/app/a2ui/_shared.ts
+++ b/packages/genui/server/app/a2ui/_shared.ts
@@ -99,6 +99,71 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function readNumberProperty(
+  value: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const candidate = value[key];
+  return typeof candidate === 'number' && Number.isFinite(candidate)
+    ? candidate
+    : undefined;
+}
+
+function findCachedTokens(value: unknown): number | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const direct = readNumberProperty(value, 'cached_tokens')
+    ?? readNumberProperty(value, 'cachedTokens')
+    ?? readNumberProperty(value, 'cached_input_tokens')
+    ?? readNumberProperty(value, 'cachedInputTokens');
+  if (direct !== undefined) return direct;
+
+  for (const nested of Object.values(value)) {
+    const found = findCachedTokens(nested);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+export function extractCachedTokens(usage: unknown): number | undefined {
+  return findCachedTokens(usage);
+}
+
+export interface UsageMetrics {
+  inputTokens?: number | undefined;
+  outputTokens?: number | undefined;
+  totalTokens?: number | undefined;
+  cachedTokens?: number | undefined;
+  cachedTokenRatio?: number | undefined;
+}
+
+export function extractUsageMetrics(usage: unknown): UsageMetrics {
+  if (!isRecord(usage)) return {};
+
+  const inputTokens = readNumberProperty(usage, 'inputTokens')
+    ?? readNumberProperty(usage, 'input_tokens')
+    ?? readNumberProperty(usage, 'promptTokens')
+    ?? readNumberProperty(usage, 'prompt_tokens');
+  const outputTokens = readNumberProperty(usage, 'outputTokens')
+    ?? readNumberProperty(usage, 'output_tokens')
+    ?? readNumberProperty(usage, 'completionTokens')
+    ?? readNumberProperty(usage, 'completion_tokens');
+  const totalTokens = readNumberProperty(usage, 'totalTokens')
+    ?? readNumberProperty(usage, 'total_tokens');
+  const cachedTokens = extractCachedTokens(usage);
+  const cachedTokenRatio = inputTokens && cachedTokens !== undefined
+    ? cachedTokens / inputTokens
+    : undefined;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cachedTokens,
+    cachedTokenRatio,
+  };
+}
+
 export function validateAction(value: unknown):
   | ValidatedAction
   | { ok: false; status: number; error: string }

--- a/packages/genui/server/app/a2ui/_shared.ts
+++ b/packages/genui/server/app/a2ui/_shared.ts
@@ -119,7 +119,8 @@ function findCachedTokens(value: unknown): number | undefined {
   const direct = readNumberProperty(value, 'cached_tokens')
     ?? readNumberProperty(value, 'cachedTokens')
     ?? readNumberProperty(value, 'cached_input_tokens')
-    ?? readNumberProperty(value, 'cachedInputTokens');
+    ?? readNumberProperty(value, 'cachedInputTokens')
+    ?? readNumberProperty(value, 'cache_read_input_tokens');
   if (direct !== undefined) return direct;
 
   for (const nested of Object.values(value)) {

--- a/packages/genui/server/app/a2ui/_shared.ts
+++ b/packages/genui/server/app/a2ui/_shared.ts
@@ -6,6 +6,7 @@ import type {
   ChatMessage,
   ChatOptions,
   ConversationContext,
+  OpenAIReasoningEffort,
 } from '../../service/a2ui-agent';
 
 export interface A2UIChatBody {
@@ -16,6 +17,7 @@ export interface A2UIChatBody {
   apiKey?: string;
   baseURL?: string;
   api?: 'chat' | 'responses';
+  reasoningEffort?: OpenAIReasoningEffort;
   catalog?: A2UICatalog;
   maxRepairAttempts?: number;
   validate?: boolean;
@@ -73,6 +75,7 @@ export function pickChatOptions(body: {
   apiKey?: string;
   baseURL?: string;
   api?: 'chat' | 'responses';
+  reasoningEffort?: OpenAIReasoningEffort;
   catalog?: A2UICatalog;
   maxRepairAttempts?: number;
 }): ChatOptions {
@@ -83,6 +86,7 @@ export function pickChatOptions(body: {
     apiKey: allowOverride ? body.apiKey : undefined,
     baseURL: allowOverride ? body.baseURL : undefined,
     api: allowOverride ? body.api : undefined,
+    reasoningEffort: allowOverride ? body.reasoningEffort : undefined,
     catalog: body.catalog,
     maxRepairAttempts: body.maxRepairAttempts,
   };

--- a/packages/genui/server/app/a2ui/action/stream/route.ts
+++ b/packages/genui/server/app/a2ui/action/stream/route.ts
@@ -18,7 +18,10 @@ import {
   resolveStaticA2UIImageComponent,
 } from '../../../../agent/image-resolver';
 import { getA2UIAgentService } from '../../../../service/a2ui-agent';
-import type { ChatMessage } from '../../../../service/a2ui-agent';
+import type {
+  ChatMessage,
+  OpenAIReasoningEffort,
+} from '../../../../service/a2ui-agent';
 import {
   MAX_MESSAGE_CHARS,
   errorMessage,
@@ -65,6 +68,7 @@ interface A2UIActionStreamBody {
   model?: string;
   apiKey?: string;
   baseURL?: string;
+  reasoningEffort?: OpenAIReasoningEffort;
   catalog?: A2UICatalog;
   maxRepairAttempts?: number;
 }

--- a/packages/genui/server/app/a2ui/action/stream/route.ts
+++ b/packages/genui/server/app/a2ui/action/stream/route.ts
@@ -22,6 +22,7 @@ import type { ChatMessage } from '../../../../service/a2ui-agent';
 import {
   MAX_MESSAGE_CHARS,
   errorMessage,
+  extractUsageMetrics,
   pickChatOptions,
   readJsonBodyWithLimit,
   validateAction,
@@ -341,11 +342,17 @@ export async function POST(req: Request) {
         await Promise.allSettled(streamingImageResolutions);
 
         let { text: finalText, usage, finishReason } = await finalize();
+        let usageMetrics = extractUsageMetrics(usage);
+        let cachedTokens = usageMetrics.cachedTokens;
         finalText ??= streamedText;
         log('upstream.finalized', {
           finalTextLength: finalText?.length ?? 0,
           finishReason,
           hasUsage: usage !== undefined,
+          catalogId: catalog.id,
+          model: opts.model ?? process.env.OPENAI_MODEL ?? 'default',
+          api: opts.api ?? process.env.OPENAI_API_STYLE ?? 'default',
+          ...usageMetrics,
         });
         let repair:
           | {
@@ -434,6 +441,8 @@ export async function POST(req: Request) {
             if (repaired.ok) {
               finalText = repaired.text;
               usage = repaired.usage;
+              usageMetrics = extractUsageMetrics(usage);
+              cachedTokens = usageMetrics.cachedTokens;
               finishReason = repaired.finishReason;
               resolvedMessages = await resolveMessagesForStreaming(
                 repaired.messages,
@@ -485,11 +494,16 @@ export async function POST(req: Request) {
           hasPreviewUrl: Boolean(preview?.messagesUrl),
           repairAttempted: repair?.attempted ?? false,
           repairOk: repair?.ok,
+          catalogId: catalog.id,
+          model: opts.model ?? process.env.OPENAI_MODEL ?? 'default',
+          api: opts.api ?? process.env.OPENAI_API_STYLE ?? 'default',
+          ...usageMetrics,
           requestId,
         });
         enqueue('done', {
           text: finalText,
           usage,
+          cachedTokens,
           finishReason,
           validation,
           preview,

--- a/packages/genui/server/app/a2ui/chat/route.ts
+++ b/packages/genui/server/app/a2ui/chat/route.ts
@@ -4,6 +4,7 @@
 import { getA2UIAgentService } from '../../../service/a2ui-agent';
 import {
   errorMessage,
+  extractUsageMetrics,
   pickChatOptions,
   readJsonBodyWithLimit,
   validateConversation,
@@ -64,7 +65,13 @@ export async function POST(req: Request) {
         opts,
         validatedConversation.conversation,
       );
-      return jsonWithCors(req, { ok: true, text, usage, finishReason });
+      return jsonWithCors(req, {
+        ok: true,
+        text,
+        usage,
+        cachedTokens: extractUsageMetrics(usage).cachedTokens,
+        finishReason,
+      });
     }
 
     const validatedResult = await service.generateValidated(
@@ -72,7 +79,10 @@ export async function POST(req: Request) {
       opts,
       validatedConversation.conversation,
     );
-    return jsonWithCors(req, validatedResult);
+    return jsonWithCors(req, {
+      ...validatedResult,
+      cachedTokens: extractUsageMetrics(validatedResult.usage).cachedTokens,
+    });
   } catch (err: unknown) {
     const { message, name } = errorMessage(err);
     return jsonWithCors(req, { ok: false, error: message, name });

--- a/packages/genui/server/app/a2ui/stream/route.ts
+++ b/packages/genui/server/app/a2ui/stream/route.ts
@@ -19,6 +19,7 @@ import {
 import { getA2UIAgentService } from '../../../service/a2ui-agent';
 import {
   errorMessage,
+  extractUsageMetrics,
   pickChatOptions,
   readJsonBodyWithLimit,
   validateConversation,
@@ -286,11 +287,17 @@ export async function POST(req: Request) {
         await Promise.allSettled(streamingImageResolutions);
 
         let { text: finalText, usage, finishReason } = await finalize();
+        let usageMetrics = extractUsageMetrics(usage);
+        let cachedTokens = usageMetrics.cachedTokens;
         finalText ??= streamedText;
         log('upstream.finalized', {
           finalTextLength: finalText?.length ?? 0,
           finishReason,
           hasUsage: usage !== undefined,
+          catalogId: catalog.id,
+          model: opts.model ?? process.env.OPENAI_MODEL ?? 'default',
+          api: opts.api ?? process.env.OPENAI_API_STYLE ?? 'default',
+          ...usageMetrics,
         });
         let repair:
           | {
@@ -367,6 +374,8 @@ export async function POST(req: Request) {
             if (repaired.ok) {
               finalText = repaired.text;
               usage = repaired.usage;
+              usageMetrics = extractUsageMetrics(usage);
+              cachedTokens = usageMetrics.cachedTokens;
               finishReason = repaired.finishReason;
               resolvedMessages = await resolveMessagesForStreaming(
                 repaired.messages,
@@ -418,11 +427,16 @@ export async function POST(req: Request) {
           hasPreviewUrl: Boolean(preview?.messagesUrl),
           repairAttempted: repair?.attempted ?? false,
           repairOk: repair?.ok,
+          catalogId: catalog.id,
+          model: opts.model ?? process.env.OPENAI_MODEL ?? 'default',
+          api: opts.api ?? process.env.OPENAI_API_STYLE ?? 'default',
+          ...usageMetrics,
           requestId,
         });
         enqueue('done', {
           text: finalText,
           usage,
+          cachedTokens,
           finishReason,
           validation,
           preview,

--- a/packages/genui/server/service/a2ui-agent.ts
+++ b/packages/genui/server/service/a2ui-agent.ts
@@ -25,12 +25,21 @@ export interface ConversationContext {
   dataModel: Record<string, unknown>;
 }
 
+export type OpenAIReasoningEffort =
+  | 'none'
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh';
+
 export interface ChatOptions {
   resourceId?: string | undefined;
   apiKey?: string | undefined;
   baseURL?: string | undefined;
   model?: string | undefined;
   api?: 'chat' | 'responses' | undefined;
+  reasoningEffort?: OpenAIReasoningEffort | undefined;
   catalog?: A2UICatalog | undefined;
   maxRepairAttempts?: number | undefined;
   onPerformanceEvent?: (
@@ -65,6 +74,15 @@ interface MastraStreamResult extends MastraResult {
   textStream?: ReadableStream<string> | AsyncIterable<string>;
 }
 
+const REASONING_EFFORTS = new Set<OpenAIReasoningEffort>([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+]);
+
 function isReadableStream(
   stream: ReadableStream<string> | AsyncIterable<string>,
 ): stream is ReadableStream<string> {
@@ -84,6 +102,31 @@ function pickDefined<T extends Record<string, unknown>>(input: T): Partial<T> {
 function hashApiKey(apiKey: string | undefined): string {
   if (!apiKey) return 'default';
   return createHash('sha256').update(apiKey).digest('hex');
+}
+
+function parseReasoningEffort(
+  value: string | undefined,
+): OpenAIReasoningEffort | undefined {
+  return REASONING_EFFORTS.has(value as OpenAIReasoningEffort)
+    ? value as OpenAIReasoningEffort
+    : undefined;
+}
+
+function resolveReasoningEffort(
+  opts: ChatOptions,
+): OpenAIReasoningEffort | undefined {
+  return opts.reasoningEffort
+    ?? parseReasoningEffort(process.env.OPENAI_REASONING_EFFORT);
+}
+
+function buildAgentRunOptions(opts: ChatOptions) {
+  const reasoningEffort = resolveReasoningEffort(opts);
+  return pickDefined({
+    resourceId: opts.resourceId,
+    providerOptions: reasoningEffort
+      ? { openai: { reasoningEffort } }
+      : undefined,
+  });
 }
 
 function buildDataModelSystemMessage(
@@ -153,12 +196,12 @@ export default class A2UIAgentService {
     });
 
     const streamStartedAt = performance.now();
-    opts.onPerformanceEvent?.('agent.stream.invoke.started');
+    opts.onPerformanceEvent?.('agent.stream.invoke.started', {
+      reasoningEffort: resolveReasoningEffort(opts),
+    });
     const result = agent.stream(
       modelMessages,
-      pickDefined({
-        resourceId: opts.resourceId,
-      }),
+      buildAgentRunOptions(opts),
     ) as MastraStreamResult;
     opts.onPerformanceEvent?.('agent.stream.invoke.completed', {
       durationMs: performance.now() - streamStartedAt,
@@ -246,9 +289,7 @@ export default class A2UIAgentService {
     const agent = await this.getAgent(opts);
     return agent.generate(
       this.toModelMessages(messages),
-      pickDefined({
-        resourceId: opts.resourceId,
-      }),
+      buildAgentRunOptions(opts),
     );
   }
 
@@ -290,9 +331,7 @@ export default class A2UIAgentService {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const result = await agent.generate(
         this.toModelMessages(convo),
-        pickDefined({
-          resourceId: opts.resourceId,
-        }),
+        buildAgentRunOptions(opts),
       ) as MastraResult;
 
       const text = await extractText(result);

--- a/packages/genui/server/service/a2ui-agent.ts
+++ b/packages/genui/server/service/a2ui-agent.ts
@@ -115,7 +115,7 @@ function parseReasoningEffort(
 function resolveReasoningEffort(
   opts: ChatOptions,
 ): OpenAIReasoningEffort | undefined {
-  return opts.reasoningEffort
+  return parseReasoningEffort(opts.reasoningEffort)
     ?? parseReasoningEffort(process.env.OPENAI_REASONING_EFFORT);
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable “reasoning effort” support to A2UI requests, reflected in both generation and streaming behavior.
  * Enhanced chat and streaming responses with richer token-usage details, including cached token counts and overall usage metrics.
  * Expanded stream event payloads and logs to include derived usage metrics and cached token information.
* **Bug Fixes**
  * Improved component validation to suppress specific “missing required” and schema validation errors for server-resolved props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

- expose cached token and token usage metrics in A2UI stream/chat responses and logs
- allow server-resolved `Image.url` path references and optional Button actions to pass validation so image resolution can complete without repair

## Checklist

- [x] Tests updated (or not required). Focused validation used; no test fixture changes required.
- [x] Documentation updated (or not required). No docs changes required for server logging/validation behavior.
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required). No package release changeset required.