### PR TITLE
feat(webpack): rename the lazy bundle output directory from async/ to lazy-bundle/

### DIFF
--- a/.changeset/lazy-bundle-output-dir.md
+++ b/.changeset/lazy-bundle-output-dir.md
@@ -1,0 +1,12 @@
+---
+"@lynx-js/template-webpack-plugin": minor
+"@lynx-js/css-extract-webpack-plugin": minor
+---
+
+Rename the lazy bundle output directory from `async/` to `lazy-bundle/`.
+
+Lazy bundles can now also be loaded synchronously with `import(..., { with: { mode: 'sync' } })`, so the `async/` directory name no longer matches how they are used. The default `lazyBundleFilename` becomes `lazy-bundle/[name].[fullhash].bundle`, and the intermediate outputs move from `.rspeedy/async/<name>/` to `.rspeedy/lazy-bundle/<name>/` accordingly.
+
+Update deployment scripts that reference the `dist/async/` directory to use `dist/lazy-bundle/` instead.
+
+`@lynx-js/css-extract-webpack-plugin` requires `@lynx-js/template-webpack-plugin` `^0.14.0`.

--- a/.changeset/react-webpack-plugin-widen-template-peer.md
+++ b/.changeset/react-webpack-plugin-widen-template-peer.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Accept `@lynx-js/template-webpack-plugin` `^0.14.0` as a peer dependency.

--- a/examples/react-et-lazy-bundle-standalone/package.json
+++ b/examples/react-et-lazy-bundle-standalone/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm run --parallel \"/^build:(producer|consumer)$/\"",
+    "build": "pnpm run \"/^build:(producer|consumer)$/\"",
     "build:consumer": "rspeedy build --config lynx.config.consumer.js",
     "build:producer": "rspeedy build --config lynx.config.producer.js",
     "dev": "node scripts/serve.mjs dev",

--- a/examples/react-lazy-bundle-standalone/package.json
+++ b/examples/react-lazy-bundle-standalone/package.json
@@ -8,7 +8,7 @@
     "build:consumer": "rspeedy build --config lynx.config.consumer.js",
     "build:fetchbundle": "cross-env LAZY_BUNDLE_FETCHBUNDLE=1 pnpm run build:querycomponent",
     "build:producer": "rspeedy build --config lynx.config.producer.js",
-    "build:querycomponent": "pnpm run --parallel \"/^build:(producer|consumer)$/\"",
+    "build:querycomponent": "pnpm run \"/^build:(producer|consumer)$/\"",
     "dev": "node scripts/serve.mjs dev",
     "dev:consumer": "rspeedy dev --config lynx.config.consumer.js",
     "dev:fetchbundle": "cross-env LAZY_BUNDLE_FETCHBUNDLE=1 node scripts/serve.mjs dev",

