### PR TITLE
feat: add preact devtools demo for web externals

### DIFF
--- a/examples/gesture/package.json
+++ b/examples/gesture/package.json
@@ -13,7 +13,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/motion/package.json
+++ b/examples/motion/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-debug-metadata/package.json
+++ b/examples/react-debug-metadata/package.json
@@ -20,7 +20,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-element-template/package.json
+++ b/examples/react-element-template/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-element/package.json
+++ b/examples/react-element/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-et-lazy-bundle-standalone/package.json
+++ b/examples/react-et-lazy-bundle-standalone/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm run \"/^build:(producer|consumer)$/\"",
+    "build": "pnpm run --parallel \"/^build:(producer|consumer)$/\"",
     "build:consumer": "rspeedy build --config lynx.config.consumer.js",
     "build:producer": "rspeedy build --config lynx.config.producer.js",
     "dev": "node scripts/serve.mjs dev",
@@ -18,7 +18,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-externals-web/package.json
+++ b/examples/react-externals-web/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm run build:comp-lib && rspeedy build",
-    "build:comp-lib": "rslib build --config rslib-comp-lib.config.ts",
+    "build": "pnpm run build:comp-lib && cross-env REACT_DEVTOOL=1 rspeedy build",
+    "build:comp-lib": "cross-env REACT_DEVTOOL=1 rslib build --config rslib-comp-lib.config.ts",
     "dev": "pnpm run build && rsbuild dev --open",
     "preview": "rsbuild dev"
   },
@@ -16,6 +16,7 @@
     "@lynx-js/external-bundle-rsbuild-plugin": "workspace:*",
     "@lynx-js/lynx-bundle-rslib-config": "workspace:*",
     "@lynx-js/lynx-core": "0.1.4",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-umd": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
@@ -23,6 +24,7 @@
     "@lynx-js/web-core": "workspace:*",
     "@lynx-js/web-elements": "workspace:*",
     "@rsbuild/core": "catalog:rsbuild",
-    "@types/react": "^18.3.28"
+    "@types/react": "^18.3.28",
+    "cross-env": "^7.0.3"
   }
 }

--- a/examples/react-externals-web/src/index.tsx
+++ b/examples/react-externals-web/src/index.tsx
@@ -1,3 +1,4 @@
+import '@lynx-js/preact-devtools';
 import '@lynx-js/react/debug';
 import { Fragment } from 'react';
 

--- a/examples/react-externals-web/web/index.ts
+++ b/examples/react-externals-web/web/index.ts
@@ -1,7 +1,18 @@
 import '@lynx-js/web-elements/index.css';
 import '@lynx-js/web-core/client';
+import '@lynx-js/preact-devtools/web-host';
 
 const view = document.createElement('lynx-view');
 view.setAttribute('url', '/main.web.bundle');
+
+if (process.env['NODE_ENV'] === 'development') {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  const devtoolsChannelName = `preact-devtools-${crypto.randomUUID()}`;
+  view.setAttribute(
+    'global-props',
+    JSON.stringify({ preactDevtoolsChannel: devtoolsChannelName }),
+  );
+}
+
 view.style.cssText = 'display:block;width:100vw;height:100vh';
 document.body.append(view);

--- a/examples/react-externals/package.json
+++ b/examples/react-externals/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@lynx-js/external-bundle-rsbuild-plugin": "workspace:*",
     "@lynx-js/lynx-bundle-rslib-config": "workspace:*",
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-keyboard/package.json
+++ b/examples/react-keyboard/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-lazy-bundle-standalone/package.json
+++ b/examples/react-lazy-bundle-standalone/package.json
@@ -8,7 +8,7 @@
     "build:consumer": "rspeedy build --config lynx.config.consumer.js",
     "build:fetchbundle": "cross-env LAZY_BUNDLE_FETCHBUNDLE=1 pnpm run build:querycomponent",
     "build:producer": "rspeedy build --config lynx.config.producer.js",
-    "build:querycomponent": "pnpm run \"/^build:(producer|consumer)$/\"",
+    "build:querycomponent": "pnpm run --parallel \"/^build:(producer|consumer)$/\"",
     "dev": "node scripts/serve.mjs dev",
     "dev:consumer": "rspeedy dev --config lynx.config.consumer.js",
     "dev:fetchbundle": "cross-env LAZY_BUNDLE_FETCHBUNDLE=1 node scripts/serve.mjs dev",
