### PR TITLE
feat(rslib): add enableJsBytecode option, off by default in development

### DIFF
--- a/.changeset/external-bundle-js-bytecode-option.md
+++ b/.changeset/external-bundle-js-bytecode-option.md
@@ -2,4 +2,4 @@
 "@lynx-js/lynx-bundle-rslib-config": minor
 ---
 
-Add an `enableJsBytecode` option to `EncodeOptions` (and `ExternalBundleWebpackPluginOptions`) that controls whether main thread chunks are compiled to JsBytecode in the emitted external bundle. It defaults to `false` when `NODE_ENV` is `'development'` — keeping main thread chunks as plain JavaScript source for faster encoding and easier debugging — and `true` otherwise. The option only affects the `'tasm'` target; for the `'web'` target the `JsBytecode` tag is routing-only and always kept.
+Add an `enableJsBytecode` option to control compiling main thread chunks to JsBytecode. Defaults to `false` when `NODE_ENV` is `'development'`, `true` otherwise.

--- a/.changeset/external-bundle-js-bytecode-option.md
+++ b/.changeset/external-bundle-js-bytecode-option.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Add an `enableJsBytecode` option to `EncodeOptions` (and `ExternalBundleWebpackPluginOptions`) that controls whether main thread chunks are compiled to JsBytecode in the emitted external bundle. It defaults to `false` when `NODE_ENV` is `'development'` — keeping main thread chunks as plain JavaScript source for faster encoding and easier debugging — and `true` otherwise. The option only affects the `'tasm'` target; for the `'web'` target the `JsBytecode` tag is routing-only and always kept.

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -22,6 +22,7 @@ export function defineExternalBundleRslibConfig(userLibConfig: ExternalBundleLib
 
 // @public
 export interface EncodeOptions {
+    enableJsBytecode?: boolean;
     engineVersion?: string;
     target?: 'web' | 'tasm';
 }
@@ -42,6 +43,7 @@ export class ExternalBundleWebpackPlugin {
 // @public
 export interface ExternalBundleWebpackPluginOptions {
     bundleFileName: string;
+    enableJsBytecode?: boolean | undefined;
     encode: (opts: unknown) => Promise<{
         buffer: Buffer;
     }>;

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -35,6 +35,21 @@ export interface EncodeOptions {
    * @defaultValue 'tasm'
    */
   target?: 'web' | 'tasm'
+
+  /**
+   * Whether to compile main thread chunks to JsBytecode in the emitted bundle.
+   *
+   * @remarks
+   * When disabled, main thread chunks are encoded as plain JavaScript source,
+   * which keeps them readable for debugging and speeds up encoding.
+   *
+   * Only takes effect for the `'tasm'` target. For the `'web'` target the
+   * `JsBytecode` tag only routes main thread chunks to the correct bundle
+   * slot (the chunk is never bytecode-compiled), so it is always kept.
+   *
+   * @defaultValue `false` when `NODE_ENV` is `'development'`, otherwise `true`
+   */
+  enableJsBytecode?: boolean
 }
 
 const DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG = {
@@ -564,6 +579,7 @@ export function defineExternalBundleRslibConfig(
       externalBundleRsbuildPlugin({
         engineVersion: encodeOptions.engineVersion,
         target: encodeOptions.target,
+        enableJsBytecode: encodeOptions.enableJsBytecode,
       }),
     ],
   }
@@ -585,9 +601,11 @@ interface ExposedLayers {
 const externalBundleRsbuildPlugin = ({
   engineVersion,
   target,
+  enableJsBytecode,
 }: {
   engineVersion: string | undefined
   target: 'web' | 'tasm' | undefined
+  enableJsBytecode: boolean | undefined
 }): rsbuild.RsbuildPlugin => ({
   name: 'lynx:external-bundle',
   // ensure dsl plugin has exposed LAYERS
@@ -740,6 +758,9 @@ const externalBundleRsbuildPlugin = ({
               encode,
               engineVersion,
               mainThreadChunks,
+              // For web the `JsBytecode` tag is routing-only (sections stay
+              // raw JS), so it must survive regardless of the user option.
+              enableJsBytecode: isWeb ? true : enableJsBytecode,
             },
           ],
         )

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -49,6 +49,18 @@ export interface ExternalBundleWebpackPluginOptions {
    * @defaultValue []
    */
   mainThreadChunks?: string[] | undefined
+
+  /**
+   * Whether to tag main thread chunks with the `JsBytecode` encoding so the
+   * encoder compiles them to bytecode.
+   *
+   * @remarks
+   * When disabled, main thread chunks are encoded as plain JavaScript source,
+   * which keeps them readable for debugging and speeds up encoding.
+   *
+   * @defaultValue `false` when `NODE_ENV` is `'development'`, otherwise `true`
+   */
+  enableJsBytecode?: boolean | undefined
 }
 
 const isDebug = (): boolean => {
@@ -99,7 +111,15 @@ export class ExternalBundleWebpackPlugin {
     compilation: Compilation,
   ): Promise<void> {
     const assets = compilation.getAssets()
-    const { buffer, encodeOptions } = await this.#encode(assets)
+    // `rslib build` always compiles with rspack mode `production`, so the
+    // development signal here is `NODE_ENV`, matching the `minify` default
+    // of `DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG`.
+    const enableJsBytecode = this.options.enableJsBytecode
+      ?? process.env['NODE_ENV'] !== 'development'
+    const { buffer, encodeOptions } = await this.#encode(
+      assets,
+      enableJsBytecode,
+    )
 
     const { RawSource } = compiler.webpack.sources
     compilation.emitAsset(
@@ -120,7 +140,7 @@ export class ExternalBundleWebpackPlugin {
     }
   }
 
-  async #encode(assets: readonly Asset[]) {
+  async #encode(assets: readonly Asset[], enableJsBytecode: boolean) {
     const customSections = assets
       .reduce<
         Record<string, {
@@ -135,7 +155,8 @@ export class ExternalBundleWebpackPlugin {
               return ({
                 ...prev,
                 [cur.name.replace(/\.js$/, '')]: {
-                  ...(this.options.mainThreadChunks?.includes(cur.name)
+                  ...(enableJsBytecode
+                      && this.options.mainThreadChunks?.includes(cur.name)
                     ? {
                       'encoding': 'JsBytecode',
                     }

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -262,6 +262,80 @@ describe('should build external bundle', () => {
   })
 })
 
+describe('JsBytecode encoding', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+
+  const buildAndDecode = async (
+    id: string,
+    encodeOptions?: { enableJsBytecode?: boolean },
+    nodeEnv?: 'development' | 'production',
+  ) => {
+    const prevNodeEnv = process.env['NODE_ENV']
+    if (nodeEnv) {
+      process.env['NODE_ENV'] = nodeEnv
+    }
+    try {
+      const rslibConfig = defineExternalBundleRslibConfig({
+        source: {
+          entry: {
+            utils: path.join(fixtureDir, 'index.ts'),
+          },
+        },
+        id,
+        output: {
+          distPath: {
+            root: path.join(fixtureDir, 'dist'),
+          },
+        },
+        plugins: [pluginReactLynx()],
+      }, encodeOptions)
+      await build(rslibConfig)
+      return await decodeTemplate(
+        path.join(fixtureDir, `dist/${id}.lynx.bundle`),
+      )
+    } finally {
+      process.env['NODE_ENV'] = prevNodeEnv
+    }
+  }
+
+  it('should emit plain JS for main thread chunks when enableJsBytecode is false', async () => {
+    const decodedResult = await buildAndDecode('utils-no-bytecode', {
+      enableJsBytecode: false,
+    })
+
+    expect(decodedResult['custom-sections']['utils__main-thread']).toBeTypeOf(
+      'string',
+    )
+    expect(decodedResult['custom-sections']['utils']).toBeTypeOf('string')
+  })
+
+  it('should not compile main thread chunks to bytecode in development by default', async () => {
+    const decodedResult = await buildAndDecode(
+      'utils-dev-no-bytecode',
+      undefined,
+      'development',
+    )
+
+    expect(decodedResult['custom-sections']['utils__main-thread']).toBeTypeOf(
+      'string',
+    )
+  })
+
+  it('should compile main thread chunks to bytecode when explicitly enabled in development', async () => {
+    const decodedResult = await buildAndDecode(
+      'utils-dev-bytecode',
+      { enableJsBytecode: true },
+      'development',
+    )
+
+    expect(
+      Array.isArray(decodedResult['custom-sections']['utils__main-thread']),
+    ).toBe(true)
+    expect(decodedResult['custom-sections']['utils__main-thread']![0])
+      .toBeTypeOf('number')
+  })
+})
+
 describe('NODE_ENV configuration', () => {
   const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
 


### PR DESCRIPTION
## Summary

Adds an `enableJsBytecode` option to `@lynx-js/lynx-bundle-rslib-config` that controls whether main thread chunks of an external bundle are tagged with the `JsBytecode` encoding (i.e. compiled to bytecode by the encoder), and turns it off by default in development.

- **New option** `EncodeOptions.enableJsBytecode` (`defineExternalBundleRslibConfig(config, { enableJsBytecode })`) and `ExternalBundleWebpackPluginOptions.enableJsBytecode`.
- **Development default**: `false` when `NODE_ENV` is `'development'`, `true` otherwise. When disabled, main thread chunks are encoded as plain JavaScript source — faster encoding, and the emitted section stays readable for debugging.
- **`'tasm'` target only**: for the `'web'` target the `JsBytecode` tag never triggers bytecode compilation; it only routes main thread chunks to the `lepusCode` slot, so it is always kept there regardless of the option.

## Why `NODE_ENV` and not rspack `mode`?

`rslib build` always compiles with rspack mode `production` (verified empirically — `NODE_ENV=development` still yields `mode: 'production'`), so `compiler.options.mode` cannot signal development here. `NODE_ENV` matches the existing development signal in this package (the `minify` default of `DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG`), and is read at encode time so it also works when set right before a build.

## Tests

- `enableJsBytecode: false` → main thread section decodes as plain JS string.
- `NODE_ENV=development` with no option → plain JS string (new dev default).
- `NODE_ENV=development` with explicit `enableJsBytecode: true` → bytecode.
- Existing tests keep asserting the production default stays bytecode.

All 25 package tests pass; API report (`etc/lynx-bundle-rslib-config.api.md`) regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `enableJsBytecode` option to control JsBytecode compilation for main-thread chunks in external bundles.
  * Defaults are now environment-aware: disabled in development and enabled otherwise.
  * Web bundle behavior preserves JsBytecode routing information even if the option is not enabled.
* **Documentation**
  * Updated the public API to include `enableJsBytecode` in the relevant options types.
* **Tests**
  * Added coverage verifying output changes across explicit `enableJsBytecode` settings and `NODE_ENV` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->