### PR TITLE
feat(react): add compat.legacySlot for children + wrapper codegen

### DIFF
--- a/.changeset/compat-children-wrapper-codegen.md
+++ b/.changeset/compat-children-wrapper-codegen.md
@@ -1,0 +1,24 @@
+---
+"@lynx-js/react": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Add `compat.legacySlot` to `pluginReactLynx`. When enabled, dynamic children are compiled to the pre-SlotV2 form (JSX `children` + `wrapper` elements + `__DynamicPartChildren`/`__DynamicPartSlot` symbols instead of `$0`/`$1` slot props + `SlotV2`), so the compiled output stays compatible with legacy runtimes without `SlotV2` support (`< 0.120.0`, which shipped the SlotV2 refactor in #1764) — e.g. a standalone lazy bundle consumed by a host App that ships an older runtime.
+
+```js
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx({
+      compat: {
+        legacySlot: true,
+      },
+    }),
+  ],
+});
+```
+
+The default (SlotV2) codegen is unchanged, and the runtime keeps supporting both forms.

--- a/packages/react/runtime/__test__/snapshot/legacySlot.legacy-slot.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/legacySlot.legacy-slot.test.jsx
@@ -1,0 +1,437 @@
+/*
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+
+// This suite is compiled with the legacy children + wrapper codegen
+// (`compat.legacySlot`, see vitest.config.ts) and asserts that the current
+// runtime renders/updates legacy-slot snapshots correctly.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { elementTree } from './utils/nativeMethod';
+import { SnapshotInstance, snapshotInstanceManager } from '../../src/snapshot';
+
+const HOLE = null;
+
+beforeEach(() => {
+  snapshotInstanceManager.clear();
+});
+
+afterEach(() => {
+  elementTree.clear();
+});
+
+it('basic', async function() {
+  expect(
+    __SNAPSHOT__(
+      <view>
+        <text>!!!</text>
+        <text>{HOLE}</text>
+      </view>,
+    ),
+  ).toMatchInlineSnapshot(`"__snapshot_a94a8_test_1"`);
+});
+
+const snapshot1 = __SNAPSHOT__(
+  <view>
+    <text>!!!</text>
+    <text>{HOLE}</text>
+  </view>,
+);
+
+const snapshot2 = __SNAPSHOT__(
+  <view>
+    <text>Hello World</text>
+  </view>,
+);
+
+describe('insertBefore', () => {
+  it('snapshot slot count = 1', async function() {
+    const a = new SnapshotInstance(snapshot1);
+    a.ensureElements();
+
+    const b = new SnapshotInstance(snapshot2);
+    const c = new SnapshotInstance(snapshot2);
+
+    a.insertBefore(b);
+    a.insertBefore(b);
+    a.insertBefore(c, b);
+
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <raw-text
+            text="!!!"
+          />
+        </text>
+        <text>
+          <view>
+            <text>
+              <raw-text
+                text="Hello World"
+              />
+            </text>
+          </view>
+          <view>
+            <text>
+              <raw-text
+                text="Hello World"
+              />
+            </text>
+          </view>
+        </text>
+      </view>
+    `);
+  });
+
+  it('snapshot slot count = 2', async function() {
+    const snapshot1 = __SNAPSHOT__(
+      <view>
+        <text>!!!</text>
+        <text>
+          {HOLE}!!!{HOLE}
+        </text>
+      </view>,
+    );
+
+    const snapshot2 = __SNAPSHOT__(
+      <view>
+        <text>Hello World</text>
+      </view>,
+    );
+
+    const a = new SnapshotInstance(snapshot1);
+    a.ensureElements();
+
+    const b = new SnapshotInstance(snapshot2);
+    const c = new SnapshotInstance(snapshot2);
+    b.__slotIndex = 0;
+    c.__slotIndex = 1;
+
+    a.insertBefore(b);
+    a.insertBefore(c);
+
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <raw-text
+            text="!!!"
+          />
+        </text>
+        <text>
+          <view>
+            <text>
+              <raw-text
+                text="Hello World"
+              />
+            </text>
+          </view>
+          <raw-text
+            text="!!!"
+          />
+          <view>
+            <text>
+              <raw-text
+                text="Hello World"
+              />
+            </text>
+          </view>
+        </text>
+      </view>
+    `);
+  });
+
+  it('keeps __current_slot_index stable when removing content inside slot wrappers', async function() {
+    const snapshot1 = __SNAPSHOT__(
+      <view>
+        <text>
+          {HOLE}!!!{HOLE}
+        </text>
+      </view>,
+    );
+
+    const snapshot2 = __SNAPSHOT__(
+      <view>
+        <text>Hello World</text>
+      </view>,
+    );
+
+    const a = new SnapshotInstance(snapshot1);
+    a.ensureElements();
+
+    // Insert two wrappers for stable slot index
+    const b = new SnapshotInstance('wrapper');
+    const c = new SnapshotInstance('wrapper');
+    expect(a.__current_slot_index).toBe(0);
+    a.insertBefore(b);
+    expect(a.__current_slot_index).toBe(1);
+    a.insertBefore(c);
+    expect(a.__current_slot_index).toBe(2);
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <wrapper />
+          <raw-text
+            text="!!!"
+          />
+          <wrapper />
+        </text>
+      </view>
+    `);
+
+    const d = new SnapshotInstance(snapshot2);
+    const e = new SnapshotInstance(snapshot2);
+
+    b.insertBefore(d);
+    c.insertBefore(e);
+
+    expect(a.__current_slot_index).toBe(2);
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <wrapper>
+            <view>
+              <text>
+                <raw-text
+                  text="Hello World"
+                />
+              </text>
+            </view>
+          </wrapper>
+          <raw-text
+            text="!!!"
+          />
+          <wrapper>
+            <view>
+              <text>
+                <raw-text
+                  text="Hello World"
+                />
+              </text>
+            </view>
+          </wrapper>
+        </text>
+      </view>
+    `);
+
+    b.removeChild(d);
+
+    expect(a.__current_slot_index).toBe(2);
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <wrapper />
+          <raw-text
+            text="!!!"
+          />
+          <wrapper>
+            <view>
+              <text>
+                <raw-text
+                  text="Hello World"
+                />
+              </text>
+            </view>
+          </wrapper>
+        </text>
+      </view>
+    `);
+  });
+
+  it('snapshot slot count = 2 - delayed ensureElements', async function() {
+    const snapshot1 = __SNAPSHOT__(
+      <view>
+        <text>!!!</text>
+        <text>
+          {HOLE}!!!{HOLE}
+        </text>
+      </view>,
+    );
+
+    const snapshot2 = __SNAPSHOT__(
+      <view>
+        <text>Hello World</text>
+      </view>,
+    );
+
+    const a = new SnapshotInstance(snapshot1);
+    const b = new SnapshotInstance(snapshot2);
+    const c = new SnapshotInstance(snapshot2);
+    a.insertBefore(b);
+    a.insertBefore(c);
+
+    a.ensureElements();
+
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <raw-text
+            text="!!!"
+          />
+        </text>
+        <text>
+          <view>
+            <text>
+              <raw-text
+                text="Hello World"
+              />
+            </text>
+          </view>
+          <raw-text
+            text="!!!"
+          />
+          <view>
+            <text>
+              <raw-text
+                text="Hello World"
+              />
+            </text>
+          </view>
+        </text>
+      </view>
+    `);
+  });
+});
+
+describe('removeChild', () => {
+  it('snapshot slot count = 1', async function() {
+    const a = new SnapshotInstance(snapshot1);
+    a.ensureElements();
+
+    const b = new SnapshotInstance(snapshot2);
+
+    a.insertBefore(b);
+    a.insertBefore(b);
+
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <raw-text
+            text="!!!"
+          />
+        </text>
+        <text>
+          <view>
+            <text>
+              <raw-text
+                text="Hello World"
+              />
+            </text>
+          </view>
+        </text>
+      </view>
+    `);
+
+    expect(snapshotInstanceManager.values.size).toMatchInlineSnapshot(`2`);
+
+    a.removeChild(b);
+    expect(() => a.removeChild(b)).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: Cannot read properties of undefined (reading '$$uiSign')]`,
+    );
+
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <raw-text
+            text="!!!"
+          />
+        </text>
+        <text />
+      </view>
+    `);
+
+    expect(snapshotInstanceManager.values.size).toMatchInlineSnapshot(`1`);
+  });
+});
+
+describe('dynamic key in snapshot', () => {
+  it('multiple slots 0', () => {
+    const snapshot = __SNAPSHOT__(
+      <view>
+        <view className='foo' key={`foo`}>
+          <view>
+            {<text>foo</text>}
+          </view>
+          <view>
+            {<text>bar</text>}
+          </view>
+        </view>
+      </view>,
+    );
+
+    const a = new SnapshotInstance(snapshot);
+    a.ensureElements();
+
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <view
+          class="foo"
+        >
+          <wrapper />
+        </view>
+      </view>
+    `);
+  });
+
+  it('multiple slots 2', () => {
+    const snapshot = __SNAPSHOT__(
+      <view className='foo' key={`foo`}>
+        <view>
+          <view>
+            {<text>foo</text>}
+          </view>
+          <view>
+            {<text>bar</text>}
+          </view>
+        </view>
+      </view>,
+    );
+
+    const a = new SnapshotInstance(snapshot);
+    a.ensureElements();
+
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view
+        class="foo"
+      >
+        <wrapper />
+      </view>
+    `);
+  });
+
+  it('multiple slots 3', () => {
+    const snapshot = __SNAPSHOT__(
+      <view>
+        <text>Hello {HOLE}</text>
+        <view className='foo' key={`foo`}>
+          <view>
+            {<text>foo</text>}
+          </view>
+          <view>
+            {<text>bar</text>}
+          </view>
+        </view>
+      </view>,
+    );
+
+    const a = new SnapshotInstance(snapshot);
+    a.ensureElements();
+
+    expect(a.__element_root).toMatchInlineSnapshot(`
+      <view>
+        <text>
+          <raw-text
+            text="Hello "
+          />
+          <wrapper />
+        </text>
+        <view
+          class="foo"
+        >
+          <wrapper />
+        </view>
+      </view>
+    `);
+  });
+});

--- a/packages/react/runtime/vitest.config.ts
+++ b/packages/react/runtime/vitest.config.ts
@@ -36,6 +36,9 @@ function transformReactLynxPlugin(): Plugin {
           jsxImportSource: '@lynx-js/react',
           filename: 'test',
           target: 'MIXED',
+          // Files named `*.legacy-slot.test.jsx` are compiled with the
+          // legacy children + wrapper codegen (`compat.legacySlot`).
+          legacySlot: relativePath.endsWith('.legacy-slot.test.jsx'),
         },
         dynamicImport: false,
         // snapshot: true,

--- a/packages/react/transform/__test__/fixture.spec.js
+++ b/packages/react/transform/__test__/fixture.spec.js
@@ -2254,3 +2254,95 @@ export class A extends Component {}
     `);
   });
 });
+
+describe('legacySlot', () => {
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const options = (legacySlot) => ({
+    mode: 'test',
+    pluginName: '',
+    filename: '',
+    sourcemap: false,
+    cssScope: false,
+    snapshot: {
+      preserveJsx: false,
+      runtimePkg: '@lynx-js/react',
+      jsxImportSource: '@lynx-js/react',
+      filename: 'test',
+      target: 'MIXED',
+      legacySlot,
+    },
+    jsx: true,
+    directiveDCE: false,
+    defineDCE: false,
+    shake: false,
+    compat: false,
+    worklet: false,
+    refresh: false,
+  });
+
+  it('should compile dynamic children as children + wrapper when enabled', async () => {
+    const inputContent = 'const jsx = <view><text>{content}</text></view>;';
+
+    const result = await transformReactLynx(inputContent, options(true));
+    expect(result.errors).toEqual([]);
+    expect(result.code).toContain('__DynamicPartChildren');
+    expect(result.code).not.toContain('SlotV2');
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+      import * as ReactLynx from "@lynx-js/react";
+      const __snapshot_a94a8_test_1 = "__snapshot_a94a8_test_1";
+      ReactLynx.snapshotCreatorMap[__snapshot_a94a8_test_1] = (__snapshot_a94a8_test_1)=>ReactLynx.createSnapshot(__snapshot_a94a8_test_1, function() {
+              const pageId = ReactLynx.__pageId;
+              const el = __CreateView(pageId);
+              const el1 = __CreateText(pageId);
+              __AppendElement(el, el1);
+              return [
+                  el,
+                  el1
+              ];
+          }, null, [
+              [
+                  ReactLynx.__DynamicPartChildren,
+                  1
+              ]
+          ], undefined, globDynamicComponentEntry, null, true);
+      /*#__PURE__*/ _jsx(__snapshot_a94a8_test_1, {
+          children: content
+      });
+      "
+    `);
+  });
+
+  it('should keep the default SlotV2 codegen when disabled', async () => {
+    const inputContent = 'const jsx = <view><text>{content}</text></view>;';
+
+    const result = await transformReactLynx(inputContent, options(false));
+    expect(result.errors).toEqual([]);
+    expect(result.code).toContain('__DynamicPartSlotV2');
+    expect(result.code).not.toContain('__DynamicPartChildren');
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+      import * as ReactLynx from "@lynx-js/react";
+      const __snapshot_a94a8_test_1 = "__snapshot_a94a8_test_1";
+      ReactLynx.snapshotCreatorMap[__snapshot_a94a8_test_1] = (__snapshot_a94a8_test_1)=>ReactLynx.createSnapshot(__snapshot_a94a8_test_1, function() {
+              const pageId = ReactLynx.__pageId;
+              const el = __CreateView(pageId);
+              const el1 = __CreateText(pageId);
+              __AppendElement(el, el1);
+              return [
+                  el,
+                  el1
+              ];
+          }, null, [
+              [
+                  ReactLynx.__DynamicPartSlotV2,
+                  1
+              ]
+          ], undefined, globDynamicComponentEntry, null, true);
+      /*#__PURE__*/ _jsx(__snapshot_a94a8_test_1, {
+          $0: content
+      });
+      "
+    `);
+  });
+});

