### PR TITLE
refactor(preset): move granular config sub-types to /config subpath

### DIFF
--- a/.changeset/rsbuild-preset-config-subpath.md
+++ b/.changeset/rsbuild-preset-config-subpath.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/preset-rsbuild-plugin": patch
+---
+
+Move the granular Lynx config sub-types (`Output`, `Source`, `Dev`, `Performance`, `Resolve`, `Server`, `Tools`, `Filename`, `CssModules`, …) from the main entry to the `@lynx-js/preset-rsbuild-plugin/config` subpath.
+
+The top-level entry now keeps only the surface most consumers need — `pluginLynxPreset`, `loadLynxConfig`, `Config`, `ExposedAPI`, `mergeRspeedyConfig`, `defineConfig`. The leaf types are all reachable through `Config` (e.g. `Config['output']`) and are re-exported unchanged by `@lynx-js/rspeedy`, so `import { Output } from '@lynx-js/rspeedy'` keeps working.

--- a/packages/rspeedy/core/src/index.ts
+++ b/packages/rspeedy/core/src/index.ts
@@ -41,6 +41,9 @@ export type {
   LoadConfigOptions,
   LoadConfigResult,
 } from '@lynx-js/preset-rsbuild-plugin'
+export type { Config } from '@lynx-js/preset-rsbuild-plugin'
+// The granular config sub-types now live at the preset's `/config` subpath;
+// re-exported here unchanged so `import { Output } from '@lynx-js/rspeedy'` works.
 export type {
   BuildCache,
   BundleFilename,
@@ -48,7 +51,6 @@ export type {
   ChunkSplit,
   ChunkSplitBySize,
   ChunkSplitCustom,
-  Config,
   ConsoleType,
   CssExtract,
   CssExtractRspackLoaderOptions,
@@ -74,7 +76,7 @@ export type {
   SourceMap,
   Tools,
   TransformImport,
-} from '@lynx-js/preset-rsbuild-plugin'
+} from '@lynx-js/preset-rsbuild-plugin/config'
 
 // RsbuildPlugin
 export type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core'

--- a/packages/rspeedy/plugin-preset/etc/preset-rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-preset/etc/preset-rsbuild-plugin.api.md
@@ -20,67 +20,36 @@ import type { ServerConfig } from '@rsbuild/core';
 import type { ToolsConfig } from '@rsbuild/core';
 import type { WatchFiles } from '@rsbuild/core';
 
-// @beta
-export interface BuildCache {
-    buildDependencies?: string[] | undefined;
-    cacheDigest?: Array<string | undefined> | undefined;
-    cacheDirectory?: string | undefined;
-}
-
-// @public
-export type BundleFilename = string | ((context: BundleFilenameContext) => string);
-
-// @public
-export interface BundleFilenameContext {
-    entryName?: string | undefined;
-    lazyBundle: boolean;
-    platform: string;
-}
-
-// @public @deprecated
-export interface ChunkSplit {
-    override?: Rspack.Configuration extends {
-        optimization?: {
-            splitChunks?: infer P;
-        } | undefined;
-    } ? P : never;
-    strategy?: 'all-in-one' | 'split-by-module' | 'split-by-experience' | 'single-vendor' | undefined;
-}
-
-// @public @deprecated
-export interface ChunkSplitBySize {
-    maxSize?: number | undefined;
-    minSize?: number | undefined;
-    override?: Rspack.Configuration extends {
-        optimization?: {
-            splitChunks?: infer P;
-        } | undefined;
-    } ? P : never;
-    strategy: 'split-by-size';
-}
-
-// @public @deprecated
-export interface ChunkSplitCustom {
-    splitChunks?: Rspack.Configuration extends {
-        optimization?: {
-            splitChunks?: infer P;
-        } | undefined;
-    } ? P : never;
-    strategy: 'custom';
-}
-
 // @public
 export interface Config {
+    // Warning: (ae-forgotten-export) The symbol "Dev" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Dev"
     dev?: Dev | undefined;
     environments?: RsbuildConfig['environments'] | undefined;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Output"
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Output"
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "CssModules"
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Output"
     mode?: 'development' | 'production' | 'none' | undefined;
+    // Warning: (ae-forgotten-export) The symbol "Output" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Output"
     output?: Output | undefined;
+    // Warning: (ae-forgotten-export) The symbol "Performance" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Performance"
     performance?: Performance | undefined;
     plugins?: RsbuildPlugins | undefined;
+    // Warning: (ae-forgotten-export) The symbol "Resolve" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Resolve"
     resolve?: Resolve | undefined;
+    // Warning: (ae-forgotten-export) The symbol "Server" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Server"
     server?: Server | undefined;
+    // Warning: (ae-forgotten-export) The symbol "Source" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Source"
     source?: Source | undefined;
     splitChunks?: RsbuildConfig['splitChunks'] | undefined;
+    // Warning: (ae-forgotten-export) The symbol "Tools" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@lynx-js/preset-rsbuild-plugin" does not have an export "Tools"
     tools?: Tools | undefined;
 }
 
@@ -88,56 +57,6 @@ export interface Config {
 export interface ConfigParams {
     command: 'build' | 'dev' | 'inspect' | 'preview' | (string & Record<never, never>);
     env: 'production' | 'development' | 'test' | (string & Record<never, never>);
-}
-
-// @public
-export type ConsoleType = 'log' | 'warn' | 'error' | 'info' | 'debug' | 'profile' | 'profileEnd' | (string & Record<never, never>);
-
-// @public
-export interface CssExtract {
-    loaderOptions?: CssExtractRspackLoaderOptions | undefined;
-    pluginOptions?: CssExtractRspackPluginOptions | undefined;
-}
-
-// @public
-export interface CssExtractRspackLoaderOptions {
-    esModule?: boolean | undefined;
-}
-
-// @public
-export interface CssExtractRspackPluginOptions {
-    ignoreOrder?: boolean | undefined;
-    pathinfo?: boolean | undefined;
-}
-
-// @public
-export interface CssLoader {
-    importLoaders?: 0 | 1 | 2 | undefined;
-    modules?: boolean | 'local' | 'global' | 'pure' | 'icss' | CssLoaderModules | undefined;
-}
-
-// @public
-export interface CssLoaderModules {
-    auto?: boolean | RegExp | ((filename: string) => boolean) | undefined;
-    exportLocalsConvention?: CssModuleLocalsConvention | undefined;
-    localIdentName?: string | undefined;
-    namedExport?: boolean | undefined;
-}
-
-// @public
-export type CssModuleLocalsConvention = 'asIs' | 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly';
-
-// @public
-export interface CssModules {
-    auto?: boolean | RegExp | ((filename: string) => boolean) | undefined;
-    exportGlobals?: boolean | undefined;
-    exportLocalsConvention?: CssModuleLocalsConvention | undefined;
-    localIdentName?: string | undefined;
-}
-
-// @public
-export interface Decorators {
-    version?: 'legacy' | '2022-03';
 }
 
 // @public
@@ -153,40 +72,6 @@ export function defineConfig(config: Promise<Config>): Promise<Config>;
 export function defineConfig(config: (params: ConfigParams) => Promise<Config>): (params: ConfigParams) => Promise<Config>;
 
 // @public
-export interface Dev {
-    assetPrefix?: string | boolean | undefined;
-    client?: DevClient | undefined;
-    hmr?: boolean | undefined;
-    liveReload?: boolean | undefined;
-    progressBar?: boolean | {
-        id?: string;
-    } | undefined;
-    watchFiles?: WatchFiles | WatchFiles[] | undefined;
-    writeToDisk?: boolean | ((filename: string) => boolean) | undefined;
-}
-
-// @public
-export interface DevClient {
-    websocketTransport?: string | undefined;
-}
-
-// @public
-export interface DistPath extends DistPathConfig {
-    // @deprecated
-    intermediate?: string | undefined;
-}
-
-// @public
-export type Entry = string | string[] | Record<string, string | string[] | EntryDescription>;
-
-// @public
-export interface EntryDescription {
-    dependOn?: string | string[] | undefined;
-    import?: string | string[] | undefined;
-    publicPath?: string | undefined;
-}
-
-// @public
 export interface ExposedAPI {
     config: Config;
     debug: (message: string | (() => string)) => void;
@@ -194,21 +79,6 @@ export interface ExposedAPI {
     exit: (code?: number) => Promise<void> | void;
     logger: typeof logger;
     version: string;
-}
-
-// @public
-export interface Filename {
-    assets?: Rspack.AssetModuleFilename;
-    bundle?: BundleFilename | undefined;
-    css?: Rspack.CssFilename | undefined;
-    font?: Rspack.AssetModuleFilename | undefined;
-    image?: Rspack.AssetModuleFilename | undefined;
-    js?: Rspack.Filename | undefined;
-    media?: Rspack.AssetModuleFilename | undefined;
-    svg?: Rspack.AssetModuleFilename | undefined;
-    // @deprecated
-    template?: string | undefined;
-    wasm?: Rspack.WebassemblyModuleFilename;
 }
 
 // @public
@@ -233,112 +103,6 @@ export function loadLynxConfig(options?: LoadConfigOptions): Promise<Config>;
 export function mergeRspeedyConfig(...configs: Config[]): Config;
 
 // @public
-export interface Minify {
-    backgroundOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined;
-    css?: boolean | undefined;
-    js?: boolean | undefined;
-    jsOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined;
-    mainThreadOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined;
-}
-
-// @public
-export interface Output {
-    assetPrefix?: string | undefined;
-    cleanDistPath?: boolean | undefined;
-    copy?: Rspack.CopyRspackPluginOptions | Rspack.CopyRspackPluginOptions['patterns'] | undefined;
-    cssModules?: CssModules | undefined;
-    dataUriLimit?: number | DataUriLimit | undefined;
-    distPath?: DistPath | undefined;
-    filename?: string | Filename | undefined;
-    filenameHash?: boolean | string | undefined;
-    inlineScripts?: InlineChunkConfig | undefined;
-    legalComments?: 'none' | 'inline' | 'linked' | undefined;
-    minify?: Minify | boolean | undefined;
-    sourceMap?: boolean | SourceMap | undefined;
-}
-
-// @public
-export interface Performance {
-    // @beta
-    buildCache?: BuildCache | boolean | undefined;
-    // @deprecated
-    chunkSplit?: ChunkSplit | ChunkSplitBySize | ChunkSplitCustom | undefined;
-    printFileSize?: PerformanceConfig['printFileSize'] | undefined;
-    profile?: boolean | undefined;
-    removeConsole?: boolean | ConsoleType[] | undefined;
-}
-
-// @public
 export function pluginLynxPreset(config?: Config): RsbuildPlugins;
-
-// @public
-export interface Resolve {
-    alias?: Record<string, string | false | string[]> | undefined;
-    aliasStrategy?: 'prefer-tsconfig' | 'prefer-alias' | undefined;
-    dedupe?: string[] | undefined;
-    extensions?: string[] | undefined;
-}
-
-// @public
-export interface RsdoctorRspackPluginOptions extends Omit<RsdoctorRspackPluginOptions_2<[]>, 'linter'> {
-    // (undocumented)
-    linter?: {
-        rules?: Record<string, unknown>;
-        level?: 'Ignore' | 'Warn' | 'Error';
-        extends?: unknown[];
-    };
-}
-
-// @public
-export interface Server {
-    base?: string | undefined;
-    compress?: boolean | CompressOptions | undefined;
-    cors?: ServerConfig['cors'] | undefined;
-    headers?: Record<string, string | string[]> | undefined;
-    host?: string | undefined;
-    port?: number | undefined;
-    proxy?: ProxyConfig | undefined;
-    strictPort?: boolean | undefined;
-}
-
-// @public
-export interface Source {
-    // @deprecated
-    alias?: Record<string, string | false | string[]> | undefined;
-    assetsInclude?: Rspack.RuleSetCondition | undefined;
-    decorators?: Decorators | undefined;
-    define?: Rspack.DefinePluginOptions;
-    entry?: Entry | undefined;
-    exclude?: Rspack.RuleSetCondition[] | undefined;
-    include?: Rspack.RuleSetCondition[] | undefined;
-    preEntry?: string | string[] | undefined;
-    transformImport?: TransformImport[] | undefined;
-    tsconfigPath?: string | undefined;
-}
-
-// @public
-export interface SourceMap {
-    css?: boolean | undefined;
-    js?: Rspack.DevTool | undefined | `${Exclude<Rspack.DevTool, false | 'eval'>}-debugids`;
-}
-
-// @public
-export interface Tools {
-    bundlerChain?: ToolsConfig['bundlerChain'] | undefined;
-    cssExtract?: CssExtract | undefined;
-    cssLoader?: CssLoader | undefined;
-    rsdoctor?: RsdoctorRspackPluginOptions | undefined;
-    rspack?: ToolsConfig['rspack'] | undefined;
-    swc?: ToolsConfig['swc'] | undefined;
-}
-
-// @public
-export interface TransformImport {
-    camelToDashComponentName?: boolean | undefined;
-    customName?: string | undefined;
-    libraryDirectory?: string | undefined;
-    libraryName: string;
-    transformToDefaultImport?: boolean | undefined;
-}
 
 ```

--- a/packages/rspeedy/plugin-preset/package.json
+++ b/packages/rspeedy/plugin-preset/package.json
@@ -30,6 +30,10 @@
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
     },
+    "./config": {
+      "types": "./lib/config-types.d.ts",
+      "default": "./lib/config-types.js"
+    },
     "./internal": {
       "types": "./lib/internal.d.ts",
       "default": "./lib/internal.js"
@@ -87,6 +91,10 @@
       ".": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
+      },
+      "./config": {
+        "types": "./dist/config-types.d.ts",
+        "default": "./dist/config-types.js"
       },
       "./internal": {
         "types": "./dist/internal.d.ts",

--- a/packages/rspeedy/plugin-preset/rslib.config.ts
+++ b/packages/rspeedy/plugin-preset/rslib.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
       source: {
         entry: {
           index: './src/index.ts',
+          // Granular config sub-types published at the `/config` subpath.
+          'config-types': './src/config-types.ts',
           // Seam consumed by the `@lynx-js/rspeedy` CLI. See `src/internal.ts`.
           internal: './src/internal.ts',
         },

--- a/packages/rspeedy/plugin-preset/src/config-types.ts
+++ b/packages/rspeedy/plugin-preset/src/config-types.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// The granular Lynx config sub-types, published under the
+// `@lynx-js/preset-rsbuild-plugin/config` subpath. The main entry keeps only
+// the surface most consumers need (`Config`, `ExposedAPI`, `mergeRspeedyConfig`,
+// `defineConfig`); these leaf types (reachable via `Config['output']` etc.) live
+// here so the top-level API stays small. `@lynx-js/rspeedy` re-exports them so
+// `import { Output } from '@lynx-js/rspeedy'` keeps working.
+
+// Dev
+export type { Dev } from './config/dev/index.js'
+export type { Client as DevClient } from './config/dev/client.js'
+
+// Output
+export type {
+  CssModuleLocalsConvention,
+  CssModules,
+} from './config/output/css-modules.js'
+export type { DistPath } from './config/output/dist-path.js'
+export type {
+  BundleFilename,
+  BundleFilenameContext,
+  Filename,
+} from './config/output/filename.js'
+export type { Minify } from './config/output/minify.js'
+export type { SourceMap } from './config/output/source-map.js'
+export type { Output } from './config/output/index.js'
+
+// Performance
+export type { ConsoleType, Performance } from './config/performance/index.js'
+export type { BuildCache } from './config/performance/build-cache.js'
+export type {
+  ChunkSplit,
+  ChunkSplitBySize,
+  ChunkSplitCustom,
+} from './config/performance/chunk-split.js'
+
+// Resolve
+export type { Resolve } from './config/resolve/index.js'
+
+// Server
+export type { Server } from './config/server/index.js'
+
+// Source
+export type { Source } from './config/source/index.js'
+export type { Decorators } from './config/source/decorators.js'
+export type { Entry, EntryDescription } from './config/source/entry.js'
+export type { TransformImport } from './config/source/transformImport.js'
+
+// Tools
+export type {
+  CssExtract,
+  CssExtractRspackLoaderOptions,
+  CssExtractRspackPluginOptions,
+} from './config/tools/css-extract.js'
+export type { CssLoader, CssLoaderModules } from './config/tools/css-loader.js'
+export type {
+  RsdoctorRspackPluginOptions,
+  Tools,
+} from './config/tools/index.js'

--- a/packages/rspeedy/plugin-preset/src/index.ts
+++ b/packages/rspeedy/plugin-preset/src/index.ts
@@ -130,54 +130,7 @@ export type { ExposedAPI } from './api.js'
 export { mergeRspeedyConfig } from './config/mergeRspeedyConfig.js'
 export type { Config } from './config/index.js'
 
-// Dev
-export type { Dev } from './config/dev/index.js'
-export type { Client as DevClient } from './config/dev/client.js'
-
-// Output
-export type {
-  CssModules,
-  CssModuleLocalsConvention,
-} from './config/output/css-modules.js'
-export type { DistPath } from './config/output/dist-path.js'
-export type {
-  BundleFilename,
-  BundleFilenameContext,
-  Filename,
-} from './config/output/filename.js'
-export type { Minify } from './config/output/minify.js'
-export type { SourceMap } from './config/output/source-map.js'
-export type { Output } from './config/output/index.js'
-
-// Performance
-export type { ConsoleType, Performance } from './config/performance/index.js'
-export type { BuildCache } from './config/performance/build-cache.js'
-export type {
-  ChunkSplit,
-  ChunkSplitBySize,
-  ChunkSplitCustom,
-} from './config/performance/chunk-split.js'
-
-// Resolve
-export type { Resolve } from './config/resolve/index.js'
-
-// Server
-export type { Server } from './config/server/index.js'
-
-// Source
-export type { Source } from './config/source/index.js'
-export type { Decorators } from './config/source/decorators.js'
-export type { Entry, EntryDescription } from './config/source/entry.js'
-export type { TransformImport } from './config/source/transformImport.js'
-
-// Tools
-export type {
-  CssExtract,
-  CssExtractRspackLoaderOptions,
-  CssExtractRspackPluginOptions,
-} from './config/tools/css-extract.js'
-export type { CssLoader, CssLoaderModules } from './config/tools/css-loader.js'
-export type {
-  RsdoctorRspackPluginOptions,
-  Tools,
-} from './config/tools/index.js'
+// The granular config sub-types (`Output`, `Source`, `Dev`, ...) are published
+// under the `@lynx-js/preset-rsbuild-plugin/config` subpath (see
+// `./config-types.ts`) to keep this top-level entry small. They are all
+// reachable through `Config` (e.g. `Config['output']`).


### PR DESCRIPTION
## What

Shrinks `@lynx-js/preset-rsbuild-plugin`'s top-level export surface. The main entry carried ~30 leaf config types (`Output`, `Source`, `Dev`, `Performance`, `Resolve`, `Server`, `Tools`, `Filename`, `CssModules`, …) that almost nobody imports from the preset directly — they are reachable via `Config` (e.g. `Config['output']`).

They now live under the `@lynx-js/preset-rsbuild-plugin/config` subpath. The main entry keeps only `pluginLynxPreset`, `loadLynxConfig`, `Config`, `ExposedAPI`, `mergeRspeedyConfig`, `defineConfig`.

## How
- New `src/config-types.ts` re-exports the leaf types; exposed as `./config` in `exports` + `publishConfig.exports`, built as a separate rslib entry.
- `@lynx-js/rspeedy` re-exports the leaf types from `/config`, so its public API — and `rspeedy.api.md` — is unchanged.

## Tradeoff
api-extractor analyzes only the main entry, so it emits `ae-forgotten-export` warnings for the leaf types `Config` still references (they are intentionally exported from `/config`). The report was regenerated via `api-extractor run --local`; CI (verbose) passes because the committed report matches. If preferred, these can instead be suppressed via `messages.extractorMessageReporting` for a warning-free report.

## Verified
- `preset` 223, `core` 212, `react-rsbuild-plugin` 175 tests — all green.
- `arethetypeswrong` ✓ and api-extractor exit 0 for both preset and core.
- `rspeedy.api.md` unchanged (leaf types still inlined via `bundledPackages`).

Part of the stacked Rspeedy-to-Rsbuild migration.