### PR TITLE
RFC(react): compile-time separation of &lt;Background&gt; subtrees — IFR as a composable architecture (L3)

### DIFF
--- a/.changeset/background-bundling-separation.md
+++ b/.changeset/background-bundling-separation.md
@@ -1,0 +1,23 @@
+---
+"@lynx-js/react": patch
+---
+
+Document and guarantee the compile-time separation of a `<Background>` subtree.
+
+By default `<Background>` is a runtime opt-out — the deferred subtree's code is still bundled into the main thread, it just does not run there. Authoring the deferred component with the `'background only'` directive now also keeps its render logic out of the main-thread bundle, so no side effect can leak onto the main thread, while its element and main-thread-script (worklet) definitions — which the first-screen hydration needs to build the real content — are retained:
+
+```tsx
+// Feed.tsx
+export function Feed() {
+  'background only';
+  // hooks, effects, event handlers, data formatting — none of this reaches the main-thread bundle
+  return <view>...</view>
+}
+
+// App.tsx
+<Background fallback={<FeedSkeleton />}>
+  <Feed />
+</Background>
+```
+
+This composition ("strip render logic, keep snapshot + worklet definitions") is verified cross-module against the real bundle. It falls out of the existing transform pass order (worklet/snapshot extraction runs before the directive strip, so the definitions are hoisted to module scope before the component body is emptied) and the boundary keeping the component reference (so its module — and its definitions — stay in the main-thread bundle).

