### PR TITLE
fix(genui): avoid long OpenUI preview URLs

### DIFF
--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -24,6 +24,10 @@ When runtime code needs to distinguish Lynx for Web from native Lynx, prefer `Sy
 
 When maintaining the OpenUI Lynx entry under `packages/genui/playground/lynx-src/openui`, keep the renderer stylesheet imported by the entry CSS through `@lynx-js/genui/openui/styles/renderer.css`. The OpenUI catalog components emit plain `OpenUI*` class names, so the native preview will look unstyled if that renderer CSS is not bundled with `openui.lynx.js`.
 
+## OpenUI Preview Payloads
+
+When building OpenUI playground preview links, avoid inlining large OpenUI Lang source in `rawText` query parameters. URL-encoded Chinese or generated DSL can exceed common request-line limits on deployed hosts; publish large source text and pass `rawTextUrl` to `render.html` instead.
+
 ## Lazy Bundles
 
 When adding an GenUI playground example that uses a ReactLynx standalone lazy bundle, build that lazy bundle with a separate Rspeedy config using `pluginReactLynx({ experimental_isLazyBundle: true })`.

--- a/packages/genui/playground/rsbuild.config.ts
+++ b/packages/genui/playground/rsbuild.config.ts
@@ -16,8 +16,9 @@ const CLIENT_PAYLOAD_STORE_ENABLED = process.env.NODE_ENV !== 'production'
 // In-memory A2UI payload store. Keeps the dev-bundle / render URLs short
 // enough to fit inside a scannable QR code.
 interface StoredPayload {
-  messages: unknown;
+  messages?: unknown;
   actionMocks?: unknown;
+  rawText?: string;
   createdAt: number;
 }
 const payloadStore = new Map<string, StoredPayload>();
@@ -58,6 +59,16 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
+function sendText(res: ServerResponse, status: number, body: string): void {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Cache-Control', 'no-store');
+  res.end(body);
+}
+
 function a2uiPayloadMiddleware(
   req: IncomingMessage,
   res: ServerResponse,
@@ -67,7 +78,12 @@ function a2uiPayloadMiddleware(
 
   if (
     req.method === 'OPTIONS'
-    && (url.startsWith('/__a2ui_payload') || url.startsWith('/__a2ui/'))
+    && (
+      url.startsWith('/__a2ui_payload')
+      || url.startsWith('/__a2ui/')
+      || url.startsWith('/__openui_payload')
+      || url.startsWith('/__openui/')
+    )
   ) {
     res.statusCode = 204;
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -107,6 +123,35 @@ function a2uiPayloadMiddleware(
     return;
   }
 
+  if (req.method === 'POST' && url.startsWith('/__openui_payload')) {
+    void (async () => {
+      try {
+        gcPayloads();
+        const body = (await readJsonBody(req)) as {
+          rawText?: unknown;
+        };
+        if (typeof body.rawText !== 'string') {
+          sendJson(res, 400, { error: 'rawText is required' });
+          return;
+        }
+        const id = randomUUID();
+        payloadStore.set(id, {
+          rawText: body.rawText,
+          createdAt: Date.now(),
+        });
+        sendJson(res, 200, {
+          id,
+          rawTextUrl: `/__openui/${id}/rawText`,
+        });
+      } catch (e) {
+        sendJson(res, 400, {
+          error: e instanceof Error ? e.message : 'bad request',
+        });
+      }
+    })();
+    return;
+  }
+
   if (req.method === 'GET' && url.startsWith('/__a2ui/')) {
     // Sweep expired entries before reads too — otherwise an idle dev
     // server keeps stale payloads retrievable far past the TTL.
@@ -120,6 +165,21 @@ function a2uiPayloadMiddleware(
           ? entry.messages
           : entry.actionMocks;
         sendJson(res, 200, value ?? null);
+        return;
+      }
+    }
+    sendJson(res, 404, { error: 'not found' });
+    return;
+  }
+
+  if (req.method === 'GET' && url.startsWith('/__openui/')) {
+    gcPayloads();
+    const m = /^\/__openui\/([^/]+)\/rawText(?:\?|$)/.exec(url);
+    if (m) {
+      const [, id] = m;
+      const entry = id ? payloadStore.get(id) : undefined;
+      if (typeof entry?.rawText === 'string') {
+        sendText(res, 200, entry.rawText);
         return;
       }
     }

--- a/packages/genui/playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/playground/src/components/PreviewPanel.tsx
@@ -27,7 +27,12 @@ import { useMediaQuery } from '../hooks/useMediaQuery.js';
 import { copyToClipboard } from '../utils/clipboard.js';
 import { DEFAULT_A2UI_DEMO_URL } from '../utils/demoUrl.js';
 import type { Protocol } from '../utils/protocol.js';
-import { buildOpenUIRenderUrl, buildRenderUrl } from '../utils/renderUrl.js';
+import { publishOpenUIPayload } from '../utils/publishPayload.js';
+import {
+  buildOpenUIRenderUrl,
+  buildRenderUrl,
+  canInlineOpenUIRenderUrl,
+} from '../utils/renderUrl.js';
 
 declare const __A2UI_PLAYGROUND_CLIENT_PAYLOAD_STORE__: boolean;
 
@@ -247,6 +252,26 @@ function absoluteUrl(url: string, origin: string): string {
 
 function shouldUseClientPayloadStore(): boolean {
   return __A2UI_PLAYGROUND_CLIENT_PAYLOAD_STORE__;
+}
+
+async function publishOpenUIRawTextToClientStore(
+  baseUrl: string,
+  rawText: string,
+): Promise<string> {
+  const payloadOrigin = new URL(baseUrl).origin;
+  const res = await window.fetch(`${payloadOrigin}/__openui_payload`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rawText }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to publish local OpenUI raw text');
+  }
+  const data = (await res.json()) as { rawTextUrl?: unknown };
+  if (typeof data.rawTextUrl !== 'string') {
+    throw new Error('Invalid local OpenUI payload response');
+  }
+  return absoluteUrl(data.rawTextUrl, payloadOrigin);
 }
 
 function isPreviewMetricName(value: unknown): value is PreviewMetricName {
@@ -736,67 +761,80 @@ export function PreviewPanel(props: PreviewPanelProps) {
       return;
     }
 
-    const url = buildOpenUIRenderUrl({
+    const inlineUrl = buildOpenUIRenderUrl({
       rawText: previewSource.rawText,
       speed,
       playbackMode: previewSource.playbackMode,
     }, baseUrl);
-    const shareUrl = buildOpenUIRenderUrl({
+    const inlineShareUrl = buildOpenUIRenderUrl({
       rawText: previewSource.rawText,
       speed,
     }, shareBaseUrl);
-    setRenderUrl(url);
-    setRenderShareUrl(shareUrl);
+    const canInline = canInlineOpenUIRenderUrl(inlineUrl)
+      && canInlineOpenUIRenderUrl(inlineShareUrl);
 
-    if (!rspeedyDevUrl) {
+    setRenderUrl(canInline ? inlineUrl : '');
+    setRenderShareUrl(canInline ? inlineShareUrl : '');
+
+    const setOpenUILynxDevUrl = (
+      payload: { rawText: string } | { rawTextUrl: string },
+    ) => {
+      if (!rspeedyDevUrl) {
+        setLynxDevUrl('');
+        return;
+      }
+      const u = new URL(rspeedyDevUrl);
+      u.pathname = u.pathname.replace('a2ui.lynx', 'openui.lynx');
+      if ('rawTextUrl' in payload) {
+        u.searchParams.set('rawTextUrl', payload.rawTextUrl);
+        u.searchParams.delete('rawText');
+      } else {
+        u.searchParams.set('rawText', payload.rawText);
+        u.searchParams.delete('rawTextUrl');
+      }
+      if (speed !== 1) {
+        u.searchParams.set('speed', String(speed));
+      }
+      setLynxDevUrl(u.toString());
+    };
+
+    if (canInline) {
+      setOpenUILynxDevUrl({ rawText: previewSource.rawText });
+      return;
+    }
+
+    if (!previewSource.rawText) {
       setLynxDevUrl('');
       return;
     }
 
-    const uInline = new URL(rspeedyDevUrl);
-    uInline.pathname = uInline.pathname.replace('a2ui.lynx', 'openui.lynx');
-    uInline.searchParams.set('rawText', previewSource.rawText);
-    if (speed !== 1) {
-      uInline.searchParams.set('speed', String(speed));
-    }
-    setLynxDevUrl(uInline.toString());
+    setLynxDevUrl('');
 
     void (async () => {
       try {
-        const rspeedyOrigin = new URL(rspeedyDevUrl).origin;
-        const res = await window.fetch(`${rspeedyOrigin}/__openui_payload`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ rawText: previewSource.rawText }),
-        });
-        if (!res.ok) return;
-        const data = (await res.json()) as { rawTextUrl?: string };
-
+        const published = shouldUseClientPayloadStore()
+          ? {
+            rawTextUrl: await publishOpenUIRawTextToClientStore(
+              baseUrl,
+              previewSource.rawText,
+            ),
+          }
+          : await publishOpenUIPayload(previewSource.rawText);
+        const rawTextUrl = published.rawTextUrl;
         if (seq !== buildSeqRef.current) return;
 
-        if (typeof data.rawTextUrl === 'string') {
-          const rawTextUrlAbs = `${rspeedyOrigin}${data.rawTextUrl}`;
-          const u = new URL(rspeedyDevUrl);
-          u.pathname = u.pathname.replace('a2ui.lynx', 'openui.lynx');
-          u.searchParams.set('rawTextUrl', rawTextUrlAbs);
-          u.searchParams.delete('rawText');
-          if (speed !== 1) {
-            u.searchParams.set('speed', String(speed));
-          }
-          setLynxDevUrl(u.toString());
-
-          setRenderUrl(buildOpenUIRenderUrl({
-            rawTextUrl: rawTextUrlAbs,
-            speed,
-            playbackMode: previewSource.playbackMode,
-          }, baseUrl));
-          setRenderShareUrl(buildOpenUIRenderUrl({
-            rawTextUrl: rawTextUrlAbs,
-            speed,
-          }, shareBaseUrl));
-        }
-      } catch {
-        // Keep the inline URLs above if shortening is unavailable.
+        setOpenUILynxDevUrl({ rawTextUrl });
+        setRenderUrl(buildOpenUIRenderUrl({
+          rawTextUrl,
+          speed,
+          playbackMode: previewSource.playbackMode,
+        }, baseUrl));
+        setRenderShareUrl(buildOpenUIRenderUrl({
+          rawTextUrl,
+          speed,
+        }, shareBaseUrl));
+      } catch (err) {
+        console.warn('[openui] Failed to publish preview raw text', err);
       }
     })();
   }, [baseUrl, previewSource, rspeedyDevUrl, shareBaseUrl, speed]);

--- a/packages/genui/playground/src/utils/publishPayload.ts
+++ b/packages/genui/playground/src/utils/publishPayload.ts
@@ -10,6 +10,10 @@ export interface PublishedPayload {
   actionMocksUrl?: string;
 }
 
+export interface PublishedOpenUIPayload {
+  rawTextUrl: string;
+}
+
 export function isDevHost(hostname: string): boolean {
   return (
     hostname === 'localhost'
@@ -28,6 +32,15 @@ export function getA2UIPayloadEndpoint(): string {
     return `http://${window.location.hostname}:${LOCAL_A2UI_SERVER_PORT}/a2ui/payload`;
   }
   return `${ONLINE_A2UI_SERVER_ORIGIN}/a2ui/payload`;
