### PR TITLE
feat(rslib): keep JsBytecode debug info out of external bundles

### DIFF
--- a/.changeset/external-bundle-debug-info-outside.md
+++ b/.changeset/external-bundle-debug-info-outside.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Keep JsBytecode debug info (per-function `pc2line` tables) out of external bundles, significantly reducing the size of bytecode-encoded main thread chunks.

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -192,6 +192,7 @@ export class ExternalBundleWebpackPlugin {
       targetSdkVersion: this.options.engineVersion ?? '3.5',
       enableCSSInvalidation: true,
       enableCSSSelector: true,
+      debugInfoOutside: true,
     }
 
     const encodeOptions = {

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -944,3 +944,34 @@ describe('DSL plugin without layer loaders', () => {
     await expect(build(rslibConfig)).resolves.toBeDefined()
   })
 })
+
+describe('debug info outside', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+
+  it('should keep bytecode debug info out of the tasm bundle', async () => {
+    rstest.stubEnv('DEBUG', 'rspeedy')
+    try {
+      const distRoot = path.join(fixtureDir, 'dist')
+      await build(defineExternalBundleRslibConfig({
+        source: {
+          entry: {
+            utils: path.join(fixtureDir, 'index.ts'),
+          },
+        },
+        id: 'utils-dbg-outside',
+        output: {
+          distPath: {
+            root: distRoot,
+          },
+        },
+        plugins: [pluginReactLynx()],
+      }))
+      const tasmJson = JSON.parse(
+        fs.readFileSync(path.join(distRoot, 'tasm.json'), 'utf-8'),
+      ) as { compilerOptions: Record<string, unknown> }
+      expect(tasmJson.compilerOptions['debugInfoOutside']).toBe(true)
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Prod external bundles with `JsBytecode` were ~2.4x the size of their plain-JS equivalent. The dominant cost is not the bytecode itself: primjs embeds per-function debug info (`filename` + `line_num` + `pc2line` tables) into the serialized bytecode unless the encoder is passed `compilerOptions.debugInfoOutside: true` — and the external bundle flow never passed it (engine default: `false`).

This PR passes `debugInfoOutside: true` in `ExternalBundleWebpackPlugin`'s encode options (no new public API). The web target is unaffected: its encoder never bytecode-compiles chunks, and its runtime only reads known config keys.

Independent of #2954.

## Measurements (real 68 KB minified react-umd `ReactLynx__main-thread.js`, `@lynx-js/tasm` 0.0.39)

| encoding | bundle size | vs plain JS | gzip | gzip vs plain |
|---|---|---|---|---|
| plain string section | 68.5 KB | 1.00x | 22.1 KB | 1.00x |
| JsBytecode (before) | 162.4 KB | **2.37x** | 69.5 KB | 3.15x |
| JsBytecode + `debugInfoOutside` (after) | 75.2 KB | **1.10x** | 37.0 KB | 1.68x |

## Compatibility

- The main template flow (`LynxTemplatePlugin`) has defaulted to `debugInfoOutside: true` since LynxSDK 2.7; this brings the external bundle flow in line.
- Decoding is self-adapting: the primjs reader detects externalized debug info from the binary (magic atom / `NEW_DEBUGINFO_FLAG`), so no client/runtime change is needed.
- Behavior change: runtime error stacks from bytecode sections report function IDs instead of line/column.

## Tests

- The tasm encoder receives `compilerOptions.debugInfoOutside: true` (asserted via the `DEBUG`-mode `tasm.json` dump).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced the size of bytecode-encoded main-thread chunks by keeping per-function debug information out of external bundles.

* **Bug Fixes**
  * Ensured external bundles consistently apply the updated debug-information handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->