### PR TITLE
feat(genui): add OpenUI prompt CLI

### DIFF
--- a/.changeset/openui-cli-prompt.md
+++ b/.changeset/openui-cli-prompt.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": patch
+---
+
+Add `genui openui generate prompt` for writing the bundled OpenUI system prompt to stdout or a file.

--- a/packages/genui/README.md
+++ b/packages/genui/README.md
@@ -122,8 +122,8 @@ a2ui-catalog-extractor --help
 ```
 
 `a2ui-cli` is also kept as a compatibility alias for existing A2UI scripts. New
-scripts should prefer the namespace-first `genui a2ui ...` form so OpenUI
-commands can be added under `genui openui ...` later.
+scripts should prefer the namespace-first `genui a2ui ...` or
+`genui openui ...` form.
 
 Generate catalog artifacts:
 
@@ -140,6 +140,12 @@ Generate an A2UI system prompt:
 genui a2ui generate prompt \
   --catalog-dir dist/catalog \
   --out dist/a2ui-system-prompt.txt
+```
+
+Generate an OpenUI system prompt:
+
+```bash
+genui openui generate prompt --out dist/openui-system-prompt.txt
 ```
 
 ## Published Package Layout

--- a/packages/genui/cli/README.md
+++ b/packages/genui/cli/README.md
@@ -1,8 +1,8 @@
 # GenUI CLI
 
 `@lynx-js/genui-cli` is the command line entry point for GenUI workflows. It is
-structured by namespace so A2UI commands can live beside future OpenUI commands
-without adding another package or binary.
+structured by namespace so A2UI and OpenUI workflows can share one package and
+binary.
 
 ## Usage
 
@@ -13,7 +13,7 @@ genui <namespace> <command> [options]
 Available namespaces:
 
 - `a2ui`: generate A2UI catalog artifacts and system prompts.
-- `openui`: reserved for future OpenUI workflows.
+- `openui`: generate OpenUI system prompts.
 
 The package also exposes `genui-cli` as an alias. `a2ui-cli` remains available as
 a compatibility alias for existing A2UI-only scripts.
@@ -54,6 +54,19 @@ genui a2ui generate prompt \
 `--catalog-dir` only when generating a prompt for custom generated catalog
 artifacts. When `--catalog-dir` is provided, the directory must contain files
 like `<Component>/catalog.json`.
+
+## OpenUI Commands
+
+Generate an OpenUI system prompt:
+
+```bash
+genui openui generate prompt --out dist/openui-system-prompt.txt
+```
+
+`generate prompt` uses the bundled OpenUI prompt library. Useful options:
+
+- `--out <file>`: write the prompt to a file instead of stdout.
+- `--appendix <text>`: append extra instructions to the generated prompt.
 
 ### `genui a2ui create`
 

