### PR TITLE
feat(react): fail fast when pluginLynxPreset() is missing

### DIFF
--- a/.changeset/rsbuild-preset-guard.md
+++ b/.changeset/rsbuild-preset-guard.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Fail fast when `pluginReactLynx()` runs on a plain Rsbuild build without `pluginLynxPreset()`.
+
+Building a Lynx app with the Rsbuild CLI directly requires `pluginLynxPreset()` (from `@lynx-js/preset-rsbuild-plugin`) to install the Lynx build engine. Without it, `pluginReactLynx()` used to silently produce a broken bundle. It now throws an actionable error pointing at the missing `pluginLynxPreset()`. The Rspeedy CLI and rslib/rstest paths are unaffected.

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -412,6 +412,28 @@ export function pluginReactLynx(
       setup(api) {
         const isRslib = api.context.callerName === 'rslib'
         const isRstest = api.context.callerName === 'rstest'
+        const isRspeedy = api.context.callerName === 'rspeedy'
+
+        // Fail fast when a user adds `pluginReactLynx()` to a plain Rsbuild
+        // config but forgets `pluginLynxPreset()`. Without the preset, the Lynx
+        // build engine (config translation, chunk loading, target, dev/HMR, ...)
+        // is never applied and the build silently produces a broken bundle.
+        // The Rspeedy CLI and rslib/rstest supply that engine another way, so
+        // only guard the direct-Rsbuild path.
+        const hasLynxPreset =
+          api.useExposed(Symbol.for('lynx.api')) !== undefined
+        if (!isRspeedy && !isRslib && !isRstest && !hasLynxPreset) {
+          throw new Error(
+            `[lynx:react] \`pluginReactLynx()\` requires \`pluginLynxPreset()\` from `
+              + `'@lynx-js/preset-rsbuild-plugin'. Add it before \`pluginReactLynx()\` `
+              + `in your \`rsbuild.config.ts\`:\n\n`
+              + `  import { pluginLynxPreset } from '@lynx-js/preset-rsbuild-plugin'\n`
+              + `  import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'\n\n`
+              + `  export default {\n`
+              + `    plugins: [pluginLynxPreset(), pluginReactLynx()],\n`
+              + `  }\n`,
+          )
+        }
 
         const exposedConfig = api.useExposed<{ config: Config }>(
           Symbol.for('lynx.config'),

--- a/packages/rspeedy/plugin-react/test/preset-guard.test.ts
+++ b/packages/rspeedy/plugin-react/test/preset-guard.test.ts
@@ -1,0 +1,28 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createRsbuild } from '@rsbuild/core'
+import { expect, test } from '@rstest/core'
+
+// When `pluginReactLynx()` runs on a plain Rsbuild build (not the Rspeedy CLI,
+// not rslib/rstest) without `pluginLynxPreset()`, the Lynx build engine is
+// never applied. The plugin must fail fast with an actionable error instead of
+// silently emitting a broken bundle.
+test('pluginReactLynx() fails fast when pluginLynxPreset() is missing', async () => {
+  const { pluginReactLynx } = await import('../src/index.js')
+
+  const rsbuild = await createRsbuild({
+    cwd: path.dirname(fileURLToPath(import.meta.url)),
+    rsbuildConfig: {
+      plugins: [pluginReactLynx()],
+      environments: { lynx: {} },
+    },
+  })
+
+  await expect(rsbuild.initConfigs()).rejects.toThrow(
+    /`pluginReactLynx\(\)` requires `pluginLynxPreset\(\)`/,
+  )
+})


### PR DESCRIPTION
## What

When `pluginReactLynx()` runs on a plain **Rsbuild** build (not the Rspeedy CLI, not rslib/rstest) **without `pluginLynxPreset()`**, the Lynx build engine (config translation, chunk loading, target, dev/HMR, …) is never applied and the build silently produces a broken bundle.

This makes `pluginReactLynx()` **fail fast** with an actionable error that names the missing `pluginLynxPreset()` and shows a copy-pasteable `rsbuild.config.ts`.

## How
- Guarded on the `lynx.api` symbol that `pluginLynxPreset` exposes via `api.expose`. Present means the preset is installed; absent on a direct-Rsbuild build means it is missing, so throw.
- The Rspeedy CLI (`callerName === 'rspeedy'`) and `rslib`/`rstest` supply the engine another way, so they are explicitly exempt.

## Verified
- New `test/preset-guard.test.ts`: a direct `createRsbuild` with only `pluginReactLynx()` makes `initConfigs()` reject with the actionable error.
- Full `@lynx-js/react-rsbuild-plugin` suite green: 176 tests (175 existing + 1 new), 0 failures. Existing tests run under `callerName: 'rspeedy'`, so the guard correctly skips them.

Part of the stacked Rspeedy-to-Rsbuild migration: main <- #2950 <- #2951 <- this.