--- a/packages/react/runtime/src/core/background.ts
+++ b/packages/react/runtime/src/core/background.ts
@@ -71,6 +71,31 @@ export interface BackgroundProps {
  * }
  * ```
  *
+ * @remarks
+ * By default the boundary is a runtime opt-out: the deferred subtree's code is
+ * still bundled into the main thread, it just does not run there. To also keep
+ * that code out of the main-thread bundle — so no side effect can leak onto the
+ * main thread — author the deferred component with the `'background only'`
+ * directive. Its render body is then stripped from the main-thread bundle,
+ * while its element and main-thread-script (worklet) definitions (which the
+ * hydration needs to build the real content) are retained:
+ *
+ * ```tsx
+ * // Feed.tsx
+ * export function Feed() {
+ *   'background only';
+ *   // hooks, effects, event handlers, data formatting — none of this reaches
+ *   // the main-thread bundle
+ *   return <view>...</view>
+ * }
+ * ```
+ *
+ * Use the two together: `<Background>` provides the runtime boundary and the
+ * fallback, while the `'background only'` component provides the compile-time
+ * separation. The component must be rendered behind a `<Background>` boundary,
+ * because its main-thread render is a no-op — rendering it on the first screen
+ * without a boundary would produce an empty frame.
+ *
  * @public
  */
 export function Background(props: BackgroundProps): ReactNode {

--- a/packages/webpack/react-webpack-plugin/test/background-bundling.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/background-bundling.test.ts
@@ -1,0 +1,123 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * L3 completeness proof: a `<Background>` boundary whose deferred subtree is a
+ * cross-module component authored with the `'background only'` directive.
+ *
+ * The main-thread (LEPUS) bundle must:
+ * - NOT contain the subtree's render logic or its logic-only imports (so no
+ *   side-effect can leak onto the main thread), and
+ * - still contain the subtree's element (snapshot) and main-thread-script
+ *   (worklet) definitions, which the first-screen hydration needs to build the
+ *   real content on the main thread.
+ *
+ * This is the "strip render logic, keep snapshot + MTS" guarantee, verified
+ * cross-module against the real bundle (not just the transform output).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { rspack } from '@rspack/core';
+import type { Compilation, Compiler, RspackOptions } from '@rspack/core';
+import { beforeAll, describe, expect, it } from '@rstest/core';
+
+// @ts-expect-error – JS helper has no type declarations
+import { createConfig as rawCreateConfig, createEntries as rawCreateEntries } from './create-react-config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+type CreateConfig = (
+  loaderOptions?: unknown,
+  pluginOptions?: { mainThreadChunks?: string[] },
+) => RspackOptions;
+type CreateEntries = (name?: string, source?: string) => RspackOptions['entry'];
+
+const createConfig = rawCreateConfig as unknown as CreateConfig;
+const createEntries = rawCreateEntries as unknown as CreateEntries;
+
+async function buildAndCapture(): Promise<Map<string, string>> {
+  const base = createConfig(undefined, {
+    mainThreadChunks: ['main__main-thread.js'],
+  });
+  const captured = new Map<string, string>();
+  const config: RspackOptions = {
+    ...base,
+    mode: 'production',
+    context: path.resolve(__dirname, 'fixtures/background-bundling'),
+    entry: createEntries('main', './index.jsx'),
+    output: { filename: '[name].js' },
+    optimization: { ...base.optimization, minimize: false },
+    plugins: [
+      ...(base.plugins ?? []),
+      {
+        apply(compiler: Compiler) {
+          compiler.hooks.compilation.tap('CapturePlugin', (compilation: Compilation) => {
+            compilation.hooks.processAssets.tap(
+              {
+                name: 'CapturePlugin',
+                stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+              },
+              (assets) => {
+                for (const name of Object.keys(assets)) {
+                  if (name.endsWith('.js')) {
+                    captured.set(name, assets[name]!.source().toString());
+                  }
+                }
+              },
+            );
+          });
+        },
+      },
+    ],
+  };
+
+  const compiler = rspack(config);
+  await new Promise<void>((resolve, reject) => {
+    compiler.run((err, stats) => {
+      const runErr = err ?? (stats?.hasErrors() ? new Error(stats.toString()) : undefined);
+      compiler.close(closeErr => {
+        if (runErr ?? closeErr) reject(runErr ?? closeErr!);
+        else resolve();
+      });
+    });
+  });
+  return captured;
+}
+
+describe('<Background> bundling separation (L3)', () => {
+  let mainThread: string;
+  let background: string;
+
+  beforeAll(async () => {
+    const assets = await buildAndCapture();
+    mainThread = assets.get('main__main-thread.js') ?? '';
+    background = assets.get('main__background.js') ?? '';
+    expect(mainThread).not.toBe('');
+    expect(background).not.toBe('');
+  });
+
+  it('strips the deferred subtree render logic from the main-thread bundle', () => {
+    expect(mainThread).not.toContain('FEED_RENDER_LOGIC_MARKER');
+  });
+
+  it('strips the deferred subtree logic-only imports from the main-thread bundle', () => {
+    expect(mainThread).not.toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+
+  it('keeps the deferred subtree element (snapshot) definitions in the main-thread bundle', () => {
+    // The scroll-view element factory must remain so hydration can build it.
+    expect(mainThread).toContain('__CreateScrollView');
+  });
+
+  it('keeps the deferred subtree main-thread-script (worklet) in the main-thread bundle', () => {
+    expect(mainThread).toContain('registerWorkletInternal("main-thread"');
+    expect(mainThread).toContain('SCROLL_WORKLET_MARKER');
+  });
+
+  it('leaves the deferred subtree fully intact on the background bundle', () => {
+    expect(background).toContain('FEED_RENDER_LOGIC_MARKER');
+    expect(background).toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+});

--- a/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/Feed.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/Feed.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from '@lynx-js/react';
+
+import { formatFeed } from './heavy-format.js';
+
+// Definition-site opt-out: this component's render never runs on the main
+// thread, so its body is stripped from the main-thread (LEPUS) bundle while
+// its element/worklet definitions (hoisted to module scope before the strip)
+// are retained for hydration.
+export function Feed() {
+  'background only';
+  const [items] = useState(() => formatFeed(1, 2, 3));
+  useEffect(() => {
+    console.log('FEED_RENDER_LOGIC_MARKER mounted');
+  }, []);
+  const onTap = () => {
+    console.log('FEED_RENDER_LOGIC_MARKER tap');
+  };
+  const onScroll = (event) => {
+    'main thread';
+    console.log('SCROLL_WORKLET_MARKER', event.detail.scrollTop);
+  };
+  return (
+    <scroll-view bindtap={onTap} main-thread:bindscroll={onScroll}>
+      {items.map((it) => <text key={it.id}>{it.label}</text>)}
+    </scroll-view>
+  );
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/heavy-format.js
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/heavy-format.js
@@ -1,0 +1,6 @@
+// Logic-only module. Must NOT appear in the main-thread bundle when its only
+// consumer is a background-rendered subtree.
+export function formatFeed(a, b, c) {
+  const HEAVY_LOGIC_MARKER = 'HEAVY_FORMAT_LOGIC_ONLY_MARKER';
+  return [a, b, c].map((n, i) => ({ id: i, label: `${HEAVY_LOGIC_MARKER}:${n}` }));
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/index.jsx
@@ -1,0 +1,16 @@
+import { Background, root } from '@lynx-js/react';
+
+import { Feed } from './Feed.jsx';
+
+export function App() {
+  return (
+    <view>
+      <text>Header renders on the first screen (IFR)</text>
+      <Background fallback={<text>Loading…</text>}>
+        <Feed />
+      </Background>
+    </view>
+  );
+}
+
+root.render(<App />);


### PR DESCRIPTION
# RFC: IFR as a composable architecture — compile-time separation of `<Background>` subtrees

> Layer 3 of the IFR opt-in/opt-out design. **Stacked on the L1 branch (`claude/lynx-ifr-opt-design-osbqod`, the `<Background>` boundary)** — this PR's diff contains only the L3 work. The PR body doubles as the RFC.

## The thesis

IFR (Instant First-Frame Rendering) is, in effect, a **forced, default, whole-tree first screen** — much like full SSR. It is currently an all-or-nothing, ad-hoc optimization: either the main thread renders the entire first screen, or (with `mainThreadRender: false`, L2) none of it.

Once first-screen participation becomes **opt-in / opt-out per subtree** (L1's `<Background>`), IFR stops being a fixed optimization and becomes a **composition knob**. The developer composes the first screen they actually want:

- **1.0 first screen** — default IFR (everything renders on the main thread first frame).
- **0.0 first screen** — `mainThreadRender: false` / root `<Background>` (nothing on the main thread; the whole tree hydrates from background). Colleague proposal "B" is exactly this end-point.
- **anything in between (0.2 / 0.5 …)** — keep the shell/above-the-fold on the first screen, `<Background>` the heavy or async parts. This can *beat* full IFR on perceived FCP: the main body paints sooner because the main thread isn't busy building the deferred parts.

"B's total abandonment of IFR" is not a separate mode — it's just one composed point on this axis. The mechanism should give the whole continuum.

## What this layer adds: completeness

L1 made the boundary a **runtime** opt-out (the deferred subtree does not *run* on the main thread). But its code is still *bundled* into the main thread. For the abstraction to be **robust and complete**, the boundary should also change the **bundling**, so the deferred code does not *exist* in a context it shouldn't — eliminating the possibility of side-effect leakage onto the main thread.

This PR establishes and guarantees that separation.

## The mechanism

Author the deferred component with the `'background only'` directive; render it behind a `<Background>` boundary:

```tsx
// Feed.tsx — the deferred subtree
export function Feed() {
  'background only';
  const [items] = useState(() => formatFeed(raw)); // heavy logic
  useEffect(() => track(), []);                     // side effect
  const onTap = () => nav.push();                   // background handler
  const onScroll = () => { 'main thread'; ... };    // main-thread-script (worklet)
  return <scroll-view bindtap={onTap} main-thread:bindscroll={onScroll}>{items.map(...)}</scroll-view>
}