--- a/packages/genui/cli/package.json
+++ b/packages/genui/cli/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "@lynx-js/genui-a2ui-catalog-extractor": "workspace:*",
-    "@lynx-js/genui-a2ui-prompt": "workspace:*"
+    "@lynx-js/genui-a2ui-prompt": "workspace:*",
+    "@lynx-js/genui-openui": "workspace:*"
   },
   "devDependencies": {
     "@rstest/core": "catalog:rstest",

--- a/packages/genui/cli/src/cli.ts
+++ b/packages/genui/cli/src/cli.ts
@@ -9,12 +9,13 @@ const usage = `Usage: genui <namespace> <command> [options]
 
 Namespaces:
   a2ui    Generate A2UI catalog artifacts and system prompts.
-  openui  Reserved for future OpenUI workflows.
+  openui  Generate OpenUI system prompts.
 
 Examples:
   genui a2ui create my-app
   genui a2ui generate catalog --catalog-dir src/catalog --out-dir dist/catalog
   genui a2ui generate prompt --out dist/a2ui-system-prompt.txt
+  genui openui generate prompt --out dist/openui-system-prompt.txt
 `;
 
 export interface CliOptions {
@@ -45,7 +46,7 @@ export async function runCli(
     return await runA2UICli(args.slice(1), cwd, { programName: 'genui a2ui' });
   }
   if (command === 'openui') {
-    return runOpenUICli(args.slice(1));
+    return await runOpenUICli(args.slice(1), cwd);
   }
 
   throw new Error(`Unknown namespace: ${command}`);

--- a/packages/genui/cli/src/openui.ts
+++ b/packages/genui/cli/src/openui.ts
@@ -1,14 +1,40 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { printPackageVersion } from './utils.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { printPackageVersion, readValue } from './utils.js';
 
 const openuiUsage = `Usage: genui openui <command> [options]
 
-OpenUI CLI commands are reserved for future GenUI workflows.
+Commands:
+  generate <target>  Generate OpenUI system prompts.
+
+Targets (for generate):
+  prompt             Generate an OpenUI system prompt.
 `;
 
-export function runOpenUICli(args: string[]): number {
+const generatePromptUsage = `Usage: genui openui generate prompt [options]
+
+Options:
+  --out <file>       Write the prompt to a file instead of stdout.
+  --appendix <text>  Append extra instructions to the generated prompt.
+  --version          Print the package version.
+  --help             Print this help message.
+`;
+
+interface GeneratePromptOptions {
+  help: boolean;
+  version: boolean;
+  out?: string;
+  appendix?: string;
+}
+
+export async function runOpenUICli(
+  args: string[],
+  cwd: string,
+): Promise<number> {
   const command = args[0];
   if (command === undefined || command === '--help' || command === '-h') {
     console.info(openuiUsage);
@@ -18,7 +44,86 @@ export function runOpenUICli(args: string[]): number {
     printPackageVersion();
     return 0;
   }
-  throw new Error(
-    `Unknown OpenUI command: ${command}. OpenUI CLI commands are not available yet.`,
+  if (command !== 'generate') {
+    throw new Error(`Unknown OpenUI command: ${command}`);
+  }
+
+  const target = args[1];
+  const targetArgs = args.slice(2);
+  if (target === undefined || target === '--help' || target === '-h') {
+    console.info(openuiUsage);
+    return 0;
+  }
+  if (target === '--version' || target === '-v') {
+    printPackageVersion();
+    return 0;
+  }
+  if (target === 'prompt') {
+    return await runGeneratePromptCli(targetArgs, cwd);
+  }
+  throw new Error(`Unknown OpenUI generate target: ${target}`);
+}
+
+async function runGeneratePromptCli(
+  args: string[],
+  cwd: string,
+): Promise<number> {
+  const options = parseGeneratePromptArgs(args);
+  if (options.help) {
+    console.info(generatePromptUsage);
+    return 0;
+  }
+  if (options.version) {
+    printPackageVersion();
+    return 0;
+  }
+
+  const { buildOpenUiSystemPrompt } = await import(
+    '../../openui/dist/openui-prompt/index.js'
   );
+  const systemPrompt = buildOpenUiSystemPrompt(
+    options.appendix ? { appendix: options.appendix } : undefined,
+  );
+
+  if (options.out) {
+    const outPath = path.resolve(cwd, options.out);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, systemPrompt);
+    console.info(`Generated OpenUI system prompt at ${options.out}.`);
+  } else {
+    process.stdout.write(systemPrompt);
+  }
+
+  return 0;
+}
+
+function parseGeneratePromptArgs(args: string[]): GeneratePromptOptions {
+  const options: GeneratePromptOptions = {
+    help: false,
+    version: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    switch (arg) {
+      case '--out':
+        options.out = readValue(args, ++index, arg);
+        break;
+      case '--appendix':
+        options.appendix = readValue(args, ++index, arg);
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--version':
+      case '-v':
+        options.version = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
 }

--- a/packages/genui/cli/test/openui-generate.test.ts
+++ b/packages/genui/cli/test/openui-generate.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterAll, describe, expect, test } from '@rstest/core';
+
+import { runCli } from '../src/cli.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'genui-cli-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+void afterAll(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('genui openui generate prompt', () => {
+  test('shows namespace help with --help flag', async () => {
+    const exitCode = await runCli(['openui', '--help']);
+    expect(exitCode).toBe(0);
+  });
+
+  test('shows prompt help with --help flag', async () => {
+    const exitCode = await runCli(['openui', 'generate', 'prompt', '--help']);
+    expect(exitCode).toBe(0);
+  });
+
+  test('generates prompt to stdout', async () => {
+    const tmpDir = makeTempDir();
+    const logs: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      logs.push(chunk.toString());
+      return true;
+    };
+
+    try {
+      const exitCode = await runCli(['openui', 'generate', 'prompt'], tmpDir);
+      expect(exitCode).toBe(0);
+      const output = logs.join('');
+      expect(output.length).toBeGreaterThan(0);
+      expect(output).toContain('OpenUI');
+      expect(output).toContain('Stack');
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+  });
+
+  test('generates prompt to file with --out', async () => {
+    const tmpDir = makeTempDir();
+    const outFile = path.join(tmpDir, 'openui-prompt.txt');
+
+    const exitCode = await runCli(
+      ['openui', 'generate', 'prompt', '--out', outFile],
+      tmpDir,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(outFile)).toBe(true);
+    const content = fs.readFileSync(outFile, 'utf-8');
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).toContain('OpenUI');
+    expect(content).toContain('Stack');
+  });
+
+  test('accepts --appendix option', async () => {
+    const tmpDir = makeTempDir();
+    const outFile = path.join(tmpDir, 'openui-prompt.txt');
+    const appendix = 'CUSTOM_OPENUI_APPENDIX';
+
+    const exitCode = await runCli(
+      [
+        'openui',
+        'generate',
+        'prompt',
+        '--out',
+        outFile,
+        '--appendix',
+        appendix,
+      ],
+      tmpDir,
+    );
+
+    expect(exitCode).toBe(0);
+    const content = fs.readFileSync(outFile, 'utf-8');
+    expect(content).toContain(appendix);
+  });
+
+  test('rejects unknown prompt option', async () => {
+    await expect(
+      runCli(['openui', 'generate', 'prompt', '--catalog-dir', 'dist']),
+    ).rejects.toThrow(/Unknown option/);
+  });
+});

--- a/packages/genui/cli/turbo.json
+++ b/packages/genui/cli/turbo.json
@@ -7,7 +7,8 @@
     "build": {
       "dependsOn": [
         "@lynx-js/genui-a2ui-catalog-extractor#build",
-        "@lynx-js/genui-a2ui-prompt#build"
+        "@lynx-js/genui-a2ui-prompt#build",
+        "@lynx-js/genui-openui#build"
       ],
       "inputs": [
         "src/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,6 +845,9 @@ importers:
       '@lynx-js/genui-a2ui-prompt':
         specifier: workspace:*
         version: link:../a2ui-prompt
+      '@lynx-js/genui-openui':
+        specifier: workspace:*
+        version: link:../openui
     devDependencies:
       '@rstest/core':
         specifier: catalog:rstest


### PR DESCRIPTION
## Summary

- add `genui openui generate prompt` for writing the bundled OpenUI system prompt to stdout or a file
- wire the GenUI CLI build to depend on `@lynx-js/genui-openui`
- document the OpenUI prompt command and add a patch changeset for `@lynx-js/genui`

## Validation

- `pnpm turbo test --filter=@lynx-js/genui-cli`
- `pnpm turbo build --filter=@lynx-js/genui --filter=@lynx-js/genui-cli --filter=@lynx-js/genui-openui`
- `pnpm changeset status --since=origin/main --output .changeset-status.json && node .github/scripts/check-dep-changes-have-changeset.cjs .changeset-status.json`