+}
+
+export function getOpenUIPayloadEndpoint(): string {
+  if (
+    window.location.protocol === 'http:' && isDevHost(window.location.hostname)
+  ) {
+    return `http://${window.location.hostname}:${LOCAL_A2UI_SERVER_PORT}/openui/payload`;
+  }
+  return `${ONLINE_A2UI_SERVER_ORIGIN}/openui/payload`;
 }
 
 /**
@@ -63,5 +76,35 @@ export async function publishA2UIPayload(
     actionMocksUrl: typeof payload.preview.actionMocksUrl === 'string'
       ? payload.preview.actionMocksUrl
       : undefined,
+  };
+}
+
+/**
+ * Upload OpenUI Lang source to the GenUI server and return a durable public
+ * text URL. Use this instead of inlining large `rawText` query params.
+ */
+export async function publishOpenUIPayload(
+  rawText: string,
+): Promise<PublishedOpenUIPayload> {
+  const res = await window.fetch(getOpenUIPayloadEndpoint(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rawText }),
+  });
+  const payload = await res.json().catch(() => ({})) as {
+    preview?: {
+      rawTextUrl?: unknown;
+    };
+    error?: unknown;
+  };
+  if (!res.ok || typeof payload.preview?.rawTextUrl !== 'string') {
+    throw new Error(
+      typeof payload.error === 'string'
+        ? payload.error
+        : 'Failed to publish OpenUI raw text',
+    );
+  }
+  return {
+    rawTextUrl: payload.preview.rawTextUrl,
   };
 }

