### PR TITLE
chore: Upgrade Ubuntu runners to 26.04

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -217,7 +217,7 @@
       "matchPackageNames": [
         "mcr.microsoft.com/playwright",
       ],
-      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-noble$",
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-resolute$",
     },
   ],
 

--- a/.github/runner-labels.instructions.md
+++ b/.github/runner-labels.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: ".github/workflows/**"
+---
+
+Self-hosted Ubuntu runner labels use the `lynx-ubuntu-<ubuntu-version>-<capacity>` pattern, for example `lynx-ubuntu-26.04-medium` and `lynx-ubuntu-26.04-xlarge`. When changing these labels, update matching matrix label comparisons and comments in the workflow files. Treat GitHub-hosted labels such as `ubuntu-latest` as a separate runner family unless the change explicitly targets hosted runners.

--- a/.github/runner-labels.instructions.md
+++ b/.github/runner-labels.instructions.md
@@ -2,4 +2,4 @@
 applyTo: ".github/workflows/**"
 ---
 
-Self-hosted Ubuntu runner labels use the `lynx-ubuntu-<ubuntu-version>-<capacity>` pattern, for example `lynx-ubuntu-26.04-medium` and `lynx-ubuntu-26.04-xlarge`. When changing these labels, update matching matrix label comparisons and comments in the workflow files. Treat GitHub-hosted labels such as `ubuntu-latest` as a separate runner family unless the change explicitly targets hosted runners.
+Self-hosted Ubuntu runner labels use the `lynx-ubuntu-<ubuntu-version>-<capacity>` pattern, for example `lynx-ubuntu-26.04-medium` and `lynx-ubuntu-26.04-xlarge`. When changing these labels, update matching matrix label comparisons and comments in the workflow files. For GitHub-hosted Ubuntu runners, prefer explicit labels such as `ubuntu-26.04` over `ubuntu-latest` when workflows should stay on a specific OS release.

--- a/.github/runner-labels.instructions.md
+++ b/.github/runner-labels.instructions.md
@@ -2,4 +2,4 @@
 applyTo: ".github/workflows/**"
 ---
 
-Self-hosted Ubuntu runner labels use the `lynx-ubuntu-<ubuntu-version>-<capacity>` pattern, for example `lynx-ubuntu-26.04-medium` and `lynx-ubuntu-26.04-xlarge`. When changing these labels, update matching matrix label comparisons and comments in the workflow files. For GitHub-hosted Ubuntu runners, prefer explicit labels such as `ubuntu-26.04` over `ubuntu-latest` when workflows should stay on a specific OS release.
+Self-hosted Ubuntu runner labels use the `lynx-ubuntu-<ubuntu-version>-<capacity>` pattern, for example `lynx-ubuntu-26.04-medium` and `lynx-ubuntu-26.04-xlarge`. When changing these labels, update matching matrix label comparisons and comments in the workflow files. For GitHub-hosted Ubuntu runners, prefer explicit labels such as `ubuntu-26.04` over `ubuntu-latest` when workflows should stay on a specific OS release. Keep Playwright Docker images pinned to the project Playwright version, and use the Ubuntu 26.04 image suffix `-resolute` for matching web test containers.

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   zizmor:
     timeout-minutes: 10
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     # Set the permissions to the lowest permissions possible needed for your steps.
     # Copilot will be given its own token for its operations.

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -87,7 +87,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: lynx-ubuntu-26.04-medium
       run: >
         pnpm run test
         --testTimeout=50000

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -19,7 +19,7 @@ env:
   NPM_CONFIG_PROVENANCE: true
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 30
     if: github.repository == 'lynx-family/lynx-stack'
     permissions:
@@ -136,7 +136,7 @@ jobs:
   publish:
     timeout-minutes: 30
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: github.repository == 'lynx-family/lynx-stack'
     concurrency:
       group: ${{ github.workflow }}-publish-${{ github.ref }}
@@ -187,7 +187,7 @@ jobs:
   canary-publish:
     timeout-minutes: 30
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: github.repository == 'lynx-family/lynx-stack'
     environment: npm
     permissions:
@@ -240,7 +240,7 @@ jobs:
     timeout-minutes: 10
     needs: website-build
     if: github.repository == 'lynx-family/lynx-stack'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write # to deploy to Pages

