### PR TITLE
feat: support async external ReactLynx bundle

### DIFF
--- a/.changeset/cache-events-async-entry.md
+++ b/.changeset/cache-events-async-entry.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/cache-events-webpack-plugin": minor
+---
+
+Cache and replay native calls for async-external entries on both threads.
+
+An async-external entry renders startup as a plain `__webpack_require__(entry)` that the event-caching runtime (keyed on `RuntimeGlobals.startup`) never hooked, so calls made while the external ReactLynx bundle was still loading were lost. The plugin now requires `startup` for such async entry chunks: the background thread caches the same `tt` / performance / `globalThis` events as the chunk-split path, and the main thread caches the first-screen `renderPage` and replays it once loaded so the page is not left blank.
+
+`setupListTransformer` now receives a second `{ isMainThread }` argument (it runs once per thread), so custom cache events can be added to a single thread — e.g. `(setupList, { isMainThread }) => isMainThread ? setupList : [...setupList, myEvent]`. Existing single-argument transformers are unaffected.

--- a/.changeset/fix-async-externals-subpath.md
+++ b/.changeset/fix-async-externals-subpath.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/externals-loading-webpack-plugin": patch
+---
+
+Fix `async: true` externals with a subpath `libraryName` (e.g. `['ReactLynx', 'React']`) resolving to `undefined`. The generated `promise` external now picks all subpath segments after the mounted namespace promise resolves, instead of reading them synchronously off the pending promise.

--- a/.changeset/fix-refresh-async-external-isComponent.md
+++ b/.changeset/fix-refresh-async-external-isComponent.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react-refresh-webpack-plugin": patch
+---
+
+Fix `isComponent is not a function` crashing the HMR runtime when ReactLynx is consumed as an async external bundle.
+
+The refresh helpers were injected via `ProvidePlugin`, whose dependency edge does not participate in async-module handling, so `@lynx-js/react/refresh` resolved to a pending Promise and `isComponent`/`flush` were `undefined`. They now ship as an ESM module (`runtime/refresh.mjs`) injected by the loader as a real import, awaited through the normal async-module machinery.

--- a/.changeset/rslib-config-async-externals.md
+++ b/.changeset/rslib-config-async-externals.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Support async externals in `defineExternalBundleRslibConfig`. An external can now use the object form `{ libraryName, async: true }` to emit a `promise` external, so importing modules await the library namespace mounted as a Promise by the host application and pick subpath segments after it resolves.
+
+The output library type also switches from Rslib's default `commonjs-static` to `commonjs2`, so an async entry exports its namespace Promise as a whole instead of a static per-name copy that would read `undefined`. A sync entry exports the same namespace object as before.

--- a/examples/react-externals/.gitignore
+++ b/examples/react-externals/.gitignore
@@ -1,1 +1,3 @@
 dist-external-bundle
+dist-external-bundle-react-async
+dist-react-async

--- a/examples/react-externals/lynx.config.ts
+++ b/examples/react-externals/lynx.config.ts
@@ -1,9 +1,39 @@
-import { pluginExternalBundle } from '@lynx-js/external-bundle-rsbuild-plugin';
+import os from 'node:os';
+
+import {
+  builtInExternalsPresetDefinitions,
+  pluginExternalBundle,
+} from '@lynx-js/external-bundle-rsbuild-plugin';
 import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
 import { defineConfig } from '@lynx-js/rspeedy';
 
 import { pluginLynxBundleAnalysisStats } from '../bundle-analysis-stats.plugin.js';
