### PR TITLE
feat(web): expose a per-card devtool message channel as lynx.getDevtool()

### DIFF
--- a/.changeset/web-devtool-message-port.md
+++ b/.changeset/web-devtool-message-port.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Add a per-card devtool message channel — the web counterpart of the native Lynx devtool pipe.
+
+Each `lynx-view` now transfers a dedicated `MessagePort` into its background worker, exposed to the card as `lynx.getDevtool()` with the native API shape (`dispatchEvent` / `addEventListener` over `{ type, data }` events). The hosting page's end is available as `lynxView.devtoolMessagePort`. Devtools clients written against native Lynx (e.g. `@lynx-js/preact-devtools`) work unchanged, and the point-to-point port avoids the cross-tab/cross-view interference of origin-wide transports such as `BroadcastChannel`.

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
@@ -14,11 +14,66 @@ import { createElement } from './createElement.js';
 import type { Cloneable, NativeApp } from '../../../types/index.js';
 import { LynxCrossThreadContext } from '../../LynxCrossThreadContext.js';
 
+export interface WebDevtoolEvent {
+  type: string;
+  data: string;
+}
+
+export interface WebDevtool {
+  dispatchEvent(event: WebDevtoolEvent): void;
+  addEventListener(
+    type: string,
+    listener: (event: WebDevtoolEvent) => void,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: (event: WebDevtoolEvent) => void,
+  ): void;
+}
+
+/**
+ * The web counterpart of the native Lynx devtool channel: a typed event bus
+ * between the card's background thread and the hosting page, backed by a
+ * dedicated MessagePort. API shape mirrors native `lynx.getDevtool()`
+ * (`dispatchEvent` / `addEventListener` with `{ type, data }` events) so
+ * devtools clients written against native Lynx work unchanged.
+ */
+function createWebDevtool(port: MessagePort): WebDevtool {
+  const listeners = new Map<string, Set<(event: WebDevtoolEvent) => void>>();
+  port.onmessage = (ev: MessageEvent) => {
+    const { type, data } = (ev.data ?? {}) as WebDevtoolEvent;
+    listeners.get(type)?.forEach((listener) => {
+      try {
+        listener({ type, data });
+      } catch (e) {
+        console.warn('[lynx-web-core] devtool listener failed:', e);
+      }
+    });
+  };
+  return {
+    dispatchEvent(event) {
+      port.postMessage({ type: event.type, data: event.data });
+    },
+    addEventListener(type, listener) {
+      let set = listeners.get(type);
+      if (!set) {
+        set = new Set();
+        listeners.set(type, set);
+      }
+      set.add(listener);
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener);
+    },
+  };
+}
+
 export function createBackgroundLynx(
   globalProps: Cloneable,
   customSections: Record<string, Cloneable>,
   nativeApp: NativeApp,
   mainThreadRpc: Rpc,
+  devtoolMessagePort?: MessagePort,
 ) {
   const coreContext = new LynxCrossThreadContext({
     rpc: mainThreadRpc,
@@ -28,8 +83,18 @@ export function createBackgroundLynx(
   const fetchExternalBundle = mainThreadRpc.createCall(
     fetchExternalBundleEndpoint,
   );
+  const devtool = devtoolMessagePort
+    ? createWebDevtool(devtoolMessagePort)
+    : undefined;
   return {
     __globalProps: globalProps,
+    ...(devtool
+      ? {
+        getDevtool(): WebDevtool {
+          return devtool;
+        },
+      }
+      : {}),
     getJSModule(_moduleName: string): any {
     },
     getNativeApp(): NativeApp {

--- a/packages/web-platform/web-core/ts/client/background/background-apis/startBackgroundThread.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/startBackgroundThread.ts
@@ -16,6 +16,7 @@ export function startBackgroundThread(
 ): void {
   const {
     mainThreadMessagePort,
+    devtoolMessagePort,
     napiModulesMap,
     nativeModulesMap,
     initData,
@@ -52,6 +53,7 @@ export function startBackgroundThread(
         customSections,
         nativeApp,
         mainThreadRpc,
+        devtoolMessagePort,
       );
       const {
         loadCard,

--- a/packages/web-platform/web-core/ts/client/mainthread/Background.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/Background.ts
@@ -73,6 +73,20 @@ export class BackgroundThread implements AsyncDisposable {
   readonly jsContext: LynxCrossThreadContext;
   #messagePort?: MessagePort;
 
+  /**
+   * A dedicated pipe between the hosting page and this card's background
+   * thread — the web counterpart of the native Lynx devtool channel. The
+   * paired port is transferred to the background worker and exposed to the
+   * card as `lynx.getDevtool()`. Created in the constructor so the hosting
+   * page can take this end before (or after) the worker starts; MessagePort
+   * buffers messages until both ends are consumed.
+   */
+  readonly #devtoolChannel = new MessageChannel();
+
+  get devtoolMessagePort(): MessagePort {
+    return this.#devtoolChannel.port1;
+  }
+
   readonly postTimingFlags: RpcCallType<typeof postTimingFlagsEndpoint>;
   readonly sendGlobalEvent: RpcCallType<typeof sendGlobalEventEndpoint>;
   readonly publicComponentEvent: RpcCallType<
@@ -157,6 +171,7 @@ export class BackgroundThread implements AsyncDisposable {
     this.#webWorker.postMessage(
       {
         mainThreadMessagePort: messageChannel.port2,
+        devtoolMessagePort: this.#devtoolChannel.port2,
         systemInfo: this.#lynxViewInstance.systemInfo,
         initData,
         globalProps,
@@ -166,7 +181,7 @@ export class BackgroundThread implements AsyncDisposable {
         napiModulesMap,
         entryTemplateUrl: this.#lynxViewInstance.templateUrl,
       } as WorkerStartMessage,
-      [messageChannel.port2],
+      [messageChannel.port2, this.#devtoolChannel.port2],
     );
     this.#messagePort = messageChannel.port1;
     this.#rpc.setMessagePort(messageChannel.port1);

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
@@ -340,6 +340,19 @@ export class LynxViewElement extends HTMLElement {
 
   /**
    * @public
+   * @property
+   * The hosting page's end of this card's devtool channel — the web
+   * counterpart of the native Lynx devtool pipe. The other end is exposed to
+   * the card's background thread as `lynx.getDevtool()`; messages are
+   * `{ type: string, data: string }` events. Available once the card has
+   * started rendering; `undefined` before that.
+   */
+  get devtoolMessagePort(): MessagePort | undefined {
+    return this.#instance?.backgroundThread.devtoolMessagePort;
+  }
+
+  /**
+   * @public
    * @method
    * update the `__initData` and trigger essential flow
    */

--- a/packages/web-platform/web-core/ts/types/WorkerStartMessage.ts
+++ b/packages/web-platform/web-core/ts/types/WorkerStartMessage.ts
@@ -8,6 +8,13 @@ import type { NativeModulesMap } from './NativeModules.js';
 
 export interface WorkerStartMessage {
   mainThreadMessagePort: MessagePort;
+  /**
+   * A dedicated pipe between the hosting page and this card's background
+   * thread, exposed to the card as `lynx.getDevtool()` (the web counterpart
+   * of the native Lynx devtool channel). The paired port is available on the
+   * hosting page via `lynxView.devtoolMessagePort`.
+   */
+  devtoolMessagePort?: MessagePort;
   systemInfo?: Record<string, any>;
   initData: Cloneable;
   globalProps: Cloneable;


### PR DESCRIPTION
## Summary

RFC/draft: give the web platform a first-class devtool pipe — the web counterpart of native Lynx's `lynx.getDevtool()`.

Each `lynx-view` now creates a dedicated `MessageChannel`, transfers one port into the card's background worker via `WorkerStartMessage`, and exposes it to the card as `lynx.getDevtool()` with the native API shape (`dispatchEvent` / `addEventListener` over `{ type, data: string }` events). The hosting page's end is available as `lynxView.devtoolMessagePort`.

## Motivation

Devtools clients written against native Lynx (e.g. [`@lynx-js/preact-devtools`](https://github.com/lynx-family/preact-devtools/pull/16)) currently need a web-specific transport because `lynx.getDevtool()` does not exist on the web. The workaround — an origin-wide `BroadcastChannel` plus a per-page channel-naming handshake through globalProps — works, but:

- `BroadcastChannel` broadcasts across the whole origin, so multiple tabs/views debugging the same origin cross-talk unless every host wires unique channel names (we hit real duplicated-tree/browser-hang bugs from this);
- every hosting page must carry bespoke pairing code.

A page↔worker `MessagePort` owned by web-core removes both problems by construction: point-to-point, per-card, zero host configuration — and native-targeting devtools clients run **unchanged**.

## Layering

web-core only provides a generic, protocol-agnostic event pipe. DSL-specific logic (e.g. relaying to the Preact Devtools browser-extension window protocol) stays outside — the host does:

```js
const port = lynxView.devtoolMessagePort;
port.onmessage = ev => {
  const { type, data } = ev.data;
  if (type !== 'PreactDevtools') return;
  window.postMessage(JSON.parse(data), '*'); // -> Preact Devtools extension
};
window.addEventListener('message', e => {
  if (e.source === window && e.data?.source === 'preact-devtools-to-client') {
    port.postMessage({ type: 'PreactDevtools', data: JSON.stringify(e.data) });
  }
});
```

## Verified locally

Wired `examples/react-externals-web` (not included in this diff) to the new port with `@lynx-js/preact-devtools`'s native code path: the official Preact Devtools browser extension detects the page and renders the component tree of the ReactLynx app running in the worker — full protocol round-trip (`attach` / `operation_v2` / `root-order`) over the port. `tsc --noEmit`, package build and `rstest` all pass.

## Open questions (hence draft)

1. Should the channel be opt-in (attribute like `<lynx-view devtool>`) instead of always-created? The cost is one `MessageChannel` per view; always-on keeps zero-config debugging.
2. Should web-core also ship the extension-protocol relay behind an opt-in, or keep it out entirely (current stance: keep out)?
3. `lynx.getDevtool()` capability negotiation: clients probing for native-only main-thread debug methods (e.g. `getUniqueIdListBySnapshotId`) still need a separate capability signal — currently handled on the devtools-client side.
4. Whether the lynx group (shared worker) case needs per-card demultiplexing on a single port (currently: one port per card, which already holds since each `BackgroundThread` instance owns its channel).