### PR TITLE
feat: refactor type of createElement and cloneElement

### DIFF
--- a/.changeset/large-clouds-build.md
+++ b/.changeset/large-clouds-build.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+refactor type of createElement and cloneElement

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -4,26 +4,28 @@
 
 ```ts
 
+import type { Attributes } from 'react';
 import { Children as Children_2 } from 'preact/compat';
-import { cloneElement } from 'react';
 import { Component } from 'react';
 import type { ComponentChild } from 'preact';
 import type { ComponentChildren } from 'preact';
 import type { ComponentClass } from 'react';
+import type { ComponentType } from 'react';
 import type { Consumer } from 'react';
 import { createContext } from 'react';
-import { createElement } from 'react';
 import { createRef } from 'react';
 import type { DependencyList } from 'react';
 import type { EffectCallback } from 'react';
 import type { FC } from 'react';
 import { forwardRef } from 'react';
 import { Fragment } from 'react';
+import type { IntrinsicElements } from '@lynx-js/types';
 import { isValidElement } from 'react';
 import { lazy } from 'react';
 import { memo } from 'react';
 import type { NodesRef } from '@lynx-js/types';
 import { PureComponent } from 'react';
+import type { ReactElement } from 'react';
 import type { ReactNode } from 'react';
 import type { RefObject } from 'react';
 import { Suspense } from 'react';
@@ -42,13 +44,26 @@ import type { VNode } from 'preact';
 // @public
 export const Children: ReactLynxChildren;
 
-export { cloneElement }
+// @public
+export interface CloneElement {
+    <Props>(element: ReactElement<Props>, props?: (Partial<Props> & Attributes) | null, ...children: ReactNode[]): ReactElement<Props>;
+}
+
+// @public
+export const cloneElement: CloneElement;
 
 export { Component }
 
 export { createContext }
 
-export { createElement }
+// @public
+export interface CreateElement {
+    <Type extends keyof IntrinsicElements>(type: Type, props?: IntrinsicElements[Type] | null, ...children: ReactNode[]): ReactElement<IntrinsicElements[Type], Type>;
+    <Props extends object>(type: ComponentType<Props> | string, props?: (Attributes & Props) | null, ...children: ReactNode[]): ReactElement<Props>;
+}
+
+// @public
+export const createElement: CreateElement;
 
 // @public
 export function createPortal(vnode: ComponentChild, container: NodesRef): VNode<any> | null;

--- a/packages/react/runtime/src/index.ts
+++ b/packages/react/runtime/src/index.ts
@@ -36,6 +36,7 @@ import { createPortal } from './snapshot/lynx/portals.js';
 import { Suspense } from './snapshot/lynx/suspense.js';
 
 export type { ReactLynxChildren } from './snapshot/lynx/children.js';
+export type { CloneElement, CreateElement } from './snapshot/lynx/element.js';
 
 installComponentCompat();
 

--- a/packages/react/runtime/src/snapshot/lynx/element.ts
+++ b/packages/react/runtime/src/snapshot/lynx/element.ts
@@ -2,32 +2,75 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { ComponentChildren, VNode } from 'preact';
 import { cloneElement as cloneElementBackground, createElement as createElementBackground } from 'preact/compat';
+import type { Attributes, ComponentType, ReactElement, ReactNode } from 'react';
 
 import { cloneElement as cloneElementMainThread, createElement as createElementMainThread } from '@lynx-js/react/lepus';
+import type { IntrinsicElements } from '@lynx-js/types';
 
 import { getCloneSnapshotInfo, getCloneSnapshotType, isCompiledSnapshot } from '../snapshot/utils.js';
 
-type CreateElement = typeof import('preact/compat').createElement;
-type CreateElementParams = Parameters<CreateElement>;
+/**
+ * The call signature of ReactLynx `createElement`.
+ *
+ * @public
+ */
+export interface CreateElement {
+  /** Creates an element for a Lynx intrinsic element. */
+  <Type extends keyof IntrinsicElements>(
+    type: Type,
+    props?: IntrinsicElements[Type] | null,
+    ...children: ReactNode[]
+  ): ReactElement<IntrinsicElements[Type], Type>;
+  /** Creates an element for a component. */
+  <Props extends object>(
+    type: ComponentType<Props> | string,
+    props?: (Attributes & Props) | null,
+    ...children: ReactNode[]
+  ): ReactElement<Props>;
+}
 
-type CloneElement = typeof import('preact/compat').cloneElement;
-type CloneElementParams = Parameters<CloneElement>;
+/**
+ * The call signature of ReactLynx `cloneElement`.
+ *
+ * @public
+ */
+export interface CloneElement {
+  /** Clones an element with optional replacement props and children. */
+  <Props>(
+    element: ReactElement<Props>,
+    props?: (Partial<Props> & Attributes) | null,
+    ...children: ReactNode[]
+  ): ReactElement<Props>;
+}
+
+type CreateElementParams = [
+  type: VNode['type'],
+  props: object | null | undefined,
+  ...children: ComponentChildren[],
+];
+
+type CloneElementParams = [
+  vnode: VNode<object>,
+  props: object | null | undefined,
+  ...children: ComponentChildren[],
+];
 
 function splitProps(
-  props: unknown,
+  props: CreateElementParams[1],
   rest: CreateElementParams[2][],
   initialKey: string | undefined = undefined,
 ): {
   key: string | undefined;
   children: CreateElementParams[2][];
-  spreadProps: Record<string, unknown>;
+  spreadProps: Record<string, ComponentChildren>;
 } {
   let key = initialKey;
   let children = rest;
-  let spreadProps: Record<string, unknown> = {};
+  let spreadProps: Record<string, ComponentChildren> = {};
   if (props && typeof props === 'object') {
-    spreadProps = props as Record<string, unknown>;
+    spreadProps = props as Record<string, ComponentChildren>;
     if ('key' in spreadProps) {
       const { key: keyValue, ...propsWithoutKey } = spreadProps;
       key = keyValue as string;
@@ -36,7 +79,7 @@ function splitProps(
     if ('children' in spreadProps) {
       const { children: childrenValue, ...propsWithoutChildren } = spreadProps;
       if (rest.length === 0) {
-        children = [childrenValue as CreateElementParams[2]];
+        children = [childrenValue];
       }
       spreadProps = propsWithoutChildren;
     }
@@ -48,8 +91,10 @@ function splitProps(
   };
 }
 
-function pickChildrenProps(props: Record<string, unknown>): Record<string, unknown> | undefined {
-  let childrenProps: Record<string, unknown> | undefined;
+function pickChildrenProps(
+  props: Record<string, ComponentChildren>,
+): Record<string, ComponentChildren> | undefined {
+  let childrenProps: Record<string, ComponentChildren> | undefined;
   for (const name in props) {
     if (name.startsWith('$')) {
       childrenProps ??= {};
@@ -60,11 +105,15 @@ function pickChildrenProps(props: Record<string, unknown>): Record<string, unkno
 }
 
 /**
- * export to users, and in framework would use preact createElement directly
+ * Creates a ReactLynx element using the snapshot runtime.
+ *
+ * @public
  */
 export const createElement =
   (function(type: CreateElementParams[0], props: CreateElementParams[1], ...rest: CreateElementParams[2][]) {
-    const _baseCreateElement = __BACKGROUND__ ? createElementBackground : createElementMainThread as CreateElement;
+    const _baseCreateElement = (__BACKGROUND__ ? createElementBackground : createElementMainThread) as (
+      ...args: CreateElementParams
+    ) => VNode;
     /**
      * for built-in element which would create snapshot instance
      *
@@ -92,7 +141,9 @@ export const createElement =
   }) as CreateElement;
 
 /**
- * export to users, and in framework would use preact cloneElement directly
+ * Clones a ReactLynx element using the snapshot runtime.
+ *
+ * @public
  */
 export const cloneElement =
   (function(vnode: CloneElementParams[0], props: CloneElementParams[1], ...rest: CloneElementParams[2][]) {
@@ -103,11 +154,13 @@ export const cloneElement =
     }
     if (!props && rest.length === 0) {
       // no props, no children. clone directly
-      const _baseCloneElement = __BACKGROUND__ ? cloneElementBackground : cloneElementMainThread as CloneElement;
+      const _baseCloneElement = (__BACKGROUND__ ? cloneElementBackground : cloneElementMainThread) as (
+        ...args: CloneElementParams
+      ) => VNode<object>;
       return _baseCloneElement(vnode, props, ...rest);
     }
-    const preProps = vnode.props as unknown as {
-      values?: Record<string, unknown>[];
+    const preProps = vnode.props as {
+      values?: Record<string, ComponentChildren>[];
       $0?: CreateElementParams[2];
     };
     const preValues = preProps.values ?? [];
@@ -128,12 +181,14 @@ export const cloneElement =
       if (children.length === 0 && '$0' in preProps) {
         children = [preProps.$0];
       }
-      return createElement(type, nextProps, ...children);
+      return (createElement as (...args: CreateElementParams) => VNode)(type, nextProps, ...children);
     }
 
     // normal compiled snapshot
     const values = preValues.slice();
-    const _baseCreateElement = __BACKGROUND__ ? createElementBackground : createElementMainThread as CreateElement;
+    const _baseCreateElement = (__BACKGROUND__ ? createElementBackground : createElementMainThread) as (
+      ...args: CreateElementParams
+    ) => VNode;
     const { cloneSpreadIndex } = getCloneSnapshotInfo(type) ?? {};
     let cloneType = type;
     if (cloneSpreadIndex === undefined) {

--- a/packages/react/types/react.docs.d.ts
+++ b/packages/react/types/react.docs.d.ts
@@ -82,9 +82,9 @@ export { Fragment, Suspense } from 'react';
  * Legacy React APIs
  * @see https://react.dev/reference/react/legacy
  */
-export { Component, PureComponent, cloneElement, createElement, createRef, isValidElement } from 'react';
+export { Component, PureComponent, createRef, isValidElement } from 'react';
 
-export type { ReactLynxChildren } from '../runtime/lib/index.js';
+export type { CloneElement, CreateElement, ReactLynxChildren } from '../runtime/lib/index.js';
 
 /**
  * ReactLynx children utilities.
@@ -102,6 +102,26 @@ export const Children: ReactLynxChildren;
  * @public
  */
 export { createPortal } from '../runtime/lib/index.js';
+
+/**
+ * Creates a ReactLynx element from a Lynx intrinsic element name or a
+ * component type. Lynx intrinsic elements are processed by the ReactLynx
+ * snapshot runtime.
+ *
+ * @see https://react.dev/reference/react/createElement
+ * @public
+ */
+export { createElement } from '../runtime/lib/index.js';
+
+/**
+ * Clones an existing ReactLynx element and applies new props through the
+ * ReactLynx runtime. Runtime-created elements and components may also receive
+ * replacement children.
+ *
+ * @see https://react.dev/reference/react/cloneElement
+ * @public
+ */
+export { cloneElement } from '../runtime/lib/index.js';
 
 /**
  * RL-defined Lynx APIs


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit TypeScript typings for `createElement` and `cloneElement`, including supported overloads.
  - Made the new `CreateElement` and `CloneElement` types publicly available.
  - Improved type handling for element props and children.

- **Bug Fixes**
  - Published a patch release with more accurate element creation and cloning type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