+
+// REACTLYNX_ASYNC=true loads the ReactLynx external bundle asynchronously
+// (mounted as a Promise) instead of as a synchronous global. Async outputs are
+// isolated in `dist-react-async` / `dist-external-bundle-react-async` so the
+// default (sync) build is untouched.
+const isAsync = process.env['REACTLYNX_ASYNC'] === 'true';
+
+// The `react.lynx.bundle` / `comp-lib.lynx.bundle` externals are loaded at
+// runtime via `lynx.loadScript`, which needs an absolute URL — a root-relative
+// `/react.lynx.bundle` fails on device/`preview` ("File not found"). Point
+// `assetPrefix` at the LAN host and a fixed port so the baked URLs are
+// reachable; `strictPort` keeps that port stable across dev/preview.
+function detectLanHost() {
+  if (process.env['LYNX_HOST']) return process.env['LYNX_HOST'];
+  for (const ifaces of Object.values(os.networkInterfaces())) {
+    for (const iface of ifaces ?? []) {
+      if (iface.family === 'IPv4' && !iface.internal) return iface.address;
+    }
+  }
+  return 'localhost';
+}
+const port = Number(process.env['PORT'] ?? 3000);
+const assetPrefix = `http://${detectLanHost()}:${port}/`;
+
+const reactlynxPreset = builtInExternalsPresetDefinitions['reactlynx']!;
 
 export default defineConfig({
   plugins: [
@@ -15,9 +45,27 @@ export default defineConfig({
       },
     }),
     pluginExternalBundle({
-      externalsPresets: {
-        reactlynx: true,
-      },
+      ...(isAsync && {
+        externalBundleRoot: 'dist-external-bundle-react-async',
+        externalsPresetDefinitions: {
+          'reactlynx-async': {
+            resolveExternals: (value, context) =>
+              Object.fromEntries(
+                Object.entries(
+                  reactlynxPreset.resolveExternals!(value, context),
+                ).map(([request, external]) => [
+                  request,
+                  { ...external, async: true },
+                ]),
+              ),
+            resolveManagedAssets: (value, context) =>
+              reactlynxPreset.resolveManagedAssets!(value, context),
+          },
+        },
+      }),
+      externalsPresets: isAsync
+        ? { 'reactlynx-async': true }
+        : { reactlynx: true },
       externals: {
         './App.js': 'comp-lib.lynx.bundle',
       },
@@ -26,10 +74,19 @@ export default defineConfig({
     pluginLynxBundleAnalysisStats(),
   ],
   environments: {
-    web: {},
+    ...(isAsync ? {} : { web: {} }),
     lynx: {},
   },
   output: {
     filenameHash: 'contenthash:8',
+    assetPrefix,
+    ...(isAsync && { distPath: { root: 'dist-react-async' } }),
+  },
+  dev: {
+    assetPrefix,
+  },
+  server: {
+    port,
+    strictPort: true,
   },
 });

--- a/examples/react-externals/package.json
+++ b/examples/react-externals/package.json
@@ -4,10 +4,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm run build:comp-lib && rspeedy build",
+    "build": "pnpm run build:comp-lib && rspeedy build && cross-env REACTLYNX_ASYNC=true pnpm run build:comp-lib && cross-env REACTLYNX_ASYNC=true rspeedy build",
     "build:comp-lib": "rslib build --config rslib-comp-lib.config.ts",
     "build:comp-lib:dev": "cross-env NODE_ENV=development rslib build --config rslib-comp-lib.config.ts",
-    "dev": "rspeedy dev"
+    "dev": "pnpm run build:comp-lib && rspeedy dev",
+    "dev:react-async": "cross-env REACTLYNX_ASYNC=true pnpm run build:comp-lib && cross-env REACTLYNX_ASYNC=true rspeedy dev",
+    "preview": "rspeedy preview",
+    "preview:react-async": "cross-env REACTLYNX_ASYNC=true rspeedy preview"
   },
   "dependencies": {
     "@lynx-js/react": "workspace:*"

--- a/examples/react-externals/rslib-comp-lib.config.ts
+++ b/examples/react-externals/rslib-comp-lib.config.ts
@@ -1,5 +1,22 @@
-import { defineExternalBundleRslibConfig } from '@lynx-js/lynx-bundle-rslib-config';
+import {
+  defineExternalBundleRslibConfig,
+  reactLynxExternalsPreset,
+} from '@lynx-js/lynx-bundle-rslib-config';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+
+// REACTLYNX_ASYNC=true builds comp-lib against async (Promise) ReactLynx
+// externals to match an async host (see lynx.config.ts); output is isolated in
+// `dist-external-bundle-react-async` so the sync build is untouched.
+const isAsync = process.env['REACTLYNX_ASYNC'] === 'true';
+
+const reactlynxAsyncExternals = Object.fromEntries(
+  Object.entries(reactLynxExternalsPreset).map(([request, external]) => [
+    request,
+    typeof external === 'object' && !Array.isArray(external)
+      ? { ...external, async: true }
+      : { libraryName: external, async: true },
+  ]),
+);
 
 export default defineExternalBundleRslibConfig({
   id: 'comp-lib',
@@ -11,10 +28,25 @@ export default defineExternalBundleRslibConfig({
   plugins: [
     pluginReactLynx(),
   ],
-  output: {
-    externalsPresets: {
-      reactlynx: true,
+  // Sync and async share this config file, so rspack's persistent cache (keyed
+  // on the config) would otherwise reuse one variant's compiled modules for the
+  // other — the `output.externals` callback isn't distinguished in the cache
+  // hash. Split the cache per variant.
+  performance: {
+    buildCache: {
+      cacheDigest: [isAsync ? 'react-async' : 'react-sync'],
     },
+  },
+  output: {
+    externalsPresets: isAsync
+      ? { 'reactlynx-async': true }
+      : { reactlynx: true },
+    ...(isAsync && {
+      externalsPresetDefinitions: {
+        'reactlynx-async': { externals: reactlynxAsyncExternals },
+      },
+      distPath: { root: 'dist-external-bundle-react-async' },
+    }),
     globalObject: 'globalThis',
   },
 });

--- a/examples/react-externals/src/index.css
+++ b/examples/react-externals/src/index.css
@@ -5,4 +5,6 @@
  * This is a limitation of Lynx engine
  * we can remove this limitation in the future
  */
-.dummy {}
+.dummy {
+  --dummy-color: red;
+}

--- a/examples/react-externals/tsconfig.json
+++ b/examples/react-externals/tsconfig.json
@@ -9,7 +9,13 @@
     "checkJs": true,
     "isolatedDeclarations": false,
   },
-  "include": ["src", "external-bundle", "lynx.config.ts", "rslib-comp-lib.config.ts", "rslib-reactlynx.config.ts"],
+  "include": [
+    "src",
+    "external-bundle",
+    "lynx.config.ts",
+    "rslib-comp-lib.config.ts",
+    "rslib-reactlynx.config.ts",
+  ],
   "references": [
     { "path": "../../packages/react/tsconfig.json" },
     { "path": "../../packages/rspeedy/core/tsconfig.build.json" },

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -50,7 +50,13 @@ export interface ExternalBundleWebpackPluginOptions {
 }
 
 // @public
-export type Externals = Record<string, string | string[]>;
+export interface ExternalObject {
+    async?: boolean;
+    libraryName: string | string[];
+}
+
+// @public
+export type Externals = Record<string, string | string[] | ExternalObject>;
 
 // @public
 export interface ExternalsPresetDefinition {

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -85,6 +85,46 @@ export const DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG: LibConfig = {
   source: {
     include: [/node_modules/],
   },
+  tools: {
+    rspack: {
+      output: {
+        library: {
+          // `commonjs2` (not rslib's default `commonjs-static`): with an async
+          // (`promise`) external the entry is an async module whose exports sit
+          // behind a Promise; a static per-name copy reads `undefined`, whereas
+          // `module.exports = ...` passes the Promise through for consumers to
+          // await.
+          type: 'commonjs2',
+        },
+      },
+    },
+  },
+}
+
+/**
+ * Object form of an external mapping.
+ *
+ * Use this instead of the plain global-name form when the external library is
+ * mounted asynchronously (as a Promise) by the consuming application, i.e. the
+ * matching `pluginExternalBundle` external is configured with `async: true`.
+ *
+ * @public
+ */
+export interface ExternalObject {
+  /**
+   * The global name (with optional subpath) of the external library.
+   */
+  libraryName: string | string[]
+
+  /**
+   * Whether the library is mounted as a Promise resolving to the library
+   * namespace. When enabled, the external is emitted as a `promise` external
+   * so importing modules await the mounted value instead of reading it
+   * synchronously.
+   *
+   * @defaultValue false
+   */
+  async?: boolean
 }
 
 /**
@@ -93,7 +133,7 @@ export const DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG: LibConfig = {
  *
  * @public
  */
-export type Externals = Record<string, string | string[]>
+export type Externals = Record<string, string | string[] | ExternalObject>
 
 /**
  * Standard ReactLynx external mappings used by the built-in `reactlynx`
@@ -357,13 +397,35 @@ function transformExternals(
 
   return function({ request }, callback) {
     if (!request) return callback()
-    const libraryName = externals[request]
-    if (!libraryName) return callback()
+    const external = externals[request]
+    if (!external) return callback()
 
-    callback(undefined, [
-      `${globalObject ?? 'lynx'}[Symbol.for("__LYNX_EXTERNAL_GLOBAL__")]`,
-      ...(Array.isArray(libraryName) ? libraryName : [libraryName]),
-    ], 'var')
+    const isObjectForm = typeof external === 'object'
+      && !Array.isArray(external)
+    const libraryName = isObjectForm ? external.libraryName : external
+    const names = Array.isArray(libraryName) ? libraryName : [libraryName]
+    const lynxExternalGlobal = `${
+      globalObject ?? 'lynx'
+    }[Symbol.for("__LYNX_EXTERNAL_GLOBAL__")]`
+
+    if (isObjectForm && external.async) {
+      // One promise per library, mounted at `names[0]` and resolving to the
+      // whole namespace; pick subpaths inside `.then` after it resolves. An
+      // array request would read them off the pending promise and yield
+      // undefined.
+      const mount = `${lynxExternalGlobal}[${JSON.stringify(names[0])}]`
+      const accessor = names.slice(1).map((name) => `[${JSON.stringify(name)}]`)
+        .join('')
+      return callback(
+        undefined,
+        accessor
+          ? `Promise.resolve(${mount}).then(function (m) { return m${accessor}; })`
+          : mount,
+        'promise',
+      )
+    }
+
+    callback(undefined, [lynxExternalGlobal, ...names], 'var')
   }
 }
 

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
@@ -16,6 +16,7 @@ export {
 export type {
   EncodeOptions,
   ExternalBundleLibConfig,
+  ExternalObject,
   Externals,
   ExternalsPresetDefinition,
   ExternalsPresetDefinitions,

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -407,6 +407,41 @@ describe('mount externals library', () => {
       .toBeTypeOf('number')
   })
 
+  it('emits a `commonjs2` module.exports assignment, not a static export copy', async () => {
+    const rslibConfig = defineExternalBundleRslibConfig({
+      source: {
+        entry: {
+          utils: path.join(__dirname, './fixtures/utils-lib/index.ts'),
+        },
+      },
+      id: 'utils-reactlynx-cjs2',
+      output: {
+        distPath: {
+          root: path.join(fixtureDir, 'dist'),
+        },
+        externals: {
+          '@lynx-js/react': ['ReactLynx', 'React'],
+        },
+        minify: false,
+      },
+      plugins: [pluginReactLynx()],
+    })
+
+    await build(rslibConfig)
+
+    const decodedResult = await decodeTemplate(
+      path.join(fixtureDir, 'dist/utils-reactlynx-cjs2.lynx.bundle'),
+    )
+    const backgroundSection = decodedResult['custom-sections']['utils']!
+
+    // `commonjs2` assigns the whole namespace, so an async-external entry can
+    // expose its exports Promise for consumers to await.
+    expect(backgroundSection).toContain('module.exports = __webpack_exports__')
+    // The default `commonjs-static` per-name copy would read `undefined` off a
+    // pending async-external entry Promise, so it must not be emitted.
+    expect(backgroundSection).not.toContain('for(var __rspack_i')
+  })
+
   it('should apply reactlynx externals preset to the final bundle', async () => {
     const rslibConfig = defineExternalBundleRslibConfig({
       source: {
@@ -638,6 +673,46 @@ describe('mount externals library', () => {
     ).toBe(true)
     expect(decodedResult['custom-sections']['utils__main-thread']![0])
       .toBeTypeOf('number')
+  })
+
+  it('should emit promise externals for async externals with subpaths', async () => {
+    const rslibConfig = defineExternalBundleRslibConfig({
+      source: {
+        entry: {
+          utils: path.join(__dirname, './fixtures/utils-lib/index.ts'),
+        },
+      },
+      id: 'utils-reactlynx-async',
+      output: {
+        distPath: {
+          root: path.join(fixtureDir, 'dist'),
+        },
+        externals: {
+          // Multi-level subpath: every segment after the mount key must be
+          // picked after the mounted namespace promise resolves.
+          '@lynx-js/react': {
+            libraryName: ['ReactLynx', 'Nested', 'React'],
+            async: true,
+          },
+        },
+        minify: false,
+      },
+      plugins: [pluginReactLynx()],
+    })
+
+    await build(rslibConfig)
+
+    const decodedResult = await decodeTemplate(
+      path.join(fixtureDir, 'dist/utils-reactlynx-async.lynx.bundle'),
+    )
+    expect(decodedResult['custom-sections']['utils']).toContain(
+      'Promise.resolve(lynx[Symbol.for("__LYNX_EXTERNAL_GLOBAL__")]["ReactLynx"])'
+        + '.then(function (m) { return m["Nested"]["React"]; })',
+    )
+    // No synchronous property access on the pending promise.
+    expect(decodedResult['custom-sections']['utils']).not.toContain(
+      '["ReactLynx"]["Nested"]',
+    )
   })
 })
 

--- a/packages/webpack/cache-events-webpack-plugin/etc/cache-events-webpack-plugin.api.md
+++ b/packages/webpack/cache-events-webpack-plugin/etc/cache-events-webpack-plugin.api.md
@@ -17,7 +17,9 @@ export class LynxCacheEventsPlugin {
 
 // @public
 export interface LynxCacheEventsPluginOptions {
-    setupListTransformer?: (setupList: string[]) => string[];
+    setupListTransformer?: (setupList: string[], context: {
+        isMainThread: boolean;
+    }) => string[];
 }
 
 ```

--- a/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsPlugin.ts
+++ b/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsPlugin.ts
@@ -18,6 +18,11 @@ export interface LynxCacheEventsPluginOptions {
   /**
    * The transformer function to modify the setup list.
    *
+   * It runs once per caching chunk — separately for the background thread and
+   * for an async-external main thread — so `context.isMainThread` tells you
+   * which thread's list you are transforming. Use it to add a cache function to
+   * only one thread.
+   *
    * @example
    * ```js
    * // webpack.config.js
@@ -26,18 +31,21 @@ export interface LynxCacheEventsPluginOptions {
    * const config = {
    *   plugins: [
    *     new LynxCacheEventsPlugin({
-   *       setupListTransformer: (setupList) => {
-   *         setupList.push(
-   *           `{
-   *             name: 'customCacheEvent',
-   *             setup: () => {
-   *               console.log('customCacheEvent setup');
-   *               return () => {
-   *                 console.log('customCacheEvent teardown');
+   *       setupListTransformer: (setupList, { isMainThread }) => {
+   *         // only cache this event on the background thread
+   *         if (!isMainThread) {
+   *           setupList.push(
+   *             `{
+   *               name: 'customCacheEvent',
+   *               setup: () => {
+   *                 console.log('customCacheEvent setup');
+   *                 return () => {
+   *                   console.log('customCacheEvent teardown');
+   *                 }
    *               }
-   *             }
-   *           }`
-   *         )
+   *             }`
+   *           )
+   *         }
    *         return setupList;
    *       },
    *     }),
@@ -47,7 +55,10 @@ export interface LynxCacheEventsPluginOptions {
    *
    * @public
    */
-  setupListTransformer?: (setupList: string[]) => string[];
+  setupListTransformer?: (
+    setupList: string[],
+    context: { isMainThread: boolean },
+  ) => string[];
 }
 
 /**
@@ -117,6 +128,30 @@ export class LynxCacheEventsPluginImpl {
     const { RuntimeGlobals } = compiler.webpack;
 
     compiler.hooks.thisCompilation.tap(this.name, compilation => {
+      // Async-external main-thread entries (their startup is wrapped below);
+      // only these need the main-thread `renderPage` cache.
+      const asyncMainThreadEntries = new WeakSet<Chunk>();
+      const isMainThreadChunk = (chunk: Chunk): boolean =>
+        chunk.name?.includes('__main-thread') ?? false;
+
+      // An async-external entry renders startup as a plain
+      // `__webpack_require__(entry)` that never requires `RuntimeGlobals.startup`,
+      // so the caching runtime below isn't injected. Force `startup` on such
+      // chunks so rspack emits a startup function whose returned Promise
+      // `next().finally(onLoaded)` awaits.
+      compilation.hooks.additionalTreeRuntimeRequirements.tap(
+        this.name,
+        (chunk, runtimeRequirements) => {
+          if (runtimeRequirements.has(RuntimeGlobals.startup)) return;
+          if (!chunk.hasRuntime()) return;
+          if (!runtimeRequirements.has(RuntimeGlobals.asyncModule)) return;
+          runtimeRequirements.add(RuntimeGlobals.startup);
+          if (isMainThreadChunk(chunk)) {
+            asyncMainThreadEntries.add(chunk);
+          }
+        },
+      );
+
       const handler = (chunk: Chunk, runtimeRequirements: Set<string>) => {
         const globalChunkLoading = compilation.outputOptions.chunkLoading;
         const isEnabledForChunk = (chunk: Chunk): boolean => {
@@ -160,7 +195,10 @@ export class LynxCacheEventsPluginImpl {
         }
         onceForChunkSet[LynxRuntimeGlobals.lynxCacheEventsSetupList].add(chunk);
 
-        if (chunk.name?.includes('__main-thread')) {
+        const isMainThread = isMainThreadChunk(chunk);
+        // Background chunks always cache; main-thread only for async-external
+        // entries (see `asyncMainThreadEntries`).
+        if (isMainThread && !asyncMainThreadEntries.has(chunk)) {
           return;
         }
 
@@ -168,6 +206,7 @@ export class LynxCacheEventsPluginImpl {
           chunk,
           new LynxCacheEventsSetupListRuntimeModule(
             this.options.setupListTransformer,
+            isMainThread,
           ),
         );
       });
@@ -180,7 +219,7 @@ export class LynxCacheEventsPluginImpl {
         }
         onceForChunkSet[LynxRuntimeGlobals.lynxCacheEvents].add(chunk);
 
-        if (chunk.name?.includes('__main-thread')) {
+        if (isMainThreadChunk(chunk) && !asyncMainThreadEntries.has(chunk)) {
           return;
         }
 

--- a/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsSetupListRuntimeModule.ts
+++ b/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsSetupListRuntimeModule.ts
@@ -12,6 +12,7 @@ type LynxCacheEventsSetupListRuntimeModule = new(
   setupListTransformer: NonNullable<
     LynxCacheEventsPluginOptions['setupListTransformer']
   >,
+  isMainThread?: boolean,
 ) => RuntimeModule;
 
 export function createLynxCacheEventsSetupListRuntimeModule(
@@ -24,6 +25,7 @@ export function createLynxCacheEventsSetupListRuntimeModule(
       public setupListTransformer: NonNullable<
         LynxCacheEventsPluginOptions['setupListTransformer']
       >,
+      public isMainThread = false,
     ) {
       super(
         'webpack/runtime/lynx cache events setup list',
@@ -34,13 +36,51 @@ export function createLynxCacheEventsSetupListRuntimeModule(
     override generate(): string {
       const { Template } = this.compilation!.compiler.webpack;
 
-      return `// lynx cache events setup list
-${LynxRuntimeGlobals.lynxCacheEvents} = {};
-${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
-        Template.asString(
-          '['
-            + this.setupListTransformer([
-              `{
+      // Main thread: native calls `renderPage` before ReactLynx loads; cache
+      // it and replay against the real one from `onLoaded`.
+      const setupList = this.isMainThread
+        ? [
+          `{
+      name: 'renderPage',
+      setup: () => {
+        const oldRenderPage = globalThis.renderPage;
+        const mockRenderPage = (...args) => {
+          if (${LynxRuntimeGlobals.lynxCacheEvents}.loaded) {
+            return oldRenderPage && oldRenderPage(...args);
+          }
+          ${LynxRuntimeGlobals.lynxCacheEvents}.cachedActions.push({
+            type: 'renderPage',
+            data: { args },
+          });
+        };
+        globalThis.renderPage = mockRenderPage;
+
+        return () => {
+          ${LynxRuntimeGlobals.lynxCacheEvents}.cachedActions.forEach(action => {
+            if (action.type === 'renderPage') {
+              // now the real renderPage installed by ReactLynx
+              globalThis.renderPage(...action.data.args);
+            }
+          });
+          // don't clobber ReactLynx's real renderPage
+          if (globalThis.renderPage === mockRenderPage) {
+            globalThis.renderPage = oldRenderPage;
+          }
+        }
+      },
+    }`,
+          `{
+      name: 'processData',
+      setup: () => {
+        // Passthrough shim (return consumed synchronously, can't be deferred);
+        // ReactLynx overwrites it once loaded.
+        globalThis.processData = globalThis.processData || ((data) => data);
+        return () => {};
+      },
+    }`,
+        ]
+        : [
+          `{
       name: 'ttMethod',
       setup: () => {
         const tt = lynxCoreInject.tt;
@@ -58,11 +98,9 @@ ${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
         const methodsToMockFn = {};
 
         methodsToMock.forEach(methodName => {
-          // biome-ignore lint/complexity/useOptionalChain: optional chain not supported here
           methodsToOldFn[methodName] = tt[methodName] && tt[methodName].bind(tt);
           tt[methodName] = methodsToMockFn[methodName] = (...args) => {
             if (${LynxRuntimeGlobals.lynxCacheEvents}.loaded) {
-              // biome-ignore lint/complexity/useOptionalChain: optional chain not supported here
               return methodsToOldFn[methodName]
                 && methodsToOldFn[methodName](...args);
             }
@@ -92,7 +130,7 @@ ${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
         }
       },
     }`,
-              `{
+          `{
       name: 'performanceEvent',
       setup: () => {
           const tt = lynxCoreInject.tt;
@@ -139,7 +177,7 @@ ${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
         }
       }
     }`,
-              `{
+          `{
       name: 'globalThis',
       setup: () => {
         const g = globalThis;
@@ -150,11 +188,9 @@ ${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
         const methodsToMockFn = {};
 
         methodsToMock.forEach(methodName => {
-          // biome-ignore lint/complexity/useOptionalChain: optional chain not supported here
           methodsToOldFn[methodName] = g[methodName] && g[methodName].bind(g);
           g[methodName] = methodsToMockFn[methodName] = (...args) => {
             if (${LynxRuntimeGlobals.lynxCacheEvents}.loaded) {
-              // biome-ignore lint/complexity/useOptionalChain: optional chain not supported here
               return methodsToOldFn[methodName]
                 && methodsToOldFn[methodName](...args);
             }
@@ -184,8 +220,16 @@ ${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
         }
       },
     }`,
-            ]).join(',')
-            + ']',
+        ];
+
+      return `// lynx cache events setup list
+${LynxRuntimeGlobals.lynxCacheEvents} = {};
+${LynxRuntimeGlobals.lynxCacheEventsSetupList} = ${
+        Template.asString(
+          '['
+            + this.setupListTransformer(setupList, {
+              isMainThread: this.isMainThread,
+            }).join(',') + ']',
         )
       };
 

--- a/packages/webpack/cache-events-webpack-plugin/test/LynxCacheEventsSetupListRuntimeModule.test.ts
+++ b/packages/webpack/cache-events-webpack-plugin/test/LynxCacheEventsSetupListRuntimeModule.test.ts
@@ -51,11 +51,14 @@ interface RuntimeSandbox {
     tt: TtMethods;
   };
   loadDynamicComponent?: (...args: unknown[]) => unknown;
+  renderPage?: (...args: unknown[]) => unknown;
+  processData?: (data: unknown) => unknown;
 }
 
 function createRuntimeSandbox(options: {
   tt?: TtMethods;
   loadDynamicComponent?: (...args: unknown[]) => unknown;
+  isMainThread?: boolean;
 } = {}): {
   runtimeCache: RuntimeCache;
   sandbox: RuntimeSandbox;
@@ -63,7 +66,10 @@ function createRuntimeSandbox(options: {
   const SetupListRuntimeModule = createLynxCacheEventsSetupListRuntimeModule(
     rspack,
   );
-  const module = new SetupListRuntimeModule((setupList) => setupList);
+  const module = new SetupListRuntimeModule(
+    (setupList) => setupList,
+    options.isMainThread,
+  );
 
   module.compilation = {
     compiler: {
@@ -253,5 +259,57 @@ describe('LynxCacheEventsSetupListRuntimeModule', () => {
 
     expect(originalLoadDynamicComponent).toHaveBeenCalledTimes(2);
     expect(originalLoadDynamicComponent).toHaveBeenLastCalledWith('card-b');
+  });
+
+  it('caches renderPage and replays it against the real one on the main thread', () => {
+    const { runtimeCache, sandbox } = createRuntimeSandbox({
+      isMainThread: true,
+    });
+
+    expect(runtimeCache.setupList.map(item => item.name)).toEqual([
+      'renderPage',
+      'processData',
+    ]);
+
+    runtimeCache.loaded = false;
+    runtimeCache.cachedActions = [];
+
+    // Native's first-screen call arrives before ReactLynx installs the real
+    // `renderPage`, so it is cached rather than lost.
+    const cleanup = getSetupItem(runtimeCache, 'renderPage').setup();
+    sandbox.renderPage?.({ initData: 1 });
+
+    expect(runtimeCache.cachedActions).toEqual([
+      {
+        type: 'renderPage',
+        data: {
+          args: [{ initData: 1 }],
+        },
+      },
+    ]);
+
+    // ReactLynx has since installed the real `renderPage`; the cached call is
+    // replayed against it once startup settles.
+    const realRenderPage = rstest.fn();
+    sandbox.renderPage = realRenderPage;
+    runtimeCache.loaded = true;
+    cleanup();
+
+    expect(realRenderPage).toHaveBeenCalledTimes(1);
+    expect(realRenderPage).toHaveBeenCalledWith({ initData: 1 });
+  });
+
+  it('passes processData through synchronously on the main thread', () => {
+    const { runtimeCache, sandbox } = createRuntimeSandbox({
+      isMainThread: true,
+    });
+
+    const cleanup = getSetupItem(runtimeCache, 'processData').setup();
+
+    // Unlike `renderPage`, `processData` must return synchronously, so it is a
+    // passthrough while the async ReactLynx runtime is still loading.
+    expect(sandbox.processData?.({ x: 2 })).toEqual({ x: 2 });
+
+    cleanup();
   });
 });

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/async-external-entry/index.js
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/async-external-entry/index.js
@@ -1,0 +1,16 @@
+/// <reference types="@rstest/core/globals" />
+
+import { add } from 'async-ext';
+
+// Captured during module eval: for an async entry this runs after the external
+// resolves but before the entry settles, so it is before `onLoaded` clears the
+// list.
+const setupNames = __webpack_require__['lynx_ce']['setupList'].map(
+  (item) => item.name,
+);
+
+it('injects the cache-events runtime for an async entry without chunk splitting', () => {
+  expect(add(1, 2)).toBe(3);
+  expect(__webpack_require__['lynx_ce']).toBeTruthy();
+  expect(setupNames).toEqual(['ttMethod', 'performanceEvent', 'globalThis']);
+});

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/async-external-entry/rspack.config.js
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/async-external-entry/rspack.config.js
@@ -1,0 +1,27 @@
+import { ChunkLoadingWebpackPlugin } from '@lynx-js/chunk-loading-webpack-plugin';
+
+import { LynxCacheEventsPlugin } from '../../../../lib/index.js';
+
+// An async entry (it imports a `promise` external, so the entry module becomes an
+// async module) WITHOUT chunk splitting. Unlike `not-splitting`, the cache-events
+// runtime must still be injected: the plugin requires `RuntimeGlobals.startup` for
+// such entries so their startup becomes a wrappable, Promise-returning function.
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  target: 'node',
+  output: {
+    filename: '[name].js',
+    chunkLoading: 'lynx',
+  },
+  optimization: {
+    moduleIds: 'named',
+  },
+  externalsType: 'promise',
+  externals: {
+    'async-ext': 'promise (Promise.resolve({ add: (a, b) => a + b }))',
+  },
+  plugins: [
+    new ChunkLoadingWebpackPlugin(),
+    new LynxCacheEventsPlugin(),
+  ],
+};

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/async-external-entry/test.config.cjs
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/async-external-entry/test.config.cjs
@@ -1,0 +1,11 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    'main.js',
+  ],
+  beforeExecute: () => {
+    global.lynxCoreInject = {
+      tt: {},
+    };
+  },
+};

--- a/packages/webpack/externals-loading-webpack-plugin/src/index.ts
+++ b/packages/webpack/externals-loading-webpack-plugin/src/index.ts
@@ -671,13 +671,32 @@ function createLoadExternalSync(handler, sectionPath, timeout) {
       ) {
         const isAsync = externals[request]?.async ?? true;
         const libraryName = externals[request]?.libraryName ?? request;
+        const names = Array.isArray(libraryName) ? libraryName : [libraryName];
+        if (isAsync) {
+          // A `promise` external must be a single expression evaluating to a
+          // promise whose resolved value becomes the module exports. The
+          // runtime module mounts one promise per library that resolves to
+          // the whole namespace, so subpaths have to be picked after that
+          // promise resolves — an array request would apply the property
+          // access synchronously on the pending promise and yield undefined.
+          const mount = `${getLynxExternalGlobal(globalObject)}[${
+            JSON.stringify(names[0])
+          }]`;
+          const accessor = names.slice(1).map((name) =>
+            `[${JSON.stringify(name)}]`
+          ).join('');
+          return callback(
+            undefined,
+            accessor
+              ? `Promise.resolve(${mount}).then(function (m) { return m${accessor}; })`
+              : mount,
+            'promise',
+          );
+        }
         return callback(
           undefined,
-          [
-            getLynxExternalGlobal(globalObject),
-            ...(Array.isArray(libraryName) ? libraryName : [libraryName]),
-          ],
-          isAsync ? 'promise' : undefined,
+          [getLynxExternalGlobal(globalObject), ...names],
+          undefined,
         );
       }
       // Continue without externalizing the import

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-subpath/index.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-subpath/index.js
@@ -1,0 +1,37 @@
+import mul from 'baz/sub1/mul';
+import add from 'foo';
+
+const consoleInfoMock = rstest.spyOn(console, 'info').mockImplementation(() =>
+  undefined
+);
+
+console.info(add(1, 2));
+console.info(mul(3, 4));
+
+it('should resolve subpath exports after the namespace promise resolves', async () => {
+  expect(consoleInfoMock).toBeCalledTimes(2);
+  expect(consoleInfoMock).toHaveBeenNthCalledWith(1, 3);
+  expect(consoleInfoMock).toHaveBeenNthCalledWith(2, 12);
+
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+
+  const background = fs.readFileSync(
+    path.resolve(__dirname, 'main:background.js'),
+    'utf-8',
+  );
+
+  // Use concatenation to avoid the literal pattern appearing inside this compiled file itself.
+
+  // The external module must await the mounted namespace promise before
+  // picking the subpath. A synchronous array lookup would read `.add` off the
+  // pending promise and export undefined.
+  const promiseExternal = 'Promise.resolve' + '(lynx[Symbol.for(';
+  expect(background).toContain(promiseExternal);
+  expect(background).toContain('return m' + '["add"]');
+  // Multi-level subpath: ALL segments after the mount key are picked inside
+  // the then callback, not just the first one.
+  expect(background).toContain('return m' + '["Sub1"]["mul"]');
+  expect(background).not.toContain(']["FooLib"]' + '["add"]');
+  expect(background).not.toContain(']["Baz"]' + '["Sub1"]');
+});

--- a/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-subpath/rspack.config.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/cases/externals-loading/async-subpath/rspack.config.js
@@ -1,0 +1,41 @@
+import { createConfig } from '../../../helpers/create-config.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: new URL('.', import.meta.url).pathname,
+  ...createConfig(
+    {
+      backgroundLayer: 'background',
+      mainThreadLayer: 'main-thread',
+      externals: {
+        // Subpath libraryName: the mounted value is a promise resolving to
+        // the WHOLE `FooLib` namespace, and `add` must be picked from the
+        // resolved value, not from the pending promise.
+        'foo': {
+          libraryName: ['FooLib', 'add'],
+          url: 'foo',
+          async: true,
+          background: {
+            sectionPath: 'background',
+          },
+          mainThread: {
+            sectionPath: 'mainThread',
+          },
+        },
+        // Deeper subpath: every segment after the mount key (`Sub1` AND
+        // `mul`) must be picked after the namespace promise resolves.
+        'baz/sub1/mul': {
+          libraryName: ['Baz', 'Sub1', 'mul'],
+          url: 'baz',
+          async: true,
+          background: {
+            sectionPath: 'Baz__background',
+          },
+          mainThread: {
+            sectionPath: 'Baz__mainThread',
+          },
+        },
+      },
+    },
+  ),
+};

--- a/packages/webpack/react-refresh-webpack-plugin/loader.cjs
+++ b/packages/webpack/react-refresh-webpack-plugin/loader.cjs
@@ -9,8 +9,27 @@ const LOADER_RUNTIME = fs.readFileSync(
   'utf-8',
 );
 
+const REFRESH_RUNTIME_ABS = path.resolve(__dirname, './runtime/refresh.mjs');
+
 const RefreshHotLoader = function RefreshHotLoader(source, inputSourceMap) {
-  this.callback(null, source + '\n\n' + LOADER_RUNTIME, inputSourceMap);
+  // Inject `__prefresh_utils__` as a real ESM import (not `ProvidePlugin`): only
+  // harmony edges are async-awaited, so the footer sees resolved
+  // `isComponent`/`flush` under async externals. Relative request keeps the
+  // bundler-derived binding name stable across machines/snapshots.
+  let request = path
+    .relative(path.dirname(this.resourcePath), REFRESH_RUNTIME_ABS)
+    .replace(/\\/g, '/');
+  if (!request.startsWith('.')) {
+    request = './' + request;
+  }
+  const importPrefreshUtils = `\nimport * as __prefresh_utils__ from ${
+    JSON.stringify(request)
+  };\n`;
+  this.callback(
+    null,
+    source + '\n\n' + LOADER_RUNTIME + importPrefreshUtils,
+    inputSourceMap,
+  );
 };
 
 module.exports = RefreshHotLoader;

--- a/packages/webpack/react-refresh-webpack-plugin/runtime/refresh.mjs
+++ b/packages/webpack/react-refresh-webpack-plugin/runtime/refresh.mjs
@@ -1,4 +1,8 @@
-const { isComponent, flush } = require('@lynx-js/react/refresh');
+// ESM (imported via `../loader.cjs`), not `ProvidePlugin`:
+// `@lynx-js/react/refresh` is an async module under async externals, and only a
+// harmony import edge is awaited, so the injected footer sees resolved
+// `isComponent`/`flush`.
+import { flush, isComponent } from '@lynx-js/react/refresh';
 
 // eslint-disable-next-line
 const getExports = m => m.exports || m.__proto__.exports;
@@ -52,9 +56,4 @@ const shouldBind = m => {
   return isCitizen;
 };
 
-module.exports = Object.freeze({
-  getExports,
-  shouldBind,
-  flush,
-  registerExports,
-});
+export { flush, getExports, registerExports, shouldBind };

--- a/packages/webpack/react-refresh-webpack-plugin/src/ReactRefreshRspackPlugin.ts
+++ b/packages/webpack/react-refresh-webpack-plugin/src/ReactRefreshRspackPlugin.ts
@@ -126,15 +126,14 @@ export class ReactRefreshRspackPlugin {
 
     const { ProvidePlugin } = compiler.webpack;
 
-    const provide: Record<string, string> = {
-      __prefresh_utils__: path.resolve(__dirname, '../runtime/refresh.cjs'),
-    };
-
+    // `__prefresh_utils__` is injected by the loader (`../loader.cjs`) as an ESM
+    // import, not here — only the optional error overlay still needs
+    // `ProvidePlugin`.
     if (this.#options.overlay) {
-      provide['__prefresh_errors__'] = this.#options.overlay.module;
+      new ProvidePlugin({
+        __prefresh_errors__: this.#options.overlay.module,
+      }).apply(compiler);
     }
-
-    new ProvidePlugin(provide).apply(compiler);
 
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
       compilation.hooks.runtimeModule.tap(PLUGIN_NAME, (runtimeModule) => {

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useContext/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useContext/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 4631
+- Update: main.LAST_HASH.hot-update.js, size: 4734
 
 ## Manifest
 
@@ -45,8 +45,8 @@ __webpack_require__.d(__webpack_exports__, {
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
 /* import */ var _lynx_js_react__rspack_import_1 = __webpack_require__(/*! @lynx-js/react */ "../../../../../../react/runtime/lib/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
-/* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../runtime/refresh.cjs */ "../../../../runtime/refresh.cjs");
 
 
 const Theme = (0,_lynx_js_react__rspack_import_1.createContext)('light');
@@ -97,21 +97,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = __prefresh_utils__.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = __prefresh_utils__.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  __prefresh_utils__.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        __prefresh_utils__.flush();
+        _runtime_refresh_mjs__rspack_import_2.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -130,7 +130,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = __prefresh_utils__.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {
@@ -146,6 +146,8 @@ if (moduleHot) {
     });
   }
 }
+
+
 
 
 },

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useState/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useState/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 4281
+- Update: main.LAST_HASH.hot-update.js, size: 4384
 
 ## Manifest
 
@@ -45,8 +45,8 @@ __webpack_require__.d(__webpack_exports__, {
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
 /* import */ var _lynx_js_react__rspack_import_1 = __webpack_require__(/*! @lynx-js/react */ "../../../../../../react/runtime/lib/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
-/* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../runtime/refresh.cjs */ "../../../../runtime/refresh.cjs");
 
 
 const __snapshot_c1b16_43c2c_1 = "__snapshot_c1b16_43c2c_1";
@@ -91,21 +91,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = __prefresh_utils__.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = __prefresh_utils__.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  __prefresh_utils__.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        __prefresh_utils__.flush();
+        _runtime_refresh_mjs__rspack_import_2.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -124,7 +124,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = __prefresh_utils__.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {
@@ -140,6 +140,8 @@ if (moduleHot) {
     });
   }
 }
+
+
 
 
 },

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3519
+- Update: main.LAST_HASH.hot-update.js, size: 3622
 
 ## Manifest
 
@@ -44,8 +44,8 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
-/* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../runtime/refresh.cjs */ "../../../../runtime/refresh.cjs");
 
 const __snapshot_d2d51_4d7b7_1 = "__snapshot_d2d51_4d7b7_1";
 (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_d2d51_4d7b7_1] = (__snapshot_d2d51_4d7b7_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_d2d51_4d7b7_1, function() {
@@ -72,21 +72,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = __prefresh_utils__.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = __prefresh_utils__.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  __prefresh_utils__.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        __prefresh_utils__.flush();
+        _runtime_refresh_mjs__rspack_import_1.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -105,7 +105,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = __prefresh_utils__.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {
@@ -121,6 +121,8 @@ if (moduleHot) {
     });
   }
 }
+
+
 
 
 },

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3519
+- Update: main.LAST_HASH.hot-update.js, size: 3622
 
 ## Manifest
 
@@ -44,8 +44,8 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
-/* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../runtime/refresh.cjs */ "../../../../runtime/refresh.cjs");
 
 const __snapshot_d2d51_b7a87_1 = "__snapshot_d2d51_b7a87_1";
 (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_d2d51_b7a87_1] = (__snapshot_d2d51_b7a87_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_d2d51_b7a87_1, function() {
@@ -72,21 +72,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = __prefresh_utils__.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = __prefresh_utils__.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  __prefresh_utils__.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        __prefresh_utils__.flush();
+        _runtime_refresh_mjs__rspack_import_1.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -105,7 +105,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = __prefresh_utils__.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {
@@ -121,6 +121,8 @@ if (moduleHot) {
     });
   }
 }
