### PR TITLE
feat(qrcode): read entries from server routes

### DIFF
--- a/.changeset/qrcode-server-routes.md
+++ b/.changeset/qrcode-server-routes.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/qrcode-rsbuild-plugin": minor
+---
+
+Read QR code entries from Rspeedy server routes.
+
+BREAKING CHANGE: `@lynx-js/qrcode-rsbuild-plugin` now requires `@lynx-js/rspeedy@^0.15.3` because it relies on dev and preview server `routes` containing Lynx bundle entries. The plugin no longer reads the internal `rspeedy.env.entries` exposed API.

--- a/.changeset/rspeedy-preview-routes.md
+++ b/.changeset/rspeedy-preview-routes.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Expose Lynx bundle routes to preview server hooks.
+
+`onAfterStartPreviewServer` now receives the same Lynx bundle route entries as `onAfterStartDevServer`, so plugins can discover preview bundle entries from the `routes` parameter.

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -6,7 +6,11 @@ import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import { logger } from '@rsbuild/core'
-import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core'
+import type {
+  EnvironmentContext,
+  RsbuildConfig,
+  RsbuildPlugin,
+} from '@rsbuild/core'
 import color from 'picocolors'
 
 import type { Dev } from '../config/dev/index.js'
@@ -75,6 +79,72 @@ export function pluginDev(
 
       debug(`dev.assetPrefix is normalized to ${assetPrefix}`)
 
+      // Resolve the main bundle filename template for a given entry/platform.
+      // When `bundle` is a function, it is called with `lazyBundle: false`
+      // since the dev URLs always point at the main bundle.
+      // Lazily initialized on first use (needs the exposed rspeedy API to be
+      // available which is guaranteed after plugin setup ordering).
+      let resolveBundleName: (entry: string, platform: string) => string
+
+      function getResolveBundleName() {
+        if (!resolveBundleName) {
+          // biome-ignore lint/correctness/useHookAtTopLevel: not react hooks
+          const rspeedyAPIs = api.useExposed<ExposedAPI>(
+            Symbol.for('rspeedy.api'),
+          )!
+          const defaultFilename = '[name].[platform].bundle'
+          const { filename } = rspeedyAPIs.config.output ?? {}
+          const bundle = typeof filename === 'object'
+            ? filename.bundle ?? filename.template
+            : filename
+          resolveBundleName = (entry: string, platform: string): string => {
+            const resolved = typeof bundle === 'function'
+              ? bundle({ lazyBundle: false, entryName: entry, platform })
+              : bundle ?? defaultFilename
+            return resolved
+              .replaceAll('[name]', entry)
+              .replaceAll('[platform]', platform)
+          }
+        }
+        return resolveBundleName
+      }
+
+      function appendBundleRoutes({
+        routes,
+        environments,
+      }: {
+        routes: { entryName: string, pathname: string }[]
+        environments: Record<string, EnvironmentContext>
+      }) {
+        const resolveName = getResolveBundleName()
+        for (
+          const [environmentName, environmentContext] of Object.entries(
+            environments,
+          )
+        ) {
+          for (const entryName of Object.keys(environmentContext.entry)) {
+            routes.push({
+              entryName,
+              pathname: `/${resolveName(entryName, environmentName)}`,
+            })
+          }
+        }
+      }
+
+      // Rsbuild's getRoutes() only includes environments that produce HTML
+      // files (htmlPaths). Lynx environments produce .bundle files instead,
+      // so we populate dev/preview routes with the correct bundle pathnames
+      // before any user plugin runs, using order: 'pre'.
+      api.onAfterStartDevServer({
+        handler: appendBundleRoutes,
+        order: 'pre',
+      })
+
+      api.onAfterStartPreviewServer({
+        handler: appendBundleRoutes,
+        order: 'pre',
+      })
+
       api.onBeforeStartDevServer(async ({ environments, server }) => {
         if (environments['web']) {
           const { createWebVirtualFilesMiddleware } = await import(
@@ -104,25 +174,7 @@ export function pluginDev(
       })
 
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-        const rspeedyAPIs = api.useExposed<ExposedAPI>(
-          Symbol.for('rspeedy.api'),
-        )!
-        const defaultFilename = '[name].[platform].bundle'
-        const { filename } = rspeedyAPIs.config.output ?? {}
-        const bundle = typeof filename === 'object'
-          ? filename.bundle ?? filename.template
-          : filename
-        // Resolve the main bundle filename template for a given entry/platform.
-        // When `bundle` is a function, it is called with `lazyBundle: false`
-        // since the dev URLs always point at the main bundle.
-        const resolveName = (entry: string, platform: string): string => {
-          const resolved = typeof bundle === 'function'
-            ? bundle({ lazyBundle: false, entryName: entry, platform })
-            : bundle ?? defaultFilename
-          return resolved
-            .replaceAll('[name]', entry)
-            .replaceAll('[platform]', platform)
-        }
+        const resolveName = getResolveBundleName()
         if (
           config.server?.printUrls === undefined
           || config.server?.printUrls === true

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -743,4 +743,97 @@ describe('Plugins - Dev', () => {
       'url': 'http://example.com:8080/__web_preview?casename=main.web.bundle',
     })
   })
+
+  test('onAfterStartDevServer routes contains bundle entries', async () => {
+    const rsbuild = await createStubRspeedy({
+      source: {
+        entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      server: {
+        port: 8080,
+      },
+    })
+
+    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
+
+    rsbuild.onAfterStartDevServer(({ routes }) => {
+      receivedRoutes = [...routes]
+    })
+
+    await using server = await rsbuild.usingDevServer()
+    await server.waitDevCompileDone()
+
+    expect(receivedRoutes).toContainEqual({
+      entryName: 'main',
+      pathname: '/main.lynx.bundle',
+    })
+  })
+
+  test('onAfterStartDevServer routes contains multiple environment entries', async () => {
+    const rsbuild = await createStubRspeedy({
+      source: {
+        entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      server: {
+        port: 8080,
+      },
+      environments: {
+        web: {},
+        lynx: {},
+      },
+    })
+
+    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
+
+    rsbuild.onAfterStartDevServer(({ routes }) => {
+      receivedRoutes = [...routes]
+    })
+
+    await using server = await rsbuild.usingDevServer()
+    await server.waitDevCompileDone()
+
+    expect(receivedRoutes).toContainEqual({
+      entryName: 'main',
+      pathname: '/main.lynx.bundle',
+    })
+    expect(receivedRoutes).toContainEqual({
+      entryName: 'main',
+      pathname: '/main.web.bundle',
+    })
+  })
+
+  test('onAfterStartPreviewServer routes contains bundle entries', async () => {
+    const rsbuild = await createStubRspeedy({
+      source: {
+        entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      server: {
+        port: 8080,
+      },
+      environments: {
+        web: {},
+        lynx: {},
+      },
+    })
+
+    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
+
+    rsbuild.onAfterStartPreviewServer(({ routes }) => {
+      receivedRoutes = [...routes]
+    })
+
+    const { server } = await rsbuild.preview({ checkDistDir: false })
+    try {
+      expect(receivedRoutes).toContainEqual({
+        entryName: 'main',
+        pathname: '/main.lynx.bundle',
+      })
+      expect(receivedRoutes).toContainEqual({
+        entryName: 'main',
+        pathname: '/main.web.bundle',
+      })
+    } finally {
+      await server.close()
+    }
+  })
 })

--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -56,7 +56,7 @@
     "uqr": "0.1.2"
   },
   "peerDependencies": {
-    "@lynx-js/rspeedy": "^0.15.0"
+    "@lynx-js/rspeedy": "^0.15.3"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/rspeedy/plugin-qrcode/src/index.ts
+++ b/packages/rspeedy/plugin-qrcode/src/index.ts
@@ -11,11 +11,8 @@
 import type {
   EnvironmentContext,
   RsbuildConfig,
-  RsbuildEntry,
   RsbuildPlugin,
 } from '@rsbuild/core'
-
-import type { ExposedAPI } from '@lynx-js/rspeedy'
 
 import { registerConsoleShortcuts } from './shortcuts.js'
 
@@ -151,63 +148,45 @@ export function pluginQRCode(
         unregisterPreviewShortcuts = undefined
       })
 
-      api.onAfterStartPreviewServer(async ({ environments, port }) => {
+      api.onAfterStartPreviewServer(async ({ environments, routes, port }) => {
         unregisterPreviewShortcuts?.()
-        unregisterPreviewShortcuts = await main(getEntries(environments), port)
+        unregisterPreviewShortcuts = await main(
+          getEntriesFromRoutes(routes, environments),
+          port,
+        )
       })
 
-      let printedQRCode = false
+      api.onAfterStartDevServer(async ({ environments, routes, port }) => {
+        const entries = getEntriesFromRoutes(routes, environments)
 
-      api.onAfterDevCompile(async ({ stats, environments }) => {
-        if (!api.context.devServer) {
+        if (entries.length === 0) {
           return
         }
 
-        if (stats.hasErrors()) {
-          return
-        }
-
-        if (printedQRCode) {
-          return
-        }
-
-        printedQRCode = true
-
-        const unregister = await main(
-          getEntries(environments),
-          api.context.devServer.port,
+        const unregister = await registerConsoleShortcuts(
+          {
+            entries,
+            api,
+            port,
+            schema: effectiveSchema,
+          },
         )
         if (unregister) {
           api.onCloseDevServer(unregister)
         }
       })
 
-      function getEntries(
-        environments: Record<string, EnvironmentContext> | undefined,
-      ) {
-        // biome-ignore lint/correctness/useHookAtTopLevel: not react hooks
-        return api.useExposed<ExposedAPI>(Symbol.for('rspeedy.env.entries'))
-          ?.entries ?? environments?.['lynx']?.entry
-      }
-
       async function main(
-        entries: RsbuildEntry | undefined,
+        entries: string[],
         port: number,
       ): Promise<(() => void) | undefined> {
-        if (!entries) {
-          // No entry points, skip print QRCode
-          return
-        }
-
-        const entriesArray = Object.keys(entries)
-
-        if (entriesArray.length === 0) {
+        if (entries.length === 0) {
           return
         }
 
         const unregister = await registerConsoleShortcuts(
           {
-            entries: entriesArray,
+            entries,
             api,
             port,
             schema: effectiveSchema,
@@ -217,6 +196,20 @@ export function pluginQRCode(
       }
     },
   }
+}
+
+function getEntriesFromRoutes(
+  routes: { entryName: string }[],
+  environments: Record<string, EnvironmentContext>,
+): string[] {
+  const entries = new Set(Object.keys(environments['lynx']?.entry ?? {}))
+  return [
+    ...new Set(
+      routes
+        .map(route => route.entryName)
+        .filter(entryName => entries.has(entryName)),
+    ),
+  ]
 }
 
 type PrintUrlsFn = Extract<

--- a/packages/rspeedy/plugin-qrcode/test/index.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/index.test.ts
@@ -9,7 +9,6 @@ import { isCancel } from '@clack/prompts'
 import { createRsbuild, logger } from '@rsbuild/core'
 import type {
   EnvironmentContext,
-  RsbuildEntry,
   RsbuildInstance,
   RsbuildPlugin,
   RsbuildPluginAPI,
@@ -37,13 +36,6 @@ const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
       logger,
       version: '1.0.0',
     })
-  },
-})
-
-const pluginStubEnvEntries = (entries: RsbuildEntry): RsbuildPlugin => ({
-  name: 'lynx:rsbuild:env-entries',
-  setup(api) {
-    api.expose(Symbol.for('rspeedy.env.entries'), { entries })
   },
 })
 
@@ -306,6 +298,7 @@ describe('Plugins - Terminal', () => {
         | ((params: {
           environments: Record<string, EnvironmentContext>
           port: number
+          routes: { entryName: string, pathname: string }[]
         }) => Promise<void>)
         | undefined
       let onExit: (() => void) | undefined
@@ -314,7 +307,7 @@ describe('Plugins - Terminal', () => {
         onAfterStartPreviewServer(handler: typeof onAfterStartPreviewServer) {
           onAfterStartPreviewServer = handler
         },
-        onAfterDevCompile: vi.fn(),
+        onAfterStartDevServer: vi.fn(),
         onCloseDevServer,
         onExit(handler: () => void) {
           onExit = handler
@@ -337,6 +330,7 @@ describe('Plugins - Terminal', () => {
           } as unknown as EnvironmentContext,
         },
         port: 3000,
+        routes: [{ entryName: 'main', pathname: '/main.lynx.bundle' }],
       })
 
       expect(registerConsoleShortcuts).toBeCalledTimes(1)
@@ -355,6 +349,7 @@ describe('Plugins - Terminal', () => {
           } as unknown as EnvironmentContext,
         },
         port: 3001,
+        routes: [{ entryName: 'main', pathname: '/main.lynx.bundle' }],
       })
 
       expect(unregister).toBeCalledTimes(1)
@@ -436,7 +431,7 @@ describe('Plugins - Terminal', () => {
       expect(renderUnicodeCompact).toBeCalledTimes(1)
     })
 
-    test('print qrcode with exposed custom environment entries', async () => {
+    test('does not print qrcode without lynx environment', async () => {
       vi.stubEnv('NODE_ENV', 'development')
       const { selectKey, isCancel } = await import('@clack/prompts')
       vi.mocked(selectKey).mockResolvedValue('foo')
@@ -469,9 +464,6 @@ describe('Plugins - Terminal', () => {
             },
             plugins: [
               pluginStubRspeedyAPI(),
-              pluginStubEnvEntries({
-                main: entry,
-              }),
               pluginQRCode(),
             ],
           },
@@ -482,7 +474,7 @@ describe('Plugins - Terminal', () => {
 
       await server.waitDevCompileDone()
 
-      expect(renderUnicodeCompact).toBeCalledTimes(1)
+      expect(renderUnicodeCompact).toBeCalledTimes(0)
     })
 
     test('print qrcode when dev with host specified', async () => {
@@ -535,7 +527,7 @@ describe('Plugins - Terminal', () => {
       )
     })
 
-    test('print qrcode when errors are fixed', async () => {
+    test('print qrcode immediately even with compile errors', async () => {
       vi.stubEnv('NODE_ENV', 'development')
 
       const entry = join(
@@ -587,12 +579,9 @@ describe('Plugins - Terminal', () => {
 
       await server.waitDevCompileDone()
 
-      expect(renderUnicodeCompact).toBeCalledTimes(0)
-      // fix syntax error
-      await writeFile(entry, source, 'utf-8')
-
-      await server.waitDevCompileSuccess()
-
+      // QR code is printed immediately when the dev server starts,
+      // regardless of compilation errors (the URL is valid once the
+      // server is listening).
       expect(renderUnicodeCompact).toBeCalledTimes(1)
     })
   })

--- a/packages/rspeedy/plugin-qrcode/test/preview.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/preview.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { createRsbuild, logger } from '@rsbuild/core'
-import type { RsbuildEntry } from '@rsbuild/core'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import type { Config, ExposedAPI, RsbuildPlugin } from '@lynx-js/rspeedy'
@@ -25,13 +24,6 @@ const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
       logger,
       version: '1.0.0',
     })
-  },
-})
-
-const pluginStubEnvEntries = (entries: RsbuildEntry): RsbuildPlugin => ({
-  name: 'lynx:rsbuild:env-entries',
-  setup(api) {
-    api.expose(Symbol.for('rspeedy.env.entries'), { entries })
   },
 })
 
@@ -239,7 +231,7 @@ describe('Preview', () => {
     expect(exit).not.toBeCalled()
   })
 
-  test('preview with exposed custom environment entries', async () => {
+  test('preview without lynx ignores custom environment routes', async () => {
     vi.stubEnv('NODE_ENV', 'development')
     const { renderUnicodeCompact } = await import('uqr')
 
@@ -258,9 +250,6 @@ describe('Preview', () => {
         },
         plugins: [
           pluginStubRspeedyAPI(),
-          pluginStubEnvEntries({
-            main: './fixtures/hello-world/index.js',
-          }),
           pluginQRCode(),
         ],
         environments: {
@@ -277,18 +266,13 @@ describe('Preview', () => {
 
     const { server } = await rsbuild.preview({ checkDistDir: false })
 
-    expect(renderUnicodeCompact).toBeCalled()
-    expect(renderUnicodeCompact).toBeCalledWith(
-      'http://example.com/main.lynx.bundle',
-    )
+    expect(renderUnicodeCompact).not.toBeCalled()
 
     await server.close()
-    await vi.waitFor(() => {
-      expect(exit).toBeCalledTimes(1)
-    })
+    expect(exit).not.toBeCalled()
   })
 
-  test('preview with empty exposed entries', async () => {
+  test('preview without routes does not print qrcode', async () => {
     vi.stubEnv('NODE_ENV', 'development')
     const { renderUnicodeCompact } = await import('uqr')
 
@@ -302,7 +286,6 @@ describe('Preview', () => {
       rsbuildConfig: {
         plugins: [
           pluginStubRspeedyAPI(),
-          pluginStubEnvEntries({}),
           pluginQRCode(),
         ],
         environments: {


### PR DESCRIPTION
## Summary
- expose Lynx bundle routes on both dev and preview server hooks in Rspeedy
- make the QR code plugin read Lynx entries from server routes instead of the internal rspeedy.env.entries exposure
- add separate changesets for Rspeedy and qrcode, with qrcode marked as a breaking minor and peerDependency updated to @lynx-js/rspeedy@^0.15.3

## Tests
- pnpm run test --project rspeedy/qrcode -- index.test.ts preview.test.ts
- pnpm test test/plugins/dev.plugin.test.ts
- pnpm dprint check .changeset/rspeedy-preview-routes.md .changeset/qrcode-server-routes.md packages/rspeedy/plugin-qrcode/package.json packages/rspeedy/plugin-qrcode/src/index.ts packages/rspeedy/plugin-qrcode/test/index.test.ts packages/rspeedy/plugin-qrcode/test/preview.test.ts packages/rspeedy/core/src/plugins/dev.plugin.ts packages/rspeedy/core/test/plugins/dev.plugin.test.ts
- git diff --check

## Note
- pnpm changeset status --since=upstream/main currently reports that qrcode must depend on the current workspace rspeedy version 0.15.2; this PR intentionally sets the peer to ^0.15.3, the version produced by the included Rspeedy patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QR code and bundle route handling now works from server routes during both dev and preview startup.

* **Bug Fixes**
  * QR code output now appears reliably at dev-server start, even when compilation errors are present.
  * Custom routes are ignored when no Lynx bundle route is available, preventing incorrect QR output.

* **Chores**
  * Updated the required Rspeedy version for the QR code plugin.
  * Documentation notes the new route-based behavior and breaking expectation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->