--- a/packages/genui/playground/src/utils/renderUrl.test.ts
+++ b/packages/genui/playground/src/utils/renderUrl.test.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  OPENUI_INLINE_RENDER_URL_MAX_LENGTH,
+  buildOpenUIRenderUrl,
+  canInlineOpenUIRenderUrl,
+} from './renderUrl.js';
+
+describe('OpenUI render URLs', () => {
+  test('marks oversized inline rawText URLs as unsafe', () => {
+    const rawText = 'root = Stack([])\n'.repeat(600);
+    const url = buildOpenUIRenderUrl({
+      rawText,
+    }, 'https://lynx-stack.dev/genui/');
+
+    expect(url.length).toBeGreaterThan(OPENUI_INLINE_RENDER_URL_MAX_LENGTH);
+    expect(canInlineOpenUIRenderUrl(url)).toBe(false);
+  });
+
+  test('keeps rawTextUrl render URLs short', () => {
+    const url = buildOpenUIRenderUrl({
+      rawTextUrl:
+        'https://example.supabase.co/storage/v1/object/public/genui/openui/id/raw.txt',
+    }, 'https://lynx-stack.dev/genui/');
+
+    expect(canInlineOpenUIRenderUrl(url)).toBe(true);
+    expect(url).toContain('rawTextUrl=');
+    expect(url).not.toContain('rawText=');
+  });
+});

