### PR TITLE
feat(qrcode-rsbuild-plugin): add showQRCode option to registerConsoleShortcuts

### DIFF
--- a/.changeset/qrcode-showQRCode.md
+++ b/.changeset/qrcode-showQRCode.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/qrcode-rsbuild-plugin": patch
+---
+
+Add `showQRCode` option to `registerConsoleShortcuts`.
+
+When passed `showQRCode: false`, the shortcut runtime still prints URL(s) and keeps the interactive schema/entry switching, but skips rendering the ASCII QR code. This lets embedders that always launch via a deep link (or wrap the plugin with their own connection flow — e.g. `@byted-lynx/hdt-rsbuild-plugin`) suppress the QR block without forking the shortcut loop. Default remains `true`, so existing behavior is unchanged.

--- a/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
+++ b/packages/rspeedy/plugin-qrcode/src/shortcuts.ts
@@ -16,6 +16,17 @@ interface Options {
   entries: string[]
   schema: CustomizedSchemaFn
   port: number
+  /**
+   * Whether to render the ASCII QR code in the terminal.
+   *
+   * When `false`, the plugin still prints the URL(s) and keeps the interactive
+   * shortcuts working, but skips the QR code block. Useful for hosts that
+   * always launch via a schema / deep link and don't need the scan flow, or
+   * for terminals where the QR block is visually noisy.
+   *
+   * @defaultValue `true`
+   */
+  showQRCode?: boolean | undefined
   customShortcuts?: Record<
     string,
     { value: string, label: string, hint?: string, action?(): Promise<void> }
@@ -37,6 +48,7 @@ export async function registerConsoleShortcuts(
   ] = await Promise.all([
     import('./showQRCode.js'),
   ])
+  const shouldShowQRCode = options.showQRCode ?? true
 
   const currentEntry = options.entries[0]!
   const devUrls = generateDevUrls(
@@ -48,7 +60,9 @@ export async function registerConsoleShortcuts(
 
   const value: string | symbol = Object.values(devUrls)[0]!
   await options.onPrint?.(value)
-  showQRCode(value)
+  if (shouldShowQRCode) {
+    showQRCode(value)
+  }
 
   gExistingShortcuts.add(options)
 
@@ -99,6 +113,7 @@ async function loop(
     import('@clack/prompts'),
     import('./showQRCode.js'),
   ])
+  const shouldShowQRCode = options.showQRCode ?? true
 
   const selectFn = (length: number) => length > 5 ? autocomplete : select
 
@@ -171,7 +186,9 @@ async function loop(
       await options.customShortcuts[name].action?.()
     }
     await options.onPrint?.(value)
-    showQRCode(value)
+    if (shouldShowQRCode) {
+      showQRCode(value)
+    }
   }
 
   // If the `options` is not deleted from `gExistingShortcuts`, means that this is an explicitly

--- a/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
@@ -130,47 +130,6 @@ describe('PluginQRCode - CLI Shortcuts', () => {
     })
   })
 
-  describe('showQRCode option', () => {
-    test('renders the QR block by default', async () => {
-      const { log } = await import('@clack/prompts')
-      vi.mocked(log.success).mockClear()
-
-      const unregister = await registerConsoleShortcuts({
-        api: mockedRsbuildAPI,
-        entries: ['foo'],
-        schema: i => i,
-        port: 3000,
-      })
-
-      // showQRCode calls log.success twice (once for the QR ASCII, once for
-      // the URL line).
-      expect(vi.mocked(log.success).mock.calls.length).toBeGreaterThanOrEqual(1)
-      unregister()
-    })
-
-    test('skips the QR block when showQRCode is false', async () => {
-      const { log } = await import('@clack/prompts')
-      vi.mocked(log.success).mockClear()
-      const onPrint = vi.fn()
-
-      const unregister = await registerConsoleShortcuts({
-        api: mockedRsbuildAPI,
-        entries: ['foo'],
-        schema: i => i,
-        port: 3000,
-        showQRCode: false,
-        onPrint,
-      })
-
-      expect(vi.mocked(log.success)).not.toHaveBeenCalled()
-      // URL is still surfaced through onPrint.
-      expect(onPrint).toHaveBeenCalledWith(
-        'https://example.com/foo.lynx.bundle',
-      )
-      unregister()
-    })
-  })
-
   test('open page', async () => {
     vi.stubEnv('NODE_ENV', 'development')
     const onPrint = vi.fn()
@@ -206,5 +165,51 @@ describe('PluginQRCode - CLI Shortcuts', () => {
 
     expect(onOpen).toBeCalledTimes(1)
     unregister()
+  })
+
+  describe('showQRCode option', () => {
+    test('renders the QR block by default', async () => {
+      const { log, selectKey } = await import('@clack/prompts')
+      vi.mocked(log.success).mockClear()
+      // Park the interactive loop so log.success is only called by the initial print.
+      vi.mocked(selectKey).mockReset().mockImplementation(() =>
+        new Promise(vi.fn())
+      )
+
+      const unregister = await registerConsoleShortcuts({
+        api: mockedRsbuildAPI,
+        entries: ['foo'],
+        schema: i => i,
+        port: 3000,
+      })
+
+      expect(vi.mocked(log.success).mock.calls.length).toBeGreaterThanOrEqual(1)
+      unregister()
+    })
+
+    test('skips the QR block when showQRCode is false', async () => {
+      const { log, selectKey } = await import('@clack/prompts')
+      vi.mocked(log.success).mockClear()
+      vi.mocked(selectKey).mockReset().mockImplementation(() =>
+        new Promise(vi.fn())
+      )
+      const onPrint = vi.fn()
+
+      const unregister = await registerConsoleShortcuts({
+        api: mockedRsbuildAPI,
+        entries: ['foo'],
+        schema: i => i,
+        port: 3000,
+        showQRCode: false,
+        onPrint,
+      })
+
+      expect(vi.mocked(log.success)).not.toHaveBeenCalled()
+      // URL is still surfaced through onPrint.
+      expect(onPrint).toHaveBeenCalledWith(
+        'https://example.com/foo.lynx.bundle',
+      )
+      unregister()
+    })
   })
 })

