### PR TITLE
fix(rspeedy): fallback to loopback for dev assets

### DIFF
--- a/.changeset/fallback-loopback-dev-host.md
+++ b/.changeset/fallback-loopback-dev-host.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Use the IPv4 loopback address for development asset URLs when no non-loopback IP address is available.

--- a/packages/rspeedy/core/src/config/server/index.ts
+++ b/packages/rspeedy/core/src/config/server/index.ts
@@ -141,7 +141,7 @@ export interface Server {
    * @defaultValue "0.0.0.0"
    *
    * @remarks
-   * During `rspeedy dev`, if `server.host` is unset, the dev plugin resolves dev-server-related URLs and client host settings with a detected local IPv4 address, such as `192.168.1.50`. If you have multiple network interfaces, set `server.host` explicitly to choose the desired address.
+   * During `rspeedy dev`, if `server.host` is unset, the dev plugin resolves dev-server-related URLs and client host settings with a detected non-loopback IPv4 address, such as `192.168.1.50`. It falls back to an eligible IPv6 address, then to an IPv4 loopback address when no non-loopback IP is available. If you have multiple network interfaces, set `server.host` explicitly to choose the desired address.
    *
    * @example
    *

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -423,7 +423,8 @@ async function resolveHostname(
     }
   }
 
-  return { hostname }
+  // Prefer an IPv4 loopback for client-facing URLs over the wildcard bind host.
+  return { hostname: await findIp('v4', true) ?? hostname }
 }
 
 function formatHostname(host: RsbuildServerHost | undefined): string {

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -79,6 +79,16 @@ describe('Plugins - Dev', () => {
           scopeid: 0,
         },
       ],
+      lo: [
+        {
+          address: '127.0.0.1',
+          family: 'IPv4',
+          internal: true,
+          netmask: '255.0.0.0',
+          mac: '00:00:00:00:00:00',
+          cidr: '127.0.0.1/8',
+        },
+      ],
     })
 
     const rsbuild = await createStubRspeedy({})
@@ -88,6 +98,60 @@ describe('Plugins - Dev', () => {
     expect(config.output?.publicPath).toBe('http://[fd00::1]:3000/')
     expect(rsbuild.getRsbuildConfig().server!.host).toBe('fd00::1')
     expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('[fd00::1]')
+  })
+
+  test('defaults fallback to ipv4 loopback when no non-loopback ip is found', async () => {
+    const { default: os } = await import('node:os')
+
+    rstest.spyOn(os, 'networkInterfaces').mockReturnValue({
+      lo: [
+        {
+          address: '127.0.0.1',
+          family: 'IPv4',
+          internal: true,
+          netmask: '255.0.0.0',
+          mac: '00:00:00:00:00:00',
+          cidr: '127.0.0.1/8',
+        },
+      ],
+    })
+
+    const rsbuild = await createStubRspeedy({})
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(rsbuild.getRsbuildConfig().server!.host).toBe('0.0.0.0')
+    expect(config.output?.publicPath).toBe('http://127.0.0.1:3000/')
+    expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('127.0.0.1')
+  })
+
+  test('explicit server.host does not fall back to ipv4 loopback', async () => {
+    const { default: os } = await import('node:os')
+
+    rstest.spyOn(os, 'networkInterfaces').mockReturnValue({
+      lo: [
+        {
+          address: '127.0.0.1',
+          family: 'IPv4',
+          internal: true,
+          netmask: '255.0.0.0',
+          mac: '00:00:00:00:00:00',
+          cidr: '127.0.0.1/8',
+        },
+      ],
+    })
+
+    const rsbuild = await createStubRspeedy({
+      server: {
+        host: '0.0.0.0',
+      },
+    })
+
+    const config = await rsbuild.unwrapConfig()
+
+    expect(rsbuild.getRsbuildConfig().server!.host).toBe('0.0.0.0')
+    expect(config.output?.publicPath).toBe('http://0.0.0.0:3000/')
+    expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('0.0.0.0')
   })
 
   test('defaults keep server.host when no ip is found', async () => {

--- a/packages/rspeedy/core/test/plugins/findIp.test.ts
+++ b/packages/rspeedy/core/test/plugins/findIp.test.ts
@@ -27,6 +27,28 @@ describe('findIp', () => {
     expect(ip).toBe('192.168.1.1')
   })
 
+  test('v4 internal', async () => {
+    const { default: os } = await import('node:os')
+
+    rstest.spyOn(os, 'networkInterfaces').mockReturnValue({
+      lo: [
+        {
+          address: '127.0.0.1',
+          family: 'IPv4',
+          internal: true,
+          netmask: '255.0.0.0',
+          mac: '00:00:00:00:00:00',
+          cidr: '127.0.0.1/8',
+        },
+      ],
+    })
+
+    const { findIp } = await import('../../src/plugins/dev.plugin.js')
+
+    const ip = await findIp('v4', true)
+    expect(ip).toBe('127.0.0.1')
+  })
+
   test('v6', async () => {
     const { default: os } = await import('node:os')
 


### PR DESCRIPTION
## Summary

- fall back to a detected IPv4 loopback address for client-facing dev asset and HMR URLs when no non-loopback IPv4 or eligible IPv6 address is available
- keep the dev server bound to `0.0.0.0`, preserve explicit `server.host` values, and retain `0.0.0.0` when no IP is detectable at all
- document the fallback order and add unit coverage plus a patch changeset

## Why

Follow-up to #2935. That change avoids throwing when a host has no usable non-loopback IP, but a loopback-only host without IPv6 still leaves the wildcard bind address in generated asset URLs. `0.0.0.0` is appropriate for listening, while the detected `127.0.0.1` loopback is the usable client-facing host.

## Validation

- `pnpm turbo build` — 65/65 tasks passed
- Rspeedy package tests — 39 files / 436 tests passed
- focused dev/findIp tests — 54 passed, 1 skipped
- `pnpm --filter @lynx-js/rspeedy test:type`
- filtered API Extractor
- dprint, Biome, ESLint, and `git diff --check`
- `pnpm changeset status --since=upstream/main`
- Linux network namespace with only `lo/127.0.0.1` and no `::1`: generated bundle uses `http://127.0.0.1:3000/`, while `server.host` remains `0.0.0.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development URLs now fall back to the IPv4 loopback address (`127.0.0.1`) when no external local address is available.
  * Explicit host settings such as `0.0.0.0` remain unchanged.
  * Improved local address selection across IPv4, IPv6, and loopback configurations.

* **Documentation**
  * Updated development server host resolution guidance to reflect the fallback order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->