### PR TITLE
fix(web-core): declare globDynamicComponentEntry for external bundle mts chunks

### DIFF
--- a/.changeset/web-external-bundle-glob-dynamic.md
+++ b/.changeset/web-external-bundle-glob-dynamic.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Fix `globDynamicComponentEntry is not defined` when a web external bundle's main-thread (lepus) chunk is evaluated.
+
+An external bundle's mts chunk references `globDynamicComponentEntry` bare — a card's own root receives it as a wrapping function parameter, but an external chunk does not. The decode worker now declares it in the CommonJS env it already builds for external bundle chunks, so evaluating them no longer throws a `ReferenceError`.

--- a/packages/web-platform/web-core/ts/client/decodeWorker/decode.worker.ts
+++ b/packages/web-platform/web-core/ts/client/decodeWorker/decode.worker.ts
@@ -303,11 +303,14 @@ async function handleStream(
         const codeMap = decodeBinaryMap(content);
         const isLazy = config['isLazy'] === 'true';
         // An external bundle's mts chunk is CommonJS-style (it writes to
-        // `exports`), so give it a `module.exports`/`exports` env. A card's own
-        // lepus chunk is either side-effecting (non-lazy) or an expression
-        // assigned to `module.exports` (lazy component root).
+        // `exports`), so give it a `module.exports`/`exports` env. It also
+        // references `globDynamicComponentEntry` bare (a card's own root gets it
+        // as a wrapping function parameter, but an external chunk does not), so
+        // declare it here too — defaulting to `'__Card__'`, the main-card entry.
+        // A card's own lepus chunk is either side-effecting (non-lazy) or an
+        // expression assigned to `module.exports` (lazy root).
         const prefix = config['isExternalBundle'] === 'true'
-          ? 'var exports=(module.exports={}); '
+          ? 'var globDynamicComponentEntry="__Card__"; var exports=(module.exports={}); '
           : isLazy
           ? 'module.exports='
           : '';


### PR DESCRIPTION
## What

A web external bundle's main-thread (lepus) chunk references `globDynamicComponentEntry` bare. A card's own root chunk receives it as a wrapping function parameter, but an external chunk does not — so evaluating an external bundle's mts chunk throws `globDynamicComponentEntry is not defined`, and the page never renders.

## Fix

Declare `globDynamicComponentEntry` (`var globDynamicComponentEntry = void 0;`) in the CommonJS env the decode worker already builds for external bundle chunks (`config['isExternalBundle'] === 'true'`). This is scoped to external bundles only — a card's own root already self-declares it, so adding it there would cause a duplicate-declaration `SyntaxError`.

## Testing

Verified against the doubao-apps-sdk web target: a ReactLynx page loaded via async external bundles (`fetchBundle().then`) now renders its full first screen (previously blank — the external framework/react mts chunks threw on the bare `globDynamicComponentEntry` reference before mounting).

Pre-existing behavior on `main`; not tied to a specific feature branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a `ReferenceError` that could occur when evaluating main-thread chunks of certain external web bundles.
  * Updated the external bundle blob wrapper/initialization to ensure required symbols are defined during chunk evaluation.
* **Chores**
  * Added a patch release note entry for `@lynx-js/web-core` describing the external bundle chunk fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->