--- a/.github/workflows/nodejs-dependencies.yml
+++ b/.github/workflows/nodejs-dependencies.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   sherif:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/pull-request-content-check.yml
+++ b/.github/workflows/pull-request-content-check.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate-pr-title:
     name: Validate PR title
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
     steps:
       # https://github.com/amannn/action-semantic-pull-request

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -35,7 +35,7 @@ jobs:
           - path: ./packages/rspeedy/core
             name: rspeedy
             key: RELATIVE_CI_PROJECT_RSPEEDY_CORE_KEY
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     name: Upload ${{ matrix.project.name }}
     env:
       RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY: ${{ secrets.RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         runs-on:
-          - label: lynx-ubuntu-24.04-xlarge
+          - label: lynx-ubuntu-26.04-xlarge
             name: Ubuntu
           # - label: lynx-windows-2022-large
           #   name: Windows
@@ -65,7 +65,7 @@ jobs:
           files: target/nextest/ci/test-report.junit.xml
 
   rustfmt:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
     permissions:
       contents: read
@@ -81,7 +81,7 @@ jobs:
         run: cargo fmt --check
 
   clippy:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       issues: write # Need write permission to mark and close stale issues
       pull-requests: write # Need write permission to mark and close stale PRs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-bundle-analysis.yml
   code-style-check:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -75,7 +75,7 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions: {}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: lynx-ubuntu-26.04-medium
       run: pnpm eslint . --flag v10_config_lookup_from_file
 
   ui-judge:
@@ -113,7 +113,7 @@ jobs:
   ui-judge-comment:
     needs: ui-judge
     if: always()
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     permissions:
       contents: read
       issues: write
@@ -206,7 +206,7 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
 
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: lynx-ubuntu-26.04-medium
       run: |
         pnpm turbo api-extractor -- --local
         if test "$(git diff -- './packages/**/*.api.md' --name-only | wc -l)" -gt 0 ; then
@@ -230,7 +230,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: lynx-ubuntu-26.04-medium
       run: |
         # Generated smoke-test projects do not carry a packageManager pin, so
         # keep this stage on pnpm 10 even when Corepack's registry default moves.
@@ -273,7 +273,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: lynx-ubuntu-26.04-medium
       run: >
         pnpm
         --filter @lynx-js/react-runtime
@@ -299,7 +299,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: lynx-ubuntu-26.04-medium
       run: pnpm -r run test:type
   test-rstest:
     needs: build
@@ -307,7 +307,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: lynx-ubuntu-26.04-medium
       run: >
         pnpm exec rstest run
         -c rstest.config.ts
@@ -326,7 +326,7 @@ jobs:
       MIDSCENE_OPENAI_INIT_CONFIG_JSON: ${{ secrets.MIDSCENE_OPENAI_INIT_CONFIG_JSON }}
     name: Kitten Lynx Android Emulator Test
     with:
-      runs-on: lynx-ubuntu-22.04-physical-medium
+      runs-on: lynx-ubuntu-26.04-physical-medium
       run: |
         # 4. Start Emulator
         echo "Starting emulator..."
@@ -382,7 +382,7 @@ jobs:
         fi
 
   test-typos:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     steps:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
       - uses: crate-ci/typos@57b11c6b7e54c402ccd9cda953f1072ec4f78e33 # v1.43.5
@@ -396,7 +396,7 @@ jobs:
       matrix:
         runs-on:
           - name: Ubuntu
-            label: lynx-ubuntu-24.04-medium
+            label: lynx-ubuntu-26.04-medium
           - name: Windows
             label: lynx-windows-2022-large
     name: Vitest (${{ matrix.runs-on.name }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -442,7 +442,7 @@ jobs:
       - web-core-e2e
       - website
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     name: Done
     steps:
       - run: exit 1

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -74,7 +74,7 @@ jobs:
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo
-          # The build job runs on lynx-ubuntu-24.04-xlarge which writes to a
+          # The build job runs on lynx-ubuntu-26.04-xlarge which writes to a
           # different OSS bucket than this physical-exclusive runner, so we
           # tolerate cache misses and let `pnpm turbo build` rebuild locally.
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   get-merge-base:
     permissions: {}
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 5
     env:
       # We have 2 cases:
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - label: lynx-ubuntu-24.04-xlarge
+          - label: lynx-ubuntu-26.04-xlarge
             name: Ubuntu
           - label: lynx-windows-2022-large
             name: Windows
@@ -134,7 +134,7 @@ jobs:
       # step above (which already runs fork install/build scripts) relies on.
       - name: Fetch base ref for changeset status
         if: >
-          matrix.runs-on.label == 'lynx-ubuntu-24.04-xlarge' &&
+          matrix.runs-on.label == 'lynx-ubuntu-26.04-xlarge' &&
           github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
@@ -161,7 +161,7 @@ jobs:
       - name: Collect packages with changesets
         id: changeset
         if: >
-          matrix.runs-on.label == 'lynx-ubuntu-24.04-xlarge' &&
+          matrix.runs-on.label == 'lynx-ubuntu-26.04-xlarge' &&
           github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -10,7 +10,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   build:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     permissions: {}
     container:
-      image: ${{ inputs.is-web && 'mcr.microsoft.com/playwright:v1.61.1-noble' || null }}
+      image: ${{ inputs.is-web && 'mcr.microsoft.com/playwright:v1.61.1-resolute' || null }}
       env:
         CI: 1
         TURBO_TELEMETRY_DISABLED: 1

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build:
     permissions: {}
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5


### PR DESCRIPTION
## Summary

- Upgrade self-hosted Ubuntu runner labels from `lynx-ubuntu-24.04-*` to `lynx-ubuntu-26.04-*` across CI workflows.
- Move the Android physical runner label to `lynx-ubuntu-26.04-physical-medium` following the existing custom runner label pattern.
- Pin GitHub-hosted Ubuntu runner jobs from `ubuntu-latest` to `ubuntu-26.04`.
- Move the reusable web test Playwright container from `mcr.microsoft.com/playwright:v1.61.1-noble` to `mcr.microsoft.com/playwright:v1.61.1-resolute`, and update Renovate's Playwright Docker tag regex to track `-resolute` tags.
- Add a small workflow instruction documenting the self-hosted, GitHub-hosted, and Playwright Ubuntu runner/image label patterns.

fix #2578 

## Validation

- `pnpm dprint fmt`
- `git diff --check`
- `rg -n "ubuntu-latest|lynx-ubuntu-(22|24)\\.04" .github/workflows` returned no matches
- `rg -n "v1\\.61\\.1-noble|-noble\\$|mcr\\.microsoft\\.com/playwright:v1\\.61\\.1-noble" .github` returned no matches
- MCR manifest probe for `mcr.microsoft.com/playwright:v1.61.1-resolute` returned HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated many CI and workflow jobs to run on newer Ubuntu 26.04 environments.
  * Refreshed the Playwright test image to the latest compatible Ubuntu variant.
  * Aligned workflow guidance and labels with the newer runner naming convention.
  * Updated a few workflow checks and comments to match the new build/test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->