// App.tsx
<Background fallback={<FeedSkeleton />}>
  <Feed />
</Background>
```

On the **main-thread (LEPUS) bundle** this yields:

| part of the deferred subtree | main-thread bundle |
|---|---|
| render logic (`Feed` body, hooks, effects, handlers) | **absent** |
| logic-only imports (`formatFeed`, …) | **absent** |
| element definitions (the `__CreateScrollView` snapshot) | **present** |
| main-thread-script worklet (`onScroll`) | **present** |

Render logic + its exclusive imports are gone (no side effect can leak onto the main thread); the element and worklet definitions — which the first-screen hydration needs to build the real content on the main thread — remain.

### Why it works (and why the obvious version doesn't)

The correctness is by construction, from the existing transform pass order `worklet → snapshot → directive_dce`:

1. The **worklet** and **snapshot** passes run first and hoist the subtree's worklet/element definitions to **module scope** (a `registerWorkletInternal("main-thread", …)` and a `snapshotCreatorMap[id] = …`), independent of the component function.
2. `directive_dce` then empties the `'background only'` component **body** on LEPUS — removing the render logic and its exclusive imports — while the already-hoisted module-scope definitions survive.
3. The `<Background>` usage keeps a **reference** to the component, so its module (and therefore its definitions) stays in the main-thread bundle.

The subtle part: the strip must happen at the component's **definition site** (empty its body, keep the import), not at the **usage site**. An earlier experiment that emptied the boundary's children at the usage site removed the import entirely, which dropped the whole subtree module from the main-thread bundle cross-module — taking the element/worklet definitions with it and breaking hydration. Keeping the reference and stripping the body is what makes it correct across module boundaries.

Relative to the two colleague bundling proposals: this is the **"extract & assemble" intent (B)** achieved *by construction* rather than by a whole-program collect+assemble pass. The definitions are "pinned" into the bundle simply because the boundary keeps the reference while the body is stripped — no separate collection stage, no discarded bundle, and IFR is untouched for everything *not* behind a boundary.

## What's in this PR

- **Docs**: the `<Background>` JSDoc now documents the compile-time separation and the `'background only'` composition, including the constraint that such a component must be rendered behind a boundary (its main-thread render is a no-op).
- **Completeness proof (committed regression test)**: `packages/webpack/react-webpack-plugin/test/background-bundling.test.ts` builds a real cross-module dual-thread bundle and asserts, against the emitted `main__main-thread.js`, that the deferred subtree's render logic and logic-only imports are **absent** while its snapshot and worklet definitions are **present** (and that the background bundle keeps everything). This guards the pass-order/reference invariant against regressions.
- **Changeset**.

No new runtime API and no protocol change: the separation composes the existing `<Background>` component (L1) with the existing `'background only'` directive. The contribution is proving the composition is correct and complete, documenting it as a supported pattern, and locking it with a real-bundle test.

## Scope and follow-ups

This version ships the mechanism, the guarantee (proof), and the docs. Deliberately deferred:

- **Ergonomic sugar** — a typed marker/HOC so the intent reads better than a bare directive.
- **A guardrail** — a build/lint diagnostic that flags a `'background only'` component used *outside* a `<Background>` boundary (which would render an empty first frame), and that flags a deferred subtree containing a nested cross-module component that is *not* itself `'background only'` (whose definitions would be dropped). The rule is "a background-deferred subtree must be transitively background-rendered"; today that's a documented constraint, not an enforced one.
- **Auto-strip for same-file inline children** of `<Background>` (a transform recognizing the boundary), so trivial inline subtrees don't need the directive. Cross-module — the important case — is already handled by the definition-site directive.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyHx91XciQDJunC9fj6bTe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyHx91XciQDJunC9fj6bTe)_