### PR TITLE
chore(renovate): raise prConcurrentLimit/prHourlyLimit above defaults

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,14 @@
 
   "labels": ["bot:renovate"],
 
+  // Raise the open-PR limits above Renovate's defaults (prConcurrentLimit: 10,
+  // prHourlyLimit: 2). This repo has enough active dependencies that a short
+  // triage lag lets the open-PR count reach 10, after which Renovate stops
+  // opening any new PR and parks every update as "Rate-Limited" on the
+  // Dependency Dashboard -- making it look like Renovate has stopped working.
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 4,
+
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Why

Renovate looked like it had stopped: the last merged Renovate PR was 2026-06-27 and the contributor graph flatlined, even though the Dependency Dashboard (#36) is still updating daily.

**Root cause:** the repo hit Renovate's default `prConcurrentLimit` of **10**. With 16 stale open Renovate PRs (oldest from 2025-09, most CI-red and behind `main`), Renovate refuses to open any new PR and parks every pending update as **`Rate-Limited`** on the dashboard. Nothing new gets created → looks dead.

The config never overrode these limits, so the defaults (`prConcurrentLimit: 10`, `prHourlyLimit: 2`) applied.

## What this does

Raises the limits to `prConcurrentLimit: 20` / `prHourlyLimit: 4` to give triage headroom so a short backlog no longer freezes all new updates.

## Note

This is the recurrence guard, not the whole fix. The real remedy is clearing the stale backlog — I've already closed the two doomed ~year-old major PRs (#1823, #2029) to free slots. Remaining stale PRs still need triage (rebase+merge or close).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated maintenance scheduling to allow more update requests to be created and processed concurrently.
  * This helps routine updates move through the workflow more efficiently while reducing delays caused by conservative rate limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->