### PR TITLE
test(web-platform): regenerate server-e2e snapshots for scroll-view fading-edge keyframes

### DIFF
--- a/packages/web-platform/web-core-e2e/server-tests/__snapshots__/server-e2e.test.ts.snap
+++ b/packages/web-platform/web-core-e2e/server-tests/__snapshots__/server-e2e.test.ts.snap
@@ -429,37 +429,6 @@ exports[`executeTemplate should run lepusCode.root from basic-element-x-overlay-
                       ::-webkit-scrollbar {
                         display: none;
                       }
-
-                      @keyframes topFading {
-                        0% {
-                          box-shadow: transparent 0px 0px 0px 0px;
-                        }
-                        5% {
-                          box-shadow: var(--scroll-view-bg-color) 0px 0px
-                            var(--scroll-view-fading-edge-length)
-                            var(--scroll-view-fading-edge-length);
-                        }
-                        100% {
-                          box-shadow: var(--scroll-view-bg-color) 0px 0px
-                            var(--scroll-view-fading-edge-length)
-                            var(--scroll-view-fading-edge-length);
-                        }
-                      }
-                      @keyframes botFading {
-                        0% {
-                          box-shadow: var(--scroll-view-bg-color) 0px 0px
-                            var(--scroll-view-fading-edge-length)
-                            var(--scroll-view-fading-edge-length);
-                        }
-                        95% {
-                          box-shadow: var(--scroll-view-bg-color) 0px 0px
-                            var(--scroll-view-fading-edge-length)
-                            var(--scroll-view-fading-edge-length);
-                        }
-                        100% {
-                          box-shadow: transparent 0px 0px 0px 0px;
-                        }
-                      }
                     </style>
                     <div
                       class="mask placeholder-dom"
@@ -581,37 +550,6 @@ exports[`executeTemplate should run lepusCode.root from basic-element-x-overlay-
                     ::-webkit-scrollbar {
                       display: none;
                     }
-
-                    @keyframes topFading {
-                      0% {
-                        box-shadow: transparent 0px 0px 0px 0px;
-                      }
-                      5% {
-                        box-shadow: var(--scroll-view-bg-color) 0px 0px
-                          var(--scroll-view-fading-edge-length)
-                          var(--scroll-view-fading-edge-length);
-                      }
-                      100% {
-                        box-shadow: var(--scroll-view-bg-color) 0px 0px
-                          var(--scroll-view-fading-edge-length)
-                          var(--scroll-view-fading-edge-length);
-                      }
-                    }
-                    @keyframes botFading {
-                      0% {
-                        box-shadow: var(--scroll-view-bg-color) 0px 0px
-                          var(--scroll-view-fading-edge-length)
-                          var(--scroll-view-fading-edge-length);
-                      }
-                      95% {
-                        box-shadow: var(--scroll-view-bg-color) 0px 0px
-                          var(--scroll-view-fading-edge-length)
-                          var(--scroll-view-fading-edge-length);
-                      }
-                      100% {
-                        box-shadow: transparent 0px 0px 0px 0px;
-                      }
-                    }
                   </style>
                   <div
                     class="mask placeholder-dom"
@@ -683,37 +621,6 @@ exports[`executeTemplate should run lepusCode.root from basic-element-x-overlay-
                       }
                       ::-webkit-scrollbar {
                         display: none;
-                      }
-
-                      @keyframes topFading {
-                        0% {
-                          box-shadow: transparent 0px 0px 0px 0px;
-                        }
-                        5% {
-                          box-shadow: var(--scroll-view-bg-color) 0px 0px
-                            var(--scroll-view-fading-edge-length)
-                            var(--scroll-view-fading-edge-length);
-                        }
-                        100% {
-                          box-shadow: var(--scroll-view-bg-color) 0px 0px
-                            var(--scroll-view-fading-edge-length)
-                            var(--scroll-view-fading-edge-length);
-                        }
-                      }
-                      @keyframes botFading {
-                        0% {
-                          box-shadow: var(--scroll-view-bg-color) 0px 0px
-                            var(--scroll-view-fading-edge-length)
-                            var(--scroll-view-fading-edge-length);
-                        }
-                        95% {
-                          box-shadow: var(--scroll-view-bg-color) 0px 0px
-                            var(--scroll-view-fading-edge-length)
-                            var(--scroll-view-fading-edge-length);
-                        }
-                        100% {
-                          box-shadow: transparent 0px 0px 0px 0px;
-                        }
                       }
                     </style>
                     <div
@@ -995,37 +902,6 @@ exports[`executeTemplate should run lepusCode.root from basic-element-x-refresh-
               }
               ::-webkit-scrollbar {
                 display: none;
-              }
-
-              @keyframes topFading {
-                0% {
-                  box-shadow: transparent 0px 0px 0px 0px;
-                }
-                5% {
-                  box-shadow: var(--scroll-view-bg-color) 0px 0px
-                    var(--scroll-view-fading-edge-length)
-                    var(--scroll-view-fading-edge-length);
-                }
-                100% {
-                  box-shadow: var(--scroll-view-bg-color) 0px 0px
-                    var(--scroll-view-fading-edge-length)
-                    var(--scroll-view-fading-edge-length);
-                }
-              }
-              @keyframes botFading {
-                0% {
-                  box-shadow: var(--scroll-view-bg-color) 0px 0px
-                    var(--scroll-view-fading-edge-length)
-                    var(--scroll-view-fading-edge-length);
-                }
-                95% {
-                  box-shadow: var(--scroll-view-bg-color) 0px 0px
-                    var(--scroll-view-fading-edge-length)
-                    var(--scroll-view-fading-edge-length);
-                }
-                100% {
-                  box-shadow: transparent 0px 0px 0px 0px;
-                }
               }
             </style>
             <div
@@ -1375,37 +1251,6 @@ exports[`executeTemplate should run lepusCode.root from basic-scroll-view.web.bu
             }
             ::-webkit-scrollbar {
               display: none;
-            }
-
-            @keyframes topFading {
-              0% {
-                box-shadow: transparent 0px 0px 0px 0px;
-              }
-              5% {
-                box-shadow: var(--scroll-view-bg-color) 0px 0px
-                  var(--scroll-view-fading-edge-length)
-                  var(--scroll-view-fading-edge-length);
-              }
-              100% {
-                box-shadow: var(--scroll-view-bg-color) 0px 0px
-                  var(--scroll-view-fading-edge-length)
-                  var(--scroll-view-fading-edge-length);
-              }
-            }
-            @keyframes botFading {
-              0% {
-                box-shadow: var(--scroll-view-bg-color) 0px 0px
-                  var(--scroll-view-fading-edge-length)
-                  var(--scroll-view-fading-edge-length);
-              }
-              95% {
-                box-shadow: var(--scroll-view-bg-color) 0px 0px
-                  var(--scroll-view-fading-edge-length)
-                  var(--scroll-view-fading-edge-length);
-              }
-              100% {
-                box-shadow: transparent 0px 0px 0px 0px;
-              }
             }
           </style>
           <div


### PR DESCRIPTION
## Problem

`test-rstest` currently fails on every PR with 3 snapshot mismatches:

```
packages/web-platform/web-core-e2e/server-tests/server-e2e.test.ts
  × executeTemplate should run lepusCode.root from basic-element-x-refresh-view-demo.web.bundle
  × executeTemplate should run lepusCode.root from basic-element-x-overlay-ng-demo.web.bundle
  × executeTemplate should run lepusCode.root from basic-scroll-view.web.bundle
```

Confirmed on at least two independent PR branches today (#2920 and the `feat/react-first-update-data-sync-timing` branch, via Codecov test analytics).

## Root cause

d7a98bd8f (#2898) moved the scroll-view fading-edge `@keyframes` out of the shadow-root html template — `topFading` / `botFading` were renamed to `scrollViewTopFading` / `scrollViewBotFading` and now live in the `@supports`-gated section of `scroll-view.css` — so they no longer appear in the SSR output of `executeTemplate`. The server-e2e snapshots were not regenerated.

The mismatch only surfaces on a **cold build**: with a warm turbo cache the SSR output still comes from pre-#2898 artifacts and the tests pass, which is presumably why it slipped through. Reproducible locally with:

```bash
pnpm turbo build --filter=@lynx-js/web-core-e2e... --force
cd packages/web-platform/web-core-e2e
pnpm rstest run server-tests/server-e2e.test.ts   # 3 failures
```

## Fix

Regenerated the snapshots (`rstest run server-tests/server-e2e.test.ts -u`). The diff is pure deletions: the 5 stale `topFading`/`botFading` keyframes blocks. All 17 server-e2e tests pass against freshly built (`--force`) artifacts.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required). — test-only change, no changeset needed