### PR TITLE
refactor(react): bind snapshot runtime via import instead of dev-only require

### DIFF
--- a/.changeset/reactlynx-preset-async.md
+++ b/.changeset/reactlynx-preset-async.md
@@ -2,4 +2,4 @@
 "@lynx-js/external-bundle-rsbuild-plugin": minor
 ---
 
-The `reactlynx` externals preset accepts `{ async: true }`. It resolves the web-encoded `@lynx-js/react-umd/{dev,prod}-web` bundle and mounts ReactLynx as an awaited promise, so the web runtime can load it via `fetchBundle().then` (the sync array form reads `React.memo` etc. off a pending promise and gets `undefined`).
+The `reactlynx` externals preset accepts `{ async: true }`, mounting ReactLynx as an awaited promise so async runtimes can load it via `fetchBundle().then` (the sync array form reads `React.memo` etc. off a pending promise and gets `undefined`). Externals presets resolve per environment (`environmentName` is available in the preset context): `lynx` / `lynx-*` environments use `react.lynx.bundle`, other environments (e.g. `web`) use the web-encoded `@lynx-js/react-umd/{dev,prod}-web` `react.web.bundle` — `async` only controls the mount form.

--- a/.changeset/snapshot-runtime-import.md
+++ b/.changeset/snapshot-runtime-import.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Bind the snapshot runtime via `import` in development instead of inline `require('@lynx-js/react/internal')`, so dev builds work with async (promise) externals. Dev snapshot creators now receive the runtime as a parameter (staying self-contained for cross-thread HMR `DEV_ONLY_AddSnapshot`); production creators keep the statically tree-shakeable module-scope reference.

--- a/.changeset/snapshot-runtime-import.md
+++ b/.changeset/snapshot-runtime-import.md
@@ -2,4 +2,4 @@
 "@lynx-js/react": patch
 ---
 
-Bind the snapshot runtime via `import` in development instead of inline `require('@lynx-js/react/internal')`, so dev builds work with async (promise) externals. Dev snapshot creators now receive the runtime as a parameter (staying self-contained for cross-thread HMR `DEV_ONLY_AddSnapshot`); production creators keep the statically tree-shakeable module-scope reference.
+Bind the snapshot runtime via `import` in development instead of inline `require('@lynx-js/react/internal')`, so dev builds work with async (promise) externals. Dev snapshot creators now receive the runtime as a parameter (staying self-contained for cross-thread HMR `DEV_ONLY_AddSnapshot`) with a temporary `__runtime__ || require(...)` fallback for older runtimes that call creators with a single argument; production creators keep the statically tree-shakeable module-scope reference.

--- a/packages/react/runtime/src/internal.ts
+++ b/packages/react/runtime/src/internal.ts
@@ -10,6 +10,7 @@ import './lynx.js';
 
 import { useMemo } from './core/hooks/react.js';
 import { loadLazyBundle } from './core/lynx/lazy-bundle.js';
+import * as ReactLynxInternalSelf from './internal.js';
 import { __root } from './root.js';
 import { factory as factory2 } from './snapshot/compat/componentIs.js';
 import { BackgroundSnapshotInstance } from './snapshot/snapshot/backgroundSnapshot.js';
@@ -17,6 +18,7 @@ import { __page, __pageId, createSnapshot, snapshotManager } from './snapshot/sn
 import { DynamicPartType } from './snapshot/snapshot/dynamicPartType.js';
 import { snapshotCreateList } from './snapshot/snapshot/list.js';
 import { SnapshotInstance, snapshotCreatorMap } from './snapshot/snapshot/snapshot.js';
+import { setSnapshotCreatorRuntime } from './snapshot/snapshot/snapshotCreatorMap.js';
 
 export { CHILDREN, COMPONENT, DIFF, DIRTY, DOM, FLAGS, INDEX, PARENT } from './shared/render-constants.js';
 
@@ -80,3 +82,11 @@ export { createBackgroundFunctionHandle as transformToWorklet } from './core/bac
 export { registerWorkletOnBackground } from './snapshot/worklet/hmr.js';
 
 export { loadWorkletRuntime } from '@lynx-js/react/worklet-runtime/bindings';
+
+if (__DEV__) {
+  // Dev snapshot creators take the runtime as a parameter (they are
+  // stringified for cross-thread HMR and must not capture module bindings);
+  // register this namespace as that runtime. Production creators close over
+  // their own module's runtime import, so this reference is dropped there.
+  setSnapshotCreatorRuntime(ReactLynxInternalSelf);
+}

