### PR TITLE
fix: x-text inline view truncation

### DIFF
--- a/.changeset/fix-web-elements-x-text-inline-view.md
+++ b/.changeset/fix-web-elements-x-text-inline-view.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Fix `x-text` custom inline truncation so inline `x-view` children are measured as one inline box instead of double-counting their descendants as extra lines.

--- a/.github/web-elements-x-text.instructions.md
+++ b/.github/web-elements-x-text.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-elements/src/elements/XText/**"
+---
+
+When updating `x-text` truncation measurement, keep text-like inline containers such as `x-text`, `inline-text`, `raw-text`, and `lynx-wrapper` transparent so their descendants are measured with DFS. Treat `x-view` as one atomic inline box; measuring both the `x-view` and its child boxes can double-count inline views and make one visual line look like multiple lines.

--- a/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
@@ -614,22 +614,27 @@ class LazyNodesList {
   #nodeCache: (Text | Element)[] = [];
   #treeWalker: TreeWalker;
   constructor(dom: HTMLElement) {
+    const isInAtomicView = (node: Node) => {
+      const parentElement = node.nodeType === Node.ELEMENT_NODE
+        ? (node as Element).parentElement
+        : node.parentElement;
+      for (
+        let element = parentElement;
+        element && element !== dom;
+        element = element.parentElement
+      ) {
+        if (element.tagName === 'X-VIEW') {
+          return true;
+        }
+      }
+      return false;
+    };
     this.#treeWalker = document.createTreeWalker(
       dom,
       NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
       (node: Node) => {
-        const parentElement = node.nodeType === Node.ELEMENT_NODE
-          ? (node as Element).parentElement
-          : node.parentElement;
-        for (
-          let element = parentElement;
-          element && element !== dom;
-          element = element.parentElement
-        ) {
-          // x-view is measured as one inline box.
-          if (element.tagName === 'X-VIEW') {
-            return NodeFilter.FILTER_REJECT;
-          }
+        if (isInAtomicView(node)) {
+          return NodeFilter.FILTER_REJECT;
         }
         if (node.nodeType === Node.ELEMENT_NODE) {
           const tagName = (node as Element).tagName;

--- a/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
@@ -612,6 +612,7 @@ class TextRenderingMeasureTool {
 }
 class LazyNodesList {
   #nodeCache: (Text | Element)[] = [];
+  #lastAtomicView?: Element;
   #treeWalker: TreeWalker;
   constructor(dom: HTMLElement) {
     this.#treeWalker = document.createTreeWalker(
@@ -646,6 +647,17 @@ class LazyNodesList {
       index >= this.#nodeCache.length
       && (currentNode = this.#treeWalker.nextNode())
     ) {
+      // x-view is measured as one inline box.
+      if (
+        this.#lastAtomicView
+        && this.#lastAtomicView.contains(currentNode)
+      ) {
+        continue;
+      }
+      this.#lastAtomicView = currentNode.nodeType === Node.ELEMENT_NODE
+          && (currentNode as Element).tagName === 'X-VIEW'
+        ? currentNode as Element
+        : undefined;
       this.#nodeCache.push(currentNode as Text | Element);
       break;
     }

--- a/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
@@ -612,13 +612,25 @@ class TextRenderingMeasureTool {
 }
 class LazyNodesList {
   #nodeCache: (Text | Element)[] = [];
-  #lastAtomicView?: Element;
   #treeWalker: TreeWalker;
   constructor(dom: HTMLElement) {
     this.#treeWalker = document.createTreeWalker(
       dom,
       NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
       (node: Node) => {
+        const parentElement = node.nodeType === Node.ELEMENT_NODE
+          ? (node as Element).parentElement
+          : node.parentElement;
+        for (
+          let element = parentElement;
+          element && element !== dom;
+          element = element.parentElement
+        ) {
+          // x-view is measured as one inline box.
+          if (element.tagName === 'X-VIEW') {
+            return NodeFilter.FILTER_REJECT;
+          }
+        }
         if (node.nodeType === Node.ELEMENT_NODE) {
           const tagName = (node as Element).tagName;
           if (
@@ -647,17 +659,6 @@ class LazyNodesList {
       index >= this.#nodeCache.length
       && (currentNode = this.#treeWalker.nextNode())
     ) {
-      // x-view is measured as one inline box.
-      if (
-        this.#lastAtomicView
-        && this.#lastAtomicView.contains(currentNode)
-      ) {
-        continue;
-      }
-      this.#lastAtomicView = currentNode.nodeType === Node.ELEMENT_NODE
-          && (currentNode as Element).tagName === 'X-VIEW'
-        ? currentNode as Element
-        : undefined;
       this.#nodeCache.push(currentNode as Text | Element);
       break;
     }

--- a/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
@@ -614,24 +614,19 @@ class LazyNodesList {
   #nodeCache: (Text | Element)[] = [];
   #treeWalker: TreeWalker;
   constructor(dom: HTMLElement) {
-    const isInAtomicView = (parentElement: Element | null) => {
-      for (
-        let element = parentElement;
-        element && element !== dom;
-        element = element.parentElement
-      ) {
-        if (element.tagName === 'X-VIEW') {
-          return true;
-        }
-      }
-      return false;
-    };
     this.#treeWalker = document.createTreeWalker(
       dom,
       NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
       (node: Node) => {
-        if (isInAtomicView(node.parentElement)) {
-          return NodeFilter.FILTER_REJECT;
+        for (
+          let element = node.parentElement;
+          element && element !== dom;
+          element = element.parentElement
+        ) {
+          if (element.tagName === 'X-VIEW') {
+            // x-view is measured as a single inline box, so skip its subtree.
+            return NodeFilter.FILTER_REJECT;
+          }
         }
         if (node.nodeType === Node.ELEMENT_NODE) {
           const tagName = (node as Element).tagName;

--- a/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
@@ -614,10 +614,7 @@ class LazyNodesList {
   #nodeCache: (Text | Element)[] = [];
   #treeWalker: TreeWalker;
   constructor(dom: HTMLElement) {
-    const isInAtomicView = (node: Node) => {
-      const parentElement = node.nodeType === Node.ELEMENT_NODE
-        ? (node as Element).parentElement
-        : node.parentElement;
+    const isInAtomicView = (parentElement: Element | null) => {
       for (
         let element = parentElement;
         element && element !== dom;
@@ -633,7 +630,7 @@ class LazyNodesList {
       dom,
       NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
       (node: Node) => {
-        if (isInAtomicView(node)) {
+        if (isInAtomicView(node.parentElement)) {
           return NodeFilter.FILTER_REJECT;
         }
         if (node.nodeType === Node.ELEMENT_NODE) {

--- a/packages/web-platform/web-elements/tests/fixtures/x-text/avatar-text-inline.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-text/avatar-text-inline.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable" />
+    <meta content="default" name="apple-mobile-web-app-status-bar-style" />
+    <meta content="telephone=no" name="format-detection" />
+    <meta content="portrait" name="screen-orientation" />
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    />
+    <meta content="portrait" name="x5-orientation" />
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-view style="width: 375px">
+      <x-text
+        id="target"
+        class="quote-text"
+        text-maxline="2"
+        text-overflow="ellipsis"
+        tag-v="02dc4"
+        tag-e="e540c"
+        data-tag="text"
+        kit-uid="text-0"
+        can-use-linear-container=""
+        style="width: 100%; font-size: 15px; font-weight: 400; line-height: 23px; color: rgba(22, 24, 35, 0.6); background-clip: initial; --lynx-text-bg-color: initial; --lynx-color: rgba(22, 24, 35, 0.6)"
+      ><x-view
+          class="avatar-slot"
+          clip-radius="true"
+          tag-v="02dc4"
+          tag-e="e540c"
+          data-tag="view"
+          kit-uid="view-0"
+          can-use-linear-container=""
+          style="position: relative; display: inline-flex; width: 18px; height: 18px; margin-right: 7px; align-items: center; vertical-align: middle; overflow: hidden; border-radius: 50%; --justify-content: center; background-color: rgba(22, 24, 35, 0.03)"
+        ><x-view
+            class="avatar"
+            mode="aspectFill"
+            skip-redirection="true"
+            tag-v="02dc4"
+            tag-e="e540c"
+            data-tag="image"
+            kit-uid="image-0"
+            can-use-linear-container=""
+            classname="avatar"
+            style="width: 18px; height: 18px"
+          ></x-view><x-view
+            class="avatar-border"
+            tag-v="02dc4"
+            tag-e="e540c"
+            data-tag="view"
+            kit-uid="view-0"
+            can-use-linear-container=""
+            style="position: absolute; inset: 0; border-radius: 50%; border: 1px solid rgba(22, 24, 35, 0.12)"
+          ></x-view></x-view>清透缎光妆感自然。<inline-truncation
+          _componentuuid="_com_1___undefined_1___"
+          containerwidth="375"
+          tag-v="02dc4"
+          tag-e="e540c"
+          data-tag="inline-truncation"
+          kit-uid="inline-truncation-0"
+          can-use-linear-container=""
+          slot="inline-truncation"
+        ><x-text
+            class="ellipsis-text"
+            tag-v="02dc4"
+            tag-e="e540c"
+            data-tag="text"
+            kit-uid="text-0"
+            can-use-linear-container=""
+            style="margin-left: -4px; font-size: 15px; font-weight: 400; line-height: 23px; color: rgba(22, 24, 35, 0.6); background-clip: initial; --lynx-text-bg-color: initial; --lynx-color: rgba(22, 24, 35, 0.6)"
+          >...</x-text><x-view
+            class="quote-mark-slot"
+            tag-v="02dc4"
+            tag-e="e540c"
+            data-tag="view"
+            kit-uid="view-0"
+            can-use-linear-container=""
+            style="width: 17px; height: 17px; align-items: center; vertical-align: top; display: flex; --lynx-display-toggle: var(--lynx-display-flex); --lynx-display: flex; --justify-content: center; margin-left: 4px"
+          ><x-view
+              class="quote-mark"
+              mode="aspectFit"
+              skip-redirection="true"
+              tag-v="02dc4"
+              tag-e="e540c"
+              data-tag="image"
+              kit-uid="image-0"
+              can-use-linear-container=""
+              classname="quote-mark"
+              style="width: 17px; height: 17px"
+            ></x-view></x-view></inline-truncation></x-text>
+    </x-view>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -274,6 +274,13 @@ test.describe('web-elements test suite', () => {
       await gotoWebComponentPage(page, title);
       await diffScreenShot(page, title, 'index');
     });
+    test('x-text/avatar-text-inline', async ({ page }, { title }) => {
+      await gotoWebComponentPage(page, title);
+      await wait(100);
+      await expect(
+        page.locator('#target'),
+      ).not.toHaveAttribute('x-show-inline-truncation', '');
+    });
 
     test('x-text/text-overflow-inherit', async ({ page }, { title }) => {
       await gotoWebComponentPage(page, title);

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -276,7 +276,25 @@ test.describe('web-elements test suite', () => {
     });
     test('x-text/avatar-text-inline', async ({ page }, { title }) => {
       await gotoWebComponentPage(page, title);
-      await wait(100);
+      await page.waitForFunction(() => {
+        const target = document.querySelector('#target');
+        const innerBox = target?.shadowRoot?.querySelector(
+          '#inner-box',
+        ) as HTMLElement | undefined;
+        const avatarSlot = document.querySelector('.avatar-slot');
+        const avatarRect = avatarSlot?.getBoundingClientRect();
+        return innerBox?.style.webkitLineClamp === '2'
+          && !!avatarRect?.width
+          && !!avatarRect.height;
+      });
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => {
+              resolve();
+            });
+          }),
+      );
       await expect(
         page.locator('#target'),
       ).not.toHaveAttribute('x-show-inline-truncation', '');


### PR DESCRIPTION
## Summary

Fix `x-text` custom inline truncation measurement when an inline `x-view` avatar appears before short text. `x-view` children are now measured as one inline box so their descendants are not double-counted as an extra visual line, while text-like inline containers still keep DFS measurement.

Adds a focused `avatar-text-inline` fixture and Playwright assertion that the short one-line text does not set `x-show-inline-truncation`. Adds a patch changeset for `@lynx-js/web-elements`.

## Root Cause

The line measurement tree walker measured an inline `x-view` and then continued into its child `x-view` nodes. Those child rects can sit near the container line start with tiny vertical metric differences, so the existing line-start heuristic could count one visual line as multiple lines and show custom truncation too early.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo build`
- `pnpm dprint check .changeset/fix-web-elements-x-text-inline-view.md .github/web-elements-x-text.instructions.md packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts packages/web-platform/web-elements/tests/web-elements.spec.ts packages/web-platform/web-elements/tests/fixtures/x-text/avatar-text-inline.html`
- `pnpm --filter @lynx-js/web-elements exec playwright test --project chromium -g "x-text/avatar-text-inline"`
- `pnpm --filter @lynx-js/web-elements exec playwright test --project chromium -g "x-text/(text-maxline-with-custom-truncation|text-maxline-just-fit-do-not-show-custom-truncation|inline-truncation-with-inline-image|truncation-first-element-is-image|text-in-text|inline-text)"`

## Notes

`pnpm changeset status --since=upstream/main` currently fails before evaluating this PR because the checkout reports an existing `@lynx-js/qrcode-rsbuild-plugin` dependency mismatch against `@lynx-js/rspeedy` (`0.14.5` vs `^0.15.0`). The patch changeset file for this PR is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `x-text` inline truncation measurement so nested inline content isn’t double-counted, preventing incorrect extra lines/ellipsis.
  * Ensured `x-view` is treated as a single atomic inline box during truncation measurement.
* **Documentation**
  * Added rules clarifying how inline truncation measurement should traverse `x-text`-related elements and handle `x-view`.
* **Tests**
  * Added an `x-text/avatar-text-inline` fixture and Playwright test verifying line clamp behavior and that inline truncation indicators remain hidden when not needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->