--- a/packages/genui/playground/src/utils/renderUrl.ts
+++ b/packages/genui/playground/src/utils/renderUrl.ts
@@ -6,6 +6,7 @@ import type { Protocol } from './protocol.js';
 
 export const RENDER_INIT_DATA_QUERY_PARAM = 'initData';
 export const RENDER_METRIC_ID_QUERY_PARAM = 'previewMetricId';
+export const OPENUI_INLINE_RENDER_URL_MAX_LENGTH = 7_000;
 
 export interface RenderInit {
   protocol: Protocol;
@@ -153,4 +154,8 @@ export function buildOpenUIRenderUrl(
   }
 
   return url.toString();
+}
+
+export function canInlineOpenUIRenderUrl(url: string): boolean {
+  return url.length <= OPENUI_INLINE_RENDER_URL_MAX_LENGTH;
 }

--- a/packages/genui/server/app/a2ui/payload-publisher.ts
+++ b/packages/genui/server/app/a2ui/payload-publisher.ts
@@ -10,6 +10,8 @@ const SUPABASE_S3_SECRET_ACCESS_KEY = process.env.SUPABASE_S3_SECRET_ACCESS_KEY;
 const SUPABASE_STORAGE_BUCKET = process.env.SUPABASE_STORAGE_BUCKET
   ?? 'genui';
 const SUPABASE_STORAGE_PREFIX = process.env.SUPABASE_STORAGE_PREFIX ?? 'a2ui';
