### PR TITLE
fix(web-core): map textarea tag to x-textarea

### DIFF
--- a/.changeset/web-core-textarea-mapping.md
+++ b/.changeset/web-core-textarea-mapping.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Map the Lynx `textarea` tag to the `x-textarea` custom element when creating elements on web.
+
+`__CreateElement` looked up `LYNX_TAG_TO_HTML_TAG_MAP`, which had no `textarea` entry, so `textarea` fell through to a bare HTML `<textarea>` instead of the `x-textarea` custom element registered by `@lynx-js/web-elements`. Because the element was never `x-textarea`, none of the Lynx event forwarding (`input`/`focus`/`blur`) was wired up, so typed input never bridged to the framework thread — any `bindinput`/`@input` binding (e.g. Vue's `v-model`) silently did nothing. `input` already worked because it was mapped to `x-input`.
+
+Adding `textarea: 'x-textarea'` to the map makes `textarea` render as `x-textarea`, matching native Lynx and the existing `input` behavior; the runtime event tables already know how to bridge `x-textarea`'s `lynxinput`/`lynxfocus`/`lynxblur` events. The same entry is added to the parallel Rust map (`src/constants.rs`) so `textarea` type selectors in Lynx stylesheets are rewritten to `x-textarea` and keep matching the rendered element.

--- a/packages/web-platform/web-core/src/constants.rs
+++ b/packages/web-platform/web-core/src/constants.rs
@@ -31,6 +31,7 @@ lazy_static::lazy_static! {
     ("wrapper", "lynx-wrapper"),
     ("list", "x-list"),
     ("page", "div"),
+    ("textarea", "x-textarea"),
     ("svg", "x-svg"),
     ("frame", "lynx-view"),
   ]);

--- a/packages/web-platform/web-core/src/template/template_sections/style_info/style_info_decoder.rs
+++ b/packages/web-platform/web-core/src/template/template_sections/style_info/style_info_decoder.rs
@@ -742,6 +742,44 @@ mod test {
   }
 
   #[test]
+  fn test_textarea_type_selector() {
+    let raw_style_info = RawStyleInfo {
+      css_id_to_style_sheet: FnvHashMap::from_iter(vec![(
+        0,
+        StyleSheet {
+          imports: vec![],
+          rules: vec![Rule {
+            nested_rules: vec![],
+            rule_type: RuleType::Declaration,
+            prelude: RulePrelude {
+              selector_list: vec![Selector {
+                simple_selectors: vec![OneSimpleSelector {
+                  selector_type: OneSimpleSelectorType::TypeSelector,
+                  value: "textarea".to_string(),
+                }],
+              }],
+            },
+            declaration_block: DeclarationBlock {
+              declarations: vec![ParsedDeclaration {
+                property_id: CSSPropertyEnum::Height.into(),
+                is_important: false,
+                value_token_list: vec![ValueToken {
+                  token_type: crate::css_tokenizer::token_types::DIMENSION_TOKEN,
+                  value: "200px".to_string(),
+                }],
+              }],
+            },
+          }],
+        },
+      )]),
+      style_content_str_size_hint: 0,
+    };
+    let result = generate_string_buf(raw_style_info, true, None);
+    let expected = "x-textarea:not([l-e-name]){height:200px;}";
+    assert_eq!(result.style_content, expected);
+  }
+
+  #[test]
   fn test_multiple_selectors() {
     let raw_style_info = RawStyleInfo {
       css_id_to_style_sheet: FnvHashMap::from_iter(vec![(

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -110,6 +110,22 @@ describe('Element APIs', () => {
     expect(mtsGlobalThis.__GetTag(element)).toBe('view');
   });
 
+  test('createElement maps input to x-input', () => {
+    // `input` is created as the `x-input` custom element so Lynx event
+    // forwarding wires up (matches native behavior on web).
+    const element = mtsGlobalThis.__CreateElement('input', 0);
+    expect(element.tagName.toLowerCase()).toBe('x-input');
+  });
+
+  test('createElement maps textarea to x-textarea', () => {
+    // `textarea` must be created as the `x-textarea` custom element, otherwise
+    // a bare <textarea> is created and input/focus/blur never bridge to the
+    // framework thread.
+    const element = mtsGlobalThis.__CreateElement('textarea', 0);
+    expect(element.tagName.toLowerCase()).toBe('x-textarea');
+    expect(mtsGlobalThis.__GetTag(element)).toBe('textarea');
+  });
+
   test('createCrossThreadEvent properly sets touch detail x and y', async () => {
     const { createCrossThreadEvent } = await import(
       '../ts/client/mainthread/elementAPIs/createCrossThreadEvent.js'

--- a/packages/web-platform/web-core/ts/constants.ts
+++ b/packages/web-platform/web-core/ts/constants.ts
@@ -86,6 +86,7 @@ export const LYNX_TAG_TO_HTML_TAG_MAP: Record<string, string> =
       'page': 'div',
       'input': 'x-input',
       'x-input-ng': 'x-input',
+      'textarea': 'x-textarea',
       'svg': 'x-svg',
       'frame': 'lynx-view',
     }),


### PR DESCRIPTION
`__CreateElement` looks up `LYNX_TAG_TO_HTML_TAG_MAP`, which had no
`textarea` entry, so `textarea` fell through to a bare HTML `<textarea>`
instead of the `x-textarea` custom element registered by
`@lynx-js/web-elements`. Because the element was never `x-textarea`, the
Lynx event forwarding (`input`/`focus`/`blur`) never wired up, so typed
input never bridged to the framework thread — `bindinput`/`@input`
bindings (e.g. Vue's `v-model`) silently did nothing. `input` already
worked because it was mapped to `x-input`.

## Changes

- **`ts/constants.ts`** — add `textarea: 'x-textarea'` to `LYNX_TAG_TO_HTML_TAG_MAP`
  so `__CreateElement('textarea', …)` produces an `x-textarea` element. The
  runtime event tables already bridge `x-textarea`'s `lynxinput`/`lynxfocus`/
  `lynxblur` events, so no further wiring is needed.
- **`src/constants.rs`** — add the same `("textarea", "x-textarea")` entry to the
  parallel Rust map, which drives CSS type-selector rewriting, so `textarea`
  selectors in Lynx stylesheets are rewritten to `x-textarea` and keep matching
  the rendered element.
- **Tests** — `element-apis.spec.ts` covers the `input`/`textarea` tag mapping at
  element creation time; `style_info_decoder.rs` gets a `textarea` type-selector
  rewrite test mirroring the existing `frame` selector test.
- **Changeset** — publishes the fix as a `@lynx-js/web-core` patch.

Note: the wasm `create_element` has no tag allow-list (it stores whatever mapped
tag the TS layer passes), so no wasm-side allow-list change is required beyond the
two maps above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Lynx `textarea` elements so `input`, `focus`, and `blur` events are forwarded correctly.
  * Updated `textarea` rendering to use the `x-textarea` custom element while preserving Lynx tag identity and selector matching.
* **Tests**
  * Added element API tests for `input` → `x-input` and `textarea` → `x-textarea`.
  * Added a decoder test confirming `textarea` CSS type selectors are rewritten to match `x-textarea` output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->