--- a/packages/rspeedy/plugin-debug-metadata/test/source-mapping-url-rewriter.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/source-mapping-url-rewriter.test.ts
@@ -16,7 +16,7 @@ describe('rewriteSourceMappingURLToAbsolute', () => {
   const ASYNC_MAP = 'static/js/async/Lazy-react__main-thread.js.map'
   const ASYNC_MAP_ENC = encodeURIComponent(ASYNC_MAP)
   const BUNDLE_URL =
-    'http://host:3020/.rspeedy/async/Lazy.js/debug-metadata.json'
+    'http://host:3020/.rspeedy/lazy-bundle/Lazy.js/debug-metadata.json'
 
   test('replaces the directive with the caller-supplied metadata URL plus path query', () => {
     const before = wrap(

--- a/packages/rspeedy/plugin-debug-metadata/test/strip-debug-metadata.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/strip-debug-metadata.test.ts
@@ -92,7 +92,7 @@ describe('stripDebugMetadataFromOutput', () => {
     const child = fakeChild({
       assets: [
         '.rspeedy/main/debug-metadata.json',
-        '.rspeedy/async/lazy-comp.jsx/debug-metadata.json',
+        '.rspeedy/lazy-bundle/lazy-comp.jsx/debug-metadata.json',
         '.rspeedy/main/main-thread.js',
       ],
     })
@@ -100,7 +100,7 @@ describe('stripDebugMetadataFromOutput', () => {
     child.trigger()
     expect(child.deleted).toEqual([
       '.rspeedy/main/debug-metadata.json',
-      '.rspeedy/async/lazy-comp.jsx/debug-metadata.json',
+      '.rspeedy/lazy-bundle/lazy-comp.jsx/debug-metadata.json',
     ])
   })
 

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -100,7 +100,7 @@ export function applyEntry(
         let templateFilename: string
         // `lazyBundleFilename` is only set when `bundle` is a function.
         // Otherwise `LynxTemplatePlugin` keeps its default
-        // (`async/[name].[fullhash].bundle`).
+        // (`lazy-bundle/[name].[fullhash].bundle`).
         let lazyBundleFilename: string | undefined
         if (typeof bundleFilename === 'function') {
           // A single function controls both the main bundle and the lazy

--- a/packages/rspeedy/plugin-react/test/config-plugin.test.ts
+++ b/packages/rspeedy/plugin-react/test/config-plugin.test.ts
@@ -137,7 +137,7 @@ describe('config plugin', () => {
     expect(templatePlugin?.options.filename).toBe('main.lynx.bundle')
 
     // The string form does not override `lazyBundleFilename`, so
-    // `LynxTemplatePlugin` keeps its default (`async/[name].[fullhash].bundle`).
+    // `LynxTemplatePlugin` keeps its default (`lazy-bundle/[name].[fullhash].bundle`).
     // @ts-expect-error private field
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(templatePlugin?.options.lazyBundleFilename).toBeUndefined()

--- a/packages/rspeedy/plugin-react/test/lazy.test.ts
+++ b/packages/rspeedy/plugin-react/test/lazy.test.ts
@@ -354,7 +354,7 @@ describe('Lazy', () => {
           backgroundJSContent,
         )![1]
       expect(cssHotUpdateList).toMatchInlineSnapshot(
-        `"[["_react_background_fixtures_lazy-bundle_LazyComponent_tsx",".rspeedy/async/fixtures/lazy-bundle/LazyComponent.tsx/background.css.hot-update.json"],["main",".rspeedy/main/main.css.hot-update.json"]]"`,
+        `"[["_react_background_fixtures_lazy-bundle_LazyComponent_tsx",".rspeedy/lazy-bundle/fixtures/lazy-bundle/LazyComponent.tsx/background.css.hot-update.json"],["main",".rspeedy/main/main.css.hot-update.json"]]"`,
       )
     } finally {
       rstest.unstubAllEnvs()
@@ -463,7 +463,7 @@ describe('Lazy', () => {
       await rsbuild.createDevServer()
       await waitCompilationDone()
       expect(appServiceJSContent).toMatchInlineSnapshot(
-        `"(function(){'use strict';function n({tt}){tt.define('/app-service.js',function(e,module,_,i,l,u,a,c,s,f,p,d,h,v,g,y,lynx){module.exports=lynx.requireModule("/.rspeedy/async/fixtures/lazy-bundle/LazyComponent.tsx/background.js",globDynamicComponentEntry?globDynamicComponentEntry:'__Card__');});return tt.require('/app-service.js');}return{init:n}})()"`,
+        `"(function(){'use strict';function n({tt}){tt.define('/app-service.js',function(e,module,_,i,l,u,a,c,s,f,p,d,h,v,g,y,lynx){module.exports=lynx.requireModule("/.rspeedy/lazy-bundle/fixtures/lazy-bundle/LazyComponent.tsx/background.js",globDynamicComponentEntry?globDynamicComponentEntry:'__Card__');});return tt.require('/app-service.js');}return{init:n}})()"`,
       )
 
       // Modify the fixtures/lazy-bundle/LazyComponent.tsx file
@@ -476,7 +476,7 @@ describe('Lazy', () => {
       await waitCompilationDone()
 
       expect(appServiceJSContent).toMatchInlineSnapshot(
-        `"(function(){'use strict';function n({tt}){tt.define('/app-service.js',function(e,module,_,i,l,u,a,c,s,f,p,d,h,v,g,y,lynx){module.exports=lynx.requireModule("/.rspeedy/async/fixtures/lazy-bundle/LazyComponent.tsx/background.js",globDynamicComponentEntry?globDynamicComponentEntry:'__Card__');});return tt.require('/app-service.js');}return{init:n}})()"`,
+        `"(function(){'use strict';function n({tt}){tt.define('/app-service.js',function(e,module,_,i,l,u,a,c,s,f,p,d,h,v,g,y,lynx){module.exports=lynx.requireModule("/.rspeedy/lazy-bundle/fixtures/lazy-bundle/LazyComponent.tsx/background.js",globDynamicComponentEntry?globDynamicComponentEntry:'__Card__');});return tt.require('/app-service.js');}return{init:n}})()"`,
       )
     } finally {
       if (tmpContent !== undefined) {

--- a/packages/rspeedy/plugin-react/test/sourcemap.test.ts
+++ b/packages/rspeedy/plugin-react/test/sourcemap.test.ts
@@ -176,7 +176,7 @@ describe('Sourcemap', () => {
       readFile(
         path.join(
           tmp,
-          '.rspeedy/async/fixtures/sourcemap/lazy-bundle-comp.tsx/debug-metadata.json',
+          '.rspeedy/lazy-bundle/fixtures/sourcemap/lazy-bundle-comp.tsx/debug-metadata.json',
         ),
         'utf-8',
       ),
@@ -193,8 +193,8 @@ describe('Sourcemap', () => {
 
     expect(mapPathsInMetadata).toMatchInlineSnapshot(`
       [
-        ".rspeedy/async/fixtures/sourcemap/lazy-bundle-comp.tsx/background.js.map",
-        ".rspeedy/async/fixtures/sourcemap/lazy-bundle-comp.tsx/main-thread.js.map",
+        ".rspeedy/lazy-bundle/fixtures/sourcemap/lazy-bundle-comp.tsx/background.js.map",
+        ".rspeedy/lazy-bundle/fixtures/sourcemap/lazy-bundle-comp.tsx/main-thread.js.map",
         ".rspeedy/main/background.js.map",
         ".rspeedy/main/main-thread.js.map",
         ".rspeedy/main/main.css.map",
@@ -257,7 +257,7 @@ describe('Sourcemap', () => {
         readFile(
           path.join(
             tmp,
-            '.rspeedy/async/fixtures/sourcemap/lazy-bundle-comp.tsx/debug-metadata.json',
+            '.rspeedy/lazy-bundle/fixtures/sourcemap/lazy-bundle-comp.tsx/debug-metadata.json',
           ),
           'utf-8',
         ),
@@ -273,8 +273,8 @@ describe('Sourcemap', () => {
 
       expect(sourceMapFiles).toMatchInlineSnapshot(`
         [
-          ".rspeedy/async/fixtures/sourcemap/lazy-bundle-comp.tsx/background.js.map",
-          ".rspeedy/async/fixtures/sourcemap/lazy-bundle-comp.tsx/main-thread.js.map",
+          ".rspeedy/lazy-bundle/fixtures/sourcemap/lazy-bundle-comp.tsx/background.js.map",
+          ".rspeedy/lazy-bundle/fixtures/sourcemap/lazy-bundle-comp.tsx/main-thread.js.map",
           ".rspeedy/main/background.js.map",
           ".rspeedy/main/main-thread.js.map",
           ".rspeedy/main/main.css.map",

--- a/packages/webpack/css-extract-webpack-plugin/package.json
+++ b/packages/webpack/css-extract-webpack-plugin/package.json
@@ -55,7 +55,7 @@
     "sass-loader": "^16.0.7"
   },
   "peerDependencies": {
-    "@lynx-js/template-webpack-plugin": "^0.13.0"
+    "@lynx-js/template-webpack-plugin": "^0.14.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/webpack/css-extract-webpack-plugin/src/CssExtractRspackPlugin.ts
+++ b/packages/webpack/css-extract-webpack-plugin/src/CssExtractRspackPlugin.ts
@@ -153,7 +153,7 @@ class CssExtractRspackPluginImpl {
     compiler: Compiler,
     public options: CssExtractRspackPluginOptions,
   ) {
-    // Route a lazy bundle's CSS chunk to `.rspeedy/async/<name>/<layer>.css`,
+    // Route a lazy bundle's CSS chunk to `.rspeedy/lazy-bundle/<name>/<layer>.css`,
     // co-located with the bundle's other intermediate outputs. Non-lazy
     // chunks keep the configured template.
     let currentCompilation: Compilation | undefined;
@@ -173,7 +173,7 @@ class CssExtractRspackPluginImpl {
             id,
           );
           if (layoutName !== undefined) {
-            return `.rspeedy/async/${layoutName}.css`;
+            return `.rspeedy/lazy-bundle/${layoutName}.css`;
           }
         }
         return userChunkFilename;
@@ -332,7 +332,7 @@ class CssExtractRspackPluginImpl {
                     options.chunkFilename ?? '.rspeedy/async/[name]/[name].css',
                     { chunk: c },
                   ).path
-                  : `.rspeedy/async/${layoutName}.css`;
+                  : `.rspeedy/lazy-bundle/${layoutName}.css`;
                 return [String(c.name ?? c.id), path] as const;
               });
 

--- a/packages/webpack/react-webpack-plugin/package.json
+++ b/packages/webpack/react-webpack-plugin/package.json
@@ -54,7 +54,7 @@
     "swc-loader": "^0.2.7"
   },
   "peerDependencies": {
-    "@lynx-js/template-webpack-plugin": "^0.13.0"
+    "@lynx-js/template-webpack-plugin": "^0.13.0 || ^0.14.0"
   },
   "peerDependenciesMeta": {
     "@lynx-js/react": {

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/index.jsx
@@ -44,7 +44,7 @@ it('should have module.exports in foo.js template', async () => {
 
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/foo.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/foo.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -58,18 +58,18 @@ it('should have module.exports in foo.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/foo.js/background.js'])
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/foo.js/background.js'])
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/foo.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/foo.js/background.js']).not
     .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/foo.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/foo.js/background.js']).not
     .toContain('function (globDynamicComponentEntry)');
 });
 
 it('should have module.exports in bar.js template', async () => {
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/bar.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/bar.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -83,18 +83,18 @@ it('should have module.exports in bar.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/bar.js/background.js'])
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/bar.js/background.js'])
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/bar.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/bar.js/background.js']).not
     .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/bar.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/bar.js/background.js']).not
     .toContain('function (globDynamicComponentEntry)');
 });
 
 it('should have module.exports in baz.js template', async () => {
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/baz.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/baz.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -108,10 +108,10 @@ it('should have module.exports in baz.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/baz.js/background.js'])
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/baz.js/background.js'])
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/baz.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/baz.js/background.js']).not
     .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/baz.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/baz.js/background.js']).not
     .toContain('function (globDynamicComponentEntry)');
 });

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-lazy-bundle-production/rspack.config.js
@@ -15,7 +15,7 @@ export default {
   ...config,
   output: {
     ...config.output,
-    chunkFilename: '.rspeedy/async/[name].js',
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
   },
   plugins: [
     ...config.plugins,

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/index.jsx
@@ -11,7 +11,7 @@ it('should have module.exports in foo.js template', async () => {
 
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/foo.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/foo.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -25,18 +25,18 @@ it('should have module.exports in foo.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/foo.js/background.js'])
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/foo.js/background.js'])
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/foo.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/foo.js/background.js']).not
     .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/foo.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/foo.js/background.js']).not
     .toContain('function (globDynamicComponentEntry)');
 });
 
 it('should have module.exports in bar.js template', async () => {
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/bar.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/bar.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -50,18 +50,18 @@ it('should have module.exports in bar.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/bar.js/background.js'])
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/bar.js/background.js'])
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/bar.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/bar.js/background.js']).not
     .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/bar.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/bar.js/background.js']).not
     .toContain('function (globDynamicComponentEntry)');
 });
 
 it('should have module.exports in baz.js template', async () => {
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/baz.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/baz.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -75,10 +75,10 @@ it('should have module.exports in baz.js template', async () => {
     expect.stringContaining('function (globDynamicComponentEntry)'),
   );
 
-  expect(tasmJSON.manifest['/.rspeedy/async/baz.js/background.js'])
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/baz.js/background.js'])
     .toBeDefined();
-  expect(tasmJSON.manifest['/.rspeedy/async/baz.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/baz.js/background.js']).not
     .toContain('const module = { exports: {} }');
-  expect(tasmJSON.manifest['/.rspeedy/async/baz.js/background.js']).not
+  expect(tasmJSON.manifest['/.rspeedy/lazy-bundle/baz.js/background.js']).not
     .toContain('function (globDynamicComponentEntry)');
 });

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-production/rspack.config.js
@@ -13,7 +13,7 @@ export default {
   ...config,
   output: {
     ...config.output,
-    chunkFilename: '.rspeedy/async/[name].js',
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
   },
   plugins: [
     ...config.plugins,

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-with-source-map/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-with-source-map/index.jsx
@@ -11,7 +11,7 @@ it('should have module.exports in foo.js template', async () => {
 
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/foo.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/foo.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -34,7 +34,7 @@ it('should have module.exports in foo.js template', async () => {
 it('should have module.exports in bar.js template', async () => {
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/bar.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/bar.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -57,7 +57,7 @@ it('should have module.exports in bar.js template', async () => {
 it('should have module.exports in baz.js template', async () => {
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/baz.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/baz.js/tasm.json'),
       'utf-8',
     ),
   );

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-with-source-map/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime-with-source-map/rspack.config.js
@@ -14,7 +14,7 @@ export default {
   devtool: 'source-map',
   output: {
     ...config.output,
-    chunkFilename: '.rspeedy/async/[name].js',
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
   },
   plugins: [
     ...config.plugins,

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime/index.jsx
@@ -11,7 +11,7 @@ it('should have module.exports in foo.js template', async () => {
 
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/foo.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/foo.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -25,7 +25,7 @@ it('should have module.exports in foo.js template', async () => {
 it('should have module.exports in bar.js template', async () => {
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/bar.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/bar.js/tasm.json'),
       'utf-8',
     ),
   );
@@ -39,7 +39,7 @@ it('should have module.exports in bar.js template', async () => {
 it('should have module.exports in baz.js template', async () => {
   const tasmJSON = JSON.parse(
     await readFile(
-      resolve(__dirname, '.rspeedy/async/baz.js/tasm.json'),
+      resolve(__dirname, '.rspeedy/lazy-bundle/baz.js/tasm.json'),
       'utf-8',
     ),
   );

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/amd-runtime/rspack.config.js
@@ -13,7 +13,7 @@ export default {
   ...config,
   output: {
     ...config.output,
-    chunkFilename: '.rspeedy/async/[name].js',
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
   },
   plugins: [
     ...config.plugins,

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/async-chunk-groups/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/async-chunk-groups/rspack.config.js
@@ -13,7 +13,7 @@ export default {
   ...config,
   output: {
     ...config.output,
-    chunkFilename: '.rspeedy/async/[name].js',
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
   },
   plugins: [
     ...config.plugins,
@@ -39,7 +39,7 @@ export default {
               [ // main entry
                 'main__main-thread.js',
                 // foo.js lazy bundle
-                '.rspeedy/async/foo.js/main-thread.js',
+                '.rspeedy/lazy-bundle/foo.js/main-thread.js',
               ],
             );
             expect(
@@ -49,7 +49,7 @@ export default {
               [ // main entry
                 'main__background.js',
                 // foo.js lazy bundle
-                '.rspeedy/async/foo.js/background.js',
+                '.rspeedy/lazy-bundle/foo.js/background.js',
               ],
             );
           },

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/async-chunk-name/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/async-chunk-name/index.jsx
@@ -9,6 +9,6 @@ it('should have async templates', async () => {
   const { foo } = await importPromise;
   await expect(foo()).resolves.toBe(`foo bar baz`);
 
-  const asyncTemplates = await readdir(resolve(__dirname, 'async'));
+  const asyncTemplates = await readdir(resolve(__dirname, 'lazy-bundle'));
   expect(asyncTemplates).toHaveLength(3); // foo, bar, baz
 });

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/async-chunk-name/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/async-chunk-name/rspack.config.js
@@ -13,7 +13,7 @@ export default {
   ...config,
   output: {
     ...config.output,
-    chunkFilename: '.rspeedy/async/[name].js',
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
   },
   plugins: [
     ...config.plugins,

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/background-only/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/background-only/index.jsx
@@ -19,7 +19,7 @@ it('should have chunkName', async () => {
 });
 
 it('should not have duplicated chunk', async () => {
-  const files = await readdir(join(__dirname, '.rspeedy/async'), {
+  const files = await readdir(join(__dirname, '.rspeedy/lazy-bundle'), {
     recursive: true,
   });
   expect(
@@ -38,7 +38,7 @@ it('should have async chunks', () => {
     expect(['foo', 'bar', 'baz'].every(entry =>
       existsSync(join(
         __dirname,
-        `.rspeedy/async/${entry}.js/background.js`,
+        `.rspeedy/lazy-bundle/${entry}.js/background.js`,
       ))
     )).toBeTruthy();
   }

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/index.jsx
@@ -16,7 +16,7 @@ it('should resolve the same file imported via different paths', async () => {
 });
 
 it('should generate a single lazy bundle inside the async directory', async () => {
-  const bundles = (await readdir(join(__dirname, 'async'), {
+  const bundles = (await readdir(join(__dirname, 'lazy-bundle'), {
     recursive: true,
   })).filter(name => name.endsWith('.bundle'));
 

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/rspack.config.js
@@ -19,7 +19,7 @@ export default {
   },
   output: {
     ...config.output,
-    chunkFilename: '.rspeedy/async/[name].js',
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
   },
   plugins: [
     ...config.plugins,

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/code-splitting/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/code-splitting/index.jsx
@@ -9,14 +9,14 @@ it('should have async debug-info.json', async () => {
   const { foo } = await importPromise;
   await expect(foo()).resolves.toBe(`foo bar baz`);
 
-  const asyncAssets = await readdir(resolve(__dirname, '.rspeedy/async'));
+  const asyncAssets = await readdir(resolve(__dirname, '.rspeedy/lazy-bundle'));
   expect(asyncAssets).toContain('foo.js');
   expect(asyncAssets).toContain('bar.js');
   expect(asyncAssets).toContain('baz.js');
 });
 
 it('should have correct main-thread content', async () => {
-  const root = resolve(__dirname, '.rspeedy/async');
+  const root = resolve(__dirname, '.rspeedy/lazy-bundle');
   const foo = resolve(root, 'foo.js/tasm.json');
   const bar = resolve(root, 'bar.js/tasm.json');
   const baz = resolve(root, 'baz.js/tasm.json');

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/code-splitting/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/code-splitting/rspack.config.js
@@ -13,7 +13,7 @@ export default {
   ...config,
   output: {
     ...config.output,
-    chunkFilename: '.rspeedy/async/[name].js',
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
   },
   plugins: [
     ...config.plugins,

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/lazy-bundle-sourcemap/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/lazy-bundle-sourcemap/rspack.config.js
@@ -10,7 +10,7 @@ const config = createConfig({
 }, {
   mainThreadChunks: [
     'main__main-thread.js',
-    '.rspeedy/async/lazy.jsx/main-thread.js',
+    '.rspeedy/lazy-bundle/lazy.jsx/main-thread.js',
   ],
   experimental_isLazyBundle: true,
 });

--- a/packages/webpack/react-webpack-plugin/test/cases/main-thread/lazy-bundle-sourcemap/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/main-thread/lazy-bundle-sourcemap/test.config.cjs
@@ -105,7 +105,7 @@ module.exports = {
       );
     }
 
-    const asyncRoot = path.join(compiler.outputPath, '.rspeedy/async');
+    const asyncRoot = path.join(compiler.outputPath, '.rspeedy/lazy-bundle');
     const asyncEntries = fs.readdirSync(asyncRoot, { recursive: true });
     const asyncDebugMetadataFile = asyncEntries.find(entry =>
       entry.endsWith('debug-metadata.json')

--- a/packages/webpack/react-webpack-plugin/test/sourcemap-verify.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/sourcemap-verify.test.ts
@@ -172,7 +172,8 @@ describe('Lazy Bundle Sourcemap Verification', () => {
     ).toContain('main__main-thread.js');
     expect(
       mainThreadFiles.some(name =>
-        name.includes('.rspeedy/async/') && name.endsWith('main-thread.js')
+        name.includes('.rspeedy/lazy-bundle/')
+        && name.endsWith('main-thread.js')
       ),
       'Should capture at least one async main-thread asset from dynamic import',
     ).toBe(true);
@@ -185,7 +186,8 @@ describe('Lazy Bundle Sourcemap Verification', () => {
       nonLazyAsyncConfig,
       path.join(__dirname, 'cases/main-thread/lazy-bundle-sourcemap'),
       name =>
-        name.includes('.rspeedy/async/') && name.endsWith('main-thread.js'),
+        name.includes('.rspeedy/lazy-bundle/')
+        && name.endsWith('main-thread.js'),
     );
 
     const assetNames = [...capturedAssets.keys()];

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -187,7 +187,7 @@ export interface LynxTemplatePluginOptions {
   /**
    * The filename of the lazy bundle.
    *
-   * @defaultValue `'async/[name].[fullhash].bundle'`
+   * @defaultValue `'lazy-bundle/[name].[fullhash].bundle'`
    */
   lazyBundleFilename?: string;
 
@@ -419,7 +419,7 @@ export class LynxTemplatePlugin {
   static defaultOptions: Readonly<Required<LynxTemplatePluginOptions>> = Object
     .freeze<Required<LynxTemplatePluginOptions>>({
       filename: '[name].bundle',
-      lazyBundleFilename: 'async/[name].[fullhash].bundle',
+      lazyBundleFilename: 'lazy-bundle/[name].[fullhash].bundle',
       intermediate: '.rspeedy',
       chunks: 'all',
       excludeChunks: [],
@@ -523,7 +523,7 @@ class LynxTemplatePluginImpl {
 
   /**
    * Route a lazy bundle's intermediate JS chunk to
-   * `<intermediateRoot>/async/<name>/<layer>.js`, co-located with the bundle's
+   * `<intermediateRoot>/lazy-bundle/<name>/<layer>.js`, co-located with the bundle's
    * other intermediate outputs (mirroring `<intermediateRoot>/main/`).
    * Non-lazy chunks keep the default `output.chunkFilename`. Installed once
    * per compiler — the plugin is instantiated once per entry.
@@ -556,7 +556,7 @@ class LynxTemplatePluginImpl {
             id,
           );
           if (layoutName !== undefined) {
-            return `${prefix}async/${layoutName}.js`;
+            return `${prefix}lazy-bundle/${layoutName}.js`;
           }
         }
         return typeof original === 'function'
@@ -956,7 +956,7 @@ class LynxTemplatePluginImpl {
             asyncAssetsInfoByGroups,
             chunkGroups,
             filenameTemplate,
-            path.join(intermediateRoot, 'async', filename),
+            path.join(intermediateRoot, 'lazy-bundle', filename),
             /** isAsync */ true,
           );
         },
@@ -1418,7 +1418,7 @@ function collectChunkGroupResources(
 /**
  * Derive a lazy bundle name from the resolved module paths. The name is
  * relative to the compiler context with `..` segments replaced, so the
- * bundle never escapes the `async/` output directory.
+ * bundle never escapes the `lazy-bundle/` output directory.
  */
 function resourcesToLazyBundleName(
   resources: string[],

--- a/packages/webpack/template-webpack-plugin/test/cases/bundle-splitting/async-chunk/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/bundle-splitting/async-chunk/index.js
@@ -36,7 +36,7 @@ it('should generate correct async chunk', async () => {
   const content = await fs.promises.readFile(
     path.resolve(
       __dirname,
-      `.rspeedy/async/bundle-splitting/async-chunk/dynamic.js.js`,
+      `.rspeedy/lazy-bundle/bundle-splitting/async-chunk/dynamic.js.js`,
     ),
     'utf-8',
   );
@@ -46,7 +46,7 @@ it('should generate correct async chunk', async () => {
   const content2 = await fs.promises.readFile(
     path.resolve(
       __dirname,
-      `.rspeedy/async/bundle-splitting/async-chunk/dynamic2.js.js`,
+      `.rspeedy/lazy-bundle/bundle-splitting/async-chunk/dynamic2.js.js`,
     ),
     'utf-8',
   );
@@ -56,7 +56,7 @@ it('should generate correct async chunk', async () => {
   const content3 = await fs.promises.readFile(
     path.resolve(
       __dirname,
-      `.rspeedy/async/bundle-splitting/async-chunk/dynamic3.js.js`,
+      `.rspeedy/lazy-bundle/bundle-splitting/async-chunk/dynamic3.js.js`,
     ),
     'utf-8',
   );

--- a/packages/webpack/template-webpack-plugin/test/cases/bundle-splitting/with-style/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/bundle-splitting/with-style/index.js
@@ -11,7 +11,7 @@ import { join } from 'node:path';
 it('should merge content of style chunk to cssMap for a lazy bundle', async () => {
   await import(/* webpackChunkName: 'test' */ './foo.js');
 
-  const tasmJSONPath = join(__dirname, 'async', 'test', 'tasm.json');
+  const tasmJSONPath = join(__dirname, 'lazy-bundle', 'test', 'tasm.json');
   const content = await readFile(tasmJSONPath, 'utf-8');
   const { css } = JSON.parse(content);
   expect(css.cssMap['0'][0].selectorText.value).toBe('.red');

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/async-chunk/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/async-chunk/index.js
@@ -24,7 +24,7 @@ it('should have correct chunk content', async () => {
 });
 
 it('should generate correct foo template', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/context/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/context/index.js
@@ -19,6 +19,6 @@ it('should have correct chunk content', async () => {
 });
 
 it('should not generate bundle for context', () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/a/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/a/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeFalsy();
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/a.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/a.js
@@ -33,15 +33,15 @@ it('should have correct tasm.json', async () => {
 it('should generate correct bundle', async () => {
   const foo = path.resolve(
     __dirname,
-    `../async/foo.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/foo.${__webpack_hash__}.bundle`,
   );
   const bar = path.resolve(
     __dirname,
-    `../async/bar.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/bar.${__webpack_hash__}.bundle`,
   );
   const baz = path.resolve(
     __dirname,
-    `../async/baz.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/baz.${__webpack_hash__}.bundle`,
   );
 
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/b.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/b.js
@@ -33,15 +33,15 @@ it('should have correct tasm.json', async () => {
 it('should generate correct bundle', async () => {
   const foo = path.resolve(
     __dirname,
-    `../async/foo.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/foo.${__webpack_hash__}.bundle`,
   );
   const bar = path.resolve(
     __dirname,
-    `../async/bar.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/bar.${__webpack_hash__}.bundle`,
   );
   const baz = path.resolve(
     __dirname,
-    `../async/baz.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/baz.${__webpack_hash__}.bundle`,
   );
 
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
@@ -56,7 +56,7 @@ it('should generate correct bundle', async () => {
   expect(bazContent).toContain('function baz()');
 
   const asyncTemplates = await fs.promises.readdir(
-    path.resolve(__dirname, '../async'),
+    path.resolve(__dirname, '../lazy-bundle'),
   );
   expect(asyncTemplates).toHaveLength(3); // foo, bar, baz
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/c.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/c.js
@@ -33,15 +33,15 @@ it('should have correct tasm.json', async () => {
 it('should generate correct bundle', async () => {
   const foo = path.resolve(
     __dirname,
-    `../async/foo.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/foo.${__webpack_hash__}.bundle`,
   );
   const bar = path.resolve(
     __dirname,
-    `../async/bar.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/bar.${__webpack_hash__}.bundle`,
   );
   const baz = path.resolve(
     __dirname,
-    `../async/baz.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/baz.${__webpack_hash__}.bundle`,
   );
 
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
@@ -56,7 +56,7 @@ it('should generate correct bundle', async () => {
   expect(bazContent).toContain('function baz()');
 
   const asyncTemplates = await fs.promises.readdir(
-    path.resolve(__dirname, '../async'),
+    path.resolve(__dirname, '../lazy-bundle'),
   );
   expect(asyncTemplates).toHaveLength(3); // foo, bar, baz
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/d.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/d.js
@@ -33,15 +33,15 @@ it('should have correct tasm.json', async () => {
 it('should generate correct bundle', async () => {
   const foo = path.resolve(
     __dirname,
-    `../async/foo.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/foo.${__webpack_hash__}.bundle`,
   );
   const bar = path.resolve(
     __dirname,
-    `../async/bar.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/bar.${__webpack_hash__}.bundle`,
   );
   const baz = path.resolve(
     __dirname,
-    `../async/baz.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/baz.${__webpack_hash__}.bundle`,
   );
 
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
@@ -56,7 +56,7 @@ it('should generate correct bundle', async () => {
   expect(bazContent).toContain('function baz()');
 
   const asyncTemplates = await fs.promises.readdir(
-    path.resolve(__dirname, '../async'),
+    path.resolve(__dirname, '../lazy-bundle'),
   );
   expect(asyncTemplates).toHaveLength(3); // foo, bar, baz
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/e.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/duplicated-async-chunk/e.js
@@ -33,15 +33,15 @@ it('should have correct tasm.json', async () => {
 it('should generate correct bundle', async () => {
   const foo = path.resolve(
     __dirname,
-    `../async/foo.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/foo.${__webpack_hash__}.bundle`,
   );
   const bar = path.resolve(
     __dirname,
-    `../async/bar.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/bar.${__webpack_hash__}.bundle`,
   );
   const baz = path.resolve(
     __dirname,
-    `../async/baz.${__webpack_hash__}.bundle`,
+    `../lazy-bundle/baz.${__webpack_hash__}.bundle`,
   );
 
   expect([foo, bar, baz].every(p => fs.existsSync(p))).toBeTruthy();
@@ -56,7 +56,7 @@ it('should generate correct bundle', async () => {
   expect(bazContent).toContain('function baz()');
 
   const asyncTemplates = await fs.promises.readdir(
-    path.resolve(__dirname, '../async'),
+    path.resolve(__dirname, '../lazy-bundle'),
   );
   expect(asyncTemplates).toHaveLength(3); // foo, bar, baz
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/code-splitting/webpack-chunk-name/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/code-splitting/webpack-chunk-name/index.js
@@ -13,7 +13,7 @@ it('should have correct chunk content', async () => {
 });
 
 it('should have both foo and bar', async () => {
-  const tasmJSONPath = join(__dirname, 'async', 'test', 'tasm.json');
+  const tasmJSONPath = join(__dirname, 'lazy-bundle', 'test', 'tasm.json');
   expect(existsSync(tasmJSONPath));
   const content = await readFile(tasmJSONPath, 'utf-8');
 

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/external/index.js
@@ -24,7 +24,7 @@ it('should have correct chunk content', async () => {
 });
 
 it('lazy bundle bts is inlined even with inlineScripts: false', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-fn/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-fn/index.js
@@ -38,7 +38,7 @@ it('should have correct bar chunk content', async () => {
 });
 
 it('should generate correct foo template', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');
@@ -53,7 +53,7 @@ it('should generate correct foo template', async () => {
 });
 
 it('should generate correct bar template', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/bar/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/bar/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-object/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-object/index.js
@@ -38,7 +38,7 @@ it('should have correct bar chunk content', async () => {
 });
 
 it('should generate correct foo template', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');
@@ -53,7 +53,7 @@ it('should generate correct foo template', async () => {
 });
 
 it('should generate correct bar template', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/bar/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/bar/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-regex/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline-regex/index.js
@@ -38,7 +38,7 @@ it('should have correct bar chunk content', async () => {
 });
 
 it('should generate correct foo template', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');
@@ -53,7 +53,7 @@ it('should generate correct foo template', async () => {
 });
 
 it('should generate correct bar template', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/bar/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/bar/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/inline/index.js
@@ -24,7 +24,7 @@ it('should have correct chunk content', async () => {
 });
 
 it('should generate correct foo template', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const content = await readFile(tasmJSONPath, 'utf-8');

--- a/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/inline-scripts/lazy-bundle-split/index.js
@@ -27,7 +27,7 @@ it('should load the lazy bundle', async () => {
 it('inlines every split background chunk of a lazy bundle', async () => {
   const tasmJSONPath = resolve(
     __dirname,
-    '.rspeedy/async/component/tasm.json',
+    '.rspeedy/lazy-bundle/component/tasm.json',
   );
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 

--- a/packages/webpack/template-webpack-plugin/test/cases/lazy-bundle-fetcher/fetchbundle/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/lazy-bundle-fetcher/fetchbundle/index.js
@@ -13,7 +13,7 @@ void import(/* webpackChunkName: 'foo:main-thread' */ './foo.mts.js');
 void import(/* webpackChunkName: 'foo:background' */ './foo.bts.js');
 
 it('FetchBundle: lazy bundle tasm.json carries customSections shape', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const tasm = JSON.parse(await readFile(tasmJSONPath, 'utf-8'));

--- a/packages/webpack/template-webpack-plugin/test/cases/lazy-bundle-fetcher/querycomponent/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/lazy-bundle-fetcher/querycomponent/index.js
@@ -13,7 +13,7 @@ void import(/* webpackChunkName: 'foo:main-thread' */ './foo.mts.js');
 void import(/* webpackChunkName: 'foo:background' */ './foo.bts.js');
 
 it('QueryComponent (default): lazy bundle keeps lepusCode + manifest shape', async () => {
-  const tasmJSONPath = resolve(__dirname, '.rspeedy/async/foo/tasm.json');
+  const tasmJSONPath = resolve(__dirname, '.rspeedy/lazy-bundle/foo/tasm.json');
   expect(existsSync(tasmJSONPath)).toBeTruthy();
 
   const tasm = JSON.parse(await readFile(tasmJSONPath, 'utf-8'));

--- a/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunk/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunk/index.js
@@ -7,6 +7,6 @@ import(
 
 it('should have changed bundle', () => {
   expect(Object.values(__webpack_require__['lynx_aci'])).toStrictEqual([
-    `async/dynamic.${__webpack_require__.h()}.bundle`,
+    `lazy-bundle/dynamic.${__webpack_require__.h()}.bundle`,
   ]);
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks-dedupe/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks-dedupe/index.js
@@ -8,6 +8,6 @@ load();
 
 it('should map both import paths to the same bundle', () => {
   expect(Object.values(__webpack_require__['lynx_aci'])).toStrictEqual([
-    `async/dynamic.js.${__webpack_require__.h()}.bundle`,
+    `lazy-bundle/dynamic.js.${__webpack_require__.h()}.bundle`,
   ]);
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks-escape/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks-escape/index.js
@@ -4,14 +4,14 @@ import('./dynamic.js');
 
 // `dynamic.js` resolves above the compiler `context` (set to `./nested`), so
 // its path relative to the context starts with `..`. The lazy bundle name must
-// replace `..` with `__` so the output stays inside the `async/` directory.
-it('should keep a bundle resolved outside the context inside async/', () => {
+// replace `..` with `__` so the output stays inside the `lazy-bundle/` directory.
+it('should keep a bundle resolved outside the context inside lazy-bundle/', () => {
   const names = Object.values(__webpack_require__['lynx_aci']);
   expect(names).toStrictEqual([
-    `async/__/dynamic.js.${__webpack_require__.h()}.bundle`,
+    `lazy-bundle/__/dynamic.js.${__webpack_require__.h()}.bundle`,
   ]);
   for (const name of names) {
-    expect(name.startsWith('async/')).toBe(true);
+    expect(name.startsWith('lazy-bundle/')).toBe(true);
     expect(name.includes('/../')).toBe(false);
   }
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks-unnamed/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks-unnamed/index.js
@@ -4,6 +4,6 @@ import('./dynamic.js');
 
 it('should map an unnamed async chunk to its lazy bundle', () => {
   expect(Object.values(__webpack_require__['lynx_aci'])).toStrictEqual([
-    `async/dynamic.js.${__webpack_require__.h()}.bundle`,
+    `lazy-bundle/dynamic.js.${__webpack_require__.h()}.bundle`,
   ]);
 });

--- a/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/runtime-module/async-chunks/index.js
@@ -17,7 +17,7 @@ import(
 
 it('should have changed bundle', () => {
   expect(Object.values(__webpack_require__['lynx_aci'])).toStrictEqual([
-    `async/dynamic.${__webpack_require__.h()}.bundle`,
-    `async/dynamic-foo.${__webpack_require__.h()}.bundle`,
+    `lazy-bundle/dynamic.${__webpack_require__.h()}.bundle`,
+    `lazy-bundle/dynamic-foo.${__webpack_require__.h()}.bundle`,
   ]);
 });

--- a/packages/webpack/template-webpack-plugin/test/lazy-bundle-fetcher.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/lazy-bundle-fetcher.test.ts
@@ -120,7 +120,7 @@ async function runAndGetMtEncoding(
 ): Promise<string | undefined> {
   const { captured, plugin } = captureBeforeEmit();
   await runWebpack(buildConfig(plugin, mode));
-  const lazy = captured.find((c) => c.outputName.startsWith('async/'));
+  const lazy = captured.find((c) => c.outputName.startsWith('lazy-bundle/'));
   return lazy?.customSections['main-thread']?.encoding;
 }
 

--- a/website/docs/en/guide/output.md
+++ b/website/docs/en/guide/output.md
@@ -13,25 +13,20 @@ In production, the `dist/` directory contains all the files that need to be depl
 ```
 dist/
 ├── [name].lynx.bundle
-├── async
-│   └── [name].lynx.bundle
+├── lazy-bundle
+│   └── [name].[fullhash].bundle
 └── static
     ├── image
     │   └── [name].[hash].png
-    ├── svg
-    │   └── [name].[hash].svg
-    └── js
-        ├── [id].[hash].js
-        │   └── async
-        │       └── [id].[hash].js
-        └── lib-preact.[hash].js
+    └── svg
+        └── [name].[hash].svg
 ```
 
 The most common output files are Bundle files, JS files and static assets:
 
 - Bundle files(`[name].lynx.bundle`), which can be configured with [`output.filename.bundle`].
-- Async(lazy) bundle files(`async/[name].lynx.bundle`).
-- JS files(`static/js/*.js`), which can be configured with [`output.distPath.js`] and [`output.filename.js`].
+- Lazy bundle files(`lazy-bundle/[name].[fullhash].bundle`).
+- JS files(`static/js/*.js`), only emitted when [`output.inlineScripts`] is disabled, which can be configured with [`output.distPath.js`] and [`output.filename.js`].
 - Static assets(`static/{font,image,media,svg}`) directory.
 
 In the filename, `[name]` is the entry name corresponding to this file, such as `index`, `main`. `[hash]` is the hash value generated based on the content of the file. `[id]` is the internal chunk ID of Rspack.
@@ -43,39 +38,36 @@ In development, an `dist/.rspeedy` directory is emitted which contains the resou
 ```
 dist/
 ├── .rspeedy
-│   ├── async
+│   ├── lazy-bundle
 │   │   └── [name]
-│   │       ├── debug-info.json
-│   │       ├── tasm.json
-│   │       └── [name].css
-│   ├── [name]
-│   │   ├── background.js
-│   │   ├── background.js.map
-│   │   ├── debug-info.json
-│   │   ├── [name].css
-│   │   ├── main-thread.js
-│   │   ├── main-thread.js.map
-│   │   └── tasm.json
-│   └── rspeedy.config.js
+│   │       ├── background.js
+│   │       ├── background.css
+│   │       ├── background.css.hot-update.json
+│   │       ├── debug-metadata.json
+│   │       ├── main-thread.js
+│   │       └── tasm.json
+│   └── [name]
+│       ├── background.js
+│       ├── debug-metadata.json
+│       ├── main-thread.js
+│       ├── [name].css
+│       ├── [name].css.hot-update.json
+│       └── tasm.json
 ├── [name].lynx.bundle
+├── lazy-bundle
+│   └── [name].[fullhash].bundle
 └── static
     ├── image
-    │   ├── [name].[hash].png
-    │   └── [name].[hash].svg
-    └── js
-        ├── [id].[hash].js
-        │   └── async
-        │       ├── [id].[hash].js
-        │       └── [id].[hash].js.map
-        ├── lib-preact.[hash].js
-        └── lib-preact.[hash].js.map
+    │   └── [name].[hash].png
+    └── svg
+        └── [name].[hash].svg
 ```
 
 In addition, Rspeedy generates some extra files in development:
 
 - Background Thread Script(BTS): The background script file that is inlined into the bundle, default output to `.rspeedy/[name]/background.js`.
 - MainThread Thread Script(MTS): The main-thread script file that is inlined into the bundle, default output to `.rspeedy/[name]/main-thread.js`.
-- Source Map files: contains the source code mappings, which is output to the same level directory of JS files and adds a `.map` suffix.
+- Source Map files: contains the source code mappings, which is output to the same level directory of JS files and adds a `.map` suffix when [`output.sourceMap`] is enabled.
 
 ## Modify the Directory
 
@@ -117,6 +109,7 @@ dist
 ```
 
 [`output.filename`]: /api/rspeedy.output.filename
+[`output.inlineScripts`]: /api/rspeedy.output.inlinescripts
 [`output.filename.js`]: /api/rspeedy.filename.js
 [`output.filename.bundle`]: /api/rspeedy.filename.bundle
 [`output.distPath`]: /api/rspeedy.output.distpath

--- a/website/docs/zh/guide/output.md
+++ b/website/docs/zh/guide/output.md
@@ -13,25 +13,20 @@
 ```
 dist/
 ├── [name].lynx.bundle
-├── async
-│   └── [name].lynx.bundle
+├── lazy-bundle
+│   └── [name].[fullhash].bundle
 └── static
     ├── image
     │   └── [name].[hash].png
-    ├── svg
-    │   └── [name].[hash].svg
-    └── js
-        ├── [id].[hash].js
-        │   └── async
-        │       └── [id].[hash].js
-        └── lib-preact.[hash].js
+    └── svg
+        └── [name].[hash].svg
 ```
 
 最常见的输出文件包括 Bundle 文件、JS 文件和静态资源：
 
 - Bundle（`[name].lynx.bundle`），可通过 [`output.filename.bundle`] 配置
-- 异步 Bundle（`async/[name].lynx.bundle`）
-- JS 文件（`static/js/*.js`），可通过 [`output.distPath.js`] 和 [`output.filename.js`] 配置
+- 懒加载 Bundle（`lazy-bundle/[name].[fullhash].bundle`）
+- JS 文件（`static/js/*.js`），仅在关闭 [`output.inlineScripts`] 时输出，可通过 [`output.distPath.js`] 和 [`output.filename.js`] 配置
 - 静态资源目录（`static/{font,image,media,svg}`）
 
 文件名中的占位符含义：
@@ -47,39 +42,36 @@ dist/
 ```
 dist/
 ├── .rspeedy
-│   ├── async
+│   ├── lazy-bundle
 │   │   └── [name]
-│   │       ├── debug-info.json
-│   │       ├── tasm.json
-│   │       └── [name].css
-│   ├── [name]
-│   │   ├── background.js
-│   │   ├── background.js.map
-│   │   ├── debug-info.json
-│   │   ├── [name].css
-│   │   ├── main-thread.js
-│   │   ├── main-thread.js.map
-│   │   └── tasm.json
-│   └── rspeedy.config.js
+│   │       ├── background.js
+│   │       ├── background.css
+│   │       ├── background.css.hot-update.json
+│   │       ├── debug-metadata.json
+│   │       ├── main-thread.js
+│   │       └── tasm.json
+│   └── [name]
+│       ├── background.js
+│       ├── debug-metadata.json
+│       ├── main-thread.js
+│       ├── [name].css
+│       ├── [name].css.hot-update.json
+│       └── tasm.json
 ├── [name].lynx.bundle
+├── lazy-bundle
+│   └── [name].[fullhash].bundle
 └── static
     ├── image
-    │   ├── [name].[hash].png
-    │   └── [name].[hash].svg
-    └── js
-        ├── [id].[hash].js
-        │   └── async
-        │       ├── [id].[hash].js
-        │       └── [id].[hash].js.map
-        ├── lib-preact.[hash].js
-        └── lib-preact.[hash].js.map
+    │   └── [name].[hash].png
+    └── svg
+        └── [name].[hash].svg
 ```
 
 开发环境额外生成的文件包括：
 
 - 后台线程脚本（Background Thread Script）：内联到 Bundle 中的脚本，默认输出到 `.rspeedy/[name]/background.js`
 - 主线程脚本（MainThread Thread Script）：默认输出到 `.rspeedy/[name]/main-thread.js`
-- Source Map 文件：与 JS 文件同目录，以 `.map` 为后缀
+- Source Map 文件：开启 [`output.sourceMap`] 后，与 JS 文件同目录，以 `.map` 为后缀
 
 ## 修改目录结构
 
@@ -119,6 +111,7 @@ dist
 ```
 
 [`output.filename`]: ../../api/rspeedy.output.filename
+[`output.inlineScripts`]: ../../api/rspeedy.output.inlinescripts
 [`output.filename.js`]: ../../api/rspeedy.filename.js
 [`output.filename.bundle`]: ../../api/rspeedy.filename.bundle
 [`output.distPath`]: ../../api/rspeedy.output.distpath


### PR DESCRIPTION
## Summary

Lazy bundles are no longer async-only: since #2584 they can be loaded synchronously with `import(..., { with: { mode: 'sync' } })`, so keeping their output under `async/` is a misnomer. The newer APIs already use the "lazy bundle" term (`lazyBundleFilename`, `BundleFilenameContext.lazyBundle`); this PR aligns the on-disk layout with it. A dedicated `lazy-bundle/` directory is also far less likely to collide with a user entry name than `async`.

- The default `lazyBundleFilename` becomes `lazy-bundle/[name].[fullhash].bundle` (was `async/[name].[fullhash].bundle`).
- Intermediate outputs move from `.rspeedy/async/<name>/` to `.rspeedy/lazy-bundle/<name>/` (JS layers, CSS, CSS hot-update manifests, `tasm.json`, `debug-metadata.json`).
- `@lynx-js/css-extract-webpack-plugin` routes lazy CSS to the new directory and now requires `@lynx-js/template-webpack-plugin` `^0.14.0`; `@lynx-js/react-webpack-plugin` widens its peer range to `^0.13.0 || ^0.14.0`.
- The output-files guide (`website/docs/{en,zh}/guide/output.md`) is updated to match the actual artifacts produced today (verified against a fresh dev/production build): `debug-info.json` → `debug-metadata.json`, no `static/js` in a default build (scripts are inlined), no source maps unless `output.sourceMap` is enabled, and the dev tree now shows the final `lazy-bundle/*.bundle` outputs.

`static/js/async/` (Rsbuild's own `jsAsync`/`cssAsync` dist paths) is unrelated and unchanged.

## Breaking

Deployment scripts that glob `dist/async/**` must switch to `dist/lazy-bundle/**`. The rename is runtime-safe: the `lynx_aci` map is generated with full paths in the same compilation, so consumer bundles and their lazy bundles stay self-consistent.

## CI fix included

`test-rstest / check` failed deterministically on the first two runs with an empty error-remapping scan index. Root cause (pre-existing, unrelated to the rename): `examples/react-{et-,}lazy-bundle-standalone` used `pnpm run --parallel "/^build:(producer|consumer)$/"` — pnpm's `--parallel` implies `-r`, so the script rebuilt every workspace package with a matching script (including `examples/react-debug-metadata`) in the middle of the turbo build, racing the sibling examples' own build tasks and poisoning their cached outputs. Dropping `--parallel` keeps the concurrent run scoped to the package's own scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lazy bundles now support both asynchronous and synchronous loading.
  * Bundle assets are generated under the clearer `lazy-bundle/` directory.

* **Bug Fixes**
  * Updated CSS hot updates, source maps, debug metadata, and deployment paths to use the new lazy-bundle location.

* **Documentation**
  * Updated output directory examples and configuration references to reflect the new bundle structure.

* **Chores**
  * Improved compatibility with the latest template and CSS extraction plugin versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->