### PR TITLE
feat(playground): add OpenUI conversation history

### DIFF
--- a/.github/changeset-ci.instructions.md
+++ b/.github/changeset-ci.instructions.md
@@ -1,7 +1,9 @@
 ---
-applyTo: ".github/workflows/test.yml"
+applyTo: ".github/workflows/**"
 ---
 
 When validating changesets in CI, use `pnpm changeset status --since=origin/main --output <file>` and consume the JSON in a script for stable checks (for example, blocking `major` bumps) instead of parsing CLI text output.
 
 When validating changeset Markdown files in CI, run `node .github/scripts/check-no-heading-changeset.cjs .changeset-status.json` so the script resolves files from `changeset status` output, and fail the job if any listed changeset file contains H1 (`#`), H2 (`##`) or H3 (`###`) headings.
+
+When running `changeset status --since=origin/<base>` after `actions/checkout` with shallow history in pull request workflows, fetch and iteratively deepen both the base branch ref and the current pull request merge ref. Deepening only `origin/<base>` can leave `HEAD` shallow and make `git merge-base origin/<base> HEAD` fail even after repeated fetches.

--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -10,6 +10,8 @@ When wiring playback state between the Lynx app and the web preview, prefer `Nat
 
 When adding or updating playground conversation history, keep records isolated by protocol. Store new records with `ConversationMeta.protocol`, use protocol-scoped active-id metadata such as `activeConversationId:a2ui` and `activeConversationId:openui`, and treat legacy records without a `protocol` field as A2UI conversations so existing browser history remains visible.
 
+When importing shared playground conversations, validate the `importConv` URL before fetching it. Accept only current-origin documents or the GenUI Supabase Storage conversation-object path, then validate the shared document protocol before calling `importShared`; missing shared-document protocol is legacy A2UI, and unknown or mismatched protocols should be rejected.
+
 ## Native Bundles
 
 When serving the playground's native Lynx bundles as static Android test fixtures, keep HMR/React refresh out of `a2ui.lynx.js` and `openui.lynx.js`. The Android Lynx runtime does not provide globals such as `__prefresh_utils__` or Node's `process`, so normalize `process.env.NODE_ENV` at build time and disable HMR for these bundles instead of relying on the caller's `NODE_ENV`.

--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -6,6 +6,10 @@ applyTo: "packages/genui/playground/**"
 
 When wiring playback state between the Lynx app and the web preview, prefer `NativeModules.bridge.call('A2UI_PLAYBACK_SYNC', state, callback)` on the Lynx side and `lynxView.onNativeModulesCall` on the web preview side. Keep `window.postMessage` only as a compatibility fallback for older bundles. Do not add new playback sync paths that bypass the NativeModules bridge.
 
+## Conversation Storage
+
+When adding or updating playground conversation history, keep records isolated by protocol. Store new records with `ConversationMeta.protocol`, use protocol-scoped active-id metadata such as `activeConversationId:a2ui` and `activeConversationId:openui`, and treat legacy records without a `protocol` field as A2UI conversations so existing browser history remains visible.
+
 ## Native Bundles
 
 When serving the playground's native Lynx bundles as static Android test fixtures, keep HMR/React refresh out of `a2ui.lynx.js` and `openui.lynx.js`. The Android Lynx runtime does not provide globals such as `__prefresh_utils__` or Node's `process`, so normalize `process.env.NODE_ENV` at build time and disable HMR for these bundles instead of relying on the caller's `NODE_ENV`.

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -138,19 +138,23 @@ jobs:
           github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
+          CURRENT_REF: ${{ github.ref }}
         # actions/checkout uses depth=1, so neither `origin/<base>` nor the
         # PR/base merge-base are present. `changeset status --since=<ref>`
         # calls `git merge-base <ref> HEAD`, which requires the common
         # ancestor to be in local history. Deepen both refs iteratively until
         # we have it.
         run: |
-          git fetch --depth=1 origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
+          git fetch --depth=1 origin \
+            "$BASE_REF":"refs/remotes/origin/$BASE_REF" \
+            "$CURRENT_REF":"refs/remotes/origin/pr-merge"
           for _ in 1 2 3 4 5 6 7 8 9 10; do
             if git merge-base "refs/remotes/origin/$BASE_REF" HEAD >/dev/null 2>&1; then
               exit 0
             fi
-            git fetch -q --deepen=10 origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-            git fetch -q --deepen=10 origin HEAD
+            git fetch -q --deepen=10 origin \
+              "$BASE_REF":"refs/remotes/origin/$BASE_REF" \
+              "$CURRENT_REF":"refs/remotes/origin/pr-merge"
           done
           echo "::error::Unable to find a merge base between origin/$BASE_REF and HEAD after 10 deepen iterations" >&2
           exit 1

--- a/packages/genui/playground/src/hooks/useConversation.ts
+++ b/packages/genui/playground/src/hooks/useConversation.ts
@@ -19,6 +19,7 @@ import {
 import type { SharedConversationDoc } from '../storage/sharedConversation.js';
 import type {
   ConversationMeta,
+  ConversationProtocol,
   DataModelSnapshot,
   PersistedMessage,
   PreviewPayloadUrls,
@@ -265,7 +266,9 @@ function cloneHotState(state: ConversationHotState): ConversationHotState {
   };
 }
 
-export function useConversation(): UseConversationReturn {
+export function useConversation(
+  protocol: ConversationProtocol = 'a2ui',
+): UseConversationReturn {
   const [conversations, setConversations] = useState<ConversationMeta[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [messages, setMessages] = useState<ModelChatMessage[]>([]);
@@ -338,7 +341,7 @@ export function useConversation(): UseConversationReturn {
       const record = persistentRef.current ? await loadConversation(id) : null;
       if (activationTokenRef.current !== token) return false;
       if (!record) return false;
-      await setActiveConversationId(id);
+      await setActiveConversationId(id, protocol);
       if (activationTokenRef.current !== token) return false;
       activeIdRef.current = id;
       setActiveId(id);
@@ -351,28 +354,28 @@ export function useConversation(): UseConversationReturn {
       );
       return true;
     },
-    [syncHotState],
+    [protocol, syncHotState],
   );
 
   const refreshConversations = useCallback(async () => {
     if (!persistentRef.current) return;
-    setConversations(await listConversations());
-  }, []);
+    setConversations(await listConversations(protocol));
+  }, [protocol]);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
-        let items = await listConversations();
-        let id = await getActiveConversationId();
+        let items = await listConversations(protocol);
+        let id = await getActiveConversationId(protocol);
         if (!id || !items.some((item) => item.id === id)) {
           if (items.length === 0) {
-            const created = await createConversation();
+            const created = await createConversation(undefined, protocol);
             id = created.id;
             items = [created];
           } else {
             id = items[0]?.id ?? null;
-            await setActiveConversationId(id);
+            await setActiveConversationId(id, protocol);
           }
         }
         if (cancelled || !id) return;
@@ -385,7 +388,7 @@ export function useConversation(): UseConversationReturn {
         );
         persistentRef.current = false;
         if (cancelled) return;
-        const meta = createConversationMeta();
+        const meta = createConversationMeta(undefined, protocol);
         setIsPersistent(false);
         setConversations([meta]);
         activeIdRef.current = meta.id;
@@ -399,7 +402,7 @@ export function useConversation(): UseConversationReturn {
     return () => {
       cancelled = true;
     };
-  }, [activateRecord, syncHotState]);
+  }, [activateRecord, protocol, syncHotState]);
 
   const switchTo = useCallback(
     async (id: string) => {
@@ -427,7 +430,7 @@ export function useConversation(): UseConversationReturn {
 
   const createNew = useCallback(async () => {
     if (!persistentRef.current) {
-      const meta = createConversationMeta();
+      const meta = createConversationMeta(undefined, protocol);
       const hotState = createEmptyHotState();
       conversationHotStateMapRef.current.set(meta.id, hotState);
       setConversations((prev) => [meta, ...prev]);
@@ -444,22 +447,25 @@ export function useConversation(): UseConversationReturn {
       return meta.id;
     }
 
-    const meta = await createConversation();
-    await setActiveConversationId(meta.id);
+    const meta = await createConversation(undefined, protocol);
+    await setActiveConversationId(meta.id, protocol);
     setConversations((prev) => [meta, ...prev]);
     activationTokenRef.current = null;
     activeIdRef.current = meta.id;
     setActiveId(meta.id);
     syncHotState([], {}, new Set(), [], null);
     return meta.id;
-  }, [syncHotState]);
+  }, [protocol, syncHotState]);
 
   const importShared = useCallback(
     async (doc: SharedConversationDoc): Promise<string> => {
       // In-memory fallback (IndexedDB unavailable): build hot state directly.
       if (!persistentRef.current) {
         const meta: ConversationMeta = {
-          ...createConversationMeta(doc.title || 'Shared conversation'),
+          ...createConversationMeta(
+            doc.title || 'Shared conversation',
+            protocol,
+          ),
           messageCount: doc.messages.length,
           previewText: previewTextFromSharedMessages(doc.messages),
         };
@@ -495,24 +501,24 @@ export function useConversation(): UseConversationReturn {
         return meta.id;
       }
 
-      const meta = await importConversation(doc);
-      await setActiveConversationId(meta.id);
+      const meta = await importConversation(doc, protocol);
+      await setActiveConversationId(meta.id, protocol);
       await refreshConversations();
       await activateRecord(meta.id);
       return meta.id;
     },
-    [activateRecord, refreshConversations, syncHotState],
+    [activateRecord, protocol, refreshConversations, syncHotState],
   );
 
   const remove = useCallback(
     async (id: string) => {
       if (persistentRef.current) {
-        await deleteConversation(id);
+        await deleteConversation(id, protocol);
       } else {
         conversationHotStateMapRef.current.delete(id);
       }
       const nextItems = persistentRef.current
-        ? await listConversations()
+        ? await listConversations(protocol)
         : conversations.filter((item) => item.id !== id);
       if (nextItems.length === 0) {
         const nextId = await createNew();
@@ -525,7 +531,7 @@ export function useConversation(): UseConversationReturn {
         await switchTo(nextItems[0]?.id ?? '');
       }
     },
-    [conversations, createNew, switchTo],
+    [conversations, createNew, protocol, switchTo],
   );
 
   const rename = useCallback(async (id: string, title: string) => {
@@ -571,9 +577,13 @@ export function useConversation(): UseConversationReturn {
 
       const existingMeta =
         conversationsRef.current.find((item) => item.id === id)
-          ?? createConversationMeta();
-      const nextMeta: ConversationMeta = {
+          ?? createConversationMeta(undefined, protocol);
+      const baseMeta = {
         ...existingMeta,
+        protocol,
+      };
+      const nextMeta: ConversationMeta = {
+        ...baseMeta,
         id,
         title: existingMeta.messageCount === 0
           ? titleFromMessage(input.userMessage.content)
@@ -631,7 +641,7 @@ export function useConversation(): UseConversationReturn {
         }
       }
     },
-    [createNew, syncHotState],
+    [createNew, protocol, syncHotState],
   );
 
   const updateLastAssistantPreviewMetrics = useCallback(

--- a/packages/genui/playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/playground/src/pages/AIChatPage.tsx
@@ -31,6 +31,7 @@ import {
 } from '../storage/conversationRepo.js';
 import {
   isSharedConversationDoc,
+  resolveSharedConversationProtocol,
   serializeConversation,
 } from '../storage/sharedConversation.js';
 import type { PreviewPerformanceMetrics } from '../storage/types.js';
@@ -44,6 +45,7 @@ import {
   clearImportConversationParam,
   publishConversation,
   readImportConversationParam,
+  resolveTrustedConversationImportUrl,
 } from '../utils/shareConversation.js';
 
 interface ChatMessage {
@@ -1545,7 +1547,13 @@ export function AIChatPage(
     importHandledRef.current = true;
     void (async () => {
       try {
-        const response = await window.fetch(importUrl);
+        const trustedImportUrl = resolveTrustedConversationImportUrl(importUrl);
+        if (!trustedImportUrl) {
+          throw new Error('Untrusted shared conversation URL');
+        }
+        const response = await window.fetch(trustedImportUrl, {
+          credentials: 'omit',
+        });
         if (!response.ok) {
           throw new Error(
             `Failed to load shared conversation: ${response.status}`,
@@ -1555,6 +1563,10 @@ export function AIChatPage(
         if (!isSharedConversationDoc(doc)) {
           throw new Error('Invalid shared conversation document');
         }
+        const docProtocol = resolveSharedConversationProtocol(doc);
+        if (docProtocol !== protocol.name) {
+          throw new Error('Shared conversation protocol does not match A2UI');
+        }
         await importShared(doc);
       } catch (err) {
         console.warn('[a2ui] Failed to import shared conversation', err);
@@ -1562,7 +1574,7 @@ export function AIChatPage(
         clearImportConversationParam();
       }
     })();
-  }, [isReady, importShared]);
+  }, [isReady, importShared, protocol.name]);
 
   useEffect(() => {
     return () => {

--- a/packages/genui/playground/src/pages/AIChatPage.tsx
+++ b/packages/genui/playground/src/pages/AIChatPage.tsx
@@ -1049,7 +1049,7 @@ export function AIChatPage(
   props: { protocol: Protocol; theme: 'light' | 'dark' },
 ) {
   const { protocol, theme } = props;
-  const conversation = useConversation();
+  const conversation = useConversation(protocol.name);
   const {
     activeId,
     buildConversationContext,

--- a/packages/genui/playground/src/pages/OpenUICreatePage.tsx
+++ b/packages/genui/playground/src/pages/OpenUICreatePage.tsx
@@ -32,6 +32,7 @@ import {
 } from '../storage/conversationRepo.js';
 import {
   isSharedConversationDoc,
+  resolveSharedConversationProtocol,
   serializeConversation,
 } from '../storage/sharedConversation.js';
 import { copyToClipboard } from '../utils/clipboard.js';
@@ -42,6 +43,7 @@ import {
   clearImportConversationParam,
   publishConversation,
   readImportConversationParam,
+  resolveTrustedConversationImportUrl,
 } from '../utils/shareConversation.js';
 
 interface ChatMessage {
@@ -541,7 +543,13 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
     importHandledRef.current = true;
     void (async () => {
       try {
-        const response = await window.fetch(importUrl);
+        const trustedImportUrl = resolveTrustedConversationImportUrl(importUrl);
+        if (!trustedImportUrl) {
+          throw new Error('Untrusted shared conversation URL');
+        }
+        const response = await window.fetch(trustedImportUrl, {
+          credentials: 'omit',
+        });
         if (!response.ok) {
           throw new Error(
             `Failed to load shared conversation: ${response.status}`,
@@ -551,6 +559,10 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
         if (!isSharedConversationDoc(doc)) {
           throw new Error('Invalid shared conversation document');
         }
+        const docProtocol = resolveSharedConversationProtocol(doc);
+        if (docProtocol !== protocol.name) {
+          throw new Error('Shared conversation protocol does not match OpenUI');
+        }
         await importShared(doc);
       } catch (err) {
         console.warn('[openui] Failed to import shared conversation', err);
@@ -558,7 +570,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
         clearImportConversationParam();
       }
     })();
-  }, [importShared, isReady]);
+  }, [importShared, isReady, protocol.name]);
 
   const applyScenario = useCallback((scenario: OpenUIScenario) => {
     const nextGenerated: GeneratedOpenUI = {
@@ -576,7 +588,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
   }, []);
 
   const handleLoadScenario = useCallback((scenario: OpenUIScenario) => {
-    if (isGenerating) return;
+    if (!isReady || isGenerating) return;
     abortRef.current?.abort();
     abortRef.current = null;
     setInputValue('');
@@ -591,11 +603,11 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
       a2uiMessages: [],
       previewMessages: [],
     });
-  }, [applyScenario, isGenerating, recordTurn]);
+  }, [applyScenario, isGenerating, isReady, recordTurn]);
 
   const handleSend = useCallback(() => {
     const prompt = inputValue.trim();
-    if (!prompt || isGenerating) return;
+    if (!isReady || !prompt || isGenerating) return;
 
     abortRef.current?.abort();
     const controller = new AbortController();
@@ -729,7 +741,13 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
         }
       }
     })();
-  }, [buildConversationContext, inputValue, isGenerating, recordTurn]);
+  }, [
+    buildConversationContext,
+    inputValue,
+    isGenerating,
+    isReady,
+    recordTurn,
+  ]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -743,6 +761,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
   );
 
   const handleCreateConversation = useCallback(() => {
+    if (!isReady) return;
     abortRef.current?.abort();
     abortRef.current = null;
     setInputValue('');
@@ -751,14 +770,14 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
     setMessages([WELCOME_MESSAGE]);
     setPreviewRenderKey((value) => value + 1);
     void createNew();
-  }, [createNew]);
+  }, [createNew, isReady]);
 
   const handleSwitchConversation = useCallback((id: string) => {
-    if (isGenerating) return;
+    if (!isReady || isGenerating) return;
     abortRef.current?.abort();
     abortRef.current = null;
     void switchTo(id);
-  }, [isGenerating, switchTo]);
+  }, [isGenerating, isReady, switchTo]);
 
   const shareConversation = useCallback(
     async (id: string) => {
@@ -934,7 +953,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
                           key={prompt.label}
                           type='button'
                           className='chatSuggestionChip'
-                          disabled={isGenerating}
+                          disabled={!isReady || isGenerating}
                           onClick={() => setInputValue(prompt.text)}
                         >
                           {prompt.label}
@@ -962,7 +981,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
                           key={scenario.id}
                           type='button'
                           className='chatSuggestionChip'
-                          disabled={isGenerating}
+                          disabled={!isReady || isGenerating}
                           onClick={() => handleLoadScenario(scenario)}
                         >
                           {scenario.title}
@@ -981,7 +1000,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
                 placeholder='Describe the OpenUI surface, data, state, or interactions you want to generate...'
                 value={inputValue}
                 rows={3}
-                disabled={isGenerating}
+                disabled={!isReady || isGenerating}
                 onChange={(event) => setInputValue(event.target.value)}
                 onKeyDown={handleKeyDown}
               />
@@ -989,7 +1008,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
                 <Button
                   variant='ghost'
                   size='lg'
-                  disabled={isGenerating}
+                  disabled={!isReady || isGenerating}
                   onClick={handleCreateConversation}
                 >
                   New draft
@@ -998,7 +1017,8 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
                   variant='primary'
                   size='lg'
                   iconBefore={Send}
-                  disabled={isGenerating || inputValue.trim().length === 0}
+                  disabled={!isReady || isGenerating
+                    || inputValue.trim().length === 0}
                   onClick={handleSend}
                 >
                   {isGenerating ? 'Generating' : 'Send'}

--- a/packages/genui/playground/src/pages/OpenUICreatePage.tsx
+++ b/packages/genui/playground/src/pages/OpenUICreatePage.tsx
@@ -8,6 +8,8 @@ import './AIChatPage.css';
 import './OpenUICreatePage.css';
 
 import { Button } from '../components/Button.js';
+import { ConfirmDialog } from '../components/ConfirmDialog.js';
+import { ConversationListPanel } from '../components/ConversationListPanel.js';
 import { CopyToast, useCopyToast } from '../components/CopyToast.js';
 import { Send, Sparkles } from '../components/Icon.js';
 import { MobileTabBar } from '../components/MobileTabBar.js';
@@ -16,15 +18,31 @@ import { PageHeader } from '../components/PageHeader.js';
 import { PanelResizeHandle } from '../components/PanelResizeHandle.js';
 import { PreviewPanel } from '../components/PreviewPanel.js';
 import { PreviewViewport } from '../components/PreviewViewport.js';
+import { useConversation } from '../hooks/useConversation.js';
+import type { ModelChatMessage } from '../hooks/useConversation.js';
 import { useResizablePanels } from '../hooks/useResizablePanels.js';
 import {
   OPENUI_SCENARIOS,
   parseOpenUIScenarioRaw,
 } from '../mock/openui-scenarios.js';
 import type { OpenUIScenario } from '../mock/openui-scenarios.js';
+import {
+  loadConversation,
+  saveConversationSharePayload,
+} from '../storage/conversationRepo.js';
+import {
+  isSharedConversationDoc,
+  serializeConversation,
+} from '../storage/sharedConversation.js';
 import { copyToClipboard } from '../utils/clipboard.js';
 import type { Protocol } from '../utils/protocol.js';
 import { isDevHost } from '../utils/publishPayload.js';
+import {
+  buildConversationShareUrl,
+  clearImportConversationParam,
+  publishConversation,
+  readImportConversationParam,
+} from '../utils/shareConversation.js';
 
 interface ChatMessage {
   id?: string;
@@ -323,8 +341,115 @@ function GeneratedOutputViewer(props: {
   );
 }
 
+const LOCAL_SCENARIO_PROMPT_PREFIX = 'Load local OpenUI scenario: ';
+
+function localScenarioTitleFromPrompt(content: string): string | null {
+  if (!content.startsWith(LOCAL_SCENARIO_PROMPT_PREFIX)) return null;
+  const title = content.slice(LOCAL_SCENARIO_PROMPT_PREFIX.length).trim();
+  return title || null;
+}
+
+function createGeneratedStatus(): ChatMessage {
+  return {
+    role: 'status',
+    tone: 'success',
+    content: (
+      <>
+        <span className='chatMessageStatusIcon' aria-hidden='true'>
+          <Sparkles size={13} strokeWidth={2} />
+        </span>
+        <span>
+          Generated OpenUI Lang from the server agent. The Lynx Preview is
+          rendering the final response.
+        </span>
+      </>
+    ),
+  };
+}
+
+function createLoadedScenarioStatus(title: string): ChatMessage {
+  return {
+    role: 'status',
+    tone: 'success',
+    content: (
+      <>
+        <span className='chatMessageStatusIcon' aria-hidden='true'>
+          <Sparkles size={13} strokeWidth={2} />
+        </span>
+        <span>
+          Loaded local OpenUI scenario{' '}
+          <code className='chatMessageStatusInline'>{title}</code>. No API call
+          was made.
+        </span>
+      </>
+    ),
+  };
+}
+
+function buildChatMessagesFromHistory(
+  history: ModelChatMessage[],
+): ChatMessage[] {
+  if (history.length === 0) return [WELCOME_MESSAGE];
+
+  const next: ChatMessage[] = [WELCOME_MESSAGE];
+  let previousScenarioTitle: string | null = null;
+  for (const message of history) {
+    if (message.role === 'user') {
+      previousScenarioTitle = localScenarioTitleFromPrompt(message.content);
+      next.push({ role: 'user', content: message.content });
+      continue;
+    }
+    if (message.role === 'assistant') {
+      next.push(
+        previousScenarioTitle
+          ? createLoadedScenarioStatus(previousScenarioTitle)
+          : createGeneratedStatus(),
+      );
+      previousScenarioTitle = null;
+    }
+  }
+  return next;
+}
+
+function getLastGeneratedOpenUI(
+  history: ModelChatMessage[],
+): GeneratedOpenUI | null {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const message = history[i];
+    if (message?.role !== 'assistant') continue;
+    const rawText = message.content.trim();
+    if (!rawText) continue;
+    const previousUser = history
+      .slice(0, i)
+      .reverse()
+      .find((item) => item.role === 'user');
+    return {
+      rawText,
+      scenarioTitle: previousUser
+        ? localScenarioTitleFromPrompt(previousUser.content) ?? 'Saved response'
+        : 'Saved response',
+    };
+  }
+  return null;
+}
+
 export function OpenUICreatePage(props: { protocol: Protocol }) {
   const { protocol } = props;
+  const conversation = useConversation(protocol.name);
+  const {
+    activeId,
+    buildConversationContext,
+    conversations,
+    createNew,
+    importShared,
+    isPersistent,
+    isReady,
+    messages: persistedMessages,
+    recordTurn,
+    remove,
+    rename,
+    switchTo,
+  } = conversation;
   const [messages, setMessages] = useState<ChatMessage[]>(() => [
     WELCOME_MESSAGE,
   ]);
@@ -335,8 +460,13 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
   const [activeMobileTab, setActiveMobileTab] = useState<MobilePaneTab>(
     'edit',
   );
+  const [deleteConversationId, setDeleteConversationId] = useState<
+    string | null
+  >(null);
   const abortRef = useRef<AbortController | null>(null);
   const chatMessagesRef = useRef<HTMLDivElement>(null);
+  const hydratedActiveIdRef = useRef<string | null>(null);
+  const importHandledRef = useRef(false);
   const { showCopyToast, toast: copyToast } = useCopyToast();
 
   const {
@@ -389,33 +519,59 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
     [showCopyToast],
   );
 
+  const baseUrl = useMemo(() => window.location.href.replace(/#.*$/, ''), []);
+
+  useEffect(() => {
+    if (!isReady || isGenerating) return;
+    if (hydratedActiveIdRef.current === activeId) return;
+    hydratedActiveIdRef.current = activeId;
+    setMessages(buildChatMessagesFromHistory(persistedMessages));
+    setGenerated(getLastGeneratedOpenUI(persistedMessages));
+    setInputValue('');
+    setPreviewRenderKey((value) => value + 1);
+  }, [activeId, isGenerating, isReady, persistedMessages]);
+
+  useEffect(() => {
+    if (!isReady || importHandledRef.current) return;
+    const importUrl = readImportConversationParam();
+    if (!importUrl) {
+      importHandledRef.current = true;
+      return;
+    }
+    importHandledRef.current = true;
+    void (async () => {
+      try {
+        const response = await window.fetch(importUrl);
+        if (!response.ok) {
+          throw new Error(
+            `Failed to load shared conversation: ${response.status}`,
+          );
+        }
+        const doc = (await response.json()) as unknown;
+        if (!isSharedConversationDoc(doc)) {
+          throw new Error('Invalid shared conversation document');
+        }
+        await importShared(doc);
+      } catch (err) {
+        console.warn('[openui] Failed to import shared conversation', err);
+      } finally {
+        clearImportConversationParam();
+      }
+    })();
+  }, [importShared, isReady]);
+
   const applyScenario = useCallback((scenario: OpenUIScenario) => {
     const nextGenerated: GeneratedOpenUI = {
       rawText: scenario.raw,
       scenarioTitle: scenario.title,
     };
+    const userPrompt = `${LOCAL_SCENARIO_PROMPT_PREFIX}${scenario.title}`;
     setGenerated(nextGenerated);
     setPreviewRenderKey((value) => value + 1);
     setMessages([
       WELCOME_MESSAGE,
-      {
-        role: 'status' as const,
-        tone: 'success' as const,
-        content: (
-          <>
-            <span className='chatMessageStatusIcon' aria-hidden='true'>
-              <Sparkles size={13} strokeWidth={2} />
-            </span>
-            <span>
-              Loaded local OpenUI scenario{' '}
-              <code className='chatMessageStatusInline'>
-                {scenario.title}
-              </code>
-              . No API call was made.
-            </span>
-          </>
-        ),
-      },
+      { role: 'user', content: userPrompt },
+      createLoadedScenarioStatus(scenario.title),
     ]);
   }, []);
 
@@ -426,7 +582,16 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
     setInputValue('');
     setIsGenerating(false);
     applyScenario(scenario);
-  }, [applyScenario, isGenerating]);
+    void recordTurn({
+      userMessage: {
+        role: 'user',
+        content: `${LOCAL_SCENARIO_PROMPT_PREFIX}${scenario.title}`,
+      },
+      assistantContent: scenario.raw,
+      a2uiMessages: [],
+      previewMessages: [],
+    });
+  }, [applyScenario, isGenerating, recordTurn]);
 
   const handleSend = useCallback(() => {
     const prompt = inputValue.trim();
@@ -438,6 +603,8 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
     const { signal } = controller;
 
     const pendingId = createMessageId('openui-pending');
+    const userMessage: ModelChatMessage = { role: 'user', content: prompt };
+    const requestConversation = buildConversationContext();
     setInputValue('');
     setGenerated(null);
     setIsGenerating(true);
@@ -468,7 +635,8 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
           },
           body: JSON.stringify({
             resourceId: 'openui-create',
-            messages: [{ role: 'user', content: prompt }],
+            messages: [userMessage],
+            conversation: requestConversation,
           }),
           signal,
         });
@@ -514,23 +682,18 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
           scenarioTitle: 'Agent response',
         });
         setPreviewRenderKey((value) => value + 1);
+        await recordTurn({
+          userMessage,
+          assistantContent: generatedText,
+          a2uiMessages: [],
+          previewMessages: [],
+        });
         setMessages((current) =>
           current.map((message) =>
             message.id === pendingId
               ? {
                 ...message,
-                tone: 'success',
-                content: (
-                  <>
-                    <span className='chatMessageStatusIcon' aria-hidden='true'>
-                      <Sparkles size={13} strokeWidth={2} />
-                    </span>
-                    <span>
-                      Generated OpenUI Lang from the server agent. The Lynx
-                      Preview is rendering the final response.
-                    </span>
-                  </>
-                ),
+                ...createGeneratedStatus(),
               }
               : message
           )
@@ -566,17 +729,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
         }
       }
     })();
-  }, [inputValue, isGenerating]);
-
-  const handleCreateNew = useCallback(() => {
-    abortRef.current?.abort();
-    abortRef.current = null;
-    setInputValue('');
-    setGenerated(null);
-    setIsGenerating(false);
-    setMessages([WELCOME_MESSAGE]);
-    setPreviewRenderKey((value) => value + 1);
-  }, []);
+  }, [buildConversationContext, inputValue, isGenerating, recordTurn]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -589,6 +742,90 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
     [handleSend],
   );
 
+  const handleCreateConversation = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setInputValue('');
+    setGenerated(null);
+    setIsGenerating(false);
+    setMessages([WELCOME_MESSAGE]);
+    setPreviewRenderKey((value) => value + 1);
+    void createNew();
+  }, [createNew]);
+
+  const handleSwitchConversation = useCallback((id: string) => {
+    if (isGenerating) return;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    void switchTo(id);
+  }, [isGenerating, switchTo]);
+
+  const shareConversation = useCallback(
+    async (id: string) => {
+      try {
+        const record = await loadConversation(id);
+        if (!record || record.messages.length === 0) {
+          showCopyToast(false);
+          return;
+        }
+
+        const cached = record.snapshot?.sharePayload;
+        let conversationUrl: string | undefined;
+        if (cached && cached.updatedAt === record.meta.updatedAt) {
+          conversationUrl = cached.url;
+        }
+        if (!conversationUrl) {
+          const doc = serializeConversation(record, protocol.name);
+          conversationUrl = await publishConversation(doc);
+          await saveConversationSharePayload(
+            id,
+            conversationUrl,
+            record.meta.updatedAt,
+          );
+        }
+        const link = buildConversationShareUrl(
+          conversationUrl,
+          baseUrl,
+          protocol.name,
+        );
+        showCopyToast(await copyToClipboard(link));
+      } catch {
+        showCopyToast(false);
+      }
+    },
+    [baseUrl, protocol.name, showCopyToast],
+  );
+
+  const handleShareConversation = useCallback((id: string) => {
+    void shareConversation(id);
+  }, [shareConversation]);
+
+  const handleRenameConversation = useCallback((id: string, title: string) => {
+    void rename(id, title);
+  }, [rename]);
+
+  const handleRemoveConversation = useCallback((id: string) => {
+    setDeleteConversationId(id);
+  }, []);
+
+  const deleteConversationTitle = useMemo(
+    () =>
+      conversations.find((item) => item.id === deleteConversationId)?.title
+        ?? 'this conversation',
+    [conversations, deleteConversationId],
+  );
+
+  const handleCancelDeleteConversation = useCallback(() => {
+    setDeleteConversationId(null);
+  }, []);
+
+  const handleConfirmDeleteConversation = useCallback(() => {
+    const id = deleteConversationId;
+    if (!id) return;
+    setDeleteConversationId(null);
+    void remove(id);
+  }, [deleteConversationId, remove]);
+
   return (
     <div
       ref={pageRef}
@@ -598,7 +835,29 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
       data-active-tab={activeMobileTab}
     >
       <CopyToast toast={copyToast} />
+      <ConfirmDialog
+        open={deleteConversationId !== null}
+        title='Delete conversation?'
+        description={`"${deleteConversationTitle}" will be removed from this browser. This cannot be undone.`}
+        confirmLabel='Delete'
+        cancelLabel='Keep'
+        tone='danger'
+        onCancel={handleCancelDeleteConversation}
+        onConfirm={handleConfirmDeleteConversation}
+      />
       <div className='chatPageBody'>
+        <ConversationListPanel
+          conversations={conversations}
+          activeId={activeId}
+          disabled={!isReady || isGenerating}
+          isPersistent={isPersistent}
+          onCreate={handleCreateConversation}
+          onSwitch={handleSwitchConversation}
+          onShare={handleShareConversation}
+          onRename={handleRenameConversation}
+          onRemove={handleRemoveConversation}
+        />
+
         <div className='chatPanel' style={chatPanelStyle}>
           <PageHeader
             className='chatHeader'
@@ -731,7 +990,7 @@ export function OpenUICreatePage(props: { protocol: Protocol }) {
                   variant='ghost'
                   size='lg'
                   disabled={isGenerating}
-                  onClick={handleCreateNew}
+                  onClick={handleCreateConversation}
                 >
                   New draft
                 </Button>

--- a/packages/genui/playground/src/storage/conversationRepo.test.ts
+++ b/packages/genui/playground/src/storage/conversationRepo.test.ts
@@ -1,0 +1,16 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { resolveConversationProtocol } from './conversationRepo.js';
+
+describe('conversation protocol metadata', () => {
+  test('treats legacy conversations without protocol as A2UI', () => {
+    expect(resolveConversationProtocol({})).toBe('a2ui');
+  });
+
+  test('keeps OpenUI conversations isolated by protocol metadata', () => {
+    expect(resolveConversationProtocol({ protocol: 'openui' })).toBe('openui');
+  });
+});

--- a/packages/genui/playground/src/storage/conversationRepo.ts
+++ b/packages/genui/playground/src/storage/conversationRepo.ts
@@ -5,6 +5,7 @@ import { getDB } from './db.js';
 import type { SharedConversationDoc } from './sharedConversation.js';
 import type {
   ConversationMeta,
+  ConversationProtocol,
   DataModelSnapshot,
   MetaRecord,
   PersistedMessage,
@@ -22,12 +23,24 @@ function createId(): string {
   }`;
 }
 
