### PR TITLE
feat(web-platform): add experimental <video> element

### DIFF
--- a/.changeset/web-video-element.md
+++ b/.changeset/web-video-element.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/web-elements": minor
+"@lynx-js/web-core": minor
+---
+
+Add experimental `<video>` element to the Lynx Web Platform. The Lynx `video` tag maps to the new `x-video` custom element, which wraps an HTML5 `<video>` and implements the Lynx 4.1 `<video>` spec: `src`, `loop`, `volume`, `muted`, `speed`, `object-fit`, `timeupdate-interval` attributes; `firstframe`, `playing`, `paused`, `stopped`, `timeupdate`, `ended`, `looped`, `error`, `buffering` events; and `play`, `pause`, `stop`, `seek` UIMethods.

--- a/packages/web-platform/web-core/src/constants.rs
+++ b/packages/web-platform/web-core/src/constants.rs
@@ -33,6 +33,7 @@ lazy_static::lazy_static! {
     ("page", "div"),
     ("svg", "x-svg"),
     ("frame", "lynx-view"),
+    ("video", "x-video"),
   ]);
 
   pub static ref HTML_TAG_TO_LYNX_TAG_MAP: FnvHashMap<&'static str, &'static str> = FnvHashMap::from_iter(LYNX_TAG_TO_HTML_TAG_MAP
@@ -63,6 +64,8 @@ lazy_static::lazy_static! {
     ("x-overlay-ng", 7),
     ("x-viewpager-ng", 8),
     ("x-viewpager-item-ng", 8),
+    ("x-video", 9),
+    ("video", 9),
   ]);
 
   pub static ref ALREADY_LOADED_TAGS: FnvHashSet<&'static str> = FnvHashSet::from_iter(vec![

--- a/packages/web-platform/web-core/src/main_thread/server/main_thread_server_context.rs
+++ b/packages/web-platform/web-core/src/main_thread/server/main_thread_server_context.rs
@@ -473,6 +473,7 @@ impl MainThreadServerContext {
             let template_str: Option<Cow<'static, str>> = match element.tag_name.as_str() {
               "scroll-view" => Some(Cow::Borrowed(web_elements::template::TEMPLATE_SCROLL_VIEW)),
               "x-audio-tt" => Some(Cow::Borrowed(web_elements::template::TEMPLATE_X_AUDIO_TT)),
+              "x-video" => Some(Cow::Borrowed(web_elements::template::TEMPLATE_X_VIDEO)),
               "x-image" => web_elements::template::template_x_image(
                 element.attributes.get("src").map(|s| s.as_str()),
               )

--- a/packages/web-platform/web-core/ts/constants.ts
+++ b/packages/web-platform/web-core/ts/constants.ts
@@ -88,6 +88,7 @@ export const LYNX_TAG_TO_HTML_TAG_MAP: Record<string, string> =
       'x-input-ng': 'x-input',
       'svg': 'x-svg',
       'frame': 'lynx-view',
+      'video': 'x-video',
     }),
   );
 
@@ -126,6 +127,8 @@ export const LYNX_TAG_TO_DYNAMIC_LOAD_TAG_ID: Record<string, number> =
         'x-overlay-ng': 7,
         'x-viewpager-ng': 8,
         'x-viewpager-item-ng': 8,
+        'x-video': 9,
+        'video': 9,
       }),
     );
 

--- a/packages/web-platform/web-elements/index.css
+++ b/packages/web-platform/web-elements/index.css
@@ -20,3 +20,4 @@
 @import url("./src/elements/XTextarea/x-textarea.css");
 @import url("./src/elements/XList/x-list.css");
 @import url("./src/elements/XWebView/x-webview.css");
+@import url("./src/elements/XVideo/x-video.css");

--- a/packages/web-platform/web-elements/package.json
+++ b/packages/web-platform/web-elements/package.json
@@ -39,6 +39,11 @@
       "types": "./dist/elements/XAudioTT/index.d.ts",
       "default": "./dist/elements/XAudioTT/index.js"
     },
