### PR TITLE
fix(kitten-lynx): fork devtool connector

### DIFF
--- a/.changeset/kitten-lynx-local-connector.md
+++ b/.changeset/kitten-lynx-local-connector.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/kitten-lynx-test-infra": patch
+---
+
+Fork the devtool connector into Kitten Lynx and allow Android app launch by any installed package name.

--- a/.github/kitten-lynx.instructions.md
+++ b/.github/kitten-lynx.instructions.md
@@ -3,3 +3,5 @@ applyTo: "packages/testing-library/kitten-lynx/**/*"
 ---
 
 For Kitten Lynx Android E2E fixtures, build Lynx bundles with `rspeedy build` into an ignored generated directory and serve those static outputs from the test process. Avoid using `rspeedy dev` as the test server because the emulator/devtool bridge is sensitive to dev-server lifecycle and transport timing.
+
+Kitten Lynx owns a local fork of the devtool connector under `src/connector`; do not reintroduce a package dependency on `@lynx-js/devtool-connector` for runtime transport code. Android app launching should accept any installed package name returned by `pm list packages`, not just a hard-coded known-app list.

--- a/packages/testing-library/kitten-lynx/AGENTS.md
+++ b/packages/testing-library/kitten-lynx/AGENTS.md
@@ -4,7 +4,7 @@ This document provides context, architecture guidelines, and workflows for agent
 
 ## Overview
 
-`kitten-lynx` is a Puppeteer-like testing library designed for interacting with the Lynx browser engine and Lynx Explorer Android application. It utilizes the `@lynx-js/devtool-connector` (stateless, short-lived connection architecture) to communicate with Lynx apps running on Android devices via ADB.
+`kitten-lynx` is a Puppeteer-like testing library designed for interacting with the Lynx browser engine and Lynx Explorer Android application. It utilizes the local `src/connector` fork of the devtool connector (stateless, short-lived connection architecture) to communicate with Lynx apps running on Android devices via ADB.
 
 Through the Chrome DevTools Protocol (CDP), `kitten-lynx` enables:
 
@@ -25,7 +25,7 @@ Through the Chrome DevTools Protocol (CDP), `kitten-lynx` enables:
 
 ### Key Design Patterns
 
-- **Stateless connector**: The `devtool-connector` does not maintain persistent WebSocket connections. Each `sendCDPMessage` / `sendListSessionMessage` call is a self-contained request through ADB/USB transport.
+- **Stateless connector**: The local `src/connector` fork does not maintain persistent WebSocket connections. Each `sendCDPMessage` / `sendListSessionMessage` call is a self-contained request through ADB/USB transport.
 - **Retry-based initialization**: After restarting the app, polling loops handle the delay before the devtool server is ready. `onAttachedToTarget()` only assigns `_channel` after all CDP domain enables succeed, making the whole operation retryable.
 - **Session URL matching**: After `Page.navigate`, the Lynx runtime creates a new session for the navigated URL. `goto()` polls `sendListSessionMessage()` and matches sessions by URL (full URL, filename, or suffix) to find the correct one.
 

--- a/packages/testing-library/kitten-lynx/README.md
+++ b/packages/testing-library/kitten-lynx/README.md
@@ -23,7 +23,7 @@ Using the Chrome DevTools Protocol (CDP) over USB/ADB, `kitten-lynx` gives you t
 
 In standard Web Playwright/Puppeteer, you connect to a persistent browser WebSocket. **Lynx is different.**
 
-1. **Stateless Connector:** This library uses `@lynx-js/devtool-connector` which operates via Android Debug Bridge (ADB). It sends isolated Request/Response commands. There is no long-living socket.
+1. **Stateless Connector:** This library uses its local `src/connector` fork of the devtool connector, which operates via Android Debug Bridge (ADB). It sends isolated Request/Response commands. There is no long-living socket.
 2. **Session Hopping:** When you tell Lynx to navigate to a new URL, Lynx creates an entirely **new debugging session**.
 3. **`Lynx.ts`**: Handles the physical device connection, force-stops the app, restarts it, and ensures the Master devtool switch is ON.
 4. **`KittenLynxView.ts`**: Represents a single "Page". When you call `goto(url)`, it sends the navigate command, and then intensely **polls** the ADB session list until it finds the new session matching your URL, and re-attaches to it.

--- a/packages/testing-library/kitten-lynx/package.json
+++ b/packages/testing-library/kitten-lynx/package.json
@@ -38,9 +38,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@lynx-js/devtool-connector": "workspace:*",
     "@yume-chan/adb": "catalog:adb",
