### PR TITLE
fix(genui-openui): render streamed image urls

### DIFF
--- a/.changeset/fix-openui-stream-image.md
+++ b/.changeset/fix-openui-stream-image.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": patch
+---
+
+Fix OpenUI streamed image rendering so partial state declaration values do not stick and image variants keep stable dimensions.

--- a/.github/openui-v05.instructions.md
+++ b/.github/openui-v05.instructions.md
@@ -11,3 +11,7 @@ When adding OpenUI v0.5 cases to `packages/genui/playground`, keep raw protocol 
 When exposing OpenUI prompt generation for server-side agents, keep prompt-only component libraries headless: mirror the ReactLynx component names and Zod schemas but use null renderers so Node routes can build system prompts without importing ReactLynx or Lynx UI runtime modules.
 
 When adding a built-in component under `packages/genui/openui/src/catalog`, update `src/catalog/index.ts`, the `DEFAULT_COMPONENTS` and `DEFAULT_COMPONENT_GROUPS` arrays in `src/core/createLibrary.tsx`, and `src/core/renderer.css` in the same change. Otherwise the component may be importable but absent from the default OpenUI library or render without its intended Lynx styles.
+
+When handling `$` state declarations in `useOpenUIState`, remember that streaming parser output can briefly contain partial string defaults such as `"h"` from an unfinished URL. During streaming, declaration defaults should be treated as transient parser output and synchronized forward; after streaming, preserve the normal store semantics that avoid clobbering existing user state.
+
+When styling OpenUI `Image` variants, remember that Lynx for Web maps `<image auto-size>` to `x-image[auto-size]` with `display: contents`; the shadow `<img>` inherits width and height from the host class. Give image variants concrete width and height values, not only `max-width` or `max-height`, or remote images can collapse to an invisible box even when `src` is valid.

--- a/packages/genui/openui/src/catalog/Image/index.tsx
+++ b/packages/genui/openui/src/catalog/Image/index.tsx
@@ -4,11 +4,12 @@
 import { z } from 'zod/v4';
 
 import { defineComponent } from '../../core/library.jsx';
+import { stringLikeSchema, stringifyValue } from '../utils.js';
 
 export const Image = defineComponent({
   name: 'Image',
   props: z.object({
-    url: z.string(),
+    url: stringLikeSchema,
     fit: z.enum(['contain', 'cover', 'fill', 'none', 'scale-down']).optional(),
     variant: z.enum([
       'icon',
@@ -23,6 +24,7 @@ export const Image = defineComponent({
   component: ({ props }) => {
     const fit = props.fit ?? 'cover';
     const variant = props.variant ?? 'mediumFeature';
+    const url = stringifyValue(props.url);
 
     const mode = (() => {
       switch (fit) {
@@ -41,7 +43,7 @@ export const Image = defineComponent({
     return (
       <image
         auto-size
-        src={props.url ?? ''}
+        src={url}
         mode={mode}
         className={`OpenUIImage OpenUIImageVariant${
           variant.charAt(0).toUpperCase() + variant.slice(1)

--- a/packages/genui/openui/src/core/hooks/useOpenUIState.ts
+++ b/packages/genui/openui/src/core/hooks/useOpenUIState.ts
@@ -171,9 +171,10 @@ export function useOpenUIState(
   const storeInitKeyRef = useRef<unknown>(Symbol());
   useEffect(() => {
     if (!result?.stateDeclarations && !initialState) return;
-    const key = `${JSON.stringify(result?.stateDeclarations)}::${
-      JSON.stringify(initialState)
-    }`;
+    const stateDeclarations = result?.stateDeclarations ?? {};
+    const key = `${isStreaming ? 'streaming' : 'stable'}::${
+      JSON.stringify(stateDeclarations)
+    }::${JSON.stringify(initialState)}`;
     if (storeInitKeyRef.current === key) return;
     storeInitKeyRef.current = key;
 
@@ -189,8 +190,22 @@ export function useOpenUIState(
         }
       }
     }
-    store.initialize(result?.stateDeclarations ?? {}, bindingDefaults);
-  }, [result?.stateDeclarations, store, initialState]);
+
+    if (isStreaming) {
+      for (const [key, value] of Object.entries(bindingDefaults)) {
+        store.set(key, value);
+      }
+      for (const [key, value] of Object.entries(stateDeclarations)) {
+        if (Object.prototype.hasOwnProperty.call(bindingDefaults, key)) {
+          continue;
+        }
+        store.set(key, value);
+      }
+      return;
+    }
+
+    store.initialize(stateDeclarations, bindingDefaults);
+  }, [result?.stateDeclarations, store, initialState, isStreaming]);
 
   // ─── Subscribe to Store and QueryManager for re-renders ───
   const storeSnapshot = useSyncExternalStore(

--- a/packages/genui/openui/src/core/renderer.css
+++ b/packages/genui/openui/src/core/renderer.css
@@ -357,15 +357,18 @@
 }
 
 .OpenUIImageVariantSmallFeature {
-  max-width: 120rpx;
+  width: 120rpx;
+  height: 90rpx;
 }
 
 .OpenUIImageVariantMediumFeature {
-  max-width: 240rpx;
+  width: 240rpx;
+  height: 160rpx;
 }
 
 .OpenUIImageVariantLargeFeature {
-  max-height: 400rpx;
+  width: 100%;
+  height: 400rpx;
 }
 
 .dark .OpenUIImage {


### PR DESCRIPTION
## Summary
- keep streaming OpenUI state declarations in sync so partial string defaults like `"h"` do not stick after the full response arrives
- allow Image URLs to use the shared string-like prop handling
- give OpenUI image feature variants concrete dimensions for Lynx for Web auto-size rendering

## Testing
- `pnpm dprint fmt packages/genui/openui/src/catalog/Image/index.tsx packages/genui/openui/src/core/hooks/useOpenUIState.ts packages/genui/openui/src/core/renderer.css .github/openui-v05.instructions.md`
- `pnpm turbo build --filter @lynx-js/genui-openui`
- `pnpm turbo build --filter genui-playground`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live streaming state behavior so partially received `$` defaults don’t persist incorrectly.
  * Fixed OpenUI `Image` rendering on web so remote images keep stable dimensions instead of collapsing.
  * Normalized `Image` URLs for more reliable rendering.
  * Refined small/medium/large image variant sizing for more consistent layouts.
* **Documentation**
  * Updated OpenUI v0.5 guidance for streaming `$` defaults and Lynx image styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->