### PR TITLE
chore(deps): upgrade @lynx-js/preact-devtools to 5.0.1-20260714130028-3bd2ab8

### DIFF
--- a/.changeset/bump-preact-devtools-react-templates.md
+++ b/.changeset/bump-preact-devtools-react-templates.md
@@ -1,0 +1,5 @@
+---
+"create-rspeedy": patch
+---
+
+Bump `@lynx-js/preact-devtools` to the latest published version in the React templates.

--- a/examples/gesture/package.json
+++ b/examples/gesture/package.json
@@ -13,7 +13,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/motion/package.json
+++ b/examples/motion/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-debug-metadata/package.json
+++ b/examples/react-debug-metadata/package.json
@@ -20,7 +20,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-element-template/package.json
+++ b/examples/react-element-template/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-element/package.json
+++ b/examples/react-element/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-et-lazy-bundle-standalone/package.json
+++ b/examples/react-et-lazy-bundle-standalone/package.json
@@ -18,7 +18,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-externals/package.json
+++ b/examples/react-externals/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@lynx-js/external-bundle-rsbuild-plugin": "workspace:*",
     "@lynx-js/lynx-bundle-rslib-config": "workspace:*",
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-keyboard/package.json
+++ b/examples/react-keyboard/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-lazy-bundle-standalone/package.json
+++ b/examples/react-lazy-bundle-standalone/package.json
@@ -18,7 +18,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-lazy-bundle/package.json
+++ b/examples/react-lazy-bundle/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-main-thread-function/package.json
+++ b/examples/react-main-thread-function/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-ui-sourcemap/package.json
+++ b/examples/react-ui-sourcemap/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/create-rspeedy/template-react-js/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-js/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*"

--- a/packages/rspeedy/create-rspeedy/template-react-ts/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/testing-library/kitten-lynx/package.json
+++ b/packages/testing-library/kitten-lynx/package.json
@@ -43,7 +43,7 @@
     "@yume-chan/adb-server-node-tcp": "catalog:adb"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260624133547-6641319",
+    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,8 +227,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -255,8 +255,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -280,8 +280,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -336,8 +336,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -370,8 +370,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -395,8 +395,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -442,8 +442,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -517,8 +517,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspeedy/lynx-bundle-rslib-config
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -585,8 +585,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -610,8 +610,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -635,8 +635,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -660,8 +660,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -685,8 +685,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -1879,8 +1879,8 @@ importers:
         version: 2.5.2
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260624133547-6641319
-        version: 5.0.1-20260624133547-6641319
+        specifier: 5.0.1-20260714130028-3bd2ab8
+        version: 5.0.1-20260714130028-3bd2ab8
       '@lynx-js/react':
         specifier: workspace:*
         version: link:../../react
@@ -4393,8 +4393,8 @@ packages:
       '@lynx-js/types':
         optional: true
 
-  '@lynx-js/preact-devtools@5.0.1-20260624133547-6641319':
-    resolution: {integrity: sha512-VH0UuKgOuSM1yk8300/tyPhJcZG0FmaJD78MbgT9oXRXI6TLxMTmD6lcI11+4zmLHVHdV2kUn7AzTbbetflO4w==}
+  '@lynx-js/preact-devtools@5.0.1-20260714130028-3bd2ab8':
+    resolution: {integrity: sha512-HtYs8/r8RG/5mtQV5U3+XLDMd+Qc/HvjpmWBI2iDyrkxaGqxfOgwbtqQA9DDuUjUTcER0eWz/mJbiQ46A2MIzg==}
 
   '@lynx-js/react-use@0.1.3':
     resolution: {integrity: sha512-48NX1DZfIqdpcFPKR3SdI/E0D2INJzgMDtl9IK0vbqWKPgj6LgUPZN0iqIDd7Juy3in5c2bv6E9jCpoq5ONeVw==}
@@ -14269,7 +14269,7 @@ snapshots:
       - react
       - react-dom
 
-  '@lynx-js/preact-devtools@5.0.1-20260624133547-6641319':
+  '@lynx-js/preact-devtools@5.0.1-20260714130028-3bd2ab8':
     dependencies:
       errorstacks: 2.4.1
       htm: 3.1.1


### PR DESCRIPTION
## What

Upgrades `@lynx-js/preact-devtools` from `5.0.1-20260624133547-6641319` to `5.0.1-20260714130028-3bd2ab8` across the React examples and `create-rspeedy` templates (and `kitten-lynx` test infra), plus the regenerated `pnpm-lock.yaml`.

## Why

The new version stores the devtools context on the per-page `lynx` object instead of the process-wide `globalThis` (lynx-family/preact-devtools#14). Previously the context hung off `globalThis`, which the ReactLynx background JS context reuses across page navigations, so a new page picked up the previous page's stale context and errored. Hanging it off the per-page `lynx` means every page starts with a fresh context.

## Changes

- 13 private example apps + 2 `create-rspeedy` React templates + `@lynx-js/kitten-lynx-test-infra`: devDependency bump.
- `pnpm-lock.yaml`: regenerated (`pnpm install --lockfile-only`).
- Changeset: `create-rspeedy` patch, matching the prior template-bump convention so the upgrade ships to scaffolded projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Preact DevTools version used by React templates and example projects.
  * Added a patch release note for the `create-rspeedy` React templates to include the updated tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->