@@ -22,7 +22,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-lazy-bundle/package.json
+++ b/examples/react-lazy-bundle/package.json
@@ -16,7 +16,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-main-thread-function/package.json
+++ b/examples/react-main-thread-function/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react-ui-sourcemap/package.json
+++ b/examples/react-ui-sourcemap/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -12,7 +12,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/create-rspeedy/template-react-js/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-js/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*"

--- a/packages/rspeedy/create-rspeedy/template-react-ts/package.json
+++ b/packages/rspeedy/create-rspeedy/template-react-ts/package.json
@@ -11,7 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/testing-library/kitten-lynx/package.json
+++ b/packages/testing-library/kitten-lynx/package.json
@@ -43,7 +43,7 @@
     "@yume-chan/adb-server-node-tcp": "catalog:adb"
   },
   "devDependencies": {
-    "@lynx-js/preact-devtools": "5.0.1-20260714130028-3bd2ab8",
+    "@lynx-js/preact-devtools": "5.0.1-20260716151326-abdb87c",
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,8 +227,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -255,8 +255,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -280,8 +280,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -336,8 +336,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -370,8 +370,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -395,8 +395,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -442,8 +442,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -517,8 +517,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspeedy/lynx-bundle-rslib-config
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -553,6 +553,9 @@ importers:
       '@lynx-js/lynx-core':
         specifier: 0.1.4
         version: 0.1.4
+      '@lynx-js/preact-devtools':
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/react-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-react
@@ -577,6 +580,9 @@ importers:
       '@types/react':
         specifier: ^18.3.28
         version: 18.3.28
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
 
   examples/react-keyboard:
     dependencies:
@@ -585,8 +591,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -610,8 +616,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -638,8 +644,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -666,8 +672,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -691,8 +697,8 @@ importers:
         version: link:../../packages/react
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-qrcode
@@ -1903,8 +1909,8 @@ importers:
         version: 2.5.2
     devDependencies:
       '@lynx-js/preact-devtools':
-        specifier: 5.0.1-20260714130028-3bd2ab8
-        version: 5.0.1-20260714130028-3bd2ab8
+        specifier: 5.0.1-20260716151326-abdb87c
+        version: 5.0.1-20260716151326-abdb87c
       '@lynx-js/react':
         specifier: workspace:*
         version: link:../../react
@@ -4420,8 +4426,8 @@ packages:
       '@lynx-js/types':
         optional: true
 
-  '@lynx-js/preact-devtools@5.0.1-20260714130028-3bd2ab8':
-    resolution: {integrity: sha512-HtYs8/r8RG/5mtQV5U3+XLDMd+Qc/HvjpmWBI2iDyrkxaGqxfOgwbtqQA9DDuUjUTcER0eWz/mJbiQ46A2MIzg==}
+  '@lynx-js/preact-devtools@5.0.1-20260716151326-abdb87c':
+    resolution: {integrity: sha512-a0k5zLVykaSx2SwoNhyHYkj94VI/Qx5irv2Xf9leJP4Mcb/7uP2g/bJLpijRPrfeLCDvKy5t6WmEWSucKZ7cug==}
 
   '@lynx-js/react-use@0.1.3':
     resolution: {integrity: sha512-48NX1DZfIqdpcFPKR3SdI/E0D2INJzgMDtl9IK0vbqWKPgj6LgUPZN0iqIDd7Juy3in5c2bv6E9jCpoq5ONeVw==}
@@ -14216,7 +14222,7 @@ snapshots:
       - react
       - react-dom
 
-  '@lynx-js/preact-devtools@5.0.1-20260714130028-3bd2ab8':
+  '@lynx-js/preact-devtools@5.0.1-20260716151326-abdb87c':
     dependencies:
       errorstacks: 2.4.1
       htm: 3.1.1


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added development DevTools integration to the React externals web example, including development-only channel setup.
  - Enabled DevTools support in additional example builds and templates.

- **Improvements**
  - Updated the development DevTools package to a newer release across examples and templates.
  - Parallelized selected example build tasks to reduce build time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
