### PR TITLE
fix(rspeedy): respect modified dev server host

### DIFF
--- a/.changeset/fix-dev-host-asset-prefix.md
+++ b/.changeset/fix-dev-host-asset-prefix.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Fix dev server host resolution for generated asset prefixes.
+
+Rspeedy now falls back from IPv4 to IPv6 when resolving the default dev host, keeps the configured server host when no local IP is found, and applies `server.host` updates from other plugins to the final dev asset prefix.

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -20,6 +20,10 @@ import type { ExposedAPI } from '../index.js'
 import { isLynx } from '../utils/is-lynx.js'
 import { ProvidePlugin } from '../webpack/ProvidePlugin.js'
 
+const DEFAULT_SERVER_HOST = '0.0.0.0'
+
+type RsbuildServerHost = NonNullable<RsbuildConfig['server']>['host']
+
 export function pluginDev(
   options?: Dev,
   server?: Server,
@@ -30,55 +34,6 @@ export function pluginDev(
       return action === 'dev' || config.mode === 'development'
     },
     async setup(api) {
-      const hostname = server?.host ?? await findIp('v4')
-
-      let assetPrefix = options?.assetPrefix
-
-      switch (typeof assetPrefix) {
-        case 'string': {
-          if (server?.port !== undefined) {
-            // We should change the port of `assetPrefix` when `server.port` is set.
-
-            const hasPortPlaceholder = assetPrefix.includes('<port>')
-            if (!hasPortPlaceholder) {
-              // There is not `<port>` in `dev.assetPrefix`.
-              const assetPrefixURL = new URL(assetPrefix)
-
-              if (assetPrefixURL.port !== String(server.port)) {
-                logger.warn(
-                  `Setting different port values in ${
-                    color.cyan('server.port')
-                  } and ${color.cyan('dev.assetPrefix')}. Using server.port(${
-                    color.cyan(server.port)
-                  }) to make HMR work.`,
-                )
-                assetPrefixURL.port = String(server.port)
-                assetPrefix = assetPrefixURL.toString()
-              }
-            }
-          }
-
-          break
-        }
-        case 'undefined':
-        case 'boolean': {
-          if (options?.assetPrefix !== false) {
-            // assetPrefix === true || assetPrefix === undefined
-            assetPrefix = `http://${hostname}:<port>/`
-          }
-          break
-        }
-      }
-
-      if (server?.base) {
-        if ((assetPrefix as string).endsWith('/')) {
-          assetPrefix = (assetPrefix as string).slice(0, -1)
-        }
-        assetPrefix = `${assetPrefix}${server.base}/`
-      }
-
-      debug(`dev.assetPrefix is normalized to ${assetPrefix}`)
-
       // Resolve the main bundle filename template for a given entry/platform.
       // When `bundle` is a function, it is called with `lazyBundle: false`
       // since the dev URLs always point at the main bundle.
@@ -157,20 +112,77 @@ export function pluginDev(
         }
       })
 