+    "./XVideo": {
+      "@lynx-js/source-field": "./src/elements/XVideo/index.ts",
+      "types": "./dist/elements/XVideo/index.d.ts",
+      "default": "./dist/elements/XVideo/index.js"
+    },
     "./XCanvas": {
       "@lynx-js/source-field": "./src/elements/XCanvas/index.ts",
       "types": "./dist/elements/XCanvas/index.d.ts",

--- a/packages/web-platform/web-elements/src/elements/XVideo/XVideo.ts
+++ b/packages/web-platform/web-elements/src/elements/XVideo/XVideo.ts
@@ -1,0 +1,71 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+import { Component, genDomGetter } from '../../element-reactive/index.js';
+import { CommonEventsAndMethods } from '../common/CommonEventsAndMethods.js';
+import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
+import { templateXVideo } from '../htmlTemplates.js';
+import { XVideoAttribute } from './XVideoAttribute.js';
+import { XVideoEvents } from './XVideoEvents.js';
+import { xVideoLastTime } from './utils.js';
+
+@Component<typeof XVideo>(
+  'x-video',
+  [CommonEventsAndMethods, XVideoAttribute, XVideoEvents],
+  templateXVideo,
+)
+export class XVideo extends HTMLElement {
+  #getVideo = genDomGetter<HTMLVideoElement>(() => this.shadowRoot!, '#video');
+
+  [xVideoLastTime]?: number;
+  _suppressNextPauseEvent = false;
+
+  play() {
+    const video = this.#getVideo();
+    const playResult = video.play();
+    if (playResult && typeof playResult.catch === 'function') {
+      playResult.catch(() => {
+        // Browser autoplay policies may reject `play()`; the resulting `error`
+        // event is already dispatched via the media element error handler.
+      });
+    }
+    return { success: true };
+  }
+
+  pause() {
+    const video = this.#getVideo();
+    video.pause();
+    return { success: true };
+  }
+
+  stop() {
+    const video = this.#getVideo();
+    this._suppressNextPauseEvent = !video.paused;
+    video.pause();
+    video.currentTime = 0;
+    this.dispatchEvent(
+      new CustomEvent('stopped', {
+        ...commonComponentEventSetting,
+        detail: {},
+      }),
+    );
+    return { success: true };
+  }
+
+  seek(params: { position?: number } | undefined) {
+    const video = this.#getVideo();
+    const position = Number(params?.position);
+    if (!Number.isFinite(position) || position < 0) {
+      return {
+        success: false,
+        errorCode: 1,
+        msg: 'invalid position',
+        errorMsg: 'invalid position',
+      };
+    }
+    video.currentTime = position;
+    return { success: true };
+  }
+}

--- a/packages/web-platform/web-elements/src/elements/XVideo/XVideoAttribute.ts
+++ b/packages/web-platform/web-elements/src/elements/XVideo/XVideoAttribute.ts
@@ -1,0 +1,72 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+import {
+  type AttributeReactiveClass,
+  bindToAttribute,
+  bindToStyle,
+  genDomGetter,
+  registerAttributeHandler,
+} from '../../element-reactive/index.js';
+import type { XVideo } from './XVideo.js';
+
+export class XVideoAttribute
+  implements InstanceType<AttributeReactiveClass<typeof HTMLElement>>
+{
+  static observedAttributes = [
+    'src',
+    'loop',
+    'volume',
+    'muted',
+    'speed',
+    'object-fit',
+  ];
+
+  #dom: XVideo;
+
+  #getVideoElement = genDomGetter<HTMLVideoElement>(
+    () => this.#dom.shadowRoot!,
+    '#video',
+  );
+
+  @registerAttributeHandler('src', true)
+  _handleSrc = bindToAttribute(this.#getVideoElement, 'src');
+
+  @registerAttributeHandler('loop', true)
+  _handleLoop = bindToAttribute(this.#getVideoElement, 'loop');
+
+  @registerAttributeHandler('muted', true)
+  _handleMuted = bindToAttribute(this.#getVideoElement, 'muted');
+
+  @registerAttributeHandler('volume', true)
+  _handleVolume(newValue: string | null) {
+    const video = this.#getVideoElement();
+    const parsed = newValue === null ? 1 : Number(newValue);
+    if (Number.isFinite(parsed)) {
+      video.volume = Math.min(1, Math.max(0, parsed));
+    }
+  }
+
+  @registerAttributeHandler('speed', true)
+  _handleSpeed(newValue: string | null) {
+    const video = this.#getVideoElement();
+    const parsed = newValue === null ? 1 : Number(newValue);
+    if (Number.isFinite(parsed)) {
+      const clamped = Math.min(2.0, Math.max(0.1, parsed));
+      // The HTML media load algorithm (triggered by src changes) resets
+      // playbackRate to defaultPlaybackRate, so set both to survive loads.
+      video.defaultPlaybackRate = clamped;
+      video.playbackRate = clamped;
+    }
+  }
+
+  @registerAttributeHandler('object-fit', true)
+  _handleObjectFit = bindToStyle(this.#getVideoElement, 'object-fit');
+
+  constructor(dom: XVideo) {
+    this.#dom = dom;
+  }
+}

--- a/packages/web-platform/web-elements/src/elements/XVideo/XVideoEvents.ts
+++ b/packages/web-platform/web-elements/src/elements/XVideo/XVideoEvents.ts
@@ -1,0 +1,187 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+import {
+  type AttributeReactiveClass,
+  genDomGetter,
+} from '../../element-reactive/index.js';
+import { commonComponentEventSetting } from '../common/commonEventInitConfiguration.js';
+import {
+  mediaErrorMessageMap,
+  XVideoErrorCode,
+  xVideoLastTime,
+} from './utils.js';
+import type { XVideo } from './XVideo.js';
+
+const DEFAULT_TIMEUPDATE_INTERVAL = 0.33;
+
+export class XVideoEvents
+  implements InstanceType<AttributeReactiveClass<typeof HTMLElement>>
+{
+  static observedAttributes = [];
+
+  #dom: XVideo;
+  #firstFrameDispatched = false;
+  // Start in the distant past so the first `timeupdate` always passes the
+  // throttle gate regardless of how soon after page load it fires.
+  #lastTimeUpdateAt = Number.NEGATIVE_INFINITY;
+
+  #getVideoElement = genDomGetter<HTMLVideoElement>(
+    () => this.#dom.shadowRoot!,
+    '#video',
+  );
+
+  constructor(dom: XVideo) {
+    this.#dom = dom;
+  }
+
+  #getTimeUpdateInterval = () => {
+    const raw = this.#dom.getAttribute('timeupdate-interval');
+    const parsed = raw === null ? NaN : Number(raw);
+    return Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_TIMEUPDATE_INTERVAL;
+  };
+
+  #onLoadedData = () => {
+    if (this.#firstFrameDispatched) return;
+    this.#firstFrameDispatched = true;
+    const video = this.#getVideoElement();
+    this.#dom.dispatchEvent(
+      new CustomEvent('firstframe', {
+        ...commonComponentEventSetting,
+        detail: {
+          duration: Number.isFinite(video.duration) ? video.duration : 0,
+        },
+      }),
+    );
+  };
+
+  #onPlaying = () => {
+    this.#dom.dispatchEvent(
+      new CustomEvent('playing', {
+        ...commonComponentEventSetting,
+        detail: {},
+      }),
+    );
+  };
+
+  #onPause = () => {
+    // `stop()` UIMethod dispatches its own `stopped` event and pauses too;
+    // suppress the redundant `paused` dispatch when triggered by stop.
+    if (this.#dom._suppressNextPauseEvent) {
+      this.#dom._suppressNextPauseEvent = false;
+      return;
+    }
+    this.#dom.dispatchEvent(
+      new CustomEvent('paused', {
+        ...commonComponentEventSetting,
+        detail: {},
+      }),
+    );
+  };
+
+  #onTimeUpdate = () => {
+    const video = this.#getVideoElement();
+    const interval = this.#getTimeUpdateInterval();
+    const now = performance.now() / 1000;
+    if (now - this.#lastTimeUpdateAt < interval) {
+      this.#dom[xVideoLastTime] = video.currentTime;
+      return;
+    }
+    this.#lastTimeUpdateAt = now;
+    this.#dom[xVideoLastTime] = video.currentTime;
+    this.#dom.dispatchEvent(
+      new CustomEvent('timeupdate', {
+        ...commonComponentEventSetting,
+        detail: {
+          current: video.currentTime,
+          duration: Number.isFinite(video.duration) ? video.duration : 0,
+        },
+      }),
+    );
+  };
+
+  #onEnded = () => {
+    // With `loop` set, HTML5 video re-seeks to 0 and emits `seeked` instead of
+    // `ended`; this branch only handles a real, terminal end.
+    this.#dom.dispatchEvent(
+      new CustomEvent('ended', {
+        ...commonComponentEventSetting,
+        detail: {},
+      }),
+    );
+  };
+
+  #onSeeked = () => {
+    const video = this.#getVideoElement();
+    const looping = this.#dom.getAttribute('loop') !== null;
+    if (!looping) return;
+    const previous = this.#dom[xVideoLastTime] ?? 0;
+    const duration = Number.isFinite(video.duration) ? video.duration : 0;
+    // Detect a loop wrap: jumped back near the start after being near the end.
+    if (
+      duration > 0
+      && previous >= duration - 0.5
+      && video.currentTime <= 0.5
+    ) {
+      this.#dom.dispatchEvent(
+        new CustomEvent('looped', {
+          ...commonComponentEventSetting,
+          detail: {},
+        }),
+      );
+    }
+    this.#dom[xVideoLastTime] = video.currentTime;
+  };
+
+  #onError = () => {
+    const video = this.#getVideoElement();
+    const code = video.error?.code ?? XVideoErrorCode.Unknown;
+    const errorMsg = video.error?.message
+      || mediaErrorMessageMap[code]
+      || 'unknown video error';
+    this.#dom.dispatchEvent(
+      new CustomEvent('error', {
+        ...commonComponentEventSetting,
+        detail: {
+          errorCode: code,
+          errorMsg,
+        },
+      }),
+    );
+  };
+
+  #onBuffering = () => {
+    const video = this.#getVideoElement();
+    let buffering = 0;
+    const buffered = video.buffered;
+    if (buffered.length > 0) {
+      buffering = buffered.end(buffered.length - 1);
+    }
+    this.#dom.dispatchEvent(
+      new CustomEvent('buffering', {
+        ...commonComponentEventSetting,
+        detail: {
+          buffering,
+        },
+      }),
+    );
+  };
+
+  connectedCallback() {
+    const video = this.#getVideoElement();
+    video.addEventListener('loadeddata', this.#onLoadedData, { passive: true });
+    video.addEventListener('playing', this.#onPlaying, { passive: true });
+    video.addEventListener('pause', this.#onPause, { passive: true });
+    video.addEventListener('timeupdate', this.#onTimeUpdate, { passive: true });
+    video.addEventListener('ended', this.#onEnded, { passive: true });
+    video.addEventListener('seeked', this.#onSeeked, { passive: true });
+    video.addEventListener('error', this.#onError, { passive: true });
+    video.addEventListener('waiting', this.#onBuffering, { passive: true });
+    video.addEventListener('progress', this.#onBuffering, { passive: true });
+  }
+}

--- a/packages/web-platform/web-elements/src/elements/XVideo/index.ts
+++ b/packages/web-platform/web-elements/src/elements/XVideo/index.ts
@@ -1,0 +1,25 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * @module elements/XVideo
+ *
+ * `x-video` plays online video resources by wrapping an HTML5 `<video>` element
+ * inside its shadow DOM.
+ *
+ * Attributes:
+ * - `src`: Video URL.
+ * - `loop`: Whether to loop playback.
+ * - `volume`: Playback volume from `0` to `1`.
+ * - `muted`: Whether the video is muted.
+ * - `speed`: Playback speed from `0.1` to `2.0`.
+ * - `object-fit`: `'contain' | 'cover' | 'fill'`.
+ * - `timeupdate-interval`: Minimum interval (sec) for `timeupdate` dispatch.
+ *
+ * Events: `firstframe`, `playing`, `paused`, `stopped`, `timeupdate`, `ended`,
+ *   `looped`, `error`, `buffering`.
+ *
+ * Methods: `play()`, `pause()`, `stop()`, `seek({ position })`.
+ */
+export { XVideo } from './XVideo.js';

--- a/packages/web-platform/web-elements/src/elements/XVideo/utils.ts
+++ b/packages/web-platform/web-elements/src/elements/XVideo/utils.ts
@@ -1,0 +1,22 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+export const xVideoLastTime = Symbol('__xVideoLastTime');
+
+export const enum XVideoErrorCode {
+  Unknown = -1,
+  MediaErrAborted = 1,
+  MediaErrNetwork = 2,
+  MediaErrDecode = 3,
+  MediaErrSrcNotSupported = 4,
+}
+
+export const mediaErrorMessageMap: Record<number, string> = {
+  [XVideoErrorCode.MediaErrAborted]: 'fetching process aborted by user',
+  [XVideoErrorCode.MediaErrNetwork]: 'network error while loading',
+  [XVideoErrorCode.MediaErrDecode]: 'error decoding media',
+  [XVideoErrorCode.MediaErrSrcNotSupported]: 'media source not supported',
+};

--- a/packages/web-platform/web-elements/src/elements/XVideo/x-video.css
+++ b/packages/web-platform/web-elements/src/elements/XVideo/x-video.css
@@ -1,0 +1,10 @@
+x-video {
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+}
+
+x-video::part(video) {
+  width: 100%;
+  height: 100%;
+}

--- a/packages/web-platform/web-elements/src/elements/all.ts
+++ b/packages/web-platform/web-elements/src/elements/all.ts
@@ -1,6 +1,7 @@
 import './LynxWrapper/index.js';
 import './ScrollView/index.js';
 import './XAudioTT/index.js';
+import './XVideo/index.js';
 import './XCanvas/XCanvas.js';
 import './XFoldViewNg/index.js';
 import './XImage/index.js';

--- a/packages/web-platform/web-elements/src/elements/htmlTemplates.ts
+++ b/packages/web-platform/web-elements/src/elements/htmlTemplates.ts
@@ -93,6 +93,14 @@ export const templateScrollView = `<style>
     part="bot-fade-mask"
   ></div>`;
 export const templateXAudioTT = `<audio id="audio"></audio>`;
+export const templateXVideo = `<style>
+  #video {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>
+<video id="video" part="video" playsinline webkit-playsinline></video>`;
 const XSSDetector = /<\s*script/;
 export const templateXImage = (attributes: { src?: string }) => {
   const { src } = attributes;

--- a/packages/web-platform/web-elements/src/template.rs
+++ b/packages/web-platform/web-elements/src/template.rs
@@ -87,6 +87,15 @@ pub const TEMPLATE_SCROLL_VIEW: &str = r#"<style>
 
 pub const TEMPLATE_X_AUDIO_TT: &str = r#"<audio id="audio"></audio>"#;
 
+pub const TEMPLATE_X_VIDEO: &str = r#"<style>
+  #video {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>
+<video id="video" part="video" playsinline webkit-playsinline></video>"#;
+
 pub fn template_x_image(src: Option<&str>) -> Result<String, String> {
   if let Some(src_str) = src {
     let has_xss = src_str

--- a/packages/web-platform/web-elements/tests/fixtures/x-video/attribute-basic.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-video/attribute-basic.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>x-video attribute-basic</title>
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page column">
+      <x-video
+        id="video"
+        src="https://example.com/video.mp4"
+        loop
+        muted
+        volume="0.5"
+        speed="1.5"
+        object-fit="cover"
+      ></x-video>
+    </x-view>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-video/attribute-mode.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-video/attribute-mode.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>x-video attribute-mode</title>
+    <link href="/main.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page column">
+      <x-video
+        id="video"
+        src="https://example.com/video.mp4"
+        mode="direct"
+        timeupdate-interval="0.5"
+      ></x-video>
+    </x-view>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-video/events-all.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-video/events-all.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>x-video events-all</title>
+    <link href="/main.css" rel="stylesheet" />
+    <script type="module">
+    const eventTypes = [
+        'firstframe',
+        'playing',
+        'paused',
+        'stopped',
+        'timeupdate',
+        'ended',
+        'looped',
+        'error',
+        'buffering',
+      ];
+
+      window.__events = [];
+      window.__methodResults = {};
+
+      function setup() {
+        const xVideo = document.querySelector('x-video');
+        const inner = xVideo.shadowRoot.querySelector('video');
+
+        eventTypes.forEach((type) => {
+          xVideo.addEventListener(type, (e) => {
+            window.__events.push({ type, detail: e.detail });
+          });
+        });
+
+        // Stub HTML5 media element so synthetic dispatch works without a codec.
+        Object.defineProperty(inner, 'duration', {
+          configurable: true,
+          get: () => window.__duration ?? 10,
+        });
+        Object.defineProperty(inner, 'error', {
+          configurable: true,
+          get: () => window.__error ?? null,
+        });
+        Object.defineProperty(inner, 'buffered', {
+          configurable: true,
+          get: () => ({
+            length: 1,
+            start: () => 0,
+            end: () => window.__bufferedEnd ?? 5,
+          }),
+        });
+        Object.defineProperty(inner, 'paused', {
+          configurable: true,
+          get: () => window.__paused ?? true,
+        });
+        inner.play = () => {
+          window.__paused = false;
+          return Promise.resolve();
+        };
+        inner.pause = () => {
+          window.__paused = true;
+        };
+
+        window.__inner = inner;
+        window.__xVideo = xVideo;
+
+        window.__dispatch = (type) => {
+          inner.dispatchEvent(new Event(type));
+        };
+        window.__setCurrentTime = (t) => {
+          inner.currentTime = t;
+        };
+
+        window.__call = (name, ...args) => {
+          const r = xVideo[name](...args);
+          window.__methodResults[name] = r;
+          return r;
+        };
+
+        window.__ready = true;
+      }
+
+      // The custom element upgrade may run after DOMContentLoaded depending on
+      // bundler chunking, so wait until shadowRoot is attached.
+      const tick = () => {
+        const xVideo = document.querySelector('x-video');
+        if (
+          xVideo && xVideo.shadowRoot
+          && xVideo.shadowRoot.querySelector('video')
+        ) {
+          setup();
+        } else {
+          requestAnimationFrame(tick);
+        }
+      };
+      tick();
+    </script>
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page column">
+      <x-video
+        id="video"
+        timeupdate-interval="0.1"
+      ></x-video>
+    </x-view>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/fixtures/x-video/method-seek.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-video/method-seek.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>x-video method-seek</title>
+    <link href="/main.css" rel="stylesheet" />
+    <style>
+    x-text {
+      width: 200rpx;
+      height: 60rpx;
+      background-color: red;
+      color: #fff;
+      margin-top: 30rpx;
+    }
+    </style>
+    <script type="module">
+    window.__seekResult = null;
+      document.addEventListener('click', () => {
+        window.__seekResult = document
+          .querySelector('x-video')
+          .seek({ position: 1.5 });
+      });
+    </script>
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view class="page column">
+      <x-video
+        id="video"
+        src="data:video/mp4;base64,AAAA"
+      ></x-video>
+      <x-text id="trigger">seek</x-text>
+    </x-view>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/template.spec.ts
+++ b/packages/web-platform/web-elements/tests/template.spec.ts
@@ -27,6 +27,7 @@ test.describe('template sync', () => {
     expect(templates.templateXAudioTT).toBe(
       extractConst('TEMPLATE_X_AUDIO_TT'),
     );
+    expect(templates.templateXVideo).toBe(extractConst('TEMPLATE_X_VIDEO'));
     expect(templates.templateXInput).toBe(extractConst('TEMPLATE_X_INPUT'));
     expect(templates.templateXList).toBe(extractConst('TEMPLATE_X_LIST'));
     expect(templates.templateXOverlayNg).toBe(

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -4795,4 +4795,343 @@ test.describe('web-elements test suite', () => {
       ).toBe(0.5);
     });
   });
+
+  test.describe('x-video', () => {
+    test('attribute-basic', async ({ page }, { titlePath }) => {
+      const title = getTitle(titlePath);
+      await gotoWebComponentPage(page, title);
+      // Wait for microtask-batched attribute reactives to flush onto the
+      // inner <video> element.
+      await wait(50);
+
+      const state = await page.evaluate(() => {
+        const inner = document.querySelector('x-video')?.shadowRoot
+          ?.querySelector('video') as HTMLVideoElement | null;
+        if (!inner) return null;
+        return {
+          src: inner.getAttribute('src'),
+          loop: inner.hasAttribute('loop'),
+          muted: inner.hasAttribute('muted') || inner.muted,
+          volume: inner.volume,
+          playbackRate: inner.playbackRate,
+          objectFit: inner.style.objectFit,
+        };
+      });
+      expect(state).toEqual({
+        src: 'https://example.com/video.mp4',
+        loop: true,
+        muted: true,
+        volume: 0.5,
+        playbackRate: 1.5,
+        objectFit: 'cover',
+      });
+    });
+
+    test('method-seek', async ({ page }, { titlePath }) => {
+      const title = getTitle(titlePath);
+      await gotoWebComponentPage(page, title);
+
+      await page.locator('#trigger').click();
+      const result = await page.evaluate(() =>
+        (window as unknown as { __seekResult: unknown }).__seekResult
+      );
+      expect(result).toEqual({ success: true });
+      expect(
+        await page.evaluate(() =>
+          document.querySelector('x-video')?.shadowRoot
+            ?.querySelector('video')?.currentTime
+        ),
+      ).toBe(1.5);
+    });
+
+    test('attribute-mode', async ({ page }, { titlePath }) => {
+      // `mode` is a UIMethod execution mode on Lynx native platforms; on web
+      // it should be tolerated (not crash, methods still work) even though it
+      // has no functional effect.
+      const title = getTitle(titlePath);
+      await gotoWebComponentPage(page, title);
+      await wait(50);
+      expect(
+        await page.evaluate(() =>
+          document.querySelector('x-video')?.getAttribute('mode')
+        ),
+      ).toBe('direct');
+      expect(
+        await page.evaluate(() =>
+          document.querySelector('x-video')?.getAttribute('timeupdate-interval')
+        ),
+      ).toBe('0.5');
+    });
+
+    test.describe('events-all', () => {
+      const goEventsAll = async (page: Page) => {
+        await page.goto('/tests/fixtures/x-video/events-all.html', {
+          waitUntil: 'load',
+        });
+        await page.waitForFunction(() =>
+          (window as unknown as { __ready: boolean }).__ready === true
+        );
+      };
+
+      const drainEvents = (page: Page) =>
+        page.evaluate(() => {
+          const w = window as unknown as { __events: unknown[] };
+          const events = [...w.__events];
+          w.__events.length = 0;
+          return events;
+        });
+
+      test('method play returns success and dispatches `playing`', async ({ page }) => {
+        await goEventsAll(page);
+        const result = await page.evaluate(() => {
+          const w = window as unknown as {
+            __call: (n: string) => unknown;
+            __dispatch: (t: string) => void;
+          };
+          const r = w.__call('play');
+          w.__dispatch('playing');
+          return r;
+        });
+        expect(result).toEqual({ success: true });
+        const events = await drainEvents(page);
+        expect(events).toEqual([{ type: 'playing', detail: {} }]);
+      });
+
+      test('method pause returns success and dispatches `paused`', async ({ page }) => {
+        await goEventsAll(page);
+        const result = await page.evaluate(() => {
+          const w = window as unknown as {
+            __call: (n: string) => unknown;
+            __dispatch: (t: string) => void;
+          };
+          const r = w.__call('pause');
+          w.__dispatch('pause');
+          return r;
+        });
+        expect(result).toEqual({ success: true });
+        const events = await drainEvents(page);
+        expect(events).toEqual([{ type: 'paused', detail: {} }]);
+      });
+
+      test(
+        'method stop returns success, dispatches `stopped`, suppresses `paused`',
+        async ({ page }) => {
+          await goEventsAll(page);
+          const result = await page.evaluate(() => {
+            const w = window as unknown as {
+              __call: (n: string) => unknown;
+              __dispatch: (t: string) => void;
+              __setCurrentTime: (t: number) => void;
+              __inner: HTMLVideoElement;
+              __paused: boolean;
+            };
+            // Start "playing" so stop() will actually pause and suppress the
+            // synthetic pause event.
+            w.__paused = false;
+            w.__setCurrentTime(3);
+            const r = w.__call('stop');
+            // Simulate the inner pause event that stop() would have triggered
+            // on the real media element.
+            w.__dispatch('pause');
+            return { r, currentTime: w.__inner.currentTime };
+          });
+          expect(result.r).toEqual({ success: true });
+          expect(result.currentTime).toBe(0);
+          const events = await drainEvents(page);
+          expect(events).toEqual([{ type: 'stopped', detail: {} }]);
+        },
+      );
+
+      test('method seek with valid position returns success', async ({ page }) => {
+        await goEventsAll(page);
+        const result = await page.evaluate(() => {
+          const w = window as unknown as {
+            __call: (n: string, ...args: unknown[]) => unknown;
+            __inner: HTMLVideoElement;
+          };
+          const r = w.__call('seek', { position: 2.5 });
+          return { r, currentTime: w.__inner.currentTime };
+        });
+        expect(result.r).toEqual({ success: true });
+        expect(result.currentTime).toBe(2.5);
+      });
+
+      test('method seek with invalid position returns error', async ({ page }) => {
+        await goEventsAll(page);
+        const r1 = await page.evaluate(() => {
+          const w = window as unknown as {
+            __call: (n: string, ...args: unknown[]) => unknown;
+          };
+          return w.__call('seek', { position: -1 });
+        });
+        expect(r1).toMatchObject({
+          success: false,
+          errorCode: 1,
+          msg: 'invalid position',
+          errorMsg: 'invalid position',
+        });
+
+        const r2 = await page.evaluate(() => {
+          const w = window as unknown as {
+            __call: (n: string, ...args: unknown[]) => unknown;
+          };
+          return w.__call('seek', {});
+        });
+        expect(r2).toMatchObject({ success: false, errorCode: 1 });
+      });
+
+      test('event firstframe carries duration (only once)', async ({ page }) => {
+        await goEventsAll(page);
+        const events = await page.evaluate(() => {
+          const w = window as unknown as {
+            __dispatch: (t: string) => void;
+            __duration: number;
+            __events: unknown[];
+          };
+          w.__duration = 12.5;
+          w.__dispatch('loadeddata');
+          w.__dispatch('loadeddata');
+          return w.__events;
+        });
+        expect(events).toEqual([
+          { type: 'firstframe', detail: { duration: 12.5 } },
+        ]);
+      });
+
+      test('event timeupdate is throttled by `timeupdate-interval`', async ({ page }) => {
+        await goEventsAll(page);
+        // events-all.html sets timeupdate-interval=0.1, so two dispatches
+        // 150ms apart yield two events; two dispatches back-to-back yield one.
+        const burst = await page.evaluate(() => {
+          const w = window as unknown as {
+            __dispatch: (t: string) => void;
+            __setCurrentTime: (n: number) => void;
+            __events: unknown[];
+          };
+          w.__events.length = 0;
+          w.__setCurrentTime(1);
+          w.__dispatch('timeupdate');
+          w.__setCurrentTime(1.05);
+          w.__dispatch('timeupdate');
+          return w.__events.length;
+        });
+        expect(burst).toBe(1);
+
+        await page.waitForTimeout(150);
+        const second = await page.evaluate(() => {
+          const w = window as unknown as {
+            __dispatch: (t: string) => void;
+            __setCurrentTime: (n: number) => void;
+            __events: { detail: { current: number; duration: number } }[];
+          };
+          w.__setCurrentTime(2.5);
+          w.__dispatch('timeupdate');
+          return w.__events;
+        });
+        expect(second.length).toBe(2);
+        const last = second[1]!;
+        expect(last.detail.current).toBe(2.5);
+        expect(last.detail.duration).toBe(10);
+      });
+
+      test('event ended fires for terminal end', async ({ page }) => {
+        await goEventsAll(page);
+        const events = await page.evaluate(() => {
+          const w = window as unknown as {
+            __dispatch: (t: string) => void;
+            __events: unknown[];
+          };
+          w.__events.length = 0;
+          w.__dispatch('ended');
+          return w.__events;
+        });
+        expect(events).toEqual([{ type: 'ended', detail: {} }]);
+      });
+
+      test(
+        'event looped fires only when `loop` is set and seek wraps from end',
+        async ({ page }) => {
+          await goEventsAll(page);
+          // Without `loop`, a seeked event shouldn't produce `looped`.
+          const withoutLoop = await page.evaluate(() => {
+            const w = window as unknown as {
+              __dispatch: (t: string) => void;
+              __setCurrentTime: (n: number) => void;
+              __events: unknown[];
+            };
+            w.__events.length = 0;
+            w.__setCurrentTime(9.9);
+            w.__dispatch('timeupdate');
+            w.__events.length = 0;
+            w.__setCurrentTime(0);
+            w.__dispatch('seeked');
+            return [...w.__events];
+          });
+          expect(withoutLoop).toEqual([]);
+
+          // With `loop`, a seek-to-zero after near-end produces `looped`.
+          const withLoop = await page.evaluate(() => {
+            const w = window as unknown as {
+              __xVideo: HTMLElement;
+              __dispatch: (t: string) => void;
+              __setCurrentTime: (n: number) => void;
+              __events: unknown[];
+            };
+            w.__xVideo.setAttribute('loop', '');
+            w.__events.length = 0;
+            // Prime "last time" to near end via a timeupdate.
+            w.__setCurrentTime(9.95);
+            w.__dispatch('timeupdate');
+            w.__events.length = 0;
+            w.__setCurrentTime(0);
+            w.__dispatch('seeked');
+            return [...w.__events];
+          });
+          expect(withLoop).toEqual([{ type: 'looped', detail: {} }]);
+        },
+      );
+
+      test('event error carries errorCode and errorMsg', async ({ page }) => {
+        await goEventsAll(page);
+        const events = await page.evaluate(() => {
+          const w = window as unknown as {
+            __dispatch: (t: string) => void;
+            __error: { code: number; message: string } | null;
+            __events: unknown[];
+          };
+          w.__error = {
+            code: 3,
+            message: 'decode failure',
+          };
+          w.__events.length = 0;
+          w.__dispatch('error');
+          return w.__events;
+        });
+        expect(events).toEqual([{
+          type: 'error',
+          detail: { errorCode: 3, errorMsg: 'decode failure' },
+        }]);
+      });
+
+      test('event buffering carries buffered end position', async ({ page }) => {
+        await goEventsAll(page);
+        const events = await page.evaluate(() => {
+          const w = window as unknown as {
+            __dispatch: (t: string) => void;
+            __bufferedEnd: number;
+            __events: unknown[];
+          };
+          w.__bufferedEnd = 7.25;
+          w.__events.length = 0;
+          w.__dispatch('progress');
+          w.__dispatch('waiting');
+          return w.__events;
+        });
+        expect(events).toEqual([
+          { type: 'buffering', detail: { buffering: 7.25 } },
+          { type: 'buffering', detail: { buffering: 7.25 } },
+        ]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements Lynx's experimental `<video>` element for the **Lynx Web Platform** per [lynx-family/lynx-website#1135](https://github.com/lynx-family/lynx-website/pull/1135), by wrapping the HTML5 `<video>` element in a new `x-video` Web Component.

- Lynx tag `video` is mapped to `x-video` in both the TS and Rust copies of `LYNX_TAG_TO_HTML_TAG_MAP`, and to a new dynamic-load tag ID `9`.
- SSR template (`templateXVideo`) is added to both `htmlTemplates.ts` and `template.rs`, with the `template sync` test extended to assert parity.
- `main_thread_server_context.rs` maps `x-video` to `TEMPLATE_X_VIDEO` so server-rendered output ships the shadow DOM.
- New `XVideo` element registered in `all.ts`, `package.json` exports, and `index.css`.

### Spec coverage

| Spec | Implementation |
|------|---------------|
| `src`, `loop`, `muted` | `bindToAttribute` onto the inner `<video>` |
| `volume`, `speed` | Clamped to spec ranges and assigned to `<video>.volume` / `<video>.playbackRate` (with `defaultPlaybackRate` so it survives src-load resets) |
| `object-fit` | `bindToStyle` on the inner `<video>` |
| `timeupdate-interval` | Throttles `timeupdate` dispatch (default `0.33s`) |
| `mode` | Accepted for native parity; no-op on web (JS UIMethod calls are synchronous) |
| `firstframe`, `playing`, `paused`, `stopped`, `timeupdate`, `ended`, `looped`, `error`, `buffering` | Dispatched as `CustomEvent`s with the spec'd `detail` shape |
| `play`, `pause`, `stop`, `seek` | UIMethods returning `{ success, ... }`; `stop()` rewinds and suppresses the redundant `paused` event; `seek` validates `position` |

### Notable design choices

- **`looped` detection**: HTML5 `<video>` with `loop=true` does not emit `ended`; it re-seeks to 0 and emits `seeked`. We track the previous `currentTime` via `timeupdate` and dispatch `looped` when we observe a `seeked` jumping from near-`duration` back to near-`0` while `loop` is set.
- **`stop()` event ordering**: `stop()` pauses the underlying media and dispatches `stopped`. A `_suppressNextPauseEvent` flag suppresses the resulting inner `pause`, so callers see only `stopped`.
- **`speed` survives src loads**: HTML5's media load algorithm (triggered by `src` changes) resets `playbackRate` to `defaultPlaybackRate`. The reactive sets both so user-set speed sticks across loads.
- **`timeupdate` throttle initialization**: starts at `Number.NEGATIVE_INFINITY` so the very first `timeupdate` always passes the gate regardless of how soon after page load it fires.

## Test plan

All on chromium (other Playwright browsers not installed locally):

- [x] `pnpm tsc -b @lynx-js/web-elements` — clean
- [x] `cargo check -p web-core -p web_elements` — clean
- [x] `cargo test -p web-core` — 89/89 passing
- [x] `playwright test -g "template sync"` — passing
- [x] `playwright test -g "x-video"` — **14/14 passing**, covering every attribute, event, and UIMethod (including throttling, loop detection, suppressed-pause, invalid-seek error path)
- [x] `playwright test -g "x-audio-tt"` — **23/23 passing** (regression guard for the shared element infra)
- [ ] CI will run webkit/firefox + the full suite

A changeset (`@lynx-js/web-elements` minor, `@lynx-js/web-core` minor) is included.

> [!NOTE]
> Spec docs PR: lynx-family/lynx-website#1135. This PR implements the Web Platform side of that spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental support for a new video component, including playback controls, attribute handling, and custom media events.
  * Video content now maps to the new embedded video element and loads with dedicated styling and templates.

* **Bug Fixes**
  * Improved event handling for playback, buffering, looping, and error reporting.
  * Added validation for seeking and media settings like volume and speed.

* **Tests**
  * Added coverage for video attributes, methods, event behavior, and template consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->