### PR TITLE
feat(react): add <Background> first-screen boundary component

### DIFF
--- a/.changeset/background-bundling-separation.md
+++ b/.changeset/background-bundling-separation.md
@@ -1,0 +1,23 @@
+---
+"@lynx-js/react": patch
+---
+
+Document and guarantee the compile-time separation of a `<Background>` subtree.
+
+By default `<Background>` is a runtime opt-out — the deferred subtree's code is still bundled into the main thread, it just does not run there. Authoring the deferred component with the `'background only'` directive now also keeps its render logic out of the main-thread bundle, so no side effect can leak onto the main thread, while its element and main-thread-script (worklet) definitions — which the first-screen hydration needs to build the real content — are retained:
+
+```tsx
+// Feed.tsx
+export function Feed() {
+  'background only';
+  // hooks, effects, event handlers, data formatting — none of this reaches the main-thread bundle
+  return <view>...</view>
+}
+
+// App.tsx
+<Background fallback={<FeedSkeleton />}>
+  <Feed />
+</Background>
+```
+
+This composition ("strip render logic, keep snapshot + worklet definitions") is verified cross-module against the real bundle. It falls out of the existing transform pass order (worklet/snapshot extraction runs before the directive strip, so the definitions are hoisted to module scope before the component body is emptied) and the boundary keeping the component reference (so its module — and its definitions — stay in the main-thread bundle).

--- a/.changeset/background-first-screen-boundary.md
+++ b/.changeset/background-first-screen-boundary.md
@@ -1,0 +1,26 @@
+---
+"@lynx-js/react": minor
+---
+
+Add the `<Background>` component, a first-screen boundary that opts a subtree out of the main-thread first-screen render (IFR, Instant First-Frame Rendering).
+
+During the main-thread first-screen render, the boundary renders `fallback` (or nothing) instead of `children`. The background thread always renders `children`, and the first-screen hydration replaces the fallback with the real content through the normal update patch.
+
+```tsx
+import { Background } from '@lynx-js/react';
+
+function ProfilePage() {
+  return (
+    <view>
+      <Header />
+      <Background fallback={<FeedSkeleton />}>
+        <Feed />
+      </Background>
+    </view>
+  );
+}
+```
+
+Use it for subtrees that cannot, or should not, participate in the first-screen render — for example when their first-screen data is only available asynchronously, or when they rely on background-thread-only capabilities.
+
+Keep the `fallback` static: event handlers and refs inside the fallback are never attached, because the fallback only ever exists on the main thread and is removed when hydration completes. Note that `<Background>` is not a performance optimization by itself — the background thread still renders the full tree, and the boundary content is inserted after hydration, which may cause layout shift unless the fallback preserves the layout of `children`.

--- a/.changeset/strip-all-components-root-background.md
+++ b/.changeset/strip-all-components-root-background.md
@@ -4,9 +4,15 @@
 "@lynx-js/react": patch
 ---
 
-Light up a whole-program strip when a root-level `<Background>` is detected, keeping every component's render logic out of the main-thread (LEPUS) bundle.
+Add `experimental_stripAllComponents` — an explicit, off-by-default whole-program strip that keeps every component's render body out of the main-thread (LEPUS) bundle, with cross-module hydration kept safe by reference keep-alive.
 
-A `<Background>` at the render root declares a 0.0 first screen: the whole first frame is the static `fallback`, and nothing renders on the main thread. Under that condition it is safe to empty _every_ component render body from the main-thread bundle — no `'background only'` annotation needed. The build detects the root `<Background>` in an entry and turns this on automatically:
+A `<Background>` at the render root declares a 0.0 first screen: the whole first frame is the static `fallback`, and nothing renders on the main thread. That alone is a **runtime** guarantee and needs no build support — every module stays in the main-thread bundle, always safe. Removing deferred _code_ from the main thread composes per-subtree with the `'background only'` directive.
+
+`experimental_stripAllComponents` is the whole-program endpoint of the same boundary, for the annotation-free 0.0:
+
+- `'auto'` — strip when a root-level `<Background>` (`root.render(<Background …>…</Background>)`) is detected in an entry.
+- `true` — force the strip regardless of detection.
+- `false` / unset (default) — never strip.
 
 ```tsx
 import { Background, root } from '@lynx-js/react';
@@ -27,6 +33,6 @@ root.render(
 
 The element (snapshot) and main-thread-script (worklet) definitions the first-screen hydration needs are hoisted to module scope before the strip, so they are retained; only the render bodies (and the logic-only modules they reached) are shaken out. The background thread is untouched — it renders and hydrates the full tree.
 
-Auto-detection can be overridden with the internal `experimental_stripAllComponents` option (`true`/`false` forces or forbids the strip regardless of detection). Because component bodies no longer exist on the main thread, a root `<Background>`'s `fallback` must be composed of host elements rather than user components.
+Emptying a body no longer severs the component references it rendered: each emptied body hands them to an inert module-level keep-alive statement (`typeof __ifrKeepComponentRefs === "function" && __ifrKeepComponentRefs(Feed, UI)`), so delegated child modules — and their hoisted snapshot/worklet definitions — survive the unused-import DCE and the bundler's tree shaking across modules. The same keep-alive now also protects a `'background only'` component that delegates to components in other modules. Logic-only imports (call targets such as formatters) still shake out.
 
-Unlike the per-component `'background only'` opt-out, this is the whole-program (0.0) endpoint of the same boundary; unlike a runtime-only switch, the render logic is physically absent from the main-thread bundle rather than merely skipped.
+Because component bodies no longer exist on the main thread under the strip, a root `<Background>`'s `fallback` must be composed of host elements rather than user components; the build warns when it can see a user component in an entry's inline fallback. Component references the strip cannot see (e.g. a component resolved through a runtime value) still shake out — prefer the `'background only'` composition for such trees.

--- a/.changeset/strip-all-components-root-background.md
+++ b/.changeset/strip-all-components-root-background.md
@@ -1,0 +1,32 @@
+---
+"@lynx-js/react-rsbuild-plugin": minor
+"@lynx-js/react-webpack-plugin": minor
+"@lynx-js/react": patch
+---
+
+Light up a whole-program strip when a root-level `<Background>` is detected, keeping every component's render logic out of the main-thread (LEPUS) bundle.
+
+A `<Background>` at the render root declares a 0.0 first screen: the whole first frame is the static `fallback`, and nothing renders on the main thread. Under that condition it is safe to empty _every_ component render body from the main-thread bundle — no `'background only'` annotation needed. The build detects the root `<Background>` in an entry and turns this on automatically:
+
+```tsx
+import { Background, root } from '@lynx-js/react';
+
+root.render(
+  // host-element fallback only — component bodies are gone from the main thread
+  <Background
+    fallback={
+      <view>
+        <text>Loading…</text>
+      </view>
+    }
+  >
+    <App />
+  </Background>,
+);
+```
+
+The element (snapshot) and main-thread-script (worklet) definitions the first-screen hydration needs are hoisted to module scope before the strip, so they are retained; only the render bodies (and the logic-only modules they reached) are shaken out. The background thread is untouched — it renders and hydrates the full tree.
+
+Auto-detection can be overridden with the internal `experimental_stripAllComponents` option (`true`/`false` forces or forbids the strip regardless of detection). Because component bodies no longer exist on the main thread, a root `<Background>`'s `fallback` must be composed of host elements rather than user components.
+
+Unlike the per-component `'background only'` opt-out, this is the whole-program (0.0) endpoint of the same boundary; unlike a runtime-only switch, the render logic is physically absent from the main-thread bundle rather than merely skipped.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,6 +3381,7 @@ version = "0.1.0"
 dependencies = [
  "napi",
  "napi-derive",
+ "rustc-hash",
  "serde",
  "swc_core",
  "swc_plugin_define_dce",

--- a/benchmark/react/cases/012-heavy-first-screen/index.tsx
+++ b/benchmark/react/cases/012-heavy-first-screen/index.tsx
@@ -1,0 +1,20 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Baseline for 013-background-boundary: the same heavy subtree rendered
+// through the regular main-thread first-screen render (IFR).
+
+import { root } from '@lynx-js/react';
+
+import { HeavyFeed } from '../../src/HeavyFeed.js';
+import { RunBenchmarkUntilHydrate } from '../../src/RunBenchmarkUntil.js';
+
+runAfterLoadScript(() => {
+  root.render(
+    <>
+      <HeavyFeed />
+      <RunBenchmarkUntilHydrate />
+    </>,
+  );
+});

--- a/benchmark/react/cases/013-background-boundary/index.tsx
+++ b/benchmark/react/cases/013-background-boundary/index.tsx
@@ -1,0 +1,24 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Counterpart of 012-heavy-first-screen: the same heavy subtree opts out of
+// the main-thread first-screen render (IFR) through the `<Background>`
+// boundary. Comparing the two traces shows the main-thread first-screen time
+// saved by the boundary against the extra hydration patch it costs.
+
+import { Background, root } from '@lynx-js/react';
+
+import { FeedSkeleton, HeavyFeed } from '../../src/HeavyFeed.js';
+import { RunBenchmarkUntilHydrate } from '../../src/RunBenchmarkUntil.js';
+
+runAfterLoadScript(() => {
+  root.render(
+    <>
+      <Background fallback={<FeedSkeleton />}>
+        <HeavyFeed />
+      </Background>
+      <RunBenchmarkUntilHydrate />
+    </>,
+  );
+});

--- a/benchmark/react/lynx.config.js
+++ b/benchmark/react/lynx.config.js
@@ -66,6 +66,14 @@ export default defineConfig({
       '011-transform-async-to-generator': [
         './cases/011-transform-async-to-generator/index.tsx',
       ],
+      '012-heavy-first-screen': [
+        './src/patchProfile.ts',
+        './cases/012-heavy-first-screen/index.tsx',
+      ],
+      '013-background-boundary': [
+        './src/patchProfile.ts',
+        './cases/013-background-boundary/index.tsx',
+      ],
     },
   },
   plugins: [

--- a/benchmark/react/package.json
+++ b/benchmark/react/package.json
@@ -16,6 +16,8 @@
     "bench:009-eval-bench": "benchx_cli run dist/009-eval-bench.lynx.bundle --wait-for-id=stop-benchmark-true",
     "bench:010-transform-exponentiation-operator": "benchx_cli run dist/010-transform-exponentiation-operator.lynx.bundle --wait-for-id=stop-benchmark-true",
     "bench:011-transform-async-to-generator": "benchx_cli run dist/011-transform-async-to-generator.lynx.bundle --wait-for-id=stop-benchmark-true",
+    "bench:012-heavy-first-screen": "benchx_cli run dist/012-heavy-first-screen.lynx.bundle --wait-for-id=stop-benchmark-true",
+    "bench:013-background-boundary": "benchx_cli run dist/013-background-boundary.lynx.bundle --wait-for-id=stop-benchmark-true",
     "build": "rspeedy build",
     "dev": "rspeedy dev",
     "perfetto": "pnpm run --sequential --stream --aggregate-output '/^perfetto:.*/'",
@@ -30,6 +32,8 @@
     "perfetto:009-eval-bench": "benchx_cli -o dist/009-eval-bench.ptrace run dist/009-eval-bench.lynx.bundle --wait-for-id=stop-benchmark-true",
     "perfetto:010-transform-exponentiation-operator": "benchx_cli -o dist/010-transform-exponentiation-operator.ptrace run dist/010-transform-exponentiation-operator.lynx.bundle --wait-for-id=stop-benchmark-true",
     "perfetto:011-transform-async-to-generator": "benchx_cli -o dist/011-transform-async-to-generator.ptrace run dist/011-transform-async-to-generator.lynx.bundle --wait-for-id=stop-benchmark-true",
+    "perfetto:012-heavy-first-screen": "benchx_cli -o dist/012-heavy-first-screen.ptrace run dist/012-heavy-first-screen.lynx.bundle --wait-for-id=stop-benchmark-true",
+    "perfetto:013-background-boundary": "benchx_cli -o dist/013-background-boundary.ptrace run dist/013-background-boundary.lynx.bundle --wait-for-id=stop-benchmark-true",
     "test": "npm run perfetto && node scripts/detectLeak.mjs"
   },
   "dependencies": {

--- a/benchmark/react/src/HeavyFeed.tsx
+++ b/benchmark/react/src/HeavyFeed.tsx
@@ -1,0 +1,36 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const FEED_SIZE = 200;
+
+export function FeedSkeleton() {
+  return (
+    <view style={{ padding: '8px' }}>
+      <text>Loading feed…</text>
+    </view>
+  );
+}
+
+export function HeavyFeed() {
+  return (
+    <view style={{ flexDirection: 'column' }}>
+      {Array.from({ length: FEED_SIZE }).map((_, i) => (
+        <view style={{ flexDirection: 'row', padding: '4px' }}>
+          <view
+            style={{
+              width: '32px',
+              height: '32px',
+              borderRadius: '16px',
+              backgroundColor: '#cccccc',
+            }}
+          />
+          <view style={{ flexDirection: 'column', marginLeft: '8px' }}>
+            <text>{`Feed item ${i}`}</text>
+            <text>{`Description of feed item ${i}`}</text>
+          </view>
+        </view>
+      ))}
+    </view>
+  );
+}

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -40,6 +40,15 @@ import { useSyncExternalStore } from 'react';
 import type { VNode } from 'preact';
 
 // @public
+export function Background(props: BackgroundProps): ReactNode;
+
+// @public
+export interface BackgroundProps {
+    children?: ReactNode | undefined;
+    fallback?: ReactNode | undefined;
+}
+
+// @public
 export const Children: ReactLynxChildren;
 
 export { cloneElement }

--- a/packages/react/runtime/__test__/element-template/imports/background.test.ts
+++ b/packages/react/runtime/__test__/element-template/imports/background.test.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest';
+
+import ReactLynx, { Background } from '@lynx-js/react';
+
+describe('Background (element template runtime)', () => {
+  it('is exported from the element-template entry', () => {
+    expect(Background).toBeTypeOf('function');
+    expect(ReactLynx.Background).toBe(Background);
+  });
+
+  it('renders fallback on the main thread and children on the background thread', () => {
+    const g = globalThis as unknown as { __MAIN_THREAD__: boolean };
+    const previous = g.__MAIN_THREAD__;
+    try {
+      g.__MAIN_THREAD__ = true;
+      expect(Background({ children: 'content', fallback: 'skeleton' })).toBe('skeleton');
+      expect(Background({ children: 'content' })).toBeNull();
+
+      g.__MAIN_THREAD__ = false;
+      expect(Background({ children: 'content', fallback: 'skeleton' })).toBe('content');
+      expect(Background({ fallback: 'skeleton' })).toBeNull();
+    } finally {
+      g.__MAIN_THREAD__ = previous;
+    }
+  });
+});

--- a/packages/react/runtime/__test__/snapshot/background.bench.jsx
+++ b/packages/react/runtime/__test__/snapshot/background.bench.jsx
@@ -1,0 +1,108 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { beforeAll, bench, describe } from 'vitest';
+
+import { Background } from '../../src/core/background';
+import { root } from '../../src/lynx-api';
+import { __root } from '../../src/root';
+import { setupPage } from '../../src/snapshot';
+import { replaceCommitHook } from '../../src/snapshot/lifecycle/patch/commit';
+import { injectUpdateMainThread } from '../../src/snapshot/lifecycle/patch/updateMainThread';
+import { globalEnvManager } from './utils/envManager';
+import { elementTree, waitSchedule } from './utils/nativeMethod';
+
+const FEED_SIZE = 200;
+
+function Feed() {
+  return (
+    <view>
+      {Array.from({ length: FEED_SIZE }).map((_, i) => (
+        <view>
+          <text>{`Feed item ${i}`}</text>
+          <text>{`Description of feed item ${i}`}</text>
+        </view>
+      ))}
+    </view>
+  );
+}
+
+function Baseline() {
+  return (
+    <view>
+      <Feed />
+    </view>
+  );
+}
+
+function Boundary() {
+  return (
+    <view>
+      <Background fallback={<text>Loading…</text>}>
+        <Feed />
+      </Background>
+    </view>
+  );
+}
+
+beforeAll(() => {
+  setupPage(__CreatePage('0', 0));
+  injectUpdateMainThread();
+  replaceCommitHook();
+});
+
+function resetIteration() {
+  globalEnvManager.resetEnv();
+  elementTree.clear();
+  globalThis.__OnLifecycleEvent.mockClear();
+  lynx.getNativeApp().callLepusMethod.mockClear();
+}
+
+function renderFirstScreen(jsx) {
+  __root.__jsx = jsx;
+  renderPage();
+}
+
+async function dualThreadStartup(makeJsx) {
+  resetIteration();
+
+  // main-thread first-screen render (IFR)
+  renderFirstScreen(makeJsx());
+
+  // background render
+  globalEnvManager.switchToBackground();
+  root.render(makeJsx());
+
+  // hydrate (LifecycleConstant.firstScreen)
+  lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+
+  // apply the hydration patch on the main thread (rLynxChange)
+  globalEnvManager.switchToMainThread();
+  const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+  globalThis[rLynxChange[0]](rLynxChange[1]);
+  rLynxChange[2]();
+  await waitSchedule();
+}
+
+describe('main-thread first-screen render (IFR)', () => {
+  bench(`render ${FEED_SIZE}-item subtree (baseline)`, () => {
+    resetIteration();
+    renderFirstScreen(<Baseline />);
+  });
+
+  bench(`render ${FEED_SIZE}-item subtree behind <Background>`, () => {
+    resetIteration();
+    renderFirstScreen(<Boundary />);
+  });
+});
+
+describe('dual-thread startup (first screen + hydration)', () => {
+  bench(`startup with ${FEED_SIZE}-item subtree (baseline)`, async () => {
+    await dualThreadStartup(() => <Baseline />);
+  });
+
+  bench(`startup with ${FEED_SIZE}-item subtree behind <Background>`, async () => {
+    await dualThreadStartup(() => <Boundary />);
+  });
+});

--- a/packages/react/runtime/__test__/snapshot/background.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/background.test.jsx
@@ -1,0 +1,420 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Background } from '../../src/core/background';
+import { root, useState } from '../../src/index';
+import { __root } from '../../src/root';
+import { setupPage } from '../../src/snapshot';
+import { replaceCommitHook } from '../../src/snapshot/lifecycle/patch/commit';
+import { injectUpdateMainThread } from '../../src/snapshot/lifecycle/patch/updateMainThread';
+import { globalEnvManager } from './utils/envManager';
+import { elementTree, waitSchedule } from './utils/nativeMethod';
+
+beforeAll(() => {
+  setupPage(__CreatePage('0', 0));
+  injectUpdateMainThread();
+  replaceCommitHook();
+});
+
+beforeEach(() => {
+  globalEnvManager.resetEnv();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  elementTree.clear();
+});
+
+describe('main thread first-screen render', () => {
+  it('renders the fallback instead of children', () => {
+    const App = () => {
+      return (
+        <view>
+          <text>Header</text>
+          <Background fallback={<text>Skeleton</text>}>
+            <text>Feed</text>
+          </Background>
+        </view>
+      );
+    };
+
+    __root.__jsx = <App />;
+    renderPage();
+    expect(__root.__element_root).toMatchInlineSnapshot(`
+      <page
+        cssId="default-entry-from-native:0"
+      >
+        <view>
+          <text>
+            <raw-text
+              text="Header"
+            />
+          </text>
+          <wrapper>
+            <text>
+              <raw-text
+                text="Skeleton"
+              />
+            </text>
+          </wrapper>
+        </view>
+      </page>
+    `);
+  });
+
+  it('renders nothing when no fallback is given', () => {
+    const App = () => {
+      return (
+        <view>
+          <text>Header</text>
+          <Background>
+            <text>Feed</text>
+          </Background>
+        </view>
+      );
+    };
+
+    __root.__jsx = <App />;
+    renderPage();
+    expect(__root.__element_root).toMatchInlineSnapshot(`
+      <page
+        cssId="default-entry-from-native:0"
+      >
+        <view>
+          <text>
+            <raw-text
+              text="Header"
+            />
+          </text>
+          <wrapper />
+        </view>
+      </page>
+    `);
+  });
+});
+
+describe('dual-thread render', () => {
+  it('replaces the fallback with children when hydration completes', async () => {
+    const handleTap = vi.fn();
+    const App = () => {
+      return (
+        <view>
+          <text>Header</text>
+          <Background fallback={<text>Skeleton</text>}>
+            <text bindtap={handleTap}>Feed</text>
+          </Background>
+        </view>
+      );
+    };
+
+    // main thread render
+    {
+      __root.__jsx = <App />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Header"
+              />
+            </text>
+            <wrapper>
+              <text>
+                <raw-text
+                  text="Skeleton"
+                />
+              </text>
+            </wrapper>
+          </view>
+        </page>
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      root.render(<App />);
+    }
+
+    // hydrate
+    {
+      // LifecycleConstant.firstScreen
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    }
+
+    // rLynxChange
+    {
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      rLynxChange[2]();
+      await waitSchedule();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Header"
+              />
+            </text>
+            <wrapper>
+              <text
+                event={
+                  {
+                    "bindEvent:tap": "3:0:",
+                  }
+                }
+              >
+                <raw-text
+                  text="Feed"
+                />
+              </text>
+            </wrapper>
+          </view>
+        </page>
+      `);
+    }
+
+    // events attached by hydration work
+    {
+      globalEnvManager.switchToBackground();
+      lynxCoreInject.tt.publishEvent('3:0:', 'data');
+      expect(handleTap).toHaveBeenCalledTimes(1);
+      expect(handleTap).toHaveBeenCalledWith('data');
+    }
+  });
+
+  it('removes the fallback when the boundary has no children', async () => {
+    const App = () => {
+      return (
+        <view>
+          <text>Header</text>
+          <Background fallback={<text>Skeleton</text>} />
+        </view>
+      );
+    };
+
+    // main thread render
+    {
+      __root.__jsx = <App />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Header"
+              />
+            </text>
+            <wrapper>
+              <text>
+                <raw-text
+                  text="Skeleton"
+                />
+              </text>
+            </wrapper>
+          </view>
+        </page>
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      root.render(<App />);
+    }
+
+    // hydrate
+    {
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    }
+
+    // rLynxChange
+    {
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      rLynxChange[2]();
+      await waitSchedule();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Header"
+              />
+            </text>
+            <wrapper />
+          </view>
+        </page>
+      `);
+    }
+  });
+
+  it('supports nested boundaries', async () => {
+    const App = () => {
+      return (
+        <view>
+          <Background fallback={<text>Outer Skeleton</text>}>
+            <view>
+              <Background fallback={<text>Inner Skeleton</text>}>
+                <text>Inner Content</text>
+              </Background>
+            </view>
+          </Background>
+        </view>
+      );
+    };
+
+    // main thread render
+    {
+      __root.__jsx = <App />;
+      renderPage();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Outer Skeleton"
+              />
+            </text>
+          </view>
+        </page>
+      `);
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      root.render(<App />);
+    }
+
+    // hydrate
+    {
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    }
+
+    // rLynxChange
+    {
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      rLynxChange[2]();
+      await waitSchedule();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <view>
+              <text>
+                <raw-text
+                  text="Inner Content"
+                />
+              </text>
+            </view>
+          </view>
+        </page>
+      `);
+    }
+  });
+});
+
+describe('updates after hydration', () => {
+  it('updates inside the boundary flow through', async () => {
+    let setCount;
+    const Feed = () => {
+      const [count, _setCount] = useState(0);
+      setCount = _setCount;
+      return <text>{`Feed ${count}`}</text>;
+    };
+    const App = () => {
+      return (
+        <view>
+          <Background fallback={<text>Skeleton</text>}>
+            <Feed />
+          </Background>
+        </view>
+      );
+    };
+
+    // main thread render
+    {
+      __root.__jsx = <App />;
+      renderPage();
+    }
+
+    // background render
+    {
+      globalEnvManager.switchToBackground();
+      root.render(<App />);
+    }
+
+    // hydrate
+    {
+      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    }
+
+    // rLynxChange
+    {
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      rLynxChange[2]();
+      await waitSchedule();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Feed 0"
+              />
+            </text>
+          </view>
+        </page>
+      `);
+    }
+
+    // update state inside the boundary
+    {
+      globalEnvManager.switchToBackground();
+      setCount(1);
+      await waitSchedule();
+
+      globalEnvManager.switchToMainThread();
+      const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[1];
+      globalThis[rLynxChange[0]](rLynxChange[1]);
+      rLynxChange[2]();
+      await waitSchedule();
+      expect(__root.__element_root).toMatchInlineSnapshot(`
+        <page
+          cssId="default-entry-from-native:0"
+        >
+          <view>
+            <text>
+              <raw-text
+                text="Feed 1"
+              />
+            </text>
+          </view>
+        </page>
+      `);
+    }
+  });
+});

