### PR TITLE
fix(example): disable Turbo cache for react-debug-metadata build

### DIFF
--- a/examples/react-debug-metadata/turbo.json
+++ b/examples/react-debug-metadata/turbo.json
@@ -3,7 +3,8 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": ["dist-producer/**", "dist-consumer/**"]
+      "outputs": ["dist-producer/**", "dist-consumer/**"],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary

`test-rstest` was failing on `feat/lazy-bundle-with-fetchBundle` (#2584) with 12 failures in `examples/react-debug-metadata/error-remapping/remap.{jsc,primjs,v8}.test.ts`, all `1 · LazyComponent (dynamic) > L1–L4`:

```
find not located in any background bundle: Error("boom from deep nested call (LazyComponent, background)
find not located in any background bundle: .gone(
marker not found in any main-thread bundle: boom from LazyComponent main-thread
find not located in any background bundle: (void 0).x
```

It reproduced only on CI, never locally (macOS or a 56-core Linux box, even with `CI=1` + clean rebuild).

## Root cause (Turbo cache poisoning under CI concurrency)

The `error-remapping` tests read the example's build products back from disk (`dist-producer` / `dist-consumer`), which are produced ahead of time by the `build` Turbo task and shared across jobs via the `.turbo` cache.

By capturing the actual CI artifacts (uploaded the built dist + restored cache from the failing run) I confirmed:

- **The build job builds the example completely** — the on-disk dist has all 40 files including `dist-producer/.rspeedy/LazyComponent/background.*.js`, `LazyComponent.lynx.bundle`, `debug-metadata.json`.
- **But the Turbo cache it saves is incomplete** — when `test-rstest` restores it, `dist-producer` contains only the config dumps (`.rsbuild/*.mjs`, `.rspeedy/rspeedy.config.js`); every Lynx bundle is missing. The test then finds no `LazyComponent` background bundle → `find not located`.
- **The missing set varies run to run** (once both `dist-producer` and `dist-consumer` were bundle-less, once only `dist-producer` was) → a write/capture **race**, not a deterministic build problem.

Mechanism: Rspeedy writes the config dumps synchronously during config resolution, but the Lynx bundles (`*.lynx.bundle`, `.rspeedy/<entry>/*`, `debug-metadata.json`) are written by the Lynx encoder during async teardown (`graceful exit process` / `awaiting exit promises`), and the CLI process can return before they are all flushed. On the high-core CI runners (`ubuntu-26.04-xlarge`, 192 cores), Turbo snapshots the output directory for caching while those writes are still in flight and stores a truncated entry. Every later job replays that poisoned cache, so the failure is stable across re-runs even though the code is fine.

## Fix

Disable Turbo caching for this debug example's `build` task so every job rebuilds it from scratch instead of replaying a possibly-truncated cache entry. Clean builds always emit complete output, so a non-cached build is reliable.

This is a targeted mitigation scoped to the fixture. The deeper hardening — making `rspeedy build` await all output writes before the process exits so Turbo can never capture a partial output — is worth a follow-up but is broader and riskier.

## Test plan

- [ ] `test-rstest` green on CI (the job that was failing).
- [x] Local build + `error-remapping` tests pass (they always did — the bug was cache-only).