--- a/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
@@ -152,9 +152,10 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
  */
 function evaluate<T>(code: string): T {
   if (__DEV__) {
-    // Creators are self-contained: the runtime is injected as a call argument
-    // (see `SnapshotCreator`), so the evaluated code needs nothing from this
-    // scope.
+    // Creators receive the runtime as a call argument (see `SnapshotCreator`).
+    // Direct `eval` is kept for the legacy `__runtime__ || require(...)`
+    // fallback, which resolves `__webpack_require__` from this scope on
+    // runtimes that call creators with a single argument.
     return eval(`(() => ${code})()`) as T;
   }
   throw new Error('unreachable: evaluate is not supported in production');

--- a/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
@@ -148,13 +148,13 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
 
 /* v8 ignore start */
 /**
- * Evaluates a string as code with ReactLynx runtime injected.
- * Used for HMR (Hot Module Replacement) to update snapshot definitions.
+ * Deserializes a stringified snapshot creator for HMR.
  */
 function evaluate<T>(code: string): T {
   if (__DEV__) {
-    // We are using `eval` here to make the updated snapshot to access variables like `__webpack_require__`.
-    // See: https://github.com/lynx-family/lynx-stack/issues/983.
+    // Creators are self-contained: the runtime is injected as a call argument
+    // (see `SnapshotCreator`), so the evaluated code needs nothing from this
+    // scope.
     return eval(`(() => ${code})()`) as T;
   }
   throw new Error('unreachable: evaluate is not supported in production');

--- a/packages/react/runtime/src/snapshot/snapshot/backgroundSnapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/backgroundSnapshot.ts
@@ -19,6 +19,7 @@ import { reconstructInstanceTree } from './reconstructInstanceTree.js';
 import { clearQueuedRefs, clearRef, getRefFromValue, queueRefAttrUpdate } from './ref.js';
 import type { Ref } from './ref.js';
 import { snapshotCreatorMap } from './snapshot.js';
+import { snapshotCreatorRuntime } from './snapshotCreatorMap.js';
 import { hydrationMap } from './snapshotInstanceHydrationMap.js';
 import { transformSpread } from './spread.js';
 import type { SerializedSnapshotInstance } from './types.js';
@@ -155,7 +156,7 @@ export class BackgroundSnapshotInstance {
     // Suspense uses 'div'
     if (!snapshotManager.values.has(type) && type !== 'div') {
       if (snapshotCreatorMap[type]) {
-        snapshotCreatorMap[type](type);
+        snapshotCreatorMap[type](type, snapshotCreatorRuntime);
       } else if (isCloneSnapshot(type)) {
         createCloneSnapshot(type);
       } else if (isCompiledSnapshot(type)) {

--- a/packages/react/runtime/src/snapshot/snapshot/definition.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/definition.ts
@@ -14,7 +14,7 @@ import {
 } from './dynamicPartType.js';
 import { snapshotCreateList } from './list.js';
 import type { SnapshotInstance } from './snapshot.js';
-import { snapshotCreatorMap } from './snapshotCreatorMap.js';
+import { snapshotCreatorMap, snapshotCreatorRuntime } from './snapshotCreatorMap.js';
 import { updateSpread } from './spread.js';
 import { entryUniqID, getCloneSnapshotInfo } from './utils.js';
 import { SnapshotOperation, __globalSnapshotPatch } from '../lifecycle/patch/snapshotPatch.js';
@@ -225,7 +225,7 @@ export function createCloneSnapshot(type: string): void {
   // get the original snapshot definition
   let originalDef = snapshotManager.values.get(originalType);
   if (!originalDef) {
-    snapshotCreatorMap[originalType]?.(originalType);
+    snapshotCreatorMap[originalType]?.(originalType, snapshotCreatorRuntime);
     originalDef = snapshotManager.values.get(originalType);
   }
   if (!originalDef) {

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -18,7 +18,8 @@ import { snapshotDestroyList } from './list.js';
 import { getListItemPlatformInfoFromIndexedValue } from './platformInfo.js';
 import type { PlatformInfo } from './platformInfo.js';
 import { unref } from './ref.js';
-import { setSnapshotCreatorMap, snapshotCreatorMap } from './snapshotCreatorMap.js';
+import { setSnapshotCreatorMap, snapshotCreatorMap, snapshotCreatorRuntime } from './snapshotCreatorMap.js';
+import type { SnapshotCreator } from './snapshotCreatorMap.js';
 import type { SerializedSnapshotInstance } from './types.js';
 import { isCloneSnapshot, isCompiledSnapshot, traverseSnapshotInstance } from './utils.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
@@ -107,7 +108,7 @@ export { snapshotCreatorMap } from './snapshotCreatorMap.js';
 if (__DEV__ && __JS__) {
   setSnapshotCreatorMap(
     new Proxy(snapshotCreatorMap, {
-      set(target, prop: string, value: (uniqId: string) => string) {
+      set(target, prop: string, value: SnapshotCreator) {
         if (
           // `__globalSnapshotPatch` does not exist before hydration,
           // so the snapshot of the first screen will not be sent to the main thread.
@@ -158,7 +159,7 @@ export class SnapshotInstance {
     // Suspense uses 'div'
     if (!snapshotManager.values.has(type) && type !== 'div') {
       if (snapshotCreatorMap[type]) {
-        snapshotCreatorMap[type](type);
+        snapshotCreatorMap[type](type, snapshotCreatorRuntime);
       } else if (isCloneSnapshot(type)) {
         createCloneSnapshot(type);
       } else if (isCompiledSnapshot(type)) {

--- a/packages/react/runtime/src/snapshot/snapshot/snapshotCreatorMap.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshotCreatorMap.ts
@@ -2,9 +2,30 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-type SnapshotCreatorMap = Record<string, (uniqId: string) => string>;
+/**
+ * The internal-runtime namespace passed to a snapshot creator as its second
+ * argument. Dev creators are stringified for cross-thread HMR
+ * (`DEV_ONLY_AddSnapshot`), so they must not capture module bindings — the
+ * caller injects the runtime instead. Production creators close over their
+ * own module's runtime import (statically tree-shakeable) and ignore it.
+ */
+export type SnapshotCreatorRuntime = typeof import('../../internal.js');
+
+export type SnapshotCreator = (uniqId: string, runtime?: SnapshotCreatorRuntime) => string;
+
+type SnapshotCreatorMap = Record<string, SnapshotCreator>;
 export let snapshotCreatorMap: SnapshotCreatorMap = {};
 
 export function setSnapshotCreatorMap(map: SnapshotCreatorMap): void {
   snapshotCreatorMap = map;
+}
+
+/**
+ * Set only in `__DEV__` (by `internal.js` registering its own namespace), so
+ * production keeps no reference to the full runtime namespace.
+ */
+export let snapshotCreatorRuntime: SnapshotCreatorRuntime | undefined;
+
+export function setSnapshotCreatorRuntime(runtime: SnapshotCreatorRuntime): void {
+  snapshotCreatorRuntime = runtime;
 }

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -61,27 +61,6 @@ fn lazy_runtime_id(init: impl FnOnce() -> Expr + 'static) -> Lazy<Expr, RuntimeI
   Lazy::new(Box::new(init))
 }
 
-fn require_runtime_id(runtime_pkg: String) -> Lazy<Expr, RuntimeIdInitializer> {
-  lazy_runtime_id(move || {
-    Expr::Call(CallExpr {
-      ctxt: SyntaxContext::default(),
-      span: DUMMY_SP,
-      callee: Callee::Expr(Box::new(Expr::Ident(
-        IdentName::new("require".into(), DUMMY_SP).into(),
-      ))),
-      args: vec![ExprOrSpread {
-        spread: None,
-        expr: Box::new(Expr::Lit(Lit::Str(Str {
-          span: DUMMY_SP,
-          value: runtime_pkg.into(),
-          raw: None,
-        }))),
-      }],
-      type_args: None,
-    })
-  })
-}
-
 fn jsx_expr_attr(name: &str, expr: Expr) -> JSXAttrOrSpread {
   JSXAttrOrSpread::JSXAttr(JSXAttr {
     span: DUMMY_SP,
@@ -278,30 +257,16 @@ where
   pub fn new_with_element_templates(
     cfg: JSXTransformerConfig,
     comments: Option<C>,
-    mode: TransformMode,
+    _mode: TransformMode,
     _source_map: Option<Lrc<SourceMap>>,
     element_templates: Option<Rc<RefCell<Vec<ElementTemplateAsset>>>>,
   ) -> Self {
     JSXTransformer {
       content_hash: "test".into(),
-      runtime_id: match mode {
-        TransformMode::Development => {
-          let runtime_pkg = cfg.runtime_pkg.clone();
-          require_runtime_id(runtime_pkg)
-        }
-        TransformMode::Production | TransformMode::Test => {
-          lazy_runtime_id(|| Expr::Ident(private_ident!("ReactLynx")))
-        }
-      },
-      internal_runtime_id: match mode {
-        TransformMode::Development => {
-          let runtime_pkg = internal_runtime_pkg(&cfg.runtime_pkg);
-          require_runtime_id(runtime_pkg)
-        }
-        TransformMode::Production | TransformMode::Test => {
-          lazy_runtime_id(|| Expr::Ident(private_ident!("ReactLynxInternal")))
-        }
-      },
+      // All modes bind the runtimes via the imports prepended in
+      // `visit_mut_module` (see the ident-gated `prepend_stmt` calls).
+      runtime_id: lazy_runtime_id(|| Expr::Ident(private_ident!("ReactLynx"))),
+      internal_runtime_id: lazy_runtime_id(|| Expr::Ident(private_ident!("ReactLynxInternal"))),
       element_templates,
       cfg,
       template_idents_by_canonical_content: HashMap::new(),

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
@@ -716,7 +716,8 @@ fn should_not_use_snapshot_ref_transform_in_element_template_mode() {
     TransformMode::Development,
   );
 
-  assert!(code.contains(r#"require("@custom/react/internal").adaptRefAttrSlot"#));
+  assert!(code.contains(r#"import * as ReactLynxInternal from "@custom/react/internal""#));
+  assert!(code.contains("ReactLynxInternal.adaptRefAttrSlot"));
   assert!(code.contains("viewRef"));
   assert!(!code.contains("transformRef"));
   assert!(!code.contains("@lynx-js/react/internal"));

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_snapshot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_snapshot.js
@@ -1,45 +1,45 @@
 import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_3, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_4, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
-        const pageId = __runtime__.__pageId;
-        const el = __runtime__.snapshotCreateList(pageId, snapshotInstance, 0);
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = (__runtime__ || require("@lynx-js/react")).snapshotCreateList(pageId, snapshotInstance, 0);
         return [
             el
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartListSlotV2,
+            (__runtime__ || require("@lynx-js/react")).__DynamicPartListSlotV2,
             0
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         return [
             el
         ];
-    }, null, __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+    }, null, (__runtime__ || require("@lynx-js/react")).__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 <__snapshot_da39a_test_1 $0={<__snapshot_da39a_test_2 $0={[
     <__snapshot_da39a_test_3 key="1" values={[
         {

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_snapshot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_snapshot.js
@@ -1,44 +1,45 @@
+import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_3, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_4, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
-        const pageId = require('@lynx-js/react/internal').__pageId;
-        const el = require('@lynx-js/react/internal').snapshotCreateList(pageId, snapshotInstance, 0);
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
+        const pageId = __runtime__.__pageId;
+        const el = __runtime__.snapshotCreateList(pageId, snapshotInstance, 0);
         return [
             el
         ];
     }, null, [
         [
-            require('@lynx-js/react/internal').__DynamicPartListSlotV2,
+            __runtime__.__DynamicPartListSlotV2,
             0
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         return [
             el
         ];
-    }, null, require('@lynx-js/react/internal').__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+    }, null, __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 <__snapshot_da39a_test_1 $0={<__snapshot_da39a_test_2 $0={[
     <__snapshot_da39a_test_3 key="1" values={[
         {

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_static_sibling_with_snapshot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_static_sibling_with_snapshot.js
@@ -1,39 +1,40 @@
+import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_3, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_4, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
-        const pageId = require('@lynx-js/react/internal').__pageId;
-        const el = require('@lynx-js/react/internal').snapshotCreateList(pageId, snapshotInstance, 0);
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
+        const pageId = __runtime__.__pageId;
+        const el = __runtime__.snapshotCreateList(pageId, snapshotInstance, 0);
         return [
             el
         ];
     }, null, [
         [
-            require('@lynx-js/react/internal').__DynamicPartListSlotV2,
+            __runtime__.__DynamicPartListSlotV2,
             0
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateWrapperElement(pageId);
         __AppendElement(el, el1);
@@ -46,7 +47,7 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] =
         ];
     }, null, [
         [
-            require('@lynx-js/react/internal').__DynamicPartSlotV2,
+            __runtime__.__DynamicPartSlotV2,
             1
         ]
     ], undefined, globDynamicComponentEntry, null, true);

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_static_sibling_with_snapshot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_static_sibling_with_snapshot.js
@@ -1,40 +1,40 @@
 import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_3, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_4, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
-        const pageId = __runtime__.__pageId;
-        const el = __runtime__.snapshotCreateList(pageId, snapshotInstance, 0);
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = (__runtime__ || require("@lynx-js/react")).snapshotCreateList(pageId, snapshotInstance, 0);
         return [
             el
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartListSlotV2,
+            (__runtime__ || require("@lynx-js/react")).__DynamicPartListSlotV2,
             0
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateWrapperElement(pageId);
         __AppendElement(el, el1);
@@ -47,7 +47,7 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartSlotV2,
+            (__runtime__ || require("@lynx-js/react")).__DynamicPartSlotV2,
             1
         ]
     ], undefined, globDynamicComponentEntry, null, true);

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_static_sibling_with_snapshot_nested.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_static_sibling_with_snapshot_nested.js
@@ -1,59 +1,60 @@
+import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_3, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_4, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_7 = "__snapshot_da39a_test_7";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_7, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_7, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_8 = "__snapshot_da39a_test_8";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_8] = (__snapshot_da39a_test_8)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_8, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_8] = (__snapshot_da39a_test_8, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_8, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_6 = "__snapshot_da39a_test_6";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_6, function(snapshotInstance) {
-        const pageId = require('@lynx-js/react/internal').__pageId;
-        const el = require('@lynx-js/react/internal').snapshotCreateList(pageId, snapshotInstance, 0);
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_6, function(snapshotInstance) {
+        const pageId = __runtime__.__pageId;
+        const el = __runtime__.snapshotCreateList(pageId, snapshotInstance, 0);
         return [
             el
         ];
     }, null, [
         [
-            require('@lynx-js/react/internal').__DynamicPartListSlotV2,
+            __runtime__.__DynamicPartListSlotV2,
             0
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_5 = "__snapshot_da39a_test_5";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_5, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_5, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         const el1 = __CreateView(pageId);
         __AppendElement(el, el1);
@@ -68,29 +69,29 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_5] =
             el3
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], [
         [
-            require('@lynx-js/react/internal').__DynamicPartSlotV2,
+            __runtime__.__DynamicPartSlotV2,
             2
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
-        const pageId = require('@lynx-js/react/internal').__pageId;
-        const el = require('@lynx-js/react/internal').snapshotCreateList(pageId, snapshotInstance, 0);
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
+        const pageId = __runtime__.__pageId;
+        const el = __runtime__.snapshotCreateList(pageId, snapshotInstance, 0);
         return [
             el
         ];
     }, null, [
         [
-            require('@lynx-js/react/internal').__DynamicPartListSlotV2,
+            __runtime__.__DynamicPartListSlotV2,
             0
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateWrapperElement(pageId);
         __AppendElement(el, el1);
@@ -103,7 +104,7 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] =
         ];
     }, null, [
         [
-            require('@lynx-js/react/internal').__DynamicPartSlotV2,
+            __runtime__.__DynamicPartSlotV2,
             1
         ]
     ], undefined, globDynamicComponentEntry, null, true);

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_static_sibling_with_snapshot_nested.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_in_view_with_static_sibling_with_snapshot_nested.js
@@ -1,60 +1,60 @@
 import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_3, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_4, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_7 = "__snapshot_da39a_test_7";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_7, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_7, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_8 = "__snapshot_da39a_test_8";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_8] = (__snapshot_da39a_test_8, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_8, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_8] = (__snapshot_da39a_test_8, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_8, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_6 = "__snapshot_da39a_test_6";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_6, function(snapshotInstance) {
-        const pageId = __runtime__.__pageId;
-        const el = __runtime__.snapshotCreateList(pageId, snapshotInstance, 0);
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_6, function(snapshotInstance) {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = (__runtime__ || require("@lynx-js/react")).snapshotCreateList(pageId, snapshotInstance, 0);
         return [
             el
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartListSlotV2,
+            (__runtime__ || require("@lynx-js/react")).__DynamicPartListSlotV2,
             0
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_5 = "__snapshot_da39a_test_5";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_5, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_5, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         const el1 = __CreateView(pageId);
         __AppendElement(el, el1);
@@ -69,29 +69,29 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5
             el3
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
     ], [
         [
-            __runtime__.__DynamicPartSlotV2,
+            (__runtime__ || require("@lynx-js/react")).__DynamicPartSlotV2,
             2
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
-        const pageId = __runtime__.__pageId;
-        const el = __runtime__.snapshotCreateList(pageId, snapshotInstance, 0);
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = (__runtime__ || require("@lynx-js/react")).snapshotCreateList(pageId, snapshotInstance, 0);
         return [
             el
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartListSlotV2,
+            (__runtime__ || require("@lynx-js/react")).__DynamicPartListSlotV2,
             0
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateWrapperElement(pageId);
         __AppendElement(el, el1);
@@ -104,7 +104,7 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartSlotV2,
+            (__runtime__ || require("@lynx-js/react")).__DynamicPartSlotV2,
             1
         ]
     ], undefined, globDynamicComponentEntry, null, true);

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_item_deferred_with_children_with_snapshot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_item_deferred_with_children_with_snapshot.js
@@ -1,7 +1,8 @@
+import * as ReactLynx from "@lynx-js/react";
 import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         __SetInlineStyles(el, "color: red; width: 100rpx;");
         __SetClasses(el, "x");
@@ -9,28 +10,28 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] =
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0),
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
-    ], require('@lynx-js/react/internal').__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_2, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         return [
             el
         ];
     }, null, null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_3, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateText(pageId);
         return [
             el
         ];
     }, null, null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_4, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateImage(pageId);
         return [
             el
@@ -47,8 +48,8 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_4] =
         <__snapshot_da39a_test_4/>
     ]} key="1" defer/>;
 const __snapshot_da39a_test_5 = "__snapshot_da39a_test_5";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_5, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_5, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         __SetInlineStyles(el, "color: red; width: 100rpx;");
         __SetClasses(el, "x");
@@ -56,12 +57,12 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_5] =
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0),
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
-    ], require('@lynx-js/react/internal').__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_6 = "__snapshot_da39a_test_6";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_6, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_6, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         return [
             el
@@ -74,8 +75,8 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_6] =
         noop
     ]} __listItemPlatformInfoIndex={0} $0={__c}/>} renderChildren={()=><__snapshot_da39a_test_6/>} key="1" defer/>;
 const __snapshot_da39a_test_7 = "__snapshot_da39a_test_7";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_7, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_7, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateElement("list-item", pageId);
         __SetInlineStyles(el, "color: red; width: 100rpx;");
         __SetClasses(el, "x");
@@ -83,9 +84,9 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_7] =
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateListItemPlatformInfo(snapshot, index, oldValue, 0),
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
-    ], require('@lynx-js/react/internal').__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 <ReactLynxRuntimeComponents.DeferredListItem renderListItem={(__c)=><__snapshot_da39a_test_7 values={[
         {
             "item-key": "1"

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_item_deferred_with_children_with_snapshot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/lib.rs/should_transform_list_item_deferred_with_children_with_snapshot.js
@@ -1,8 +1,8 @@
 import * as ReactLynx from "@lynx-js/react";
 import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         __SetInlineStyles(el, "color: red; width: 100rpx;");
         __SetClasses(el, "x");
@@ -10,28 +10,28 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0),
-        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
-    ], __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], (__runtime__ || require("@lynx-js/react")).__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_2, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         return [
             el
         ];
     }, null, null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_3, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateText(pageId);
         return [
             el
         ];
     }, null, null, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_4, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateImage(pageId);
         return [
             el
@@ -48,8 +48,8 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4
         <__snapshot_da39a_test_4/>
     ]} key="1" defer/>;
 const __snapshot_da39a_test_5 = "__snapshot_da39a_test_5";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_5, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_5, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         __SetInlineStyles(el, "color: red; width: 100rpx;");
         __SetClasses(el, "x");
@@ -57,12 +57,12 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0),
-        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
-    ], __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], (__runtime__ || require("@lynx-js/react")).__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 const __snapshot_da39a_test_6 = "__snapshot_da39a_test_6";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_6, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_6, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         return [
             el
@@ -75,8 +75,8 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6
         noop
     ]} __listItemPlatformInfoIndex={0} $0={__c}/>} renderChildren={()=><__snapshot_da39a_test_6/>} key="1" defer/>;
 const __snapshot_da39a_test_7 = "__snapshot_da39a_test_7";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_7, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_7, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateElement("list-item", pageId);
         __SetInlineStyles(el, "color: red; width: 100rpx;");
         __SetClasses(el, "x");
@@ -84,9 +84,9 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateListItemPlatformInfo(snapshot, index, oldValue, 0),
-        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
-    ], __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], (__runtime__ || require("@lynx-js/react")).__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 <ReactLynxRuntimeComponents.DeferredListItem renderListItem={(__c)=><__snapshot_da39a_test_7 values={[
         {
             "item-key": "1"

--- a/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
@@ -1159,6 +1159,7 @@ where
   filename_hash: String,
   content_hash: String,
   runtime_id: Lazy<Expr>,
+  dev_creator_param: bool,
   runtime_components_ident: Ident,
   runtime_components_module_item: Option<ModuleItem>,
   css_id_value: Option<Expr>,
@@ -1188,15 +1189,15 @@ where
     JSXTransformer {
       filename_hash: calc_hash(&cfg.filename.clone()),
       content_hash: "test".into(),
-      runtime_id: match mode {
-        TransformMode::Development => {
-          // We should find a way to use `cfg.runtime_pkg`
-          Lazy::new(|| quote!("require('@lynx-js/react/internal')" as Expr))
-        }
-        TransformMode::Production | TransformMode::Test => {
-          Lazy::new(|| Expr::Ident(private_ident!("ReactLynx")))
-        }
-      },
+      // Bound via the `import * as ReactLynx from <cfg.runtime_pkg>` prepended
+      // in `visit_mut_module` — no dev-only `require()`, so promise (async)
+      // externals are awaited through the regular import machinery.
+      runtime_id: Lazy::new(|| Expr::Ident(private_ident!("ReactLynx"))),
+      // Dev creators are stringified for cross-thread HMR
+      // (`DEV_ONLY_AddSnapshot`) and take the runtime as an arrow parameter
+      // instead of capturing module bindings. Production creators keep the
+      // module-scope reference, which stays statically tree-shakeable.
+      dev_creator_param: matches!(mode, TransformMode::Development),
       runtime_components_ident: private_ident!("ReactLynxRuntimeComponents"),
       runtime_components_module_item: None,
       cfg,
@@ -1321,6 +1322,16 @@ where
 
     let target = self.cfg.target;
     let runtime_id = self.runtime_id.clone();
+    // In dev the creator arrow is stringified for cross-thread HMR
+    // (`DEV_ONLY_AddSnapshot`), so everything inside it references the runtime
+    // through the arrow's own parameter; in production it keeps the
+    // module-scope import binding (statically tree-shakeable).
+    let creator_runtime_id = private_ident!("__runtime__");
+    let creator_runtime_expr = if self.dev_creator_param {
+      Expr::Ident(creator_runtime_id.clone())
+    } else {
+      self.runtime_id.clone()
+    };
     let filename_hash = self.filename_hash.clone();
     let content_hash = self.content_hash.clone();
     let ui_source_map_records = self.ui_source_map_records.clone();
@@ -1355,7 +1366,7 @@ where
     };
 
     let mut dynamic_part_extractor = DynamicPartExtractor::new(
-      self.runtime_id.clone(),
+      creator_runtime_expr.clone(),
       self,
       self.cfg.enable_ui_source_map,
       node_index_fn,
@@ -1401,7 +1412,7 @@ where
           snapshot_dynamic_part_def.push(Some(ExprOrSpread {
             spread: None,
             expr: Box::new(dynamic_part.to_updater(
-              runtime_id.clone(),
+              creator_runtime_expr.clone(),
               target,
               snapshot_dynamic_part_def.len() as i32,
             )),
@@ -1461,7 +1472,7 @@ where
         snapshot_children.push(expr.clone());
         quote!(
           "$runtime_id.__DynamicPartSlotV2_0" as Expr,
-          runtime_id: Expr = runtime_id.clone(),
+          runtime_id: Expr = creator_runtime_expr.clone(),
         )
       }
       _ => {
@@ -1476,7 +1487,7 @@ where
                 spread: None,
                 expr: Box::new(quote!(
                   "[$runtime_id.__DynamicPartListSlotV2, $element_index]" as Expr,
-                  runtime_id: Expr = runtime_id.clone(),
+                  runtime_id: Expr = creator_runtime_expr.clone(),
                   element_index: Expr = i32_to_expr(&element_index),
                 )),
               }));
@@ -1487,7 +1498,7 @@ where
                 spread: None,
                 expr: Box::new(quote!(
                   "[$runtime_id.__DynamicPartSlotV2, $element_index]" as Expr,
-                  runtime_id: Expr = runtime_id.clone(),
+                  runtime_id: Expr = creator_runtime_expr.clone(),
                   element_index: Expr = i32_to_expr(&element_index),
                 )),
               }));
@@ -1520,37 +1531,70 @@ where
       Expr::Ident("globDynamicComponentEntry".into())
     };
 
-    let snapshot_create_call = quote!(
-        r#"$runtime_id.snapshotCreatorMap[$snapshot_id] = ($snapshot_id) => $runtime_id.createSnapshot(
-             $snapshot_id,
-             $snapshot_creator,
-             $snapshot_dynamic_parts_def,
-             $slot,
-             $css_id,
-             $entry_name,
-             $snapshot_refs_and_spread_index,
-             true
-        )"# as Expr,
-        runtime_id: Expr = self.runtime_id.clone(),
-        snapshot_id = snapshot_id.clone(),
-        entry_name: Expr = entry_name,
-        snapshot_creator: Expr = snapshot_creator,
-        snapshot_dynamic_parts_def: Expr = match (target, snapshot_dynamic_part_def.len()) {
-          (TransformTarget::JS, _) | (_, 0) => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
-          _ => Expr::Array(ArrayLit { span: DUMMY_SP, elems: snapshot_dynamic_part_def }),
-        },
-        slot: Expr = slot_expr,
-        css_id: Expr = match &self.css_id_value {
-          Some(css_id_expr) => css_id_expr.clone(),
-          // We use `undefined` here since runtime will skip `__SetCSSId` when `cssId === undefined && entryName === undefined`
-          None => Expr::Ident("undefined".into()),
-        },
-        snapshot_refs_and_spread_index: Expr = match snapshot_refs_and_spread_index.len() {
-          0 => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
-          _ => Expr::Array(ArrayLit { span: DUMMY_SP, elems: snapshot_refs_and_spread_index }),
-        },
-        // has_multi_children: Expr = Expr::Lit(Lit::Num(Number { span: DUMMY_SP, value: wrap_dynamic_part.dynamic_part_count as f64, raw: None })),
-    );
+    let snapshot_dynamic_parts_def: Expr = match (target, snapshot_dynamic_part_def.len()) {
+      (TransformTarget::JS, _) | (_, 0) => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+      _ => Expr::Array(ArrayLit {
+        span: DUMMY_SP,
+        elems: snapshot_dynamic_part_def,
+      }),
+    };
+    let css_id: Expr = match &self.css_id_value {
+      Some(css_id_expr) => css_id_expr.clone(),
+      // We use `undefined` here since runtime will skip `__SetCSSId` when `cssId === undefined && entryName === undefined`
+      None => Expr::Ident("undefined".into()),
+    };
+    let snapshot_refs_and_spread_index: Expr = match snapshot_refs_and_spread_index.len() {
+      0 => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+      _ => Expr::Array(ArrayLit {
+        span: DUMMY_SP,
+        elems: snapshot_refs_and_spread_index,
+      }),
+    };
+
+    let snapshot_create_call = if self.dev_creator_param {
+      quote!(
+          r#"$runtime_id.snapshotCreatorMap[$snapshot_id] = ($snapshot_id, $creator_runtime) => $creator_runtime.createSnapshot(
+               $snapshot_id,
+               $snapshot_creator,
+               $snapshot_dynamic_parts_def,
+               $slot,
+               $css_id,
+               $entry_name,
+               $snapshot_refs_and_spread_index,
+               true
+          )"# as Expr,
+          runtime_id: Expr = self.runtime_id.clone(),
+          creator_runtime = creator_runtime_id.clone(),
+          snapshot_id = snapshot_id.clone(),
+          entry_name: Expr = entry_name,
+          snapshot_creator: Expr = snapshot_creator,
+          snapshot_dynamic_parts_def: Expr = snapshot_dynamic_parts_def,
+          slot: Expr = slot_expr,
+          css_id: Expr = css_id,
+          snapshot_refs_and_spread_index: Expr = snapshot_refs_and_spread_index,
+      )
+    } else {
+      quote!(
+          r#"$runtime_id.snapshotCreatorMap[$snapshot_id] = ($snapshot_id) => $runtime_id.createSnapshot(
+               $snapshot_id,
+               $snapshot_creator,
+               $snapshot_dynamic_parts_def,
+               $slot,
+               $css_id,
+               $entry_name,
+               $snapshot_refs_and_spread_index,
+               true
+          )"# as Expr,
+          runtime_id: Expr = self.runtime_id.clone(),
+          snapshot_id = snapshot_id.clone(),
+          entry_name: Expr = entry_name,
+          snapshot_creator: Expr = snapshot_creator,
+          snapshot_dynamic_parts_def: Expr = snapshot_dynamic_parts_def,
+          slot: Expr = slot_expr,
+          css_id: Expr = css_id,
+          snapshot_refs_and_spread_index: Expr = snapshot_refs_and_spread_index,
+      )
+    };
 
     let mut entry_snapshot_uid = quote!("$snapshot_uid" as Expr, snapshot_uid: Expr = Expr::Lit(Lit::Str(snapshot_uid.clone().into())));
     if matches!(self.cfg.is_dynamic_component, Some(true)) {

--- a/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
@@ -1328,7 +1328,18 @@ where
     // module-scope import binding (statically tree-shakeable).
     let creator_runtime_id = private_ident!("__runtime__");
     let creator_runtime_expr = if self.dev_creator_param {
-      Expr::Ident(creator_runtime_id.clone())
+      // `__runtime__` is passed by runtimes that pass `SnapshotCreator`'s
+      // second argument; the inline `require` keeps the compiled output
+      // working on older runtimes that still call creators with a single
+      // argument (they load synchronously, so the pending-promise issue the
+      // parameter solves cannot occur there).
+      // TODO(compat): drop the `require` fallback once runtimes without
+      // `snapshotCreatorRuntime` are out of support.
+      quote!(
+        "($creator_runtime || require($runtime_pkg))" as Expr,
+        creator_runtime = creator_runtime_id.clone(),
+        runtime_pkg: Expr = Expr::Lit(Lit::Str(self.cfg.runtime_pkg.clone().into())),
+      )
     } else {
       self.runtime_id.clone()
     };
@@ -1553,7 +1564,7 @@ where
 
     let snapshot_create_call = if self.dev_creator_param {
       quote!(
-          r#"$runtime_id.snapshotCreatorMap[$snapshot_id] = ($snapshot_id, $creator_runtime) => $creator_runtime.createSnapshot(
+          r#"$runtime_id.snapshotCreatorMap[$snapshot_id] = ($snapshot_id, $creator_runtime) => $creator_runtime_ref.createSnapshot(
                $snapshot_id,
                $snapshot_creator,
                $snapshot_dynamic_parts_def,
@@ -1565,6 +1576,7 @@ where
           )"# as Expr,
           runtime_id: Expr = self.runtime_id.clone(),
           creator_runtime = creator_runtime_id.clone(),
+          creator_runtime_ref: Expr = creator_runtime_expr.clone(),
           snapshot_id = snapshot_id.clone(),
           entry_name: Expr = entry_name,
           snapshot_creator: Expr = snapshot_creator,

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_event.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_event.js
@@ -1,7 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -13,7 +14,7 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] =
             el2
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateEvent(snapshot, index, oldValue, 1, "bindEvent", "tap", '')
+        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 1, "bindEvent", "tap", '')
     ], null, undefined, globDynamicComponentEntry, null, true);
 function Comp() {
     const handleTap = ()=>{};

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_event.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_event.js
@@ -1,8 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -14,7 +14,7 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1
             el2
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 1, "bindEvent", "tap", '')
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateEvent(snapshot, index, oldValue, 1, "bindEvent", "tap", '')
     ], null, undefined, globDynamicComponentEntry, null, true);
 function Comp() {
     const handleTap = ()=>{};

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_ref.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_ref.js
@@ -1,7 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -25,9 +26,9 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] =
             el6
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateRef(snapshot, index, oldValue, 1),
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateEvent(snapshot, index, oldValue, 3, "bindEvent", "tap", ''),
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateRef(snapshot, index, oldValue, 5)
+        (snapshot, index, oldValue)=>__runtime__.updateRef(snapshot, index, oldValue, 1),
+        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 3, "bindEvent", "tap", ''),
+        (snapshot, index, oldValue)=>__runtime__.updateRef(snapshot, index, oldValue, 5)
     ], null, undefined, globDynamicComponentEntry, [
         0,
         2
@@ -36,9 +37,9 @@ function Comp() {
     const handleRef = ()=>{};
     return _jsx(__snapshot_da39a_test_1, {
         values: [
-            require('@lynx-js/react/internal').transformRef(handleRef),
+            ReactLynx.transformRef(handleRef),
             handleRef,
-            require('@lynx-js/react/internal').transformRef(handleRef)
+            ReactLynx.transformRef(handleRef)
         ]
     });
 }

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_ref.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_ref.js
@@ -1,8 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -26,9 +26,9 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1
             el6
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateRef(snapshot, index, oldValue, 1),
-        (snapshot, index, oldValue)=>__runtime__.updateEvent(snapshot, index, oldValue, 3, "bindEvent", "tap", ''),
-        (snapshot, index, oldValue)=>__runtime__.updateRef(snapshot, index, oldValue, 5)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateRef(snapshot, index, oldValue, 1),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateEvent(snapshot, index, oldValue, 3, "bindEvent", "tap", ''),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateRef(snapshot, index, oldValue, 5)
     ], null, undefined, globDynamicComponentEntry, [
         0,
         2

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_timing_flag.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_timing_flag.js
@@ -1,8 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_timing_flag.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/basic_timing_flag.js
@@ -1,7 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/gesture.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/gesture.js
@@ -1,7 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -13,7 +14,7 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] =
             el2
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateGesture(snapshot, index, oldValue, 1, "main-thread")
+        (snapshot, index, oldValue)=>__runtime__.updateGesture(snapshot, index, oldValue, 1, "main-thread")
     ], null, undefined, globDynamicComponentEntry, null, true);
 function Comp() {
     const gesture = {};

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/gesture.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/gesture.js
@@ -1,8 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -14,7 +14,7 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1
             el2
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateGesture(snapshot, index, oldValue, 1, "main-thread")
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateGesture(snapshot, index, oldValue, 1, "main-thread")
     ], null, undefined, globDynamicComponentEntry, null, true);
 function Comp() {
     const gesture = {};

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/mode_development_spread.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/mode_development_spread.js
@@ -1,13 +1,13 @@
 import * as ReactLynx from "@lynx-js/react/internal";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react/internal")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react/internal")).__pageId;
         const el = __CreateView(pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateSpread(snapshot, index, oldValue, 0, false)
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react/internal")).updateSpread(snapshot, index, oldValue, 0, false)
     ], null, undefined, globDynamicComponentEntry, [
         0
     ], true);

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/mode_development_spread.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/mode_development_spread.js
@@ -1,12 +1,13 @@
+import * as ReactLynx from "@lynx-js/react/internal";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         return [
             el
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateSpread(snapshot, index, oldValue, 0, false)
+        (snapshot, index, oldValue)=>__runtime__.updateSpread(snapshot, index, oldValue, 0, false)
     ], null, undefined, globDynamicComponentEntry, [
         0
     ], true);

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/page_element_dev.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/page_element_dev.js
@@ -1,12 +1,13 @@
+import * as ReactLynx from "@lynx-js/react";
 import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         return [
             el
         ];
