### PR TITLE
ci: anchor turbo cache-key hashFiles glob to fix Windows timeout

### DIFF
--- a/.changeset/ci-anchor-turbo-cache-hashfiles.md
+++ b/.changeset/ci-anchor-turbo-cache-hashfiles.md
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 ci: anchor the TurboCache `hashFiles` glob to the repo-root `packages/` tree
@@ -9,7 +10,7 @@ matches `packages/` at any depth, so after `pnpm install` the glob walks into
 every `node_modules`, which deterministically exceeds GitHub's 120s expression
 limit on Windows runners (`Vitest (Windows)` failing with "hashFiles(...)
 couldn't finish within 120 seconds"). It was also inconsistent with the job
-that *saves* the cache (`workflow-build.yml`), which already uses the anchored
+that _saves_ the cache (`workflow-build.yml`), which already uses the anchored
 `hashFiles('packages/**/src/**/*.rs')`.
 
 Aligning all consumers to the anchored form fixes the Windows timeout and

--- a/.changeset/ci-anchor-turbo-cache-hashfiles.md
+++ b/.changeset/ci-anchor-turbo-cache-hashfiles.md
@@ -1,0 +1,16 @@
+---
+---
+
+ci: anchor the TurboCache `hashFiles` glob to the repo-root `packages/` tree
+
+The consumer workflows (test, rust, bundle-analysis, website, bench) keyed the
+turbo cache on `hashFiles('**/packages/**/src/**/*.rs')`. The leading `**/`
+matches `packages/` at any depth, so after `pnpm install` the glob walks into
+every `node_modules`, which deterministically exceeds GitHub's 120s expression
+limit on Windows runners (`Vitest (Windows)` failing with "hashFiles(...)
+couldn't finish within 120 seconds"). It was also inconsistent with the job
+that *saves* the cache (`workflow-build.yml`), which already uses the anchored
+`hashFiles('packages/**/src/**/*.rs')`.
+
+Aligning all consumers to the anchored form fixes the Windows timeout and
+removes a latent cache-key mismatch. No package changes — empty changeset.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          key: turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install
         uses: ./.github/actions/pnpm-install

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -78,7 +78,7 @@ jobs:
           # The build job runs on lynx-ubuntu-26.04-xlarge which writes to a
           # different OSS bucket than this physical-exclusive runner, so we
           # tolerate cache misses and let `pnpm turbo build` rebuild locally.
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          key: turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.sha }}
       - name: Build
         run: |
           pnpm turbo build

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          key: turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install
         uses: ./.github/actions/pnpm-install

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          key: turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install
         uses: ./.github/actions/pnpm-install

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -19,7 +19,7 @@ jobs:
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
           path: .turbo
-          key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
+          key: turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
## Summary

The consumer workflows key the TurboCache on:

```yaml
key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}
```

The leading `**/` makes the glob match `packages/` at **any** depth, so after
`pnpm install` it walks into every `node_modules` tree. That deterministically
exceeds GitHub Actions' 120s expression-evaluation limit on Windows runners,
surfacing as `Vitest (Windows)` failing with:

```
The template is not valid ... (Line: 77, Col: 16):
hashFiles('**/packages/**/src/**/*.rs') couldn't finish within 120 seconds.
```

The Vitest tests themselves pass — the job dies computing the cache key at the
cache step. (Observed blocking PR #2971, where it failed on every run/re-run.)

The job that **saves** the cache (`workflow-build.yml`) already uses the
anchored form `hashFiles('packages/**/src/**/*.rs')`, which only matches the
real repo-root `packages/` tree. So the consumers were both **slow** (walking
`node_modules`) and **inconsistent** with the producer (a latent cache-key
mismatch).

This aligns all five consumer workflows to the anchored form:

- `.github/workflows/workflow-test.yml`
- `.github/workflows/rust.yml`
- `.github/workflows/workflow-bundle-analysis.yml`
- `.github/workflows/workflow-website.yml`
- `.github/workflows/workflow-bench.yml`

`workflow-build.yml` is left unchanged (it was already anchored). The `.rs`
source that legitimately contributes to the hash lives under the repo-root
`packages/` tree only, so dropping the leading `**/` produces the same hash of
real source while no longer traversing `node_modules`.

## Checklist

- [x] Tests updated (or not required). — _CI-config-only change; no package code affected._
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required). — _Empty changeset added (no release impact)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2xZwePKMwXEvSjhbLy6En)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI TurboCache key generation to hash a narrower, anchored set of Rust source files, reducing unnecessary cache invalidations and avoiding Windows-related evaluation timeouts.
  * Standardized cache key inputs across the test, benchmark, bundle analysis, Rust, and website workflows for consistent cache reuse.
  * Cache reuse now more reliably depends on the same source file set across workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->