### PR TITLE
fix(debug-metadata): keep the legacy source-map release authoritative during the transition

### DIFF
--- a/.changeset/debug-metadata-background-release.md
+++ b/.changeset/debug-metadata-background-release.md
@@ -1,5 +1,6 @@
 ---
 "@lynx-js/debug-metadata-rsbuild-plugin": patch
+"@lynx-js/runtime-wrapper-webpack-plugin": patch
 ---
 
-fix(debug-metadata): bake the release banner inside the bundle wrapper so the background thread registers its release
+fix(debug-metadata): register the background-thread release inside the bundle wrapper, keeping the legacy source-map release authoritative during the transition

--- a/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
@@ -114,22 +114,18 @@ export class LynxDebugMetadataPluginImpl {
     }
 
     compiler.hooks.thisCompilation.tap(this.name, compilation => {
-      // Bake the per-chunk release banner into each JS asset here (rather than
-      // via `BannerPlugin`) so it can read `compilation.chunkGraph` to derive
-      // the release key. Runs at PROCESS_ASSETS_STAGE_DERIVED — before source
-      // maps are generated, so the maps account for the prepended banner, and
-      // strictly before `RuntimeWrapperWebpackPlugin`'s `BannerPlugin` (default
-      // PROCESS_ASSETS_STAGE_ADDITIONS, -100). Since `raw` banners prepend, the
-      // banner that runs first ends up innermost: prepending here means the
-      // wrapper wraps AROUND this banner, so the release runtime lands inside
-      // the bundle wrapper where `tt` / `lynxCoreInject` are in scope. The
-      // background (JS) thread has no global `_SetSourceMapRelease` and
-      // `lynxCoreInject` is the wrapper parameter, not a global, so a top-level
-      // banner would never register the release there.
+      // Prepend the per-chunk release banner (reads `chunkGraph` for the key,
+      // so not `BannerPlugin`). `raw` banners prepend, so the earliest stage is
+      // innermost and runs last, and the engine keeps the last
+      // `_SetSourceMapRelease`. Stage `ADDITIONS + 1` is just after the legacy
+      // source-map release banner, so the legacy release runs last and wins
+      // during the debug-metadata transition. The wrapper runs later (`NONE`)
+      // so this stays inside it.
       compilation.hooks.processAssets.tap(
         {
           name: this.name,
-          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_DERIVED,
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+            + 1,
         },
         () => {
           for (const chunk of compilation.chunks) {

--- a/packages/rspeedy/plugin-debug-metadata/src/release-banner.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/release-banner.ts
@@ -50,7 +50,7 @@ export const RELEASE_DEFINE = '__DEBUG_METADATA_RELEASE__'
 /**
  * Prefix tagging the runtime release as debug-metadata-origin. Reverse-
  * resolution services route releases starting with this to the debug-metadata
- * container path (vs the legacy slardar source-map path) and strip it before
+ * container path (vs the legacy source-map path) and strip it before
  * matching the bare release `key` stored in `debug-metadata.json`.
  */
 export const RELEASE_PREFIX = 'debugmetadata:'

--- a/packages/rspeedy/plugin-react/test/fixtures/release-order/index.tsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/release-order/index.tsx
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from '@lynx-js/react'
+
+function App() {
+  return (
+    <view>
+      <text>release-order</text>
+    </view>
+  )
+}
+
+root.render(
+  <page>
+    <App />
+  </page>,
+)

--- a/packages/rspeedy/plugin-react/test/release-order.test.ts
+++ b/packages/rspeedy/plugin-react/test/release-order.test.ts
@@ -1,0 +1,115 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+import { glob, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type { RsbuildPlugin } from '@rsbuild/core'
+import { afterAll, beforeAll, describe, expect, test } from '@rstest/core'
+
+import { createStubRspeedy as createRspeedy } from './createRspeedy.js'
+
+const tempDirs: string[] = []
+afterAll(async () => {
+  await Promise.all(
+    tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+// A stand-in for the (out-of-tree) legacy source-map release plugin: a raw
+// banner at BannerPlugin's default stage (ADDITIONS) that calls
+// `_SetSourceMapRelease`, like the real one.
+const legacyReleaseStub: RsbuildPlugin = {
+  name: 'legacy-release-stub',
+  setup(api) {
+    api.modifyBundlerChain((chain, { rspack }) => {
+      chain.plugin('legacy-release-stub').use(rspack.BannerPlugin, [{
+        test: /\.js$/,
+        raw: true,
+        banner:
+          'var __LEGACY_RELEASE__="legacy";try{throw Error(__LEGACY_RELEASE__)}catch(e){if(typeof _SetSourceMapRelease==="function")_SetSourceMapRelease(e)}\n',
+      }])
+    })
+  },
+}
+
+async function build(): Promise<string> {
+  const tmp = await mkdtemp(path.join(tmpdir(), 'rspeedy-release-order'))
+  tempDirs.push(tmp)
+
+  const { pluginReactLynx } = await import('../src/index.js')
+
+  const rsbuild = await createRspeedy({
+    rspeedyConfig: {
+      source: {
+        entry: {
+          main: fileURLToPath(
+            new URL('./fixtures/release-order/index.tsx', import.meta.url),
+          ),
+        },
+      },
+      output: {
+        distPath: { root: tmp },
+        filenameHash: false,
+        minify: false,
+      },
+      plugins: [pluginReactLynx(), legacyReleaseStub],
+    },
+  })
+  const result = await rsbuild.build()
+  await result.close()
+
+  return tmp
+}
+
+async function readBundle(tmp: string, name: string): Promise<string> {
+  for await (const file of glob(path.join(tmp, '.rspeedy', '**', name))) {
+    return await readFile(file, 'utf8')
+  }
+  throw new Error(`${name} not found`)
+}
+
+/**
+ * Both threads inject `_SetSourceMapRelease` and the engine keeps the last one.
+ * debug-metadata is prepended in front of the legacy release, so the legacy
+ * `_SetSourceMapRelease` runs last and wins. `insideWrapper` additionally checks
+ * the release sits inside the background bundle wrapper (the background thread
+ * has no global `_SetSourceMapRelease`, so it must register from within).
+ */
+async function expectLegacyWins(
+  tmp: string,
+  bundleName: string,
+  insideWrapper = false,
+) {
+  const bundle = await readBundle(tmp, bundleName)
+  const debugMetadata = bundle.indexOf('__DEBUG_METADATA_RELEASE__')
+  const legacy = bundle.indexOf('__LEGACY_RELEASE__')
+
+  expect(debugMetadata).toBeGreaterThan(-1)
+  expect(legacy).toBeGreaterThan(debugMetadata) // legacy runs last -> wins
+
+  if (insideWrapper) {
+    const wrapperOpen = bundle.indexOf('.define(')
+    expect(wrapperOpen).toBeGreaterThan(-1)
+    expect(debugMetadata).toBeGreaterThan(wrapperOpen)
+  }
+}
+
+describe('source-map release ordering', () => {
+  let tmp: string
+  beforeAll(async () => {
+    tmp = await build()
+  }, 60_000)
+
+  test('background: legacy release wins, inside the wrapper', async () => {
+    await expectLegacyWins(tmp, 'background*.js', true)
+  })
+
+  test('main-thread: legacy release wins', async () => {
+    await expectLegacyWins(tmp, 'main-thread*.js')
+  })
+})

--- a/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
@@ -157,6 +157,12 @@ class RuntimeWrapperWebpackPluginImpl {
     new BannerPlugin({
       test: test!,
       raw: true,
+      // Wrap at PROCESS_ASSETS_STAGE_NONE (0), after the release BannerPlugins
+      // the legacy source-map plugin + debug-metadata, at/around ADDITIONS
+      // (-100) so the wrapper stays outermost and their `_SetSourceMapRelease`
+      // runtimes land INSIDE it, yet still before DEV_TOOLING so the source map
+      // accounts for it.
+      stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_NONE,
       banner: ({ chunk, filename }) => {
         const banner = this.#getBannerType(filename) === 'script'
           ? loadScriptBanner()
@@ -187,6 +193,7 @@ class RuntimeWrapperWebpackPluginImpl {
       test: test!,
       footer: true,
       raw: true,
+      stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_NONE,
       banner: ({ filename }) => {
         const footer = this.#getBannerType(filename) === 'script'
           ? loadScriptFooter


### PR DESCRIPTION
## What

During the debug-metadata transition, keep the existing source-map release (from the legacy release plugin) as the one the engine reports, instead of the `debugmetadata:` release.

## Why

Both the legacy source-map release plugin and `@lynx-js/debug-metadata-rsbuild-plugin` inject `_SetSourceMapRelease`, and the engine keeps the last one called. The debug-metadata backend is not serving yet, so a `debugmetadata:` release can't be reversed: errors would report a release nothing can resolve. The legacy source-map release must win until the backend is live.

## How

`raw` banners prepend, so the banner added at the earliest stage ends up innermost and runs last.

- `LynxDebugMetadataPlugin`: release banner `DERIVED` -> `ADDITIONS + 1` (just after the legacy release banner, whose default is `ADDITIONS`), so debug-metadata runs first and the legacy release runs last and wins.
- `RuntimeWrapperWebpackPlugin`: wrapper banner -> `PROCESS_ASSETS_STAGE_NONE`, so it stays outermost and the release still lands inside the wrapper (the background thread has no global `_SetSourceMapRelease`). Still before `DEV_TOOLING`, so the source map accounts for the banner.

If an older wrapper is paired with the new plugin, the banner falls outside the wrapper and just does not register on the background thread. That is harmless during the transition, since the legacy release stays authoritative either way.

## Tests

- `plugin-debug-metadata`: asserts the release banner registers at `ADDITIONS + 1`.
- `runtime-wrapper-webpack-plugin`: asserts the wrapper banners inject at `NONE`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release ordering so debug metadata and legacy source-map output are applied in the correct sequence, helping ensure the final bundled runtime behaves consistently.
  * Adjusted bundle wrapper handling for background-thread releases to keep output ordering stable.

* **Tests**
  * Added coverage for release-order behavior, including a background-bundle scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->