--- a/packages/react/transform/crates/swc_plugin_list/legacy_slot.rs
+++ b/packages/react/transform/crates/swc_plugin_list/legacy_slot.rs
@@ -1,3 +1,11 @@
+//! Frozen legacy (pre-SlotV2) list pass, used together with the
+//! `legacy_slot.rs` snapshot codegen when `legacySlot` is enabled.
+//!
+//! Unlike the mainline `ListVisitor`, it performs no SlotV2-oriented
+//! `<list>` children pre-wrapping — the legacy snapshot codegen extracts
+//! list children itself. Like `swc_plugin_snapshot/legacy_slot.rs`, this
+//! module is FROZEN: do not refactor it along with mainline changes.
+
 use swc_core::{
   common::{comments::Comments, util::take::Take, DUMMY_SP},
   ecma::{
@@ -8,14 +16,9 @@ use swc_core::{
   quote,
 };
 
-use swc_plugins_shared::jsx_helpers::{
-  jsx_attr_value, jsx_children_to_expr, jsx_is_list, jsx_is_list_item,
-};
+use swc_plugins_shared::jsx_helpers::{jsx_attr_value, jsx_children_to_expr, jsx_is_list_item};
 
-mod legacy_slot;
-pub use legacy_slot::LegacyListVisitor;
-
-pub struct ListVisitor<C>
+pub struct LegacyListVisitor<C>
 where
   C: Comments,
 {
@@ -24,12 +27,12 @@ where
   _comments: Option<C>,
 }
 
-impl<C> ListVisitor<C>
+impl<C> LegacyListVisitor<C>
 where
   C: Comments,
 {
   pub fn new(comments: Option<C>) -> Self {
-    ListVisitor {
+    LegacyListVisitor {
       runtime_components_ident: private_ident!("ReactLynxRuntimeComponents"),
       runtime_components_module_item: None,
       _comments: comments,
@@ -60,7 +63,7 @@ fn jsx_list_item_deferred(n: &JSXElement) -> bool {
   })
 }
 
-impl<C> VisitMut for ListVisitor<C>
+impl<C> VisitMut for LegacyListVisitor<C>
 where
   C: Comments,
 {
@@ -75,13 +78,6 @@ where
   //   renderChildren={() => <>...</>}
   // />
   fn visit_mut_jsx_element(&mut self, n: &mut JSXElement) {
-    if jsx_is_list(n) {
-      n.children = vec![JSXElementChild::JSXExprContainer(JSXExprContainer {
-        expr: JSXExpr::Expr(Box::new(jsx_children_to_expr(n.children.take()))),
-        span: DUMMY_SP,
-      })];
-    }
-
     n.visit_mut_children_with(self);
 
     if jsx_list_item_deferred(n) {
@@ -174,21 +170,6 @@ where
     }
   }
 
-  fn visit_mut_jsx_element_child(&mut self, node: &mut JSXElementChild) {
-    if let JSXElementChild::JSXElement(jsx_element) = node {
-      if jsx_is_list(jsx_element) {
-        jsx_element.visit_mut_with(self);
-        *node = JSXElementChild::JSXExprContainer(JSXExprContainer {
-          expr: JSXExpr::Expr(Box::new(Expr::JSXElement(Box::new(*jsx_element.take())))),
-          span: DUMMY_SP,
-        });
-        return;
-      }
-    }
-
-    node.visit_mut_children_with(self);
-  }
-
   fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
     let mut new_items: Vec<ModuleItem> = vec![];
     for item in n.iter_mut() {
@@ -215,7 +196,7 @@ mod tests {
     },
   };
 
-  use super::ListVisitor;
+  use super::LegacyListVisitor;
   #[cfg(feature = "napi")]
   use swc_plugin_snapshot::napi::{JSXTransformer, JSXTransformerConfig};
   use swc_plugins_shared::{target_napi::TransformTarget, transform_mode_napi::TransformMode};
@@ -228,9 +209,10 @@ mod tests {
     }),
     |t| {
       (
-        visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
+        visit_mut_pass(LegacyListVisitor::new(Some(t.comments.clone()))),
         visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
           JSXTransformerConfig {
+            legacy_slot: Some(true),
             preserve_jsx: true,
             ..Default::default()
           },
@@ -240,7 +222,7 @@ mod tests {
         )),
       )
     },
-    basic_list,
+    basic_list_legacy_slot,
     // Input codes
     r#"
     <view>
@@ -260,9 +242,10 @@ mod tests {
     }),
     |t| {
       (
-        visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
+        visit_mut_pass(LegacyListVisitor::new(Some(t.comments.clone()))),
         visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
           JSXTransformerConfig {
+            legacy_slot: Some(true),
             preserve_jsx: true,
             ..Default::default()
           },
@@ -272,7 +255,7 @@ mod tests {
         )),
       )
     },
-    basic_list_with_fragment,
+    basic_list_with_fragment_legacy_slot,
     // Input codes
     r#"
     <view>
@@ -295,9 +278,10 @@ mod tests {
     }),
     |t| {
       (
-        visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
+        visit_mut_pass(LegacyListVisitor::new(Some(t.comments.clone()))),
         visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
           JSXTransformerConfig {
+            legacy_slot: Some(true),
             preserve_jsx: true,
             ..Default::default()
           },
@@ -307,7 +291,7 @@ mod tests {
         )),
       )
     },
-    basic_list_toplevel,
+    basic_list_toplevel_legacy_slot,
     // Input codes
     r#"
     <list>
@@ -323,8 +307,8 @@ mod tests {
       jsx: true,
       ..Default::default()
     }),
-    |t| visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-    should_transform_list_in_view,
+    |t| visit_mut_pass(LegacyListVisitor::new(Some(t.comments.clone()))),
+    should_transform_list_in_view_legacy_slot,
     r#"
     <view>
       <list>
@@ -343,9 +327,10 @@ mod tests {
     }),
     |t| {
       (
-        visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
+        visit_mut_pass(LegacyListVisitor::new(Some(t.comments.clone()))),
         visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
           JSXTransformerConfig {
+            legacy_slot: Some(true),
             preserve_jsx: false,
             target: TransformTarget::MIXED,
             ..Default::default()
@@ -356,7 +341,7 @@ mod tests {
         )),
       )
     },
-    should_transform_list_in_view_with_snapshot,
+    should_transform_list_in_view_with_snapshot_legacy_slot,
     r#"
     <view>
       <list>
@@ -373,143 +358,8 @@ mod tests {
       jsx: true,
       ..Default::default()
     }),
-    |t| {
-      (
-        visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-        visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
-          JSXTransformerConfig {
-            preserve_jsx: false,
-            target: TransformTarget::MIXED,
-            ..Default::default()
-          },
-          None,
-          TransformMode::Development,
-          None,
-        )),
-      )
-    },
-    should_transform_list_in_view_with_static_sibling_with_snapshot,
-    r#"
-    <view>
-      <list>
-        <list-item key="1" item-key="1"></list-item>
-        <list-item key="2" item-key="2"></list-item>
-      </list>
-      <view/>
-    </view>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| { visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))) },
-    should_transform_list_in_view_with_static_sibling_nested,
-    r#"
-    <view>
-      <list>
-        <list-item key="1" item-key="1"></list-item>
-        <list-item key="2" item-key="2"></list-item>
-        <list-item key="3" item-key="3">
-          <view>
-            <list>
-              <list-item key="1" item-key="1"></list-item>
-              <list-item key="2" item-key="2"></list-item>
-            </list>
-            <view />
-          </view>
-        </list-item>
-      </list>
-      <view/>
-    </view>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| {
-      (
-        visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-        visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
-          JSXTransformerConfig {
-            preserve_jsx: false,
-            target: TransformTarget::MIXED,
-            ..Default::default()
-          },
-          None,
-          TransformMode::Development,
-          None,
-        )),
-      )
-    },
-    should_transform_list_in_view_with_static_sibling_with_snapshot_nested,
-    r#"
-    <view>
-      <list>
-        <list-item key="1" item-key="1"></list-item>
-        <list-item key="2" item-key="2"></list-item>
-        <list-item key="3" item-key="3">
-          <view>
-            <list>
-              <list-item key="1" item-key="1"></list-item>
-              <list-item key="2" item-key="2"></list-item>
-            </list>
-            <view />
-          </view>
-        </list-item>
-      </list>
-      <view/>
-    </view>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| { visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))) },
-    should_transform_list_in_view_with_static_sibling,
-    r#"
-    <view>
-      <list>
-        <list-item key="1" item-key="1"></list-item>
-        <list-item key="2" item-key="2"></list-item>
-      </list>
-      <view/>
-    </view>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-    should_transform_list_item_deferred_basic,
-    r#"
-    <list-item defer key="1" item-key="1"></list-item>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-    should_transform_list_item_deferred_in_list,
+    |t| visit_mut_pass(LegacyListVisitor::new(Some(t.comments.clone()))),
+    should_transform_list_item_deferred_in_list_legacy_slot,
     r#"
     <list>
       <list-item defer key="1" item-key="1"></list-item>
@@ -524,83 +374,12 @@ mod tests {
       jsx: true,
       ..Default::default()
     }),