-    }, null, require('@lynx-js/react/internal').__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+    }, null, __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 <ReactLynxRuntimeComponents.Page custom-key-str="custom-value" custom-key-var={customVariable} class="classValue" data-attr={dataAttr}>
       <__snapshot_da39a_test_1 $0={[
     <ReactLynxRuntimeComponents.Page/>,

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/page_element_dev.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/page_element_dev.js
@@ -1,13 +1,13 @@
 import * as ReactLynx from "@lynx-js/react";
 import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         return [
             el
         ];
-    }, null, __runtime__.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
+    }, null, (__runtime__ || require("@lynx-js/react")).__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
 <ReactLynxRuntimeComponents.Page custom-key-str="custom-value" custom-key-var={customVariable} class="classValue" data-attr={dataAttr}>
       <__snapshot_da39a_test_1 $0={[
     <ReactLynxRuntimeComponents.Page/>,

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/worklet.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/worklet.js
@@ -1,8 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
 import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = __runtime__.__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -20,8 +20,8 @@ ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1
             el4
         ];
     }, [
-        (snapshot, index, oldValue)=>__runtime__.updateWorkletEvent(snapshot, index, oldValue, 1, "main-thread", "bindEvent", "tap"),
-        (snapshot, index, oldValue)=>__runtime__.updateWorkletRef(snapshot, index, oldValue, 3, "main-thread")
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateWorkletEvent(snapshot, index, oldValue, 1, "main-thread", "bindEvent", "tap"),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateWorkletRef(snapshot, index, oldValue, 3, "main-thread")
     ], null, undefined, globDynamicComponentEntry, null, true);
 function Comp() {
     const handleTap = ()=>{};

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/worklet.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/worklet.js
@@ -1,7 +1,8 @@
 import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+import * as ReactLynx from "@lynx-js/react";
 const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
-require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>require('@lynx-js/react/internal').createSnapshot(__snapshot_da39a_test_1, function() {
-        const pageId = require('@lynx-js/react/internal').__pageId;
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -19,8 +20,8 @@ require('@lynx-js/react/internal').snapshotCreatorMap[__snapshot_da39a_test_1] =
             el4
         ];
     }, [
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateWorkletEvent(snapshot, index, oldValue, 1, "main-thread", "bindEvent", "tap"),
-        (snapshot, index, oldValue)=>require('@lynx-js/react/internal').updateWorkletRef(snapshot, index, oldValue, 3, "main-thread")
+        (snapshot, index, oldValue)=>__runtime__.updateWorkletEvent(snapshot, index, oldValue, 1, "main-thread", "bindEvent", "tap"),
+        (snapshot, index, oldValue)=>__runtime__.updateWorkletRef(snapshot, index, oldValue, 3, "main-thread")
     ], null, undefined, globDynamicComponentEntry, null, true);
 function Comp() {
     const handleTap = ()=>{};

--- a/packages/rspeedy/plugin-external-bundle/etc/external-bundle-rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-external-bundle/etc/external-bundle-rsbuild-plugin.api.md
@@ -13,6 +13,7 @@ export const builtInExternalsPresetDefinitions: ExternalsPresetDefinitions;
 
 // @public
 export interface ExternalsPresetContext {
+    environmentName?: string;
     rootPath: string;
 }
 

--- a/packages/rspeedy/plugin-external-bundle/src/index.ts
+++ b/packages/rspeedy/plugin-external-bundle/src/index.ts
@@ -213,6 +213,17 @@ export interface ExternalsPresetContext {
    * The current Rsbuild project root path.
    */
   rootPath: string
+
+  /**
+   * The Rsbuild environment being resolved (e.g. `'lynx'`, `'web'`).
+   *
+   * @remarks
+   *
+   * Presets use this to pick environment-specific artifacts — for example the
+   * built-in `reactlynx` preset resolves the web-encoded `react.web.bundle`
+   * for the `web` environment and `react.lynx.bundle` otherwise.
+   */
+  environmentName?: string
 }
 
 /**
@@ -366,9 +377,10 @@ export function normalizeBundlePath(bundlePath: string): string {
 function createBuiltInExternalsPresetDefinitions(): ExternalsPresetDefinitions {
   return {
     reactlynx: {
-      resolveExternals(value) {
+      resolveExternals(value, context) {
         return createReactLynxExternals(
           normalizeReactLynxPreset(value as ExternalsPresets['reactlynx']),
+          isWebEnvironment(context),
         )
       },
       resolveManagedAssets(value, context) {
@@ -378,19 +390,32 @@ function createBuiltInExternalsPresetDefinitions(): ExternalsPresetDefinitions {
         if (!preset || preset.url) {
           return new Map()
         }
+        const isWeb = isWebEnvironment(context)
         return new Map([
           [
-            getDefaultReactLynxBundlePath(preset),
+            getDefaultReactLynxBundlePath(preset, isWeb),
             getReactLynxBundlePath(
               context.rootPath,
               preset.reactUmdPackageName ?? DEFAULT_REACT_UMD_PACKAGE_NAME,
-              preset.async ?? false,
+              isWeb,
             ),
           ],
         ])
       },
     },
   }
+}
+
+// The bundle encoding follows the target environment: `lynx` / `lynx-*`
+// environments decode `tasm` bundles (mirroring rspeedy's `isLynx`
+// convention), every other environment (e.g. `web`) decodes web-encoded
+// bundles. `async` only controls how the external is mounted.
+function isWebEnvironment(context: ExternalsPresetContext): boolean {
+  const name = context.environmentName
+  if (name === undefined) {
+    return false
+  }
+  return name !== 'lynx' && !name.startsWith('lynx-')
 }
 
 function getReactLynxBundlePath(
@@ -569,10 +594,11 @@ function resolvePresetExternals(
 
 function createReactLynxExternals(
   preset: ReactLynxExternalsPresetOptions | undefined,
+  isWeb: boolean,
 ): ExternalsLoadingPluginOptions['externals'] {
   const bundleReference = preset?.url
     ? { url: preset.url }
-    : { bundlePath: getDefaultReactLynxBundlePath(preset) }
+    : { bundlePath: getDefaultReactLynxBundlePath(preset, isWeb) }
 
   return Object.fromEntries(
     Object.entries(reactLynxExternalTemplate).map(([request, external]) => [
@@ -630,11 +656,12 @@ class EmitManagedBundleAssetsPlugin {
 
 function getDefaultReactLynxBundlePath(
   preset: ReactLynxExternalsPresetOptions | undefined,
+  isWeb: boolean,
 ) {
   if (preset?.bundlePath) {
     return normalizeBundlePath(preset.bundlePath)
   }
-  return preset?.async
+  return isWeb
     ? REACT_LYNX_WEB_BUNDLE_FILE_NAME
     : REACT_LYNX_BUNDLE_FILE_NAME
 }
@@ -687,29 +714,6 @@ function getManagedBundleAssets(
         externalBundleRoot,
         normalizeBundlePath(external.bundlePath),
       ),
-    )
-  }
-
-  return assets
-}
-
-function getLocalBundleAssets(
-  options: PluginExternalBundleOptions,
-  presetManagedAssets: ManagedBundleAssets,
-  api: RsbuildPluginAPI,
-  serverBase: string | undefined,
-): Map<string, string> {
-  const assets = new Map<string, string>()
-  for (
-    const [bundlePath, sourcePath] of getManagedBundleAssets(
-      options,
-      presetManagedAssets,
-      api,
-    )
-  ) {
-    assets.set(
-      joinUrlPath(serverBase, bundlePath),
-      sourcePath,
     )
   }
 
@@ -802,23 +806,20 @@ export function pluginExternalBundle(
       const presetDefinitions = resolvePresetDefinitions(
         options.externalsPresetDefinitions,
       )
-      const presetResolution = resolvePresetExternals(
-        options.externalsPresets,
-        presetDefinitions,
-        {
-          rootPath: api.context.rootPath,
-        },
-      )
+      // Presets resolve per environment (in `modifyRspackConfig`, where the
+      // environment name is known); this map collects every environment's
+      // local bundle assets for the dev-server middleware, which reads it at
+      // request time.
+      const localBundleAssets = new Map<string, string>()
+      let serverBase: string | undefined
 
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-        const localBundleAssets = getLocalBundleAssets(
-          options,
-          presetResolution.managedAssets,
-          api,
-          config.server?.base,
-        )
+        serverBase = config.server?.base
 
-        if (localBundleAssets.size === 0) {
+        if (
+          options.externals === undefined
+          && options.externalsPresets === undefined
+        ) {
           return config
         }
 
@@ -860,7 +861,7 @@ export function pluginExternalBundle(
         })
       })
 
-      api.modifyRspackConfig((config) => {
+      api.modifyRspackConfig((config, { environment }) => {
         const LAYERS = api.useExposed<ExposedLayers>(
           Symbol.for('LAYERS'),
         )
@@ -871,6 +872,14 @@ export function pluginExternalBundle(
           )
         }
 
+        const presetResolution = resolvePresetExternals(
+          options.externalsPresets,
+          presetDefinitions,
+          {
+            rootPath: api.context.rootPath,
+            environmentName: environment.name,
+          },
+        )
         const explicitExternals = resolvePluginExternals(
           options.externals,
         )
@@ -883,6 +892,12 @@ export function pluginExternalBundle(
           presetResolution.managedAssets,
           api,
         )
+        for (const [bundlePath, sourcePath] of managedBundleAssets) {
+          localBundleAssets.set(
+            joinUrlPath(serverBase, bundlePath),
+            sourcePath,
+          )
+        }
 
         config.plugins = config.plugins || []
         if (managedBundleAssets.size > 0) {

--- a/packages/rspeedy/plugin-external-bundle/test/index.test.ts
+++ b/packages/rspeedy/plugin-external-bundle/test/index.test.ts
@@ -114,6 +114,9 @@ describe('pluginExternalBundle', () => {
         dev: {
           assetPrefix: 'http://example.com/assets/',
         },
+        environments: {
+          lynx: {},
+        },
         source: {
           entry: {
             main: './fixtures/basic.tsx',
@@ -320,6 +323,9 @@ describe('pluginExternalBundle', () => {
         dev: {
           assetPrefix: 'http://example.com/assets/',
         },
+        environments: {
+          lynx: {},
+        },
         source: {
           entry: {
             main: './fixtures/basic.tsx',
@@ -376,6 +382,9 @@ describe('pluginExternalBundle', () => {
         dev: {
           assetPrefix: 'http://100.82.226.164:<port>/',
         },
+        environments: {
+          lynx: {},
+        },
         source: {
           entry: {
             main: './fixtures/basic.tsx',
@@ -406,6 +415,68 @@ describe('pluginExternalBundle', () => {
     expect(reactExternal?.bundlePath).toBe('react.lynx.bundle')
   })
 
+  test('should pick bundle encoding per environment for the async reactlynx preset', async () => {
+    const { pluginExternalBundle } = await import('../src/index.js')
+
+    const capturedByEnv: Record<string, unknown[]> = {}
+
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        environments: {
+          lynx: {},
+          web: {},
+        },
+        source: {
+          entry: {
+            main: './fixtures/basic.tsx',
+          },
+        },
+        tools: {
+          rspack(config, { environment }) {
+            capturedByEnv[environment.name] = config.plugins ?? []
+            return config
+          },
+        },
+        plugins: [
+          pluginStubLayers(),
+          pluginExternalBundle({
+            externalsPresets: {
+              reactlynx: { async: true },
+            },
+          }),
+        ],
+      },
+    })
+
+    await rsbuild.inspectConfig()
+
+    // `async` controls the mount form only; the bundle encoding follows the
+    // environment (lynx -> tasm, web -> web-encoded).
+    expect(getExternalsLoadingPlugin(capturedByEnv['lynx'] ?? []))
+      .toMatchObject({
+        options: {
+          externals: {
+            '@lynx-js/react': {
+              async: true,
+              bundlePath: 'react.lynx.bundle',
+            },
+          },
+        },
+      })
+    expect(getExternalsLoadingPlugin(capturedByEnv['web'] ?? []))
+      .toMatchObject({
+        options: {
+          externals: {
+            '@lynx-js/react': {
+              async: true,
+              bundlePath: 'react.web.bundle',
+            },
+          },
+        },
+      })
+  })
+
   test('should emit the reactlynx bundle into build output by default', async () => {
     const { pluginExternalBundle } = await import('../src/index.js')
 
@@ -424,6 +495,9 @@ describe('pluginExternalBundle', () => {
             distPath: {
               root: distRoot,
             },
+          },
+          environments: {
+            lynx: {},
           },
           source: {
             entry: {
@@ -462,6 +536,9 @@ describe('pluginExternalBundle', () => {
       rsbuildConfig: {
         dev: {
           assetPrefix: 'http://example.com/assets/',
+        },
+        environments: {
+          lynx: {},
         },
         source: {
           entry: {
@@ -569,6 +646,9 @@ describe('pluginExternalBundle', () => {
       rsbuildConfig: {
         dev: {
           assetPrefix: 'http://example.com/assets/',
+        },
+        environments: {
+          lynx: {},
         },
         source: {
           entry: {
@@ -715,6 +795,9 @@ describe('pluginExternalBundle', () => {
             distPath: {
               root: distRoot,
             },
+          },
+          environments: {
+            lynx: {},
           },
           source: {
             entry: {

--- a/packages/rspeedy/plugin-external-bundle/test/resolve-root-path.test.ts
+++ b/packages/rspeedy/plugin-external-bundle/test/resolve-root-path.test.ts
@@ -64,9 +64,12 @@ describe('pluginExternalBundle reactlynx peer resolution', () => {
         )
       },
       modifyRspackConfig(
-        callback: (config: { plugins?: unknown[] }) => { plugins?: unknown[] },
+        callback: (
+          config: { plugins?: unknown[] },
+          utils: { environment: { name: string } },
+        ) => { plugins?: unknown[] },
       ) {
-        callback({ plugins: [] })
+        callback({ plugins: [] }, { environment: { name: 'lynx' } })
       },
       getRsbuildConfig() {
         return {}

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useContext/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useContext/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 4734
+- Update: main.LAST_HASH.hot-update.js, size: 4485
 
 ## Manifest
 
@@ -44,15 +44,17 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
-/* import */ var _lynx_js_react__rspack_import_1 = __webpack_require__(/*! @lynx-js/react */ "../../../../../../react/runtime/lib/index.js");
-/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
+/* import */ var _lynx_js_react_internal__rspack_import_1 = __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js");
+/* import */ var _lynx_js_react__rspack_import_2 = __webpack_require__(/*! @lynx-js/react */ "../../../../../../react/runtime/lib/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_3 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
 
-const Theme = (0,_lynx_js_react__rspack_import_1.createContext)('light');
+
+const Theme = (0,_lynx_js_react__rspack_import_2.createContext)('light');
 const __snapshot_481ab_6688c_1 = "__snapshot_481ab_6688c_1";
-(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_481ab_6688c_1] = (__snapshot_481ab_6688c_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_481ab_6688c_1, function() {
-        const pageId = (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__pageId */.__pageId);
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_481ab_6688c_1] = (__snapshot_481ab_6688c_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_481ab_6688c_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateText(pageId);
         const el1 = __CreateRawText("after: ");
         __AppendElement(el, el1);
@@ -65,12 +67,12 @@ const __snapshot_481ab_6688c_1 = "__snapshot_481ab_6688c_1";
         ];
     }, null, [
         [
-            (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__DynamicPartSlotV2 */.__DynamicPartSlotV2),
+            __runtime__.__DynamicPartSlotV2,
             2
         ]
     ], undefined, globDynamicComponentEntry, null, true);
 function Inner() {
-    const theme = (0,_lynx_js_react__rspack_import_1.useContext)(Theme);
+    const theme = (0,_lynx_js_react__rspack_import_2.useContext)(Theme);
     __RenderContent(`after: ${theme}`);
     return /*#__PURE__*/ (0,_lynx_js_react_jsx_dev_runtime__rspack_import_0.jsxDEV)(__snapshot_481ab_6688c_1, {
         $0: theme
@@ -97,21 +99,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_3.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_3.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_3.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        _runtime_refresh_mjs__rspack_import_2.flush();
+        _runtime_refresh_mjs__rspack_import_3.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -130,7 +132,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_3.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useContext/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useContext/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 4485
+- Update: main.LAST_HASH.hot-update.js, size: 4806
 
 ## Manifest
 
@@ -53,8 +53,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 const Theme = (0,_lynx_js_react__rspack_import_2.createContext)('light');
 const __snapshot_481ab_6688c_1 = "__snapshot_481ab_6688c_1";
-_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_481ab_6688c_1] = (__snapshot_481ab_6688c_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_481ab_6688c_1, function() {
-        const pageId = __runtime__.__pageId;
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_481ab_6688c_1] = (__snapshot_481ab_6688c_1, __runtime__)=>(__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).createSnapshot(__snapshot_481ab_6688c_1, function() {
+        const pageId = (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__pageId;
         const el = __CreateText(pageId);
         const el1 = __CreateRawText("after: ");
         __AppendElement(el, el1);
@@ -67,7 +67,7 @@ _lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_481ab_668
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartSlotV2,
+            (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__DynamicPartSlotV2,
             2
         ]
     ], undefined, globDynamicComponentEntry, null, true);

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useState/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useState/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 4135
+- Update: main.LAST_HASH.hot-update.js, size: 4456
 
 ## Manifest
 
@@ -52,8 +52,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 const __snapshot_c1b16_43c2c_1 = "__snapshot_c1b16_43c2c_1";
-_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_c1b16_43c2c_1] = (__snapshot_c1b16_43c2c_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_c1b16_43c2c_1, function() {
-        const pageId = __runtime__.__pageId;
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_c1b16_43c2c_1] = (__snapshot_c1b16_43c2c_1, __runtime__)=>(__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).createSnapshot(__snapshot_c1b16_43c2c_1, function() {
+        const pageId = (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__pageId;
         const el = __CreateText(pageId);
         const el1 = __CreateRawText("after: ");
         __AppendElement(el, el1);
@@ -66,7 +66,7 @@ _lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_c1b16_43c
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartSlotV2,
+            (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__DynamicPartSlotV2,
             2
         ]
     ], undefined, globDynamicComponentEntry, null, true);

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useState/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/hook/useState/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 4384
+- Update: main.LAST_HASH.hot-update.js, size: 4135
 
 ## Manifest
 
@@ -44,14 +44,16 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
-/* import */ var _lynx_js_react__rspack_import_1 = __webpack_require__(/*! @lynx-js/react */ "../../../../../../react/runtime/lib/index.js");
-/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
+/* import */ var _lynx_js_react_internal__rspack_import_1 = __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js");
+/* import */ var _lynx_js_react__rspack_import_2 = __webpack_require__(/*! @lynx-js/react */ "../../../../../../react/runtime/lib/index.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_3 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
 
+
 const __snapshot_c1b16_43c2c_1 = "__snapshot_c1b16_43c2c_1";
-(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_c1b16_43c2c_1] = (__snapshot_c1b16_43c2c_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_c1b16_43c2c_1, function() {
-        const pageId = (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__pageId */.__pageId);
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_c1b16_43c2c_1] = (__snapshot_c1b16_43c2c_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_c1b16_43c2c_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateText(pageId);
         const el1 = __CreateRawText("after: ");
         __AppendElement(el, el1);
@@ -64,7 +66,7 @@ const __snapshot_c1b16_43c2c_1 = "__snapshot_c1b16_43c2c_1";
         ];
     }, null, [
         [
-            (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__DynamicPartSlotV2 */.__DynamicPartSlotV2),
+            __runtime__.__DynamicPartSlotV2,
             2
         ]
     ], undefined, globDynamicComponentEntry, null, true);
@@ -79,7 +81,7 @@ function Inner({ theme }) {
     }, this);
 }
 function App() {
-    const [theme] = (0,_lynx_js_react__rspack_import_1.useState)("light");
+    const [theme] = (0,_lynx_js_react__rspack_import_2.useState)("light");
     return /*#__PURE__*/ (0,_lynx_js_react_jsx_dev_runtime__rspack_import_0.jsxDEV)(Inner, {
         theme: theme
     }, void 0, false, {
@@ -91,21 +93,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_3.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_3.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_3.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        _runtime_refresh_mjs__rspack_import_2.flush();
+        _runtime_refresh_mjs__rspack_import_3.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -124,7 +126,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_3.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3491
+- Update: main.LAST_HASH.hot-update.js, size: 3705
 
 ## Manifest
 
@@ -50,8 +50,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 const __snapshot_d2d51_4d7b7_1 = "__snapshot_d2d51_4d7b7_1";
-_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_d2d51_4d7b7_1] = (__snapshot_d2d51_4d7b7_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_d2d51_4d7b7_1, function() {
-        const pageId = __runtime__.__pageId;
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_d2d51_4d7b7_1] = (__snapshot_d2d51_4d7b7_1, __runtime__)=>(__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).createSnapshot(__snapshot_d2d51_4d7b7_1, function() {
+        const pageId = (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3622
+- Update: main.LAST_HASH.hot-update.js, size: 3491
 
 ## Manifest
 
@@ -44,12 +44,14 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
-/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
+/* import */ var _lynx_js_react_internal__rspack_import_1 = __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
+
 const __snapshot_d2d51_4d7b7_1 = "__snapshot_d2d51_4d7b7_1";
-(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_d2d51_4d7b7_1] = (__snapshot_d2d51_4d7b7_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_d2d51_4d7b7_1, function() {
-        const pageId = (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__pageId */.__pageId);
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_d2d51_4d7b7_1] = (__snapshot_d2d51_4d7b7_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_d2d51_4d7b7_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -72,21 +74,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        _runtime_refresh_mjs__rspack_import_1.flush();
+        _runtime_refresh_mjs__rspack_import_2.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -105,7 +107,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3491
+- Update: main.LAST_HASH.hot-update.js, size: 3705
 
 ## Manifest
 
@@ -50,8 +50,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 const __snapshot_d2d51_b7a87_1 = "__snapshot_d2d51_b7a87_1";
-_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_d2d51_b7a87_1] = (__snapshot_d2d51_b7a87_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_d2d51_b7a87_1, function() {
-        const pageId = __runtime__.__pageId;
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_d2d51_b7a87_1] = (__snapshot_d2d51_b7a87_1, __runtime__)=>(__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).createSnapshot(__snapshot_d2d51_b7a87_1, function() {
+        const pageId = (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/basic/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3622
+- Update: main.LAST_HASH.hot-update.js, size: 3491
 
 ## Manifest
 
@@ -44,12 +44,14 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
-/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
+/* import */ var _lynx_js_react_internal__rspack_import_1 = __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
+
 const __snapshot_d2d51_b7a87_1 = "__snapshot_d2d51_b7a87_1";
-(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_d2d51_b7a87_1] = (__snapshot_d2d51_b7a87_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_d2d51_b7a87_1, function() {
-        const pageId = (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__pageId */.__pageId);
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_d2d51_b7a87_1] = (__snapshot_d2d51_b7a87_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_d2d51_b7a87_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -72,21 +74,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        _runtime_refresh_mjs__rspack_import_1.flush();
+        _runtime_refresh_mjs__rspack_import_2.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -105,7 +107,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/recovery/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/recovery/__snapshot__/rspack/2.snap.txt
@@ -5,12 +5,12 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.b1bb781f47ee97e4.hot-update.json, size: 28
-- Update: main.b1bb781f47ee97e4.hot-update.js, size: 3625
+- Manifest: main.567bf7563370307f.hot-update.json, size: 28
+- Update: main.567bf7563370307f.hot-update.js, size: 3494
 
 ## Manifest
 
-### main.b1bb781f47ee97e4.hot-update.json
+### main.567bf7563370307f.hot-update.json
 
 ```json
 {"c":["main"],"r":[],"m":[]}
@@ -20,7 +20,7 @@
 ## Update
 
 
-### main.b1bb781f47ee97e4.hot-update.js
+### main.567bf7563370307f.hot-update.js
 
 #### Changed Modules
 - ./app.jsx
@@ -44,12 +44,14 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
-/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
+/* import */ var _lynx_js_react_internal__rspack_import_1 = __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
+
 const __snapshot_b0c31_b7a87_1 = "__snapshot_b0c31_b7a87_1";
-(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_b0c31_b7a87_1] = (__snapshot_b0c31_b7a87_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_b0c31_b7a87_1, function() {
-        const pageId = (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__pageId */.__pageId);
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_b0c31_b7a87_1] = (__snapshot_b0c31_b7a87_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_b0c31_b7a87_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -72,21 +74,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        _runtime_refresh_mjs__rspack_import_1.flush();
+        _runtime_refresh_mjs__rspack_import_2.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -105,7 +107,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/recovery/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/recovery/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.567bf7563370307f.hot-update.json, size: 28
-- Update: main.567bf7563370307f.hot-update.js, size: 3494
+- Update: main.567bf7563370307f.hot-update.js, size: 3708
 
 ## Manifest
 
@@ -50,8 +50,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 const __snapshot_b0c31_b7a87_1 = "__snapshot_b0c31_b7a87_1";
-_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_b0c31_b7a87_1] = (__snapshot_b0c31_b7a87_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_b0c31_b7a87_1, function() {
-        const pageId = __runtime__.__pageId;
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_b0c31_b7a87_1] = (__snapshot_b0c31_b7a87_1, __runtime__)=>(__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).createSnapshot(__snapshot_b0c31_b7a87_1, function() {
+        const pageId = (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3508
+- Update: main.LAST_HASH.hot-update.js, size: 3829
 
 ## Manifest
 
@@ -50,8 +50,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 const __snapshot_8bc4c_170ee_1 = "__snapshot_8bc4c_170ee_1";
-_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_8bc4c_170ee_1] = (__snapshot_8bc4c_170ee_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_8bc4c_170ee_1, function() {
-        const pageId = __runtime__.__pageId;
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_8bc4c_170ee_1] = (__snapshot_8bc4c_170ee_1, __runtime__)=>(__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).createSnapshot(__snapshot_8bc4c_170ee_1, function() {
+        const pageId = (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -61,7 +61,7 @@ _lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_8bc4c_170
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartSlotV2,
+            (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__DynamicPartSlotV2,
             1
         ]
     ], undefined, globDynamicComponentEntry, null, true);

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3757
+- Update: main.LAST_HASH.hot-update.js, size: 3508
 
 ## Manifest
 
@@ -44,12 +44,14 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
-/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
+/* import */ var _lynx_js_react_internal__rspack_import_1 = __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
+
 const __snapshot_8bc4c_170ee_1 = "__snapshot_8bc4c_170ee_1";
-(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_8bc4c_170ee_1] = (__snapshot_8bc4c_170ee_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_8bc4c_170ee_1, function() {
-        const pageId = (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__pageId */.__pageId);
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_8bc4c_170ee_1] = (__snapshot_8bc4c_170ee_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_8bc4c_170ee_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -59,7 +61,7 @@ const __snapshot_8bc4c_170ee_1 = "__snapshot_8bc4c_170ee_1";
         ];
     }, null, [
         [
-            (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__DynamicPartSlotV2 */.__DynamicPartSlotV2),
+            __runtime__.__DynamicPartSlotV2,
             1
         ]
     ], undefined, globDynamicComponentEntry, null, true);
@@ -76,21 +78,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        _runtime_refresh_mjs__rspack_import_1.flush();
+        _runtime_refresh_mjs__rspack_import_2.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -109,7 +111,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3757
+- Update: main.LAST_HASH.hot-update.js, size: 3508
 
 ## Manifest
 
@@ -44,12 +44,14 @@ __webpack_require__.d(__webpack_exports__, {
   App: () => (App)
 });
 /* import */ var _lynx_js_react_jsx_dev_runtime__rspack_import_0 = __webpack_require__(/*! @lynx-js/react/jsx-dev-runtime */ "../../../../../../react/runtime/jsx-dev-runtime/index.js");
-/* import */ var _runtime_refresh_mjs__rspack_import_1 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
+/* import */ var _lynx_js_react_internal__rspack_import_1 = __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js");
+/* import */ var _runtime_refresh_mjs__rspack_import_2 = __webpack_require__(/*! ../../../../runtime/refresh.mjs */ "../../../../runtime/refresh.mjs");
 /* module decorator */ module = __webpack_require__.hmd(module);
 
+
 const __snapshot_8bc4c_00662_1 = "__snapshot_8bc4c_00662_1";
-(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .snapshotCreatorMap */.snapshotCreatorMap)[__snapshot_8bc4c_00662_1] = (__snapshot_8bc4c_00662_1)=>(__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .createSnapshot */.createSnapshot)(__snapshot_8bc4c_00662_1, function() {
-        const pageId = (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__pageId */.__pageId);
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_8bc4c_00662_1] = (__snapshot_8bc4c_00662_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_8bc4c_00662_1, function() {
+        const pageId = __runtime__.__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -59,7 +61,7 @@ const __snapshot_8bc4c_00662_1 = "__snapshot_8bc4c_00662_1";
         ];
     }, null, [
         [
-            (__webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")/* .__DynamicPartSlotV2 */.__DynamicPartSlotV2),
+            __runtime__.__DynamicPartSlotV2,
             1
         ]
     ], undefined, globDynamicComponentEntry, null, true);
@@ -76,21 +78,21 @@ function App() {
 
 
 // @ts-nocheck
-const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_1.shouldBind(module);
+const isPrefreshComponent = _runtime_refresh_mjs__rspack_import_2.shouldBind(module);
 
 const moduleHot = module.hot;
 
 if (moduleHot) {
-  const currentExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+  const currentExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
   const previousHotModuleExports = moduleHot.data
     && moduleHot.data.moduleExports;
 
-  _runtime_refresh_mjs__rspack_import_1.registerExports(currentExports, module.id);
+  _runtime_refresh_mjs__rspack_import_2.registerExports(currentExports, module.id);
 
   if (isPrefreshComponent) {
     if (previousHotModuleExports) {
       try {
-        _runtime_refresh_mjs__rspack_import_1.flush();
+        _runtime_refresh_mjs__rspack_import_2.flush();
         if (
           typeof __prefresh_errors__ !== 'undefined'
           && __prefresh_errors__
@@ -109,7 +111,7 @@ if (moduleHot) {
     }
 
     moduleHot.dispose(data => {
-      data.moduleExports = _runtime_refresh_mjs__rspack_import_1.getExports(module);
+      data.moduleExports = _runtime_refresh_mjs__rspack_import_2.getExports(module);
     });
 
     moduleHot.accept(function errorRecovery() {

--- a/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/react-refresh-webpack-plugin/test/hotCases/jsx/value/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 3508
+- Update: main.LAST_HASH.hot-update.js, size: 3829
 
 ## Manifest
 
@@ -50,8 +50,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 const __snapshot_8bc4c_00662_1 = "__snapshot_8bc4c_00662_1";
-_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_8bc4c_00662_1] = (__snapshot_8bc4c_00662_1, __runtime__)=>__runtime__.createSnapshot(__snapshot_8bc4c_00662_1, function() {
-        const pageId = __runtime__.__pageId;
+_lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_8bc4c_00662_1] = (__snapshot_8bc4c_00662_1, __runtime__)=>(__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).createSnapshot(__snapshot_8bc4c_00662_1, function() {
+        const pageId = (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__pageId;
         const el = __CreateView(pageId);
         const el1 = __CreateText(pageId);
         __AppendElement(el, el1);
@@ -61,7 +61,7 @@ _lynx_js_react_internal__rspack_import_1.snapshotCreatorMap[__snapshot_8bc4c_006
         ];
     }, null, [
         [
-            __runtime__.__DynamicPartSlotV2,
+            (__runtime__ || __webpack_require__(/*! @lynx-js/react/internal */ "../../../../../../react/runtime/lib/internal.js")).__DynamicPartSlotV2,
             1
         ]
     ], undefined, globDynamicComponentEntry, null, true);


### PR DESCRIPTION
## Problem

The snapshot transform inlined `require('@lynx-js/react/internal')` in **development** so that stringified snapshot creators (cross-thread HMR, `DEV_ONLY_AddSnapshot`) could re-resolve the runtime after `eval` on the main thread. But a bare `require()` of an **async module** returns the *pending promise* (rspack async-module semantics — same family as web-infra-dev/rspack#14724), so dev builds crash with async (promise) externals:

```
main-thread.js: __webpack_require__("@lynx-js/react/internal").snapshotCreatorMap  // ← a Promise
```

## Design

| | module scope | inside the creator arrow | size impact |
|---|---|---|---|
| **dev** | `import * as ReactLynx from <runtime_pkg>` (awaited by async-module machinery) | `(id, __runtime__) => __runtime__.createSnapshot(...)` — the runtime is an **arrow parameter**, so the stringified creator has **no free identifiers** and evals in any realm | n/a |
| **prod/test** | unchanged | unchanged (module-scope closure — statically tree-shakeable) | **byte-identical codegen** |

- The runtime object is injected at the call sites (`snapshotCreatorMap[type](type, snapshotCreatorRuntime)`); the holder is only assigned under `__DEV__` (by `internal.js` registering its own namespace), so production retains **no** reference to the full runtime namespace — tree-shaking is unaffected (verified: prod bundles contain 0 `__runtime__` / 0 `setSnapshotCreatorRuntime`).
- `evaluate()` no longer depends on direct-eval capturing `__webpack_require__` (#983's motivation is gone).
- `swc_plugin_element_template` gets the same treatment for both of its runtime ids (dev `require(runtime_pkg)` → import ident); its ident-gated import-prepend already existed.
- The `// We should find a way to use cfg.runtime_pkg` TODO is resolved for free — the import uses `cfg.runtime_pkg`.

## Verification

- `swc_plugin_snapshot` 40+3, `swc_plugin_element_template` 21+43, `swc_plugin_list`, `swc_plugin_worklet` — all green; only **dev-mode** fixtures changed (11 files), prod/test fixtures have **zero diff**.
- `packages/react/runtime`: snapshot suite **91 files / 688 tests** ✓, core 12/48 ✓, `preact.test.jsx` (the `DEV_ONLY_AddSnapshot` stringify→transfer→eval path, compiled with the new transform) **17/17** ✓. (element-template suite failures are pre-existing on main — identical 23 failures on a clean checkout.)
- Dev + async externals artifact (`examples/react-externals` `REACTLYNX_ASYNC=true` dev): `@lynx-js/react/internal` import is in `__rspack_load_async_deps` and reassigned after await; creators are `(id, __runtime__)`; **0** bare-require property accesses.
- Prod bundles (sync + async): `__runtime__` 0, `setSnapshotCreatorRuntime` 0 — dev machinery fully DCE'd.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development snapshot runtime binding to better support hot reload and cross-thread updates.
  * Updated snapshot creation to receive the runtime in development, improving compatibility with async/promise-based externals.
  * Regenerated snapshot-related build output to consistently use the public runtime import path while keeping production behavior unchanged.
* **New Features**
  * Made the externals preset resolution environment-aware so the correct ReactLynx bundle is chosen per environment.
* **Documentation**
  * Clarified async preset mounting and environment-based bundle selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->