### PR TITLE
chore: Split CI build dependencies by platform

### DIFF
--- a/.github/workflow-cache.instructions.md
+++ b/.github/workflow-cache.instructions.md
@@ -3,3 +3,5 @@ applyTo: ".github/workflows/**/*.yml"
 ---
 
 Keep `hashFiles` globs rooted at the repository directories they need, such as `packages/**/src/**/*.rs`, instead of starting with `**/`; broad leading globs can time out on Windows runners after dependencies and build outputs are present.
+When a workflow-test job restores the strict `.turbo` cache by `runner.os`, make it depend only on the matching OS build job. Linux-only tests should not wait for Windows build cache priming.
+Keep the reusable build workflow single-runner; callers that need multiple operating systems should own the matrix and pass the selected runner label into the reusable workflow.

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -56,11 +56,23 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
       cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on:
+          - label: lynx-ubuntu-26.04-xlarge
+            name: Ubuntu
+          - label: lynx-windows-2022-large
+            name: Windows
+    name: Build (${{ matrix.runs-on.name }})
     uses: ./.github/workflows/workflow-build.yml
     if: github.repository == 'lynx-family/lynx-stack'
     permissions: {}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      runs-on: ${{ matrix.runs-on.label }}
+      runs-on-name: ${{ matrix.runs-on.name }}
   benchmark:
     needs: build-all
     uses: ./.github/workflows/workflow-bench.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,21 @@ jobs:
       BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
       REGION: ${{ secrets.REGION }}
   build:
+    name: Build (Ubuntu)
     uses: ./.github/workflows/workflow-build.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      runs-on: lynx-ubuntu-26.04-xlarge
+      runs-on-name: Ubuntu
+  build-windows:
+    name: Build (Windows)
+    uses: ./.github/workflows/workflow-build.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      runs-on: lynx-windows-2022-large
+      runs-on-name: Windows
   bundle-analysis:
     needs: build
     uses: ./.github/workflows/workflow-bundle-analysis.yml
@@ -387,19 +399,34 @@ jobs:
   test-vitest:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on:
-          - name: Ubuntu
-            label: lynx-ubuntu-26.04-medium
-          - name: Windows
-            label: lynx-windows-2022-large
-    name: Vitest (${{ matrix.runs-on.name }})
+    name: Vitest (Ubuntu)
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: ${{ matrix.runs-on.label }}
+      runs-on: lynx-ubuntu-26.04-medium
+      run: >
+        pnpm run test
+        --reporter=github-actions
+        --reporter=dot
+        --reporter=junit
+        --outputFile=test-report.junit.xml
+        --expect.poll.timeout=5000
+        --testTimeout=50000
+        --hookTimeout=50000
+        --coverage
+        --coverage.reporter='json'
+        --coverage.reporter='text'
+        --no-cache
+        --logHeapUsage
+        --silent
+  test-vitest-windows:
+    needs: build-windows
+    uses: ./.github/workflows/workflow-test.yml
+    name: Vitest (Windows)
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      runs-on: lynx-windows-2022-large
       run: >
         pnpm run test
         --reporter=github-actions
@@ -435,6 +462,7 @@ jobs:
       - test-rstest
       - test-typos
       - test-vitest
+      - test-vitest-windows
       - web-core-e2e
       - website
     if: always()

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -1,6 +1,13 @@
 name: Build
 on:
   workflow_call:
+    inputs:
+      runs-on:
+        required: true
+        type: string
+      runs-on-name:
+        required: true
+        type: string
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -67,16 +74,8 @@ jobs:
           echo "merge-base=$(git merge-base "$CLEAN_BASE_REF" "$CLEAN_HEAD_REF" || git rev-parse "$CLEAN_BASE_REF")" >> $GITHUB_OUTPUT
   build-all:
     permissions: {}
-    name: Build (${{ matrix.runs-on.name }})
-    runs-on: ${{ matrix.runs-on.label }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on:
-          - label: lynx-ubuntu-26.04-xlarge
-            name: Ubuntu
-          - label: lynx-windows-2022-large
-            name: Windows
+    name: Build (${{ inputs.runs-on-name }})
+    runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     needs: get-merge-base
     steps:
@@ -125,8 +124,8 @@ jobs:
           retention-days: 1
           overwrite: true
           include-hidden-files: true
-      # Publish PR previews to pkg.pr.new. Only runs on the Ubuntu leg of the
-      # build matrix, and only when the PR adds a changeset that actually
+      # Publish PR previews to pkg.pr.new. Only runs on the Ubuntu build, and
+      # only when the PR adds a changeset that actually
       # bumps a publishable package. Fork PRs are included: this is a
       # `pull_request` (not `pull_request_target`) workflow, so fork runs use
       # a read-only token with no base-repo secrets, and are gated by the
@@ -134,7 +133,7 @@ jobs:
       # step above (which already runs fork install/build scripts) relies on.
       - name: Fetch base ref for changeset status
         if: >
-          matrix.runs-on.label == 'lynx-ubuntu-26.04-xlarge' &&
+          inputs.runs-on == 'lynx-ubuntu-26.04-xlarge' &&
           github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
@@ -161,7 +160,7 @@ jobs:
       - name: Collect packages with changesets
         id: changeset
         if: >
-          matrix.runs-on.label == 'lynx-ubuntu-26.04-xlarge' &&
+          inputs.runs-on == 'lynx-ubuntu-26.04-xlarge' &&
           github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
## Summary

- Make the reusable build workflow run on a single caller-provided runner instead of owning the OS matrix internally.
- Split PR CI build priming into Linux and Windows jobs so Linux-only downstream jobs only wait for the Linux build cache.
- Keep deploy-main's build cache warmup on the original Ubuntu and Windows fan-out, and document the cache dependency pattern.

## Impact

Linux-only checks in `test.yml` can start after the Linux build completes instead of waiting for the Windows build. Windows Vitest still waits for the Windows build cache, preserving the platform-specific cache dependency.

## Validation

- Parsed updated workflow YAML files with Ruby YAML loader.
- Ran `git diff --check` on the changed workflow/instruction files.
- Ran `pnpm exec dprint check --incremental=false .github/workflows/test.yml .github/workflows/workflow-build.yml .github/workflows/deploy-main.yml .github/workflow-cache.instructions.md`.