### PR TITLE
chore: clean caches before walltime benchmark

### DIFF
--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -124,6 +124,7 @@ jobs:
           overwrite: true
       - name: Run benchmark (walltime)
         run: |
+          sync; echo 1 > /proc/sys/vm/drop_caches
           export HOME=/root
           . "$HOME/.cargo/env"
           taskset -c 176-191 codspeed run --mode walltime -- pnpm -r run --workspace-concurrency=1 bench


### PR DESCRIPTION
Make dirty pages are flushed before the page cache is cleared. This makes benchmark runs start from a colder filesystem cache state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved benchmark consistency by clearing filesystem caches before walltime benchmark runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->