### PR TITLE
fix(web-core): pass the lepus method's return value to the callLepusMethod callback

### DIFF
--- a/.changeset/web-core-call-lepus-method-return.md
+++ b/.changeset/web-core-call-lepus-method-return.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Fix `nativeApp.callLepusMethod` always invoking its callback with `undefined`: the UI-thread handler now returns the lepus method's result so the callback receives it.

--- a/packages/web-platform/web-core-e2e/tests/web-core.test.ts
+++ b/packages/web-platform/web-core-e2e/tests/web-core.test.ts
@@ -332,6 +332,31 @@ test.describe('web core tests', () => {
     await wait(100);
     expect(jsonContent).toBe('{}');
   });
+  test('api-nativeApp-callLepusMethod-callback-receives-return-value', async ({ page, browserName }) => {
+    // firefox dose not support this.
+    test.skip(browserName === 'firefox');
+    await goto(page);
+
+    // Define a lepus method on the main-thread globalThis, like
+    // `injectLepusMethods` in @lynx-js/react does for `getUniqueIdListBySnapshotId`.
+    await page.evaluate(() => {
+      globalThis.runtime.callLepusMethodE2EEcho = (data: { value: number }) => {
+        return { doubled: data.value * 2 };
+      };
+    });
+
+    const backWorker = await getBackgroundThreadWorker(page);
+    const ret = await backWorker.evaluate(() => {
+      return new Promise((resolve) => {
+        globalThis.runtime.lynx.getNativeApp().callLepusMethod(
+          'callLepusMethodE2EEcho',
+          { value: 21 },
+          (ret: unknown) => resolve(ret),
+        );
+      });
+    });
+    expect(ret).toEqual({ doubled: 42 });
+  });
   test('registerDataProcessor-as-global-var-update', async ({ page, browserName }) => {
     await goto(page);
     const registerDataProcessor = await page.evaluate(() => {

--- a/packages/web-platform/web-core/ts/client/endpoints.ts
+++ b/packages/web-platform/web-core/ts/client/endpoints.ts
@@ -65,7 +65,7 @@ export const reportErrorEndpoint = createRpcEndpoint<
 
 export const callLepusMethodEndpoint = createRpcEndpoint<
   [name: string, data: unknown],
-  void
+  unknown
 >('callLepusMethod', false, true);
 
 export const invokeUIMethodEndpoint = createRpcEndpoint<

--- a/packages/web-platform/web-core/ts/client/mainthread/Background.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/Background.ts
@@ -183,7 +183,10 @@ export class BackgroundThread implements AsyncDisposable {
           this.#lynxViewInstance.mainThreadGlobalThis as any
         )[methodName];
         if (typeof method === 'function') {
-          method.call(this.#lynxViewInstance.mainThreadGlobalThis, data);
+          return method.call(
+            this.#lynxViewInstance.mainThreadGlobalThis,
+            data,
+          );
         } else {
           console.error(
             `Method ${methodName} not found on mainThreadGlobalThis`,


### PR DESCRIPTION
## Summary

On the web platform, `nativeApp.callLepusMethod(name, data, callback)` never delivers the lepus method's return value: the callback always receives `undefined`.

`callLepusMethod` is implemented with `createCallbackify`, which splices the callback out of the arguments and resolves it with the RPC's return value:

https://github.com/lynx-family/lynx-stack/blob/08dd06ae3f60ee85e0f7c17e5473ff97e3dbcf39/packages/web-platform/web-worker-rpc/src/Rpc.ts#L494-L508

The endpoint is declared with `hasReturn`, but the UI-thread handler in `Background.ts` called the main-thread method without returning its result, so the RPC always resolved with `undefined`.

This silently breaks consumers that read the result. Concretely, `@lynx-js/react`'s `injectLepusMethods` exposes `getUniqueIdListBySnapshotId` for preact devtools, which calls it exactly this way to build its snapshotId → element uniqueId mapping (used for hover-highlight); on web the callback always got `undefined`, the mapping stayed empty, and highlight never fired.

## Changes

Two commits, test first:

1. **test(web-core)**: e2e test reproducing the bug — defines a lepus method on the main-thread `globalThis` and asserts the background-thread callback observes its return value. Fails on `main` with `Received: undefined`.
2. **fix(web-core)**: return the method's result from the `callLepusMethodEndpoint` handler, and correct the endpoint's return type from `void` to `unknown` to match the `NativeApp` interface (`callback: (ret: unknown) => void`). The test from commit 1 passes.

Verified locally: the new test fails before the fix and passes after; `api-nativeApp-*` chromium e2e tests pass; `web-core` typecheck is clean.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `callLepusMethod` so callbacks receive the actual return value from the invoked Lepus method, improving correctness of cross-thread native calls.
* **Developer Experience**
  * Updated `callLepusMethod` response typing to reflect that a value may be returned.
* **Tests**
  * Added an end-to-end test verifying that returned values are delivered correctly to the callback (skips Firefox).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->