### PR TITLE
fix(create-lynx-library): link Lynxtron runtime on Windows

### DIFF
--- a/packages/lynx/create-lynx-library/template-element/shared/elements/CMakeLists.txt.tmpl
+++ b/packages/lynx/create-lynx-library/template-element/shared/elements/CMakeLists.txt.tmpl
@@ -1,27 +1,43 @@
 file(GLOB LYNX_ELEMENT_SOURCES CONFIGURE_DEPENDS
   "${CMAKE_CURRENT_SOURCE_DIR}/*.cc"
-  "${CMAKE_CURRENT_SOURCE_DIR}/backends/texture/*.cc"
 )
 
+set(LYNX_ELEMENT_BACKEND_SOURCES)
 set(LYNX_ELEMENT_PLATFORM_SOURCES)
 
-if(APPLE)
-  file(GLOB_RECURSE LYNX_ELEMENT_PLATFORM_SOURCES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/backends/texture/macos/*.cc"
-    "${CMAKE_CURRENT_SOURCE_DIR}/backends/texture/macos/*.mm"
-    "${CMAKE_CURRENT_SOURCE_DIR}/backends/native-ui/macos/*.cc"
-    "${CMAKE_CURRENT_SOURCE_DIR}/backends/native-ui/macos/*.mm"
+if(LYNX_NATIVE_ELEMENT_BACKEND_TEXTURE)
+  file(GLOB LYNX_ELEMENT_BACKEND_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/backends/texture/*.cc"
   )
-elseif(WIN32)
-  file(GLOB_RECURSE LYNX_ELEMENT_PLATFORM_SOURCES CONFIGURE_DEPENDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/backends/texture/windows/*.cc"
-    "${CMAKE_CURRENT_SOURCE_DIR}/backends/native-ui/windows/*.cc"
-  )
+
+  if(APPLE)
+    file(GLOB_RECURSE LYNX_ELEMENT_PLATFORM_SOURCES CONFIGURE_DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/backends/texture/macos/*.cc"
+      "${CMAKE_CURRENT_SOURCE_DIR}/backends/texture/macos/*.mm"
+    )
+  elseif(WIN32)
+    file(GLOB_RECURSE LYNX_ELEMENT_PLATFORM_SOURCES CONFIGURE_DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/backends/texture/windows/*.cc"
+    )
+  endif()
+else()
+  if(APPLE)
+    file(GLOB_RECURSE LYNX_ELEMENT_PLATFORM_SOURCES CONFIGURE_DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/backends/native-ui/macos/*.cc"
+      "${CMAKE_CURRENT_SOURCE_DIR}/backends/native-ui/macos/*.mm"
+    )
+  elseif(WIN32)
+    file(GLOB_RECURSE LYNX_ELEMENT_PLATFORM_SOURCES CONFIGURE_DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/backends/native-ui/windows/*.cc"
+    )
+  endif()
 endif()
+
+list(APPEND LYNX_ELEMENT_BACKEND_SOURCES ${LYNX_ELEMENT_PLATFORM_SOURCES})
 
 add_library(__ADDON_TARGET_NAME__Elements OBJECT
   ${LYNX_ELEMENT_SOURCES}
-  ${LYNX_ELEMENT_PLATFORM_SOURCES}
+  ${LYNX_ELEMENT_BACKEND_SOURCES}
 )
 
 target_include_directories(__ADDON_TARGET_NAME__Elements PRIVATE

--- a/packages/lynx/create-lynx-library/template-shared/shared/CMakeLists.txt.tmpl
+++ b/packages/lynx/create-lynx-library/template-shared/shared/CMakeLists.txt.tmpl
@@ -99,6 +99,25 @@ if(NOT DEFINED LYNX_EXTENSION_HEADERS_DIR)
   )
 endif()
 
+if(WIN32 AND NOT DEFINED LYNX_EXTENSION_HEADERS_PACKAGE_ROOT)
+  lynx_resolve_node_package(
+    "@lynx-js/lynx-library-headers"
+    LYNX_EXTENSION_HEADERS_PACKAGE_ROOT
+  )
+endif()
+
+if(DEFINED LYNX_EXTENSION_HEADERS_PACKAGE_ROOT)
+  set(
+    LYNX_LIBRARY_HEADERS_CMAKE
+    "${LYNX_EXTENSION_HEADERS_PACKAGE_ROOT}/cmake/lynx-library-headers.cmake"
+  )
+  if(EXISTS "${LYNX_LIBRARY_HEADERS_CMAKE}")
+    include("${LYNX_LIBRARY_HEADERS_CMAKE}")
+  elseif(WIN32)
+    message(FATAL_ERROR "Missing Lynx library CMake helper: ${LYNX_LIBRARY_HEADERS_CMAKE}")
+  endif()
+endif()
+
 if(NOT EXISTS "${LYNX_EXTENSION_HEADERS_DIR}/include/lynx/registration.h")
   message(FATAL_ERROR "Missing Lynx extension headers. Run npm install first.")
 endif()
@@ -210,6 +229,12 @@ elseif(WIN32)
     gdi32
     user32
   )
+  if(COMMAND lynx_resolve_lynxtron_import_library)
+    lynx_resolve_lynxtron_import_library(LYNXTRON_RESOLVED_IMPORT_LIB)
+    list(APPEND LYNX_SHARED_PLATFORM_LINK_LIBRARIES
+      "${LYNXTRON_RESOLVED_IMPORT_LIB}"
+    )
+  endif()
 endif()
 
 set(LYNX_SHARED_TARGETS)

--- a/packages/lynx/create-lynx-library/test/create.test.ts
+++ b/packages/lynx/create-lynx-library/test/create.test.ts
@@ -176,10 +176,16 @@ describe('create-lynx-library', () => {
       '"@lynx-js/lynx-library-headers"',
     );
     expect(read(dir, 'shared/CMakeLists.txt')).toContain(
+      'lynx_resolve_lynxtron_import_library',
+    );
+    expect(read(dir, 'shared/CMakeLists.txt')).toContain(
       '"@lynx-js/weak-node-api"',
     );
     expect(read(dir, 'shared/elements/CMakeLists.txt')).not.toContain(
       'LYNX_SHARED_ENABLE_STATIC_REGISTER',
+    );
+    expect(read(dir, 'shared/elements/CMakeLists.txt')).toMatch(
+      /if\(LYNX_NATIVE_ELEMENT_BACKEND_TEXTURE\)[\s\S]*backends\/texture\/windows\/\*\.cc[\s\S]*else\(\)[\s\S]*backends\/native-ui\/windows\/\*\.cc/,
     );
     expect(read(dir, 'ios/build.podspec')).toContain(
       's.dependency \'LynxServiceAPI\'',
@@ -396,6 +402,9 @@ describe('create-lynx-library', () => {
       '"@lynx-js/lynx-library-headers"',
     );
     expect(read(dir, 'shared/CMakeLists.txt')).toContain(
+      'lynx_resolve_lynxtron_import_library',
+    );
+    expect(read(dir, 'shared/CMakeLists.txt')).toContain(
       '"@lynx-js/weak-node-api"',
     );
     expect(read(dir, 'shared/nativeModule/CMakeLists.txt')).toContain(
@@ -406,6 +415,9 @@ describe('create-lynx-library', () => {
     );
     expect(read(dir, 'shared/elements/CMakeLists.txt')).not.toContain(
       'LYNX_SHARED_ENABLE_STATIC_REGISTER',
+    );
+    expect(read(dir, 'shared/elements/CMakeLists.txt')).toMatch(
+      /if\(LYNX_NATIVE_ELEMENT_BACKEND_TEXTURE\)[\s\S]*backends\/texture\/windows\/\*\.cc[\s\S]*else\(\)[\s\S]*backends\/native-ui\/windows\/\*\.cc/,
     );
     expect(read(dir, 'README.md')).toContain('`lynxtron/`');
     expect(read(dir, 'README.md')).toContain('`shared/`');


### PR DESCRIPTION
## Summary

- resolve and include the CMake helper published by `@lynx-js/lynx-library-headers`
- link generated Lynxtron native libraries against the matching Windows `lynxtron.dll.lib`
- gate generated element backend sources so `LYNX_NATIVE_ELEMENT_BACKEND=texture` and `native-ui` build only their selected backend

## Related

Requires the companion Lynxtron package/header changes in https://github.com/lynx-family/lynxtron/pull/56.

## Validation

- `vitest run test/create.test.ts` from `packages/lynx/create-lynx-library`
- Locally generated and packed a Lynxtron library using the updated templates and headers package
- Installed the generated package through the shell demo via `pluginLynxtron`
- Smoke checked both `LYNX_NATIVE_ELEMENT_BACKEND=texture` and `LYNX_NATIVE_ELEMENT_BACKEND=native-ui` build paths in Lynxtron shell demo
- Smoke checked generated NAPI native module invocation in shell demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project templates now support choosing between texture-based and native UI element backends during library generation.
  * Windows builds can now automatically include the required Lynx headers package when available.
  * Generated projects now link an additional Lynxtron library when supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->