--- a/packages/react/runtime/lazy/compat.js
+++ b/packages/react/runtime/lazy/compat.js
@@ -5,6 +5,7 @@
 import { sExportsReactCompat, target } from './target.js';
 
 export const {
+  Background,
   Children,
   Component,
   Fragment,

--- a/packages/react/runtime/lazy/react.js
+++ b/packages/react/runtime/lazy/react.js
@@ -5,6 +5,7 @@
 import { sExportsReact, target } from './target';
 
 export const {
+  Background,
   Children,
   Component,
   Fragment,

--- a/packages/react/runtime/package.json
+++ b/packages/react/runtime/package.json
@@ -15,6 +15,7 @@
     "src"
   ],
   "scripts": {
+    "bench": "vitest bench __test__/snapshot/background.bench.jsx",
     "build": "tsc --build",
     "test": "pnpm run test:snapshot && pnpm run test:core && pnpm run test:et",
     "test:core": "vitest run __test__/core",

--- a/packages/react/runtime/src/core/background.ts
+++ b/packages/react/runtime/src/core/background.ts
@@ -96,6 +96,24 @@ export interface BackgroundProps {
  * because its main-thread render is a no-op — rendering it on the first screen
  * without a boundary would produce an empty frame.
  *
+ * At the render root, `<Background>` becomes the 0.0 first screen — the whole
+ * first frame is the static `fallback` and nothing renders on the main thread:
+ *
+ * ```tsx
+ * root.render(
+ *   // host-element fallback only, since component bodies are stripped from the
+ *   // main thread
+ *   <Background fallback={<view><text>Loading…</text></view>}>
+ *     <App />
+ *   </Background>,
+ * )
+ * ```
+ *
+ * The build detects this and strips every component render body from the
+ * main-thread bundle automatically — the whole-program endpoint of the same
+ * boundary, with no per-component annotation. The `fallback` must then be
+ * composed of host elements rather than user components.
+ *
  * @public
  */
 export function Background(props: BackgroundProps): ReactNode {

--- a/packages/react/runtime/src/core/background.ts
+++ b/packages/react/runtime/src/core/background.ts
@@ -71,6 +71,31 @@ export interface BackgroundProps {
  * }
  * ```
  *
+ * @remarks
+ * By default the boundary is a runtime opt-out: the deferred subtree's code is
+ * still bundled into the main thread, it just does not run there. To also keep
+ * that code out of the main-thread bundle — so no side effect can leak onto the
+ * main thread — author the deferred component with the `'background only'`
+ * directive. Its render body is then stripped from the main-thread bundle,
+ * while its element and main-thread-script (worklet) definitions (which the
+ * hydration needs to build the real content) are retained:
+ *
+ * ```tsx
+ * // Feed.tsx
+ * export function Feed() {
+ *   'background only';
+ *   // hooks, effects, event handlers, data formatting — none of this reaches
+ *   // the main-thread bundle
+ *   return <view>...</view>
+ * }
+ * ```
+ *
+ * Use the two together: `<Background>` provides the runtime boundary and the
+ * fallback, while the `'background only'` component provides the compile-time
+ * separation. The component must be rendered behind a `<Background>` boundary,
+ * because its main-thread render is a no-op — rendering it on the first screen
+ * without a boundary would produce an empty frame.
+ *
  * @public
  */
 export function Background(props: BackgroundProps): ReactNode {

--- a/packages/react/runtime/src/core/background.ts
+++ b/packages/react/runtime/src/core/background.ts
@@ -1,0 +1,81 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { ReactNode } from 'react';
+
+/**
+ * Props of the {@link Background} component.
+ *
+ * @public
+ */
+export interface BackgroundProps {
+  /**
+   * The content that opts out of the main-thread first-screen render. It is
+   * always rendered by the background thread and shows up once the
+   * first-screen hydration completes.
+   */
+  children?: ReactNode | undefined;
+
+  /**
+   * The placeholder rendered during the first screen (e.g. a skeleton). It
+   * only ever exists on the main thread: the first-screen hydration replaces
+   * it with `children`.
+   *
+   * Keep the fallback static. Event handlers and refs inside the fallback are
+   * never attached, because the fallback is removed when hydration completes.
+   *
+   * @defaultValue `null` (render nothing during the first screen)
+   */
+  fallback?: ReactNode | undefined;
+}
+
+/**
+ * A first-screen boundary that opts its subtree out of the main-thread
+ * first-screen render (IFR, Instant First-Frame Rendering).
+ *
+ * During the main-thread first-screen render, the boundary renders `fallback`
+ * (or nothing) instead of `children`. The background thread always renders
+ * `children`, and the first-screen hydration replaces the fallback with the
+ * real content through the normal update patch.
+ *
+ * Use it for subtrees that cannot, or should not, participate in the
+ * first-screen render, for example when:
+ *
+ * - the first-screen data of the subtree is only available asynchronously
+ *
+ * - the subtree relies on capabilities that only exist on the background
+ *   thread
+ *
+ * - the subtree must not run twice (once per thread) during startup
+ *
+ * `<Background>` is not a performance optimization by itself: the background
+ * thread still renders the full tree, and the boundary content is inserted
+ * after hydration, which may cause layout shift unless the fallback preserves
+ * the layout of `children`.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { Background } from '@lynx-js/react'
+ *
+ * function ProfilePage() {
+ *   return (
+ *     <view>
+ *       <Header />
+ *       <Background fallback={<FeedSkeleton />}>
+ *         <Feed />
+ *       </Background>
+ *     </view>
+ *   )
+ * }
+ * ```
+ *
+ * @public
+ */
+export function Background(props: BackgroundProps): ReactNode {
+  if (__MAIN_THREAD__) {
+    return props.fallback ?? null;
+  }
+  return props.children ?? null;
+}

--- a/packages/react/runtime/src/core/background.ts
+++ b/packages/react/runtime/src/core/background.ts
@@ -101,18 +101,20 @@ export interface BackgroundProps {
  *
  * ```tsx
  * root.render(
- *   // host-element fallback only, since component bodies are stripped from the
- *   // main thread
  *   <Background fallback={<view><text>Loading…</text></view>}>
  *     <App />
  *   </Background>,
  * )
  * ```
  *
- * The build detects this and strips every component render body from the
- * main-thread bundle automatically — the whole-program endpoint of the same
- * boundary, with no per-component annotation. The `fallback` must then be
- * composed of host elements rather than user components.
+ * This is a runtime guarantee and always safe: every module stays in the
+ * main-thread bundle; only the fallback renders. To additionally keep every
+ * component's render body out of the main-thread bundle without per-component
+ * annotation — the whole-program endpoint of the same boundary — opt in to the
+ * experimental `experimental_stripAllComponents` build option (`'auto'`
+ * lights it up on a detected root `<Background>`). Under the strip the
+ * `fallback` must be composed of host elements rather than user components,
+ * since component bodies no longer exist on the main thread.
  *
  * @public
  */

--- a/packages/react/runtime/src/element-template/index.ts
+++ b/packages/react/runtime/src/element-template/index.ts
@@ -34,6 +34,7 @@ import {
   useState,
 } from '@lynx-js/react/hooks';
 
+import { Background } from '../core/background.js';
 import { installComponentCompat } from '../core/component.js';
 import { createGlobalProps } from '../core/globalProps.js';
 import type { GlobalProps } from '../core/globalProps.js';
@@ -77,9 +78,11 @@ export default {
   Suspense,
   lazy,
   createElement,
+  Background,
 };
 
 export {
+  Background,
   Children,
   createRef,
   Fragment,
@@ -128,6 +131,7 @@ export const useGlobalPropsChanged: (callback: (data: GlobalProps) => void) => v
 
 export { withInitDataInState };
 export { useLynxGlobalEventListener };
+export type { BackgroundProps } from '../core/background.js';
 
 export * from './client/root.js';
 export { runOnBackground } from './runtime/template/main-thread-background-function.js';

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -17,6 +17,7 @@ import {
   useSyncExternalStore,
 } from 'preact/compat';
 
+import { Background } from './core/background.js';
 import { installComponentCompat } from './core/component.js';
 import {
   useCallback,
@@ -36,6 +37,7 @@ import { createPortal } from './snapshot/lynx/portals.js';
 import { Suspense } from './snapshot/lynx/suspense.js';
 
 export type { ReactLynxChildren } from './snapshot/lynx/children.js';
+export type { BackgroundProps } from './core/background.js';
 
 installComponentCompat();
 
@@ -74,9 +76,11 @@ export default {
   createElement,
   cloneElement,
   createPortal,
+  Background,
 };
 
 export {
+  Background,
   Children,
   createRef,
   Fragment,

--- a/packages/react/runtime/vitest.config.ts
+++ b/packages/react/runtime/vitest.config.ts
@@ -157,6 +157,7 @@ export default defineConfig({
         '__test__/snapshot/page.test.jsx',
         '**/*.d.ts',
         '**/*.test-d.*',
+        '**/*.bench.*',
       ],
       thresholds: {
         lines: 100,

--- a/packages/react/transform/crates/swc_plugin_directive_dce/Cargo.toml
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/Cargo.toml
@@ -9,10 +9,16 @@ path = "lib.rs"
 [dependencies]
 napi = { workspace = true, optional = true }
 napi-derive = { workspace = true, optional = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-swc_core = { workspace = true, features = ["ecma_parser", "ecma_visit", "testing_transform"] }
+swc_core = { workspace = true, features = ["ecma_parser", "ecma_utils", "ecma_visit", "testing_transform"] }
 swc_plugin_define_dce = { path = "../swc_plugin_define_dce" }
 swc_plugins_shared = { path = "../swc_plugins_shared" }
+
+[dev-dependencies]
+# The keep-alive regression tests compose this pass with the same
+# `simplify::dce` configuration the real pipeline runs after it.
+swc_core = { workspace = true, features = ["ecma_transforms_optimization"] }
 
 [features]
 napi = ["dep:napi", "dep:napi-derive", "swc_plugins_shared/napi", "swc_plugin_define_dce/napi"]

--- a/packages/react/transform/crates/swc_plugin_directive_dce/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/lib.rs
@@ -1,9 +1,11 @@
+use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use std::fmt::Debug;
 use swc_core::{
-  common::{errors::HANDLER, Span, DUMMY_SP},
+  common::{errors::HANDLER, Span, SyntaxContext, DUMMY_SP},
   ecma::{
     ast::*,
+    utils::collect_decls,
     visit::{Visit, VisitMut, VisitMutWith, VisitWith},
   },
 };
@@ -33,9 +35,12 @@ impl Eliminate for ArrowExpr {
     self.params.clear();
     match &mut *self.body {
       BlockStmtOrExpr::BlockStmt(block) => block.stmts.clear(),
-      // Expression-bodied arrow (`() => <jsx/>`): drop the JSX by replacing the
-      // body with `null`, so the elements/components it referenced become
-      // unreferenced and are shaken from the main-thread bundle.
+      // Expression-bodied arrow (`() => <jsx/>`): drop the JSX by replacing
+      // the body with `null`. Logic-only references become unreferenced and
+      // are shaken from the main-thread bundle; the *component* references the
+      // body held are preserved separately (harvested before elimination into
+      // the module-level keep-alive), because the modules they point at carry
+      // the snapshot/worklet definitions hydration still needs.
       BlockStmtOrExpr::Expr(expr) => {
         *expr = Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP })));
       }
@@ -90,6 +95,99 @@ fn block_returns_jsx(block: &BlockStmt) -> bool {
   finder.found
 }
 
+/// The callee name of the module-level keep-alive probe emitted after
+/// component bodies are emptied on the main thread:
+///
+/// ```js
+/// typeof __ifrKeepComponentRefs === "function" && __ifrKeepComponentRefs(Feed, UI);
+/// ```
+///
+/// No runtime ever defines it — the `typeof` guard makes the statement inert —
+/// but a call to an unresolved global can never be proven side-effect free, so
+/// the statement (and the component references it carries) survives every
+/// later dead-code-elimination layer: this pipeline's `simplify::dce` (which
+/// removes now-unused imports, `preserve_imports_with_side_effects: false`),
+/// and the bundler's tree shaking. That keeps the referenced modules — and the
+/// module-scope snapshot/worklet definitions hydration needs — in the
+/// main-thread bundle even though the render bodies that referenced them are
+/// gone.
+pub const KEEP_COMPONENT_REFS_PROBE: &str = "__ifrKeepComponentRefs";
+
+fn is_capitalized(sym: &str) -> bool {
+  sym.chars().next().is_some_and(char::is_uppercase)
+}
+
+/// Collects the *component* references a render body holds, so a body about to
+/// be emptied can hand them over to the module-level keep-alive instead of
+/// severing them. Severed references let the unused-import DCE downstream drop
+/// the referenced modules — and with them the hoisted snapshot/worklet
+/// definitions that first-screen hydration still needs (the cross-module
+/// hydration break of a whole-program strip).
+///
+/// "Component reference" is deliberately narrow, so logic-only imports (call
+/// targets, hook arguments, …) still shake out of the main-thread bundle:
+/// - a capitalized JSX element name (`<Feed/>`) — the JSX
+///   intrinsic-vs-component convention, which also skips the hoisted
+///   `__snapshot_*` element references, or
+/// - the root object of a JSX member-expression name (`<UI.Card/>`; member
+///   names are always components, whatever their casing), or
+/// - a capitalized bare identifier used directly as a JSX attribute value
+///   (`<Layout header={Header}/>` — a component passed as a prop).
+///
+/// It descends into nested functions (`items.map(it => <Card/>)` renders
+/// `Card` all the same), unlike the `ReturnsJsxFinder` discriminator.
+#[derive(Default)]
+struct ComponentRefCollector {
+  refs: Vec<Ident>,
+}
+
+impl ComponentRefCollector {
+  fn push_component(&mut self, ident: &Ident) {
+    self.refs.push(ident.clone());
+  }
+}
+
+impl Visit for ComponentRefCollector {
+  fn visit_jsx_element_name(&mut self, n: &JSXElementName) {
+    match n {
+      JSXElementName::Ident(ident) => {
+        if is_capitalized(ident.sym.as_str()) {
+          self.push_component(ident);
+        }
+      }
+      JSXElementName::JSXMemberExpr(member) => {
+        let mut obj = &member.obj;
+        loop {
+          match obj {
+            JSXObject::Ident(ident) => {
+              self.push_component(ident);
+              break;
+            }
+            JSXObject::JSXMemberExpr(inner) => obj = &inner.obj,
+          }
+        }
+      }
+      JSXElementName::JSXNamespacedName(_) => {}
+      #[cfg(swc_ast_unknown)]
+      _ => {}
+    }
+  }
+
+  fn visit_jsx_attr(&mut self, n: &JSXAttr) {
+    if let Some(JSXAttrValue::JSXExprContainer(container)) = &n.value {
+      if let JSXExpr::Expr(expr) = &container.expr {
+        if let Expr::Ident(ident) = &**expr {
+          if is_capitalized(ident.sym.as_str()) {
+            self.push_component(ident);
+          }
+        }
+      }
+    }
+    // Still descend: an attribute value may nest JSX (`fallback={<Spin/>}`).
+    n.visit_children_with(self);
+  }
+}
+
 #[derive(Deserialize, Clone, Debug, PartialEq)]
 pub struct DirectiveDCEVisitorConfig {
   /// @internal
@@ -100,6 +198,13 @@ pub struct DirectiveDCEVisitorConfig {
   /// `<Background>` (or the explicit main-thread-render opt-out) keeps all
   /// component render logic out of the main-thread bundle without per-component
   /// annotation.
+  ///
+  /// Emptying a body must not sever the component references it held: the
+  /// modules they point at carry the snapshot/worklet definitions that
+  /// first-screen hydration builds the real tree from. Every emptied body
+  /// therefore hands its component references over to a module-level
+  /// keep-alive statement (see [`KEEP_COMPONENT_REFS_PROBE`]), while its
+  /// logic-only references still shake out.
   /// @internal
   #[serde(default)]
   pub strip_all_components: bool,
@@ -116,16 +221,117 @@ impl Default for DirectiveDCEVisitorConfig {
 
 pub struct DirectiveDCEVisitor {
   opts: DirectiveDCEVisitorConfig,
+  /// Component references harvested from bodies emptied on the `LEPUS` target,
+  /// in source order, awaiting the module-level keep-alive flush.
+  kept_refs: Vec<Ident>,
+  /// Dedup index over `kept_refs` (`Id` = symbol + syntax context).
+  kept_ref_ids: FxHashSet<Id>,
 }
 
 impl DirectiveDCEVisitor {
   pub fn new(opts: DirectiveDCEVisitorConfig) -> Self {
-    DirectiveDCEVisitor { opts }
+    DirectiveDCEVisitor {
+      opts,
+      kept_refs: Vec::new(),
+      kept_ref_ids: FxHashSet::default(),
+    }
   }
 
   /// Whether "strip every component render body" is active for this pass.
   fn strip_all_active(&self) -> bool {
     self.opts.strip_all_components && self.opts.target == TransformTarget::LEPUS
+  }
+
+  /// Harvest the component references of a function-like that is about to be
+  /// eliminated, minus the bindings local to it (a body-local component dies
+  /// with the body — there is nothing left to reference).
+  ///
+  /// Only the `LEPUS` target harvests: an eliminated body's component subtree
+  /// still hydrates on the main thread (background render → main-thread
+  /// element construction through the module-scope snapshot/worklet
+  /// definitions), so those modules must stay referenced there. On the `JS`
+  /// target (`'use lepus only'` elimination) no such obligation exists.
+  fn harvest_component_refs<N>(&mut self, n: &N)
+  where
+    N: VisitWith<ComponentRefCollector> + VisitWith<swc_core::ecma::utils::BindingCollector<Id>>,
+  {
+    if self.opts.target != TransformTarget::LEPUS {
+      return;
+    }
+    let mut collector = ComponentRefCollector::default();
+    n.visit_with(&mut collector);
+    if collector.refs.is_empty() {
+      return;
+    }
+    let locals: FxHashSet<Id> = collect_decls(n);
+    for ident in collector.refs {
+      let id = ident.to_id();
+      if locals.contains(&id) {
+        continue;
+      }
+      if self.kept_ref_ids.insert(id) {
+        self.kept_refs.push(ident);
+      }
+    }
+  }
+
+  /// Append the keep-alive statement carrying every harvested component
+  /// reference of this module:
+  ///
+  /// ```js
+  /// typeof __ifrKeepComponentRefs === "function" && __ifrKeepComponentRefs(Feed, UI);
+  /// ```
+  ///
+  /// Inert at runtime (the probe is never defined), un-eliminable at compile
+  /// time (a call to an unresolved global is never provably pure) — see
+  /// [`KEEP_COMPONENT_REFS_PROBE`].
+  fn flush_kept_refs(&mut self) -> Option<Stmt> {
+    if self.kept_refs.is_empty() {
+      return None;
+    }
+    self.kept_ref_ids.clear();
+    let probe = Ident::new(
+      KEEP_COMPONENT_REFS_PROBE.into(),
+      DUMMY_SP,
+      SyntaxContext::empty(),
+    );
+    let probe_is_function = Expr::Bin(BinExpr {
+      span: DUMMY_SP,
+      op: BinaryOp::EqEqEq,
+      left: Box::new(Expr::Unary(UnaryExpr {
+        span: DUMMY_SP,
+        op: UnaryOp::TypeOf,
+        arg: Box::new(Expr::Ident(probe.clone())),
+      })),
+      right: Box::new(Expr::Lit(Lit::Str(Str {
+        span: DUMMY_SP,
+        value: "function".into(),
+        raw: None,
+      }))),
+    });
+    let keep_call = Expr::Call(CallExpr {
+      span: DUMMY_SP,
+      ctxt: SyntaxContext::empty(),
+      callee: Callee::Expr(Box::new(Expr::Ident(probe))),
+      args: self
+        .kept_refs
+        .drain(..)
+        .map(|ident| ExprOrSpread {
+          spread: None,
+          expr: Box::new(Expr::Ident(ident)),
+        })
+        .collect(),
+      type_args: None,
+    });
+    Some(Stmt::Expr(ExprStmt {
+      span: DUMMY_SP,
+      expr: Box::new(Expr::Bin(BinExpr {
+        span: DUMMY_SP,
+        op: BinaryOp::LogicalAnd,
+        left: Box::new(probe_is_function),
+        right: Box::new(keep_call),
+      })),
+    }))
   }
 
   fn should_eliminate(&self, n: &BlockStmt) -> (bool, Option<Span>) {
@@ -219,6 +425,7 @@ impl VisitMut for DirectiveDCEVisitor {
             self.should_eliminate(stmt).0 || (self.strip_all_active() && block_returns_jsx(stmt));
           // if should_eliminate, then clear the body
           if should_eliminate {
+            self.harvest_component_refs(&**function);
             function.eliminate();
           }
 
@@ -243,7 +450,8 @@ impl VisitMut for DirectiveDCEVisitor {
 
     // if should_eliminate, then clear the body and params
     if should_eliminate {
-      function.eliminate();
+      self.harvest_component_refs(&*n.function);
+      n.function.eliminate();
     }
 
     n.visit_mut_children_with(self);
@@ -262,6 +470,7 @@ impl VisitMut for DirectiveDCEVisitor {
 
     // if should_eliminate, then clear the body
     if should_eliminate {
+      self.harvest_component_refs(&*arrow);
       arrow.eliminate();
     }
 
@@ -278,6 +487,7 @@ impl VisitMut for DirectiveDCEVisitor {
 
     // if should_eliminate, then clear the body
     if should_eliminate {
+      self.harvest_component_refs(&*n.function);
       n.function.eliminate();
     }
 
@@ -291,6 +501,7 @@ impl VisitMut for DirectiveDCEVisitor {
         Some(stmt) => {
           let (should_eliminate, _) = self.should_eliminate(stmt);
           if should_eliminate {
+            self.harvest_component_refs(&**function);
             function.eliminate();
           }
 
@@ -302,19 +513,207 @@ impl VisitMut for DirectiveDCEVisitor {
       }
     }
   }
+
+  fn visit_mut_module(&mut self, n: &mut Module) {
+    n.visit_mut_children_with(self);
+    if let Some(stmt) = self.flush_kept_refs() {
+      n.body.push(ModuleItem::Stmt(stmt));
+    }
+  }
+
+  fn visit_mut_script(&mut self, n: &mut Script) {
+    n.visit_mut_children_with(self);
+    if let Some(stmt) = self.flush_kept_refs() {
+      n.body.push(stmt);
+    }
+  }
 }
 
 #[cfg(test)]
 mod tests {
   use crate::{DirectiveDCEVisitor, DirectiveDCEVisitorConfig};
   use swc_core::{
+    common::Mark,
     ecma::parser::Syntax,
+    ecma::transforms::base::resolver,
+    ecma::transforms::optimization::{simplifier, simplify},
     ecma::visit::visit_mut_pass,
     ecma::{parser::EsSyntax, transforms::testing::test},
   };
   use swc_plugins_shared::target::TransformTarget;
 
   // use crate::{DirectiveDCEVisitor, DirectiveDCEVisitorConfig};
+
+  // ---------------------------------------------------------------------------
+  // Keep-alive component references: emptying a body must not sever the
+  // component references it held (their modules carry the snapshot/worklet
+  // definitions first-screen hydration needs), while logic-only references
+  // must still shake out.
+  // ---------------------------------------------------------------------------
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
+      target: TransformTarget::LEPUS,
+      strip_all_components: true,
+    })),
+    strip_all_components_keeps_cross_module_component_refs,
+    r#"
+    import { Feed } from './Feed.jsx';
+    import { Header } from './Header.jsx';
+    import * as UI from './ui.jsx';
+    import { formatFeed } from './heavy-format.js';
+
+    export function App() {
+      const items = formatFeed(1, 2, 3);
+      const Local = () => <text>local</text>;
+      return (
+        <view>
+          <Feed />
+          <Feed />
+          <UI.Card />
+          <Local />
+          {items.map((it) => <Header key={it} />)}
+        </view>
+      );
+    }
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
+      target: TransformTarget::LEPUS,
+      strip_all_components: true,
+    })),
+    strip_all_components_keeps_component_valued_attr_refs,
+    r#"
+    import { Layout } from './Layout.jsx';
+    import { Hero } from './Hero.jsx';
+
+    export const Page = () => <Layout header={Hero} />;
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
+      target: TransformTarget::LEPUS,
+      strip_all_components: true,
+    })),
+    strip_all_components_emits_no_keep_alive_without_component_refs,
+    r#"
+    export function App() {
+      return (
+        <view>
+          <text>host elements only</text>
+        </view>
+      );
+    }
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
+      target: TransformTarget::LEPUS,
+      strip_all_components: false,
+    })),
+    background_only_component_keeps_child_component_refs,
+    r#"
+    import { Wrapped } from './Wrapped.jsx';
+
+    export function Card() {
+      'background only';
+      return <Wrapped />;
+    }
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
+      target: TransformTarget::JS,
+      strip_all_components: false,
+    })),
+    lepus_only_elimination_on_js_target_emits_no_keep_alive,
+    r#"
+    import { Gadget } from './Gadget.jsx';
+
+    export function lepusOnly() {
+      'use lepus only';
+      return <Gadget />;
+    }
+    "#
+  );
+
+  // The regression proof for the cross-module hydration break: compose the
+  // strip with the same `simplify::dce` configuration the real pipeline runs
+  // right after it (`preserve_imports_with_side_effects: false` — the pass
+  // that severed the child modules). The keep-alive must carry the component
+  // import through, while the logic-only import still shakes out.
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      jsx: true,
+      ..Default::default()
+    }),
+    |_| {
+      let unresolved_mark = Mark::new();
+      let top_level_mark = Mark::new();
+      (
+        resolver(unresolved_mark, top_level_mark, true),
+        visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
+          target: TransformTarget::LEPUS,
+          strip_all_components: true,
+        })),
+        simplifier(
+          top_level_mark,
+          simplify::Config {
+            dce: simplify::dce::Config {
+              preserve_imports_with_side_effects: false,
+              ..Default::default()
+            },
+            ..Default::default()
+          },
+        ),
+      )
+    },
+    strip_keep_alive_survives_simplify_dce,
+    r#"
+    import { Feed } from './Feed.jsx';
+    import { formatFeed } from './heavy-format.js';
+
+    export function App() {
+      const items = formatFeed(1, 2, 3);
+      return (
+        <view>
+          <Feed items={items} />
+        </view>
+      );
+    }
+    "#
+  );
 
   test!(
     module,

--- a/packages/react/transform/crates/swc_plugin_directive_dce/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/lib.rs
@@ -1,10 +1,10 @@
 use serde::Deserialize;
 use std::fmt::Debug;
 use swc_core::{
-  common::{errors::HANDLER, Span},
+  common::{errors::HANDLER, Span, DUMMY_SP},
   ecma::{
     ast::*,
-    visit::{VisitMut, VisitMutWith},
+    visit::{Visit, VisitMut, VisitMutWith, VisitWith},
   },
 };
 
@@ -31,22 +31,85 @@ impl Eliminate for ArrowExpr {
   fn eliminate(&mut self) {
     // TODO(hongzhiyuan.hzy): don't change `length` of function
     self.params.clear();
-    if let BlockStmtOrExpr::BlockStmt(block) = &mut *self.body {
-      block.stmts.clear();
+    match &mut *self.body {
+      BlockStmtOrExpr::BlockStmt(block) => block.stmts.clear(),
+      // Expression-bodied arrow (`() => <jsx/>`): drop the JSX by replacing the
+      // body with `null`, so the elements/components it referenced become
+      // unreferenced and are shaken from the main-thread bundle.
+      BlockStmtOrExpr::Expr(expr) => {
+        *expr = Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP })));
+      }
     }
   }