+
+
 
 
 },

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/recovery/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/recovery/__snapshot__/rspack/2.snap.txt
@@ -5,12 +5,12 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.62bf02c4f0f7ac9e.hot-update.json, size: 28
-- Update: main.62bf02c4f0f7ac9e.hot-update.js, size: 3522
+- Manifest: main.b1bb781f47ee97e4.hot-update.json, size: 28
+- Update: main.b1bb781f47ee97e4.hot-update.js, size: 3625
 
 ## Manifest
 
-### main.62bf02c4f0f7ac9e.hot-update.json
+### main.b1bb781f47ee97e4.hot-update.json
 
 ```json
 {"c":["main"],"r":[],"m":[]}
@@ -20,7 +20,7 @@
 ## Update
 
 
-### main.62bf02c4f0f7ac9e.hot-update.js
+### main.b1bb781f47ee97e4.hot-update.js
 
 #### Changed Modules
 - ./app.jsx
@@ -44,8 +44,8 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
-/* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../runtime/refresh.cjs */ "../../../../runtime/refresh.cjs");
 
 const __snapshot_b0c31_b7a87_1 = "__snapshot_b0c31_b7a87_1";
 (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_b0c31_b7a87_1] = (__snapshot_b0c31_b7a87_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_b0c31_b7a87_1, function() {
@@ -72,21 +72,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = __prefresh_utils__.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = __prefresh_utils__.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  __prefresh_utils__.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        __prefresh_utils__.flush();
+        _runtime_refresh_mjs__rspack_import_1.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -105,7 +105,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = __prefresh_utils__.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {
@@ -121,6 +121,8 @@ if (moduleHot) {
     });
   }
 }
+
+
 
 
 },

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3654
+- Update: main.LAST_HASH.hot-update.js, size: 3757
 
 ## Manifest
 
@@ -44,8 +44,8 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
-/* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../runtime/refresh.cjs */ "../../../../runtime/refresh.cjs");
 
 const __snapshot_8bc4c_170ee_1 = "__snapshot_8bc4c_170ee_1";
 (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_8bc4c_170ee_1] = (__snapshot_8bc4c_170ee_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_8bc4c_170ee_1, function() {
@@ -76,21 +76,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = __prefresh_utils__.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = __prefresh_utils__.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  __prefresh_utils__.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        __prefresh_utils__.flush();
+        _runtime_refresh_mjs__rspack_import_1.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -109,7 +109,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = __prefresh_utils__.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {
@@ -125,6 +125,8 @@ if (moduleHot) {
     });
   }
 }
+
+
 
 
 },

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3654
+- Update: main.LAST_HASH.hot-update.js, size: 3757
 
 ## Manifest
 
@@ -44,8 +44,8 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
-/* provided dependency */ var __prefresh_utils__ = __webpack_require__(/*! ../../../../runtime/refresh.cjs */ "../../../../runtime/refresh.cjs");
 
 const __snapshot_8bc4c_00662_1 = "__snapshot_8bc4c_00662_1";
 (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_8bc4c_00662_1] = (__snapshot_8bc4c_00662_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_8bc4c_00662_1, function() {
@@ -76,21 +76,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = __prefresh_utils__.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = __prefresh_utils__.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  __prefresh_utils__.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        __prefresh_utils__.flush();
+        _runtime_refresh_mjs__rspack_import_1.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -109,7 +109,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = __prefresh_utils__.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {
@@ -125,6 +125,8 @@ if (moduleHot) {
     });
   }
 }
+
+
 
 
 },


### PR DESCRIPTION
## Summary

Enable consuming ReactLynx (and its component libraries) as an **async external bundle** — fetched at runtime via `lynx.fetchBundle` / `lynx.loadScript` and mounted as a Promise — instead of a synchronous global. This lets a host embed a pinned ReactLynx runtime and load app/component bundles built against it separately.

The async-loading model breaks four sync assumptions across the toolchain; each is fixed in its own package (separate changesets):

### `@lynx-js/lynx-bundle-rslib-config` — `commonjs2` output
Rslib's `cjs` format defaults to `commonjs-static`, which copies named exports one-by-one at startup. When an external is async, the entry becomes an async module whose exports are only available behind a Promise, so that copy reads `undefined`. Switched to `commonjs2` (whole `module.exports` assignment) so a sync entry exports the same namespace and an async entry exports a Promise consumers await.

### `@lynx-js/externals-loading-webpack-plugin` — async subpath externals
`async: true` externals with a subpath `libraryName` (e.g. `['ReactLynx', 'React']`) now pick subpath segments **after** the mounted namespace Promise resolves, instead of reading them synchronously off the pending Promise.

### `@lynx-js/react-refresh-webpack-plugin` — ESM HMR runtime injection
The refresh runtime helpers were injected via `ProvidePlugin`, whose dependency edge does not participate in async-module handling. Under async externals `@lynx-js/react/refresh` becomes an async module, so `isComponent` / `flush` resolved to a pending Promise and `shouldBind` crashed at every module footer. The runtime is now an ESM module injected as a **real import** by the loader, so the importing module awaits it through the normal async-module machinery.

### `@lynx-js/cache-events-webpack-plugin` — async-entry + main-thread caching
The event-caching runtime is keyed on `RuntimeGlobals.startup`, which async-external entries don't require (their startup is a plain `__webpack_require__(entry)`). The plugin now requires `startup` for async entries so their startup becomes a wrappable, Promise-returning function, and:
- **Background**: caches the same `tt` / performance / `globalThis` events as chunk-split entries.
- **Main thread**: caches the first-screen `renderPage` call and replays it against the real `renderPage` once the async ReactLynx runtime has loaded (otherwise the page element is never created and the screen stays blank); shims `processData` as a synchronous passthrough.

## Example
Adds the `examples/react-externals` async variant (`*.react-async.ts` configs) demonstrating the full flow.

## Tests
- `lynx-bundle-rslib-config`: asserts `commonjs2` output (`module.exports =` assignment, no static per-name copy).
- `externals-loading-webpack-plugin`: async-subpath case.
- `react-refresh-webpack-plugin`: HMR snapshots updated for the ESM-import injection.
- `cache-events-webpack-plugin`: async-external-entry integration + main-thread `renderPage`/`processData` unit tests.

## Not verified here
Runtime rendering on a real device (LynxExplorer) — the mechanisms are verified via built-artifact inspection and unit/integration tests, but end-to-end first-screen rendering + cross-thread firstScreen timing should be confirmed on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added async externals support via `{ libraryName, async }`, including Promise-based loading for nested subpaths, and React async example build/dev/preview workflows.
* **Bug Fixes**
  * Prevented blank pages for async externals by ensuring main-thread caching waits for async startup readiness and replays the first-screen `renderPage`.
  * Fixed async subpath resolution timing and resolved React Fast Refresh crashes with async ReactLynx externals.
* **API / Configuration**
  * Updated `setupListTransformer` to accept `{ isMainThread }` context for thread-specific cache event setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->