### PR TITLE
ci: cache pnpm store to reduce install timeouts

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -1,0 +1,48 @@
+name: pnpm install
+description: Install pnpm dependencies with store cache
+
+inputs:
+  node-version:
+    description: Node.js version to install
+    default: "22"
+    required: false
+  save-if:
+    description: Whether to save the cache
+    default: "false"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      with:
+        node-version: ${{ inputs.node-version }}
+        package-manager-cache: false
+
+    - name: Get pnpm store directory
+      id: pnpm-store
+      shell: bash
+      run: | # zizmor: ignore[adhoc-packages] corepack must be installed globally outside of a lockfile
+        npm install -g corepack@latest
+        corepack enable
+        echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore pnpm store cache
+      id: restore
+      uses: lynx-infra/cache/restore@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: pnpm-store-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-v1-${{ runner.os }}-
+
+    - name: Install
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store cache
+      if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      uses: lynx-infra/cache/save@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: pnpm-store-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -33,15 +33,11 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
         with:
           cache: false
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - name: Install
+        uses: ./.github/actions/pnpm-install
         with:
           node-version: "24"
-          package-manager-cache: false
-      - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable && corepack prepare
-          corepack pnpm install --frozen-lockfile
+          save-if: ${{ github.ref_name == 'main' }}
       - name: build
         run: |
           corepack pnpm turbo --filter !benchx_cli --filter "!@lynx-js/benchmark-*" build --summarize
@@ -160,10 +156,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
       - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable && corepack prepare
-          corepack pnpm install --frozen-lockfile
+        uses: ./.github/actions/pnpm-install
+        with:
+          node-version: "24"
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Download Turbo Cache
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         timeout-minutes: 5
@@ -208,10 +204,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
       - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable && corepack prepare
-          corepack pnpm install --frozen-lockfile
+        uses: ./.github/actions/pnpm-install
+        with:
+          node-version: "24"
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Download Turbo Cache
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,15 +44,11 @@ jobs:
           # We need full history for changeset status check
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - name: Install
+        uses: ./.github/actions/pnpm-install
         with:
           node-version: "24"
-          package-manager-cache: false
-      - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-          pnpm install --frozen-lockfile
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Code Style Check
         run: |
           pnpm dprint check

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -37,10 +37,11 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - name: Install
+        uses: ./.github/actions/pnpm-install
         with:
           node-version: "24"
-          package-manager-cache: false
+          save-if: ${{ github.ref_name == 'main' }}
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       - name: Setup Rust
         shell: bash
@@ -78,11 +79,6 @@ jobs:
           # different OSS bucket than this physical-exclusive runner, so we
           # tolerate cache misses and let `pnpm turbo build` rebuild locally.
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
-      - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-          pnpm install --frozen-lockfile
       - name: Build
         run: |
           pnpm turbo build

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -85,10 +85,6 @@ jobs:
           persist-credentials: false
       - name: Disable local Git maintenance
         run: git config --local maintenance.auto false
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: "22"
-          package-manager-cache: false
       - name: Setup Rust
         uses: ./.github/actions/rustup
         with:
@@ -109,10 +105,10 @@ jobs:
             turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-
             turbo-v4-${{ runner.os }}-
       - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-          pnpm install --frozen-lockfile
+        uses: ./.github/actions/pnpm-install
+        with:
+          node-version: "22"
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Build
         id: build
         run: |

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -34,10 +34,6 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: "24"
-          package-manager-cache: false
       - name: TurboCache
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
@@ -46,10 +42,10 @@ jobs:
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-          pnpm install --frozen-lockfile
+        uses: ./.github/actions/pnpm-install
+        with:
+          node-version: "24"
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Build
         run: |
           pnpm turbo build --summarize

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -79,10 +79,6 @@ jobs:
           # Codecov requires fetch-depth: 0
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: "22"
-          package-manager-cache: false
       - name: TurboCache
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
@@ -91,10 +87,9 @@ jobs:
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-          pnpm install --frozen-lockfile
+        uses: ./.github/actions/pnpm-install
+        with:
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Build
         run: pnpm turbo build --summarize
       - name: Test # zizmor: ignore[template-injection] The inputs.run is provided by us.

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -15,10 +15,6 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: "24"
-          package-manager-cache: false
       - name: TurboCache
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
@@ -29,10 +25,10 @@ jobs:
         id: pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Install
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-          pnpm install --frozen-lockfile
+        uses: ./.github/actions/pnpm-install
+        with:
+          node-version: "24"
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Build
         run: |
           pnpm turbo --filter website build:docs


### PR DESCRIPTION
## Summary

Add a composite action (`.github/actions/pnpm-install`) that caches the pnpm content-addressable store via `lynx-infra/cache`, keyed on `pnpm-lock.yaml` and runner OS.

## Problem

CI frequently times out during `pnpm install --frozen-lockfile` because every run downloads all packages from the registry from scratch. Example: https://github.com/lynx-family/lynx-stack/actions/runs/28160909050/job/83410632355?pr=2884

## Solution

When the pnpm store cache is warm, `pnpm install` only needs to hard-link packages from the local store into `node_modules` — no network downloads required. This eliminates timeout failures caused by slow/flaky registry connections.

The composite action:
1. Sets up Node.js via `actions/setup-node`
2. Installs corepack and enables pnpm
3. Restores pnpm store from `lynx-infra/cache` (same cache backend as turbo cache)
4. Runs `pnpm install --frozen-lockfile`
5. Saves the store cache on miss

All workflows that previously had inline install steps now use `uses: ./.github/actions/pnpm-install`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared pnpm install composite action with configurable Node version and cached pnpm store.
* **Bug Fixes**
  * Standardized dependency installation across build, test, deploy, benchmark, bundle analysis, and website workflows to use a consistent frozen-lockfile flow.
* **Chores**
  * Updated workflows to remove inline Corepack/pnpm install steps and conditionally save the cache only on the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->