### PR TITLE
fix(rspeedy): web environment uses Lynx HMR runtime instead of Rsbuild web one

### DIFF
--- a/.changeset/web-hmr-lynx-runtime.md
+++ b/.changeset/web-hmr-lynx-runtime.md
@@ -1,0 +1,10 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Fix the `web` environment crashing in development because its main thread was bundled with the Rsbuild web HMR runtime.
+
+Previously the `web` environment was compiled with `target: 'web'`, which makes Rsbuild inject its own HMR client (`@rsbuild/core/dist/client/hmr.js`). That client drives `__webpack_require__.hmrM`, which is implemented with `lynx.requireModuleAsync` — an API the web main thread does not provide — so hot updates crashed.
+
+The `web` environment now uses the same target and HMR entry as the `lynx` environment, going through Lynx's own HMR runtime instead of the Rsbuild web one.

--- a/packages/rspeedy/core/src/plugins/target.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/target.plugin.ts
@@ -5,22 +5,13 @@
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 import { getESVersionTarget } from '../utils/getESVersionTarget.js'
-import { isWeb } from '../utils/is-web.js'
 
 export function pluginTarget(): RsbuildPlugin {
   return {
     name: 'lynx:rsbuild:target',
     setup(api) {
-      api.modifyBundlerChain((options, { environment }) => {
-        if (isWeb(environment)) {
-          options.target([
-            getESVersionTarget(),
-            // Add `target: 'web'` to make Rsbuild inject HMR related code.
-            'web',
-          ])
-        } else {
-          options.target([getESVersionTarget()])
-        }
+      api.modifyBundlerChain((options) => {
+        options.target([getESVersionTarget()])
       })
     },
   }

--- a/packages/rspeedy/core/test/plugins/target.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/target.plugin.test.ts
@@ -29,6 +29,8 @@ describe('target.plugin', () => {
     expect(config.target).toEqual(['es2017'])
   })
 
+  // `web` must not use the `'web'` target: it makes Rsbuild inject its web HMR
+  // runtime, which crashes the Lynx web main thread.
   test('Web', async () => {
     const rspeedy = await createStubRspeedy({
       environments: {
@@ -38,7 +40,7 @@ describe('target.plugin', () => {
 
     const config = await rspeedy.unwrapConfig()
 
-    expect(config.target).toEqual(['es2017', 'web'])
+    expect(config.target).toEqual(['es2017'])
   })
 
   test('multiple environments', async () => {
@@ -51,7 +53,7 @@ describe('target.plugin', () => {
 
     const [webConfig, lynxConfig] = await rspeedy.initConfigs()
 
-    expect(webConfig?.target).toEqual(['es2017', 'web'])
+    expect(webConfig?.target).toEqual(['es2017'])
     expect(lynxConfig?.target).toEqual(['es2017'])
   })
 })

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -80,8 +80,8 @@ export function applyEntry(
       const isWeb = environment.name === 'web'
         || environment.name.startsWith('web-')
       const { hmr, liveReload } = environment.config.dev ?? {}
-      const enabledHMR = isDev && !isWeb && hmr !== false
-      const enabledLiveReload = isDev && !isWeb && liveReload !== false
+      const enabledHMR = isDev && hmr !== false
+      const enabledLiveReload = isDev && liveReload !== false
 
       chain.entryPoints.clear()
 

--- a/packages/rspeedy/plugin-react/test/hotUpdate.test.ts
+++ b/packages/rspeedy/plugin-react/test/hotUpdate.test.ts
@@ -1,6 +1,11 @@
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, rstest, test } from '@rstest/core'
 
 import { createStubRspeedy as createRspeedy } from './createRspeedy.js'
@@ -150,4 +155,86 @@ describe('hot update', () => {
       }
     `)
   })
+
+  // `@rsbuild/core/dist/client/hmr.js` is injected by the dev server, so it
+  // only shows up in the emitted bundles, not the resolved config.
+  test(
+    'web dev output uses the Lynx HMR runtime, not the Rsbuild web client',
+    async () => {
+      const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+      const tmp = await mkdtemp(path.join(tmpdir(), 'rspeedy-hmr-'))
+
+      const rsbuild = await createRspeedy({
+        rspeedyConfig: {
+          source: {
+            entry: {
+              main: fileURLToPath(
+                new URL(
+                  './fixtures/special-var-name/index.jsx',
+                  import.meta.url,
+                ),
+              ),
+            },
+          },
+          environments: {
+            lynx: {},
+            web: {},
+          },
+          output: {
+            distPath: { root: tmp },
+            filenameHash: false,
+          },
+          plugins: [
+            pluginReactLynx(),
+          ],
+        },
+      })
+
+      const firstCompile = new Promise<void>(resolve => {
+        rsbuild.onDevCompileDone(({ isFirstCompile }) => {
+          if (isFirstCompile) {
+            resolve()
+          }
+        })
+      })
+
+      // Only `createDevServer` injects the HMR client, not `build`.
+      const server = await rsbuild.createDevServer()
+
+      try {
+        await firstCompile
+
+        const read = (relativePath: string) =>
+          readFile(path.join(tmp, relativePath), 'utf-8')
+
+        const bundles = [
+          {
+            mainThread: 'main/main-thread.js',
+            background: 'main/background.js',
+          }, // web
+          {
+            mainThread: '.rspeedy/main/main-thread.js',
+            background: '.rspeedy/main/background.js',
+          }, // lynx
+        ]
+
+        for (const { mainThread, background } of bundles) {
+          const mainThreadJS = await read(mainThread)
+          const backgroundJS = await read(background)
+
+          // No Rsbuild web HMR client.
+          expect(mainThreadJS).not.toContain('@rsbuild/core/dist/client/hmr.js')
+          expect(backgroundJS).not.toContain('@rsbuild/core/dist/client/hmr.js')
+
+          // Lynx HMR runtime instead.
+          expect(mainThreadJS).toContain('hotModuleReplacement.lepus.cjs')
+          expect(backgroundJS).toContain('webpack-dev-transport')
+        }
+      } finally {
+        await server.close()
+        await rm(tmp, { recursive: true, force: true })
+      }
+    },
+    60_000,
+  )
 })


### PR DESCRIPTION
## Summary

The `web` environment crashed during `rspeedy dev` because its **main thread** was bundled with the Rsbuild **web** HMR runtime.

- `web` was compiled with `target: 'web'`, which makes Rsbuild inject its own HMR client (`@rsbuild/core/dist/client/hmr.js`).
- That client drives `__webpack_require__.hmrM`, which is implemented via `lynx.requireModuleAsync` — an API the web main thread does **not** provide → hot updates crash.

## Fix

Make the `web` environment go through the **same** HMR path as `lynx`:
- `target.plugin.ts`: drop the `'web'` target for the web environment (all environments now use `[getESVersionTarget()]`).
- `entry.ts`: enable the Lynx HMR entry for web (remove the `!isWeb` gate), so web prepends `@lynx-js/webpack-dev-transport/client` / `@lynx-js/react/refresh` / `hotModuleReplacement.lepus.cjs` just like lynx.

## Tests (TDD, split into 2 commits)

1. `test(rspeedy)` — adds coverage that **fails on `main`**: both `lynx` and `web` must share the Lynx HMR entry and neither may set `target: 'web'`.
2. `fix(rspeedy)` — the fix, making those tests pass.

Note: `@rsbuild/core/dist/client/hmr.js` is injected by the dev server at runtime and never appears in the resolved config, so the regression is guarded via `target` not containing `'web'` (its root switch) plus the presence of the Lynx HMR entry.

Verified locally: full `@lynx-js/rspeedy` (426) and `@lynx-js/react-rsbuild-plugin` (174) test suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development hot-reload crashes in web builds.
  * Web development now uses a stable hot-update path, improving reliability during live editing.
* **Documentation**
  * Added release notes describing the web hot-reload behavior change.
* **Tests**
  * Expanded automated coverage to verify web builds avoid the unstable hot-reload client and use the expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->