-    |t| visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-    should_transform_list_item_not_deferred,
-    r#"
-    <list-item key="1" item-key="1"></list-item>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-    should_transform_list_item_with_spread_deferred,
-    r#"
-    <list-item defer key="1" item-key="1" {...spread}></list-item>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-    should_not_transform_list_item_with_defer_false,
-    r#"
-    <list-item defer={false}></list-item>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-    should_transform_list_item_when_defer_is_expr,
-    r#"
-    <list-item defer={index >= 10}></list-item>;
-    <list-item defer={shouldDefer}></list-item>;
-    <list-item defer={"x"}></list-item>;
-    "#
-  );
-
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
-    |t| visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
-    should_transform_list_item_deferred_with_children,
-    r#"
-    <list-item defer key="1" item-key="1" style="color: red; width: 100rpx;" className="x" bindtap={noop}>
-      <view/>
-      <text/>
-      <image/>
-    </list-item>;
-    "#
-  );
-
-  #[cfg(feature = "napi")]
-  test!(
-    module,
-    Syntax::Es(EsSyntax {
-      jsx: true,
-      ..Default::default()
-    }),
     |t| {
       (
-        visit_mut_pass(ListVisitor::new(Some(t.comments.clone()))),
+        visit_mut_pass(LegacyListVisitor::new(Some(t.comments.clone()))),
         visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
           JSXTransformerConfig {
+            legacy_slot: Some(true),
             preserve_jsx: false,
             target: TransformTarget::MIXED,
             ..Default::default()
@@ -611,7 +390,7 @@ mod tests {
         )),
       )
     },
-    should_transform_list_item_deferred_with_children_with_snapshot,
+    should_transform_list_item_deferred_with_children_with_snapshot_legacy_slot,
     r#"
     <list-item defer key="1" item-key="1" style="color: red; width: 100rpx;" className="x" bindtap={noop}>
       <view/>

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/basic_list_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/basic_list_legacy_slot.js
@@ -1,0 +1,61 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>ReactLynx.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateElement("list-item", pageId);
+        return [
+            el
+        ];
+    }, [
+        (snapshot, index, oldValue)=>ReactLynx.updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+    ], null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
+        const pageId = ReactLynx.__pageId;
+        const el = ReactLynx.snapshotCreateList(pageId, snapshotInstance, 0);
+        return [
+            el
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartListChildren,
+            0
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4)=>ReactLynx.createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el2);
+        return [
+            el,
+            el1,
+            el2
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartSlot,
+            1
+        ],
+        [
+            ReactLynx.__DynamicPartSlot,
+            2
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1><__snapshot_da39a_test_2><__snapshot_da39a_test_3 values={[
+    {
+        "full-span": true,
+        "reuse-identifier": x
+    }
+]} __listItemPlatformInfoIndex={0}/></__snapshot_da39a_test_2><__snapshot_da39a_test_4><A/></__snapshot_da39a_test_4></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/basic_list_toplevel_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/basic_list_toplevel_legacy_slot.js
@@ -1,0 +1,40 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateElement("list-item", pageId);
+        const el1 = __CreateRawText("!!!");
+        __AppendElement(el, el1);
+        return [
+            el,
+            el1
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>ReactLynx.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateElement("list-item", pageId);
+        const el1 = __CreateRawText("!!!");
+        __AppendElement(el, el1);
+        return [
+            el,
+            el1
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function(snapshotInstance) {
+        const pageId = ReactLynx.__pageId;
+        const el = ReactLynx.snapshotCreateList(pageId, snapshotInstance, 0);
+        return [
+            el
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartListChildren,
+            0
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1>{[
+    <__snapshot_da39a_test_2/>,
+    <__snapshot_da39a_test_3/>
+]}</__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/basic_list_with_fragment_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/basic_list_with_fragment_legacy_slot.js
@@ -1,0 +1,65 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>ReactLynx.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateElement("list-item", pageId);
+        return [
+            el
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4)=>ReactLynx.createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateElement("list-item", pageId);
+        return [
+            el
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function(snapshotInstance) {
+        const pageId = ReactLynx.__pageId;
+        const el = ReactLynx.snapshotCreateList(pageId, snapshotInstance, 0);
+        return [
+            el
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartListChildren,
+            0
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_5 = "__snapshot_da39a_test_5";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5)=>ReactLynx.createSnapshot(__snapshot_da39a_test_5, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el2);
+        return [
+            el,
+            el1,
+            el2
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartSlot,
+            1
+        ],
+        [
+            ReactLynx.__DynamicPartSlot,
+            2
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1><__snapshot_da39a_test_2>{<>
+          <__snapshot_da39a_test_3/>
+          <__snapshot_da39a_test_4/>
+        </>}</__snapshot_da39a_test_2><__snapshot_da39a_test_5><A/></__snapshot_da39a_test_5></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/should_transform_list_in_view_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/should_transform_list_in_view_legacy_slot.js
@@ -1,0 +1,6 @@
+<view>
+      <list>
+        <list-item key="1" item-key="1"></list-item>
+        <list-item key="2" item-key="2"></list-item>
+      </list>
+    </view>;

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/should_transform_list_in_view_with_snapshot_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/should_transform_list_in_view_with_snapshot_legacy_slot.js
@@ -1,0 +1,49 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateElement("list-item", pageId);
+        return [
+            el
+        ];
+    }, [
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+    ], null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateElement("list-item", pageId);
+        return [
+            el
+        ];
+    }, [
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0)
+    ], null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function(snapshotInstance) {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateView(pageId);
+        const el1 = (__runtime__ || require("@lynx-js/react")).snapshotCreateList(pageId, snapshotInstance, 1);
+        __AppendElement(el, el1);
+        return [
+            el,
+            el1
+        ];
+    }, null, [
+        [
+            (__runtime__ || require("@lynx-js/react")).__DynamicPartListChildren,
+            1
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1>{[
+    <__snapshot_da39a_test_2 key="1" values={[
+        {
+            "item-key": "1"
+        }
+    ]} __listItemPlatformInfoIndex={0}/>,
+    <__snapshot_da39a_test_3 key="2" values={[
+        {
+            "item-key": "2"
+        }
+    ]} __listItemPlatformInfoIndex={0}/>
+]}</__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/should_transform_list_item_deferred_in_list_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/should_transform_list_item_deferred_in_list_legacy_slot.js
@@ -1,0 +1,5 @@
+import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
+<list>
+      <ReactLynxRuntimeComponents.DeferredListItem renderListItem={(__c)=><list-item item-key="1">{__c}</list-item>} renderChildren={()=>[]} key="1" defer/>
+      <ReactLynxRuntimeComponents.DeferredListItem renderListItem={(__c)=><list-item item-key="2">{__c}</list-item>} renderChildren={()=>[]} key="2" defer/>
+    </list>;

--- a/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/should_transform_list_item_deferred_with_children_with_snapshot_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_list/tests/__swc_snapshots__/legacy_slot.rs/should_transform_list_item_deferred_with_children_with_snapshot_legacy_slot.js
@@ -1,0 +1,95 @@
+import * as ReactLynx from "@lynx-js/react";
+import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateElement("list-item", pageId);
+        __SetInlineStyles(el, "color: red; width: 100rpx;");
+        __SetClasses(el, "x");
+        return [
+            el
+        ];
+    }, [
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], (__runtime__ || require("@lynx-js/react")).__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateText(pageId);
+        return [
+            el
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_4 = "__snapshot_da39a_test_4";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_4] = (__snapshot_da39a_test_4, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_4, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateImage(pageId);
+        return [
+            el
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+<ReactLynxRuntimeComponents.DeferredListItem renderListItem={(__c)=><__snapshot_da39a_test_1 values={[
+        {
+            "item-key": "1"
+        },
+        noop
+    ]} __listItemPlatformInfoIndex={0}>{__c}</__snapshot_da39a_test_1>} renderChildren={()=>[
+        <__snapshot_da39a_test_2/>,
+        <__snapshot_da39a_test_3/>,
+        <__snapshot_da39a_test_4/>
+    ]} key="1" defer/>;
+const __snapshot_da39a_test_5 = "__snapshot_da39a_test_5";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_5] = (__snapshot_da39a_test_5, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_5, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateElement("list-item", pageId);
+        __SetInlineStyles(el, "color: red; width: 100rpx;");
+        __SetClasses(el, "x");
+        return [
+            el
+        ];
+    }, [
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], (__runtime__ || require("@lynx-js/react")).__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_6 = "__snapshot_da39a_test_6";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_6] = (__snapshot_da39a_test_6, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_6, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+<ReactLynxRuntimeComponents.DeferredListItem renderListItem={(__c)=><__snapshot_da39a_test_5 values={[
+        {
+            "item-key": "1"
+        },
+        noop
+    ]} __listItemPlatformInfoIndex={0}>{__c}</__snapshot_da39a_test_5>} renderChildren={()=><__snapshot_da39a_test_6/>} key="1" defer/>;
+const __snapshot_da39a_test_7 = "__snapshot_da39a_test_7";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_7] = (__snapshot_da39a_test_7, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_7, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateElement("list-item", pageId);
+        __SetInlineStyles(el, "color: red; width: 100rpx;");
+        __SetClasses(el, "x");
+        return [
+            el
+        ];
+    }, [
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateListItemPlatformInfo(snapshot, index, oldValue, 0),
+        (snapshot, index, oldValue)=>(__runtime__ || require("@lynx-js/react")).updateEvent(snapshot, index, oldValue, 0, "bindEvent", "tap", '')
+    ], (__runtime__ || require("@lynx-js/react")).__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+<ReactLynxRuntimeComponents.DeferredListItem renderListItem={(__c)=><__snapshot_da39a_test_7 values={[
+        {
+            "item-key": "1"
+        },
+        noop
+    ]} __listItemPlatformInfoIndex={0}>{__c}</__snapshot_da39a_test_7>} renderChildren={()=><App/>} key="1" defer/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/legacy_slot.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/legacy_slot.rs
@@ -1,0 +1,2179 @@
+//! Frozen legacy (pre-SlotV2) snapshot codegen, enabled by the
+//! `legacySlot` config (`pluginReactLynx({ compat: { legacySlot: true } })`).
+//!
+//! This module compiles dynamic children as children + wrapper (`Slot`/
+//! `Children`/`ListChildren` dynamic parts rendered through wrapper
+//! elements), matching the output consumed by `@lynx-js/react` runtimes
+//! without `SlotV2` support (< 0.120.0, before #1764).
+//!
+//! It is intentionally self-contained and FROZEN: do not refactor it along
+//! with the default (SlotV2) codegen in `lib.rs`, and do not "fix" it to
+//! follow mainline changes — its whole purpose is to keep emitting exactly
+//! the output that legacy runtimes were verified against.
+
+use std::{cell::RefCell, collections::HashMap};
+
+use once_cell::sync::Lazy;
+use swc_core::{
+  common::{comments::Comments, util::take::Take, Mark, Span, Spanned, SyntaxContext, DUMMY_SP},
+  ecma::{
+    ast::{JSXExpr, *},
+    utils::{is_literal, private_ident},
+    visit::{VisitMut, VisitMutWith},
+  },
+  quote, quote_expr,
+};
+
+use swc_plugins_shared::{
+  css::get_string_inline_style_from_literal,
+  jsx_helpers::{
+    jsx_attr_name, jsx_attr_to_prop, jsx_attr_value, jsx_children_to_expr, jsx_has_dynamic_key,
+    jsx_is_children_full_dynamic, jsx_is_custom, jsx_is_list, jsx_is_list_item, jsx_name,
+    jsx_props_to_obj, jsx_text_to_str, transform_jsx_attr_str,
+  },
+  target::TransformTarget,
+  utils::calc_hash_number,
+};
+
+use super::{
+  attr_name::AttrName, bool_jsx_attr, bool_to_expr, i32_to_expr, JSXTransformer, UISourceMapRecord,
+  NO_FLATTEN_ATTRIBUTES, WRAPPER_NODE, WRAPPER_NODE_2,
+};
+
+// ---------------------------------------------------------------------------
+// Wrapper marker pre-pass (formerly slot_marker.rs)
+// ---------------------------------------------------------------------------
+
+pub static INTERNAL_SLOT_STR: &str = "internal-slot";
+
+pub fn jsx_is_internal_slot(jsx: &JSXElement) -> bool {
+  match *jsx_name(jsx.opening.name.clone()) {
+    Expr::Lit(Lit::Str(s)) => s.value.to_string_lossy().as_ref() == INTERNAL_SLOT_STR,
+    _ => false,
+  }
+}
+
+pub fn jsx_unwrap_internal_slot(mut jsx: JSXElement) -> JSXElement {
+  if jsx_is_internal_slot(&jsx) {
+    if let Some(JSXElementChild::JSXElement(jsx)) = jsx.children.first_mut() {
+      return *jsx.take();
+    }
+  }
+  unreachable!("unwrap_internal_slot");
+}
+
+fn jsx_wrapped(with: &str, n: JSXElement) -> JSXElement {
+  JSXElement {
+    span: DUMMY_SP,
+    opening: JSXOpeningElement {
+      span: DUMMY_SP,
+      name: JSXElementName::Ident(IdentName::new(with.into(), DUMMY_SP).into()),
+      attrs: vec![],
+      self_closing: false,
+      type_args: None,
+    },
+    closing: Some(JSXClosingElement {
+      span: DUMMY_SP,
+      name: JSXElementName::Ident(IdentName::new(with.into(), DUMMY_SP).into()),
+    }),
+    children: vec![JSXElementChild::JSXElement(Box::new(n))],
+  }
+}
+
+// Wrap dynamic part with wrapper node (or if it's children is full dynamic, do nothing)
+// after this pass, all dynamic part will be wrapped with wrapper node
+pub struct WrapperMarker {
+  pub current_is_children_full_dynamic: bool,
+  pub dynamic_part_count: i32,
+}
+
+impl VisitMut for WrapperMarker {
+  fn visit_mut_jsx_element_childs(&mut self, n: &mut Vec<JSXElementChild>) {
+    if self.current_is_children_full_dynamic {
+      return;
+    }
+
+    if n.is_empty() {
+      return;
+    }
+
+    // merge dynamic parts together to reduce wrapper node count
+
+    let mut merged_children: Vec<JSXElementChild> = vec![];
+    let mut current_chunk: Vec<JSXElementChild> = vec![];
+    for mut child in n.take() {
+      let should_merge: bool;
+      match child {
+        JSXElementChild::JSXText(ref text) => {
+          if jsx_text_to_str(&text.value).is_empty() {
+            should_merge = current_chunk.is_empty();
+          } else {
+            should_merge = true;
+          }
+        }
+        JSXElementChild::JSXElement(ref element) => {
+          should_merge = !jsx_is_custom(element);
+        }
+        JSXElementChild::JSXExprContainer(JSXExprContainer {
+          expr: JSXExpr::Expr(ref _expr),
+          ..
+        }) => {
+          should_merge = false;
+        }
+        JSXElementChild::JSXFragment(_)
+        | JSXElementChild::JSXExprContainer(JSXExprContainer {
+          expr: JSXExpr::JSXEmptyExpr(_),
+          ..
+        }) => {
+          should_merge = true;
+        }
+        JSXElementChild::JSXSpreadChild(_) => {
+          unreachable!("JSXSpreadChild is not supported yet");
+        }
+      }
+
+      if should_merge {
+        if !current_chunk.is_empty() {
+          let child = JSXElementChild::JSXElement(Box::new({
+            let mut el = WRAPPER_NODE_2.clone();
+            el.children = current_chunk.take();
+            jsx_wrapped(INTERNAL_SLOT_STR, el)
+          }));
+          merged_children.push(child);
+          self.dynamic_part_count += 1;
+        }
+
+        child.visit_mut_with(self);
+        merged_children.push(child);
+      } else {
+        current_chunk.push(child);
+      }
+    }
+
+    if !current_chunk.is_empty() {
+      let child = JSXElementChild::JSXElement(Box::new({
+        let mut el = WRAPPER_NODE_2.clone();
+        el.children = current_chunk.take();
+        jsx_wrapped(INTERNAL_SLOT_STR, el)
+      }));
+      merged_children.push(child);
+      self.dynamic_part_count += 1;
+    }
+
+    *n = merged_children;
+  }
+
+  fn visit_mut_jsx_element(&mut self, n: &mut JSXElement) {
+    if jsx_is_custom(n) {
+      // always ignore top level custom element
+    } else {
+      // let is_children_full_static = jsx_is_children_full_static(&n);
+      // let is_list = jsx_is_list(&n) || !is_children_full_static;
+      // let is_children_full_dynamic = is_list || jsx_is_children_full_dynamic(&n);
+
+      let is_list = jsx_is_list(n);
+      let is_children_full_dynamic = is_list || jsx_is_children_full_dynamic(n);
+      let has_dynamic_key = jsx_has_dynamic_key(n);
+
+      if (is_list || has_dynamic_key) && !n.children.is_empty() {
+        n.children = vec![JSXElementChild::JSXExprContainer(JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(jsx_children_to_expr(n.children.take()))),
+        })];
+      }
+
+      if is_children_full_dynamic {
+        self.dynamic_part_count += 1;
+        *n = jsx_wrapped(INTERNAL_SLOT_STR, n.take());
+      }
+
+      let pre_is_children_full_dynamic = self.current_is_children_full_dynamic;
+      self.current_is_children_full_dynamic = is_children_full_dynamic;
+      n.visit_mut_children_with(self);
+      self.current_is_children_full_dynamic = pre_is_children_full_dynamic;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy dynamic parts
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum DynamicPart {
+  Attr(Expr, i32, AttrName),
+  Spread(Expr, i32, bool),
+  Slot(JSXElement, i32),
+  Children(Expr, i32),
+  ListChildren(Expr, i32),
+}
+
+impl DynamicPart {
+  fn to_updater(&self, runtime_id: Expr, target: TransformTarget, exp_index: i32) -> Expr {
+    match target {
+      TransformTarget::LEPUS | TransformTarget::MIXED => match self {
+        DynamicPart::Attr(_, element_index, attr_name) => match attr_name {
+          AttrName::Attr(name) => quote!(
+            "function (ctx) {
+              if (ctx.__elements) {
+                __SetAttribute(ctx.__elements[$element_index], $name, ctx.__values[$exp_index]);
+              }
+            }" as Expr,
+            name: Expr = Expr::Lit(Lit::Str(name.clone().into())),
+            element_index: Expr = i32_to_expr(element_index),
+            exp_index: Expr = i32_to_expr(&exp_index),
+          ),
+          AttrName::TimingFlag => quote!(
+            "function (ctx) {
+              if (ctx.__elements) {
+                __SetAttribute(ctx.__elements[$element_index], '__lynx_timing_flag', ctx.__values[$exp_index].__ltf);
+              }
+            }" as Expr,
+            element_index: Expr = i32_to_expr(element_index),
+            exp_index: Expr = i32_to_expr(&exp_index),
+          ),
+          AttrName::Dataset(name) => quote!(
+            "function (ctx) {
+              if (ctx.__elements) {
+                __AddDataset(ctx.__elements[$element_index], $name, ctx.__values[$exp_index]);
+              }
+            }" as Expr,
+            name: Expr = Expr::Lit(Lit::Str(name.clone().into())),
+            element_index: Expr = i32_to_expr(element_index),
+            exp_index: Expr = i32_to_expr(&exp_index),
+          ),
+          AttrName::Style => quote!(
+            "function (ctx) {
+              if (ctx.__elements) {
+                __SetInlineStyles(ctx.__elements[$element_index], ctx.__values[$exp_index]);
+              }
+            }" as Expr,
+            element_index: Expr = i32_to_expr(element_index),
+            exp_index: Expr = i32_to_expr(&exp_index),
+          ),
+          AttrName::Class => quote!(
+            "function (ctx) {
+              if (ctx.__elements) {
+                __SetClasses(ctx.__elements[$element_index], ctx.__values[$exp_index] || '');
+              }
+            }" as Expr,
+            element_index: Expr = i32_to_expr(element_index),
+            exp_index: Expr = i32_to_expr(&exp_index),
+          ),
+          AttrName::ID => quote!(
+            "function (ctx) {
+              if (ctx.__elements) {
+                __SetID(ctx.__elements[$element_index], ctx.__values[$exp_index]);
+              }
+            }" as Expr,
+            element_index: Expr = i32_to_expr(element_index),
+            exp_index: Expr = i32_to_expr(&exp_index),
+          ),
+          AttrName::Event(event_type, event_name) => quote!(
+            "(snapshot, index, oldValue) => $runtime_id.updateEvent(snapshot, index, oldValue, $element_index, $event_type, $event_name, '')" as Expr,
+            runtime_id: Expr = runtime_id.clone(),
+            event_type: Expr = Expr::Lit(Lit::Str(event_type.clone().into())),
+            event_name: Expr = Expr::Lit(Lit::Str(event_name.clone().into())),
+            element_index: Expr = i32_to_expr(element_index),
+          ),
+          AttrName::WorkletEvent(worklet_type, event_type, event_name) => quote!(
+            "(snapshot, index, oldValue) => $runtime_id.updateWorkletEvent(snapshot, index, oldValue, $element_index, $worklet_type, $event_type, $event_name)" as Expr,
+            runtime_id: Expr = runtime_id.clone(),
+            worklet_type: Expr = Expr::Lit(Lit::Str(worklet_type.clone().into())),
+            event_type: Expr = Expr::Lit(Lit::Str(event_type.clone().into())),
+            event_name: Expr = Expr::Lit(Lit::Str(event_name.clone().into())),
+            element_index: Expr = i32_to_expr(element_index),
+          ),
+          AttrName::Ref => quote!(
+            "(snapshot, index, oldValue) => $runtime_id.updateRef(snapshot, index, oldValue, $element_index)" as Expr,
+            runtime_id: Expr = runtime_id.clone(),
+            element_index: Expr = i32_to_expr(element_index),
+          ),
+          AttrName::WorkletRef(worklet_type) => quote!(
+            "(snapshot, index, oldValue) => $runtime_id.updateWorkletRef(snapshot, index, oldValue, $element_index, $worklet_type)" as Expr,
+            runtime_id: Expr = runtime_id.clone(),
+            element_index: Expr = i32_to_expr(element_index),
+            worklet_type: Expr = Expr::Lit(Lit::Str(worklet_type.clone().into())),
+          ),
+          AttrName::ListItemPlatformInfo => quote!(
+            "(snapshot, index, oldValue) => $runtime_id.updateListItemPlatformInfo(snapshot, index, oldValue, $element_index)" as Expr,
+            runtime_id: Expr = runtime_id.clone(),
+            element_index: Expr = i32_to_expr(element_index),
+          ),
+          AttrName::Gesture(ns) => quote!(
+            "(snapshot, index, oldValue) => $runtime_id.updateGesture(snapshot, index, oldValue, $element_index, $ns)" as Expr,
+            runtime_id: Expr = runtime_id.clone(),
+            element_index: Expr = i32_to_expr(element_index),
+            ns: Expr = Expr::Lit(Lit::Str(ns.clone().into())),
+          ),
+        },
+        DynamicPart::Spread(_, element_index, is_list_item) => quote!(
+          "(snapshot, index, oldValue) => $runtime_id.updateSpread(snapshot, index, oldValue, $element_index, $is_list_item)" as Expr,
+          runtime_id: Expr = runtime_id.clone(),
+          element_index: Expr = i32_to_expr(element_index),
+          is_list_item: Expr = bool_to_expr(is_list_item)
+        ),
+        DynamicPart::Slot(_, _) => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+        DynamicPart::Children(_, _) => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+        DynamicPart::ListChildren(_, _) => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+      },
+      TransformTarget::JS => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+    }
+  }
+}
+
+pub struct DynamicPartExtractor<'a, V, F>
+where
+  V: VisitMut,
+  F: Fn(Span) -> Expr,
+{
+  page_id: Lazy<Ident>,
+  runtime_id: Expr,
+  parent_element: Option<Ident>,
+  element_index: i32,
+  element_ids: HashMap<i32, Ident>,
+  static_stmts: Vec<RefCell<Stmt>>,
+  si_id: Lazy<Ident>,
+  snapshot_creator: Option<Function>,
+  dynamic_part_count: i32,
+  dynamic_parts: Vec<DynamicPart>,
+  dynamic_part_visitor: &'a mut V,
+  key: Option<JSXAttrValue>,
+  enable_ui_source_map: bool,
+  node_index_fn: F,
+}
+
+impl<'a, V, F> DynamicPartExtractor<'a, V, F>
+where
+  V: VisitMut,
+  F: Fn(Span) -> Expr,
+{
+  fn new(
+    runtime_id: Expr,
+    dynamic_part_count: i32,
+    dynamic_part_visitor: &'a mut V,
+    enable_ui_source_map: bool,
+    node_index_fn: F,
+  ) -> Self {
+    DynamicPartExtractor {
+      page_id: Lazy::new(|| private_ident!("pageId")),
+      runtime_id,
+      parent_element: None,
+      element_index: 0,
+      element_ids: HashMap::new(),
+      static_stmts: vec![],
+      si_id: Lazy::new(|| private_ident!("snapshotInstance")),
+      snapshot_creator: None,
+      dynamic_part_count,
+      dynamic_parts: vec![],
+      dynamic_part_visitor,
+      key: None,
+      enable_ui_source_map,
+      node_index_fn,
+    }
+  }
+
+  fn node_index_expr_from_span(&self, span: Span) -> Expr {
+    (self.node_index_fn)(span)
+  }
+
+  fn node_index_config_expr(&self, span: Span) -> Expr {
+    Expr::Object(ObjectLit {
+      span: DUMMY_SP,
+      props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+        key: PropName::Ident(IdentName::new("nodeIndex".into(), DUMMY_SP)),
+        value: Box::new(self.node_index_expr_from_span(span)),
+      })))],
+    })
+  }
+
+  fn static_stmt_from_create_call(
+    &self,
+    element: Ident,
+    callee: &str,
+    mut args: Vec<Expr>,
+    span: Span,
+  ) -> Stmt {
+    if self.enable_ui_source_map {
+      args.push(self.node_index_config_expr(span));
+    }
+
+    Stmt::Decl(Decl::Var(Box::new(VarDecl {
+      ctxt: SyntaxContext::default(),
+      span: DUMMY_SP,
+      kind: VarDeclKind::Const,
+      declare: false,
+      decls: vec![VarDeclarator {
+        span: DUMMY_SP,
+        definite: false,
+        name: Pat::Ident(element.into()),
+        init: Some(Box::new(Expr::Call(CallExpr {
+          ctxt: SyntaxContext::default(),
+          span: DUMMY_SP,
+          callee: Callee::Expr(Box::new(Expr::Ident(
+            IdentName::new(callee.into(), DUMMY_SP).into(),
+          ))),
+          args: args
+            .into_iter()
+            .map(|expr| ExprOrSpread {
+              spread: None,
+              expr: Box::new(expr),
+            })
+            .collect(),
+          type_args: None,
+        }))),
+      }],
+    })))
+  }
+
+  fn static_stmt_from_jsx_element(&mut self, n: &JSXElement, el: Ident) -> Stmt {
+    let mut static_stmt: Stmt = Stmt::Empty(EmptyStmt { span: DUMMY_SP });
+
+    if let Expr::Lit(Lit::Str(str)) = *jsx_name(n.opening.name.clone()) {
+      let tag = str.value.to_string_lossy();
+      match tag.as_ref() {
+        "view" => {
+          static_stmt = self.static_stmt_from_create_call(
+            el.clone(),
+            "__CreateView",
+            vec![Expr::Ident(self.page_id.clone())],
+            n.opening.span,
+          );
+        }
+        "scroll-view" => {
+          static_stmt = self.static_stmt_from_create_call(
+            el.clone(),
+            "__CreateScrollView",
+            vec![Expr::Ident(self.page_id.clone())],
+            n.opening.span,
+          );
+        }
+        "x-scroll-view" => {
+          static_stmt = self.static_stmt_from_create_call(
+            el.clone(),
+            "__CreateScrollView",
+            vec![Expr::Ident(self.page_id.clone())],
+            n.opening.span,
+          );
+        }
+        "image" => {
+          static_stmt = self.static_stmt_from_create_call(
+            el.clone(),
+            "__CreateImage",
+            vec![Expr::Ident(self.page_id.clone())],
+            n.opening.span,
+          );
+        }
+        "text" => {
+          static_stmt = self.static_stmt_from_create_call(
+            el.clone(),
+            "__CreateText",
+            vec![Expr::Ident(self.page_id.clone())],
+            n.opening.span,
+          );
+        }
+        "wrapper" => {
+          static_stmt = quote!(
+            r#"const $element = __CreateWrapperElement($page_id)"# as Stmt,
+            element = el.clone(),
+            page_id = self.page_id.clone(),
+          );
+        }
+        "list" => {
+          static_stmt = quote!(
+              r#"const $element = $runtime_id.snapshotCreateList($page_id, $si_id, $element_index)"#
+                  as Stmt,
+              element = el.clone(),
+              runtime_id: Expr = self.runtime_id.clone(),
+              page_id = self.page_id.clone(),
+              si_id = self.si_id.clone(),
+              element_index: Expr = Expr::Lit(Lit::Num(Number { span: DUMMY_SP, value: self.element_index as f64, raw: None })),
+          );
+        }
+        "frame" => {
+          static_stmt = self.static_stmt_from_create_call(
+            el.clone(),
+            "__CreateFrame",
+            vec![Expr::Ident(self.page_id.clone())],
+            n.opening.span,
+          );
+        }
+        _ => {
+          static_stmt = self.static_stmt_from_create_call(
+            el.clone(),
+            "__CreateElement",
+            vec![Expr::Lit(Lit::Str(str)), Expr::Ident(self.page_id.clone())],
+            n.opening.span,
+          );
+        }
+      };
+    }
+
+    static_stmt
+  }
+}
+
+impl<V, F> VisitMut for DynamicPartExtractor<'_, V, F>
+where
+  V: VisitMut,
+  F: Fn(Span) -> Expr,
+{
+  fn visit_mut_jsx_element(&mut self, n: &mut JSXElement) {
+    if jsx_is_internal_slot(n) {
+      if self.dynamic_part_count > 1 {
+        n.visit_mut_children_with(self.dynamic_part_visitor);
+        self.dynamic_parts.push(DynamicPart::Slot(
+          jsx_unwrap_internal_slot(n.take()),
+          self.element_index,
+        ));
+        *n = WRAPPER_NODE_2.clone();
+      } else {
+        *n = jsx_unwrap_internal_slot(n.take());
+      }
+    }
+
+    if !jsx_is_custom(n) {
+      match Lazy::<Ident>::get(&self.page_id) {
+        Some(_) => {}
+        None => {
+          self.static_stmts.push(RefCell::new(quote!(
+            r#"const $page_id = $runtime_id.__pageId"# as Stmt,
+            page_id = self.page_id.clone(),
+            runtime_id: Expr = self.runtime_id.clone(),
+          )));
+        }
+      }
+
+      let el = private_ident!("el");
+      self.element_ids.insert(self.element_index, el.clone());
+
+      let static_stmt = self.static_stmt_from_jsx_element(n, el.clone());
+      let static_stmt = RefCell::new(static_stmt);
+      self.static_stmts.push(static_stmt.clone());
+
+      {
+        let mut flatten = None;
+        for attr in &n.opening.attrs {
+          if let JSXAttrOrSpread::JSXAttr(attr) = attr {
+            let name = jsx_attr_name(&attr.name.clone()).to_string();
+            if NO_FLATTEN_ATTRIBUTES.contains(&name) {
+              flatten = Some(JSXAttrOrSpread::JSXAttr(JSXAttr {
+                span: DUMMY_SP,
+                name: JSXAttrName::Ident(IdentName::new("flatten".into(), DUMMY_SP)),
+                value: Some(bool_jsx_attr(false)),
+              }));
+              break;
+            }
+          }
+        }
+
+        if let Some(flatten) = flatten {
+          let mut has_origin_flatten = false;
+          for attr in &mut n.opening.attrs {
+            if let JSXAttrOrSpread::JSXAttr(attr) = attr {
+              let name = jsx_attr_name(&attr.name.clone()).to_string();
+              if name == *"flatten" {
+                attr.value = Some(bool_jsx_attr(false));
+                has_origin_flatten = true;
+              }
+            }
+          }
+          if !has_origin_flatten {
+            n.opening.attrs.push(flatten);
+          }
+        }
+      }
+
+      let has_spread_element = n
+        .opening
+        .attrs
+        .iter()
+        .any(|attr_or_spread| match attr_or_spread {
+          JSXAttrOrSpread::SpreadElement(_) => true,
+          JSXAttrOrSpread::JSXAttr(_) => false,
+          #[cfg(swc_ast_unknown)]
+          _ => panic!("unknown node"),
+        });
+
+      let is_list_item = jsx_is_list_item(n);
+      if is_list_item {
+        if has_spread_element {
+        } else {
+          let mut list_item_platform_info: Vec<JSXAttr> = vec![];
+          n.opening.attrs.retain_mut(|attr_or_spread| {
+            match attr_or_spread {
+              JSXAttrOrSpread::JSXAttr(attr) => {
+                if let JSXAttrName::Ident(id) = &attr.name {
+                  match id.sym.to_string().as_str() {
+                    "reuse-identifier"
+                    | "full-span"
+                    | "item-key"
+                    | "sticky-top"
+                    | "sticky-bottom"
+                    | "estimated-height"
+                    | "estimated-height-px"
+                    | "estimated-main-axis-size-px"
+                    | "recyclable" => {
+                      list_item_platform_info.push(attr.clone());
+                      return false;
+                    }
+                    &_ => {}
+                  }
+                }
+              }
+              JSXAttrOrSpread::SpreadElement(_spread) => {
+                return false;
+              }
+              #[cfg(swc_ast_unknown)]
+              _ => panic!("unknown node"),
+            }
+
+            true
+          });
+          if !list_item_platform_info.is_empty() {
+            self.dynamic_parts.push(DynamicPart::Attr(
+              Expr::Object(ObjectLit {
+                span: DUMMY_SP,
+                props: list_item_platform_info
+                  .iter()
+                  .map(jsx_attr_to_prop)
+                  .collect(),
+              }),
+              self.element_index,
+              AttrName::ListItemPlatformInfo,
+            ));
+          }
+        }
+      }
+
+      // pick key from n.opening.attrs
+      n.opening
+        .attrs
+        .retain_mut(|attr_or_spread| match attr_or_spread {
+          JSXAttrOrSpread::SpreadElement(_) => true,
+          JSXAttrOrSpread::JSXAttr(JSXAttr { name, value, .. }) => match name {
+            JSXAttrName::Ident(ident_name) => match ident_name.sym.as_ref() {
+              "key" => {
+                if self.parent_element.is_none() {
+                  self.key = value.take();
+                }
+                false
+              }
+              _ => true,
+            },
+            JSXAttrName::JSXNamespacedName(_) => true,
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unknown node"),
+          },
+          #[cfg(swc_ast_unknown)]
+          _ => panic!("unknown node"),
+        });
+
+      if has_spread_element {
+        // TODO: avoid clone
+        let mut spread_obj = jsx_props_to_obj(n).unwrap();
+        spread_obj.props.push(
+          Prop::KeyValue(KeyValueProp {
+            key: PropName::Ident(IdentName::new("__spread".into(), DUMMY_SP)),
+            value: Expr::Lit(Lit::Bool(true.into())).into(),
+          })
+          .into(),
+        );
+        self.dynamic_parts.push(DynamicPart::Spread(
+          Expr::Object(spread_obj),
+          self.element_index,
+          is_list_item,
+        ));
+      } else {
+        let el = Expr::Ident(el.clone());
+
+        n.opening
+          .attrs
+          .iter_mut()
+          .for_each(|attr_or_spread| match attr_or_spread {
+            JSXAttrOrSpread::SpreadElement(_) => todo!(),
+            JSXAttrOrSpread::JSXAttr(JSXAttr { name, value, .. }) => {
+              match name {
+                JSXAttrName::Ident(ident_name) => {
+                  let attr_name = AttrName::from(<IdentName as Into<Ident>>::into(ident_name.clone()));
+                  match &attr_name {
+                    AttrName::Attr(name) => {
+                      match value {
+                        None => {
+                          let stmt = quote!(
+                              r#"__SetAttribute($element, $name, $value)"# as Stmt,
+                              element: Expr = el.clone(),
+                              name: Expr = name.clone().into(),
+                              value: Expr = Expr::Lit(Lit::Bool(Bool {span: DUMMY_SP, value: true}))
+                          );
+                          self.static_stmts.push(RefCell::new(stmt));
+                        }
+                        Some(JSXAttrValue::Str(s)) => {
+                          let value = transform_jsx_attr_str(&s.value);
+                          let stmt = quote!(
+                              r#"__SetAttribute($element, $name, $value)"# as Stmt,
+                              element: Expr = el.clone(),
+                              name: Expr =  name.clone().into(),
+                              value: Expr = Expr::Lit(Lit::Str(Str { span: s.span, value: value.into(), raw: None }))
+                          );
+                          self.static_stmts.push(RefCell::new(stmt));
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::Expr(expr),
+                          ..
+                        })) => {
+                          // expr.map_with_mut(|value| {
+                          //     value.fold_with(self.dynamic_part_visitor)
+                          // });
+                          match &**expr {
+                            Expr::Lit(value) => {
+                              let stmt = quote!(
+                                  r#"__SetAttribute($element, $name, $value)"# as Stmt,
+                                  element: Expr = el.clone(),
+                                  name: Expr =  name.clone().into(),
+                                  value: Expr = Expr::Lit(value.clone())
+                              );
+                              self.static_stmts.push(RefCell::new(stmt));
+                            }
+                            _ => {
+                              self.dynamic_parts.push(DynamicPart::Attr(
+                                *expr.clone(),
+                                self.element_index,
+                                attr_name.clone(),
+                              ));
+                            }
+                          }
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::JSXEmptyExpr(_),
+                          ..
+                        })) => {}
+                        Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
+                        Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
+                        #[cfg(swc_ast_unknown)]
+                        _ => panic!("unknown node"),
+                      };
+                    }
+                    AttrName::Dataset(name) => {
+                      match value {
+                        None => {
+                          let stmt = quote!(
+                              r#"__AddDataset($element, $name, $value)"# as Stmt,
+                              element: Expr = el.clone(),
+                              name: Expr =  name.clone().into(),
+                              value: Expr = Expr::Lit(Lit::Bool(Bool {span: DUMMY_SP, value: true}))
+                          );
+                          self.static_stmts.push(RefCell::new(stmt));
+                        }
+                        Some(JSXAttrValue::Str(s)) => {
+                          let value = transform_jsx_attr_str(&s.value);
+                          let stmt = quote!(
+                              r#"__AddDataset($element, $name, $value)"# as Stmt,
+                              element: Expr = el.clone(),
+                              name: Expr =  name.clone().into(),
+                              value: Expr = Expr::Lit(Lit::Str(Str { span: s.span, value: value.into(), raw: None }))
+                          );
+                          self.static_stmts.push(RefCell::new(stmt));
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::Expr(expr),
+                          ..
+                        })) => {
+                          self.dynamic_parts.push(DynamicPart::Attr(
+                            *expr.clone(),
+                            self.element_index,
+                            attr_name.clone(),
+                          ));
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::JSXEmptyExpr(_),
+                          ..
+                        })) => {}
+                        Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
+                        Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
+                        #[cfg(swc_ast_unknown)]
+                        _ => panic!("unknown node"),
+                      };
+                    }
+                    AttrName::Event(..) | AttrName::Ref => {
+                      self.dynamic_parts.push(DynamicPart::Attr(
+                        *jsx_attr_value((*value).clone()),
+                        self.element_index,
+                        attr_name.clone(),
+                      ));
+                    }
+                    AttrName::TimingFlag => {
+                      self.dynamic_parts.push(DynamicPart::Attr(
+                        *quote_expr!("{__ltf: $flag}", flag: Expr = *jsx_attr_value((*value).clone())),
+                        self.element_index,
+                        attr_name.clone(),
+                      ));
+                    }
+                    AttrName::Style => {
+                      match value {
+                        None => {}
+                        Some(JSXAttrValue::Str(s)) => {
+                          // <view style="width: 100rpx" />;
+                          let value = transform_jsx_attr_str(&s.value);
+                          let stmt = quote!(
+                              r#"__SetInlineStyles($element, $value)"# as Stmt,
+                              element: Expr = el.clone(),
+                              value: Expr = Expr::Lit(Lit::Str(Str { span: s.span, value: value.into(), raw: None }))
+                          );
+                          self.static_stmts.push(RefCell::new(stmt));
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::Expr(expr),
+                          span,
+                          ..
+                        })) => {
+                          let expr = &**expr;
+                          if is_literal(expr) {
+                            if let Some(s) = get_string_inline_style_from_literal(expr, span) {
+                              // <view style={{backgroundColor: "red"}} />;
+                              // <view style={`background-color: red;`} />;
+                              let s = Lit::Str(Str {
+                                span: *span,
+                                value: s.into(),
+                                raw: None,
+                              });
+                              let stmt = quote!(
+                                r#"__SetInlineStyles($element, $value)"# as Stmt,
+                                element: Expr = el.clone(),
+                                value: Expr = Expr::Lit(s)
+                              );
+                              self.static_stmts.push(RefCell::new(stmt));
+                            }
+                          } else {
+                            self.dynamic_parts.push(DynamicPart::Attr(
+                              expr.clone(),
+                              self.element_index,
+                              attr_name.clone(),
+                            ));
+                          }
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::JSXEmptyExpr(_),
+                          ..
+                        })) => {}
+                        Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
+                        Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
+                        #[cfg(swc_ast_unknown)]
+                        _ => panic!("unknown node"),
+                      };
+                    }
+                    AttrName::Class => {
+                      match value {
+                        None => {}
+                        Some(JSXAttrValue::Str(s)) => {
+                          let value = transform_jsx_attr_str(&s.value);
+                          let stmt = quote!(
+                              r#"__SetClasses($element, $value)"# as Stmt,
+                              element: Expr = el.clone(),
+                              value: Expr = Expr::Lit(Lit::Str(Str { span: s.span, value: value.into(), raw: None }))
+                          );
+                          self.static_stmts.push(RefCell::new(stmt));
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::Expr(expr),
+                          ..
+                        })) => match &**expr {
+                          Expr::Lit(value) => {
+                            let stmt = quote!(
+                                r#"__SetClasses($element, $value)"# as Stmt,
+                                element: Expr = el.clone(),
+                                value: Expr = Expr::Lit(value.clone())
+                            );
+                            self.static_stmts.push(RefCell::new(stmt));
+                          }
+                          _ => {
+                            self.dynamic_parts.push(DynamicPart::Attr(
+                              *expr.clone(),
+                              self.element_index,
+                              attr_name.clone(),
+                            ));
+                          }
+                        },
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::JSXEmptyExpr(_),
+                          ..
+                        })) => {}
+                        Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
+                        Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
+                        #[cfg(swc_ast_unknown)]
+                        _ => panic!("unknown node"),
+                      };
+                    }
+                    AttrName::ID => {
+                      match value {
+                        None => {}
+                        Some(JSXAttrValue::Str(s)) => {
+                          let value = transform_jsx_attr_str(&s.value);
+                          let stmt = quote!(
+                              r#"__SetID($element, $value)"# as Stmt,
+                              element: Expr = el.clone(),
+                              value: Expr = Expr::Lit(Lit::Str(Str { span: s.span, value: value.into(), raw: None }))
+                          );
+                          self.static_stmts.push(RefCell::new(stmt));
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::Expr(expr),
+                          ..
+                        })) => {
+                          self.dynamic_parts.push(DynamicPart::Attr(
+                            *expr.clone(),
+                            self.element_index,
+                            attr_name,
+                          ));
+                        }
+                        Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                          expr: JSXExpr::JSXEmptyExpr(_),
+                          ..
+                        })) => {}
+                        Some(JSXAttrValue::JSXElement(_)) => unreachable!("Unexpected JSXElement in JSX attribute value - not supported"),
+                        Some(JSXAttrValue::JSXFragment(_)) => unreachable!("Unexpected JSXFragment in JSX attribute value - not supported"),
+                        #[cfg(swc_ast_unknown)]
+                        _ => panic!("unknown node"),
+                      };
+                    }
+                    AttrName::ListItemPlatformInfo => unreachable!("Unexpected ListItemPlatformInfo attribute in static JSX processing"),
+                    AttrName::WorkletEvent(..) | AttrName::WorkletRef(..) => {
+                      unreachable!("A worklet event should have an attribute namespace.")
+                    }
+                    AttrName::Gesture(..) => {
+                      unreachable!("A gesture should have an attribute namespace.")
+                    }
+                  }
+                }
+                JSXAttrName::JSXNamespacedName(JSXNamespacedName { ns, name, .. }) => {
+                  let attr_name: AttrName = AttrName::from_ns(ns.clone().into(), name.clone().into());
+                  match attr_name {
+                    AttrName::WorkletEvent(..) | AttrName::WorkletRef(..) => {
+                      self.dynamic_parts.push(DynamicPart::Attr(
+                        *jsx_attr_value((*value).clone()),
+                        self.element_index,
+                        attr_name.clone(),
+                      ));
+                    }
+                    AttrName::Gesture(..) => {
+                      self.dynamic_parts.push(DynamicPart::Attr(
+                        *jsx_attr_value((*value).clone()),
+                        self.element_index,
+                        attr_name.clone(),
+                      ));
+                    }
+                    _ => todo!(),
+                  }
+                }
+                #[cfg(swc_ast_unknown)]
+                _ => panic!("unknown node"),
+              };
+            }
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unknown node"),
+          });
+      }
+
+      if let Some(parent_el) = &self.parent_element {
+        self.static_stmts.push(RefCell::new(quote!(
+            r#"__AppendElement($parent, $child)"# as Stmt,
+            parent: Ident = parent_el.clone(),
+            child: Ident = el.clone(),
+        )));
+      };
+
+      let is_list = jsx_is_list(n);
+      let is_children_full_dynamic = is_list || jsx_is_children_full_dynamic(n);
+
+      if !is_children_full_dynamic {
+        self.element_index += 1;
+
+        let pre_parent_element = self.parent_element.take();
+        self.parent_element = Some(el.clone());
+        // n.children.iter_mut().for_each(|child| match child {
+        //     JSXElementChild::JSXText(_) => {
+        //         child.visit_mut_children_with(self);
+        //     }
+        //     JSXElementChild::JSXElement(_) => {
+        //         child.visit_mut_children_with(self);
+        //     }
+        //     JSXElementChild::JSXFragment(_) => {
+        //         child.visit_mut_children_with(self);
+        //     }
+        //     JSXElementChild::JSXExprContainer(JSXExprContainer {
+        //         expr: JSXExpr::Expr(_expr),
+        //         ..
+        //     }) => {
+        //         unreachable!("should be handled by WrapDynamicPart");
+        //     }
+        //     JSXElementChild::JSXExprContainer(JSXExprContainer {
+        //         expr: JSXExpr::JSXEmptyExpr(_),
+        //         ..
+        //     }) => {
+        //         // comment, just ignore
+        //     }
+        //     JSXElementChild::JSXSpreadChild(_) => {
+        //         unreachable!("JSXSpreadChild is not supported yet");
+        //     }
+        // });
+
+        n.visit_mut_children_with(self);
+
+        self.parent_element = pre_parent_element;
+      } else {
+        if self.dynamic_part_count <= 1 {
+          n.visit_mut_children_with(self.dynamic_part_visitor);
+          let children_expr = jsx_children_to_expr(n.children.take());
+          if is_list {
+            self
+              .dynamic_parts
+              .push(DynamicPart::ListChildren(children_expr, self.element_index));
+          } else {
+            self
+              .dynamic_parts
+              .push(DynamicPart::Children(children_expr, self.element_index));
+          }
+        } else {
+          // static_stmt.replace_with(|_| {
+          //     let r = WRAPPER_NODE.clone();
+          //     let (static_stmt, _) =
+          //         self.static_stmt_from_jsx_element(&r, el.clone());
+          //     static_stmt
+          // });
+
+          // n.map_with_mut(|value| value.fold_with(self.dynamic_part_visitor));
+          // if is_list {
+          //     // unreachable!()
+          //     self.dynamic_parts
+          //         .push(DynamicPart::Slot(n.take(), self.element_index));
+          // } else {
+          //     self.dynamic_parts
+          //         .push(DynamicPart::Slot(n.take(), self.element_index));
+          // }
+
+          unreachable!("should be handled by WrapDynamicPart");
+        }
+
+        self.element_index += 1;
+      }
+
+      if self.parent_element.is_none() {
+        let elements = Expr::Array(ArrayLit {
+          span: DUMMY_SP,
+          elems: (0..self.element_ids.len())
+            .step_by(1)
+            .map(|e| e as i32)
+            .map(|e| {
+              Some(ExprOrSpread {
+                spread: None,
+                expr: Box::new(Expr::Ident(self.element_ids[&e].clone())),
+              })
+            })
+            .collect(),
+        });
+
+        self.static_stmts.push(RefCell::new(quote!(
+          r#"return $elements;"# as Stmt,
+          elements: Expr = elements,
+        )));
+
+        self.snapshot_creator = Some(Function {
+          ctxt: SyntaxContext::default(),
+          params: match Lazy::<Ident>::get(&self.si_id) {
+            Some(_) => vec![Param {
+              span: DUMMY_SP,
+              decorators: vec![],
+              pat: Pat::Ident(BindingIdent {
+                id: self.si_id.take(),
+                type_ann: None,
+              }),
+            }],
+            None => vec![],
+          },
+          decorators: vec![],
+          span: DUMMY_SP,
+          body: Some(BlockStmt {
+            ctxt: SyntaxContext::default(),
+            span: DUMMY_SP,
+            stmts: self
+              .static_stmts
+              .take()
+              .into_iter()
+              .map(|mut stmt| stmt.get_mut().take())
+              .collect(),
+          }),
+          is_generator: false,
+          is_async: false,
+          type_params: None,
+          return_type: None,
+        });
+      };
+    } else {
+      n.visit_mut_children_with(self.dynamic_part_visitor);
+
+      if self.parent_element.is_some() {
+        self.dynamic_parts.push(DynamicPart::Children(
+          Expr::JSXElement(Box::new(n.take())),
+          self.element_index,
+        ));
+
+        // self.element_index += 1;
+        *n = WRAPPER_NODE.clone();
+        n.visit_mut_with(self);
+      }
+    }
+  }
+
+  fn visit_mut_jsx_text(&mut self, n: &mut JSXText) {
+    let t = jsx_text_to_str(&n.value);
+
+    if !t.is_empty() {
+      let el = private_ident!("el");
+      self.element_ids.insert(self.element_index, el.clone());
+
+      self.static_stmts.push(RefCell::new(quote!(
+          r#"const $element = __CreateRawText($t)"# as Stmt,
+          element = el.clone(),
+          t: Expr = t.into(),
+      )));
+
+      if let Some(parent_el) = &self.parent_element {
+        self.static_stmts.push(RefCell::new(quote!(
+            r#"__AppendElement($parent, $child)"# as Stmt,
+            parent: Ident = parent_el.clone(),
+            child: Ident = el.clone(),
+        )));
+      };
+
+      self.element_index += 1;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot transformation entry (dispatched from JSXTransformer)
+// ---------------------------------------------------------------------------
+
+pub(crate) fn transform_jsx_element<C>(t: &mut JSXTransformer<C>, node: &mut JSXElement)
+where
+  C: Comments + Clone,
+{
+  t.snapshot_counter += 1;
+
+  let snapshot_uid = format!(
+    "__snapshot_{}_{}_{}",
+    t.filename_hash, t.content_hash, t.snapshot_counter
+  );
+  let snapshot_id = Ident::new(
+    // format!("__snapshot_{}", snapshot_uid).into(),
+    snapshot_uid.clone().into(),
+    DUMMY_SP,
+    SyntaxContext::default().apply_mark(Mark::fresh(Mark::root())),
+  );
+
+  let mut wrap_dynamic_part = WrapperMarker {
+    current_is_children_full_dynamic: false,
+    dynamic_part_count: 0,
+  };
+  node.visit_mut_with(&mut wrap_dynamic_part);
+
+  let target = t.cfg.target;
+  let runtime_id = t.runtime_id.clone();
+  // In dev the creator arrow is stringified for cross-thread HMR
+  // (`DEV_ONLY_AddSnapshot`), so everything inside it references the runtime
+  // through the arrow's own parameter; in production it keeps the
+  // module-scope import binding (statically tree-shakeable).
+  let creator_runtime_id = private_ident!("__runtime__");
+  let creator_runtime_expr = if t.dev_creator_param {
+    // `__runtime__` is passed by runtimes that pass `SnapshotCreator`'s
+    // second argument; the inline `require` keeps the compiled output
+    // working on older runtimes that still call creators with a single
+    // argument (they load synchronously, so the pending-promise issue the
+    // parameter solves cannot occur there).
+    // TODO(compat): drop the `require` fallback once runtimes without
+    // `snapshotCreatorRuntime` are out of support.
+    quote!(
+      "($creator_runtime || require($runtime_pkg))" as Expr,
+      creator_runtime = creator_runtime_id.clone(),
+      runtime_pkg: Expr = Expr::Lit(Lit::Str(t.cfg.runtime_pkg.clone().into())),
+    )
+  } else {
+    t.runtime_id.clone()
+  };
+  let filename_hash = t.filename_hash.clone();
+  let content_hash = t.content_hash.clone();
+  let ui_source_map_records = t.ui_source_map_records.clone();
+  let snapshot_uid_for_captured = snapshot_uid.clone();
+  let source_map = t.source_map.clone();
+  let node_index_fn = move |span: Span| {
+    let ui_source_map =
+      calc_hash_number(&format!("{}:{}:{}", filename_hash, content_hash, span.lo.0));
+
+    // record ui source map entry
+    let mut line_number = 0;
+    let mut column_number = 0;
+    if span.lo.0 > 0 {
+      if let Some(cm) = &source_map {
+        let loc = cm.lookup_char_pos(span.lo);
+        line_number = loc.line as u32;
+        column_number = loc.col.0 as u32 + 1;
+      }
+    }
+    ui_source_map_records.borrow_mut().push(UISourceMapRecord {
+      ui_source_map,
+      line_number,
+      column_number,
+      snapshot_id: snapshot_uid_for_captured.clone(),
+    });
+
+    Expr::Lit(Lit::Num(Number {
+      span: DUMMY_SP,
+      value: ui_source_map as f64,
+      raw: None,
+    }))
+  };
+
+  let mut dynamic_part_extractor = DynamicPartExtractor::new(
+    creator_runtime_expr.clone(),
+    wrap_dynamic_part.dynamic_part_count,
+    t,
+    t.cfg.enable_ui_source_map,
+    node_index_fn,
+  );
+
+  node.visit_mut_with(&mut dynamic_part_extractor);
+
+  let mut snapshot_values: Vec<Option<ExprOrSpread>> = vec![];
+  let mut snapshot_values_has_attr = false;
+  let mut snapshot_attrs: Vec<JSXAttrOrSpread> = vec![];
+  let mut snapshot_children: Vec<JSXElementChild> = vec![];
+  let mut snapshot_dynamic_part_def: Vec<Option<ExprOrSpread>> = vec![];
+  let mut snapshot_refs_and_spread_index: Vec<Option<ExprOrSpread>> = vec![];
+  let mut snapshot_slot_def: Vec<Option<ExprOrSpread>> = vec![];
+  let mut list_item_platform_info_index: Option<i32> = None;
+
+  if let Some(key) = dynamic_part_extractor.key {
+    snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
+      span: DUMMY_SP,
+      name: JSXAttrName::Ident(IdentName::new("key".into(), DUMMY_SP)),
+      value: Some(key),
+    }));
+  }
+
+  let (dynamic_part_attr, dynamic_part_children): (Vec<_>, Vec<_>) = dynamic_part_extractor
+    .dynamic_parts
+    .into_iter()
+    .partition(|dynamic_part| match dynamic_part {
+      DynamicPart::Attr(_, _, _) | DynamicPart::Spread(_, _, _) => true,
+      DynamicPart::Slot(_, _) | DynamicPart::Children(_, _) | DynamicPart::ListChildren(_, _) => {
+        false
+      }
+    });
+
+  dynamic_part_attr.into_iter().for_each(|dynamic_part| {
+    match &dynamic_part {
+      DynamicPart::Attr(_, _, _) | DynamicPart::Spread(_, _, _) => {
+        if let DynamicPart::Attr(_, _, AttrName::Ref) | DynamicPart::Spread(_, _, _) = dynamic_part
+        {
+          snapshot_refs_and_spread_index.push(Some(
+            Expr::Lit(Lit::Num(snapshot_dynamic_part_def.len().into())).into(),
+          ));
+        }
+        snapshot_dynamic_part_def.push(Some(ExprOrSpread {
+          spread: None,
+          expr: Box::new(dynamic_part.to_updater(
+            creator_runtime_expr.clone(),
+            target,
+            snapshot_dynamic_part_def.len() as i32,
+          )),
+        }));
+      }
+      DynamicPart::Slot(_, _) => {}
+      DynamicPart::Children(_, _) => {}
+      DynamicPart::ListChildren(_, _) => {}
+    }
+
+    match dynamic_part {
+      DynamicPart::Attr(value, _, attr_name) => {
+        if matches!(attr_name, AttrName::ListItemPlatformInfo) {
+          list_item_platform_info_index = Some(snapshot_values.len() as i32);
+        }
+        snapshot_values.push(Some(ExprOrSpread {
+          spread: None,
+          expr: Box::new(if let AttrName::Event(_, _) = attr_name {
+            if target == TransformTarget::LEPUS {
+              quote!("1" as Expr)
+            } else {
+              value
+            }
+          } else if let AttrName::Ref = attr_name {
+            if target == TransformTarget::LEPUS {
+              quote!("1" as Expr)
+            } else {
+              quote!(
+                "$runtime_id.transformRef($value)" as Expr,
+                runtime_id: Expr = runtime_id.clone(),
+                value: Expr = value,
+              )
+            }
+          } else {
+            value
+          }),
+        }));
+        snapshot_values_has_attr = true;
+      }
+      DynamicPart::Spread(value, _, is_list_item) => {
+        if is_list_item {
+          list_item_platform_info_index = Some(snapshot_values.len() as i32);
+        }
+        snapshot_values.push(Some(ExprOrSpread {
+          spread: None,
+          expr: Box::new(value),
+        }));
+        snapshot_values_has_attr = true;
+      }
+      DynamicPart::Children(_, _) => {}
+      DynamicPart::ListChildren(_, _) => {}
+      DynamicPart::Slot(_, _) => {}
+    }
+  });
+
+  let slot_expr = match (dynamic_part_children.len(), dynamic_part_children.first()) {
+    (0, _) => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+    (1, Some(DynamicPart::Children(expr, 0))) => {
+      let expr = expr.clone();
+      snapshot_children.push(match expr {
+        Expr::JSXElement(jsx) => JSXElementChild::JSXElement(jsx),
+        _ => JSXElementChild::JSXExprContainer(JSXExprContainer {
+          span: DUMMY_SP,
+          expr: JSXExpr::Expr(Box::new(expr)),
+        }),
+      });
+
+      quote!(
+        "$runtime_id.__DynamicPartChildren_0" as Expr,
+        runtime_id: Expr = creator_runtime_expr.clone(),
+      )
+    }
+    _ => {
+      dynamic_part_children.into_iter().for_each(|dynamic_part| {
+        match dynamic_part {
+          DynamicPart::Attr(_, _, _) => {}
+          DynamicPart::Spread(_, _, _) => {}
+          DynamicPart::ListChildren(expr, element_index) => {
+            // snapshot_values.push(None);
+            snapshot_children.push(match expr {
+              Expr::JSXElement(jsx) => JSXElementChild::JSXElement(jsx),
+              _ => JSXElementChild::JSXExprContainer(JSXExprContainer {
+                span: DUMMY_SP,
+                expr: JSXExpr::Expr(Box::new(expr)),
+              }),
+            });
+            snapshot_slot_def.push(Some(ExprOrSpread {
+              spread: None,
+              expr: Box::new(quote!(
+                "[$runtime_id.__DynamicPartListChildren, $element_index]" as Expr,
+                runtime_id: Expr = creator_runtime_expr.clone(),
+                element_index: Expr = i32_to_expr(&element_index),
+              )),
+            }));
+          }
+          DynamicPart::Children(expr, element_index) => {
+            // snapshot_values.push(None);
+            snapshot_children.push(match expr {
+              Expr::JSXElement(jsx) => JSXElementChild::JSXElement(jsx),
+              _ => JSXElementChild::JSXExprContainer(JSXExprContainer {
+                span: DUMMY_SP,
+                expr: JSXExpr::Expr(Box::new(expr)),
+              }),
+            });
+            snapshot_slot_def.push(Some(ExprOrSpread {
+              spread: None,
+              expr: Box::new(quote!(
+                "[$runtime_id.__DynamicPartChildren, $element_index]" as Expr,
+                runtime_id: Expr = creator_runtime_expr.clone(),
+                element_index: Expr = i32_to_expr(&element_index),
+              )),
+            }));
+          }
+          DynamicPart::Slot(jsx, element_index) => {
+            // snapshot_values.push(None);
+            snapshot_children.push(JSXElementChild::JSXElement(Box::new(jsx)));
+            snapshot_slot_def.push(Some(ExprOrSpread {
+              spread: None,
+              expr: Box::new(quote!(
+                "[$runtime_id.__DynamicPartSlot, $element_index]" as Expr,
+                runtime_id: Expr = creator_runtime_expr.clone(),
+                element_index: Expr = i32_to_expr(&element_index),
+              )),
+            }));
+          }
+        }
+      });
+
+      Expr::Array(ArrayLit {
+        span: DUMMY_SP,
+        elems: snapshot_slot_def,
+      })
+    }
+  };
+
+  let snapshot_creator = if target == TransformTarget::JS {
+    Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))
+  } else {
+    Expr::Fn(FnExpr {
+      ident: None,
+      function: Box::new(dynamic_part_extractor.snapshot_creator.unwrap()),
+    })
+  };
+
+  // External bundles have no `globDynamicComponentEntry` in scope; use the
+  // `__Card__` entry-name literal.
+  let entry_name: Expr = if matches!(t.cfg.is_external_bundle, Some(true))
+    && !matches!(t.cfg.is_dynamic_component, Some(true))
+  {
+    Expr::Lit(Lit::Str("__Card__".into()))
+  } else {
+    Expr::Ident("globDynamicComponentEntry".into())
+  };
+
+  let snapshot_dynamic_parts_def: Expr = match (target, snapshot_dynamic_part_def.len()) {
+    (TransformTarget::JS, _) | (_, 0) => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+    _ => Expr::Array(ArrayLit {
+      span: DUMMY_SP,
+      elems: snapshot_dynamic_part_def,
+    }),
+  };
+  let css_id: Expr = match &t.css_id_value {
+    Some(css_id_expr) => css_id_expr.clone(),
+    // We use `undefined` here since runtime will skip `__SetCSSId` when `cssId === undefined && entryName === undefined`
+    None => Expr::Ident("undefined".into()),
+  };
+  let snapshot_refs_and_spread_index: Expr = match snapshot_refs_and_spread_index.len() {
+    0 => Expr::Lit(Lit::Null(Null { span: DUMMY_SP })),
+    _ => Expr::Array(ArrayLit {
+      span: DUMMY_SP,
+      elems: snapshot_refs_and_spread_index,
+    }),
+  };
+
+  let snapshot_create_call = if t.dev_creator_param {
+    quote!(
+        r#"$runtime_id.snapshotCreatorMap[$snapshot_id] = ($snapshot_id, $creator_runtime) => $creator_runtime_ref.createSnapshot(
+             $snapshot_id,
+             $snapshot_creator,
+             $snapshot_dynamic_parts_def,
+             $slot,
+             $css_id,
+             $entry_name,
+             $snapshot_refs_and_spread_index,
+             true
+        )"# as Expr,
+        runtime_id: Expr = t.runtime_id.clone(),
+        creator_runtime = creator_runtime_id.clone(),
+        creator_runtime_ref: Expr = creator_runtime_expr.clone(),
+        snapshot_id = snapshot_id.clone(),
+        entry_name: Expr = entry_name,
+        snapshot_creator: Expr = snapshot_creator,
+        snapshot_dynamic_parts_def: Expr = snapshot_dynamic_parts_def,
+        slot: Expr = slot_expr,
+        css_id: Expr = css_id,
+        snapshot_refs_and_spread_index: Expr = snapshot_refs_and_spread_index,
+    )
+  } else {
+    quote!(
+        r#"$runtime_id.snapshotCreatorMap[$snapshot_id] = ($snapshot_id) => $runtime_id.createSnapshot(
+             $snapshot_id,
+             $snapshot_creator,
+             $snapshot_dynamic_parts_def,
+             $slot,
+             $css_id,
+             $entry_name,
+             $snapshot_refs_and_spread_index,
+             true
+        )"# as Expr,
+        runtime_id: Expr = t.runtime_id.clone(),
+        snapshot_id = snapshot_id.clone(),
+        entry_name: Expr = entry_name,
+        snapshot_creator: Expr = snapshot_creator,
+        snapshot_dynamic_parts_def: Expr = snapshot_dynamic_parts_def,
+        slot: Expr = slot_expr,
+        css_id: Expr = css_id,
+        snapshot_refs_and_spread_index: Expr = snapshot_refs_and_spread_index,
+    )
+  };
+
+  let mut entry_snapshot_uid = quote!("$snapshot_uid" as Expr, snapshot_uid: Expr = Expr::Lit(Lit::Str(snapshot_uid.clone().into())));
+  if matches!(t.cfg.is_dynamic_component, Some(true)) {
+    entry_snapshot_uid = quote!("`${globDynamicComponentEntry}:${$snapshot_uid}`" as Expr, snapshot_uid: Expr = Expr::Lit(Lit::Str(snapshot_uid.clone().into())));
+  }
+
+  let entry_snapshot_uid_def = ModuleItem::Stmt(quote!(
+      r#"const $snapshot_id = $entry_snapshot_uid"#
+          as Stmt,
+      snapshot_id = snapshot_id.clone(),
+      entry_snapshot_uid: Expr = entry_snapshot_uid.clone(),
+  ));
+  let snapshot_def = ModuleItem::Stmt(quote!(
+      r#"$snapshot_create_call"#
+          as Stmt,
+      snapshot_create_call: Expr = snapshot_create_call,
+  ));
+
+  t.current_snapshot_id = Some(snapshot_id.clone());
+  t.current_snapshot_defs.push(entry_snapshot_uid_def);
+  t.current_snapshot_defs.push(snapshot_def);
+
+  *node = JSXElement {
+    span: node.span(),
+    opening: JSXOpeningElement {
+      name: JSXElementName::Ident(snapshot_id.clone()),
+      span: node.span,
+      attrs: {
+        if snapshot_values_has_attr {
+          snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
+            span: DUMMY_SP,
+            name: JSXAttrName::Ident(IdentName::new("values".into(), DUMMY_SP)),
+            value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+              span: DUMMY_SP,
+              expr: JSXExpr::Expr(Box::new(Expr::Array(ArrayLit {
+                span: DUMMY_SP,
+                elems: snapshot_values,
+              }))),
+            })),
+          }))
+        };
+        if let Some(index) = list_item_platform_info_index {
+          snapshot_attrs.push(JSXAttrOrSpread::JSXAttr(JSXAttr {
+            span: DUMMY_SP,
+            name: JSXAttrName::Ident(IdentName::new(
+              "__listItemPlatformInfoIndex".into(),
+              DUMMY_SP,
+            )),
+            value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+              span: DUMMY_SP,
+              expr: JSXExpr::Expr(Box::new(i32_to_expr(&index))),
+            })),
+          }))
+        }
+        snapshot_attrs
+      },
+      self_closing: wrap_dynamic_part.dynamic_part_count == 0,
+      type_args: None,
+    },
+    children: snapshot_children,
+    closing: if wrap_dynamic_part.dynamic_part_count == 0 {
+      None
+    } else {
+      Some(JSXClosingElement {
+        name: JSXElementName::Ident(snapshot_id.clone()),
+        span: DUMMY_SP,
+      })
+    },
+  };
+}
+
+#[cfg(test)]
+mod tests {
+  use swc_core::{
+    common::{comments::SingleThreadedComments, Mark},
+    ecma::parser::{EsSyntax, Syntax},
+    ecma::transforms::{base::resolver, react, testing::test},
+    ecma::visit::visit_mut_pass,
+  };
+
+  use crate::JSXTransformer;
+  use swc_plugins_shared::{target::TransformTarget, transform_mode::TransformMode};
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |_| {
+      let unresolved_mark = Mark::new();
+      let top_level_mark = Mark::new();
+
+      (
+        resolver(unresolved_mark, top_level_mark, true),
+        visit_mut_pass(super::WrapperMarker {
+          current_is_children_full_dynamic: false,
+          dynamic_part_count: 0,
+        }),
+      )
+    },
+    should_wrap_dynamic_part,
+    r#"
+        <view/>; // should not handle top-level JSXElement
+        <A/>; // should not handle top-level JSXElement
+        <A><view></view></A>;
+        <view><A/></view>; // children is full dynamic
+        <view><A/><A/></view>; // children is full dynamic
+        <view><A/><text/><A/></view>; // <A/> should be wrapped inside wrapper
+        <view>{1}</view>;
+        <view>{1}{2}</view>;
+        <view>{1}2</view>;
+        <list><list-item/><list-item/></list>;
+        <list><list-item><A/>A</list-item><list-item/></list>;
+        <view>{<view><A/><text/><A/></view>}</view>;
+        <view><list><list-item/><list-item/></list>a<view><A/></view></view>;
+        <view key={hello}>hello</view>;
+        <view key={hello}>{hello}</view>;
+        <view><text key={hello}>{hello}</text></view>;
+        <view><text>Hello, ReactLynx, {hello}</text><text key={hello}>{hello}</text></view>;
+<view>
+  <text>!!!</text>
+  <A/>
+</view>;
+<view>
+  <text>!!!</text>
+  {a}
+</view>;
+        "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |_| {
+      let unresolved_mark = Mark::new();
+      let top_level_mark = Mark::new();
+
+      (
+        resolver(unresolved_mark, top_level_mark, true),
+        visit_mut_pass(super::WrapperMarker {
+          current_is_children_full_dynamic: false,
+          dynamic_part_count: 0,
+        }),
+      )
+    },
+    should_not_wrap_dynamic_part,
+    r#" 
+<view className="parent">
+  <view className="child"/>
+  <view className="child"/>
+</view>;
+<view className="parent">
+  <view className="child">
+  </view>
+  <view className="child">
+  </view>
+</view>;
+<view className="parent">
+  <view className="child">
+    {/** foo */}
+  </view>
+  <view className="child">
+    {/** bar */}
+  </view>
+</view>;
+// TODO: fix the redundant <internal-slot> here
+<view className="parent">
+  <view className="child">{[].map(() => null)}</view>
+  <view className="child">{[].map(() => null)}</view>
+</view>;
+<view style={{ color: "red", 'height': "100px", flexShrink: 1 }}>
+</view>;
+        "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| {
+      let unresolved_mark = Mark::new();
+      let top_level_mark = Mark::new();
+
+      (
+        resolver(unresolved_mark, top_level_mark, true),
+        visit_mut_pass(JSXTransformer::new(
+          crate::JSXTransformerConfig {
+            legacy_slot: Some(true),
+            preserve_jsx: true,
+            target: TransformTarget::MIXED,
+            ..Default::default()
+          },
+          Some(t.comments.clone()),
+          TransformMode::Test,
+          Some(t.cm.clone()),
+        )),
+      )
+    },
+    should_emit_list_item_platform_info_marker_for_spread_props_legacy_slot,
+    // Input codes
+    r#"
+    const node = (
+      <list>
+        <list-item {...getProps()} />
+      </list>
+    );
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| {
+      let unresolved_mark = Mark::new();
+      let top_level_mark = Mark::new();
+
+      (
+        resolver(unresolved_mark, top_level_mark, true),
+        visit_mut_pass(JSXTransformer::new(
+          crate::JSXTransformerConfig {
+            legacy_slot: Some(true),
+            preserve_jsx: true,
+            ..Default::default()
+          },
+          Some(t.comments.clone()),
+          TransformMode::Test,
+          Some(t.cm.clone()),
+        )),
+      )
+    },
+    full_static_children_map_jsx_legacy_slot,
+    // Input codes
+    r#"
+    <view className="parent">
+			<view className="child">{[].map(() => null)}</view>
+			<view className="child">{[].map(() => null)}</view>
+		</view>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    basic_component_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      <A/>
+    </view>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    page_component_legacy_slot,
+    // Input codes
+    r#"
+    <Page custom-key-str="custom-value" custom-key-var={customVariable} class="classValue" data-attr={dataAttr}>
+      <view>
+        <Page/>
+        <A/>
+      </view>
+    </Page>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Development,
+      Some(t.cm.clone()),
+    )),
+    page_element_dev_legacy_slot,
+    // Input codes
+    r#"
+    <page custom-key-str="custom-value" custom-key-var={customVariable} class="classValue" data-attr={dataAttr}>
+      <view>
+        <page />
+        <A/>
+      </view>
+    </page>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    page_element_legacy_slot,
+    // Input codes
+    r#"
+    <page custom-key-str="custom-value" custom-key-var={customVariable} class="classValue" data-attr={dataAttr}>
+      <view>
+        <page />
+        <A/>
+      </view>
+    </page>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    basic_component_with_static_sibling_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      <text>!!!</text>
+      <A/>
+    </view>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| {
+      let top_level_mark = Mark::new();
+      let unresolved_mark = Mark::new();
+      (
+        visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
+          crate::JSXTransformerConfig {
+            legacy_slot: Some(true),
+            preserve_jsx: false,
+            ..Default::default()
+          },
+          None,
+          TransformMode::Test,
+          Some(t.cm.clone()),
+        )),
+        react::react::<&SingleThreadedComments>(
+          t.cm.clone(),
+          None,
+          react::Options {
+            next: Some(false),
+            runtime: Some(react::Runtime::Automatic),
+            import_source: Some("@lynx-js/react".into()),
+            pragma: None,
+            pragma_frag: None,
+            throw_if_namespace: None,
+            development: Some(false),
+            refresh: None,
+            ..Default::default()
+          },
+          top_level_mark,
+          unresolved_mark,
+        ),
+      )
+    },
+    basic_component_with_static_sibling_jsx_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      <text>!!!</text>
+      <A/>
+    </view>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| {
+      let top_level_mark = Mark::new();
+      let unresolved_mark = Mark::new();
+      (
+        visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
+          crate::JSXTransformerConfig {
+            legacy_slot: Some(true),
+            preserve_jsx: false,
+            ..Default::default()
+          },
+          None,
+          TransformMode::Test,
+          Some(t.cm.clone()),
+        )),
+        react::react::<&SingleThreadedComments>(
+          t.cm.clone(),
+          None,
+          react::Options {
+            next: Some(false),
+            runtime: Some(react::Runtime::Automatic),
+            import_source: Some("@lynx-js/react".into()),
+            pragma: None,
+            pragma_frag: None,
+            throw_if_namespace: None,
+            development: Some(true),
+            refresh: None,
+            ..Default::default()
+          },
+          top_level_mark,
+          unresolved_mark,
+        ),
+      )
+    },
+    basic_component_with_static_sibling_jsx_dev_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      <text>!!!</text>
+      <A/>
+    </view>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    basic_expr_container_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      {a}
+    </view>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    basic_expr_container_with_static_sibling_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      <text>!!!</text>
+      {a}
+    </view>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    should_inject_implicit_flatten_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      <view className={'commdityV1Wrapper'}>
+        <view id={id} className={'dotComm'} />
+        <view className={'commdityV1TextWrapper'}>
+          <view className={'commdityV1TextVerticalWrapper'}>
+            <ItemTextWithTag/>
+            {desc}
+          </view>
+          {unit}
+        </view>
+        {unit}
+        {unit}
+      </view>
+    </view>;
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| {
+      let top_level_mark = Mark::new();
+      let unresolved_mark = Mark::new();
+      (
+        visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
+          crate::JSXTransformerConfig {
+            legacy_slot: Some(true),
+            preserve_jsx: false,
+            ..Default::default()
+          },
+          None,
+          TransformMode::Test,
+          Some(t.cm.clone()),
+        )),
+        react::react::<&SingleThreadedComments>(
+          t.cm.clone(),
+          None,
+          react::Options {
+            next: Some(false),
+            runtime: Some(react::Runtime::Automatic),
+            import_source: Some("@lynx-js/react".into()),
+            pragma: None,
+            pragma_frag: None,
+            throw_if_namespace: None,
+            development: Some(false),
+            refresh: None,
+            ..Default::default()
+          },
+          top_level_mark,
+          unresolved_mark,
+        ),
+      )
+    },
+    basic_spread_list_item_legacy_slot,
+    // Input codes
+    r#"
+    <list>
+      <list-item key="hello" item-key="world" {...obj}>!!!</list-item>
+    </list>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    should_wrap_dynamic_key_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      <text>Hello, ReactLynx, {hello}</text>
+      <text key={hello}>{hello}</text>
+      <text key="hello">{hello}</text>
+    </view>
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |t| visit_mut_pass(JSXTransformer::new(
+      crate::JSXTransformerConfig {
+        legacy_slot: Some(true),
+        preserve_jsx: true,
+        ..Default::default()
+      },
+      Some(t.comments.clone()),
+      TransformMode::Test,
+      Some(t.cm.clone()),
+    )),
+    should_create_raw_text_node_for_text_node_legacy_slot,
+    // Input codes
+    r#"
+    <view>
+      <text>{hello}, ReactLynx 1</text>
+      <text>{hello}</text>
+      <text>
+        Hello
+        <text text="ReactLynx 2"></text>
+      </text>
+      <x-text>Hello, ReactLynx 3</x-text>
+    </view>
+    "#
+  );
+}