+}
+
+/// Whether an expression in return position evaluates to JSX. Unwraps the
+/// shapes a render commonly returns (parenthesized, ternary, `&&`/`||`,
+/// sequence) but treats anything else — notably a call like
+/// `root.render(<App/>)`, where JSX is only an *argument* — as not-JSX.
+fn expr_is_jsx(e: &Expr) -> bool {
+  match e {
+    Expr::JSXElement(_) | Expr::JSXFragment(_) => true,
+    Expr::Paren(p) => expr_is_jsx(&p.expr),
+    Expr::Cond(c) => expr_is_jsx(&c.cons) || expr_is_jsx(&c.alt),
+    Expr::Bin(b) if matches!(b.op, BinaryOp::LogicalAnd | BinaryOp::LogicalOr) => {
+      expr_is_jsx(&b.left) || expr_is_jsx(&b.right)
+    }
+    Expr::Seq(s) => s.exprs.last().is_some_and(|e| expr_is_jsx(e)),
+    _ => false,
+  }
+}
+
+/// Detects whether a function-like *returns* JSX, i.e. it is a component render.
+/// It deliberately does NOT descend into nested functions, so:
+/// - a render is identified by the JSX it returns (not JSX merely passed to a
+///   call, so `() => root.render(<App/>)` is not a component), and
+/// - the generated snapshot `create`/`update` and worklet closures (which
+///   return element-PAPI arrays / nothing, never JSX) are never mistaken for
+///   components.
+#[derive(Default)]
+struct ReturnsJsxFinder {
+  found: bool,
+}
+
+impl Visit for ReturnsJsxFinder {
+  fn visit_return_stmt(&mut self, n: &ReturnStmt) {
+    if let Some(arg) = &n.arg {
+      if expr_is_jsx(arg) {
+        self.found = true;
+      }
+    }
+  }
+  fn visit_function(&mut self, _: &Function) {}
+  fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
+}
+
+fn block_returns_jsx(block: &BlockStmt) -> bool {
+  let mut finder = ReturnsJsxFinder::default();
+  block.visit_with(&mut finder);
+  finder.found
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]
 pub struct DirectiveDCEVisitorConfig {
   /// @internal
   pub target: TransformTarget,
+  /// When `true` on the `LEPUS` target, empties the render body of every
+  /// component (a function-like whose own body contains JSX), while keeping the
+  /// module-scope snapshot and worklet definitions. This is how a root-level
+  /// `<Background>` (or the explicit main-thread-render opt-out) keeps all
+  /// component render logic out of the main-thread bundle without per-component
+  /// annotation.
+  /// @internal
+  #[serde(default)]
+  pub strip_all_components: bool,
 }
 
 impl Default for DirectiveDCEVisitorConfig {
   fn default() -> Self {
     DirectiveDCEVisitorConfig {
       target: TransformTarget::MIXED,
+      strip_all_components: false,
     }
   }
 }
