### PR TITLE
feat(create-lynx-library): share element view scaffold

### DIFF
--- a/packages/lynx/create-lynx-library/template-element/shared/elements/__ELEMENT_CLASS_NAME__.h.tmpl
+++ b/packages/lynx/create-lynx-library/template-element/shared/elements/__ELEMENT_CLASS_NAME__.h.tmpl
@@ -1,9 +1,66 @@
 #pragma once
 
+#include <functional>
+#include <string>
+
 #if __has_include(<lynx_extension.h>)
 #include <lynx_extension.h>
 #elif __has_include(<lynx/extension.h>)
 #include <lynx/extension.h>
 #endif
+
+#include <lynx_native_view.h>
+
+class __ELEMENT_SYMBOL_NAME__View : public lynx::pub::LynxNativeView {
+ public:
+  explicit __ELEMENT_SYMBOL_NAME__View(void* opaque)
+      : lynx_view_(static_cast<lynx_view_t*>(opaque)) {}
+
+  void OnPropertiesChanged(const lynx::pub::LynxValue& attrs,
+                           const lynx::pub::LynxValue& events) override {
+    (void)events;
+    if (!attrs.HasProperty("value")) {
+      return;
+    }
+    SetValue(attrs.GetProperty("value").StdString());
+  }
+
+  void OnMethodInvoked(
+      const char* method,
+      const lynx::pub::LynxValue& params,
+      std::function<void(int, lynx::pub::LynxValue&&)> callback) override {
+    if (method != nullptr && std::string(method) == "setValue") {
+      if (!params.HasProperty("value")) {
+        callback(kInvalidParameter,
+                 lynx::pub::LynxValue(
+                     lynx::pub::LynxValue::kCreateAsNullTag));
+        return;
+      }
+      SetValue(params.GetProperty("value").StdString());
+      callback(kSuccess,
+               lynx::pub::LynxValue(
+                   lynx::pub::LynxValue::kCreateAsNullTag));
+      return;
+    }
+
+    callback(kMethodNotFound,
+             lynx::pub::LynxValue(lynx::pub::LynxValue::kCreateAsNullTag));
+  }
+
+ protected:
+  lynx_view_t* lynx_view() const { return lynx_view_; }
+  const std::string& value() const { return value_; }
+
+  virtual void OnValueChanged(const std::string& value) { (void)value; }
+
+ private:
+  void SetValue(const std::string& value) {
+    value_ = value;
+    OnValueChanged(value_);
+  }
+
+  lynx_view_t* lynx_view_ = nullptr;
+  std::string value_ = "__ELEMENT_NAME__";
+};
 
 lynx_native_view_t* Create__ELEMENT_SYMBOL_NAME__NativeView(void* opaque);

--- a/packages/lynx/create-lynx-library/template-element/shared/elements/backends/native-ui/macos/__ELEMENT_CLASS_NAME__NativeUI.mm.tmpl
+++ b/packages/lynx/create-lynx-library/template-element/shared/elements/backends/native-ui/macos/__ELEMENT_CLASS_NAME__NativeUI.mm.tmpl
@@ -2,16 +2,19 @@
 
 #import <Cocoa/Cocoa.h>
 