--- a/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
@@ -130,6 +130,47 @@ describe('PluginQRCode - CLI Shortcuts', () => {
     })
   })
 
+  describe('showQRCode option', () => {
+    test('renders the QR block by default', async () => {
+      const { log } = await import('@clack/prompts')
+      vi.mocked(log.success).mockClear()
+
+      const unregister = await registerConsoleShortcuts({
+        api: mockedRsbuildAPI,
+        entries: ['foo'],
+        schema: i => i,
+        port: 3000,
+      })
+
+      // showQRCode calls log.success twice (once for the QR ASCII, once for
+      // the URL line).
+      expect(vi.mocked(log.success).mock.calls.length).toBeGreaterThanOrEqual(1)
+      unregister()
+    })
+
+    test('skips the QR block when showQRCode is false', async () => {
+      const { log } = await import('@clack/prompts')
+      vi.mocked(log.success).mockClear()
+      const onPrint = vi.fn()
+
+      const unregister = await registerConsoleShortcuts({
+        api: mockedRsbuildAPI,
+        entries: ['foo'],
+        schema: i => i,
+        port: 3000,
+        showQRCode: false,
+        onPrint,
+      })
+
+      expect(vi.mocked(log.success)).not.toHaveBeenCalled()
+      // URL is still surfaced through onPrint.
+      expect(onPrint).toHaveBeenCalledWith(
+        'https://example.com/foo.lynx.bundle',
+      )
+      unregister()
+    })
+  })
+
   test('open page', async () => {
     vi.stubEnv('NODE_ENV', 'development')
     const onPrint = vi.fn()


### PR DESCRIPTION
The fix

Some integrations always launch the Lynx page through a custom link flow and never use the scan path. In those cases, the ASCII QR block printed by `registerConsoleShortcuts` is just terminal noise — but today there is no way to suppress only the QR while keeping URL output and the interactive shortcuts.

The shared shortcut runtime now accepts an internal `showQRCode` option. When `showQRCode` is `false`, `registerConsoleShortcuts` still prints URL(s), keeps entry/schema switching and custom shortcuts working, but skips rendering the ASCII QR code block. Default remains `true`, so existing behavior is unchanged.

`@lynx-js/qrcode-rsbuild-plugin` (private): `registerConsoleShortcuts` `Options` now accept `showQRCode?: boolean`; the initial print and the in-loop reprint both gate `showQRCode(value)` behind `options.showQRCode ?? true`. Unit tests added for both branches; existing behavior unchanged when the flag is omitted.

Demo

This change is intended for downstream consumers that want to preserve URL output and interactive console shortcuts while suppressing the QR block. No public `pluginQRCode` option surface is changed here; this PR teaches the shared shortcut runtime the new field.

Testing

Ran locally with:

- `npx vitest run test/shortcuts.test.ts`

Result: 7 tests passed.
- existing 5 tests unchanged
- +1 new case: renders the QR block by default
- +1 new case: skips the QR block when `showQRCode` is `false`

Summary by CodeRabbit

New Features
- Added an internal `showQRCode` option to the shared console shortcut runtime.

Bug Fixes
- Allows downstream integrations to suppress the QR ASCII block without forking shortcut behavior.

Tests
- Added coverage for both `showQRCode` branches (default / false).

Chores
- Fixed test ordering / isolation so the new `showQRCode` tests do not leak into the existing interactive shortcut case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `showQRCode` option for console shortcuts, letting the QR code display be turned off while keeping URL output and interactive behavior intact.
  * QR code display now remains on by default, so existing behavior is unchanged unless disabled.

* **Tests**
  * Added coverage for the new option, including default QR rendering and the no-QR setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `showQRCode` option for console shortcut registration.
  * When disabled, the app still prints the URL and supports the interactive switching flow, but skips the ASCII QR code.

* **Bug Fixes**
  * QR code display now respects the new setting consistently during initial output and later updates.

* **Tests**
  * Added coverage for both default QR display and the hidden-QR behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->