-    "@yume-chan/adb-server-node-tcp": "catalog:adb"
+    "@yume-chan/adb-server-node-tcp": "catalog:adb",
+    "debug": "^4.4.3",
+    "usbmux-client": "^0.2.1"
   },
   "devDependencies": {
     "@lynx-js/preact-devtools": "5.0.1-20260525112551-dfe2d03",
@@ -48,6 +49,7 @@
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/types": "4.0.0",
+    "@types/debug": "^4.1.12",
     "@types/react": "^18.3.28",
     "execa": "^9.6.1",
     "jpeg-js": "^0.4.4",

--- a/packages/testing-library/kitten-lynx/src/CDPChannel.ts
+++ b/packages/testing-library/kitten-lynx/src/CDPChannel.ts
@@ -1,4 +1,4 @@
-import type { Connector } from '@lynx-js/devtool-connector';
+import type { Connector } from './connector/index.js';
 
 const sessionIdToChannel: Record<string, WeakRef<CDPChannel>> = {};
 type Quad = [number, number, number, number, number, number, number, number];

--- a/packages/testing-library/kitten-lynx/src/KittenLynxView.ts
+++ b/packages/testing-library/kitten-lynx/src/KittenLynxView.ts
@@ -1,4 +1,4 @@
-import type { Connector } from '@lynx-js/devtool-connector';
+import type { Connector } from './connector/index.js';
 import { CDPChannel } from './CDPChannel.js';
 import type { NodeInfoInGetDocument } from './CDPChannel.js';
 import { ElementNode } from './ElementNode.js';

--- a/packages/testing-library/kitten-lynx/src/Lynx.ts
+++ b/packages/testing-library/kitten-lynx/src/Lynx.ts
@@ -1,7 +1,7 @@
-import { Connector } from '@lynx-js/devtool-connector';
-import { AndroidTransport } from '@lynx-js/devtool-connector/transport';
 import { AdbServerClient } from '@yume-chan/adb';
 import { AdbServerNodeTcpConnector } from '@yume-chan/adb-server-node-tcp';
+import { Connector } from './connector/index.js';
+import { AndroidTransport } from './connector/transport/android.js';
 import { KittenLynxView } from './KittenLynxView.js';
 
 /**

--- a/packages/testing-library/kitten-lynx/src/connector/index.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/index.ts
@@ -1,0 +1,500 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { randomInt } from 'node:crypto';
+import { ReadableStream, type TransformStream } from 'node:stream/web';
+
+import createDebug from 'debug';
+
+import {
+  CDPOutputTransformStream,
+  CDPRequestTransformStream,
+  CDPResponseTransformStream,
+} from './streams/cdp.js';
+import {
+  AppResponseTransformStream,
+  CustomizedRequestTransformStream,
+  CustomizedResponseTransformStream,
+  GlobalSwitchRequestTransformStream,
+} from './streams/customized.js';
+import {
+  MessageToPeertalkTransformStream,
+  PeertalkToMessageTransformStream,
+} from './streams/peertalk.js';
+import { FilterTransformStream, InspectStream } from './streams/utils.js';
+import { takeoverDebugRouterLock } from './takeover.js';
+import type {
+  App,
+  Client,
+  Device,
+  OpenAppOptions,
+  Transport,
+  TransportConnectOptions,
+} from './transport/transport.js';
+import {
+  isGetGlobalSwitchResponse,
+  isInitializeResponse,
+  isListSessionResponse,
+  isSetGlobalSwitchResponse,
+} from './types.js';
+import type {
+  AppInfo,
+  CDPRequestMessage,
+  GetGlobalSwitchResponse,
+  GlobalKeys,
+  InitializeRequest,
+  InitializeResponse,
+  ListSessionRequest,
+  ListSessionResponse,
+  Session,
+} from './types.js';
+
+export { MessageToPeertalkTransformStream, PeertalkToMessageTransformStream };
+
+const debug = createDebug('devtool-mcp-server:connector');
+
+interface OutputStream<O> extends AsyncDisposable, ReadableStream<O> {}
+
+export class ClientId {
+  static serialize(deviceId: string, port: number): string {
+    return `${encodeURIComponent(deviceId)}:${port}`;
+  }
+
+  static deserialize(
+    clientId: string,
+  ): { deviceId: string; port: number } | null {
+    try {
+      const lastColonIndex = clientId.lastIndexOf(':');
+      if (lastColonIndex === -1) return null;
+
+      const port = Number.parseInt(clientId.substring(lastColonIndex + 1), 10);
+      if (Number.isNaN(port)) return null;
+
+      return {
+        deviceId: decodeURIComponent(clientId.substring(0, lastColonIndex)),
+        port,
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+interface Pipeline {
+  input: TransformStream[];
+  output: TransformStream[];
+}
+
+export class Connector {
+  #transports: Transport[];
+
+  constructor(transports: Transport[]) {
+    this.#transports = transports;
+  }
+
+  async listClients(): Promise<Client[]> {
+    const transportDevices = await Promise.allSettled(
+      this.#transports.map(async (transport) => ({
+        transport,
+        devices: await transport.listDevices(),
+      })),
+    );
+
+    const results = await Promise.allSettled(
+      transportDevices
+        .filter(r => r.status === 'fulfilled')
+        .map(r => r.value)
+        .flatMap(({ transport, devices }) =>
+          devices.flatMap(({ id }) => this.#listClientsForDevice(transport, id))
+        ),
+    );
+
+    return results
+      .filter((r) => r.status === 'fulfilled')
+      .flatMap((r) => r.value);
+  }
+
+  async listDevices(): Promise<Device[]> {
+    const results = await Promise.allSettled(
+      this.#transports.map(t => t.listDevices()),
+    );
+
+    return results
+      .filter(result => result.status === 'fulfilled')
+      .flatMap(({ value }) => value);
+  }
+
+  async close(): Promise<void> {
+    await Promise.allSettled(
+      this.#transports.map(t => t.close()),
+    );
+  }
+
+  async listAvailableApps(deviceId: string): Promise<App[]> {
+    const transport = await this.#findTransportWithDeviceId(deviceId);
+
+    return await transport.listAvailableApps(deviceId);
+  }
+
+  async openApp(
+    deviceId: string,
+    packageName: string,
+    options?: OpenAppOptions,
+  ): Promise<void> {
+    const transport = await this.#findTransportWithDeviceId(deviceId);
+
+    await transport.openApp(deviceId, packageName, options);
+
+    const signal = AbortSignal.any([
+      options?.signal,
+      AbortSignal.timeout(60_000),
+    ].filter(i => i !== undefined));
+
+    const { setTimeout } = await import('node:timers/promises');
+    while (!signal.aborted) {
+      try {
+        const clients = await this.#listClientsForDevice(transport, deviceId);
+
+        if (
+          clients.some(({ info }) =>
+            /** Android */ info.AppProcessName === packageName
+              /** iOS */ || info.bundleId === packageName
+              /** OpenHarmony */ || info.bundleName === packageName
+          )
+        ) {
+          break;
+        }
+      } catch (err) {
+        // ignore error
+        debug(`openApp ${deviceId} ${packageName} client not found %o`, err);
+      }
+      await setTimeout(1_000);
+    }
+  }
+
+  async sendMessage<T, R>(clientId: string, message: T): Promise<R> {
+    return await this.#sendMessage(clientId, message);
+  }
+
+  async sendAppMessage<Output, Params = never>(
+    clientId: string,
+    method: string,
+    params?: Params,
+  ): Promise<Output> {
+    const { port } = this.#resolveClientId(clientId);
+    const id = randomInt(10_000, 50_000);
+
+    return await this.#sendMessage<Record<string, unknown>, Output>(clientId, {
+      method,
+      params: /** App message requires params to be an object */ { ...params },
+    }, {
+      input: [
+        new CustomizedRequestTransformStream({
+          type: 'App',
+          port,
+          sessionId: -1,
+          messageBuilder: (message) => ({ id, ...message }),
+        }),
+      ],
+      output: [
+        new CustomizedResponseTransformStream('App', id),
+        new AppResponseTransformStream(method),
+      ],
+    });
+  }
+
+  async sendCDPMessage<Output, Params = never>(
+    clientId: string,
+    sessionId: number,
+    method: string,
+    params?: Params,
+  ): Promise<Output> {
+    const { port } = this.#resolveClientId(clientId);
+    const id = randomInt(10_000, 50_000);
+
+    return await this.#sendMessage<Record<string, unknown>, Output>(clientId, {
+      method,
+      params,
+      sessionId,
+    }, {
+      input: [
+        new CDPRequestTransformStream(port, id),
+      ],
+      output: [
+        new CDPResponseTransformStream(id),
+        new CDPOutputTransformStream(),
+      ],
+    });
+  }
+
+  async sendListSessionMessage(
+    clientId: string,
+  ): Promise<Session[]> {
+    const options = this.#resolveClientId(clientId);
+    const { data: { data: sessions } } = await this.#sendMessage<
+      ListSessionRequest,
+      ListSessionResponse
+    >(
+      clientId,
+      {
+        event: 'Customized',
+        data: {
+          type: 'ListSession',
+          sender: options.port,
+          data: {},
+        },
+      },
+      {
+        input: [],
+        output: [
+          new FilterTransformStream(isListSessionResponse),
+        ],
+      },
+    );
+
+    return sessions;
+  }
+
+  async getGlobalSwitch(
+    clientId: string,
+    key: GlobalKeys,
+  ): Promise<boolean> {
+    const options = this.#resolveClientId(clientId);
+    const {
+      data: { data: { message } },
+    } = await this.#sendMessage<{ key: GlobalKeys }, GetGlobalSwitchResponse>(
+      clientId,
+      { key },
+      {
+        input: [
+          new GlobalSwitchRequestTransformStream(
+            'GetGlobalSwitch',
+            options.port,
+          ),
+        ],
+        output: [
+          new FilterTransformStream(isGetGlobalSwitchResponse),
+        ],
+      },
+    );
+
+    if (typeof message === 'object') {
+      return message?.global_value === 'true' || message?.global_value === true;
+    } else {
+      return message === 'true' || message === true;
+    }
+  }
+
+  async setGlobalSwitch(
+    clientId: string,
+    key: GlobalKeys,
+    value: boolean,
+  ): Promise<void> {
+    const options = this.#resolveClientId(clientId);
+    await this.#sendMessage(clientId, { key, value }, {
+      input: [
+        new GlobalSwitchRequestTransformStream('SetGlobalSwitch', options.port),
+      ],
+      output: [
+        new FilterTransformStream(isSetGlobalSwitchResponse),
+      ],
+    });
+  }
+
+  async sendStream<I, O>(
+    clientId: string,
+    inputStream: ReadableStream<I>,
+    { signal }: { signal?: AbortSignal },
+  ): Promise<OutputStream<O>> {
+    const { deviceId, port } = this.#resolveClientId(clientId);
+    const transport = await this.#findTransportWithDeviceId(deviceId);
+
+    return await this.#connect(
+      transport,
+      { deviceId, port, signal },
+      inputStream,
+      { input: [], output: [] },
+    );
+  }
+
+  async sendCDPStream(
+    clientId: string,
+    inputStream: ReadableStream<CDPRequestMessage & { sessionId: number }>,
+    { signal }: { signal?: AbortSignal } = {},
+  ): Promise<OutputStream<CDPRequestMessage>> {
+    const { deviceId, port } = this.#resolveClientId(clientId);
+    const transport = await this.#findTransportWithDeviceId(deviceId);
+
+    return await this.#connect(
+      transport,
+      { deviceId, port, signal },
+      inputStream,
+      {
+        input: [
+          new CDPRequestTransformStream(port),
+        ],
+        output: [
+          new CDPResponseTransformStream<CDPRequestMessage>(),
+        ],
+      },
+    );
+  }
+
+  #resolveClientId(clientId: string): TransportConnectOptions {
+    const parsed = ClientId.deserialize(clientId);
+    if (!parsed) {
+      throw new Error(`Invalid clientId: ${clientId}`);
+    }
+    return parsed;
+  }
+
+  async #findTransportWithDeviceId(deviceId: string): Promise<Transport> {
+    return await Promise.any(
+      this.#transports.map(async (t) => {
+        const devices = await t.listDevices();
+        if (devices.some(({ id }) => id === deviceId)) return t;
+        throw new Error('Not found in this transport');
+      }),
+    ).catch(() => {
+      throw new Error(`Device with id: ${deviceId} not found`);
+    });
+  }
+
+  async #connect<I, O>(
+    transport: Transport,
+    options: TransportConnectOptions,
+    inputStream: ReadableStream<I>,
+    pipeline: Pipeline,
+  ): Promise<OutputStream<O>> {
+    const { deviceId, port } = options;
+
+    await takeoverDebugRouterLock();
+
+    const conn = await transport.connect(options);
+
+    void [
+      ...pipeline.input,
+      new InspectStream((msg) =>
+        debug(`connect ${deviceId}:${port} input stream send %O`, msg)
+      ),
+      new MessageToPeertalkTransformStream(),
+    ].reduce((stream, transform) => stream.pipeThrough(transform), inputStream)
+      .pipeTo(conn.writable, { preventClose: true })
+      .catch((err) => {
+        debug(`connect ${deviceId}:${port} input stream err %O`, err);
+        void conn[Symbol.asyncDispose]();
+      });
+
+    const outputStream = [
+      new PeertalkToMessageTransformStream(),
+      new InspectStream((msg) =>
+        debug(`connect ${deviceId}:${port} output stream receive %O`, msg)
+      ),
+      ...pipeline.output,
+    ].reduce(
+      (stream, transform) => stream.pipeThrough(transform),
+      conn.readable,
+    );
+
+    return Object.assign(outputStream, {
+      async [Symbol.asyncDispose]() {
+        debug(`connect ${deviceId}:${port} close connection`);
+        return await conn[Symbol.asyncDispose]();
+      },
+    });
+  }
+
+  async #sendMessage<I, O>(
+    clientId: string,
+    input: I,
+    pipeline: Pipeline = { input: [], output: [] },
+  ): Promise<O> {
+    const { deviceId, port } = this.#resolveClientId(clientId);
+    const transport = await this.#findTransportWithDeviceId(deviceId);
+
+    const signal = AbortSignal.timeout(5000);
+
+    return this.#sendMessageWithTransport(
+      transport,
+      { deviceId, port, signal },
+      input,
+      pipeline,
+    );
+  }
+
+  async #sendMessageWithTransport<I, O>(
+    transport: Transport,
+    options: TransportConnectOptions,
+    input: I,
+    pipeline: Pipeline,
+  ): Promise<O> {
+    await using outputStream = await this.#connect<I, O>(
+      transport,
+      options,
+      ReadableStream.from([input]),
+      pipeline,
+    );
+    for await (const response of outputStream) {
+      return response;
+    }
+
+    const { deviceId, port } = options;
+    throw new Error(
+      `No response found for deviceId: ${deviceId} port: ${port}`,
+    );
+  }
+
+  async #listClientsForDevice(
+    transport: Transport,
+    deviceId: string,
+  ): Promise<{ id: string; info: AppInfo; port: number }[]> {
+    const MIN_PORT = 8901;
+    const PORTS = Array.from({ length: 10 }, (_, i) => MIN_PORT + i);
+    const results = await Promise.allSettled(PORTS.map(async (port) => {
+      const { data: { info } } = await this.#sendMessageWithTransport<
+        InitializeRequest,
+        InitializeResponse
+      >(
+        transport,
+        { deviceId, port, signal: AbortSignal.timeout(5_000) },
+        { event: 'Initialize', data: port },
+        {
+          input: [],
+          output: [
+            new FilterTransformStream(isInitializeResponse),
+          ],
+        },
+      );
+
+      try {
+        await this.#sendMessageWithTransport<
+          { key: GlobalKeys; value: boolean },
+          never
+        >(
+          transport,
+          { deviceId, port, signal: AbortSignal.timeout(3_000) },
+          { key: 'enable_devtool', value: true },
+          {
+            input: [
+              new GlobalSwitchRequestTransformStream('SetGlobalSwitch', port),
+            ],
+            output: [
+              new FilterTransformStream(isSetGlobalSwitchResponse),
+            ],
+          },
+        );
+      } catch (err) {
+        debug(
+          `listClientsForDevice ${deviceId}:${port} enable_devtool failed %O`,
+          err,
+        );
+      }
+
+      return { id: ClientId.serialize(deviceId, port), info, port };
+    }));
+
+    return results
+      .filter(result => result.status === 'fulfilled')
+      .map(result => result.value);
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/streams/cdp.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/streams/cdp.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { randomInt } from 'node:crypto';
+
+import type { CDPRequestMessage, CDPResponseMessage } from '../types.js';
+import {
+  CustomizedRequestTransformStream,
+  CustomizedResponseTransformStream,
+  ResponseParserTransformStream,
+} from './customized.js';
+
+export class CDPRequestTransformStream extends CustomizedRequestTransformStream<
+  CDPRequestMessage & { sessionId: number }
+> {
+  constructor(port: number, fixedId?: number) {
+    super({
+      type: 'CDP',
+      port,
+      sessionId: (chunk) => chunk.sessionId,
+      messageBuilder: (chunk) => {
+        const id = fixedId ?? randomInt(10_000, 50_000);
+        const { method, params } = chunk;
+        return { id, method, params };
+      },
+    });
+  }
+}
+
+export class CDPResponseTransformStream<Output = CDPResponseMessage>
+  extends CustomizedResponseTransformStream<'CDP', Output>
+{
+  constructor(id?: number) {
+    super('CDP', id);
+  }
+}
+
+export class CDPOutputTransformStream<Output>
+  extends ResponseParserTransformStream<CDPResponseMessage, Output>
+{
+  constructor() {
+    super({
+      checkError: (message) => {
+        if ('error' in message) {
+          return new Error(
+            `CDP request error: ${message.error.message}`,
+            { cause: message },
+          );
+        }
+        return null;
+      },
+      parseResult: (message) => {
+        if ('result' in message) {
+          return message.result as Output;
+        }
+        throw new Error('No result in CDP response message', {
+          cause: message,
+        });
+      },
+    });
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/streams/customized.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/streams/customized.ts
@@ -1,0 +1,157 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { TransformStream } from 'node:stream/web';
+
+import { isCustomizedResponseWithType } from '../types.js';
+import type {
+  AppResponseMessage,
+  CustomizedResponseMap,
+  CustomizedResponseMessageMap,
+  Response,
+} from '../types.js';
+
+export class CustomizedRequestTransformStream<T = unknown>
+  extends TransformStream<T, unknown>
+{
+  protected port: number;
+
+  constructor(options: {
+    type: string;
+    port: number;
+    sessionId?: number | ((chunk: T) => number);
+    messageBuilder: (chunk: T) => unknown;
+  }) {
+    const { type, port, sessionId = -1, messageBuilder } = options;
+    super({
+      transform(chunk, controller) {
+        const sid = typeof sessionId === 'function'
+          ? sessionId(chunk)
+          : sessionId;
+        controller.enqueue({
+          event: 'Customized',
+          data: {
+            type,
+            data: {
+              client_id: port,
+              session_id: sid,
+              message: messageBuilder(chunk),
+            },
+            sender: port,
+          },
+        });
+      },
+    });
+    this.port = port;
+  }
+}
+
+export class CustomizedResponseTransformStream<
+  T extends keyof CustomizedResponseMap,
+  Output = CustomizedResponseMessageMap[T],
+> extends TransformStream<Response, Output> {
+  constructor(type: T, id?: number) {
+    super({
+      transform(response, controller) {
+        if (!isCustomizedResponseWithType(response, type)) {
+          return;
+        }
+
+        try {
+          const message = JSON.parse(response.data.data.message) as Output & {
+            id?: number;
+          };
+          if (id === undefined || message?.id === id) {
+            controller.enqueue(message);
+          }
+        } catch (err) {
+          controller.error(
+            new Error(`Failed to parse response for type ${type}`, {
+              cause: err,
+            }),
+          );
+        }
+      },
+    });
+  }
+}
+
+/**
+ * Common response parser that handles JSON parsing and error checking in the payload.
+ */
+export class ResponseParserTransformStream<Input, Output>
+  extends TransformStream<Input, Output>
+{
+  constructor(options: {
+    parseResult: (input: Input) => Output;
+    checkError: (input: Input) => Error | null;
+  }) {
+    const { parseResult, checkError } = options;
+    super({
+      transform(chunk, controller) {
+        const error = checkError(chunk);
+        if (error) {
+          controller.error(error);
+          return;
+        }
+
+        try {
+          controller.enqueue(parseResult(chunk));
+        } catch (err) {
+          controller.error(err);
+        }
+      },
+    });
+  }
+}
+
+export class AppResponseTransformStream<Output>
+  extends ResponseParserTransformStream<AppResponseMessage, Output>
+{
+  constructor(method: string) {
+    super({
+      checkError: (message) => {
+        try {
+          const result = JSON.parse(message.result) as {
+            code: number | string;
+            message: string;
+          };
+          if (
+            /** Android */ result.code !== 0 && /** iOS */ result.code !== '0'
+          ) {
+            return new Error(`App request ${method} error: ${result.message}`, {
+              cause: message,
+            });
+          }
+          return null;
+        } catch (err) {
+          return new Error('Failed to parse App response message', {
+            cause: err,
+          });
+        }
+      },
+      parseResult: (message) => {
+        return JSON.parse(message.result) as Output;
+      },
+    });
+  }
+}
+
+export class GlobalSwitchRequestTransformStream
+  extends CustomizedRequestTransformStream<{
+    key: string;
+    value?: boolean;
+  }>
+{
+  constructor(type: 'SetGlobalSwitch' | 'GetGlobalSwitch', port: number) {
+    super({
+      type,
+      port,
+      sessionId: -1,
+      messageBuilder: ({ key, value }) => ({
+        global_key: key,
+        global_value: value,
+      }),
+    });
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/streams/peertalk.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/streams/peertalk.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { TransformStream } from 'node:stream/web';
+
+import type { Response } from '../types.js';
+
+export class PeertalkToMessageTransformStream
+  extends TransformStream<Uint8Array, Response>
+{
+  constructor() {
+    let buffer = new Uint8Array(0); // Buffer for partial frames
+    const decoder = new TextDecoder(); // Reuse decoder instance
+
+    super({
+      transform: (chunk, c) => {
+        // 1. Simple buffer merge
+        const n = new Uint8Array(buffer.length + chunk.length);
+        n.set(buffer);
+        n.set(chunk, buffer.length);
+        buffer = n;
+
+        // 2. Parse in a loop
+        // Offset 16 is the length field (fourth I in !IIIII)
+        while (buffer.length >= 20) {
+          const v = new DataView(buffer.buffer, buffer.byteOffset);
+          const len = v.getUint32(16); // DataView is big-endian by default, no flag needed
+
+          if (buffer.length < 20 + len) break; // Wait for a full frame
+
+          // 3. Extract payload and emit
+          try {
+            c.enqueue(
+              JSON.parse(decoder.decode(buffer.subarray(20, 20 + len))),
+            );
+          } catch (e) {
+            c.error(e);
+          }
+
+          // 4. Slice consumed bytes
+          buffer = buffer.subarray(20 + len);
+        }
+      },
+    });
+  }
+}
+
+export class MessageToPeertalkTransformStream<TMessage = unknown>
+  extends TransformStream<
+    TMessage,
+    Uint8Array
+  >
+{
+  constructor() {
+    const encoder = new TextEncoder(); // Reuse encoder instance
+
+    super({
+      transform(chunk, controller) {
+        // 1. Encode message body (UTF-8)
+        // chunk is a single message; trim here if your messages can contain newlines
+        const body = encoder.encode(JSON.stringify(chunk));
+        const len = body.length;
+
+        // 2. Allocate buffer (20-byte header + body length)
+        const data = new Uint8Array(20 + len);
+        const view = new DataView(data.buffer);
+
+        // 3. Write header (DataView is big-endian by default)
+        // Layout: [1, 101, 0, len + 4, len]
+        view.setUint32(0, 1); // Version
+        view.setUint32(4, 101); // Type
+        view.setUint32(8, 0); // Tag
+        view.setUint32(12, len + 4); // Total Length (Reference logic)
+        view.setUint32(16, len); // Payload Length
+
+        // 4. Write message body
+        data.set(body, 20);
+
+        // 5. Push downstream
+        controller.enqueue(data);
+      },
+    });
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/streams/utils.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/streams/utils.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { TransformStream } from 'node:stream/web';
+
+export class FilterTransformStream<T, P extends T>
+  extends TransformStream<T, P>
+{
+  constructor(filter: (chunk: T) => chunk is P) {
+    super({
+      transform(chunk, controller) {
+        if (filter(chunk)) {
+          controller.enqueue(chunk);
+        }
+      },
+    });
+  }
+}
+
+export class InspectStream<T> extends TransformStream<T, T> {
+  constructor(callback: (message: T) => void) {
+    super({
+      transform(chunk, controller) {
+        callback(chunk);
+        controller.enqueue(chunk);
+      },
+    });
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/takeover.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/takeover.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import createDebug from 'debug';
+
+const debug = createDebug('devtool-mcp-server:takeover');
+
+const DEBUG_ROUTER_DIR = path.join(os.homedir(), '.DebugRouterConnector');
+const DEBUG_ROUTER_LOCK_DIR = path.join(DEBUG_ROUTER_DIR, 'lockfile');
+const DEBUG_ROUTER_LATEST_FILE = path.join(
+  DEBUG_ROUTER_DIR,
+  'LatestDriverProcess',
+);
+
+export async function takeoverDebugRouterLock(): Promise<void> {
+  try {
+    await fs.mkdir(DEBUG_ROUTER_DIR, { recursive: true });
+
+    await fs.rm(DEBUG_ROUTER_LOCK_DIR, { recursive: true, force: true });
+
+    await fs.mkdir(DEBUG_ROUTER_LOCK_DIR, { recursive: true });
+
+    await fs.writeFile(DEBUG_ROUTER_LATEST_FILE, `${process.pid}`, 'utf-8');
+    debug(`wrote PID=${process.pid}`);
+  } catch (err) {
+    debug('skipped due to filesystem error %O', err);
+  } finally {
+    try {
+      await fs.rm(DEBUG_ROUTER_LOCK_DIR, { recursive: true, force: true });
+    } catch (_cleanupError) {
+      debug('failed to remove lock directory %O', _cleanupError);
+    }
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/transport/android.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/transport/android.ts
@@ -1,0 +1,218 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { SocketConnectOpts } from 'node:net';
+
+import { AdbServerClient } from '@yume-chan/adb';
+import type { Adb } from '@yume-chan/adb';
+import { AdbServerNodeTcpConnector } from '@yume-chan/adb-server-node-tcp';
+import createDebug from 'debug';
+
+import type {
+  App,
+  Connection,
+  Device,
+  OpenAppOptions,
+  Transport,
+  TransportConnectOptions,
+} from './transport.js';
+
+const debug = createDebug('devtool-mcp-server:connector:android');
+
+export class AndroidTransport implements Transport {
+  #client: AdbServerClient;
+
+  constructor(spec: SocketConnectOpts = { port: 5037 }) {
+    this.#client = new AdbServerClient(new AdbServerNodeTcpConnector(spec));
+  }
+
+  async #createAdb(deviceId: string): Promise<Adb & AsyncDisposable> {
+    const adb = await this.#client.createAdb({ serial: deviceId });
+    return Object.assign(adb, {
+      async [Symbol.asyncDispose]() {
+        await adb.close();
+      },
+    });
+  }
+
+  close(): Promise<void> {
+    // noop
+    debug('Android transport closed');
+    return Promise.resolve();
+  }
+
+  async connect(
+    { deviceId, port, signal }: TransportConnectOptions,
+  ): Promise<Connection> {
+    const adb = await this.#client.createAdb({ serial: deviceId });
+
+    debug(`connect: create connection to deviceId: ${deviceId}, port: ${port}`);
+
+    signal?.throwIfAborted();
+
+    const service = `tcp:${port}`;
+
+    let socket: Awaited<ReturnType<Adb['createSocket']>>;
+    try {
+      socket = await adb.createSocket(service);
+    } catch (err) {
+      await adb.close();
+      debug(`connect: create socket to ${service} failed with err: %o`, err);
+      throw err;
+    }
+
+    const abortHandler = () => {
+      void Promise.resolve(socket.close()).catch((err: unknown) => {
+        debug(`connect: socket ${service} close on abort err: %o`, err);
+      });
+    };
+    signal?.addEventListener('abort', abortHandler, { once: true });
+
+    if (signal?.aborted) {
+      await socket.close();
+      await adb.close();
+      signal.throwIfAborted();
+    }
+
+    void Promise.resolve(socket.closed).catch((err: unknown) => {
+      debug(`connect: socket ${service} closed with err: %o`, err);
+    });
+
+    return {
+      readable: socket.readable as never,
+      writable: socket.writable as never,
+      async [Symbol.asyncDispose]() {
+        signal?.removeEventListener('abort', abortHandler);
+        debug(
+          `connect: close connection to deviceId: ${deviceId}, port: ${port}`,
+        );
+        try {
+          await socket.close();
+        } finally {
+          await adb.close();
+        }
+      },
+    };
+  }
+
+  async withConnection<T>(
+    options: TransportConnectOptions,
+    callback: (conn: Connection) => Promise<T>,
+  ): Promise<T> {
+    await using conn = await this.connect(options);
+    return await callback(conn);
+  }
+
+  async listDevices(): Promise<Device[]> {
+    const devices = await this.#client.getDevices();
+
+    debug('listDevices: devices %o', devices);
+
+    return devices.map(({ serial }) => ({
+      os: 'Android',
+      id: serial,
+    }));
+  }
+
+  async listAvailableApps(deviceId: string): Promise<App[]> {
+    await using adb = await this.#createAdb(deviceId);
+    const output = await adb.subprocess.noneProtocol.spawnWaitText([
+      // adb shell pm list packages
+      'pm',
+      'list',
+      'packages',
+    ]);
+    const packages = new Set(
+      output
+        .split('\n')
+        .map((line) => line.replace('package:', '').trim())
+        .filter(i => i !== ''),
+    );
+    debug(`listAvailableApps all packages: %o`, packages);
+
+    return Array.from(packages, packageName => ({
+      packageName,
+      name: packageName,
+    }));
+  }
+
+  async openApp(
+    deviceId: string,
+    packageName: string,
+    { withDataCleared }: OpenAppOptions = {},
+  ): Promise<void> {
+    const apps = await this.listAvailableApps(deviceId);
+    await using adb = await this.#createAdb(deviceId);
+
+    if (!apps.some((app) => app.packageName === packageName)) {
+      throw new Error(`package ${packageName} not found`);
+    }
+
+    if (withDataCleared) {
+      const output = await adb.subprocess.noneProtocol.spawnWaitText([
+        // adb shell pm clear <package_name>
+        'pm',
+        'clear',
+        packageName,
+      ]);
+      debug(`openApp clear data output ${output}`);
+    }
+
+    // Attempt to use cmd package resolve-activity like appium-adb
+    try {
+      const resolveOutput = await adb.subprocess.noneProtocol.spawnWaitText([
+        'cmd',
+        'package',
+        'resolve-activity',
+        '--brief',
+        packageName,
+      ]);
+      const lines = resolveOutput.split('\n').map((line) => line.trim());
+      const activityName = lines.find((line) => line.includes('/'));
+
+      if (
+        activityName
+        && activityName !== 'android/com.android.internal.app.ResolverActivity'
+      ) {
+        debug(`openApp am start: ${activityName}`);
+        const amOutput = await adb.subprocess.noneProtocol.spawnWaitText([
+          'am',
+          'start',
+          '-a',
+          'android.intent.action.MAIN',
+          '-c',
+          'android.intent.category.LAUNCHER',
+          '-f',
+          '0x10200000',
+          '-n',
+          activityName,
+        ]);
+        debug(`openApp am start output: ${amOutput}`);
+        if (!(/^error:/im.exec(amOutput))) {
+          return;
+        }
+      }
+    } catch (e) {
+      debug(`openApp cmd package resolve-activity failed: %o`, e);
+    }
+
+    // Fallback to monkey
+    debug('openApp trying fallback to monkey');
+    const output = await adb.subprocess.noneProtocol.spawnWaitText([
+      // adb shell monkey -p <package_name> -c android.intent.category.LAUNCHER 1
+      'monkey',
+      '-p',
+      packageName,
+      '-c',
+      'android.intent.category.LAUNCHER',
+      '1',
+    ]);
+    debug(`openApp LAUNCHER output ${output}`);
+
+    if (!output.includes('Events injected:')) {
+      throw new Error(
+        `Failed to open app ${packageName}: appium-adb style activation and monkey fallback both failed.`,
+      );
+    }
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/transport/desktop.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/transport/desktop.ts
@@ -1,0 +1,81 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import net from 'node:net';
+import { Duplex } from 'node:stream';
+
+import createDebug from 'debug';
+
+import type {
+  App,
+  Connection,
+  Device,
+  Transport,
+  TransportConnectOptions,
+} from './transport.js';
+
+const debug = createDebug('devtool-mcp-server:connector:desktop');
+
+export class DesktopTransport implements Transport {
+  close(): Promise<void> {
+    debug('Desktop transport closed');
+    return Promise.resolve();
+  }
+
+  listDevices(): Promise<Device[]> {
+    return Promise.resolve([{ id: 'localhost', os: 'Desktop' }]);
+  }
+
+  listAvailableApps(): Promise<App[]> {
+    return Promise.resolve([]);
+  }
+
+  openApp(): Promise<void> {
+    throw new Error('openApp is not supported on DesktopTransport');
+  }
+
+  async connect({
+    deviceId,
+    port,
+    signal,
+  }: TransportConnectOptions): Promise<Connection> {
+    if (deviceId !== 'localhost') {
+      throw new Error(
+        `DesktopTransport only supports 'localhost' deviceId, got: ${deviceId}`,
+      );
+    }
+
+    debug(`connect: connecting to 127.0.0.1:${port}`);
+
+    const socket = net.createConnection({ host: '127.0.0.1', port, signal });
+
+    try {
+      if (socket.connecting) {
+        await new Promise<void>((resolve, reject) => {
+          socket.once('connect', resolve);
+          socket.once('error', reject);
+        });
+      } else {
+        // already connected or failed immediately
+      }
+
+      debug(`connect: connected to 127.0.0.1:${port}`);
+
+      const { readable, writable } = Duplex.toWeb(socket);
+      return {
+        readable,
+        writable,
+        [Symbol.asyncDispose]() {
+          debug(`connect: closing connection to 127.0.0.1:${port}`);
+          socket.destroy();
+          return Promise.resolve();
+        },
+      };
+    } catch (err) {
+      debug(`connect: error connecting to 127.0.0.1:${port} %O`, err);
+      socket.destroy();
+      throw err;
+    }
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/transport/index.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/transport/index.ts
@@ -1,0 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+export * from './android.js';
+export * from './desktop.js';
+export * from './ios.js';
+export * from './transport.js';

--- a/packages/testing-library/kitten-lynx/src/connector/transport/ios.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/transport/ios.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { NetConnectOpts } from 'node:net';
+import { Duplex } from 'node:stream';
+import type { WritableStream } from 'node:stream/web';
+
+import createDebug from 'debug';
+import { UsbmuxClient } from 'usbmux-client';
+
+import type {
+  App,
+  Connection,
+  Device,
+  Transport,
+  TransportConnectOptions,
+} from './transport.js';
+
+const debug = createDebug('devtool-mcp-server:connector:ios');
+
+export class iOSTransport implements Transport {
+  #client: UsbmuxClient;
+
+  constructor(options?: NetConnectOpts) {
+    this.#client = new UsbmuxClient(options);
+  }
+
+  async close(): Promise<void> {
+    await this.#client.close();
+    debug('iOS transport closed');
+  }
+
+  async connect(
+    { deviceId, port, signal }: TransportConnectOptions,
+  ): Promise<Connection> {
+    debug(`connect: create connection to deviceId: ${deviceId}, port: ${port}`);
+    signal?.throwIfAborted();
+
+    const conn = await this.#client.createDeviceTunnel(deviceId, port);
+
+    const abortHandler = () => {
+      conn.destroy();
+    };
+    signal?.addEventListener('abort', abortHandler, { once: true });
+
+    if (signal?.aborted) {
+      conn.destroy();
+      signal.throwIfAborted();
+    }
+
+    const { readable, writable } = Duplex.toWeb(conn);
+    return {
+      readable,
+      writable: writable as WritableStream<Uint8Array>,
+      [Symbol.asyncDispose]() {
+        signal?.removeEventListener('abort', abortHandler);
+        debug(
+          `connect: close connection to deviceId: ${deviceId}, port: ${port}`,
+        );
+        conn.destroy();
+        return Promise.resolve();
+      },
+    };
+  }
+
+  async withConnection<T>(
+    options: TransportConnectOptions,
+    callback: (conn: Connection) => Promise<T>,
+  ): Promise<T> {
+    await using conn = await this.connect(options);
+    return await callback(conn);
+  }
+
+  async listDevices(): Promise<Device[]> {
+    const devices = await this.#client.getDevices();
+    debug('listDevices: devices %o', devices);
+    return Object.values(devices).map(({ DeviceID }) => ({
+      os: 'iOS',
+      id: `${DeviceID}`,
+    }));
+  }
+
+  listAvailableApps(): Promise<App[]> {
+    throw new Error('Not implemented');
+  }
+
+  openApp(): Promise<void> {
+    throw new Error('Not implemented');
+  }
+}

--- a/packages/testing-library/kitten-lynx/src/connector/transport/transport.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/transport/transport.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { ReadableStream, WritableStream } from 'node:stream/web';
+
+import type { AppInfo } from '../types.js';
+
+export interface TransportConnectOptions {
+  deviceId: string;
+  port: number;
+  signal?: AbortSignal | undefined;
+}
+
+export interface OpenAppOptions {
+  signal?: AbortSignal;
+  withDataCleared?: boolean | undefined;
+}
+
+export interface Transport {
+  close(): Promise<void>;
+
+  listDevices(): Promise<Device[]>;
+
+  listAvailableApps(deviceId: string): Promise<App[]>;
+
+  openApp(
+    deviceId: string,
+    packageName: string,
+    options?: OpenAppOptions,
+  ): Promise<void>;
+
+  connect(options: TransportConnectOptions): Promise<Connection>;
+}
+
+export interface Device {
+  id: string;
+  os: 'iOS' | 'Android' | 'Desktop' | 'OpenHarmony';
+}
+
+export interface Client {
+  id: string;
+  info: AppInfo;
+}
+
+export interface App {
+  packageName: string;
+  name: string;
+}
+
+export interface Connection extends AsyncDisposable {
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+}

--- a/packages/testing-library/kitten-lynx/src/connector/types.ts
+++ b/packages/testing-library/kitten-lynx/src/connector/types.ts
@@ -1,0 +1,162 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+interface Event<E extends string, D> {
+  event: E;
+  data: D;
+}
+
+type CustomizedEvent<TType extends string, TData> = Event<'Customized', {
+  type: TType;
+  sender: number;
+  data: TData;
+}>;
+
+export interface AppInfo {
+  App: string;
+  AppVersion: string;
+  /** Android only */
+  AppProcessName?: string;
+  /** iOS only */
+  bundleId?: string;
+  /** OpenHarmony only */
+  bundleName?: string;
+  debugRouterId: string;
+  debugRouterVersion: string;
+  deviceModel: string;
+  network: string;
+  osVersion: string;
+  sdkVersion: string;
+}
+export type InitializeRequest = Event<'Initialize', number>;
+export type InitializeResponse = Event<'Register', {
+  id: number;
+  info: AppInfo;
+}>;
+
+export type AppResponse = CustomizedEvent<'App', {
+  /** JSON string. See {@link AppResponseMessage} for parsed result. */
+  message: string;
+}>;
+export interface AppResponseMessage {
+  id: number;
+  /** JSON string */
+  result: string;
+}
+export interface CDPRequestMessage<T = unknown> {
+  method: string;
+  params?: T | undefined;
+}
+export type CDPRequest = CustomizedEvent<'CDP', {
+  client_id: number;
+  session_id: number;
+  message: CDPRequestMessage & { id: number };
+}>;
+export type CDPResponse = CustomizedEvent<'CDP', {
+  /** JSON string. See {@link CDPResponseMessage} for parsed result. */
+  message: string;
+}>;
+export type CDPResponseMessage =
+  & { id: number }
+  & ({ result: unknown } | { error: { code: number; message: string } });
+
+export interface Session {
+  session_id: number;
+  type: '';
+  url: string;
+}
+export type ListSessionRequest = CustomizedEvent<
+  'ListSession',
+  Record<string, never>
+>;
+export type ListSessionResponse = CustomizedEvent<'SessionList', Session[]>;
+
+export type GlobalKeys =
+  | 'enable_devtool'
+  | 'enable_logbox'
+  | 'enable_debug_mode'
+  | 'enable_launch_record'
+  | 'enable_quickjs_debug'
+  | 'enable_quickjs_cache'
+  | 'enable_v8'
+  | 'enable_dom_tree'
+  | 'enable_long_press_menu'
+  | 'enable_highlight_touch'
+  | 'enable_preview_screen_shot'
+  | 'enable_pixel_copy'
+  | 'enable_fsp_screenshot'
+  | 'enable_perf_metrics';
+export type GetGlobalSwitchRequest = CustomizedEvent<'GetGlobalSwitch', {
+  client_id: number;
+  session_id: number;
+  message: { global_key: GlobalKeys };
+}>;
+export type GetGlobalSwitchResponse = CustomizedEvent<'GetGlobalSwitch', {
+  client_id: number;
+  session_id: number;
+  message: string | boolean | { global_value: string | boolean };
+}>;
+export type SetGlobalSwitchRequest = CustomizedEvent<'SetGlobalSwitch', {
+  client_id: number;
+  session_id: number;
+  message: { global_key: GlobalKeys; global_value: boolean };
+}>;
+export type SetGlobalSwitchResponse = CustomizedEvent<'SetGlobalSwitch', {
+  client_id: number;
+  session_id: number;
+  /** JSON string */
+  message: string;
+}>;
+
+export interface CustomizedResponseMap {
+  App: AppResponse;
+  CDP: CDPResponse;
+}
+export interface CustomizedResponseMessageMap {
+  App: AppResponseMessage;
+  CDP: CDPResponseMessage;
+}
+
+export type Response =
+  | InitializeResponse
+  | ListSessionResponse
+  | AppResponse
+  | CDPResponse
+  | GetGlobalSwitchResponse
+  | SetGlobalSwitchResponse;
+
+export function isInitializeResponse(
+  response: Response,
+): response is InitializeResponse {
+  return response.event === 'Register';
+}
+
+export function isListSessionResponse(
+  response: Response,
+): response is ListSessionResponse {
+  return response.event === 'Customized'
+    && response.data.type === 'SessionList';
+}
+
+export function isGetGlobalSwitchResponse(
+  response: Response,
+): response is GetGlobalSwitchResponse {
+  return response.event === 'Customized'
+    && response.data.type === 'GetGlobalSwitch';
+}
+
+export function isSetGlobalSwitchResponse(
+  response: Response,
+): response is SetGlobalSwitchResponse {
+  return response.event === 'Customized'
+    && response.data.type === 'SetGlobalSwitch';
+}
+
+export function isCustomizedResponseWithType<
+  T extends keyof CustomizedResponseMap,
+>(
+  response: Response,
+  type: T,
+): response is CustomizedResponseMap[T] {
+  return response.event === 'Customized' && response.data.type === type;
+}

--- a/packages/testing-library/kitten-lynx/tests/android-transport.spec.ts
+++ b/packages/testing-library/kitten-lynx/tests/android-transport.spec.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const adbMock = vi.hoisted(() => ({
+  close: vi.fn(),
+  createAdb: vi.fn(),
+  getDevices: vi.fn(),
+  spawnWaitText: vi.fn(),
+}));
+
+vi.mock('@yume-chan/adb', () => ({
+  AdbServerClient: vi.fn().mockImplementation(() => ({
+    createAdb: adbMock.createAdb,
+    getDevices: adbMock.getDevices,
+  })),
+}));
+
+vi.mock('@yume-chan/adb-server-node-tcp', () => ({
+  AdbServerNodeTcpConnector: vi.fn(),
+}));
+
+import { AndroidTransport } from '../src/connector/transport/android.js';
+
+describe('AndroidTransport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adbMock.createAdb.mockResolvedValue({
+      close: adbMock.close,
+      subprocess: {
+        noneProtocol: {
+          spawnWaitText: adbMock.spawnWaitText,
+        },
+      },
+    });
+  });
+
+  it('lists arbitrary installed packages instead of known apps only', async () => {
+    adbMock.spawnWaitText.mockResolvedValue([
+      'package:com.lynx.explorer',
+      'package:com.example.custom',
+      '',
+    ].join('\n'));
+
+    const transport = new AndroidTransport();
+
+    await expect(transport.listAvailableApps('device-1')).resolves.toEqual([
+      { packageName: 'com.lynx.explorer', name: 'com.lynx.explorer' },
+      { packageName: 'com.example.custom', name: 'com.example.custom' },
+    ]);
+    expect(adbMock.spawnWaitText).toHaveBeenCalledWith([
+      'pm',
+      'list',
+      'packages',
+    ]);
+  });
+
+  it('opens any installed package name', async () => {
+    adbMock.spawnWaitText.mockImplementation(async (args: string[]) => {
+      if (args.join(' ') === 'pm list packages') {
+        return 'package:com.example.custom\n';
+      }
+      if (
+        args.join(' ')
+          === 'cmd package resolve-activity --brief com.example.custom'
+      ) {
+        return 'com.example.custom/.MainActivity\n';
+      }
+      if (args[0] === 'am') {
+        return 'Starting: Intent { cmp=com.example.custom/.MainActivity }';
+      }
+      throw new Error(`unexpected adb command: ${args.join(' ')}`);
+    });
+
+    const transport = new AndroidTransport();
+
+    await expect(
+      transport.openApp('device-1', 'com.example.custom'),
+    ).resolves.toBeUndefined();
+    expect(adbMock.spawnWaitText).toHaveBeenCalledWith([
+      'am',
+      'start',
+      '-a',
+      'android.intent.action.MAIN',
+      '-c',
+      'android.intent.category.LAUNCHER',
+      '-f',
+      '0x10200000',
+      '-n',
+      'com.example.custom/.MainActivity',
+    ]);
+    expect(adbMock.spawnWaitText).not.toHaveBeenCalledWith([
+      'monkey',
+      '-p',
+      'com.example.custom',
+      '-c',
+      'android.intent.category.LAUNCHER',
+      '1',
+    ]);
+  });
+});

--- a/packages/testing-library/kitten-lynx/tsconfig.json
+++ b/packages/testing-library/kitten-lynx/tsconfig.json
@@ -13,10 +13,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "paths": {
-      "@lynx-js/devtool-connector": ["../../mcp-servers/devtool-connector/dist/index.d.ts"],
-      "@lynx-js/devtool-connector/transport": ["../../mcp-servers/devtool-connector/dist/transport/index.d.ts"],
-    },
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1918,15 +1918,18 @@ importers:
 
   packages/testing-library/kitten-lynx:
     dependencies:
-      '@lynx-js/devtool-connector':
-        specifier: workspace:*
-        version: link:../../mcp-servers/devtool-connector
       '@yume-chan/adb':
         specifier: catalog:adb
         version: 2.5.1
       '@yume-chan/adb-server-node-tcp':
         specifier: catalog:adb
         version: 2.5.2
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3
+      usbmux-client:
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       '@lynx-js/preact-devtools':
         specifier: 5.0.1-20260525112551-dfe2d03
@@ -1943,6 +1946,9 @@ importers:
       '@lynx-js/types':
         specifier: 4.0.0
         version: 4.0.0
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28


### PR DESCRIPTION
## Summary

- Fork the devtool connector implementation into `packages/testing-library/kitten-lynx/src/connector`.
- Switch Kitten Lynx runtime imports to the local connector fork and drop the workspace dependency on `@lynx-js/devtool-connector`.
- Remove the Android known-app whitelist by listing installed packages from `pm list packages`, allowing any installed package name to be launched.
- Move/add connector coverage under Kitten Lynx with mocked ADB transport tests.

## Why

Kitten Lynx needs to own the connector behavior directly so app startup is not constrained by the devtool connector package's hard-coded known apps list.

## Validation

- Read PR-triggered GitHub Actions: `test.yml`, `workflow-build.yml`, `workflow-test.yml`, `nodejs-dependencies.yml`, and PR title/content checks.
- `pnpm dprint check ...`
- `pnpm dedupe --check`
- `pnpm --package=@pnpm/meta-updater@2.0.6 dlx meta-updater --test`
- `pnpm changeset status --since=origin/main --output .changeset-status.json`
- `node .github/scripts/check-dep-changes-have-changeset.cjs .changeset-status.json origin/main`
- `node .github/scripts/check-no-major-changeset.cjs .changeset-status.json`
- `node .github/scripts/check-no-heading-changeset.cjs .changeset-status.json`
- `pnpm --filter @lynx-js/kitten-lynx-test-infra exec vitest run tests/android-transport.spec.ts`
- `pnpm turbo build --filter=@lynx-js/kitten-lynx-test-infra`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader device connection support across Android, desktop, and iOS environments.
  * Improved app launching so any installed package can be selected, not just a fixed set.
  * Expanded device and session discovery for more reliable test automation.

* **Bug Fixes**
  * Removed a dependency on an external connector path, making local test tooling more self-contained.
  * Improved handling of connector sessions and streaming responses for more stable interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->