@@ -58,6 +121,11 @@ pub struct DirectiveDCEVisitor {
 impl DirectiveDCEVisitor {
   pub fn new(opts: DirectiveDCEVisitorConfig) -> Self {
     DirectiveDCEVisitor { opts }
+  }
+
+  /// Whether "strip every component render body" is active for this pass.
+  fn strip_all_active(&self) -> bool {
+    self.opts.strip_all_components && self.opts.target == TransformTarget::LEPUS
   }
 
   fn should_eliminate(&self, n: &BlockStmt) -> (bool, Option<Span>) {
@@ -147,7 +215,8 @@ impl VisitMut for DirectiveDCEVisitor {
       | ClassMember::PrivateMethod(PrivateMethod { function, .. }) => match &function.body {
         None => {}
         Some(stmt) => {
-          let (should_eliminate, _) = self.should_eliminate(stmt);
+          let should_eliminate =
+            self.should_eliminate(stmt).0 || (self.strip_all_active() && block_returns_jsx(stmt));
           // if should_eliminate, then clear the body
           if should_eliminate {
             function.eliminate();
@@ -167,7 +236,9 @@ impl VisitMut for DirectiveDCEVisitor {
     let function = &mut n.function;
     let should_eliminate = match &function.body {
       None => false,
-      Some(stmt) => self.should_eliminate(stmt).0,
+      Some(stmt) => {
+        self.should_eliminate(stmt).0 || (self.strip_all_active() && block_returns_jsx(stmt))
+      }
     };
 
     // if should_eliminate, then clear the body and params
@@ -179,14 +250,19 @@ impl VisitMut for DirectiveDCEVisitor {
   }
 
   fn visit_mut_arrow_expr(&mut self, arrow: &mut ArrowExpr) {
-    if arrow.body.is_block_stmt() {
-      let body = arrow.body.as_mut_block_stmt().unwrap();
-      let (should_eliminate, _) = self.should_eliminate(body);
-
-      // if should_eliminate, then clear the body
-      if should_eliminate {
-        arrow.eliminate();
+    let should_eliminate = match &*arrow.body {
+      BlockStmtOrExpr::BlockStmt(body) => {
+        self.should_eliminate(body).0 || (self.strip_all_active() && block_returns_jsx(body))
       }
+      // Expression-bodied arrows carry no directive prologue, so only the
+      // strip-all mode (a component written as `const App = () => <view/>`)
+      // targets them.
+      BlockStmtOrExpr::Expr(expr) => self.strip_all_active() && expr_is_jsx(expr),
+    };
+
+    // if should_eliminate, then clear the body
+    if should_eliminate {
+      arrow.eliminate();
     }
 
     arrow.visit_mut_children_with(self);
@@ -195,7 +271,9 @@ impl VisitMut for DirectiveDCEVisitor {
   fn visit_mut_fn_expr(&mut self, n: &mut FnExpr) {
     let should_eliminate = match &n.function.body {
       None => false,
-      Some(stmt) => self.should_eliminate(stmt).0,
+      Some(stmt) => {
+        self.should_eliminate(stmt).0 || (self.strip_all_active() && block_returns_jsx(stmt))
+      }
     };
 
     // if should_eliminate, then clear the body
@@ -246,6 +324,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_js_only_but_keep_constructor,
     r#"
@@ -266,6 +345,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_js_only_class_method,
     r#"
@@ -290,6 +370,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_js_only_class_property,
     r#"
@@ -314,6 +395,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_js_only_embedded,
     r#"
@@ -337,6 +419,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::MIXED,
+      strip_all_components: false,
     })),
     should_do_nothing_in_mixed_target,
     r#"
@@ -357,6 +440,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::MIXED,
+      strip_all_components: false,
     })),
     should_do_nothing_when_arrow_function_return_directive,
     r#"
@@ -372,6 +456,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_native_modules_in_default_params,
     r#"
@@ -390,6 +475,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_fn_body_in_component_props,
     r#"
@@ -409,6 +495,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_fn_decl,
     r#"
@@ -427,6 +514,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_transpiled_async_arrow_with_background_only_generator,
     r#"
@@ -445,6 +533,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_async_arrow_with_background_only_directive,
     r#"
@@ -463,6 +552,7 @@ mod tests {
     }),
     |_| visit_mut_pass(DirectiveDCEVisitor::new(DirectiveDCEVisitorConfig {
       target: TransformTarget::LEPUS,
+      strip_all_components: false,
     })),
     should_eliminate_background_only_generator_forms,
     r#"

--- a/packages/react/transform/crates/swc_plugin_directive_dce/napi.rs
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/napi.rs
@@ -11,12 +11,20 @@ pub struct DirectiveDCEVisitorConfig {
   /// @internal
   #[napi(ts_type = "'LEPUS' | 'JS' | 'MIXED'")]
   pub target: TransformTarget,
+  /// When `true` on the `LEPUS` target, empties the render body of every
+  /// component while keeping the module-scope snapshot and worklet
+  /// definitions — the compile-time half of a root-level `<Background>`
+  /// (0.0 first screen), so component render logic never reaches the
+  /// main-thread bundle without per-component annotation.
+  /// @internal
+  pub strip_all_components: Option<bool>,
 }
 
 impl Default for DirectiveDCEVisitorConfig {
   fn default() -> Self {
     DirectiveDCEVisitorConfig {
       target: TransformTarget::MIXED,
+      strip_all_components: None,
     }
   }
 }
@@ -25,6 +33,7 @@ impl From<DirectiveDCEVisitorConfig> for CoreConfig {
   fn from(val: DirectiveDCEVisitorConfig) -> Self {
     CoreConfig {
       target: val.target.into(),
+      strip_all_components: val.strip_all_components.unwrap_or(false),
     }
   }
 }
@@ -33,6 +42,7 @@ impl From<CoreConfig> for DirectiveDCEVisitorConfig {
   fn from(val: CoreConfig) -> Self {
     DirectiveDCEVisitorConfig {
       target: val.target.into(),
+      strip_all_components: Some(val.strip_all_components),
     }
   }
 }

--- a/packages/react/transform/crates/swc_plugin_directive_dce/napi.rs
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/napi.rs
@@ -72,4 +72,15 @@ impl VisitMut for DirectiveDCEVisitor {
   fn visit_mut_fn_expr(&mut self, n: &mut FnExpr) {
     self.inner.visit_mut_fn_expr(n)
   }
+  // The module/script hooks let the core visitor flush the keep-alive
+  // statement that carries the component references of every body it emptied
+  // (see `KEEP_COMPONENT_REFS_PROBE`). Forwarding them also roots the whole
+  // traversal in the core visitor, so its visit methods see the same tree the
+  // wasm plugin (which uses the core visitor directly) sees.
+  fn visit_mut_module(&mut self, n: &mut Module) {
+    self.inner.visit_mut_module(n)
+  }
+  fn visit_mut_script(&mut self, n: &mut Script) {
+    self.inner.visit_mut_script(n)
+  }
 }

--- a/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/background_only_component_keeps_child_component_refs.js
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/background_only_component_keeps_child_component_refs.js
@@ -1,0 +1,3 @@
+import { Wrapped } from './Wrapped.jsx';
+export function Card() {}
+typeof __ifrKeepComponentRefs === "function" && __ifrKeepComponentRefs(Wrapped);

--- a/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/lepus_only_elimination_on_js_target_emits_no_keep_alive.js
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/lepus_only_elimination_on_js_target_emits_no_keep_alive.js
@@ -1,0 +1,2 @@
+import { Gadget } from './Gadget.jsx';
+export function lepusOnly() {}

--- a/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/strip_all_components_emits_no_keep_alive_without_component_refs.js
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/strip_all_components_emits_no_keep_alive_without_component_refs.js
@@ -1,0 +1,1 @@
+export function App() {}

--- a/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/strip_all_components_keeps_component_valued_attr_refs.js
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/strip_all_components_keeps_component_valued_attr_refs.js
@@ -1,0 +1,4 @@
+import { Layout } from './Layout.jsx';
+import { Hero } from './Hero.jsx';
+export const Page = ()=>null;
+typeof __ifrKeepComponentRefs === "function" && __ifrKeepComponentRefs(Layout, Hero);

--- a/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/strip_all_components_keeps_cross_module_component_refs.js
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/strip_all_components_keeps_cross_module_component_refs.js
@@ -1,0 +1,6 @@
+import { Feed } from './Feed.jsx';
+import { Header } from './Header.jsx';
+import * as UI from './ui.jsx';
+import { formatFeed } from './heavy-format.js';
+export function App() {}
+typeof __ifrKeepComponentRefs === "function" && __ifrKeepComponentRefs(Feed, UI, Header);

--- a/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/strip_keep_alive_survives_simplify_dce.js
+++ b/packages/react/transform/crates/swc_plugin_directive_dce/tests/__swc_snapshots__/lib.rs/strip_keep_alive_survives_simplify_dce.js
@@ -1,0 +1,3 @@
+import { Feed } from './Feed.jsx';
+export function App() {}
+typeof __ifrKeepComponentRefs === "function" && __ifrKeepComponentRefs(Feed);

--- a/packages/react/transform/index.d.ts
+++ b/packages/react/transform/index.d.ts
@@ -425,6 +425,15 @@ export interface DefineDceVisitorConfig {
 export interface DirectiveDceVisitorConfig {
   /** @internal */
   target: 'LEPUS' | 'JS' | 'MIXED'
+  /**
+   * When `true` on the `LEPUS` target, empties the render body of every
+   * component while keeping the module-scope snapshot and worklet
+   * definitions — the compile-time half of a root-level `<Background>`
+   * (0.0 first screen), so component render logic never reaches the
+   * main-thread bundle without per-component annotation.
+   * @internal
+   */
+  stripAllComponents?: boolean
 }
 export interface DynamicImportVisitorConfig {
   /** @internal */

--- a/packages/react/types/react.docs.d.ts
+++ b/packages/react/types/react.docs.d.ts
@@ -98,6 +98,17 @@ export const Children: ReactLynxChildren;
 export { createPortal } from '../runtime/lib/index.js';
 
 /**
+ * A first-screen boundary that opts its subtree out of the main-thread
+ * first-screen render (IFR, Instant First-Frame Rendering): the main thread
+ * renders `fallback` during the first screen, and the background thread
+ * replaces it with `children` when hydration completes.
+ *
+ * @public
+ */
+export { Background } from '../runtime/lib/index.js';
+export type { BackgroundProps } from '../runtime/lib/index.js';
+
+/**
  * RL-defined Lynx APIs
  */
 export * from '../runtime/lib/lynx-api.js';

--- a/packages/rspeedy/plugin-react/etc/react-rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-react/etc/react-rsbuild-plugin.api.md
@@ -80,7 +80,7 @@ export interface PluginReactLynxOptions {
     // @alpha
     experimental_isLazyBundle?: boolean;
     // @alpha
-    experimental_stripAllComponents?: boolean | undefined;
+    experimental_stripAllComponents?: boolean | 'auto' | undefined;
     experimental_useElementTemplate?: boolean;
     extractStr?: Partial<ExtractStrConfig> | boolean;
     firstScreenSyncTiming?: 'immediately' | 'jsReady' | 'manual';

--- a/packages/rspeedy/plugin-react/etc/react-rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-react/etc/react-rsbuild-plugin.api.md
@@ -79,6 +79,8 @@ export interface PluginReactLynxOptions {
     engineVersion?: string;
     // @alpha
     experimental_isLazyBundle?: boolean;
+    // @alpha
+    experimental_stripAllComponents?: boolean | undefined;
     experimental_useElementTemplate?: boolean;
     extractStr?: Partial<ExtractStrConfig> | boolean;
     firstScreenSyncTiming?: 'immediately' | 'jsReady' | 'manual';

--- a/packages/rspeedy/plugin-react/src/loaders.ts
+++ b/packages/rspeedy/plugin-react/src/loaders.ts
@@ -1,11 +1,14 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core'
+import path from 'node:path'
+
+import type { RsbuildPluginAPI, Rspack, RspackChain } from '@rsbuild/core'
 
 import { LAYERS, ReactWebpackPlugin } from '@lynx-js/react-webpack-plugin'
 
 import type { PluginReactLynxOptions } from './pluginReactLynx.js'
+import { resolveStripAllComponents } from './stripComponents.js'
 
 // The transforms an `es2019` SWC target lowers (ES2020+ syntax), expressed as
 // an explicit `env.include` so the main thread no longer relies on
@@ -32,6 +35,7 @@ function getLoaderOptions(
   api: RsbuildPluginAPI,
   options: Required<PluginReactLynxOptions>,
   isMainThread = false,
+  stripAllComponents = false,
 ) {
   const { output } = api.getRsbuildConfig()
 
@@ -68,9 +72,47 @@ function getLoaderOptions(
       ? {
         enableUiSourceMap,
         shake,
+        // The compile-time half of a root-level `<Background>`: only the
+        // main-thread (LEPUS) loader empties component render bodies.
+        stripAllComponents,
       }
       : {},
   }
+}
+
+/**
+ * Collect the source files an entry pulls in, so they can be scanned for a
+ * root-level `<Background>`. Paths are resolved against the project root so a
+ * relative entry (`./src/index.tsx`) is readable; bare specifiers and injected
+ * runtime entries survive resolution as non-existent paths, and
+ * {@link resolveStripAllComponents} skips whatever it cannot read.
+ */
+function collectEntryImports(
+  chain: RspackChain,
+  rootPath: string,
+): Set<string> {
+  const files = new Set<string>()
+  const add = (item: unknown) => {
+    if (typeof item === 'string') {
+      files.add(path.resolve(rootPath, item))
+    }
+  }
+  const entryPoints = chain.entryPoints.entries() ?? {}
+  for (const entryPoint of Object.values(entryPoints)) {
+    for (const value of entryPoint.values()) {
+      if (typeof value === 'string' || Array.isArray(value)) {
+        for (const item of Array.isArray(value) ? value : [value]) {
+          add(item)
+        }
+      } else if (value && typeof value === 'object' && 'import' in value) {
+        const imports = (value as { import?: string | string[] }).import
+        for (const item of Array.isArray(imports) ? imports : [imports]) {
+          add(item)
+        }
+      }
+    }
+  }
+  return files
 }
 
 const TESTING_RULE_NAME = 'react:testing'
@@ -96,6 +138,13 @@ export function applyLoaders(
   options: Required<PluginReactLynxOptions>,
 ): void {
   api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+    // A root-level `<Background>` (or the explicit `experimental_stripAllComponents`
+    // switch) turns on emptying every component body from the main-thread bundle.
+    const stripAllComponents = resolveStripAllComponents(
+      options.experimental_stripAllComponents,
+      collectEntryImports(chain, api.context.rootPath),
+    )
+
     const rule = chain.module.rule(CHAIN_ID.RULE.JS)
     const jsMainRule = rule.oneOf(CHAIN_ID.ONE_OF.JS_MAIN)
     const type = jsMainRule.get('type') as string | undefined
@@ -165,7 +214,7 @@ export function applyLoaders(
       })
       .use(LAYERS.MAIN_THREAD)
         .loader(ReactWebpackPlugin.loaders.MAIN_THREAD)
-        .options(getLoaderOptions(api, options, true))
+        .options(getLoaderOptions(api, options, true, stripAllComponents))
       .end()
   })
 }

--- a/packages/rspeedy/plugin-react/src/loaders.ts
+++ b/packages/rspeedy/plugin-react/src/loaders.ts
@@ -1,6 +1,7 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import fs from 'node:fs'
 import path from 'node:path'
 
 import type { RsbuildPluginAPI, Rspack, RspackChain } from '@rsbuild/core'
@@ -8,7 +9,10 @@ import type { RsbuildPluginAPI, Rspack, RspackChain } from '@rsbuild/core'
 import { LAYERS, ReactWebpackPlugin } from '@lynx-js/react-webpack-plugin'
 
 import type { PluginReactLynxOptions } from './pluginReactLynx.js'
-import { resolveStripAllComponents } from './stripComponents.js'
+import {
+  resolveStripAllComponents,
+  rootBackgroundFallbackHasUserComponent,
+} from './stripComponents.js'
 
 // The transforms an `es2019` SWC target lowers (ES2020+ syntax), expressed as
 // an explicit `env.include` so the main thread no longer relies on
@@ -138,12 +142,38 @@ export function applyLoaders(
   options: Required<PluginReactLynxOptions>,
 ): void {
   api.modifyBundlerChain((chain, { CHAIN_ID }) => {
-    // A root-level `<Background>` (or the explicit `experimental_stripAllComponents`
-    // switch) turns on emptying every component body from the main-thread bundle.
+    // The whole-program strip is an explicit opt-in: `'auto'` empties every
+    // component body when an entry declares a root-level `<Background>`,
+    // `true` forces it. By default (`false`/`undefined`) a root `<Background>`
+    // is the runtime-only 0.0 — the fallback renders, all code stays.
+    const entryImports = collectEntryImports(chain, api.context.rootPath)
     const stripAllComponents = resolveStripAllComponents(
       options.experimental_stripAllComponents,
-      collectEntryImports(chain, api.context.rootPath),
+      entryImports,
     )
+
+    // Guardrail: with every component body emptied from the main-thread
+    // bundle, a *user component* inside the root `<Background>`'s `fallback`
+    // renders nothing on the first screen. Warn when the entry source shows
+    // one (best-effort — the canonical inline-fallback shape).
+    if (stripAllComponents) {
+      for (const file of entryImports) {
+        let source: string
+        try {
+          source = fs.readFileSync(file, 'utf8')
+        } catch {
+          continue
+        }
+        if (rootBackgroundFallbackHasUserComponent(source)) {
+          ;(api.logger ?? console).warn(
+            `experimental_stripAllComponents: the root <Background> fallback in ${file} `
+              + `appears to contain a user component. Component bodies are emptied from the `
+              + `main-thread bundle, so it would render nothing on the first screen — compose `
+              + `the fallback from host elements (<view>, <text>, …) instead.`,
+          )
+        }
+      }
+    }
 
     const rule = chain.module.rule(CHAIN_ID.RULE.JS)
     const jsMainRule = rule.oneOf(CHAIN_ID.ONE_OF.JS_MAIN)

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -340,6 +340,32 @@ export interface PluginReactLynxOptions {
       mainThread?: boolean
       background?: boolean
     }
+
+  /**
+   * Empty the render body of every component in the main-thread (LEPUS)
+   * bundle, keeping only the snapshot and worklet definitions the first-screen
+   * hydration needs. This is the compile-time half of a root-level
+   * `<Background>` — a 0.0 first screen, where the whole first frame is the
+   * static `fallback` and no component render logic ever reaches the main
+   * thread.
+   *
+   * @remarks
+   * This is the low-level switch behind the `<Background>` user-space API.
+   * Leaving it `undefined` (the default) lets the plugin light it up
+   * automatically when it detects a root-level `<Background>` in an entry
+   * (`root.render(<Background …>…</Background>)`). Set it explicitly to
+   * `true`/`false` to force or forbid the optimization regardless of
+   * detection.
+   *
+   * Because component bodies are gone from the main thread, a root
+   * `<Background>`'s `fallback` must be composed of host elements (e.g.
+   * `<view>`/`<text>`) rather than user components.
+   *
+   * @defaultValue `undefined` (auto-detected from a root-level `<Background>`)
+   *
+   * @alpha
+   */
+  experimental_stripAllComponents?: boolean | undefined
 }
 
 /**
@@ -392,6 +418,8 @@ export function pluginReactLynx(
     experimental_useElementTemplate: false,
     optimizeBundleSize: false,
     enableUiSourceMap: false,
+    // `undefined` means "auto-detect from a root-level `<Background>`".
+    experimental_stripAllComponents: undefined,
   }
   const resolvedOptions = Object.assign(defaultOptions, userOptions, {
     // Use `engineVersion` to override the default values

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -350,22 +350,37 @@ export interface PluginReactLynxOptions {
    * thread.
    *
    * @remarks
-   * This is the low-level switch behind the `<Background>` user-space API.
-   * Leaving it `undefined` (the default) lets the plugin light it up
-   * automatically when it detects a root-level `<Background>` in an entry
-   * (`root.render(<Background …>…</Background>)`). Set it explicitly to
-   * `true`/`false` to force or forbid the optimization regardless of
-   * detection.
+   * This is the low-level switch behind the `<Background>` user-space API,
+   * and it is **off by default**: a root-level `<Background>` alone already
+   * yields a 0.0 first screen at *runtime* (only the `fallback` renders),
+   * with every module kept in the main-thread bundle — always safe. Removing
+   * deferred *code* from the main thread composes per-subtree with the
+   * `'background only'` directive (the L3 path), which needs no whole-program
+   * switch.
+   *
+   * - `'auto'` — strip when a root-level `<Background>`
+   *   (`root.render(<Background …>…</Background>)`) is detected in an entry.
+   * - `true` — force the strip regardless of detection (e.g. an entry shape
+   *   the detection cannot see).
+   * - `false` / `undefined` (default) — never strip.
+   *
+   * When a body is emptied, the component references it rendered are kept
+   * alive (an inert module-level statement), so the child modules — and the
+   * snapshot/worklet definitions hydration needs — stay in the main-thread
+   * bundle even across modules. Component references the strip cannot see
+   * (e.g. a component resolved through a runtime value) still shake out —
+   * prefer the `'background only'` composition for such trees.
    *
    * Because component bodies are gone from the main thread, a root
    * `<Background>`'s `fallback` must be composed of host elements (e.g.
-   * `<view>`/`<text>`) rather than user components.
+   * `<view>`/`<text>`) rather than user components; the build warns when it
+   * can see a user component in the fallback.
    *
-   * @defaultValue `undefined` (auto-detected from a root-level `<Background>`)
+   * @defaultValue `false`
    *
    * @alpha
    */
-  experimental_stripAllComponents?: boolean | undefined
+  experimental_stripAllComponents?: boolean | 'auto' | undefined
 }
 
 /**
@@ -418,8 +433,10 @@ export function pluginReactLynx(
     experimental_useElementTemplate: false,
     optimizeBundleSize: false,
     enableUiSourceMap: false,
-    // `undefined` means "auto-detect from a root-level `<Background>`".
-    experimental_stripAllComponents: undefined,
+    // Off by default: a root `<Background>` alone is the (always safe)
+    // runtime 0.0; the whole-program strip is an explicit opt-in
+    // (`'auto'` = root-`<Background>`-detected, `true` = forced).
+    experimental_stripAllComponents: false,
   }
   const resolvedOptions = Object.assign(defaultOptions, userOptions, {
     // Use `engineVersion` to override the default values

--- a/packages/rspeedy/plugin-react/src/stripComponents.ts
+++ b/packages/rspeedy/plugin-react/src/stripComponents.ts
@@ -1,0 +1,77 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import fs from 'node:fs'
+
+/**
+ * A root-level `<Background>` — `root.render(<Background …>…</Background>)` —
+ * declares a 0.0 first screen: the whole app's first frame is the static
+ * `fallback`, so no component render logic should reach the main thread. That
+ * is exactly the condition under which emptying every component body from the
+ * main-thread (LEPUS) bundle is safe.
+ *
+ * We can decide this at compile time by scanning the entry sources: a
+ * `<Background>` (imported from `@lynx-js/react`) sitting directly in a
+ * `.render(...)` call is the signal. A `<Background>` nested *inside* the app
+ * (a partial opt-out) never appears in the entry's `.render(...)`, so it is
+ * correctly ignored here.
+ *
+ * @internal
+ */
+
+// A named import of `Background` from `@lynx-js/react` (or a subpath such as
+// `@lynx-js/react/internal`), scoped to a *single* import statement: `[^}]*`
+// keeps the match inside one `{ … }` (it may span lines), and only whitespace
+// is allowed between `}` and `from`, so a `Background` imported from another
+// module never binds to a separate `@lynx-js/react` import.
+const BACKGROUND_IMPORT_RE =
+  /import[^{}]*\{[^}]*\bBackground\b[^}]*\}\s*from\s*['"]@lynx-js\/react(?:\/[^'"]*)?['"]/
+
+// `<Background>` sitting directly inside a `.render(` call (`root.render(...)`,
+// `createRoot().render(...)`, …). `\s*` spans the whitespace/newlines a
+// formatter inserts between `.render(` and the opening tag.
+const ROOT_BACKGROUND_RENDER_RE = /\.render\(\s*<Background[\s/>]/
+
+/**
+ * Whether a single entry's source declares a root-level `<Background>`.
+ *
+ * @internal
+ */
+export function sourceHasRootBackground(source: string): boolean {
+  return BACKGROUND_IMPORT_RE.test(source)
+    && ROOT_BACKGROUND_RENDER_RE.test(source)
+}
+
+/**
+ * Resolve whether the main thread should strip every component render body.
+ *
+ * An explicit `experimental_stripAllComponents` (the internal switch) always
+ * wins. When it is `undefined`, we auto-detect a root-level `<Background>` by
+ * reading the given entry files — unreadable paths (bare specifiers, injected
+ * runtime entries) are skipped.
+ *
+ * @internal
+ */
+export function resolveStripAllComponents(
+  explicit: boolean | undefined,
+  entryFiles: Iterable<string>,
+): boolean {
+  if (explicit !== undefined) {
+    return explicit
+  }
+
+  for (const file of entryFiles) {
+    let source: string
+    try {
+      source = fs.readFileSync(file, 'utf8')
+    } catch {
+      // Not a readable local file (e.g. a bare specifier or a virtual entry).
+      continue
+    }
+    if (sourceHasRootBackground(source)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/packages/rspeedy/plugin-react/src/stripComponents.ts
+++ b/packages/rspeedy/plugin-react/src/stripComponents.ts
@@ -6,15 +6,16 @@ import fs from 'node:fs'
 /**
  * A root-level `<Background>` — `root.render(<Background …>…</Background>)` —
  * declares a 0.0 first screen: the whole app's first frame is the static
- * `fallback`, so no component render logic should reach the main thread. That
- * is exactly the condition under which emptying every component body from the
+ * `fallback`, so no component render logic needs to *run* on the main thread.
+ * That is the condition under which emptying every component body from the
  * main-thread (LEPUS) bundle is safe.
  *
- * We can decide this at compile time by scanning the entry sources: a
- * `<Background>` (imported from `@lynx-js/react`) sitting directly in a
- * `.render(...)` call is the signal. A `<Background>` nested *inside* the app
- * (a partial opt-out) never appears in the entry's `.render(...)`, so it is
- * correctly ignored here.
+ * The runtime half of that declaration is always on — the boundary renders
+ * the `fallback` on the main thread with no build support. The compile-time
+ * half (the whole-program strip) is an *opt-in*: `'auto'` lights it up when a
+ * root-level `<Background>` is detected in the entry sources, `true` forces
+ * it. A `<Background>` nested *inside* the app (a partial opt-out) never
+ * appears in the entry's `.render(...)`, so detection correctly ignores it.
  *
  * @internal
  */
@@ -45,19 +46,26 @@ export function sourceHasRootBackground(source: string): boolean {
 /**
  * Resolve whether the main thread should strip every component render body.
  *
- * An explicit `experimental_stripAllComponents` (the internal switch) always
- * wins. When it is `undefined`, we auto-detect a root-level `<Background>` by
- * reading the given entry files — unreadable paths (bare specifiers, injected
- * runtime entries) are skipped.
+ * - `true` — force the strip (the internal switch; e.g. for an entry shape
+ *   the detection cannot see).
+ * - `'auto'` — strip when an entry declares a root-level `<Background>`,
+ *   detected by reading the given entry files. Unreadable paths (bare
+ *   specifiers, injected runtime entries) are skipped.
+ * - `false` / `undefined` (the default) — never strip. A root-level
+ *   `<Background>` still yields a 0.0 first screen at runtime (the fallback
+ *   is all that renders); every module stays in the main-thread bundle.
  *
  * @internal
  */
 export function resolveStripAllComponents(
-  explicit: boolean | undefined,
+  explicit: boolean | 'auto' | undefined,
   entryFiles: Iterable<string>,
 ): boolean {
-  if (explicit !== undefined) {
-    return explicit
+  if (explicit === true) {
+    return true
+  }
+  if (explicit !== 'auto') {
+    return false
   }
 
   for (const file of entryFiles) {
@@ -74,4 +82,81 @@ export function resolveStripAllComponents(
   }
 
   return false
+}
+
+/**
+ * Best-effort extraction of the root `<Background>`'s `fallback={…}` attribute
+ * value from an entry source: find the `<Background` that sits in a
+ * `.render(...)` call, then the `fallback` attribute inside that tag (scanning
+ * with brace balance, since the value may nest JSX with its own braces).
+ *
+ * Returns `undefined` when there is no root `<Background>` or no inline
+ * `fallback` attribute to inspect (e.g. `fallback={fallbackFromElsewhere}` is
+ * still inspected, but yields no element to flag).
+ */
+function extractRootBackgroundFallback(source: string): string | undefined {
+  const render = ROOT_BACKGROUND_RENDER_RE.exec(source)
+  if (!render) {
+    return undefined
+  }
+  const tagStart = source.indexOf('<Background', render.index)
+  if (tagStart === -1) {
+    return undefined
+  }
+
+  // The opening tag ends at the first `>` at brace depth 0 (a `>` inside a
+  // `fallback={<view/>}` value sits at depth ≥ 1).
+  let tagEnd = source.length
+  let depth = 0
+  for (let i = tagStart; i < source.length; i++) {
+    const ch = source[i]
+    if (ch === '{') depth++
+    else if (ch === '}') depth--
+    else if (ch === '>' && depth === 0) {
+      tagEnd = i
+      break
+    }
+  }
+
+  const fallbackIdx = source.slice(tagStart, tagEnd).search(/\bfallback\s*=/)
+  if (fallbackIdx === -1) {
+    return undefined
+  }
+  const braceStart = source.indexOf('{', tagStart + fallbackIdx)
+  if (braceStart === -1 || braceStart >= tagEnd) {
+    return undefined
+  }
+  depth = 0
+  for (let i = braceStart; i < source.length; i++) {
+    const ch = source[i]
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) {
+        return source.slice(braceStart + 1, i)
+      }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Guardrail for the strip: a root `<Background>`'s `fallback` is what the 0.0
+ * first screen renders, and with every component body emptied from the
+ * main-thread bundle a *user component* in that fallback would silently render
+ * nothing. Flags a capitalized JSX tag in the fallback so the build can warn.
+ *
+ * Best-effort by design (regex + brace scan, not a parse): it flags the
+ * canonical inline-fallback shape and stays silent on anything it cannot see.
+ *
+ * @internal
+ */
+export function rootBackgroundFallbackHasUserComponent(
+  source: string,
+): boolean {
+  const fallback = extractRootBackgroundFallback(source)
+  if (fallback === undefined) {
+    return false
+  }
+  return /<\s*[A-Z]/.test(fallback)
 }

--- a/packages/rspeedy/plugin-react/test/fixtures/strip-detect/nested-background.jsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/strip-detect/nested-background.jsx
@@ -1,0 +1,16 @@
+import { Background, root } from '@lynx-js/react'
+
+// `<Background>` is used, but NOT at the render root — it is a partial opt-out
+// nested inside the app. The whole-program strip must NOT be auto-detected here.
+function App() {
+  return (
+    <view>
+      <text>Header renders on the first screen</text>
+      <Background fallback={<text>Loading…</text>}>
+        <Feed />
+      </Background>
+    </view>
+  )
+}
+
+root.render(<App />)

--- a/packages/rspeedy/plugin-react/test/fixtures/strip-detect/no-background.jsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/strip-detect/no-background.jsx
@@ -1,0 +1,5 @@
+import { root } from '@lynx-js/react'
+
+import { App } from './App.jsx'
+
+root.render(<App />)

--- a/packages/rspeedy/plugin-react/test/fixtures/strip-detect/root-background.jsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/strip-detect/root-background.jsx
@@ -1,0 +1,15 @@
+import { Background, root } from '@lynx-js/react'
+
+import { App } from './App.jsx'
+
+root.render(
+  <Background
+    fallback={
+      <view>
+        <text>Loading…</text>
+      </view>
+    }
+  >
+    <App />
+  </Background>,
+)

--- a/packages/rspeedy/plugin-react/test/stripComponents.test.ts
+++ b/packages/rspeedy/plugin-react/test/stripComponents.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from '@rstest/core'
 
 import {
   resolveStripAllComponents,
+  rootBackgroundFallbackHasUserComponent,
   sourceHasRootBackground,
 } from '../src/stripComponents.js'
 
@@ -86,39 +87,101 @@ describe('resolveStripAllComponents', () => {
       .toBe(false)
   })
 
-  test('auto-detects a root <Background> from the entry files', () => {
+  test('the default (`undefined`) never strips — a root <Background> alone is the runtime 0.0', () => {
     expect(
       resolveStripAllComponents(undefined, [fixture('root-background.jsx')]),
+    ).toBe(false)
+  })
+
+  test('\'auto\' detects a root <Background> from the entry files', () => {
+    expect(
+      resolveStripAllComponents('auto', [fixture('root-background.jsx')]),
     )
       .toBe(true)
   })
 
-  test('does not auto-detect a nested <Background>', () => {
+  test('\'auto\' does not detect a nested <Background>', () => {
     expect(
-      resolveStripAllComponents(undefined, [fixture('nested-background.jsx')]),
+      resolveStripAllComponents('auto', [fixture('nested-background.jsx')]),
     ).toBe(false)
   })
 
-  test('does not auto-detect a plain entry', () => {
-    expect(resolveStripAllComponents(undefined, [fixture('no-background.jsx')]))
+  test('\'auto\' does not detect a plain entry', () => {
+    expect(resolveStripAllComponents('auto', [fixture('no-background.jsx')]))
       .toBe(false)
   })
 
-  test('skips unreadable paths (bare specifiers, virtual entries)', () => {
+  test('\'auto\' skips unreadable paths (bare specifiers, virtual entries)', () => {
     expect(
-      resolveStripAllComponents(undefined, [
+      resolveStripAllComponents('auto', [
         '@lynx-js/react/refresh',
         fixture('root-background.jsx'),
       ]),
     ).toBe(true)
   })
 
-  test('returns false when no entry file declares a root <Background>', () => {
+  test('\'auto\' returns false when no entry file declares a root <Background>', () => {
     expect(
-      resolveStripAllComponents(undefined, [
+      resolveStripAllComponents('auto', [
         fixture('no-background.jsx'),
         fixture('nested-background.jsx'),
       ]),
     ).toBe(false)
+  })
+})
+
+describe('rootBackgroundFallbackHasUserComponent', () => {
+  test('flags a user component in the root <Background> fallback', () => {
+    expect(rootBackgroundFallbackHasUserComponent(`
+      import { Background, root } from '@lynx-js/react'
+      root.render(
+        <Background fallback={<Spinner />}>
+          <App/>
+        </Background>,
+      )
+    `)).toBe(true)
+  })
+
+  test('flags a user component nested under host elements in the fallback', () => {
+    expect(rootBackgroundFallbackHasUserComponent(`
+      import { Background, root } from '@lynx-js/react'
+      root.render(
+        <Background fallback={<view><text>Loading</text><Brand.Logo/></view>}>
+          <App/>
+        </Background>,
+      )
+    `)).toBe(true)
+  })
+
+  test('accepts a host-element-only fallback', () => {
+    expect(rootBackgroundFallbackHasUserComponent(`
+      import { Background, root } from '@lynx-js/react'
+      root.render(
+        <Background fallback={<view><text>Loading…</text></view>}>
+          <App/>
+        </Background>,
+      )
+    `)).toBe(false)
+  })
+
+  test('stays silent without a root <Background>', () => {
+    expect(rootBackgroundFallbackHasUserComponent(`
+      import { root } from '@lynx-js/react'
+      root.render(<App/>)
+    `)).toBe(false)
+  })
+
+  test('stays silent without an inline fallback element', () => {
+    expect(rootBackgroundFallbackHasUserComponent(`
+      import { Background, root } from '@lynx-js/react'
+      root.render(<Background fallback={fallbackFromElsewhere}><App/></Background>)
+    `)).toBe(false)
+  })
+
+  test('does not read a later fallback attribute as the root one', () => {
+    expect(rootBackgroundFallbackHasUserComponent(`
+      import { Background, root } from '@lynx-js/react'
+      root.render(<Background><App fallback={<Spinner/>}/></Background>)
+    `)).toBe(false)
   })
 })

--- a/packages/rspeedy/plugin-react/test/stripComponents.test.ts
+++ b/packages/rspeedy/plugin-react/test/stripComponents.test.ts
@@ -1,0 +1,124 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, test } from '@rstest/core'
+
+import {
+  resolveStripAllComponents,
+  sourceHasRootBackground,
+} from '../src/stripComponents.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const fixture = (name: string) =>
+  path.resolve(__dirname, 'fixtures/strip-detect', name)
+
+describe('sourceHasRootBackground', () => {
+  test('detects a root-level <Background> in render position', () => {
+    expect(sourceHasRootBackground(`
+      import { Background, root } from '@lynx-js/react'
+      root.render(<Background fallback={<view/>}><App/></Background>)
+    `)).toBe(true)
+  })
+
+  test('detects it across multiple lines', () => {
+    expect(sourceHasRootBackground(`
+      import { Background, root } from '@lynx-js/react'
+      root.render(
+        <Background fallback={<view><text>Loading…</text></view>}>
+          <App/>
+        </Background>,
+      )
+    `)).toBe(true)
+  })
+
+  test('detects a subpath import of Background', () => {
+    expect(sourceHasRootBackground(`
+      import { root } from '@lynx-js/react'
+      import { Background } from '@lynx-js/react/internal'
+      root.render(<Background fallback={<view/>}><App/></Background>)
+    `)).toBe(true)
+  })
+
+  test('detects a self-closing root <Background/>', () => {
+    expect(sourceHasRootBackground(`
+      import { Background, root } from '@lynx-js/react'
+      root.render(<Background fallback={<view/>}/>)
+    `)).toBe(true)
+  })
+
+  test('ignores a <Background> nested inside the app (a partial opt-out)', () => {
+    expect(sourceHasRootBackground(`
+      import { Background, root } from '@lynx-js/react'
+      function App() {
+        return <view><Background fallback={<text/>}><Feed/></Background></view>
+      }
+      root.render(<App/>)
+    `)).toBe(false)
+  })
+
+  test('ignores a <Background> not imported from @lynx-js/react', () => {
+    expect(sourceHasRootBackground(`
+      import { Background } from './my-background.js'
+      import { root } from '@lynx-js/react'
+      root.render(<Background><App/></Background>)
+    `)).toBe(false)
+  })
+
+  test('ignores a plain root.render(<App/>)', () => {
+    expect(sourceHasRootBackground(`
+      import { root } from '@lynx-js/react'
+      root.render(<App/>)
+    `)).toBe(false)
+  })
+})
+
+describe('resolveStripAllComponents', () => {
+  test('an explicit `true` wins, without reading any file', () => {
+    expect(resolveStripAllComponents(true, [fixture('no-background.jsx')]))
+      .toBe(true)
+  })
+
+  test('an explicit `false` wins even when a root <Background> exists', () => {
+    expect(resolveStripAllComponents(false, [fixture('root-background.jsx')]))
+      .toBe(false)
+  })
+
+  test('auto-detects a root <Background> from the entry files', () => {
+    expect(
+      resolveStripAllComponents(undefined, [fixture('root-background.jsx')]),
+    )
+      .toBe(true)
+  })
+
+  test('does not auto-detect a nested <Background>', () => {
+    expect(
+      resolveStripAllComponents(undefined, [fixture('nested-background.jsx')]),
+    ).toBe(false)
+  })
+
+  test('does not auto-detect a plain entry', () => {
+    expect(resolveStripAllComponents(undefined, [fixture('no-background.jsx')]))
+      .toBe(false)
+  })
+
+  test('skips unreadable paths (bare specifiers, virtual entries)', () => {
+    expect(
+      resolveStripAllComponents(undefined, [
+        '@lynx-js/react/refresh',
+        fixture('root-background.jsx'),
+      ]),
+    ).toBe(true)
+  })
+
+  test('returns false when no entry file declares a root <Background>', () => {
+    expect(
+      resolveStripAllComponents(undefined, [
+        fixture('no-background.jsx'),
+        fixture('nested-background.jsx'),
+      ]),
+    ).toBe(false)
+  })
+})

--- a/packages/webpack/react-webpack-plugin/src/loaders/options.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/options.ts
@@ -102,6 +102,17 @@ export interface ReactLoaderOptions {
    * @experimental
    */
   experimental_useElementTemplate?: boolean | undefined;
+
+  /**
+   * Empty the render body of every component from the main-thread (LEPUS)
+   * bundle, keeping only the snapshot and worklet definitions the first-screen
+   * hydration needs. This is the compile-time half of a root-level
+   * `<Background>` (a 0.0 first screen): no component render logic reaches the
+   * main thread, with no per-component annotation.
+   *
+   * @internal
+   */
+  stripAllComponents?: boolean | undefined;
 }
 
 function normalizeSlashes(file: string) {
@@ -324,6 +335,7 @@ export function getMainThreadTransformOptions(
     },
     directiveDCE: {
       target: 'LEPUS',
+      stripAllComponents: this.getOptions().stripAllComponents ?? false,
     },
   };
 }

--- a/packages/webpack/react-webpack-plugin/test/background-bundling.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/background-bundling.test.ts
@@ -1,0 +1,123 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * L3 completeness proof: a `<Background>` boundary whose deferred subtree is a
+ * cross-module component authored with the `'background only'` directive.
+ *
+ * The main-thread (LEPUS) bundle must:
+ * - NOT contain the subtree's render logic or its logic-only imports (so no
+ *   side-effect can leak onto the main thread), and
+ * - still contain the subtree's element (snapshot) and main-thread-script
+ *   (worklet) definitions, which the first-screen hydration needs to build the
+ *   real content on the main thread.
+ *
+ * This is the "strip render logic, keep snapshot + MTS" guarantee, verified
+ * cross-module against the real bundle (not just the transform output).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { rspack } from '@rspack/core';
+import type { Compilation, Compiler, RspackOptions } from '@rspack/core';
+import { beforeAll, describe, expect, it } from '@rstest/core';
+
+// @ts-expect-error – JS helper has no type declarations
+import { createConfig as rawCreateConfig, createEntries as rawCreateEntries } from './create-react-config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+type CreateConfig = (
+  loaderOptions?: unknown,
+  pluginOptions?: { mainThreadChunks?: string[] },
+) => RspackOptions;
+type CreateEntries = (name?: string, source?: string) => RspackOptions['entry'];
+
+const createConfig = rawCreateConfig as unknown as CreateConfig;
+const createEntries = rawCreateEntries as unknown as CreateEntries;
+
+async function buildAndCapture(): Promise<Map<string, string>> {
+  const base = createConfig(undefined, {
+    mainThreadChunks: ['main__main-thread.js'],
+  });
+  const captured = new Map<string, string>();
+  const config: RspackOptions = {
+    ...base,
+    mode: 'production',
+    context: path.resolve(__dirname, 'fixtures/background-bundling'),
+    entry: createEntries('main', './index.jsx'),
+    output: { filename: '[name].js' },
+    optimization: { ...base.optimization, minimize: false },
+    plugins: [
+      ...(base.plugins ?? []),
+      {
+        apply(compiler: Compiler) {
+          compiler.hooks.compilation.tap('CapturePlugin', (compilation: Compilation) => {
+            compilation.hooks.processAssets.tap(
+              {
+                name: 'CapturePlugin',
+                stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+              },
+              (assets) => {
+                for (const name of Object.keys(assets)) {
+                  if (name.endsWith('.js')) {
+                    captured.set(name, assets[name]!.source().toString());
+                  }
+                }
+              },
+            );
+          });
+        },
+      },
+    ],
+  };
+
+  const compiler = rspack(config);
+  await new Promise<void>((resolve, reject) => {
+    compiler.run((err, stats) => {
+      const runErr = err ?? (stats?.hasErrors() ? new Error(stats.toString()) : undefined);
+      compiler.close(closeErr => {
+        if (runErr ?? closeErr) reject(runErr ?? closeErr!);
+        else resolve();
+      });
+    });
+  });
+  return captured;
+}
+
+describe('<Background> bundling separation (L3)', () => {
+  let mainThread: string;
+  let background: string;
+
+  beforeAll(async () => {
+    const assets = await buildAndCapture();
+    mainThread = assets.get('main__main-thread.js') ?? '';
+    background = assets.get('main__background.js') ?? '';
+    expect(mainThread).not.toBe('');
+    expect(background).not.toBe('');
+  });
+
+  it('strips the deferred subtree render logic from the main-thread bundle', () => {
+    expect(mainThread).not.toContain('FEED_RENDER_LOGIC_MARKER');
+  });
+
+  it('strips the deferred subtree logic-only imports from the main-thread bundle', () => {
+    expect(mainThread).not.toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+
+  it('keeps the deferred subtree element (snapshot) definitions in the main-thread bundle', () => {
+    // The scroll-view element factory must remain so hydration can build it.
+    expect(mainThread).toContain('__CreateScrollView');
+  });
+
+  it('keeps the deferred subtree main-thread-script (worklet) in the main-thread bundle', () => {
+    expect(mainThread).toContain('registerWorkletInternal("main-thread"');
+    expect(mainThread).toContain('SCROLL_WORKLET_MARKER');
+  });
+
+  it('leaves the deferred subtree fully intact on the background bundle', () => {
+    expect(background).toContain('FEED_RENDER_LOGIC_MARKER');
+    expect(background).toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+});

--- a/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/Feed.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/Feed.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from '@lynx-js/react';
+
+import { formatFeed } from './heavy-format.js';
+
+// Definition-site opt-out: this component's render never runs on the main
+// thread, so its body is stripped from the main-thread (LEPUS) bundle while
+// its element/worklet definitions (hoisted to module scope before the strip)
+// are retained for hydration.
+export function Feed() {
+  'background only';
+  const [items] = useState(() => formatFeed(1, 2, 3));
+  useEffect(() => {
+    console.log('FEED_RENDER_LOGIC_MARKER mounted');
+  }, []);
+  const onTap = () => {
+    console.log('FEED_RENDER_LOGIC_MARKER tap');
+  };
+  const onScroll = (event) => {
+    'main thread';
+    console.log('SCROLL_WORKLET_MARKER', event.detail.scrollTop);
+  };
+  return (
+    <scroll-view bindtap={onTap} main-thread:bindscroll={onScroll}>
+      {items.map((it) => <text key={it.id}>{it.label}</text>)}
+    </scroll-view>
+  );
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/heavy-format.js
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/heavy-format.js
@@ -1,0 +1,6 @@
+// Logic-only module. Must NOT appear in the main-thread bundle when its only
+// consumer is a background-rendered subtree.
+export function formatFeed(a, b, c) {
+  const HEAVY_LOGIC_MARKER = 'HEAVY_FORMAT_LOGIC_ONLY_MARKER';
+  return [a, b, c].map((n, i) => ({ id: i, label: `${HEAVY_LOGIC_MARKER}:${n}` }));
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/background-bundling/index.jsx
@@ -1,0 +1,16 @@
+import { Background, root } from '@lynx-js/react';
+
+import { Feed } from './Feed.jsx';
+
+export function App() {
+  return (
+    <view>
+      <text>Header renders on the first screen (IFR)</text>
+      <Background fallback={<text>Loading…</text>}>
+        <Feed />
+      </Background>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/webpack/react-webpack-plugin/test/fixtures/strip-all-components/App.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/strip-all-components/App.jsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from '@lynx-js/react';
+
+import { formatFeed } from './heavy-format.js';
+
+// A plain component — NO `'background only'` annotation. Under the root-level
+// `<Background>` (0.0) whole-program strip, its render body is emptied from the
+// main-thread (LEPUS) bundle, while the element (snapshot) and main-thread
+// script (worklet) definitions hoisted to module scope survive for hydration.
+export function App() {
+  const [items] = useState(() => formatFeed(1, 2, 3));
+  // A computed value bound dynamically (not a static child, so it is NOT hoisted
+  // into the snapshot): it lives in the render body and vanishes when the body
+  // is emptied.
+  const title = `APP_BODY_LOGIC_MARKER-${items.length}`;
+  useEffect(() => {
+    console.info('APP_EFFECT_MARKER mounted');
+  }, []);
+  const onTap = () => {
+    console.info('APP_EVENT_MARKER tap');
+  };
+  const onScroll = (event) => {
+    'main thread';
+    console.info('SCROLL_WORKLET_MARKER', event.detail.scrollTop);
+  };
+  return (
+    <scroll-view bindtap={onTap} main-thread:bindscroll={onScroll}>
+      <text>{title}</text>
+      {items.map((it) => <text key={it.id}>{it.label}</text>)}
+    </scroll-view>
+  );
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/strip-all-components/heavy-format.js
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/strip-all-components/heavy-format.js
@@ -1,0 +1,10 @@
+// Logic-only module, reachable only from a component render body. Once every
+// component body is emptied from the main-thread bundle, its only consumer is
+// gone, so it must be shaken out of the main thread entirely.
+export function formatFeed(a, b, c) {
+  const HEAVY_LOGIC_MARKER = 'HEAVY_FORMAT_LOGIC_ONLY_MARKER';
+  return [a, b, c].map((n, i) => ({
+    id: i,
+    label: `${HEAVY_LOGIC_MARKER}:${n}`,
+  }));
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/strip-all-components/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/strip-all-components/index.jsx
@@ -1,0 +1,19 @@
+import { Background, root } from '@lynx-js/react';
+
+import { App } from './App.jsx';
+
+// A root-level `<Background>` declares a 0.0 first screen: the whole first
+// frame is the static `fallback`, and NOTHING renders on the main thread. The
+// fallback is composed of host elements only (no user components), because the
+// strip empties every component body from the main-thread bundle.
+root.render(
+  <Background
+    fallback={
+      <view>
+        <text>LOADING_FALLBACK_MARKER</text>
+      </view>
+    }
+  >
+    <App />
+  </Background>,
+);

--- a/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/App.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/App.jsx
@@ -1,0 +1,18 @@
+import { Feed } from './Feed.jsx';
+import * as UI from './ui.jsx';
+
+// A structural component with NO annotations: it only composes children from
+// other modules. The strip empties its body, and the component references the
+// body held (`Feed`, `UI`) are handed to the module-level keep-alive — that is
+// what pins './Feed.jsx' and './ui.jsx' (and their hoisted definitions) into
+// the main-thread bundle.
+export function App() {
+  const title = `APP_BODY_LOGIC_MARKER`;
+  return (
+    <view>
+      <text>{title}</text>
+      <UI.Card />
+      <Feed />
+    </view>
+  );
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/Feed.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/Feed.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from '@lynx-js/react';
+
+import { formatFeed } from './heavy-format.js';
+
+// A heavy leaf component in its own module, with NO 'background only'
+// annotation. Under the whole-program strip its render body is emptied from
+// the main-thread bundle, but the element (snapshot) and main-thread-script
+// (worklet) definitions hoisted to this module's scope must survive for
+// first-screen hydration — which they can only do if the module itself stays
+// referenced after the parent's body is emptied.
+export function Feed() {
+  const [items] = useState(() => formatFeed(1, 2, 3));
+  const title = `FEED_BODY_LOGIC_MARKER-${items.length}`;
+  useEffect(() => {
+    console.info('FEED_EFFECT_MARKER mounted');
+  }, []);
+  const onScroll = (event) => {
+    'main thread';
+    console.info('SCROLL_WORKLET_MARKER', event.detail.scrollTop);
+  };
+  return (
+    <scroll-view main-thread:bindscroll={onScroll}>
+      <text>FEED_SNAPSHOT_STATIC_MARKER</text>
+      <text>{title}</text>
+      {items.map((it) => <text key={it.id}>{it.label}</text>)}
+    </scroll-view>
+  );
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/heavy-format.js
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/heavy-format.js
@@ -1,0 +1,10 @@
+// Logic-only module, reachable only from a component render body. Emptying the
+// bodies must still shake it out of the main-thread bundle — the keep-alive
+// carries *component* references only, never call targets like this one.
+export function formatFeed(a, b, c) {
+  const HEAVY_LOGIC_MARKER = 'HEAVY_FORMAT_LOGIC_ONLY_MARKER';
+  return [a, b, c].map((n, i) => ({
+    id: i,
+    label: `${HEAVY_LOGIC_MARKER}:${n}`,
+  }));
+}

--- a/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/index.jsx
@@ -1,0 +1,20 @@
+import { Background, root } from '@lynx-js/react';
+
+import { App } from './App.jsx';
+
+// A root-level <Background> (0.0 first screen) over an App that DELEGATES to
+// components living in other modules — the realistic multi-module shape a
+// whole-program strip must keep hydratable. Emptying App's body must not
+// sever its references to <Feed/> / <UI.Card/>: those modules carry the
+// snapshot/worklet definitions the main thread builds the real tree from.
+root.render(
+  <Background
+    fallback={
+      <view>
+        <text>LOADING_FALLBACK_MARKER</text>
+      </view>
+    }
+  >
+    <App />
+  </Background>,
+);

--- a/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/ui.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/strip-multi-module/ui.jsx
@@ -1,0 +1,12 @@
+// A namespace-imported module (`import * as UI from './ui.jsx'`), rendered as
+// a member-expression component (`<UI.Card/>`): the keep-alive must pin the
+// namespace root so this module's snapshot definitions survive the strip.
+export function Card() {
+  const label = `UI_CARD_BODY_LOGIC_MARKER`;
+  return (
+    <view>
+      <text>UI_CARD_SNAPSHOT_STATIC_MARKER</text>
+      <text>{label}</text>
+    </view>
+  );
+}

--- a/packages/webpack/react-webpack-plugin/test/strip-all-components.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/strip-all-components.test.ts
@@ -1,0 +1,156 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * L4 completeness proof: a root-level `<Background>` (a 0.0 first screen) with
+ * ZERO per-component annotations, driven purely by the `stripAllComponents`
+ * loader option — the compile-time half of the whole-program optimization.
+ *
+ * With the strip active, the main-thread (LEPUS) bundle must:
+ * - NOT contain ANY component's render logic (no `'background only'` markers
+ *   were used — the strip empties every component body), nor the logic-only
+ *   imports that only render bodies reached, and
+ * - still contain the element (snapshot) and main-thread-script (worklet)
+ *   definitions — hoisted to module scope before the strip — so first-screen
+ *   hydration can build the real content on the main thread, and
+ * - still contain the static host-element `fallback`, which is what the main
+ *   thread actually renders for the 0.0 first screen.
+ *
+ * A control build WITHOUT the option proves the render logic is only absent
+ * because of the strip, not because it was never bundled.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { rspack } from '@rspack/core';
+import type { Compilation, Compiler, RspackOptions } from '@rspack/core';
+import { beforeAll, describe, expect, it } from '@rstest/core';
+
+// @ts-expect-error – JS helper has no type declarations
+import {
+  createConfig as rawCreateConfig,
+  createEntries as rawCreateEntries,
+} from './create-react-config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+type CreateConfig = (
+  loaderOptions?: unknown,
+  pluginOptions?: { mainThreadChunks?: string[] },
+) => RspackOptions;
+type CreateEntries = (name?: string, source?: string) => RspackOptions['entry'];
+
+const createConfig = rawCreateConfig as unknown as CreateConfig;
+const createEntries = rawCreateEntries as unknown as CreateEntries;
+
+async function buildAndCapture(
+  loaderOptions: unknown,
+): Promise<Map<string, string>> {
+  const base = createConfig(loaderOptions, {
+    mainThreadChunks: ['main__main-thread.js'],
+  });
+  const captured = new Map<string, string>();
+  const config: RspackOptions = {
+    ...base,
+    mode: 'production',
+    context: path.resolve(__dirname, 'fixtures/strip-all-components'),
+    entry: createEntries('main', './index.jsx'),
+    output: { filename: '[name].js' },
+    optimization: { ...base.optimization, minimize: false },
+    plugins: [
+      ...(base.plugins ?? []),
+      {
+        apply(compiler: Compiler) {
+          compiler.hooks.compilation.tap(
+            'CapturePlugin',
+            (compilation: Compilation) => {
+              compilation.hooks.processAssets.tap(
+                {
+                  name: 'CapturePlugin',
+                  stage:
+                    compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+                },
+                (assets) => {
+                  for (const name of Object.keys(assets)) {
+                    if (name.endsWith('.js')) {
+                      captured.set(name, assets[name]!.source().toString());
+                    }
+                  }
+                },
+              );
+            },
+          );
+        },
+      },
+    ],
+  };
+
+  const compiler = rspack(config);
+  await new Promise<void>((resolve, reject) => {
+    compiler.run((err, stats) => {
+      const runErr = err
+        ?? (stats?.hasErrors() ? new Error(stats.toString()) : undefined);
+      compiler.close(closeErr => {
+        if (runErr ?? closeErr) reject(runErr ?? closeErr!);
+        else resolve();
+      });
+    });
+  });
+  return captured;
+}
+
+describe('root <Background> whole-program strip (L4)', () => {
+  let mainThread: string;
+  let background: string;
+  let controlMainThread: string;
+
+  beforeAll(async () => {
+    const stripped = await buildAndCapture({ stripAllComponents: true });
+    mainThread = stripped.get('main__main-thread.js') ?? '';
+    background = stripped.get('main__background.js') ?? '';
+    expect(mainThread).not.toBe('');
+    expect(background).not.toBe('');
+
+    const control = await buildAndCapture({ stripAllComponents: false });
+    controlMainThread = control.get('main__main-thread.js') ?? '';
+    expect(controlMainThread).not.toBe('');
+  });
+
+  it('empties every component render body from the main-thread bundle', () => {
+    // No component used `'background only'`; the strip empties them all. The
+    // in-body computed value (a dynamic text binding, not a hoisted snapshot)
+    // is gone.
+    expect(mainThread).not.toContain('APP_BODY_LOGIC_MARKER');
+  });
+
+  it('shakes the logic-only imports that only render bodies reached', () => {
+    expect(mainThread).not.toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+
+  it('keeps the element (snapshot) definitions in the main-thread bundle', () => {
+    // The scroll-view factory must remain so hydration can build it.
+    expect(mainThread).toContain('__CreateScrollView');
+  });
+
+  it('keeps the main-thread-script (worklet) in the main-thread bundle', () => {
+    expect(mainThread).toContain('registerWorkletInternal("main-thread"');
+    expect(mainThread).toContain('SCROLL_WORKLET_MARKER');
+  });
+
+  it('keeps the static host-element fallback (what the 0.0 first screen renders)', () => {
+    expect(mainThread).toContain('LOADING_FALLBACK_MARKER');
+  });
+
+  it('leaves every component fully intact on the background bundle', () => {
+    // The strip is LEPUS-only; the background renders and hydrates everything.
+    expect(background).toContain('APP_BODY_LOGIC_MARKER');
+    expect(background).toContain('APP_EFFECT_MARKER');
+    expect(background).toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+
+  it('control build (no strip) keeps the render logic — proving the strip is the cause', () => {
+    expect(controlMainThread).toContain('APP_BODY_LOGIC_MARKER');
+    expect(controlMainThread).toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+});

--- a/packages/webpack/react-webpack-plugin/test/strip-multi-module.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/strip-multi-module.test.ts
@@ -1,0 +1,166 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * The multi-module hydration proof for the whole-program strip (the test L4
+ * originally lacked): a root-level `<Background>` over an `App` that DELEGATES
+ * to components in other modules — `<Feed/>` (named import) and `<UI.Card/>`
+ * (namespace import) — with zero per-component annotations.
+ *
+ * Emptying `App`'s body must NOT sever its component references: the emptied
+ * body hands them to a module-level keep-alive statement
+ * (`typeof __ifrKeepComponentRefs === "function" && __ifrKeepComponentRefs(…)`),
+ * so the child modules — carrying the hoisted element (snapshot) and
+ * main-thread-script (worklet) definitions — stay in the main-thread bundle
+ * and first-screen hydration can build the real tree.
+ *
+ * At the same time the strip must still deliver its size win: every render
+ * body's logic and the logic-only imports (call targets like `formatFeed`)
+ * must be absent from the main-thread bundle.
+ *
+ * A control build WITHOUT the strip proves absence is caused by the strip.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { rspack } from '@rspack/core';
+import type { Compilation, Compiler, RspackOptions } from '@rspack/core';
+import { beforeAll, describe, expect, it } from '@rstest/core';
+
+// @ts-expect-error – JS helper has no type declarations
+import {
+  createConfig as rawCreateConfig,
+  createEntries as rawCreateEntries,
+} from './create-react-config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+type CreateConfig = (
+  loaderOptions?: unknown,
+  pluginOptions?: { mainThreadChunks?: string[] },
+) => RspackOptions;
+type CreateEntries = (name?: string, source?: string) => RspackOptions['entry'];
+
+const createConfig = rawCreateConfig as unknown as CreateConfig;
+const createEntries = rawCreateEntries as unknown as CreateEntries;
+
+async function buildAndCapture(
+  loaderOptions: unknown,
+): Promise<Map<string, string>> {
+  const base = createConfig(loaderOptions, {
+    mainThreadChunks: ['main__main-thread.js'],
+  });
+  const captured = new Map<string, string>();
+  const config: RspackOptions = {
+    ...base,
+    mode: 'production',
+    context: path.resolve(__dirname, 'fixtures/strip-multi-module'),
+    entry: createEntries('main', './index.jsx'),
+    output: { filename: '[name].js' },
+    optimization: { ...base.optimization, minimize: false },
+    plugins: [
+      ...(base.plugins ?? []),
+      {
+        apply(compiler: Compiler) {
+          compiler.hooks.compilation.tap(
+            'CapturePlugin',
+            (compilation: Compilation) => {
+              compilation.hooks.processAssets.tap(
+                {
+                  name: 'CapturePlugin',
+                  stage:
+                    compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+                },
+                (assets) => {
+                  for (const name of Object.keys(assets)) {
+                    if (name.endsWith('.js')) {
+                      captured.set(name, assets[name]!.source().toString());
+                    }
+                  }
+                },
+              );
+            },
+          );
+        },
+      },
+    ],
+  };
+
+  const compiler = rspack(config);
+  await new Promise<void>((resolve, reject) => {
+    compiler.run((err, stats) => {
+      const runErr = err
+        ?? (stats?.hasErrors() ? new Error(stats.toString()) : undefined);
+      compiler.close(closeErr => {
+        if (runErr ?? closeErr) reject(runErr ?? closeErr!);
+        else resolve();
+      });
+    });
+  });
+  return captured;
+}
+
+describe('root <Background> whole-program strip over a multi-module tree (L4)', () => {
+  let mainThread: string;
+  let background: string;
+  let controlMainThread: string;
+
+  beforeAll(async () => {
+    const stripped = await buildAndCapture({ stripAllComponents: true });
+    mainThread = stripped.get('main__main-thread.js') ?? '';
+    background = stripped.get('main__background.js') ?? '';
+    expect(mainThread).not.toBe('');
+    expect(background).not.toBe('');
+
+    const control = await buildAndCapture({ stripAllComponents: false });
+    controlMainThread = control.get('main__main-thread.js') ?? '';
+    expect(controlMainThread).not.toBe('');
+  });
+
+  it('empties every render body across all modules', () => {
+    expect(mainThread).not.toContain('APP_BODY_LOGIC_MARKER');
+    expect(mainThread).not.toContain('FEED_BODY_LOGIC_MARKER');
+    expect(mainThread).not.toContain('UI_CARD_BODY_LOGIC_MARKER');
+    expect(mainThread).not.toContain('FEED_EFFECT_MARKER');
+  });
+
+  it('still shakes the logic-only imports out of the main-thread bundle', () => {
+    expect(mainThread).not.toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+
+  it('emits the keep-alive that pins the delegated component modules', () => {
+    expect(mainThread).toContain('__ifrKeepComponentRefs');
+  });
+
+  it('keeps the named-import child\'s snapshot definitions (hydration can build <Feed/>)', () => {
+    expect(mainThread).toContain('__CreateScrollView');
+    expect(mainThread).toContain('FEED_SNAPSHOT_STATIC_MARKER');
+  });
+
+  it('keeps the named-import child\'s worklet definition on the main thread', () => {
+    expect(mainThread).toContain('registerWorkletInternal("main-thread"');
+    expect(mainThread).toContain('SCROLL_WORKLET_MARKER');
+  });
+
+  it('keeps the namespace-import child\'s snapshot definitions (hydration can build <UI.Card/>)', () => {
+    expect(mainThread).toContain('UI_CARD_SNAPSHOT_STATIC_MARKER');
+  });
+
+  it('keeps the static host-element fallback (the 0.0 first screen)', () => {
+    expect(mainThread).toContain('LOADING_FALLBACK_MARKER');
+  });
+
+  it('leaves every module fully intact on the background bundle', () => {
+    expect(background).toContain('APP_BODY_LOGIC_MARKER');
+    expect(background).toContain('FEED_BODY_LOGIC_MARKER');
+    expect(background).toContain('UI_CARD_BODY_LOGIC_MARKER');
+    expect(background).toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+
+  it('control build (no strip) keeps the render logic — proving the strip is the cause', () => {
+    expect(controlMainThread).toContain('APP_BODY_LOGIC_MARKER');
+    expect(controlMainThread).toContain('FEED_BODY_LOGIC_MARKER');
+    expect(controlMainThread).toContain('HEAVY_FORMAT_LOGIC_ONLY_MARKER');
+  });
+});


### PR DESCRIPTION
Add a first-screen boundary that opts a subtree out of the main-thread
first-screen render (IFR): the main thread renders `fallback` during the
first screen, the background thread always renders `children`, and the
first-screen hydration replaces the fallback with the real content
through the normal update patch.

- runtime: `Background` component shared by the Snapshot and Element
  Template backends, exported from both entries and the lazy entries
- tests: dual-thread render/hydration/eventing/nesting coverage for the
  Snapshot backend, plus an Element Template export test
- benchmarks: vitest micro-bench (IFR render & dual-thread startup) and
  two benchx cases (012-heavy-first-screen vs 013-background-boundary)
- docs: public JSDoc, API report, changeset

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LyHx91XciQDJunC9fj6bTe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `<Background>` component, which displays a fallback during first-screen rendering and hydrates to background-rendered content.
  * Added the experimental `experimental_stripAllComponents` option to reduce main-thread bundle work while preserving hydration requirements.
  * Added `'background only'` support to keep deferred render logic out of main-thread execution.

* **Documentation**
  * Documented usage constraints, fallback requirements, hydration behavior, and bundle-separation guarantees.

* **Tests**
  * Added coverage for hydration, nested boundaries, cross-module bundling, and benchmark scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->