### PR TITLE
perf(benchmark): bump benchx_cli to the mimalloc release (benchx_cli-202607011810)

### DIFF
--- a/packages/lynx/benchx_cli/scripts/build_unix.sh
+++ b/packages/lynx/benchx_cli/scripts/build_unix.sh
@@ -13,7 +13,7 @@ if [ ! -f "package.json" ] || ! grep -q '"name": "benchx_cli"' package.json; the
   exit 1
 fi
 
-LOCKED_VERSION="benchx_cli-202606120920"
+LOCKED_VERSION="benchx_cli-202607011810"
 
 # Check if binary is up to date
 if [ -f "./dist/bin/benchx_cli" ] && [ -f "./dist/bin/benchx_cli.version" ]; then


### PR DESCRIPTION
## What

Bump the benchmark's `benchx_cli` binary from `benchx_cli-202606120920` to **`benchx_cli-202607011810`** (one line in `packages/lynx/benchx_cli/scripts/build_unix.sh`, which downloads the pinned release from lynx-community/benchx_cli).

## Why

`benchx_cli-202607011810` is the first release that links **mimalloc** as the benchmark process allocator ([lynx-community/benchx_cli#7](https://github.com/lynx-community/benchx_cli/pull/7)).

The CodSpeed simulation profiles for these benchmarks show allocator-induced variance from glibc's `ptmalloc` — e.g. `malloc_consolidate` (free-chunk coalescing) appearing as a multi-percent self-time spike in some runs but not others, depending on heap state. mimalloc's sharded thread-local free lists give a uniform, history-independent malloc/free fast path and avoid on-critical-path consolidation, so the numbers should be more reproducible (lower walltime jitter, fewer phantom path differences in simulation).

The override is verified active in the release build (on Linux via strong-vs-weak symbols; on macOS via `MI_OSX_ZONE` + `MI_OSX_INTERPOSE`, confirmed at runtime with `MIMALLOC_SHOW_STATS`).

## Notes

- Only `build_unix.sh` changes — the benchmark runs on Linux/macOS only, there is no Windows benchx_cli build to bump.
- No checksum to update; the script fetches the release asset by tag.

## Test

- The release `benchx_cli-202607011810` has both assets published (`benchx_cli_Linux_x86_64.tar.gz`, `benchx_cli_Darwin_arm64.tar.gz`), so the download resolves.
- CI's benchmark job will exercise the new binary end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled CLI release used during builds to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->