-#include <lynx_native_view.h>
-
 namespace {
 
-class __ELEMENT_SYMBOL_NAME__NativeUIView : public lynx::pub::LynxNativeView {
+NSString* NSStringFromStdString(const std::string& value) {
+  NSString* result = [NSString stringWithUTF8String:value.c_str()];
+  return result != nil ? result : @"";
+}
+
+class __ELEMENT_SYMBOL_NAME__NativeUIView : public __ELEMENT_SYMBOL_NAME__View {
  public:
   explicit __ELEMENT_SYMBOL_NAME__NativeUIView(void* opaque)
-      : lynx_view_(static_cast<lynx_view_t*>(opaque)) {
+      : __ELEMENT_SYMBOL_NAME__View(opaque) {
     RunOnMainThreadSync(^{
-      label_ = [NSTextField labelWithString:@"__ELEMENT_NAME__"];
+      label_ = [NSTextField labelWithString:NSStringFromStdString(value())];
       label_.textColor = [NSColor blackColor];
     });
   }
@@ -59,6 +62,15 @@ class __ELEMENT_SYMBOL_NAME__NativeUIView : public lynx::pub::LynxNativeView {
  private:
   using MainThreadBlock = void (^)(void);
 
+  void OnValueChanged(const std::string& value) override {
+    std::string text = value;
+    RunOnMainThreadSync(^{
+      if (label_ != nil) {
+        label_.stringValue = NSStringFromStdString(text);
+      }
+    });
+  }
+
   static void RunOnMainThreadSync(MainThreadBlock block) {
     if ([NSThread isMainThread]) {
       block();
@@ -68,10 +80,10 @@ class __ELEMENT_SYMBOL_NAME__NativeUIView : public lynx::pub::LynxNativeView {
   }
 
   NSView* ParentView() {
-    if (lynx_view_ == nullptr) {
+    if (lynx_view() == nullptr) {
       return nil;
     }
-    return (__bridge NSView*)lynx_view_get_native_window(lynx_view_);
+    return (__bridge NSView*)lynx_view_get_native_window(lynx_view());
   }
 
   NSView* AttachToParent() { return AttachToParent(ParentView()); }
@@ -90,7 +102,6 @@ class __ELEMENT_SYMBOL_NAME__NativeUIView : public lynx::pub::LynxNativeView {
     return parent;
   }
 
-  lynx_view_t* lynx_view_ = nullptr;
   NSTextField* label_ = nil;
 };
 

--- a/packages/lynx/create-lynx-library/template-element/shared/elements/backends/native-ui/windows/__ELEMENT_CLASS_NAME__NativeUI.cc.tmpl
+++ b/packages/lynx/create-lynx-library/template-element/shared/elements/backends/native-ui/windows/__ELEMENT_CLASS_NAME__NativeUI.cc.tmpl
@@ -12,8 +12,6 @@
 #include <algorithm>
 #include <string>
 
-#include <lynx_native_view.h>
-
 namespace {
 
 constexpr wchar_t kHostClassName[] = L"__ELEMENT_SYMBOL_NAME__NativeUIHost";
@@ -74,8 +72,11 @@ HWND FindMainWindow() {
   return search.hwnd != nullptr ? search.hwnd : GetActiveWindow();
 }
 
-class __ELEMENT_SYMBOL_NAME__NativeUIView : public lynx::pub::LynxNativeView {
+class __ELEMENT_SYMBOL_NAME__NativeUIView : public __ELEMENT_SYMBOL_NAME__View {
  public:
+  explicit __ELEMENT_SYMBOL_NAME__NativeUIView(void* opaque)
+      : __ELEMENT_SYMBOL_NAME__View(opaque) {}
+
   ~__ELEMENT_SYMBOL_NAME__NativeUIView() override {
     if (label_ != nullptr) {
       DestroyWindow(label_);
@@ -135,10 +136,11 @@ class __ELEMENT_SYMBOL_NAME__NativeUIView : public lynx::pub::LynxNativeView {
     }
 
     if (label_ == nullptr) {
+      const std::wstring text = Utf8ToWide(value().c_str());
       label_ = CreateWindowExW(
           0,
           L"STATIC",
-          Utf8ToWide("__ELEMENT_NAME__").c_str(),
+          text.c_str(),
           WS_CHILD | WS_VISIBLE,
           0,
           0,
@@ -162,6 +164,14 @@ class __ELEMENT_SYMBOL_NAME__NativeUIView : public lynx::pub::LynxNativeView {
   }
 
  private:
+  void OnValueChanged(const std::string& value) override {
+    if (label_ == nullptr) {
+      return;
+    }
+    const std::wstring text = Utf8ToWide(value.c_str());
+    SetWindowTextW(label_, text.c_str());
+  }
+
   HWND host_ = nullptr;
   HWND label_ = nullptr;
 };
@@ -169,7 +179,6 @@ class __ELEMENT_SYMBOL_NAME__NativeUIView : public lynx::pub::LynxNativeView {
 }  // namespace
 
 lynx_native_view_t* Create__ELEMENT_SYMBOL_NAME__NativeUINativeView(void* opaque) {
-  (void)opaque;
-  auto* view = new __ELEMENT_SYMBOL_NAME__NativeUIView();
+  auto* view = new __ELEMENT_SYMBOL_NAME__NativeUIView(opaque);
   return view->native_view();
 }

--- a/packages/lynx/create-lynx-library/template-element/shared/elements/backends/texture/__ELEMENT_CLASS_NAME__Texture.cc.tmpl
+++ b/packages/lynx/create-lynx-library/template-element/shared/elements/backends/texture/__ELEMENT_CLASS_NAME__Texture.cc.tmpl
@@ -3,8 +3,6 @@
 #include <algorithm>
 #include <cmath>
 
-#include <lynx_native_view.h>
-
 // This shared texture backend depends on LynxNativeView C API surface handles.
 bool Draw__ELEMENT_SYMBOL_NAME__TextureSurface(
     lynx_surface_handle_t* handle,
@@ -16,8 +14,11 @@ namespace {
 
 constexpr float kYFlipTransform[3 * 3] = {1, 0, 0, 0, -1, 1, 0, 0, 1};
 
-class __ELEMENT_SYMBOL_NAME__TextureView : public lynx::pub::LynxNativeView {
+class __ELEMENT_SYMBOL_NAME__TextureView : public __ELEMENT_SYMBOL_NAME__View {
  public:
+  explicit __ELEMENT_SYMBOL_NAME__TextureView(void* opaque)
+      : __ELEMENT_SYMBOL_NAME__View(opaque) {}
+
   bool IsSurfaceEnabled() override { return true; }
   lynx_surface_buffer_mode_t SurfaceBufferMode() override {
     return kTripleBuffer;
@@ -45,6 +46,11 @@ class __ELEMENT_SYMBOL_NAME__TextureView : public lynx::pub::LynxNativeView {
   }
 
  private:
+  void OnValueChanged(const std::string& value) override {
+    (void)value;
+    Render();
+  }
+
   void Render() {
     if (!attached_ || width_px_ <= 0 || height_px_ <= 0) {
       return;
@@ -59,7 +65,7 @@ class __ELEMENT_SYMBOL_NAME__TextureView : public lynx::pub::LynxNativeView {
             surface,
             width_px_,
             height_px_,
-            "__ELEMENT_NAME__")) {
+            value().c_str())) {
       PresentSurface(width_px_, height_px_, kYFlipTransform, surface);
     }
   }
@@ -72,7 +78,6 @@ class __ELEMENT_SYMBOL_NAME__TextureView : public lynx::pub::LynxNativeView {
 }  // namespace
 
 lynx_native_view_t* Create__ELEMENT_SYMBOL_NAME__TextureNativeView(void* opaque) {
-  (void)opaque;
-  auto* view = new __ELEMENT_SYMBOL_NAME__TextureView();
+  auto* view = new __ELEMENT_SYMBOL_NAME__TextureView(opaque);
   return view->native_view();
 }

--- a/packages/lynx/create-lynx-library/test/create.test.ts
+++ b/packages/lynx/create-lynx-library/test/create.test.ts
@@ -241,6 +241,24 @@ describe('create-lynx-library', () => {
     expect(read(dir, 'shared/elements/ButtonElementRegistration.cc')).toContain(
       'LYNX_REGISTER_ELEMENT(',
     );
+    expect(read(dir, 'shared/elements/ButtonElement.h')).toContain(
+      'class ButtonElementView : public lynx::pub::LynxNativeView',
+    );
+    expect(
+      read(dir, 'shared/elements/backends/texture/ButtonElementTexture.cc'),
+    ).toContain('class ButtonElementTextureView : public ButtonElementView');
+    expect(
+      read(
+        dir,
+        'shared/elements/backends/native-ui/macos/ButtonElementNativeUI.mm',
+      ),
+    ).toContain('class ButtonElementNativeUIView : public ButtonElementView');
+    expect(
+      read(
+        dir,
+        'shared/elements/backends/native-ui/windows/ButtonElementNativeUI.cc',
+      ),
+    ).toContain('class ButtonElementNativeUIView : public ButtonElementView');
     expect(files.every((file) => !/__[A-Z0-9_]+__/.test(file.path))).toBe(
       true,
     );


### PR DESCRIPTION
## Summary

- Move the generated element smoke behavior into a shared `LynxNativeView` subclass under `shared/elements/<Element>.h`.
- Make texture, macOS native UI, and Windows native UI backends inherit the shared view definition.
- Keep backend selection controlled by `LYNX_NATIVE_ELEMENT_BACKEND`, with texture remaining the default.

## Why

The generated element scaffold now has one shared definition for properties and method handling, while each desktop backend only implements platform-specific presentation. This matches the new shared source layout and keeps texture/native-ui behavior symmetric across macOS and Windows.

## Validation

- `pnpm --filter create-lynx-library test -- --runInBand`
- Generated a Lynxtron element library and built both backends locally:
  - `-DLYNX_NATIVE_ELEMENT_BACKEND=texture`
  - `-DLYNX_NATIVE_ELEMENT_BACKEND=native-ui`
- Smoked the generated package through `lynxtron-shell-demo` on macOS.
- Windows was statically checked from generated sources and CMake wiring; this environment cannot compile Windows artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated native library templates now include a shared element view base, with value handling that updates UI output automatically.
  * Native UI and texture backends now reflect the current element value instead of a fixed placeholder.

* **Bug Fixes**
  * Value updates now propagate consistently across macOS, Windows, and texture rendering.
  * Native view creation now properly uses the provided runtime context.

* **Tests**
  * Added coverage for the newly generated view classes in all supported backend templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->