--- a/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
@@ -23,6 +23,7 @@ use swc_core::{
 };
 
 mod attr_name;
+mod legacy_slot;
 
 #[cfg(feature = "napi")]
 pub mod napi;
@@ -1133,6 +1134,12 @@ pub struct JSXTransformerConfig {
   /// @internal
   #[serde(default)]
   pub is_external_bundle: Option<bool>,
+  /// Compile dynamic children with the frozen legacy (pre-SlotV2) codegen in
+  /// `legacy_slot.rs` so the output runs on legacy runtimes without `SlotV2`
+  /// support (< 0.120.0).
+  /// @internal
+  #[serde(default)]
+  pub legacy_slot: Option<bool>,
 }
 
 impl Default for JSXTransformerConfig {
@@ -1146,6 +1153,7 @@ impl Default for JSXTransformerConfig {
       enable_ui_source_map: false,
       is_dynamic_component: Some(false),
       is_external_bundle: Some(false),
+      legacy_slot: Some(false),
     }
   }
 }
@@ -1305,6 +1313,12 @@ where
       _ => {
         return node.visit_mut_children_with(self);
       }
+    }
+
+    if matches!(self.cfg.legacy_slot, Some(true)) {
+      // Frozen pre-SlotV2 codegen lives entirely in legacy_slot.rs; keep the
+      // default (SlotV2) pipeline below free of legacy concerns.
+      return legacy_slot::transform_jsx_element(self, node);
     }
 
     self.snapshot_counter += 1;

