### PR TITLE
fix(website): support zh genui playground route

### DIFF
--- a/.github/genui-playground-website.instructions.md
+++ b/.github/genui-playground-website.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: ".github/workflows/workflow-website.yml,packages/genui/playground/**"
+---
+
+The hosted GenUI playground is deployed by building `packages/genui/playground` and copying its full `dist` directory into `website/doc_build/genui` in `.github/workflows/workflow-website.yml`. When adding another hosted route alias such as `/zh/genui`, copy the full `dist` directory to that route as well instead of adding only an HTML redirect, because the playground opens `render.html`, demo JSON, and bundle files relative to the current route.

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -59,8 +59,10 @@ jobs:
           pnpm --filter genui-playground build
       - name: Copy GenUI Playground into website output
         run: |
-          rm -rf website/doc_build/genui
+          rm -rf website/doc_build/genui website/doc_build/zh/genui
+          mkdir -p website/doc_build/zh
           cp -r packages/genui/playground/dist website/doc_build/genui
+          cp -r packages/genui/playground/dist website/doc_build/zh/genui
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:


### PR DESCRIPTION
## Summary
- copy the GenUI playground dist into both /genui and /zh/genui during website deployment
- document the hosted playground route alias deployment pattern

## Verification
- pnpm dprint fmt --allow-no-files -- .github/workflows/workflow-website.yml .github/genui-playground-website.instructions.md
- simulated the workflow copy and verified zh/genui index.html, render.html, a2ui.web.js, and demos/recs.json exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GenUI Playground is now deployed for both the default site and the localized `/zh/genui` route.
  * Route-specific files are copied into each location so the playground works correctly from either path.

* **Bug Fixes**
  * Fixed issues where demos, bundled assets, or rendered pages could fail to load when accessed through localized routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->