### PR TITLE
fix(website): redirect legacy a2ui route

### DIFF
--- a/.github/genui-docs.instructions.md
+++ b/.github/genui-docs.instructions.md
@@ -14,4 +14,6 @@ When documenting GenUI CLI usage, use `npx @lynx-js/a2ui-cli` as the user-facing
 
 When documenting the GenUI playground, only present the hosted URL `https://lynx-stack.dev/genui/` as the trial path. Do not document local `genui-playground` package usage, local server startup, or local playground endpoint overrides in user-facing docs; the package is not planned as a published product surface.
 
+Keep the legacy hosted playground route `https://lynx-stack.dev/a2ui` as a Rspress client redirect to `https://lynx-stack.dev/genui` for users with old links. Configure it in `website/rspress.config.ts` with `@rspress/plugin-client-redirects`, and preserve hash fragments when changing redirect code so links such as `/a2ui/#/openui` continue to land on the matching GenUI route.
+
 Avoid literal wording such as "recommended shape" / "推荐形状" in user-facing docs. Prefer "interface best practice", "implementation pattern", "接口设计最佳实践", or other product-facing phrases that read naturally to React developers.

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { defineConfig } from '@rspress/core';
 import type { Sidebar, UserConfig } from '@rspress/core';
+import { pluginClientRedirects } from '@rspress/plugin-client-redirects';
 import {
   transformerNotationDiff,
   transformerNotationFocus,
@@ -471,6 +472,16 @@ const config: UserConfig = defineConfig({
   route: {
     cleanUrls: true,
   },
+  plugins: [
+    pluginClientRedirects({
+      redirects: [
+        {
+          from: '^/a2ui(?:\\.html|/index\\.html|/)?$',
+          to: '/genui',
+        },
+      ],
+    }),
+  ],
   themeConfig: {
     editLink: {
       docRepoBaseUrl:


### PR DESCRIPTION
## Summary
- configure @rspress/plugin-client-redirects for the legacy /a2ui playground route
- redirect /a2ui, /a2ui/, /a2ui.html, and /a2ui/index.html to /genui
- document the legacy client redirect expectation in GenUI docs instructions

## Tests
- pnpm dprint check
- git diff --check
- pnpm biome check --no-errors-on-unmatched .github/genui-docs.instructions.md website/rspress.config.ts
- pnpm turbo --filter website build:docs
- node redirect mapping smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Legacy links to the old playground route now automatically redirect to the new GenUI page.
  * Redirects preserve query strings and hash fragments, so existing bookmarked links continue to open the correct location.
* **Bug Fixes**
  * Improved compatibility for older hosted playground URLs, reducing broken link issues for existing users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->