--- a/packages/react/transform/crates/swc_plugin_snapshot/napi.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/napi.rs
@@ -33,6 +33,8 @@ pub struct JSXTransformerConfig {
   pub is_dynamic_component: Option<bool>,
   /// @internal
   pub is_external_bundle: Option<bool>,
+  /// @internal
+  pub legacy_slot: Option<bool>,
 }
 
 /// @internal
@@ -80,6 +82,7 @@ impl Default for JSXTransformerConfig {
       enable_ui_source_map: Some(false),
       is_dynamic_component: Some(false),
       is_external_bundle: Some(false),
+      legacy_slot: Some(false),
     }
   }
 }
@@ -95,6 +98,7 @@ impl From<JSXTransformerConfig> for CoreJSXTransformerConfig {
       enable_ui_source_map: val.enable_ui_source_map.unwrap_or(false),
       is_dynamic_component: val.is_dynamic_component,
       is_external_bundle: val.is_external_bundle,
+      legacy_slot: val.legacy_slot,
     }
   }
 }
@@ -110,6 +114,7 @@ impl From<CoreJSXTransformerConfig> for JSXTransformerConfig {
       enable_ui_source_map: Some(val.enable_ui_source_map),
       is_dynamic_component: val.is_dynamic_component,
       is_external_bundle: val.is_external_bundle,
+      legacy_slot: val.legacy_slot,
     }
   }
 }

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_component_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_component_legacy_slot.js
@@ -1,0 +1,10 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1><A/></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_component_with_static_sibling_jsx_dev_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_component_with_static_sibling_jsx_dev_legacy_slot.js
@@ -1,0 +1,35 @@
+import { jsxDEV as _jsxDEV } from "@lynx-js/react/jsx-dev-runtime";
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateText(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateRawText("!!!");
+        __AppendElement(el1, el2);
+        const el3 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el3);
+        return [
+            el,
+            el1,
+            el2,
+            el3
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartChildren,
+            3
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+_jsxDEV(__snapshot_da39a_test_1, {
+    children: _jsxDEV(A, {}, void 0, false, {
+        fileName: "input.js",
+        lineNumber: 4,
+        columnNumber: 7
+    }, this)
+}, void 0, false, {
+    fileName: "input.js",
+    lineNumber: 2,
+    columnNumber: 5
+}, this);

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_component_with_static_sibling_jsx_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_component_with_static_sibling_jsx_legacy_slot.js
@@ -1,0 +1,27 @@
+import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateText(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateRawText("!!!");
+        __AppendElement(el1, el2);
+        const el3 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el3);
+        return [
+            el,
+            el1,
+            el2,
+            el3
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartChildren,
+            3
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+_jsx(__snapshot_da39a_test_1, {
+    children: _jsx(A, {})
+});

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_component_with_static_sibling_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_component_with_static_sibling_legacy_slot.js
@@ -1,0 +1,24 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateText(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateRawText("!!!");
+        __AppendElement(el1, el2);
+        const el3 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el3);
+        return [
+            el,
+            el1,
+            el2,
+            el3
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartChildren,
+            3
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1><A/></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_expr_container_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_expr_container_legacy_slot.js
@@ -1,0 +1,10 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1>{a}</__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_expr_container_with_static_sibling_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_expr_container_with_static_sibling_legacy_slot.js
@@ -1,0 +1,24 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateText(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateRawText("!!!");
+        __AppendElement(el1, el2);
+        const el3 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el3);
+        return [
+            el,
+            el1,
+            el2,
+            el3
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartChildren,
+            3
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1>{a}</__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_spread_list_item_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/basic_spread_list_item_legacy_slot.js
@@ -1,0 +1,42 @@
+import { jsx as _jsx } from "@lynx-js/react/jsx-runtime";
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateElement("list-item", pageId);
+        const el1 = __CreateRawText("!!!");
+        __AppendElement(el, el1);
+        return [
+            el,
+            el1
+        ];
+    }, [
+        (snapshot, index, oldValue)=>ReactLynx.updateSpread(snapshot, index, oldValue, 0, true)
+    ], null, undefined, globDynamicComponentEntry, [
+        0
+    ], true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function(snapshotInstance) {
+        const pageId = ReactLynx.__pageId;
+        const el = ReactLynx.snapshotCreateList(pageId, snapshotInstance, 0);
+        return [
+            el
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartListChildren,
+            0
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+_jsx(__snapshot_da39a_test_1, {
+    children: _jsx(__snapshot_da39a_test_2, {
+        values: [
+            {
+                "item-key": "world",
+                ...obj,
+                __spread: true
+            }
+        ],
+        __listItemPlatformInfoIndex: 0
+    }, "hello")
+});

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/full_static_children_map_jsx_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/full_static_children_map_jsx_legacy_slot.js
@@ -1,0 +1,44 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        __SetClasses(el, "child");
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>ReactLynx.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        __SetClasses(el, "child");
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        __SetClasses(el, "parent");
+        const el1 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el2);
+        return [
+            el,
+            el1,
+            el2
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartSlot,
+            1
+        ],
+        [
+            ReactLynx.__DynamicPartSlot,
+            2
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1><__snapshot_da39a_test_2>{[].map(()=>null)}</__snapshot_da39a_test_2><__snapshot_da39a_test_3>{[].map(()=>null)}</__snapshot_da39a_test_3></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/page_component_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/page_component_legacy_slot.js
@@ -1,0 +1,15 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+<Page custom-key-str="custom-value" custom-key-var={customVariable} class="classValue" data-attr={dataAttr}>
+      <__snapshot_da39a_test_1>{[
+    <Page/>,
+    <A/>
+]}</__snapshot_da39a_test_1>
+    </Page>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/page_element_dev_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/page_element_dev_legacy_slot.js
@@ -1,0 +1,16 @@
+import * as ReactLynx from "@lynx-js/react";
+import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1, __runtime__)=>(__runtime__ || require("@lynx-js/react")).createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = (__runtime__ || require("@lynx-js/react")).__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, (__runtime__ || require("@lynx-js/react")).__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+<ReactLynxRuntimeComponents.Page custom-key-str="custom-value" custom-key-var={customVariable} class="classValue" data-attr={dataAttr}>
+      <__snapshot_da39a_test_1>{[
+    <ReactLynxRuntimeComponents.Page/>,
+    <A/>
+]}</__snapshot_da39a_test_1>
+    </ReactLynxRuntimeComponents.Page>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/page_element_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/page_element_legacy_slot.js
@@ -1,0 +1,16 @@
+import * as ReactLynx from "@lynx-js/react";
+import * as ReactLynxRuntimeComponents from '@lynx-js/react/runtime-components';
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+<ReactLynxRuntimeComponents.Page custom-key-str="custom-value" custom-key-var={customVariable} class="classValue" data-attr={dataAttr}>
+      <__snapshot_da39a_test_1>{[
+    <ReactLynxRuntimeComponents.Page/>,
+    <A/>
+]}</__snapshot_da39a_test_1>
+    </ReactLynxRuntimeComponents.Page>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_create_raw_text_node_for_text_node_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_create_raw_text_node_for_text_node_legacy_slot.js
@@ -1,0 +1,55 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateText(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateText(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateWrapperElement(pageId);
+        __AppendElement(el1, el2);
+        const el3 = __CreateRawText(", ReactLynx 1");
+        __AppendElement(el1, el3);
+        const el4 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el4);
+        const el5 = __CreateText(pageId);
+        __AppendElement(el, el5);
+        const el6 = __CreateRawText("Hello");
+        __AppendElement(el5, el6);
+        const el7 = __CreateText(pageId);
+        __SetAttribute(el7, "text", "ReactLynx 2");
+        __AppendElement(el5, el7);
+        const el8 = __CreateElement("x-text", pageId);
+        __AppendElement(el, el8);
+        const el9 = __CreateRawText("Hello, ReactLynx 3");
+        __AppendElement(el8, el9);
+        return [
+            el,
+            el1,
+            el2,
+            el3,
+            el4,
+            el5,
+            el6,
+            el7,
+            el8,
+            el9
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartSlot,
+            2
+        ],
+        [
+            ReactLynx.__DynamicPartSlot,
+            4
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1><wrapper>{hello}</wrapper><__snapshot_da39a_test_2>{hello}</__snapshot_da39a_test_2></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_emit_list_item_platform_info_marker_for_spread_props_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_emit_list_item_platform_info_marker_for_spread_props_legacy_slot.js
@@ -1,0 +1,32 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateElement("list-item", pageId);
+        return [
+            el
+        ];
+    }, [
+        (snapshot, index, oldValue)=>ReactLynx.updateSpread(snapshot, index, oldValue, 0, true)
+    ], null, undefined, globDynamicComponentEntry, [
+        0
+    ], true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function(snapshotInstance) {
+        const pageId = ReactLynx.__pageId;
+        const el = ReactLynx.snapshotCreateList(pageId, snapshotInstance, 0);
+        return [
+            el
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartListChildren,
+            0
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+const node = <__snapshot_da39a_test_1><__snapshot_da39a_test_2 values={[
+    {
+        ...getProps(),
+        __spread: true
+    }
+]} __listItemPlatformInfoIndex={0}/></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_inject_implicit_flatten_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_inject_implicit_flatten_legacy_slot.js
@@ -1,0 +1,67 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        __SetClasses(el, 'commdityV1TextVerticalWrapper');
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateView(pageId);
+        __SetClasses(el1, 'commdityV1Wrapper');
+        __AppendElement(el, el1);
+        const el2 = __CreateView(pageId);
+        __SetClasses(el2, 'dotComm');
+        __AppendElement(el1, el2);
+        const el3 = __CreateView(pageId);
+        __SetClasses(el3, 'commdityV1TextWrapper');
+        __AppendElement(el1, el3);
+        const el4 = __CreateWrapperElement(pageId);
+        __AppendElement(el3, el4);
+        const el5 = __CreateWrapperElement(pageId);
+        __AppendElement(el3, el5);
+        const el6 = __CreateWrapperElement(pageId);
+        __AppendElement(el1, el6);
+        return [
+            el,
+            el1,
+            el2,
+            el3,
+            el4,
+            el5,
+            el6
+        ];
+    }, [
+        function(ctx) {
+            if (ctx.__elements) {
+                __SetID(ctx.__elements[2], ctx.__values[0]);
+            }
+        }
+    ], [
+        [
+            ReactLynx.__DynamicPartSlot,
+            4
+        ],
+        [
+            ReactLynx.__DynamicPartSlot,
+            5
+        ],
+        [
+            ReactLynx.__DynamicPartSlot,
+            6
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1 values={[
+    id
+]}><__snapshot_da39a_test_2>{[
+    <ItemTextWithTag/>,
+    desc
+]}</__snapshot_da39a_test_2><wrapper>{unit}
+        </wrapper><wrapper>{unit}
+        {unit}
+      </wrapper></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_not_wrap_dynamic_part.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_not_wrap_dynamic_part.js
@@ -1,0 +1,29 @@
+<view className="parent">
+  <view className="child"/>
+  <view className="child"/>
+</view>;
+<view className="parent">
+  <view className="child">
+  </view>
+  <view className="child">
+  </view>
+</view>;
+<view className="parent">
+  <view className="child">
+    { /** foo */ }
+  </view>
+  <view className="child">
+    { /** bar */ }
+  </view>
+</view>;
+// TODO: fix the redundant <internal-slot> here
+<view className="parent">
+  <internal-slot><view className="child">{[].map(()=>null)}</view></internal-slot>
+  <internal-slot><view className="child">{[].map(()=>null)}</view></internal-slot>
+</view>;
+<view style={{
+    color: "red",
+    'height': "100px",
+    flexShrink: 1
+}}>
+</view>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_wrap_dynamic_key_legacy_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_wrap_dynamic_key_legacy_slot.js
@@ -1,0 +1,54 @@
+import * as ReactLynx from "@lynx-js/react";
+const __snapshot_da39a_test_2 = "__snapshot_da39a_test_2";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_2] = (__snapshot_da39a_test_2)=>ReactLynx.createSnapshot(__snapshot_da39a_test_2, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateText(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_3 = "__snapshot_da39a_test_3";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_3] = (__snapshot_da39a_test_3)=>ReactLynx.createSnapshot(__snapshot_da39a_test_3, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateText(pageId);
+        return [
+            el
+        ];
+    }, null, ReactLynx.__DynamicPartChildren_0, undefined, globDynamicComponentEntry, null, true);
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        const el1 = __CreateText(pageId);
+        __AppendElement(el, el1);
+        const el2 = __CreateRawText("Hello, ReactLynx, ");
+        __AppendElement(el1, el2);
+        const el3 = __CreateWrapperElement(pageId);
+        __AppendElement(el1, el3);
+        const el4 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el4);
+        const el5 = __CreateWrapperElement(pageId);
+        __AppendElement(el, el5);
+        return [
+            el,
+            el1,
+            el2,
+            el3,
+            el4,
+            el5
+        ];
+    }, null, [
+        [
+            ReactLynx.__DynamicPartSlot,
+            3
+        ],
+        [
+            ReactLynx.__DynamicPartSlot,
+            4
+        ],
+        [
+            ReactLynx.__DynamicPartSlot,
+            5
+        ]
+    ], undefined, globDynamicComponentEntry, null, true);
+<__snapshot_da39a_test_1><wrapper>{hello}</wrapper><__snapshot_da39a_test_2 key={hello}>{hello}</__snapshot_da39a_test_2><__snapshot_da39a_test_3 key="hello">{hello}</__snapshot_da39a_test_3></__snapshot_da39a_test_1>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_wrap_dynamic_part.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/legacy_slot.rs/should_wrap_dynamic_part.js
@@ -1,0 +1,34 @@
+<view/>; // should not handle top-level JSXElement
+<A/>; // should not handle top-level JSXElement
+<A><view></view></A>;
+<internal-slot><view><A/></view></internal-slot>; // children is full dynamic
+<internal-slot><view><A/><A/></view></internal-slot>; // children is full dynamic
+<view><internal-slot><wrapper><A/></wrapper></internal-slot><text/><internal-slot><wrapper><A/></wrapper></internal-slot></view>; // <A/> should be wrapped inside wrapper
+<internal-slot><view>{1}</view></internal-slot>;
+<internal-slot><view>{1}{2}</view></internal-slot>;
+<view><internal-slot><wrapper>{1}</wrapper></internal-slot>2</view>;
+<internal-slot><list>{[
+    <list-item/>,
+    <list-item/>
+]}</list></internal-slot>;
+<internal-slot><list>{[
+    <list-item><A/>A</list-item>,
+    <list-item/>
+]}</list></internal-slot>;
+<internal-slot><view>{<view><A/><text/><A/></view>}</view></internal-slot>;
+<view><internal-slot><list>{[
+    <list-item/>,
+    <list-item/>
+]}</list></internal-slot>a<internal-slot><view><A/></view></internal-slot></view>;
+<view key={hello}><internal-slot><wrapper>{"hello"}</wrapper></internal-slot></view>;
+<internal-slot><view key={hello}>{hello}</view></internal-slot>;
+<view><internal-slot><text key={hello}>{hello}</text></internal-slot></view>;
+<view><text>Hello, ReactLynx, <internal-slot><wrapper>{hello}</wrapper></internal-slot></text><internal-slot><text key={hello}>{hello}</text></internal-slot></view>;
+<view>
+  <text>!!!</text>
+  <internal-slot><wrapper><A/>
+</wrapper></internal-slot></view>;
+<view>
+  <text>!!!</text>
+  <internal-slot><wrapper>{a}
+</wrapper></internal-slot></view>;

--- a/packages/react/transform/index.d.ts
+++ b/packages/react/transform/index.d.ts
@@ -362,6 +362,40 @@ export interface CompatVisitorConfig {
    * ```
    */
   darkMode?: boolean | DarkModeConfig
+
+  /**
+   * Compile dynamic children as children + wrapper (the pre-SlotV2 slot
+   * codegen: `Slot`/`Children` dynamic parts rendered through wrapper
+   * elements) instead of the default SlotV2 codegen (`$N` slot props).
+   *
+   * @remarks
+   *
+   * Enable this when the compiled output needs to run on legacy
+   * `@lynx-js/react` runtimes without `SlotV2` support (`< 0.120.0`),
+   * e.g. a standalone lazy bundle consumed by a host App that ships an
+   * older runtime. It only changes the compile output; the runtime
+   * supports both forms.
+   *
+   * @example
+   *
+   * ```js
+   * import { defineConfig } from '@lynx-js/rspeedy'
+   * import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
+   *
+   * export default defineConfig({
+   *   plugins: [
+   *     pluginReactLynx({
+   *       compat: {
+   *         legacySlot: true,
+   *       },
+   *     })
+   *   ],
+   * })
+   * ```
+   *
+   * @defaultValue `false`
+   */
+  legacySlot?: boolean
 }
 export interface CssScopeVisitorConfig {
   /** @public */
@@ -600,6 +634,8 @@ export interface JsxTransformerConfig {
   isDynamicComponent?: boolean
   /** @internal */
   isExternalBundle?: boolean
+  /** @internal */
+  legacySlot?: boolean
 }
 /** @internal */
 export interface ElementTemplateConfig {

--- a/packages/react/transform/src/lib.rs
+++ b/packages/react/transform/src/lib.rs
@@ -594,9 +594,14 @@ fn transform_react_lynx_inner(
       )
     };
 
+    let legacy_slot = matches!(snapshot_plugin_config.legacy_slot, Some(true));
     let list_plugin = Optional::new(
       visit_mut_pass(swc_plugin_list::ListVisitor::new(Some(&comments))),
-      jsx_backend_enabled,
+      jsx_backend_enabled && !legacy_slot,
+    );
+    let legacy_list_plugin = Optional::new(
+      visit_mut_pass(swc_plugin_list::LegacyListVisitor::new(Some(&comments))),
+      jsx_backend_enabled && legacy_slot,
     );
 
     let is_ge_3_1: bool = is_engine_version_ge(&options.engine_version, "3.1");
@@ -732,6 +737,7 @@ fn transform_react_lynx_inner(
       (
         text_plugin,
         list_plugin,
+        legacy_list_plugin,
         snapshot_plugin,
         element_template_plugin,
       ),

--- a/packages/react/transform/swc-plugin-reactlynx/index.d.ts
+++ b/packages/react/transform/swc-plugin-reactlynx/index.d.ts
@@ -25,6 +25,8 @@ export interface JsxTransformerConfig {
   enableUiSourceMap?: boolean;
   /** @internal */
   isDynamicComponent?: boolean;
+  /** @internal */
+  legacySlot?: boolean;
 }
 
 /** @internal */

--- a/packages/react/transform/swc-plugin-reactlynx/src/lib.rs
+++ b/packages/react/transform/swc-plugin-reactlynx/src/lib.rs
@@ -26,7 +26,7 @@ use swc_plugin_directive_dce::{DirectiveDCEVisitor, DirectiveDCEVisitorConfig};
 use swc_plugin_dynamic_import::{DynamicImportVisitor, DynamicImportVisitorConfig};
 use swc_plugin_element_template::{ElementTemplateTransformer, ElementTemplateTransformerConfig};
 use swc_plugin_inject::{InjectVisitor, InjectVisitorConfig};
-use swc_plugin_list::ListVisitor;
+use swc_plugin_list::{LegacyListVisitor, ListVisitor};
 use swc_plugin_shake::{ShakeVisitor, ShakeVisitorConfig};
 use swc_plugin_snapshot::{
   JSXTransformer as SnapshotJSXTransformer, JSXTransformerConfig as SnapshotJSXTransformerConfig,
@@ -238,6 +238,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
   let use_snapshot_plugin = snapshot_enabled && !use_element_template_plugin;
   let jsx_backend_enabled = use_snapshot_plugin || use_element_template_plugin;
 
+  let legacy_slot = matches!(snapshot_plugin_config.legacy_slot, Some(true));
   let snapshot_plugin = Optional::new(
     visit_mut_pass(
       SnapshotJSXTransformer::new(
@@ -266,7 +267,11 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
 
   let list_plugin = Optional::new(
     visit_mut_pass(ListVisitor::new(Some(&comments))),
-    jsx_backend_enabled,
+    jsx_backend_enabled && !legacy_slot,
+  );
+  let legacy_list_plugin = Optional::new(
+    visit_mut_pass(LegacyListVisitor::new(Some(&comments))),
+    jsx_backend_enabled && legacy_slot,
   );
 
   let is_ge_3_1: bool = is_engine_version_ge(&options.engine_version, "3.1");
@@ -347,6 +352,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
     (
       text_plugin,
       list_plugin,
+      legacy_list_plugin,
       snapshot_plugin,
       element_template_plugin,
     ),

--- a/packages/rspeedy/plugin-react/etc/react-rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-react/etc/react-rsbuild-plugin.api.md
@@ -24,6 +24,7 @@ export interface CompatVisitorConfig {
     // @deprecated (undocumented)
     darkMode?: boolean | DarkModeConfig
     disableDeprecatedWarning: boolean
+    legacySlot?: boolean
     newRuntimePkg: string
     oldRuntimePkg: Array<string>
     // @deprecated

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -51,11 +51,12 @@ export interface PluginReactLynxOptions {
   enableUiSourceMap?: boolean
 
   /**
-   * The `compat` option controls compatibilities with ReactLynx2.0.
+   * The `compat` option controls compatibilities with legacy ReactLynx.
    *
    * @remarks
    *
-   * These options should only be used for migrating from ReactLynx2.0.
+   * These options should only be used for migrating from ReactLynx2.0 or
+   * targeting legacy ReactLynx3 runtimes.
    *
    * @defaultValue `undefined`
    */

--- a/packages/webpack/react-webpack-plugin/src/loaders/options.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/options.ts
@@ -197,6 +197,7 @@ function getCommonOptions(
       filename,
       isDynamicComponent: isDynamicComponent ?? false,
       isExternalBundle: isExternalBundle ?? false,
+      legacySlot: compat?.legacySlot ?? false,
     },
     elementTemplate: useElementTemplate
       ? {


### PR DESCRIPTION
## Summary

Add a **`compat.legacySlot`** option to `pluginReactLynx`. When enabled, dynamic children are compiled with the **pre-SlotV2 children + wrapper codegen** (`Slot`/`Children`/`ListChildren` dynamic parts rendered through wrapper elements) instead of the default SlotV2 codegen (`$0`/`$1` slot props introduced in #1764), so the compiled output runs on legacy `@lynx-js/react` runtimes without `SlotV2` support (< 0.120.0, which shipped the SlotV2 refactor in #1764) — e.g. a standalone lazy bundle consumed by a host App that ships an older runtime.

Both codegen modes are now maintained side by side; the **default output is unchanged** (SlotV2), and the **runtime is untouched** (it keeps supporting both forms).

```js
import { defineConfig } from '@lynx-js/rspeedy'
import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'

export default defineConfig({
  plugins: [
    pluginReactLynx({
      compat: {
        legacySlot: true,
      },
    }),
  ],
})
```

## Implementation

- **`swc_plugin_snapshot`**: the legacy codegen lives entirely in a **frozen, self-contained `legacy_slot.rs` module** (`WrapperMarker` pre-pass wrapping dynamic parts in `<internal-slot>`, a legacy `DynamicPart` extractor, and the children + `__DynamicPartChildren`/`__DynamicPartSlot`/`__DynamicPartListChildren` snapshot emission — the pre-#1764 pipeline). `lib.rs` keeps the mainline SlotV2 pipeline byte-for-byte identical to `main` apart from a config field and a one-line dispatch (+14 lines, 0 deletions), so future codegen iteration never has to reason about legacy semantics. The module header documents that it is frozen and must not be refactored along with mainline changes.
- **`swc_plugin_list`**: the legacy list pass is likewise a **frozen `legacy_slot.rs` module** (`LegacyListVisitor`, without the SlotV2-oriented `<list>` children pre-wrapping); mainline `lib.rs` is untouched apart from the module declaration (+3 lines), and the two visitors are selected at pass-composition time.
- **Option plumbing**: `pluginReactLynx({ compat: { legacySlot } })` (typia-validated, API report updated) → `react-webpack-plugin` loader options → snapshot transform config (napi + serde camelCase, standalone SWC wasm plugin included).

## Real-runtime verification

Verified against the **real `@lynx-js/react@0.117.0` npm package** (its runtime + testing library), compiling with this PR's transform:

- `legacySlot: true` output **renders and updates correctly** on 0.117.0 — dynamic children, conditional slots through wrappers, keyed `.map()` list updates, and the `snapshotCreatorMap` registration path all work.
- Control: the same component compiled with the default SlotV2 codegen **fails** on 0.117.0 (`snapshotPatchApply failed: ctx not found`) — confirming `legacySlot` is what provides the compatibility.

## Tests

- **Rust**: every default-mode swc snapshot fixture is byte-identical to `main`; each mode-diverging case gains a `*_legacy_slot` twin. The generated legacy fixtures are **byte-identical to the compiled output of the previous unconditional-compat revision of this PR**, whose full JS suites (runtime / testing-library / web-platform server-e2e) passed — i.e. the flag reproduces exactly the verified compat output.
- **Transform JS**: `fixture.spec.js` asserts both modes through the real wasm/napi pipeline (`__DynamicPartChildren` + `children:` vs `__DynamicPartSlotV2` + `$0:`).
- **Runtime**: new `legacySlot.legacy-slot.test.jsx` is compiled with `legacySlot: true` (vitest transform hook) and exercises wrapper/slot semantics (insertBefore/removeChild/slot-index/dynamic-key) of legacy-compiled snapshots on the current runtime.
- **Default-mode JS suites** (runtime, testing-library, react-compiler examples, react-refresh HMR snapshots, web-platform server-e2e) are identical to `main` and pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `legacySlot` compatibility setting for older runtimes without SlotV2 support.
  * Opt-in compilation now uses the legacy dynamic children/slot wrapper format for broader runtime compatibility.
  * Added support for legacy list and deferred list-item rendering.
* **Bug Fixes**
  * Improved correctness for legacy rendering and updates involving dynamic children, slots, lists, keys, and spread props.
* **Documentation**
  * Updated API docs to describe `legacySlot` behavior and default support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->