### PR TITLE
fix(docs-mcp-server): add Codex startup shim

### DIFF
--- a/.changeset/docs-mcp-codex-compat.md
+++ b/.changeset/docs-mcp-codex-compat.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/docs-mcp-server": patch
+---
+
+Add a disabled `dummyTool` so Codex can discover tool support during MCP startup without exposing any real tools.

--- a/packages/mcp-servers/docs-mcp-server/main.ts
+++ b/packages/mcp-servers/docs-mcp-server/main.ts
@@ -54,6 +54,27 @@ const pkg = JSON.parse(await readFile(pkgPath, 'utf-8')) as {
 
 const MCP_SERVER_NAME = 'lynx-docs';
 
+function registerCodexCompatibilityHandlers(mcpServer: McpServer) {
+  // Codex expects tool discovery to exist during startup. Register one disabled
+  // placeholder so the SDK exposes tools/list while keeping the catalog empty.
+  const dummyTool = mcpServer.registerTool(
+    'dummyTool',
+    {
+      description: 'Internal compatibility shim for Codex MCP startup.',
+    },
+    async () => ({
+      content: [
+        {
+          type: 'text',
+          text: 'This compatibility shim should never be called.',
+        },
+      ],
+    }),
+  );
+
+  dummyTool.disable();
+}
+
 async function crawlAndRegisterResources(
   baseURL: string,
   mcpServer: McpServer,
@@ -238,6 +259,8 @@ For any questions or requirements regarding Lynx:
     ROOT_DOC_MARKDOWN,
     visited,
   );
+
+  registerCodexCompatibilityHandlers(mcpServer);
 
   const transport = new StdioServerTransport();
   await mcpServer.connect(transport);


### PR DESCRIPTION
## Summary

Codex expects `tools/list` to exist during MCP startup. When a server only provides resources (no tools), the MCP SDK never exposes the `tools/list` handler, causing Codex to crash during tool discovery.

## Solution

Register a disabled `dummyTool` placeholder so the SDK always exposes `tools/list`. Since the tool is disabled, it won't appear in the tool catalog — Codex sees an empty list and starts up normally.

## Changeset

Patch bump for `@lynx-js/docs-mcp-server`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Codex-style tool discovery during startup, helping supported clients detect the server more reliably.
  * Added a non-usable placeholder response for compatibility checks, while keeping real tools unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->