### PR TITLE
ci(rstest): add default reporter on CI for failure details in logs

### DIFF
--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -2,9 +2,12 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { defineConfig } from '@rstest/core';
+import type { RstestConfig } from '@rstest/core';
 
-const reporters = process.env.GITHUB_ACTIONS || process.env.GITHUB_STEP_SUMMARY
+const reporters: RstestConfig['reporters'] = process.env.GITHUB_ACTIONS
+    || process.env.GITHUB_STEP_SUMMARY
   ? [
+    'default',
     ['github-actions', { annotations: false, summary: true }],
     ['junit', { outputPath: './test-report.junit.xml' }],
   ]


### PR DESCRIPTION
## Summary

- Add the `default` reporter alongside `github-actions` and `junit` when running rstest on CI. Previously CI logs only contained the GitHub Actions summary output, so the actual failure reasons (assertion diffs, stack traces) were missing from the job logs.
- Fix a type error in `rstest.config.ts`: the `reporters` array literal was inferred as `(string | object)[]` instead of the `[BuiltInReporterNames, options]` tuple union expected by `RstestConfig['reporters']`. Annotating the variable with `RstestConfig['reporters']` lets TypeScript check the literal contextually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal typing for test reporter settings.
  * Kept reporter selection behavior the same, including the GitHub Actions-specific output and default fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->