+const SUPABASE_OPENUI_STORAGE_PREFIX =
+  process.env.SUPABASE_OPENUI_STORAGE_PREFIX ?? 'openui';
 const SUPABASE_STORAGE_REGION = process.env.SUPABASE_STORAGE_REGION
   ?? 'us-east-1';
 
@@ -18,12 +20,20 @@ export interface A2UIPublishedPayload {
   actionMocksUrl?: string;
 }
 
+export interface OpenUIPublishedPayload {
+  rawTextUrl: string;
+}
+
 function trimSlashes(value: string): string {
   return value.replace(/^\/+|\/+$/g, '');
 }
 
-function buildSupabaseStoragePath(id: string, file: string): string {
-  const prefix = trimSlashes(SUPABASE_STORAGE_PREFIX);
+function buildSupabaseStoragePath(
+  id: string,
+  file: string,
+  storagePrefix = SUPABASE_STORAGE_PREFIX,
+): string {
+  const prefix = trimSlashes(storagePrefix);
   return prefix ? `${prefix}/${id}/${file}` : `${id}/${file}`;
 }
 
@@ -59,15 +69,46 @@ async function uploadSupabaseJson(
   path: string,
   payload: unknown,
 ): Promise<void> {
+  await uploadSupabaseObject(
+    path,
+    JSON.stringify(payload),
+    'application/json; charset=utf-8',
+  );
+}
+
+async function uploadSupabaseText(
+  path: string,
+  text: string,
+): Promise<void> {
+  await uploadSupabaseObject(
+    path,
+    text,
+    'text/plain; charset=utf-8',
+  );
+}
+
+async function uploadSupabaseObject(
+  path: string,
+  body: string,
+  contentType: string,
+): Promise<void> {
   const client = createSupabaseS3Client();
   await client.send(
     new PutObjectCommand({
       Bucket: SUPABASE_STORAGE_BUCKET,
       Key: path,
-      Body: JSON.stringify(payload),
-      ContentType: 'application/json; charset=utf-8',
+      Body: body,
+      ContentType: contentType,
       CacheControl: 'public, max-age=1800',
     }),
+  );
+}
+
+function isSupabaseStorageConfigured(): boolean {
+  return Boolean(
+    SUPABASE_URL
+      && SUPABASE_S3_ACCESS_KEY_ID
+      && SUPABASE_S3_SECRET_ACCESS_KEY,
   );
 }
 
@@ -77,11 +118,7 @@ export async function publishA2UIPayload(
 ): Promise<A2UIPublishedPayload | undefined> {
   if (messages === undefined) return undefined;
 
-  if (
-    !SUPABASE_URL
-    || !SUPABASE_S3_ACCESS_KEY_ID
-    || !SUPABASE_S3_SECRET_ACCESS_KEY
-  ) {
+  if (!isSupabaseStorageConfigured()) {
     console.warn(
       '[a2ui:payload-publisher] Supabase Storage S3 is not configured',
     );
@@ -107,6 +144,36 @@ export async function publishA2UIPayload(
   } catch (err) {
     console.warn(
       '[a2ui:payload-publisher] Supabase Storage upload failed',
+      err,
+    );
+    return undefined;
+  }
+}
+
+export async function publishOpenUIRawText(
+  rawText: string,
+): Promise<OpenUIPublishedPayload | undefined> {
+  if (!isSupabaseStorageConfigured()) {
+    console.warn(
+      '[openui:payload-publisher] Supabase Storage S3 is not configured',
+    );
+    return undefined;
+  }
+
+  try {
+    const id = crypto.randomUUID();
+    const rawTextPath = buildSupabaseStoragePath(
+      id,
+      'raw.txt',
+      SUPABASE_OPENUI_STORAGE_PREFIX,
+    );
+    await uploadSupabaseText(rawTextPath, rawText);
+    const rawTextUrl = buildSupabaseObjectUrl(rawTextPath);
+    if (!rawTextUrl) return undefined;
+    return { rawTextUrl };
+  } catch (err) {
+    console.warn(
+      '[openui:payload-publisher] Supabase Storage upload failed',
       err,
     );
     return undefined;

--- a/packages/genui/server/app/openui/payload/route.ts
+++ b/packages/genui/server/app/openui/payload/route.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { errorMessage, readJsonBodyWithLimit } from '../../a2ui/_shared';
+import { corsPreflight, jsonWithCors } from '../../a2ui/cors';
+import { publishOpenUIRawText } from '../../a2ui/payload-publisher';
+import { checkRateLimit } from '../../a2ui/rate-limit';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface OpenUIPayloadBody {
+  rawText?: unknown;
+}
+
+export function OPTIONS(req: Request) {
+  return corsPreflight(req);
+}
+
+export async function POST(req: Request) {
+  const decision = checkRateLimit(req);
+  if (!decision.ok) {
+    return jsonWithCors(
+      req,
+      { ok: false, error: 'rate limit exceeded' },
+      { status: 429 },
+    );
+  }
+
+  const parsed = await readJsonBodyWithLimit<OpenUIPayloadBody>(req);
+  if (!parsed.ok) {
+    return jsonWithCors(
+      req,
+      { ok: false, error: parsed.error },
+      { status: parsed.status },
+    );
+  }
+
+  if (typeof parsed.body.rawText !== 'string') {
+    return jsonWithCors(
+      req,
+      { ok: false, error: 'rawText is required' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const preview = await publishOpenUIRawText(parsed.body.rawText);
+    if (!preview) {
+      return jsonWithCors(
+        req,
+        { ok: false, error: 'payload publishing is not configured' },
+        { status: 503 },
+      );
+    }
+
+    return jsonWithCors(req, { ok: true, preview });
+  } catch (err) {
+    return jsonWithCors(
+      req,
+      { ok: false, error: errorMessage(err).message },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add an OpenUI raw-text payload publishing route backed by Supabase Storage
- switch oversized OpenUI preview links from inline rawText query params to rawTextUrl
- extend the local playground payload store and add render URL coverage

## Validation
- pnpm -C packages/genui/playground test
- pnpm -C packages/genui/playground build
- pnpm -C packages/genui/server build
- pnpm -C packages/genui/server lint
- pnpm exec eslint --no-warn-ignored packages/genui/playground/rsbuild.config.ts packages/genui/playground/src/components/PreviewPanel.tsx packages/genui/playground/src/utils/publishPayload.ts packages/genui/playground/src/utils/renderUrl.ts packages/genui/playground/src/utils/renderUrl.test.ts
- pnpm exec dprint check .github/genui-playground.instructions.md packages/genui/playground/rsbuild.config.ts packages/genui/playground/src/components/PreviewPanel.tsx packages/genui/playground/src/utils/publishPayload.ts packages/genui/playground/src/utils/renderUrl.ts packages/genui/playground/src/utils/renderUrl.test.ts packages/genui/server/app/a2ui/payload-publisher.ts packages/genui/server/app/openui/payload/route.ts
- pnpm exec biome check --files-ignore-unknown=true .github/genui-playground.instructions.md packages/genui/playground/rsbuild.config.ts packages/genui/playground/src/components/PreviewPanel.tsx packages/genui/playground/src/utils/publishPayload.ts packages/genui/playground/src/utils/renderUrl.ts packages/genui/playground/src/utils/renderUrl.test.ts packages/genui/server/app/a2ui/payload-publisher.ts packages/genui/server/app/openui/payload/route.ts
- NODE_OPTIONS="--max-old-space-size=32768" pnpm turbo build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenUI playground previews now support publishing large text payloads separately, making shareable preview links work better for longer content.
  * Preview URLs now choose the safest format automatically, using inline text only when it fits within limits.

* **Bug Fixes**
  * Reduced failures caused by oversized preview URLs.
  * Added more reliable handling for preview publishing, including clearer fallback behavior when publishing isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->