### PR TITLE
refactor(preset): share the Lynx build-plugin set via composeLynxBuildPlugins

### DIFF
--- a/.changeset/rsbuild-preset-compose-plugins.md
+++ b/.changeset/rsbuild-preset-compose-plugins.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/preset-rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+De-duplicate the Lynx build-plugin composition. The 11-plugin set (chunk loading, dev/HMR, swc, target, minify, output, …) was listed twice — once in `pluginLynxPreset` and once in the Rspeedy CLI's `applyDefaultPlugins` — and exposed as 11 individual exports on `@lynx-js/preset-rsbuild-plugin/internal` that the CLI had to keep in sync by hand.
+
+It is now a single `composeLynxBuildPlugins(resolved)` function that both call, so the set/order/args are one source of truth. No behavior change: the composed plugin list is identical, and the example build is byte-identical (verified modulo the pre-existing async-chunk content hash).

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -27,39 +27,16 @@ export async function applyDefaultPlugins(
   rsbuildInstance: RsbuildInstance,
   config: Config,
 ): Promise<void> {
-  // The default build plugins now live in `@lynx-js/preset-rsbuild-plugin`.
-  // The CLI composes them itself (threading the loaded `lynx.config.ts` into
-  // each) rather than using the batteries-included `pluginLynxPreset`.
+  // The default build plugins live in `@lynx-js/preset-rsbuild-plugin`. The CLI
+  // composes them through the same `composeLynxBuildPlugins` seam that
+  // `pluginLynxPreset` uses (one source of truth for the set/order/args), and
+  // adds its own API plugin (with the real CLI `exit`) around it.
   const defaultPlugins = Promise.all([
     import('./api.plugin.js'),
-    import('@lynx-js/debug-metadata-rsbuild-plugin'),
     import('@lynx-js/preset-rsbuild-plugin/internal'),
-  ]).then(([{ pluginAPI }, { pluginLynxDebugMetadata }, {
-    pluginChunkLoading,
-    pluginDev,
-    pluginMinify,
-    pluginOptimization,
-    pluginOutput,
-    pluginResolve,
-    pluginRsdoctor,
-    pluginSourcemap,
-    pluginStatsJson,
-    pluginSwc,
-    pluginTarget,
-  }]) => [
+  ]).then(([{ pluginAPI }, { composeLynxBuildPlugins }]) => [
     pluginAPI(config),
-    pluginChunkLoading(),
-    pluginLynxDebugMetadata(),
-    pluginDev(config.dev, config.server),
-    pluginMinify(config.output?.minify),
-    pluginOptimization(),
-    pluginOutput(config.output),
-    pluginResolve(),
-    pluginRsdoctor(config.tools?.rsdoctor),
-    pluginSourcemap(),
-    pluginStatsJson(config),
-    pluginSwc(),
-    pluginTarget(),
+    ...composeLynxBuildPlugins(config),
   ])
 
   const promises: Promise<void>[] = [

--- a/packages/rspeedy/plugin-preset/src/build-plugins.ts
+++ b/packages/rspeedy/plugin-preset/src/build-plugins.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { RsbuildPlugin } from '@rsbuild/core'
+
+import { pluginLynxDebugMetadata } from '@lynx-js/debug-metadata-rsbuild-plugin'
+
+import type { Config } from './config/index.js'
+import { pluginChunkLoading } from './plugins/chunkLoading.plugin.js'
+import { pluginDev } from './plugins/dev.plugin.js'
+import { pluginMinify } from './plugins/minify.plugin.js'
+import { pluginOptimization } from './plugins/optimization.plugin.js'
+import { pluginOutput } from './plugins/output.plugin.js'
+import { pluginResolve } from './plugins/resolve.plugin.js'
+import { pluginRsdoctor } from './plugins/rsdoctor.plugin.js'
+import { pluginSourcemap } from './plugins/sourcemap.plugin.js'
+import { pluginStatsJson } from './plugins/statsJson.plugin.js'
+import { pluginSwc } from './plugins/swc.plugin.js'
+import { pluginTarget } from './plugins/target.plugin.js'
+
+/**
+ * The Lynx build plugins (chunk loading, dev/HMR, swc, target, minify, …) with
+ * the resolved config threaded into each — a single source of truth shared by
+ * {@link pluginLynxPreset} and the Rspeedy CLI's `applyDefaultPlugins`.
+ *
+ * Excludes the API plugin (differs between the two callers), the config
+ * translation, and `@rsbuild/plugin-css-minimizer` (the CLI adds it
+ * conditionally). Callers compose those around this set.
+ *
+ * @param resolved - The Lynx config after `applyDefaultRspeedyConfig`.
+ */
+export function composeLynxBuildPlugins(resolved: Config): RsbuildPlugin[] {
+  return [
+    pluginChunkLoading(),
+    pluginLynxDebugMetadata(),
+    pluginDev(resolved.dev, resolved.server),
+    pluginMinify(resolved.output?.minify),
+    pluginOptimization(),
+    pluginOutput(resolved.output),
+    pluginResolve(),
+    pluginRsdoctor(resolved.tools?.rsdoctor),
+    pluginSourcemap(),
+    pluginStatsJson(resolved),
+    pluginSwc(),
+    pluginTarget(),
+  ]
+}

--- a/packages/rspeedy/plugin-preset/src/index.ts
+++ b/packages/rspeedy/plugin-preset/src/index.ts
@@ -27,8 +27,7 @@
 import type { RsbuildPlugins } from '@rsbuild/core'
 import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer'
 
-import { pluginLynxDebugMetadata } from '@lynx-js/debug-metadata-rsbuild-plugin'
-
+import { composeLynxBuildPlugins } from './build-plugins.js'
 import { applyDefaultRspeedyConfig } from './config/defaults.js'
 import type { Config } from './config/index.js'
 import { loadConfig } from './config/loadConfig.js'
@@ -37,19 +36,6 @@ import type {
   LoadConfigResult,
 } from './config/loadConfig.js'
 import { pluginLynxConfig } from './defaults.js'
-import {
-  pluginChunkLoading,
-  pluginDev,
-  pluginMinify,
-  pluginOptimization,
-  pluginOutput,
-  pluginResolve,
-  pluginRsdoctor,
-  pluginSourcemap,
-  pluginStatsJson,
-  pluginSwc,
-  pluginTarget,
-} from './internal.js'
 import { pluginLynxAPI } from './plugin-api.js'
 
 /**
@@ -73,22 +59,10 @@ export function pluginLynxPreset(config: Config = {}): RsbuildPlugins {
     pluginLynxAPI(resolved),
     pluginLynxConfig(resolved),
 
-    pluginChunkLoading(),
-    pluginLynxDebugMetadata(),
-    // Thread the resolved config into the sub-plugins that read from their
-    // arguments (not only from the translated Rsbuild config), matching the
-    // Rspeedy CLI's `applyDefaultPlugins`. Without this, user-set fields like
-    // `dev.assetPrefix` are silently replaced by defaults.
-    pluginDev(resolved.dev, resolved.server),
-    pluginMinify(resolved.output?.minify),
-    pluginOptimization(),
-    pluginOutput(resolved.output),
-    pluginResolve(),
-    pluginRsdoctor(resolved.tools?.rsdoctor),
-    pluginSourcemap(),
-    pluginStatsJson(resolved),
-    pluginSwc(),
-    pluginTarget(),
+    // The Lynx build plugins, shared with the Rspeedy CLI (single source of
+    // truth for the set/order/args — see `composeLynxBuildPlugins`).
+    ...composeLynxBuildPlugins(resolved),
+
     pluginCssMinimizer(),
   ]
 }

--- a/packages/rspeedy/plugin-preset/src/internal.ts
+++ b/packages/rspeedy/plugin-preset/src/internal.ts
@@ -11,17 +11,9 @@
 // Keep these as plain `//` comments: a leading `/** @packageDocumentation */`
 // JSDoc block makes tsc's declaration emitter drop the first `export` below.
 
-export { pluginChunkLoading } from './plugins/chunkLoading.plugin.js'
-export { pluginDev } from './plugins/dev.plugin.js'
-export { pluginMinify } from './plugins/minify.plugin.js'
-export { pluginOptimization } from './plugins/optimization.plugin.js'
-export { pluginOutput } from './plugins/output.plugin.js'
-export { pluginResolve } from './plugins/resolve.plugin.js'
-export { pluginRsdoctor } from './plugins/rsdoctor.plugin.js'
-export { pluginSourcemap } from './plugins/sourcemap.plugin.js'
-export { pluginStatsJson } from './plugins/statsJson.plugin.js'
-export { pluginSwc } from './plugins/swc.plugin.js'
-export { pluginTarget } from './plugins/target.plugin.js'
+// The Lynx build plugins as one shared composer (was 11 individual exports the
+// CLI had to list in the same order — now a single source of truth).
+export { composeLynxBuildPlugins } from './build-plugins.js'
 
 export { debug, isDebug } from './debug.js'
 export { isCI } from './utils/is-ci.js'

--- a/packages/rspeedy/plugin-preset/test/createStubRspeedy.ts
+++ b/packages/rspeedy/plugin-preset/test/createStubRspeedy.ts
@@ -14,22 +14,10 @@ import type {
 import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer'
 import { rstest } from '@rstest/core'
 
-import { pluginLynxDebugMetadata } from '@lynx-js/debug-metadata-rsbuild-plugin'
-
 import type { Config } from '../src/config/index.js'
 import {
   applyDefaultRspeedyConfig,
-  pluginChunkLoading,
-  pluginDev,
-  pluginMinify,
-  pluginOptimization,
-  pluginOutput,
-  pluginResolve,
-  pluginRsdoctor,
-  pluginSourcemap,
-  pluginStatsJson,
-  pluginSwc,
-  pluginTarget,
+  composeLynxBuildPlugins,
   toRsbuildConfig,
 } from '../src/internal.js'
 import { pluginLynxAPI } from '../src/plugin-api.js'
@@ -67,18 +55,7 @@ export async function createStubRspeedy(
 
   rsbuild.addPlugins([
     pluginLynxAPI(resolved),
-    pluginChunkLoading(),
-    pluginLynxDebugMetadata(),
-    pluginDev(resolved.dev, resolved.server),
-    pluginMinify(resolved.output?.minify),
-    pluginOptimization(),
-    pluginOutput(resolved.output),
-    pluginResolve(),
-    pluginRsdoctor(resolved.tools?.rsdoctor),
-    pluginSourcemap(),
-    pluginStatsJson(resolved),
-    pluginSwc(),
-    pluginTarget(),
+    ...composeLynxBuildPlugins(resolved),
     pluginCssMinimizer(),
   ])
 


### PR DESCRIPTION
## What

The 11 Lynx build plugins (chunk loading, dev/HMR, swc, target, minify, output, resolve, rsdoctor, sourcemap, statsJson, debug-metadata) were listed **twice** — once in `pluginLynxPreset` and once in the Rspeedy CLI's `applyDefaultPlugins` — and `@lynx-js/preset-rsbuild-plugin/internal` exposed them as 11 individual exports the CLI had to keep in sync by hand.

This extracts a single `composeLynxBuildPlugins(resolved)` that both call, so the set / order / args are one source of truth. `/internal` now exposes that one composer instead of 11 plugins.

## Why not delete /internal entirely
`/internal` also carries config-translation utilities the CLI genuinely needs (`debug`, `isDebug`, `isCI`, `applyDefaultRspeedyConfig`, `toRsbuildConfig`, `DEFAULT_DIST_PATH_INTERMEDIATE`). Making those public would undo #2968's export shrink, and duplicating them into the CLI would re-introduce drift. So `/internal` stays as the internal seam — but the fragile part (the hand-synced plugin list) is gone.

## Verified (no behavior change — pure extraction)
- `examples/react` build is **byte-identical** to baseline after normalizing the async-chunk content hash. Note: that hash varies run-to-run **even without this change** (the Lynx build is non-deterministic at the byte level for the async chunk), so raw md5 comparison isn't meaningful; normalized comparison is exact.
- `preset` 223, `core` 212, `react-rsbuild-plugin` 175 tests green.
- `arethetypeswrong` ✓, api-extractor exit 0.
- The preset test stub now uses the composer too (was another hand-maintained copy of the list).

Part of the stacked Rspeedy-to-Rsbuild migration.