-      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-        return mergeRsbuildConfig(config, {
-          dev: {
-            assetPrefix,
-            client: {
-              // Lynx cannot use `location.hostname`.
-              host: hostname,
-              port: '<port>',
+      api.modifyRsbuildConfig({
+        handler: async (config, { mergeRsbuildConfig }) => {
+          const hostname = await resolveHostname(
+            config.server?.host,
+            server?.host,
+          )
+
+          let assetPrefix = options?.assetPrefix
+
+          switch (typeof assetPrefix) {
+            case 'string': {
+              if (server?.port !== undefined) {
+                // We should change the port of `assetPrefix` when `server.port` is set.
+
+                const hasPortPlaceholder = assetPrefix.includes('<port>')
+                if (!hasPortPlaceholder) {
+                  // There is not `<port>` in `dev.assetPrefix`.
+                  const assetPrefixURL = new URL(assetPrefix)
+
+                  if (assetPrefixURL.port !== String(server.port)) {
+                    logger.warn(
+                      `Setting different port values in ${
+                        color.cyan('server.port')
+                      } and ${
+                        color.cyan('dev.assetPrefix')
+                      }. Using server.port(${
+                        color.cyan(server.port)
+                      }) to make HMR work.`,
+                    )
+                    assetPrefixURL.port = String(server.port)
+                    assetPrefix = assetPrefixURL.toString()
+                  }
+                }
+              }
+
+              break
+            }
+            case 'undefined':
+            case 'boolean': {
+              if (options?.assetPrefix !== false) {
+                // assetPrefix === true || assetPrefix === undefined
+                assetPrefix = `http://${hostname}:<port>/`
+              }
+              break
+            }
+          }
+
+          if (server?.base) {
+            if ((assetPrefix as string).endsWith('/')) {
+              assetPrefix = (assetPrefix as string).slice(0, -1)
+            }
+            assetPrefix = `${assetPrefix}${server.base}/`
+          }
+
+          debug(`dev.assetPrefix is normalized to ${assetPrefix}`)
+
+          return mergeRsbuildConfig(config, {
+            dev: {
+              assetPrefix,
+              client: {
+                // Lynx cannot use `location.hostname`.
+                host: hostname,
+                port: '<port>',
+              },
             },
-          },
-          // When using `rspeedy dev --mode production`
-          // Rsbuild would use `output.assetPrefix` instead of `dev.assetPrefix`
-          output: { assetPrefix },
-        } as RsbuildConfig)
+            // When using `rspeedy dev --mode production`
+            // Rsbuild would use `output.assetPrefix` instead of `dev.assetPrefix`
+            output: { assetPrefix },
+          } as RsbuildConfig)
+        },
+        order: 'post',
       })
 
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
@@ -183,6 +195,10 @@ export function pluginDev(
           return mergeRsbuildConfig(config, {
             server: {
               printUrls: (param) => {
+                const currentConfig = api.getRsbuildConfig('current')
+                const assetPrefix = currentConfig.dev?.assetPrefix
+                const hostname = currentConfig.dev?.client?.host
+                  ?? formatHostname(currentConfig.server?.host)
                 const finalUrls: { label: string, url: string }[] = []
                 const baseForUrls = (
                   typeof assetPrefix === 'string'
@@ -238,6 +254,7 @@ export function pluginDev(
         const rspeedyDir = path.dirname(
           require.resolve('@lynx-js/rspeedy/package.json'),
         )
+        const hostname = environment.config.dev?.client?.host ?? ''
 
         const searchParams = new URLSearchParams({
           hostname,
@@ -317,7 +334,7 @@ export function pluginDev(
 export async function findIp(
   family: 'v4' | 'v6',
   isInternal = false,
-): Promise<string> {
+): Promise<string | undefined> {
   // Use the `default` export (the live CJS exports object) instead of the
   // namespace: builtin namespaces snapshot named exports, which breaks
   // `spyOn(os, 'networkInterfaces')` in tests.
@@ -374,10 +391,33 @@ export async function findIp(
     }
   }
 
-  if (!host) {
-    throw new Error(`No valid IP found`)
+  return host
+}
+
+async function resolveHostname(
+  host: RsbuildServerHost | undefined,
+  originalHost: string | undefined,
+): Promise<string> {
+  const hostname = formatHostname(host)
+  if (originalHost !== undefined || hostname !== DEFAULT_SERVER_HOST) {
+    return hostname
   }
 
+  return await findIp('v4')
+    ?? await findIp('v6')
+    ?? hostname
+}
+
+function formatHostname(host: RsbuildServerHost | undefined): string {
+  if (host === true || host === undefined) {
+    return DEFAULT_SERVER_HOST
+  }
+  if (host === false) {
+    return 'localhost'
+  }
+  if (host.includes(':') && !host.startsWith('[')) {
+    return `[${host}]`
+  }
   return host
 }
 

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -114,7 +114,7 @@ export function pluginDev(
 
       api.modifyRsbuildConfig({
         handler: async (config, { mergeRsbuildConfig }) => {
-          const hostname = await resolveHostname(
+          const { bindHost, hostname } = await resolveHostname(
             config.server?.host,
             server?.host,
           )
@@ -159,9 +159,9 @@ export function pluginDev(
             }
           }
 
-          if (server?.base) {
-            if ((assetPrefix as string).endsWith('/')) {
-              assetPrefix = (assetPrefix as string).slice(0, -1)
+          if (server?.base && typeof assetPrefix === 'string') {
+            if (assetPrefix.endsWith('/')) {
+              assetPrefix = assetPrefix.slice(0, -1)
             }
             assetPrefix = `${assetPrefix}${server.base}/`
           }
@@ -169,6 +169,13 @@ export function pluginDev(
           debug(`dev.assetPrefix is normalized to ${assetPrefix}`)
 
           return mergeRsbuildConfig(config, {
+            ...(bindHost
+              ? {
+                server: {
+                  host: bindHost,
+                },
+              }
+              : {}),
             dev: {
               assetPrefix,
               client: {
@@ -397,15 +404,26 @@ export async function findIp(
 async function resolveHostname(
   host: RsbuildServerHost | undefined,
   originalHost: string | undefined,
-): Promise<string> {
+): Promise<{ bindHost?: string, hostname: string }> {
   const hostname = formatHostname(host)
   if (originalHost !== undefined || hostname !== DEFAULT_SERVER_HOST) {
-    return hostname
+    return { hostname }
   }
 
-  return await findIp('v4')
-    ?? await findIp('v6')
-    ?? hostname
+  const ipv4Hostname = await findIp('v4')
+  if (ipv4Hostname) {
+    return { hostname: ipv4Hostname }
+  }
+
+  const ipv6Hostname = await findIp('v6')
+  if (ipv6Hostname) {
+    return {
+      bindHost: stripHostnameBrackets(ipv6Hostname),
+      hostname: ipv6Hostname,
+    }
+  }
+
+  return { hostname }
 }
 
 function formatHostname(host: RsbuildServerHost | undefined): string {
@@ -419,6 +437,13 @@ function formatHostname(host: RsbuildServerHost | undefined): string {
     return `[${host}]`
   }
   return host
+}
+
+function stripHostnameBrackets(hostname: string): string {
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1)
+  }
+  return hostname
 }
 
 function getNetworkPriority(name: string, address: string): number {

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -86,6 +86,7 @@ describe('Plugins - Dev', () => {
     const config = await rsbuild.unwrapConfig()
 
     expect(config.output?.publicPath).toBe('http://[fd00::1]:3000/')
+    expect(rsbuild.getRsbuildConfig().server!.host).toBe('fd00::1')
     expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('[fd00::1]')
   })
 
@@ -400,6 +401,23 @@ describe('Plugins - Dev', () => {
 
     expect(typeof config.output?.publicPath).toBe('string')
     expect(config.output?.publicPath).toBe('/')
+  })
+
+  test('dev.assetPrefix: false with server.base', async () => {
+    const rsbuild = await createStubRspeedy({
+      dev: {
+        assetPrefix: false,
+      },
+      server: {
+        base: '/dist',
+      },
+    })
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(typeof config.output?.publicPath).toBe('string')
+    expect(config.output?.publicPath).toBe('/')
+    expect(rsbuild.getRsbuildConfig().dev!.assetPrefix).toBe(false)
   })
 
   test('assetPrefix with mode production', async () => {

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -5,6 +5,7 @@ import { isIP, isIPv4 } from 'node:net'
 import type { AddressInfo } from 'node:net'
 import path from 'node:path'
 
+import type { RsbuildPlugin } from '@rsbuild/core'
 import {
   assert,
   beforeEach,
@@ -61,6 +62,69 @@ describe('Plugins - Dev', () => {
     expect(isIPv4(rsbuild.getRsbuildConfig().dev!.client!.host!)).toBe(true)
 
     assert(config.resolve?.alias)
+  })
+
+  test('defaults fallback to ipv6 when no ipv4 is found', async () => {
+    const { default: os } = await import('node:os')
+
+    rstest.spyOn(os, 'networkInterfaces').mockReturnValue({
+      eth0: [
+        {
+          address: 'fd00::1',
+          family: 'IPv6',
+          internal: false,
+          netmask: 'ffff:ffff:ffff:ffff::',
+          mac: '00:00:00:00:00:00',
+          cidr: 'fd00::1/64',
+          scopeid: 0,
+        },
+      ],
+    })
+
+    const rsbuild = await createStubRspeedy({})
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(config.output?.publicPath).toBe('http://[fd00::1]:3000/')
+    expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('[fd00::1]')
+  })
+
+  test('defaults keep server.host when no ip is found', async () => {
+    const { default: os } = await import('node:os')
+
+    rstest.spyOn(os, 'networkInterfaces').mockReturnValue({})
+
+    const rsbuild = await createStubRspeedy({})
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(rsbuild.getRsbuildConfig().server!.host).toBe('0.0.0.0')
+    expect(config.output?.publicPath).toBe('http://0.0.0.0:3000/')
+    expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('0.0.0.0')
+  })
+
+  test('dev.assetPrefix uses server.host modified by plugins', async () => {
+    const rsbuild = await createStubRspeedy({
+      plugins: [
+        {
+          name: 'test:server-host',
+          setup(api) {
+            api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+              return mergeRsbuildConfig(config, {
+                server: {
+                  host: '10.0.0.2',
+                },
+              })
+            })
+          },
+        } satisfies RsbuildPlugin,
+      ],
+    })
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(config.output?.publicPath).toBe('http://10.0.0.2:3000/')
+    expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('10.0.0.2')
   })
 
   test('provide HMR variables', async () => {

--- a/packages/rspeedy/core/test/plugins/findIp.test.ts
+++ b/packages/rspeedy/core/test/plugins/findIp.test.ts
@@ -215,9 +215,7 @@ describe('findIp', () => {
 
     const { findIp } = await import('../../src/plugins/dev.plugin.js')
 
-    await expect(findIp('v4')).rejects.toThrow(
-      'No valid IP found',
-    )
+    await expect(findIp('v4')).resolves.toBeUndefined()
   })
 
   test('no ips', async () => {
@@ -227,9 +225,7 @@ describe('findIp', () => {
 
     const { findIp } = await import('../../src/plugins/dev.plugin.js')
 
-    await expect(findIp('v4')).rejects.toThrow(
-      'No valid IP found',
-    )
+    await expect(findIp('v4')).resolves.toBeUndefined()
   })
 
   test('invalid network interfaces', async () => {
@@ -242,9 +238,7 @@ describe('findIp', () => {
 
     const { findIp } = await import('../../src/plugins/dev.plugin.js')
 
-    await expect(findIp('v4')).rejects.toThrow(
-      'No valid IP found',
-    )
+    await expect(findIp('v4')).resolves.toBeUndefined()
   })
 
   test('invalid ip address', async () => {
@@ -261,8 +255,6 @@ describe('findIp', () => {
 
     const { findIp } = await import('../../src/plugins/dev.plugin.js')
 
-    await expect(findIp('v4')).rejects.toThrow(
-      'No valid IP found',
-    )
+    await expect(findIp('v4')).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
### Summary
- Resolve the dev asset prefix after post-order Rsbuild config modifications so plugin-updated `server.host` is respected.
- Fall back from IPv4 to IPv6 when resolving the default dev host.
- Keep the configured server host when no local IP is found instead of throwing.
- Add a patch changeset for `@lynx-js/rspeedy`.

### Test Plan
- `pnpm --filter @lynx-js/rspeedy exec rstest test/plugins/findIp.test.ts test/plugins/dev.plugin.test.ts`
- `pnpm --filter @lynx-js/rspeedy test:type`
- `pnpm dprint check .changeset/fix-dev-host-asset-prefix.md packages/rspeedy/core/src/plugins/dev.plugin.ts packages/rspeedy/core/test/plugins/dev.plugin.test.ts packages/rspeedy/core/test/plugins/findIp.test.ts`
- `pnpm biome check packages/rspeedy/core/src/plugins/dev.plugin.ts packages/rspeedy/core/test/plugins/dev.plugin.test.ts packages/rspeedy/core/test/plugins/findIp.test.ts`
- `pnpm turbo build`
- `pnpm changeset status --since=upstream/main` (fails: existing `@lynx-js/qrcode-rsbuild-plugin` dependency expects `@lynx-js/rspeedy@^0.15.3` while the current version is `0.15.2`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dev server host and asset prefix resolution, with reliable fallback between IPv4/IPv6 so generated asset URLs load correctly.
  * When no local IP is available, the configured `server.host` is preserved to prevent incorrect URL generation.
  * Ensured `server.host` updates from plugins are reflected consistently in dev/public URLs and HMR client settings.
  * Fixed edge cases where `dev.assetPrefix` is `false` (with `server.base`) to keep `output.publicPath` as `/`.
* **Tests**
  * Added/updated coverage for host/publicPath behavior across mocked networking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->