### PR TITLE
feat(lynx-bundle-rslib-config): keep names for external bundles when REACT_DEVTOOL is set

### DIFF
--- a/.changeset/external-bundle-react-devtool-keep-names.md
+++ b/.changeset/external-bundle-react-devtool-keep-names.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Support enabling preact devtools for external bundles via the `REACT_DEVTOOL` environment variable.
+
+When `REACT_DEVTOOL` is set, `defineExternalBundleRslibConfig` now keeps function and class names during minification (`keep_fnames`/`keep_classnames` on both `compress` and `mangle`), which devtools needs to resolve component names (`type.name`) and to reconstruct the hook tree (it matches minified stack frames by function name). The default output is unchanged when `REACT_DEVTOOL` is unset. This mirrors `pluginMinify` in `@lynx-js/rspeedy` (#2880).

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -52,6 +52,14 @@ export interface EncodeOptions {
   enableJsBytecode?: boolean
 }
 
+// When preact devtools is enabled (`REACT_DEVTOOL`), keep function and class
+// names. Devtools relies on them to resolve component names (`type.name`) and
+// to reconstruct the hook tree (it matches minified stack frames by function
+// name). Minification would otherwise mangle/inline those names away. Only
+// enabled with devtools since it slightly increases bundle size. Mirrors
+// `pluginMinify` in @lynx-js/rspeedy (lynx-family/lynx-stack#2880).
+const keepNames = Boolean(process.env['REACT_DEVTOOL'])
+
 const DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG = {
   jsOptions: {
     minimizerOptions: {
@@ -63,7 +71,15 @@ const DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG = {
         negate_iife: false,
         // Allow return in module wrapper
         side_effects: false,
+
+        // `mangle.keep_*` below preserves most names, but the compressor can
+        // still inline single-use functions (incl. one-shot components) into
+        // anonymity; `compress.keep_*` stops that. Cheap, so we keep both.
+        ...(keepNames ? { keep_fnames: true, keep_classnames: true } : {}),
       },
+      ...(keepNames
+        ? { mangle: { keep_fnames: true, keep_classnames: true } }
+        : {}),
     },
   },
 }

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -8,7 +8,15 @@ import { fileURLToPath } from 'node:url'
 
 import { createRslib } from '@rslib/core'
 import type { RslibConfig, rsbuild } from '@rslib/core'
-import { afterAll, beforeAll, describe, expect, it, rstest } from '@rstest/core'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  rstest,
+} from '@rstest/core'
 
 import { LAYERS, pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
 
@@ -93,6 +101,60 @@ describe('define config', () => {
         },
       },
     })
+  })
+})
+
+describe('REACT_DEVTOOL minify', () => {
+  const prevReactDevtool = process.env['REACT_DEVTOOL']
+
+  afterEach(() => {
+    if (prevReactDevtool === undefined) {
+      delete process.env['REACT_DEVTOOL']
+    } else {
+      process.env['REACT_DEVTOOL'] = prevReactDevtool
+    }
+    rstest.resetModules()
+  })
+
+  it('keeps function and class names when REACT_DEVTOOL is set', async () => {
+    process.env['REACT_DEVTOOL'] = '1'
+    rstest.resetModules()
+    const { defineExternalBundleRslibConfig } = await import('../src/index.js')
+
+    const rslibConfig = defineExternalBundleRslibConfig({
+      output: { minify: true },
+    })
+
+    expect(rslibConfig.lib[0]?.output?.minify).toMatchObject({
+      jsOptions: {
+        minimizerOptions: {
+          compress: { keep_fnames: true, keep_classnames: true },
+          mangle: { keep_fnames: true, keep_classnames: true },
+        },
+      },
+    })
+  })
+
+  it('does not keep names when REACT_DEVTOOL is unset', async () => {
+    delete process.env['REACT_DEVTOOL']
+    rstest.resetModules()
+    const { defineExternalBundleRslibConfig } = await import('../src/index.js')
+
+    const rslibConfig = defineExternalBundleRslibConfig({
+      output: { minify: true },
+    })
+
+    const minify = rslibConfig.lib[0]?.output?.minify as {
+      jsOptions?: {
+        minimizerOptions?: {
+          compress?: { keep_fnames?: boolean }
+          mangle?: unknown
+        }
+      }
+    }
+    expect(minify.jsOptions?.minimizerOptions?.compress?.keep_fnames)
+      .toBeUndefined()
+    expect(minify.jsOptions?.minimizerOptions?.mangle).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

Add `REACT_DEVTOOL` support to `defineExternalBundleRslibConfig` (`@lynx-js/lynx-bundle-rslib-config`), mirroring what #2880 did for `pluginMinify` in `@lynx-js/rspeedy`.

When the `REACT_DEVTOOL` environment variable is set, the default external-bundle minify config now keeps function and class names (`keep_fnames`/`keep_classnames` on both `compress` and `mangle`). Preact devtools needs these to resolve component names (`type.name`) and to reconstruct the hook tree (it matches minified stack frames by function name); without them, minification mangles/inlines the names away, so components show up as `Anonymous` and hook inspection breaks.

This makes preact devtools usable on standalone external / lazy bundles built with `defineExternalBundleRslibConfig`, not just apps built through `@lynx-js/rspeedy`.

The default output is byte-for-byte unchanged when `REACT_DEVTOOL` is unset.

## Changes

- `packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts`: gate `keep_fnames` / `keep_classnames` (on `compress` and `mangle`) behind `REACT_DEVTOOL`.
- Tests: assert the keep-names config is present when `REACT_DEVTOOL` is set and absent when unset.
- Changeset (`patch`).

## Test

`rstest run` in `@lynx-js/lynx-bundle-rslib-config`: **28 passed** (incl. 2 new).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for preserving function and class names in external bundles when React DevTools is enabled.
  - Improved DevTools component name resolution and hook-tree reconstruction.

- **Documentation**
  - Documented how to enable this behavior with the `REACT_DEVTOOL` environment variable.

- **Bug Fixes**
  - No changes to default bundle output when React DevTools is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->