### PR TITLE
ci: prepare Rust workflow for headless runner

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,7 +35,7 @@ jobs:
           cache-key: test-ubuntu-copilot-setup-steps
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm install --frozen-lockfile
       - name: Build

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -39,7 +39,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
       - name: build
@@ -161,7 +161,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
       - name: Download Turbo Cache
@@ -209,7 +209,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable && corepack prepare
           corepack pnpm install --frozen-lockfile
       - name: Download Turbo Cache

--- a/.github/workflows/nodejs-dependencies.yml
+++ b/.github/workflows/nodejs-dependencies.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: "24"
           package-manager-cache: false
       - run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm dedupe --check
           pnpm dlx sherif@latest -i tailwindcss

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,10 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "22"
+          package-manager-cache: false
       - uses: ./.github/actions/rustup
         with:
           key: test
@@ -48,6 +52,23 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libepoxy0
+      - name: TurboCache
+        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        with:
+          path: .turbo
+          # We have to be strict here to make sure getting the cache of build-all
+          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: Install
+        run: |
+          npm install -g corepack@0.35.0
+          corepack enable
+          pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm turbo build --summarize
+      - name: Build React fixture
+        run: |
+          NODE_ENV=production node packages/rspeedy/core/bin/rspeedy.js build --root packages/genui/ui-judge/tests/fixtures/react
       - name: Test
         env:
           CARGO_LLVM_COV_FLAGS_NO_RUNNER: --no-sparse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           package-manager-cache: false
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm install --frozen-lockfile
       - name: Code Style Check
@@ -290,6 +290,7 @@ jobs:
         --logHeapUsage
         --silent
   test-rust:
+    needs: build
     uses: ./.github/workflows/rust.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -80,7 +80,7 @@ jobs:
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm install --frozen-lockfile
       - name: Build

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -110,7 +110,7 @@ jobs:
             turbo-v4-${{ runner.os }}-
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm install --frozen-lockfile
       - name: Build

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -47,7 +47,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm install --frozen-lockfile
       - name: Build

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -92,7 +92,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm install --frozen-lockfile
       - name: Build

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
## Summary

- Add Node, pnpm install, Turbo cache restore, and fixture build steps to the reusable Rust workflow so Rust integration tests can consume built JS fixtures.
- Make the main test workflow wait for the build job before invoking the Rust workflow.
- Pin all workflow `corepack@latest` installs to `corepack@0.35.0` to avoid floating tool installation.

## Validation

- `rg -uu -n "corepack@latest" . --glob '!node_modules/**' --glob '!target/**' --glob '!packages/lynx/engine-bridge/target/**' --glob '!.git/**'` returned no matches.
- `DPRINT_CACHE_DIR=/private/tmp/codex-dprint-cache node_modules/.bin/dprint check ...`
- `git diff --check`