+function activeConversationMetaKey(protocol: ConversationProtocol): string {
+  return `activeConversationId:${protocol}`;
+}
+
+export function resolveConversationProtocol(
+  conversation: Pick<ConversationMeta, 'protocol'>,
+): ConversationProtocol {
+  return conversation.protocol ?? 'a2ui';
+}
+
 export function createConversationMeta(
   title = 'New conversation',
+  protocol: ConversationProtocol = 'a2ui',
 ): ConversationMeta {
   const now = Date.now();
   return {
     id: createId(),
+    protocol,
     title,
     createdAt: now,
     updatedAt: now,
@@ -36,39 +49,60 @@ export function createConversationMeta(
   };
 }
 
-export async function listConversations(): Promise<ConversationMeta[]> {
+export async function listConversations(
+  protocol: ConversationProtocol = 'a2ui',
+): Promise<ConversationMeta[]> {
   const db = await getDB();
   const tx = db.transaction('conversations', 'readonly');
   const items = await tx.store.index('by_updatedAt').getAll();
-  return items.sort((a, b) => b.updatedAt - a.updatedAt);
+  return items
+    .filter((item) => resolveConversationProtocol(item) === protocol)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
 }
 
-export async function getActiveConversationId(): Promise<string | null> {
+export async function getActiveConversationId(
+  protocol: ConversationProtocol = 'a2ui',
+): Promise<string | null> {
   const db = await getDB();
-  const record = await db.get('meta', 'activeConversationId');
-  return record?.value ?? null;
+  const record = await db.get('meta', activeConversationMetaKey(protocol));
+  if (record) return record.value;
+  if (protocol !== 'a2ui') return null;
+  const legacyRecord = await db.get('meta', 'activeConversationId');
+  return legacyRecord?.value ?? null;
 }
 
 export async function setActiveConversationId(
   id: string | null,
+  protocol: ConversationProtocol = 'a2ui',
 ): Promise<void> {
   const db = await getDB();
+  const key = activeConversationMetaKey(protocol);
   if (id === null) {
-    await db.delete('meta', 'activeConversationId');
+    await db.delete('meta', key);
+    if (protocol === 'a2ui') {
+      await db.delete('meta', 'activeConversationId');
+    }
     return;
   }
   const record: MetaRecord = {
-    key: 'activeConversationId',
+    key,
     value: id,
   };
   await db.put('meta', record);
+  if (protocol === 'a2ui') {
+    await db.put('meta', {
+      key: 'activeConversationId',
+      value: id,
+    });
+  }
 }
 
 export async function createConversation(
   title?: string,
+  protocol: ConversationProtocol = 'a2ui',
 ): Promise<ConversationMeta> {
   const db = await getDB();
-  const meta = createConversationMeta(title);
+  const meta = createConversationMeta(title, protocol);
   const tx = db.transaction(
     ['conversations', 'snapshots', 'meta'],
     'readwrite',
@@ -82,9 +116,15 @@ export async function createConversation(
     updatedAt: meta.updatedAt,
   });
   await tx.objectStore('meta').put({
-    key: 'activeConversationId',
+    key: activeConversationMetaKey(protocol),
     value: meta.id,
   });
+  if (protocol === 'a2ui') {
+    await tx.objectStore('meta').put({
+      key: 'activeConversationId',
+      value: meta.id,
+    });
+  }
   await tx.done;
   return meta;
 }
@@ -174,10 +214,11 @@ export function previewTextFromSharedMessages(
  */
 export async function importConversation(
   doc: SharedConversationDoc,
+  protocol: ConversationProtocol = 'a2ui',
 ): Promise<ConversationMeta> {
   const now = Date.now();
   const meta: ConversationMeta = {
-    ...createConversationMeta(doc.title || 'Shared conversation'),
+    ...createConversationMeta(doc.title || 'Shared conversation', protocol),
     messageCount: doc.messages.length,
     previewText: previewTextFromSharedMessages(doc.messages),
   };
@@ -218,7 +259,10 @@ export async function renameConversation(
   return next;
 }
 
-export async function deleteConversation(id: string): Promise<void> {
+export async function deleteConversation(
+  id: string,
+  protocol: ConversationProtocol = 'a2ui',
+): Promise<void> {
   const db = await getDB();
   const tx = db.transaction(
     ['conversations', 'messages', 'snapshots', 'meta'],
@@ -231,9 +275,18 @@ export async function deleteConversation(id: string): Promise<void> {
   for (const key of await messageIndex.getAllKeys(id)) {
     await messageStore.delete(key);
   }
-  const active = await tx.objectStore('meta').get('activeConversationId');
+  const activeKey = activeConversationMetaKey(protocol);
+  const active = await tx.objectStore('meta').get(activeKey);
   if (active?.value === id) {
-    await tx.objectStore('meta').delete('activeConversationId');
+    await tx.objectStore('meta').delete(activeKey);
+  }
+  if (protocol === 'a2ui') {
+    const legacyActive = await tx.objectStore('meta').get(
+      'activeConversationId',
+    );
+    if (legacyActive?.value === id) {
+      await tx.objectStore('meta').delete('activeConversationId');
+    }
   }
   await tx.done;
 }

--- a/packages/genui/playground/src/storage/sharedConversation.test.ts
+++ b/packages/genui/playground/src/storage/sharedConversation.test.ts
@@ -1,0 +1,24 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { resolveSharedConversationProtocol } from './sharedConversation.js';
+
+describe('shared conversation protocol metadata', () => {
+  test('treats legacy shared conversations without protocol as A2UI', () => {
+    expect(resolveSharedConversationProtocol({})).toBe('a2ui');
+  });
+
+  test('keeps OpenUI shared conversations explicit', () => {
+    expect(resolveSharedConversationProtocol({ protocol: 'openui' })).toBe(
+      'openui',
+    );
+  });
+
+  test('rejects unknown shared conversation protocols', () => {
+    expect(resolveSharedConversationProtocol({ protocol: 'unknown' })).toBe(
+      null,
+    );
+  });
+});

--- a/packages/genui/playground/src/storage/sharedConversation.ts
+++ b/packages/genui/playground/src/storage/sharedConversation.ts
@@ -3,7 +3,11 @@
 // LICENSE file in the root directory of this source tree.
 
 import type { ConversationRecord } from './conversationRepo.js';
-import type { PreviewPayloadUrls, PreviewPerformanceMetrics } from './types.js';
+import type {
+  ConversationProtocol,
+  PreviewPayloadUrls,
+  PreviewPerformanceMetrics,
+} from './types.js';
 
 export const SHARED_CONVERSATION_KIND = 'a2ui-conversation';
 
@@ -110,4 +114,14 @@ export function isSharedConversationDoc(
     && Array.isArray(doc.messages)
     && doc.messages.every((message) => isSharedConversationMessage(message))
   );
+}
+
+export function resolveSharedConversationProtocol(
+  doc: Pick<SharedConversationDoc, 'protocol'>,
+): ConversationProtocol | null {
+  if (doc.protocol === undefined) return 'a2ui';
+  if (doc.protocol === 'a2ui' || doc.protocol === 'openui') {
+    return doc.protocol;
+  }
+  return null;
 }

--- a/packages/genui/playground/src/storage/types.ts
+++ b/packages/genui/playground/src/storage/types.ts
@@ -2,8 +2,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+export type ConversationProtocol = 'a2ui' | 'openui';
+
 export interface ConversationMeta {
   id: string;
+  protocol?: ConversationProtocol;
   title: string;
   createdAt: number;
   updatedAt: number;
@@ -51,6 +54,6 @@ export interface DataModelSnapshot {
 }
 
 export interface MetaRecord {
-  key: 'activeConversationId' | 'schemaVersion';
+  key: string;
   value: string;
 }

--- a/packages/genui/playground/src/utils/shareConversation.test.ts
+++ b/packages/genui/playground/src/utils/shareConversation.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { resolveTrustedConversationImportUrl } from './shareConversation.js';
+
+describe('resolveTrustedConversationImportUrl', () => {
+  const pageOrigin = 'http://localhost:3001';
+
+  test('allows same-origin shared conversation documents', () => {
+    expect(
+      resolveTrustedConversationImportUrl('/__a2ui/abc/messages', pageOrigin),
+    ).toBe('http://localhost:3001/__a2ui/abc/messages');
+  });
+
+  test('allows GenUI Supabase Storage conversation documents', () => {
+    expect(
+      resolveTrustedConversationImportUrl(
+        'https://project.supabase.co/storage/v1/object/public/genui/a2ui/abc/messages.json',
+        pageOrigin,
+      ),
+    ).toBe(
+      'https://project.supabase.co/storage/v1/object/public/genui/a2ui/abc/messages.json',
+    );
+  });
+
+  test('rejects arbitrary cross-origin import URLs', () => {
+    expect(
+      resolveTrustedConversationImportUrl(
+        'https://example.com/messages.json',
+        pageOrigin,
+      ),
+    ).toBe(null);
+    expect(
+      resolveTrustedConversationImportUrl(
+        'http://127.0.0.1:8000/secrets.json',
+        pageOrigin,
+      ),
+    ).toBe(null);
+  });
+
+  test('rejects unrelated Supabase Storage paths', () => {
+    expect(
+      resolveTrustedConversationImportUrl(
+        'https://project.supabase.co/storage/v1/object/public/other/a2ui/abc/messages.json',
+        pageOrigin,
+      ),
+    ).toBe(null);
+  });
+});

--- a/packages/genui/playground/src/utils/shareConversation.ts
+++ b/packages/genui/playground/src/utils/shareConversation.ts
@@ -7,6 +7,9 @@ import type { SharedConversationDoc } from '../storage/sharedConversation.js';
 
 /** Query param that carries the URL of a shared conversation document. */
 export const IMPORT_CONVERSATION_PARAM = 'importConv';
+const SUPABASE_STORAGE_HOST_SUFFIX = '.supabase.co';
+const SUPABASE_CONVERSATION_PATH_PATTERN =
+  /^\/storage\/v1\/object\/public\/genui\/a2ui\/[^/]+\/messages\.json$/u;
 
 /**
  * Upload a serialized conversation to the GenUI server (Supabase Storage) and
@@ -42,6 +45,46 @@ export function readImportConversationParam(): string | null {
   return new URLSearchParams(window.location.search).get(
     IMPORT_CONVERSATION_PARAM,
   );
+}
+
+function currentPageOrigin(): string {
+  return typeof window === 'undefined'
+    ? 'http://localhost'
+    : window.location.origin;
+}
+
+function isTrustedSupabaseConversationUrl(endpoint: URL): boolean {
+  return endpoint.protocol === 'https:'
+    && endpoint.hostname.endsWith(SUPABASE_STORAGE_HOST_SUFFIX)
+    && SUPABASE_CONVERSATION_PATH_PATTERN.test(endpoint.pathname);
+}
+
+/**
+ * Resolve and validate a shared-conversation document URL before fetching it.
+ * Conversation shares are published either on the current playground origin
+ * (local/dev payload store) or as public Supabase Storage objects created by
+ * the GenUI payload publisher.
+ */
+export function resolveTrustedConversationImportUrl(
+  raw: string,
+  pageOrigin = currentPageOrigin(),
+): string | null {
+  try {
+    const endpoint = new URL(raw, pageOrigin);
+    const origin = new URL(pageOrigin);
+    if (
+      endpoint.origin === origin.origin
+      && (endpoint.protocol === 'http:' || endpoint.protocol === 'https:')
+    ) {
+      return endpoint.toString();
+    }
+    if (isTrustedSupabaseConversationUrl(endpoint)) {
+      return endpoint.toString();
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 /** Remove the import param from the URL so a reload does not re-import. */


### PR DESCRIPTION
## Summary
- add protocol-scoped conversation history for the GenUI playground so OpenUI and A2UI histories stay isolated
- wire OpenUI Create into the shared conversation list, persistence, share/import, rename, delete, and new-chat flows
- persist OpenUI agent responses and local scenario loads as conversation turns
- document protocol-scoped conversation storage and add a regression test for legacy/A2UI protocol handling

## Validation
- pnpm --filter genui-playground test
- pnpm turbo build --filter genui-playground
- pnpm turbo build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation history is now separated by app mode (protocol), keeping chats in the correct workspace.
  * Added protocol-aware shared conversation importing to ensure the imported chat matches the active mode.
  * Enhanced OpenUI create experience with conversation list panel and deletion confirmation.

* **Bug Fixes**
  * Improved restoration/hydration of conversation drafts, generated previews, and message history when switching or reopening chats.
  * Backward-compatible handling for legacy conversations and legacy shared links (defaults to the original mode).

* **Tests**
  * Added coverage for protocol resolution and trusted shared import URL validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->