### PR TITLE
chore: add changeset for shared element view scaffold

### DIFF
--- a/.changeset/share-desktop-element-view.md
+++ b/.changeset/share-desktop-element-view.md
@@ -1,0 +1,6 @@
+---
+"create-lynx-library": patch
+---
+
+Refine desktop element templates to share `LynxNativeView` state between Native
+UI and Texture backends.


### PR DESCRIPTION
## Summary

- Add the missing changeset for #2908.
- Mark `create-lynx-library` as a patch release for the shared desktop element view scaffold refinement.

## Testing

- Commit hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop element templates now keep state in sync between Native UI and Texture rendering, improving consistency across both views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->