### PR TITLE
feat(genui-doc): add lynx-stack doc for openui

### DIFF
--- a/.github/genui-website.instructions.md
+++ b/.github/genui-website.instructions.md
@@ -2,4 +2,4 @@
 applyTo: "website/sidebars/genui.ts"
 ---
 
-Expose the website GenUI guide through the A2UI README-generated pages. Do not add a separate `A2UI Catalog Extractor` sidebar entry or generated website page unless the product direction changes; public extractor behavior should be summarized inside `packages/genui/a2ui/README*.md` and surfaced through the A2UI guide.
+Expose the website GenUI guide through package-owned Markdown: `packages/genui/docs` for the protocol chooser, `packages/genui/a2ui` for A2UI, `packages/genui/a2ui-catalog-extractor/README.md` and `readme.zh_cn.md` for the A2UI Catalog Extractor, and `packages/genui/openui` for OpenUI. Keep English and Simplified Chinese source pairs there, then synchronize them into `website/docs/{en,zh}/guide/genui` from `website/sidebars/genui.ts` so package and website documentation cannot drift. Keep the Catalog Extractor as an unlisted supporting page under the A2UI route: link to it from the Catalog Guide, but do not add it as a standalone navbar or sidebar entry. Rewrite package-relative cross-links to the corresponding website routes instead of GitHub URLs.

--- a/packages/genui/README.md
+++ b/packages/genui/README.md
@@ -13,8 +13,9 @@ monorepo.
 pnpm add @lynx-js/genui @lynx-js/react
 ```
 
-`@lynx-js/react` is a peer dependency. Some built-in A2UI catalog components
-also use `@lynx-js/lynx-ui`; install it when your app renders those components.
+`@lynx-js/react` is a peer dependency. Some built-in A2UI components and the
+default OpenUI Library also use `@lynx-js/lynx-ui`; install it when your app
+uses those surfaces.
 
 ## Entry Points
 
@@ -102,11 +103,13 @@ export function OpenUIScreen() {
 }
 ```
 
-Renderer styles are explicit:
+Import the optional OpenUI theme tokens once in your app:
 
 ```ts
-import '@lynx-js/genui/openui/styles/renderer.css';
+import '@lynx-js/genui/openui/styles/theme.css';
 ```
+
+The renderer and component styles are imported by their modules.
 
 See [`openui/README.md`](./openui/README.md) for streaming and custom library
 examples.

--- a/packages/genui/docs/overview.md
+++ b/packages/genui/docs/overview.md
@@ -1,0 +1,42 @@
+# GenUI for Lynx
+
+Lynx Stack provides two declarative Generative UI integrations: A2UI and
+OpenUI. Both keep generated output as data and render only components trusted
+by the Lynx application, but they use different wire formats and component
+contracts.
+
+## Choose a protocol
+
+| Component          | A2UI                                         | OpenUI                                               |
+| ------------------ | -------------------------------------------- | ---------------------------------------------------- |
+| Protocol           | A2UI v0.9 messages                           | OpenUI Lang v0.5 assignments                         |
+| Component contract | Catalog                                      | Library                                              |
+| Client input       | Incremental protocol messages                | Accumulated OpenUI text                              |
+| Primary renderer   | `<A2UI>`                                     | `<OpenUiRenderer>`                                   |
+| State and data     | Protocol operations and client message store | `$variables`, Query, Mutation, and Action statements |
+| Best fit           | Agents and transports that speak A2UI        | Agents that generate compact declarative UI text     |
+
+Choose the protocol your Agent and transport already support. The two
+renderers can coexist in one application, but a single generated surface must
+use one protocol from end to end.
+
+## Documentation
+
+### A2UI
+
+- [Introduction](/guide/genui/a2ui)
+- [Overview and architecture](/guide/genui/a2ui/overview)
+- [Catalogs and components](/guide/genui/a2ui/catalog-guide)
+- [System prompts](/guide/genui/a2ui/system-prompts)
+
+### OpenUI
+
+- [Introduction](/guide/genui/openui)
+- [Overview and architecture](/guide/genui/openui/overview)
+- [Libraries and components](/guide/genui/openui/library-guide)
+- [System prompts](/guide/genui/openui/system-prompts)
+
+## Playground
+
+Use the [GenUI Playground](https://lynx-stack.dev/genui/) to inspect the built-in
+A2UI and OpenUI component sets.

--- a/packages/genui/docs/overview_zh.md
+++ b/packages/genui/docs/overview_zh.md
@@ -1,0 +1,40 @@
+# Lynx GenUI
+
+Lynx Stack 提供两种声明式 Generative UI 接入：A2UI 和 OpenUI。两者都会把模型
+输出视为数据，并且只渲染 Lynx 应用信任的组件；它们的 wire format 和组件 contract
+不同。
+
+## 选择协议
+
+| 组成部分      | A2UI                                        | OpenUI                                             |
+| ------------- | ------------------------------------------- | -------------------------------------------------- |
+| 协议          | A2UI v0.9 messages                          | OpenUI Lang v0.5 assignments                       |
+| 组件 contract | Catalog                                     | Library                                            |
+| Client 输入   | 增量 protocol messages                      | 累计的 OpenUI 文本                                 |
+| 主要 renderer | `<A2UI>`                                    | `<OpenUiRenderer>`                                 |
+| 状态和数据    | Protocol operations 与 client message store | `$variables`、Query、Mutation 和 Action statements |
+| 适合场景      | Agent 和 transport 已经使用 A2UI            | Agent 生成紧凑的声明式 UI 文本                     |
+
+应选择 Agent 和 transport 已支持的协议。两个 renderer 可以共存于同一个应用，但
+单个 generated surface 必须端到端使用同一种协议。
+
+## 文档目录
+
+### A2UI
+
+- [简介](/zh/guide/genui/a2ui)
+- [概览与架构](/zh/guide/genui/a2ui/overview)
+- [Catalogs 与组件](/zh/guide/genui/a2ui/catalog-guide)
+- [System Prompts](/zh/guide/genui/a2ui/system-prompts)
+
+### OpenUI
+
+- [简介](/zh/guide/genui/openui)
+- [概览与架构](/zh/guide/genui/openui/overview)
+- [Libraries 与组件](/zh/guide/genui/openui/library-guide)
+- [System Prompts](/zh/guide/genui/openui/system-prompts)
+
+## Playground
+
+可以通过 [GenUI Playground](https://lynx-stack.dev/genui/) 查看内置的 A2UI 和
+OpenUI 组件集。

--- a/packages/genui/openui/README.md
+++ b/packages/genui/openui/README.md
@@ -1,217 +1,121 @@
 # @lynx-js/genui/openui
 
-ReactLynx renderer for the [OpenUI DSL](https://www.openui.com/). Parses
-OpenUI functional notation into a renderable tree and renders it via a
-pluggable component catalog in Lynx applications.
+English | [简体中文](./README_zh.md)
 
-This package includes:
+`@lynx-js/genui/openui` is the ReactLynx client runtime for OpenUI Lang v0.5.
+It parses declarative OpenUI text, evaluates reactive state and data operations,
+and renders the result with a trusted ReactLynx component library.
 
-- `createOpenUiLibrary`: factory that builds an OpenUI `Library` instance
-  with built-in components, fully customizable via options.
-- `defineComponent`: define custom components with Zod-validated props.
-- `OpenUiRenderer`: ReactLynx component that parses and renders OpenUI Lang
-  v0.5 responses, including `$variables`, `Query()`, `Mutation()`, and
-  `Action([@...])` steps.
-- `createParser` / `createStreamingParser`: parse OpenUI DSL text
-  (functional notation) into a renderable AST.
-- `catalog/*`: built-in component renderers (Stack, Row, Column, List, Card,
-  CardHeader, Text, TextContent, Separator, Divider, Button, Buttons, Tag,
-  Image, Icon, Video, AudioPlayer, Loading, Tabs, Modal, CheckBox,
-  RadioGroup, ChoicePicker, Slider, TextField, DateTimeInput).
+Use this package when an Agent produces OpenUI Lang and your Lynx app owns the
+transport, tools, state persistence, and host actions. The Agent emits data, not
+executable UI code: it can only instantiate components described by the library
+you give to the renderer.
 
-## Exports
+If you are new to OpenUI, think of it this way:
 
-- `@lynx-js/genui/openui`: `createOpenUiLibrary`, `defineComponent`,
-  `OpenUiRenderer`, parser utilities, and all core types.
-- `@lynx-js/genui/openui/catalog`: re-exports of built-in catalog
-  components for tree-shake-friendly subpath access.
+- In React, your code chooses components and passes props.
+- In OpenUI, an Agent writes one assignment per line using the components in
+  your library.
+- The client parses those assignments and renders the real ReactLynx
+  components you registered.
 
-## Installation
+## Install
 
-Make sure your app provides the peer dependencies:
+Install the published GenUI package in a ReactLynx app:
 
-- `@lynx-js/react`
-
-```bash
-pnpm add @lynx-js/genui
+```sh
+pnpm add @lynx-js/genui @lynx-js/react @lynx-js/lynx-ui
 ```
 
-## Quick Start
+The built-in `RadioGroup`, `Slider`, and `TextField` components use
+`@lynx-js/lynx-ui`, so include that peer when using the default Library.
 
-1. Create a library.
-2. Pass raw OpenUI Lang text to `<OpenUiRenderer response={...}>`.
-3. Handle actions from `@ToAssistant()` / `@OpenUrl()` with `onAction`.
+Import the optional theme tokens once, then apply a light or dark theme class
+around the renderer. Renderer and component CSS are included by their modules;
+there is no separate renderer stylesheet to import.
+
+```ts
+import '@lynx-js/genui/openui/styles/theme.css';
+```
+
+## Quick start
+
+Create a library, pass raw OpenUI Lang to `<OpenUiRenderer>`, and handle actions
+that need the host application.
 
 ```tsx
 import { createOpenUiLibrary, OpenUiRenderer } from '@lynx-js/genui/openui';
 import { useMemo } from '@lynx-js/react';
 
-const rawText = `
-root = Stack([header, card], "column", "l", "center")
-header = TextContent("Hello OpenUI", "large-heavy")
-card = Card([content, btn], "card")
-content = TextContent("Welcome to OpenUI")
-btn = Buttons([Button("Get Started", Action([@ToAssistant("clicked")]), "primary")])
+import '@lynx-js/genui/openui/styles/theme.css';
+
+const response = String.raw`
+root = Stack([header, card], "column", false, "m", "stretch", "start")
+header = Text("Hello OpenUI", "h2")
+card = Card([message, actions])
+message = TextContent("This UI was described as data.")
+actions = Buttons([Button("Continue", Action([@ToAssistant("Continue")]), "primary")])
 `.trim();
 
-export function App() {
+export function GeneratedView() {
   const library = useMemo(() => createOpenUiLibrary(), []);
 
   return (
-    <OpenUiRenderer
-      response={rawText}
-      library={library}
-      onAction={(event) => {
-        console.log('Action:', event.humanFriendlyMessage);
-      }}
-    />
-  );
-}
-```
-
-## Streaming
-
-For real-time streaming scenarios (e.g., LLM output), feed chunks
-incrementally:
-
-```tsx
-import { createOpenUiLibrary, OpenUiRenderer } from '@lynx-js/genui/openui';
-import { useEffect, useMemo, useState } from '@lynx-js/react';
-
-const CHUNK_SIZE = 8;
-const STREAM_DELAY_MS = 30;
-
-export function StreamingApp({ rawText }: { rawText: string }) {
-  const library = useMemo(() => createOpenUiLibrary(), []);
-  const [response, setResponse] = useState('');
-  const [isStreaming, setIsStreaming] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    setIsStreaming(true);
-    setResponse('');
-    let offset = 0;
-
-    const tick = () => {
-      if (cancelled || offset >= rawText.length) {
-        setIsStreaming(false);
-        return;
-      }
-      const chunk = rawText.slice(offset, offset + CHUNK_SIZE);
-      offset += CHUNK_SIZE;
-      setResponse((prev) => prev + chunk);
-      setTimeout(tick, STREAM_DELAY_MS);
-    };
-
-    tick();
-    return () => {
-      cancelled = true;
-    };
-  }, [library, rawText]);
-
-  return (
-    <OpenUiRenderer
-      response={response}
-      library={library}
-      isStreaming={isStreaming}
-    />
-  );
-}
-```
-
-## v0.5 Runtime
-
-Use the `response` renderer entry point for v0.5 features:
-
-```tsx
-const ui = `
-$title = ""
-data = Query("list_items", { search: $title }, { rows: [] })
-save = Mutation("save_item", { title: $title })
-root = Stack([
-  TextContent("Rows: " + @Count(data.rows)),
-  Button("Save", Action([@Run(save), @Run(data), @Reset($title)]))
-])
-`.trim();
-
-<OpenUiRenderer
-  response={ui}
-  library={library}
-  toolProvider={{
-    list_items: async (args) => ({ rows: [] }),
-    save_item: async (args) => ({ ok: true }),
-  }}
-  onStateUpdate={(state) => persist(state)}
-  initialState={{ $title: 'Draft' }}
-/>;
-```
-
-`OpenUiRenderer` still accepts `result={parseResult}` for legacy/static
-callers, but `Query()`, `Mutation()`, `$variables`, and runtime expression
-evaluation require the raw `response` path.
-
-## Customizing the Library
-
-`createOpenUiLibrary` accepts an optional `CreateOpenUiLibraryOptions`
-object. Provided `components` and `componentGroups` are **merged** with
-the built-in defaults (appended after the defaults):
-
-```tsx
-import { createOpenUiLibrary, defineComponent } from '@lynx-js/genui/openui';
-import { z } from 'zod/v4';
-
-const MyBanner = defineComponent({
-  name: 'Banner',
-  description: 'A promotional banner',
-  props: z.object({ title: z.string(), color: z.string().optional() }),
-  component: (props) => (
-    <view style={{ backgroundColor: props.color ?? '#f0f0f0' }}>
-      <text>{props.title}</text>
+    <view className='openui-light'>
+      <OpenUiRenderer
+        response={response}
+        library={library}
+        onAction={(event) => {
+          // Forward ContinueConversation/OpenUrl events to your host.
+          console.info(event.humanFriendlyMessage);
+        }}
+      />
     </view>
-  ),
-});
-
-const library = createOpenUiLibrary({
-  root: 'Stack',
-  components: [MyBanner],
-  componentGroups: [
-    { name: 'Custom', components: ['Banner'] },
-  ],
-});
+  );
+}
 ```
 
-### Options
+The raw response must be OpenUI Lang, not a Markdown code fence. Every line is
+an assignment, and the render entry point must be named `root`:
 
-| Option            | Type                 | Default       | Description                                    |
-| ----------------- | -------------------- | ------------- | ---------------------------------------------- |
-| `root`            | `string`             | `'Stack'`     | Name of the root component                     |
-| `components`      | `DefinedComponent[]` | `[]` (merged) | Additional components appended to built-in set |
-| `componentGroups` | `ComponentGroup[]`   | `[]` (merged) | Additional groups appended to built-in groups  |
-
-## OpenUI DSL Syntax
-
-The DSL uses a **functional notation** (not XML). Each statement assigns
-a component instance to an identifier:
-
-```
-root = Stack([header, card], "column", "l", "center")
-header = TextContent("Choose Your Plan", "large-heavy")
-card = Card([cardHeader, sep, features, btn], "card")
-cardHeader = CardHeader("Pro", "For growing teams")
-sep = Separator("horizontal", true)
-features = Stack([f1, f2], "column", "s")
-f1 = TextContent("✓  Unlimited projects")
-f2 = TextContent("✓  Priority support")
-btn = Buttons([Button("Start Trial", Action([@ToAssistant("start")]), "primary")])
+```text
+identifier = Component(positional, arguments)
+$variable = defaultValue
+data = Query("tool_name", { argument: $variable }, { fallback: true })
 ```
 
-## JSON Schema
+## What you own
 
-Generate a JSON Schema representation of the library for LLM agent
-handshakes:
+| Part                    | Owner            | Role                                                                                                    |
+| ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `@lynx-js/genui/openui` | This package     | OpenUI parser/runtime adapter, ReactLynx renderer, built-in library, state/actions, and prompt helpers. |
+| Your Agent service      | Your application | Calls a model with the OpenUI system prompt and returns raw OpenUI Lang text.                           |
+| Your transport adapter  | Your application | Streams or sets the accumulated response text and cancels stale requests.                               |
+| Your tool provider      | Your application | Implements the tools referenced by `Query()` and `Mutation()`.                                          |
+| Your host shell         | Your application | Persists state and handles assistant/open-URL actions emitted by the renderer.                          |
 
-```ts
-const library = createOpenUiLibrary();
-const schema = library.toJSONSchema();
-// Pass `schema` to your LLM / agent for structured output generation.
-```
+## First things to know
+
+- Prefer `<OpenUiRenderer response={...}>` for OpenUI v0.5. The legacy
+  `result={parseResult}` path renders pre-parsed static trees but does not own
+  the v0.5 query, mutation, or reactive-state runtime.
+- While a model is streaming, pass the accumulated response together with
+  `isStreaming`. The incremental parser keeps completed statements renderable,
+  and built-in interactions stay disabled until the stream finishes.
+- `Query()` executes after a complete response and re-runs when reactive
+  arguments change. `Mutation()` only runs through `@Run(...)` in an action.
+- `onAction` receives host actions such as `@ToAssistant(...)` and
+  `@OpenUrl(...)`. State steps and tool steps execute inside the runtime first.
+- `onError` returns structured parser, runtime, render, and tool errors suitable
+  for an Agent correction loop.
+- `createOpenUiLibrary()` includes 26 built-in components. Additional
+  definitions are appended, and a later component with the same name replaces
+  the built-in implementation.
+
+## More docs
+
+- [Overview and architecture](./docs/overview.md)
+- [Libraries, built-ins, and custom components](./docs/library-guide.md)
+- [System prompts](./docs/system-prompts.md)
+- [Open the GenUI playground](https://lynx-stack.dev/genui/#/openui)
+- [Read the OpenUI Lang v0.5 specification](https://www.openui.com/docs/openui-lang/specification-v05)

--- a/packages/genui/openui/README_zh.md
+++ b/packages/genui/openui/README_zh.md
@@ -1,0 +1,116 @@
+# @lynx-js/genui/openui
+
+[English](./README.md) | 简体中文
+
+`@lynx-js/genui/openui` 是面向 OpenUI Lang v0.5 的 ReactLynx 客户端运行时。
+它会解析声明式 OpenUI 文本、求值响应式状态和数据操作，并通过可信的
+ReactLynx 组件 Library 渲染结果。
+
+当 Agent 输出 OpenUI Lang，而你的 Lynx 应用负责传输、工具调用、状态持久化和
+宿主 action 时，可以使用这个包。Agent 输出的是数据，而不是可执行 UI 代码；它
+只能实例化你交给 renderer 的 Library 中声明过的组件。
+
+如果你第一次接触 OpenUI，可以先这样理解：
+
+- 在 React 里，是你的代码选择组件并传入 props。
+- 在 OpenUI 里，是 Agent 使用你的 Library 中的组件，逐行写出 assignment。
+- Client 解析这些 assignments，再渲染你注册的真实 ReactLynx 组件。
+
+## 安装
+
+在 ReactLynx 应用中安装公开的 GenUI 包：
+
+```sh
+pnpm add @lynx-js/genui @lynx-js/react @lynx-js/lynx-ui
+```
+
+内置的 `RadioGroup`、`Slider` 和 `TextField` 组件使用
+`@lynx-js/lynx-ui`，因此使用默认 Library 时应包含这个 peer dependency。
+
+在入口处引入一次可选的主题 tokens，并在 renderer 外应用 light 或 dark 主题
+class。Renderer 和各组件的 CSS 会随对应模块自动引入，不需要额外导入 renderer
+样式表。
+
+```ts
+import '@lynx-js/genui/openui/styles/theme.css';
+```
+
+## 快速开始
+
+创建一个 Library，把原始 OpenUI Lang 传给 `<OpenUiRenderer>`，并处理需要宿主
+应用接管的 actions。
+
+```tsx
+import { createOpenUiLibrary, OpenUiRenderer } from '@lynx-js/genui/openui';
+import { useMemo } from '@lynx-js/react';
+
+import '@lynx-js/genui/openui/styles/theme.css';
+
+const response = String.raw`
+root = Stack([header, card], "column", false, "m", "stretch", "start")
+header = Text("Hello OpenUI", "h2")
+card = Card([message, actions])
+message = TextContent("This UI was described as data.")
+actions = Buttons([Button("Continue", Action([@ToAssistant("Continue")]), "primary")])
+`.trim();
+
+export function GeneratedView() {
+  const library = useMemo(() => createOpenUiLibrary(), []);
+
+  return (
+    <view className='openui-light'>
+      <OpenUiRenderer
+        response={response}
+        library={library}
+        onAction={(event) => {
+          // 把 ContinueConversation/OpenUrl events 转发给宿主。
+          console.info(event.humanFriendlyMessage);
+        }}
+      />
+    </view>
+  );
+}
+```
+
+原始 response 必须是 OpenUI Lang，而不是 Markdown code fence。每一行都是一条
+assignment，渲染入口必须命名为 `root`：
+
+```text
+identifier = Component(positional, arguments)
+$variable = defaultValue
+data = Query("tool_name", { argument: $variable }, { fallback: true })
+```
+
+## 你需要负责什么
+
+| 部分                    | 负责人   | 作用                                                                                              |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `@lynx-js/genui/openui` | 这个包   | OpenUI parser/runtime adapter、ReactLynx renderer、内置 Library、状态/actions 和 prompt helpers。 |
+| 你的 Agent 服务         | 你的应用 | 使用 OpenUI system prompt 调用模型，并返回原始 OpenUI Lang 文本。                                 |
+| 你的 transport adapter  | 你的应用 | 流式追加或设置累计 response 文本，并取消已经过期的请求。                                          |
+| 你的 tool provider      | 你的应用 | 实现 `Query()` 和 `Mutation()` 引用的工具。                                                       |
+| 你的 host shell         | 你的应用 | 持久化状态，并处理 renderer 抛出的 assistant/open-URL actions。                                   |
+
+## 首次接入要知道
+
+- OpenUI v0.5 应优先使用 `<OpenUiRenderer response={...}>`。旧版
+  `result={parseResult}` 路径可以渲染预解析的静态树，但不拥有 v0.5 的 query、
+  mutation 或响应式状态运行时。
+- 模型流式输出期间，把累计 response 和 `isStreaming` 一起传入。增量 parser
+  会持续保留已完成且可渲染的 statements；内置交互在流结束前保持禁用。
+- `Query()` 会在完整 response 到达后执行，并在响应式参数变化时重新执行。
+  `Mutation()` 只会通过 action 中的 `@Run(...)` 触发。
+- `onAction` 接收 `@ToAssistant(...)`、`@OpenUrl(...)` 等宿主 actions；状态
+  steps 和工具 steps 会先在 runtime 内执行。
+- `onError` 会返回结构化的 parser、runtime、render 和 tool errors，适合接入
+  Agent correction loop。
+- `createOpenUiLibrary()` 内置 26 个组件。额外 definitions 会追加在默认组件后；
+  如果名称相同，后加入的组件会替换默认实现。
+
+## 更多文档
+
+- [概览与架构](./docs/overview_zh.md)
+- [Libraries、内置组件与自定义组件](./docs/library-guide_zh.md)
+- [System Prompts](./docs/system-prompts_zh.md)
+- [打开 GenUI Playground](https://lynx-stack.dev/genui/#/openui)
+- [阅读 OpenUI Lang v0.5 规范](https://www.openui.com/docs/openui-lang/specification-v05)

--- a/packages/genui/openui/docs/library-guide.md
+++ b/packages/genui/openui/docs/library-guide.md
@@ -1,0 +1,260 @@
+# Libraries, built-ins, and custom components
+
+An OpenUI **Library** is the contract between your Agent and your client. It
+describes the component calls the Agent may write, provides JSON Schema for
+parsing and prompt generation, and maps each allowed name to a trusted
+ReactLynx renderer.
+
+This guide covers the default Library, its 26 built-in components, and the
+process for adding or replacing components.
+
+## What a Library contains
+
+Each component definition has four parts:
+
+- a stable OpenUI component `name`;
+- a Zod object schema whose field order defines positional argument order;
+- a short `description` used in generated prompts;
+- a trusted ReactLynx `component` implementation.
+
+`createOpenUiLibrary()` assembles those definitions into a `Library` with:
+
+| Member            | Purpose                                                                                                                                                           |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `components`      | Name-to-definition map used by the renderer.                                                                                                                      |
+| `componentGroups` | Categories and ordering hints used in prompts and tooling.                                                                                                        |
+| `root`            | Required component type for the `root` statement; defaults to `Stack`.                                                                                            |
+| `toJSONSchema()`  | Parser/handshake schema with positional prop definitions.                                                                                                         |
+| `toSpec()`        | Framework-independent prompt specification.                                                                                                                       |
+| `prompt(options)` | Low-level prompt generation for this exact Library. For server use, prefer the headless prompt entry described in the [system prompt guide](./system-prompts.md). |
+
+Create the default Library once and keep its identity stable:
+
+```tsx
+const library = useMemo(() => createOpenUiLibrary(), []);
+
+<OpenUiRenderer response={response} library={library} />;
+```
+
+## Built-in components
+
+`createOpenUiLibrary()` includes the following components. Their definitions
+are also exported from `@lynx-js/genui/openui/catalog`.
+
+### Layout
+
+| Component | Purpose                                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------------------- |
+| `Stack`   | General row/column layout with wrapping, spacing, alignment, and justification. The default Library root. |
+| `Row`     | Horizontal layout container.                                                                              |
+| `Column`  | Vertical layout container.                                                                                |
+| `List`    | Vertical or horizontal collection with optional dividers and spacing.                                     |
+
+### Content
+
+| Component     | Purpose                                                                      |
+| ------------- | ---------------------------------------------------------------------------- |
+| `Card`        | Styled `card`, `sunk`, or `clear` container with Stack-like layout props.    |
+| `CardHeader`  | Title and optional subtitle for a card.                                      |
+| `Text`        | Plain text with semantic variants such as `h1`, `h2`, `caption`, and `body`. |
+| `TextContent` | Content text with compact size/weight variants.                              |
+| `Separator`   | Simple visual separator.                                                     |
+| `Divider`     | Horizontal or vertical dividing rule.                                        |
+
+### Buttons
+
+| Component | Purpose                                                                            |
+| --------- | ---------------------------------------------------------------------------------- |
+| `Button`  | Tappable primary, secondary, or tertiary action with optional destructive styling. |
+| `Buttons` | Group of `Button` components.                                                      |
+
+### Data display and media
+
+| Component     | Purpose                                                    |
+| ------------- | ---------------------------------------------------------- |
+| `Tag`         | Compact label or status tag.                               |
+| `Image`       | Remote image with fit and semantic size variants.          |
+| `Icon`        | Bundled Material Icons glyph with size and color variants. |
+| `Video`       | Video attachment placeholder with URL and optional title.  |
+| `AudioPlayer` | Audio attachment placeholder with URL and description.     |
+| `Loading`     | Inline or block skeleton/loading feedback.                 |
+
+### Overlays
+
+| Component | Purpose                                                  |
+| --------- | -------------------------------------------------------- |
+| `Tabs`    | Switches among labeled child views.                      |
+| `Modal`   | Opens generated detail content from a trigger component. |
+
+### Inputs
+
+| Component       | Purpose                                                                          |
+| --------------- | -------------------------------------------------------------------------------- |
+| `CheckBox`      | Boolean input with optional action and form name.                                |
+| `RadioGroup`    | Single-choice input with default, card, or row presentation.                     |
+| `ChoicePicker`  | Choice UI displayed as chips, a list, or a dropdown-like control.                |
+| `Slider`        | Numeric range input with optional step and action.                               |
+| `TextField`     | Short text, number, password, or multiline input with optional regex validation. |
+| `DateTimeInput` | Date/time value with label, bounds, and date/time display flags.                 |
+
+`RadioGroup`, `Slider`, and `TextField` use `@lynx-js/lynx-ui`; add that peer
+dependency when those components are available to generated UI.
+
+For exact current positional signatures and a live preview, open the
+[OpenUI Catalog](https://lynx-stack.dev/genui/#/openui/catalog). The schema is
+the source of truth: optional arguments may be omitted only from the right, and
+named-argument syntax is not supported.
+
+## OpenUI component syntax
+
+The order of fields in a component's Zod object is its wire-level positional
+argument order. For example, the built-in Stack schema begins with
+`children`, `direction`, `wrap`, `gap`, `align`, and `justify`, so this is valid:
+
+```text
+root = Stack([header, body], "column", false, "m", "stretch", "start")
+```
+
+This is not valid OpenUI Lang:
+
+```text
+root = Stack(children: [header, body], gap: "m")
+```
+
+Child components are values. They can be declared as named statements or used
+inline when the parent schema accepts them:
+
+```text
+root = Card([title, TextContent("Inline content")])
+title = CardHeader("Account", "Updated just now")
+```
+
+## Add a custom component
+
+Install Zod if the application does not already depend on it:
+
+```sh
+pnpm add zod
+```
+
+Define a component with a stable name, ordered prop schema, prompt description,
+and ReactLynx renderer. Put styles in a CSS class rather than inline style
+objects, and wrap visible text in `<text>`.
+
+```tsx
+import { createOpenUiLibrary, defineComponent } from '@lynx-js/genui/openui';
+import { z } from 'zod/v4';
+
+import './Banner.css';
+
+export const Banner = defineComponent({
+  name: 'Banner',
+  description: 'Compact status banner with a title and tone.',
+  props: z.object({
+    title: z.string(),
+    tone: z.enum(['info', 'success', 'warning']).optional(),
+  }),
+  component: ({ props }) => (
+    <view className={`Banner Banner-${props.tone ?? 'info'}`}>
+      <text className='BannerTitle'>{props.title}</text>
+    </view>
+  ),
+});
+
+export const library = createOpenUiLibrary({
+  components: [Banner],
+  componentGroups: [
+    { name: 'Product', components: ['Banner'] },
+  ],
+});
+```
+
+The Agent can now emit:
+
+```text
+root = Stack([notice])
+notice = Banner("Payment received", "success")
+```
+
+Caller-provided components and groups are appended after the defaults. If a
+custom component uses the same name as a built-in, the later custom definition
+wins in the `components` map. Treat that as an intentional override and keep
+the prompt-side schema identical.
+
+## Render nested component values
+
+If a custom prop accepts child components, use `renderNode` from the component
+render contract. It recursively renders elements, arrays, and primitive values
+using the active Library.
+
+```tsx
+export const Panel = defineComponent({
+  name: 'Panel',
+  description: 'A titled container for generated child content.',
+  props: z.object({
+    title: z.string(),
+    children: z.array(z.any()),
+  }),
+  component: ({ props, renderNode }) => (
+    <view className='Panel'>
+      <text className='PanelTitle'>{props.title}</text>
+      <view className='PanelBody'>{renderNode(props.children)}</view>
+    </view>
+  ),
+});
+```
+
+Do not call generated functions or evaluate generated strings inside a custom
+component. Let the OpenUI parser/runtime resolve expressions before props reach
+the renderer.
+
+## Runtime hooks for interactive components
+
+Custom components may use the hooks exported from
+`@lynx-js/genui/openui`:
+
+| Hook                                                | Use                                                                |
+| --------------------------------------------------- | ------------------------------------------------------------------ |
+| `useRenderNode()`                                   | Render nested generated values.                                    |
+| `useTriggerAction()`                                | Run an `ActionPlan` or emit a host action.                         |
+| `useIsStreaming()`                                  | Disable interaction while generated text is incomplete.            |
+| `useIsQueryLoading()`                               | Read whether any Query is in flight.                               |
+| `useGetFieldValue()`                                | Read `$variables` or form values from the runtime Store.           |
+| `useSetFieldValue()`                                | Update form state and optionally trigger persistence.              |
+| `useSetDefaultValue()`                              | Initialize a field after streaming without overwriting user input. |
+| `useOpenUI()`                                       | Access the complete runtime context for advanced integrations.     |
+| `useFormValidation()` / `useCreateFormValidation()` | Read or create a validation boundary for custom forms.             |
+
+All of these hooks must run below `<OpenUiRenderer>`. Interactive components
+should honor `isStreaming` so a user cannot act on a partial model response.
+
+## JSON Schema and parser utilities
+
+Use the Library schema for parsing outside the renderer or for inspection:
+
+```ts
+import { createOpenUiLibrary, createParser } from '@lynx-js/genui/openui';
+
+const library = createOpenUiLibrary();
+const parser = createParser(library.toJSONSchema(), library.root);
+const result = parser.parse('root = Stack([TextContent("Hello")])');
+```
+
+For streamed text, use `createStreamingParser`. Its `set(fullText)` method is
+convenient when your UI stores the accumulated response; `push(chunk)` accepts
+only the new delta.
+
+Use the renderer's `onParseResult` callback when you already render the same
+response. That avoids creating a second parser just to inspect `root`,
+`stateDeclarations`, data statements, or `meta` diagnostics.
+
+## Keep the Agent contract aligned
+
+Adding a component only to the ReactLynx Library is not enough: the Agent must
+receive the same name, positional schema, and description. The default prompt
+entry is deliberately headless so server code does not import ReactLynx or
+component CSS. For custom components, define matching headless prompt entries
+and pass them to `buildOpenUiSystemPrompt`.
+
+See [System prompts](./system-prompts.md) for the complete CLI and programmatic
+flow.

--- a/packages/genui/openui/docs/library-guide_zh.md
+++ b/packages/genui/openui/docs/library-guide_zh.md
@@ -1,0 +1,251 @@
+# Libraries、内置组件与自定义组件
+
+OpenUI **Library** 是 Agent 与 client 之间的 contract。它描述 Agent 可以写出的
+component calls，提供解析和 prompt 生成所需的 JSON Schema，并把每个允许的名称
+映射到可信的 ReactLynx renderer。
+
+这篇指南介绍默认 Library、其中 26 个内置组件，以及新增或替换组件的流程。
+
+## Library 包含什么
+
+每个 component definition 有四部分：
+
+- 稳定的 OpenUI component `name`；
+- 一个 Zod object schema，字段顺序决定位置参数顺序；
+- 一段用于 generated prompt 的简短 `description`；
+- 可信的 ReactLynx `component` 实现。
+
+`createOpenUiLibrary()` 把这些 definitions 组合成带以下成员的 `Library`：
+
+| 成员              | 用途                                                                                                                                   |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `components`      | Renderer 使用的 name-to-definition map。                                                                                               |
+| `componentGroups` | Prompt 和 tooling 使用的分类及排序提示。                                                                                               |
+| `root`            | `root` statement 必须使用的组件类型；默认为 `Stack`。                                                                                  |
+| `toJSONSchema()`  | 带位置 prop definitions 的 parser/handshake schema。                                                                                   |
+| `toSpec()`        | 框架无关的 prompt specification。                                                                                                      |
+| `prompt(options)` | 面向这个精确 Library 的底层 prompt 生成。Server 侧应优先使用 [system prompt 指南](./system-prompts_zh.md)介绍的 headless prompt 入口。 |
+
+默认 Library 应只创建一次，并保持对象 identity 稳定：
+
+```tsx
+const library = useMemo(() => createOpenUiLibrary(), []);
+
+<OpenUiRenderer response={response} library={library} />;
+```
+
+## 内置组件
+
+`createOpenUiLibrary()` 包含以下组件。它们也从
+`@lynx-js/genui/openui/catalog` 导出。
+
+### 布局
+
+| 组件     | 用途                                                             |
+| -------- | ---------------------------------------------------------------- |
+| `Stack`  | 支持换行、间距、对齐和排列的通用横/纵向布局；默认 Library root。 |
+| `Row`    | 横向布局容器。                                                   |
+| `Column` | 纵向布局容器。                                                   |
+| `List`   | 带可选分割线和间距的纵向或横向集合。                             |
+
+### 内容
+
+| 组件          | 用途                                                          |
+| ------------- | ------------------------------------------------------------- |
+| `Card`        | 带 Stack 类布局 props 的 `card`、`sunk` 或 `clear` 样式容器。 |
+| `CardHeader`  | Card 的标题和可选副标题。                                     |
+| `Text`        | 带 `h1`、`h2`、`caption`、`body` 等语义 variants 的普通文本。 |
+| `TextContent` | 带紧凑字号/字重 variants 的内容文本。                         |
+| `Separator`   | 简单视觉分隔符。                                              |
+| `Divider`     | 横向或纵向分割线。                                            |
+
+### 按钮
+
+| 组件      | 用途                                                                    |
+| --------- | ----------------------------------------------------------------------- |
+| `Button`  | 可点击的 primary、secondary 或 tertiary action，支持 destructive 样式。 |
+| `Buttons` | `Button` 组件组。                                                       |
+
+### 数据展示与媒体
+
+| 组件          | 用途                                                |
+| ------------- | --------------------------------------------------- |
+| `Tag`         | 紧凑标签或状态 tag。                                |
+| `Image`       | 带 fit 和语义尺寸 variants 的远程图片。             |
+| `Icon`        | 内置 Material Icons 字形，支持尺寸和颜色 variants。 |
+| `Video`       | 带 URL 和可选标题的视频附件占位。                   |
+| `AudioPlayer` | 带 URL 和描述的音频附件占位。                       |
+| `Loading`     | Inline 或 block skeleton/loading feedback。         |
+
+### 浮层
+
+| 组件    | 用途                                           |
+| ------- | ---------------------------------------------- |
+| `Tabs`  | 在带 label 的多个 child view 间切换。          |
+| `Modal` | 从 trigger 组件打开 generated detail content。 |
+
+### 输入
+
+| 组件            | 用途                                                   |
+| --------------- | ------------------------------------------------------ |
+| `CheckBox`      | 带可选 action 和 form name 的布尔输入。                |
+| `RadioGroup`    | 带 default、card 或 row 展示方式的单选输入。           |
+| `ChoicePicker`  | 以 chips、list 或 dropdown-like control 展示的选择器。 |
+| `Slider`        | 带可选 step 和 action 的数值范围输入。                 |
+| `TextField`     | 支持可选 regex 校验的短文本、数字、密码或多行输入。    |
+| `DateTimeInput` | 带 label、上下界和日期/时间展示开关的值。              |
+
+`RadioGroup`、`Slider` 和 `TextField` 使用 `@lynx-js/lynx-ui`；generated UI
+允许使用这些组件时，需要添加该 peer dependency。
+
+完整、最新的位置参数签名和 live preview 见
+[OpenUI Catalog](https://lynx-stack.dev/genui/#/openui/catalog)。Schema 是唯一事实来源：
+可选参数只能从右侧开始省略，也不支持 named-argument syntax。
+
+## OpenUI component 语法
+
+组件 Zod object 中的字段顺序，就是 wire-level 位置参数顺序。例如内置 Stack
+schema 依次以 `children`、`direction`、`wrap`、`gap`、`align` 和 `justify`
+开头，因此下面的写法合法：
+
+```text
+root = Stack([header, body], "column", false, "m", "stretch", "start")
+```
+
+下面不是合法的 OpenUI Lang：
+
+```text
+root = Stack(children: [header, body], gap: "m")
+```
+
+Child components 也是 values。它们既可以声明为具名 statements，也可以在 parent
+schema 允许时 inline 使用：
+
+```text
+root = Card([title, TextContent("Inline content")])
+title = CardHeader("Account", "Updated just now")
+```
+
+## 添加自定义组件
+
+如果应用还没有直接依赖 Zod，先安装：
+
+```sh
+pnpm add zod
+```
+
+用稳定名称、有序 prop schema、prompt description 和 ReactLynx renderer 定义
+组件。样式应放进 CSS class，而不是 inline style object；可见文本必须包在
+`<text>` 中。
+
+```tsx
+import { createOpenUiLibrary, defineComponent } from '@lynx-js/genui/openui';
+import { z } from 'zod/v4';
+
+import './Banner.css';
+
+export const Banner = defineComponent({
+  name: 'Banner',
+  description: 'Compact status banner with a title and tone.',
+  props: z.object({
+    title: z.string(),
+    tone: z.enum(['info', 'success', 'warning']).optional(),
+  }),
+  component: ({ props }) => (
+    <view className={`Banner Banner-${props.tone ?? 'info'}`}>
+      <text className='BannerTitle'>{props.title}</text>
+    </view>
+  ),
+});
+
+export const library = createOpenUiLibrary({
+  components: [Banner],
+  componentGroups: [
+    { name: 'Product', components: ['Banner'] },
+  ],
+});
+```
+
+Agent 现在可以输出：
+
+```text
+root = Stack([notice])
+notice = Banner("Payment received", "success")
+```
+
+调用方提供的 components 和 groups 会追加在默认值后。如果自定义组件与内置组件
+同名，后加入的自定义 definition 会覆盖 `components` map 中的默认值。这应当被
+视为一次有意 override，并且 prompt 侧 schema 必须与它保持一致。
+
+## 渲染嵌套 component values
+
+如果自定义 prop 接受 child components，请使用 component render contract 中的
+`renderNode`。它会通过 active Library 递归渲染 elements、arrays 和 primitive
+values。
+
+```tsx
+export const Panel = defineComponent({
+  name: 'Panel',
+  description: 'A titled container for generated child content.',
+  props: z.object({
+    title: z.string(),
+    children: z.array(z.any()),
+  }),
+  component: ({ props, renderNode }) => (
+    <view className='Panel'>
+      <text className='PanelTitle'>{props.title}</text>
+      <view className='PanelBody'>{renderNode(props.children)}</view>
+    </view>
+  ),
+});
+```
+
+不要在自定义组件里调用 generated functions，也不要执行 generated strings。让
+OpenUI parser/runtime 在 props 到达 renderer 前完成表达式求值。
+
+## 交互组件使用的 runtime hooks
+
+自定义组件可以使用 `@lynx-js/genui/openui` 导出的 hooks：
+
+| Hook                                                | 用途                                                |
+| --------------------------------------------------- | --------------------------------------------------- |
+| `useRenderNode()`                                   | 渲染嵌套 generated values。                         |
+| `useTriggerAction()`                                | 执行 `ActionPlan` 或发出宿主 action。               |
+| `useIsStreaming()`                                  | Generated text 不完整时禁用交互。                   |
+| `useIsQueryLoading()`                               | 读取是否有 Query 正在执行。                         |
+| `useGetFieldValue()`                                | 从 runtime Store 读取 `$variables` 或 form values。 |
+| `useSetFieldValue()`                                | 更新 form state，并按需触发持久化。                 |
+| `useSetDefaultValue()`                              | Streaming 结束后初始化字段，同时避免覆盖用户输入。  |
+| `useOpenUI()`                                       | 高级接入时访问完整 runtime context。                |
+| `useFormValidation()` / `useCreateFormValidation()` | 读取或创建自定义 form validation boundary。         |
+
+这些 hooks 都必须运行在 `<OpenUiRenderer>` 下方。交互组件应遵守
+`isStreaming`，防止用户操作尚未完成的模型 response。
+
+## JSON Schema 与 parser utilities
+
+在 renderer 外解析或检查 OpenUI 时，可以使用 Library schema：
+
+```ts
+import { createOpenUiLibrary, createParser } from '@lynx-js/genui/openui';
+
+const library = createOpenUiLibrary();
+const parser = createParser(library.toJSONSchema(), library.root);
+const result = parser.parse('root = Stack([TextContent("Hello")])');
+```
+
+流式文本使用 `createStreamingParser`。如果 UI 保存累计 response，可以调用
+`set(fullText)`；如果只传新增 delta，则调用 `push(chunk)`。
+
+如果同一 response 已经交给 renderer，优先使用它的 `onParseResult` callback，避免
+为了检查 `root`、`stateDeclarations`、data statements 或 `meta` diagnostics 而
+创建第二个 parser。
+
+## 保持 Agent contract 一致
+
+只把组件加入 ReactLynx Library 还不够：Agent 必须收到相同的名称、位置 schema
+和描述。默认 prompt 入口刻意保持 headless，使 server code 不需要导入 ReactLynx
+或组件 CSS。使用自定义组件时，需要定义匹配的 headless prompt entries，并传给
+`buildOpenUiSystemPrompt`。
+
+完整 CLI 与程序化流程见 [System Prompts](./system-prompts_zh.md)。

--- a/packages/genui/openui/docs/overview.md
+++ b/packages/genui/openui/docs/overview.md
@@ -1,0 +1,284 @@
+# Overview and architecture
+
+This page explains what `@lynx-js/genui/openui` is, how OpenUI Lang maps to a
+trusted ReactLynx component tree, and what happens between a streamed Agent
+response and the rendered UI.
+
+## What this package is
+
+`@lynx-js/genui/openui` is the ReactLynx **client runtime** for OpenUI Lang
+v0.5. It combines the framework-agnostic parser and evaluator from
+`@openuidev/lang-core` with a ReactLynx renderer and a built-in mobile component
+library.
+
+The package provides:
+
+- `<OpenUiRenderer>` for raw or pre-parsed OpenUI input;
+- `createOpenUiLibrary()` and 26 trusted component implementations;
+- incremental parsing for model streams;
+- reactive `$variables`, expression evaluation, and form state;
+- `Query()`, `Mutation()`, and multi-step `Action([...])` execution;
+- structured parser, runtime, render, and tool errors;
+- prompt builders that describe the matching component contract to an Agent.
+
+It does **not** host an Agent, call an LLM, define your network transport, or
+provide backend tools. Your application owns those pieces.
+
+## Quick start
+
+Install the package and optional default theme in a ReactLynx app:
+
+```sh
+pnpm add @lynx-js/genui @lynx-js/react @lynx-js/lynx-ui
+```
+
+```tsx
+import { createOpenUiLibrary, OpenUiRenderer } from '@lynx-js/genui/openui';
+import { useMemo } from '@lynx-js/react';
+
+import '@lynx-js/genui/openui/styles/theme.css';
+
+export function GeneratedView({ response }: { response: string }) {
+  const library = useMemo(() => createOpenUiLibrary(), []);
+
+  return (
+    <view className='openui-light'>
+      <OpenUiRenderer response={response} library={library} />
+    </view>
+  );
+}
+```
+
+The simplest valid response is:
+
+```text
+root = Stack([message])
+message = TextContent("Hello OpenUI")
+```
+
+OpenUI uses positional arguments. The parser maps them to named props in the
+order of each component's Zod schema. Forward references are allowed, so the
+root can refer to statements that appear later in the response.
+
+## The mental model
+
+In ordinary React, your source code chooses a component and passes props:
+
+```tsx
+<Card>
+  <TextContent text='Hello' />
+</Card>;
+```
+
+In OpenUI, the Agent writes the same intent as declarative assignments:
+
+```text
+root = Card([message])
+message = TextContent("Hello")
+```
+
+The renderer never evaluates generated JavaScript. It parses the text against
+the JSON Schema produced by your `Library`, turns valid component calls into an
+element tree, and looks up each element's trusted ReactLynx implementation by
+name. A component that is not in the Library cannot be rendered.
+
+The Library is therefore the contract on both sides:
+
+```text
+Agent prompt                              ReactLynx client
+Library signatures                       Library implementations
+Stack(children, direction?, ...)   <──►   Stack -> trusted renderer
+Text(text, variant?)               <──►   Text  -> trusted renderer
+```
+
+Keep the prompt Library and renderer Library aligned whenever you add or
+override a component. A name or prop-order mismatch can produce text that the
+client cannot validate.
+
+## OpenUI Lang v0.5 in one minute
+
+An OpenUI program contains one assignment per line. There are three statement
+families:
+
+| Statement | Example                                                            | Purpose                                               |
+| --------- | ------------------------------------------------------------------ | ----------------------------------------------------- |
+| Component | `header = CardHeader("Orders")`                                    | Declares a renderable component.                      |
+| State     | `$status = "open"`                                                 | Declares reactive client state and its default value. |
+| Data      | `orders = Query("list_orders", { status: $status }, { rows: [] })` | Declares a read or write tool operation.              |
+
+Expressions can contain primitives, arrays, objects, references, member access,
+operators, ternaries, and built-ins such as `@Count(...)`. The renderer needs a
+statement named `root`; by default its component must be `Stack` because that is
+the default Library root.
+
+State values are reactive. When `$status` changes, expressions that read it are
+evaluated again and Queries whose arguments depend on it are refreshed.
+
+```text
+$status = "open"
+orders = Query("list_orders", { status: $status }, { rows: [] })
+root = Stack([summary, refresh])
+summary = TextContent("Orders: " + @Count(orders.rows))
+refresh = Button("Refresh", Action([@Run(orders)]), "secondary")
+```
+
+For the complete language grammar and built-ins, read the
+[OpenUI Lang v0.5 specification](https://www.openui.com/docs/openui-lang/specification-v05).
+
+## The end-to-end picture
+
+OpenUI is a loop between an Agent that writes declarative UI and a client that
+parses, evaluates, and renders it.
+
+```text
+       ┌──────────────── Your application ────────────────┐
+user   │                                                  │
+input ─┼─► Transport ──prompt/action──► Agent service     │
+       │      ▲                              │             │
+       │      │   accumulated OpenUI text    │             │
+       │      └──────────────────────────────┘             │
+       │      │                                            │
+       │      ▼                                            │
+       │ <OpenUiRenderer response={text}>                  │
+       │      │                                            │
+       │      ├─ parser ─► AST ─► evaluator ─► UI tree     │
+       │      ├─ Store ($state + form state)               │
+       │      └─ QueryManager ─► your toolProvider         │
+       │                    │                               │
+       │                    └─ onAction ─► host/transport ──┤
+       └───────────────────────────────────────────────────┘
+```
+
+1. Your transport sends the user request to an Agent service.
+2. The service calls a model with an OpenUI system prompt built from the same
+   component contract the client supports.
+3. The transport appends chunks to one accumulated `response` string and passes
+   it to `<OpenUiRenderer>`.
+4. The streaming parser validates completed statements and resolves references.
+5. The runtime initializes state, evaluates expressions, and runs complete
+   Queries through your `toolProvider`.
+6. The renderer walks the evaluated root and mounts trusted ReactLynx
+   components from the Library.
+7. User interactions execute action steps. Host-facing actions leave through
+   `onAction`; state and tool steps stay inside the runtime.
+
+## Inside the client
+
+The raw `response` path creates the complete v0.5 runtime:
+
+```text
+response text
+     │
+     ▼
+createStreamingParser(library.toJSONSchema(), library.root)
+     │
+     ├─ ParseResult: root + state/query/mutation statements + metadata
+     │
+     ▼
+useOpenUIState
+     ├─ Store: $variables and form fields
+     ├─ QueryManager: Query/Mutation execution and cache
+     ├─ EvaluationContext: state and data reference resolution
+     └─ structured errors
+     │
+     ▼
+RenderNode ──name lookup──► library.components[name].component
+```
+
+Important runtime behavior:
+
+- **Incremental parsing.** The parser caches completed statements while the
+  accumulated response grows. Forward references become renderable when their
+  targets arrive.
+- **Stable Library.** Create the Library once with `useMemo` or outside the
+  component. Changing its identity creates a new parser and can reset parsing
+  work.
+- **Streaming guard.** Pass `isStreaming` while generation is active. Query and
+  mutation execution waits for stable output, and built-in interactions are
+  disabled.
+- **Reactive state.** `$variables` and form values live in one external Store.
+  `onStateUpdate` can persist its snapshots; `$`-prefixed values in
+  `initialState` hydrate reactive declarations.
+- **Queries and mutations.** Queries execute when their statements are complete
+  and re-run when referenced state changes. Mutations are registered but run
+  only when an action calls `@Run(mutationRef)`.
+- **Sequential actions.** `@Run`, `@Set`, `@Reset`, `@ToAssistant`, and
+  `@OpenUrl` execute in order. A failed mutation stops the remaining steps.
+- **Soft component failure.** An element whose component name is not registered
+  renders nothing. `onError` receives other parse, evaluation, render, and tool
+  failures after streaming settles.
+
+## Who owns what
+
+| Piece              | Runs in                 | Owner                      | Responsibility                                                                                            |
+| ------------------ | ----------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Agent service      | Server                  | Your application           | Produces raw OpenUI Lang using the system prompt and component/tool contract.                             |
+| Transport adapter  | Client shell            | Your application           | Streams accumulated response text, handles cancellation, and forwards conversation actions.               |
+| `Library`          | Client + Agent contract | Shared                     | Names components, fixes positional prop order, provides JSON Schema, and maps names to trusted renderers. |
+| Parser/evaluator   | Client                  | This package + `lang-core` | Parses statements, validates props, resolves state/data expressions, and reports structured errors.       |
+| Store/QueryManager | Client                  | This package + `lang-core` | Owns reactive/form state and executes tool-backed Query/Mutation statements.                              |
+| `<OpenUiRenderer>` | Client                  | This package               | Renders the evaluated root and wires state, tools, and actions to ReactLynx components.                   |
+| `toolProvider`     | Client integration      | Your application           | Maps tool names to async functions or an MCP-compatible client.                                           |
+
+## `<OpenUiRenderer>` props
+
+Use the raw response form for all new integrations.
+
+| Prop            | Type                                       | Required | Purpose                                                                  |
+| --------------- | ------------------------------------------ | -------- | ------------------------------------------------------------------------ |
+| `response`      | `string \| null`                           | yes      | Accumulated raw OpenUI Lang text. Enables the v0.5 runtime.              |
+| `library`       | `Library`                                  | yes      | Component schemas and trusted ReactLynx implementations.                 |
+| `isStreaming`   | `boolean`                                  | no       | Marks partial model output and disables unstable interactions/tool work. |
+| `onAction`      | `(event: ActionEvent) => void`             | no       | Receives assistant and URL actions that the host must handle.            |
+| `onStateUpdate` | `(state: Record<string, unknown>) => void` | no       | Receives reactive/form state snapshots for persistence.                  |
+| `initialState`  | `Record<string, unknown>`                  | no       | Hydrates `$variables` and form state.                                    |
+| `onParseResult` | `(result: ParseResult \| null) => void`    | no       | Exposes the latest raw AST and parser metadata.                          |
+| `toolProvider`  | function map, MCP-like client, or `null`   | no       | Executes tools referenced by Query/Mutation statements.                  |
+| `queryLoader`   | `ReactNode`                                | no       | Replaces the default indicator while Queries are in flight.              |
+| `onError`       | `(errors: OpenUIError[]) => void`          | no       | Receives deduplicated structured errors after streaming.                 |
+
+`<OpenUiRenderer result={parseResult} library={library}>` remains available for
+legacy/static callers. It can render a pre-parsed element tree and forward
+simple actions, but it does not create the v0.5 QueryManager or fully execute
+`@Run`, `@Set`, and `@Reset`. Do not use it for a new v0.5 integration.
+
+## Tool providers
+
+For local functions, pass a name-to-function map:
+
+```tsx
+<OpenUiRenderer
+  response={response}
+  library={library}
+  toolProvider={{
+    list_orders: async ({ status }) => {
+      return await api.listOrders({ status: String(status) });
+    },
+    save_order: async (args) => await api.saveOrder(args),
+  }}
+/>;
+```
+
+You may also pass an MCP-compatible object with
+`callTool({ name, arguments })`. The runtime extracts structured MCP tool
+results before expression evaluation. Missing tools and tool failures are
+reported through `onError`.
+
+## Exports
+
+| Import                                   | What you get                                                                                     |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `@lynx-js/genui/openui`                  | Renderer, Library helpers, parser/runtime exports, hooks, built-in components, and public types. |
+| `@lynx-js/genui/openui/catalog`          | Tree-shake-friendly re-exports of the built-in component definitions.                            |
+| `@lynx-js/genui/openui/prompt`           | Headless prompt Library, prompt builder, default prompt, and prompt-specific types.              |
+| `@lynx-js/genui/openui/styles/theme.css` | Optional light/dark CSS custom-property tokens.                                                  |
+
+Component styles, the core renderer stylesheet, and the Material Icons font are
+implementation details imported by the relevant modules. Do not import private
+files under `styles/catalog` or `dist/core`.
+
+## Where to go next
+
+- [Libraries, built-ins, and custom components](./library-guide.md)
+- [System prompts](./system-prompts.md)
+- [Open the OpenUI playground](https://lynx-stack.dev/genui/#/openui)

--- a/packages/genui/openui/docs/overview_zh.md
+++ b/packages/genui/openui/docs/overview_zh.md
@@ -1,0 +1,268 @@
+# 概览与架构
+
+这篇文档解释 `@lynx-js/genui/openui` 是什么、OpenUI Lang 如何映射成可信的
+ReactLynx 组件树，以及一段流式 Agent response 如何变成最终 UI。
+
+## 这个包是什么
+
+`@lynx-js/genui/openui` 是面向 OpenUI Lang v0.5 的 ReactLynx **客户端运行时**。
+它把 `@openuidev/lang-core` 提供的框架无关 parser/evaluator，与 ReactLynx
+renderer 和内置移动端组件 Library 组合在一起。
+
+这个包提供：
+
+- 处理原始或预解析 OpenUI 输入的 `<OpenUiRenderer>`；
+- `createOpenUiLibrary()` 和 26 个可信组件实现；
+- 面向模型流式输出的增量解析；
+- 响应式 `$variables`、表达式求值和表单状态；
+- `Query()`、`Mutation()` 和多步骤 `Action([...])` 执行；
+- 结构化 parser、runtime、render 和 tool errors；
+- 用来向 Agent 描述同一组件 contract 的 prompt builders。
+
+它**不会**托管 Agent、调用 LLM、定义网络传输，也不提供你的后端工具。这些部分由
+你的应用负责。
+
+## Quick start
+
+在 ReactLynx 应用里安装包，并引入可选的默认主题：
+
+```sh
+pnpm add @lynx-js/genui @lynx-js/react @lynx-js/lynx-ui
+```
+
+```tsx
+import { createOpenUiLibrary, OpenUiRenderer } from '@lynx-js/genui/openui';
+import { useMemo } from '@lynx-js/react';
+
+import '@lynx-js/genui/openui/styles/theme.css';
+
+export function GeneratedView({ response }: { response: string }) {
+  const library = useMemo(() => createOpenUiLibrary(), []);
+
+  return (
+    <view className='openui-light'>
+      <OpenUiRenderer response={response} library={library} />
+    </view>
+  );
+}
+```
+
+最简单的合法 response 是：
+
+```text
+root = Stack([message])
+message = TextContent("Hello OpenUI")
+```
+
+OpenUI 使用位置参数。Parser 按每个组件 Zod schema 的字段顺序，把位置参数映射为
+具名 props。它允许 forward references，所以 root 可以引用 response 后面才声明的
+statements。
+
+## 心智模型
+
+在普通 React 中，是你的源码选择组件并传入 props：
+
+```tsx
+<Card>
+  <TextContent text='Hello' />
+</Card>;
+```
+
+在 OpenUI 中，Agent 用声明式 assignments 表达同样的意图：
+
+```text
+root = Card([message])
+message = TextContent("Hello")
+```
+
+Renderer 不会执行生成的 JavaScript。它用 `Library` 生成的 JSON Schema 解析文本，
+把合法 component calls 转换为 element tree，再按名称查找对应的可信 ReactLynx
+实现。没有注册进 Library 的组件无法被渲染。
+
+所以 Library 是 wire 两侧共享的 contract：
+
+```text
+Agent prompt                              ReactLynx client
+Library signatures                       Library implementations
+Stack(children, direction?, ...)   <──►   Stack -> trusted renderer
+Text(text, variant?)               <──►   Text  -> trusted renderer
+```
+
+新增或覆盖组件时，必须保持 prompt Library 和 renderer Library 一致。名称或 prop
+顺序不一致，会让 Agent 产出 client 无法校验的文本。
+
+## 一分钟理解 OpenUI Lang v0.5
+
+一段 OpenUI program 每行包含一个 assignment，共有三类 statement：
+
+| Statement | 示例                                                               | 用途                             |
+| --------- | ------------------------------------------------------------------ | -------------------------------- |
+| Component | `header = CardHeader("Orders")`                                    | 声明可渲染组件。                 |
+| State     | `$status = "open"`                                                 | 声明响应式客户端状态及其默认值。 |
+| Data      | `orders = Query("list_orders", { status: $status }, { rows: [] })` | 声明读或写工具操作。             |
+
+表达式可以包含 primitives、arrays、objects、references、member access、operators、
+ternaries，以及 `@Count(...)` 等 built-ins。Renderer 必须找到名为 `root` 的
+statement；默认情况下它的组件应为 `Stack`，因为 `Stack` 是默认 Library root。
+
+State values 是响应式的。当 `$status` 改变，读取它的表达式会重新求值，参数依赖
+它的 Queries 也会刷新。
+
+```text
+$status = "open"
+orders = Query("list_orders", { status: $status }, { rows: [] })
+root = Stack([summary, refresh])
+summary = TextContent("Orders: " + @Count(orders.rows))
+refresh = Button("Refresh", Action([@Run(orders)]), "secondary")
+```
+
+完整语言语法和 built-ins 见
+[OpenUI Lang v0.5 规范](https://www.openui.com/docs/openui-lang/specification-v05)。
+
+## 端到端全貌
+
+OpenUI 是一个由 Agent 编写声明式 UI、client 解析求值并渲染的循环。
+
+```text
+       ┌──────────────── Your application ────────────────┐
+user   │                                                  │
+input ─┼─► Transport ──prompt/action──► Agent service     │
+       │      ▲                              │             │
+       │      │   accumulated OpenUI text    │             │
+       │      └──────────────────────────────┘             │
+       │      │                                            │
+       │      ▼                                            │
+       │ <OpenUiRenderer response={text}>                  │
+       │      │                                            │
+       │      ├─ parser ─► AST ─► evaluator ─► UI tree     │
+       │      ├─ Store ($state + form state)               │
+       │      └─ QueryManager ─► your toolProvider         │
+       │                    │                               │
+       │                    └─ onAction ─► host/transport ──┤
+       └───────────────────────────────────────────────────┘
+```
+
+1. 你的 transport 把用户请求发送给 Agent 服务。
+2. 服务使用由同一 client component contract 构建的 OpenUI system prompt 调用模型。
+3. Transport 把 chunks 追加到同一个累计 `response` 字符串，再传给
+   `<OpenUiRenderer>`。
+4. Streaming parser 校验已完成的 statements，并解析引用关系。
+5. Runtime 初始化状态、求值表达式，并通过你的 `toolProvider` 执行完整 Queries。
+6. Renderer 遍历求值后的 root，挂载 Library 中可信的 ReactLynx 组件。
+7. 用户交互触发 action steps。宿主 actions 通过 `onAction` 抛出；状态和 tool
+   steps 留在 runtime 内执行。
+
+## Client 内部
+
+原始 `response` 路径会创建完整的 v0.5 runtime：
+
+```text
+response text
+     │
+     ▼
+createStreamingParser(library.toJSONSchema(), library.root)
+     │
+     ├─ ParseResult: root + state/query/mutation statements + metadata
+     │
+     ▼
+useOpenUIState
+     ├─ Store: $variables and form fields
+     ├─ QueryManager: Query/Mutation execution and cache
+     ├─ EvaluationContext: state and data reference resolution
+     └─ structured errors
+     │
+     ▼
+RenderNode ──name lookup──► library.components[name].component
+```
+
+几个重要的 runtime 行为：
+
+- **增量解析。** 累计 response 持续增长时，parser 会缓存已经完成的 statements。
+  Forward references 在目标到达后变为可渲染状态。
+- **稳定的 Library。** 用 `useMemo` 或组件外常量只创建一次 Library。改变其对象
+  identity 会创建新 parser，并可能丢失已有解析工作。
+- **Streaming guard。** 生成期间传入 `isStreaming`。Query/mutation 会等待输出
+  稳定，内置交互也保持禁用。
+- **响应式状态。** `$variables` 和 form values 位于同一个外部 Store 中。
+  `onStateUpdate` 可以持久化 snapshots；`initialState` 中以 `$` 开头的值会 hydrate
+  响应式 declarations。
+- **Queries 与 mutations。** Query statement 完整后执行，并在引用状态变化时重新
+  执行。Mutation 只注册定义，直到 action 调用 `@Run(mutationRef)` 才执行。
+- **顺序 actions。** `@Run`、`@Set`、`@Reset`、`@ToAssistant` 和 `@OpenUrl`
+  按顺序执行。Mutation 失败会终止后续 steps。
+- **组件软失败。** Element 的 component name 未注册时不会渲染任何内容。其他
+  parse、evaluation、render 和 tool failures 会在 streaming 稳定后交给
+  `onError`。
+
+## 谁负责什么
+
+| 部分               | 运行位置                | 负责人               | 职责                                                                            |
+| ------------------ | ----------------------- | -------------------- | ------------------------------------------------------------------------------- |
+| Agent 服务         | Server                  | 你的应用             | 使用 system prompt 和 component/tool contract 生成原始 OpenUI Lang。            |
+| Transport adapter  | Client shell            | 你的应用             | 流式传入累计 response 文本、处理取消，并转发 conversation actions。             |
+| `Library`          | Client + Agent contract | 双方共享             | 命名组件、固定位置参数顺序、提供 JSON Schema，并把名称映射为可信 renderer。     |
+| Parser/evaluator   | Client                  | 这个包 + `lang-core` | 解析 statements、校验 props、解析 state/data expressions，并报告结构化 errors。 |
+| Store/QueryManager | Client                  | 这个包 + `lang-core` | 管理响应式/form state，并执行工具支持的 Query/Mutation statements。             |
+| `<OpenUiRenderer>` | Client                  | 这个包               | 渲染求值后的 root，把状态、tools 和 actions 接到 ReactLynx 组件。               |
+| `toolProvider`     | Client integration      | 你的应用             | 把工具名映射到 async functions 或 MCP-compatible client。                       |
+
+## `<OpenUiRenderer>` props
+
+所有新接入都应使用原始 response 形式。
+
+| Prop            | 类型                                       | 必填 | 用途                                               |
+| --------------- | ------------------------------------------ | ---- | -------------------------------------------------- |
+| `response`      | `string \| null`                           | 是   | 累计的原始 OpenUI Lang 文本，启用 v0.5 runtime。   |
+| `library`       | `Library`                                  | 是   | 组件 schemas 和可信 ReactLynx 实现。               |
+| `isStreaming`   | `boolean`                                  | 否   | 标记模型输出仍不完整，并禁用不稳定交互/tool work。 |
+| `onAction`      | `(event: ActionEvent) => void`             | 否   | 接收需要宿主处理的 assistant 和 URL actions。      |
+| `onStateUpdate` | `(state: Record<string, unknown>) => void` | 否   | 接收响应式/form state snapshots，以便持久化。      |
+| `initialState`  | `Record<string, unknown>`                  | 否   | Hydrate `$variables` 和 form state。               |
+| `onParseResult` | `(result: ParseResult \| null) => void`    | 否   | 暴露最新原始 AST 和 parser metadata。              |
+| `toolProvider`  | function map、MCP-like client 或 `null`    | 否   | 执行 Query/Mutation statements 引用的工具。        |
+| `queryLoader`   | `ReactNode`                                | 否   | Queries 执行期间替换默认 indicator。               |
+| `onError`       | `(errors: OpenUIError[]) => void`          | 否   | Streaming 结束后接收去重的结构化 errors。          |
+
+`<OpenUiRenderer result={parseResult} library={library}>` 仍为 legacy/static
+callers 保留。它可以渲染预解析 element tree 并转发简单 actions，但不会创建 v0.5
+QueryManager，也无法完整执行 `@Run`、`@Set` 和 `@Reset`。新 v0.5 接入不要使用
+这条路径。
+
+## Tool providers
+
+本地函数可以通过 name-to-function map 传入：
+
+```tsx
+<OpenUiRenderer
+  response={response}
+  library={library}
+  toolProvider={{
+    list_orders: async ({ status }) => {
+      return await api.listOrders({ status: String(status) });
+    },
+    save_order: async (args) => await api.saveOrder(args),
+  }}
+/>;
+```
+
+也可以传入带 `callTool({ name, arguments })` 的 MCP-compatible 对象。Runtime 会在
+表达式求值前提取结构化 MCP tool result。缺失工具和工具失败会通过 `onError`
+报告。
+
+## Exports
+
+| 导入                                     | 你得到什么                                                                       |
+| ---------------------------------------- | -------------------------------------------------------------------------------- |
+| `@lynx-js/genui/openui`                  | Renderer、Library helpers、parser/runtime exports、hooks、内置组件和公共 types。 |
+| `@lynx-js/genui/openui/catalog`          | 内置组件 definitions 的 tree-shake-friendly 再导出。                             |
+| `@lynx-js/genui/openui/prompt`           | Headless prompt Library、prompt builder、默认 prompt 和 prompt-specific types。  |
+| `@lynx-js/genui/openui/styles/theme.css` | 可选的 light/dark CSS custom-property tokens。                                   |
+
+组件样式、core renderer stylesheet 和 Material Icons font 都是由对应模块自动引入的
+实现细节。不要导入 `styles/catalog` 或 `dist/core` 下的私有文件。
+
+## 下一步
+
+- [Libraries、内置组件与自定义组件](./library-guide_zh.md)
+- [System Prompts](./system-prompts_zh.md)
+- [打开 OpenUI Playground](https://lynx-stack.dev/genui/#/openui)

--- a/packages/genui/openui/docs/system-prompts.md
+++ b/packages/genui/openui/docs/system-prompts.md
@@ -1,0 +1,280 @@
+# System prompts
+
+Generate and customize the instructions that teach an LLM to emit valid OpenUI
+Lang for the component Library your ReactLynx client renders.
+
+Use the CLI when the built-in Library and a static prompt file are enough. Use
+the programmatic API when tools, feature flags, custom components, or deployment
+policy must be assembled in backend code.
+
+## The contract to preserve
+
+An OpenUI system prompt describes:
+
+- the one-assignment-per-line language syntax;
+- the required `root` entry point and top-down streaming order;
+- component signatures derived from ordered Zod schemas;
+- reactive `$variables` and built-in functions;
+- Query/Mutation and Action rules;
+- tool names and input/output schemas, when supplied;
+- examples and hard constraints for parseable output.
+
+The prompt-side Library and client renderer Library must agree on every
+component name and positional prop order. If they drift, the model can produce
+valid text for one side that the other side rejects.
+
+## 1. CLI
+
+Generate the default built-in OpenUI prompt to a file:
+
+```sh
+npx @lynx-js/genui openui generate prompt \
+  --out dist/openui-system-prompt.txt
+```
+
+Print it to stdout:
+
+```sh
+npx @lynx-js/genui openui generate prompt
+```
+
+Append deployment-specific rules:
+
+```sh
+npx @lynx-js/genui openui generate prompt \
+  --appendix "Prefer compact mobile layouts for booking flows." \
+  --out dist/openui-system-prompt.txt
+```
+
+The CLI uses the headless mirror of the built-in ReactLynx Library. Its prompt
+generation command accepts:
+
+| Option              | Purpose                                                            |
+| ------------------- | ------------------------------------------------------------------ |
+| `--out <file>`      | Write to a file instead of stdout. Parent directories are created. |
+| `--appendix <text>` | Append application-specific instructions.                          |
+| `--version`         | Print the package version.                                         |
+| `--help`            | Print command help.                                                |
+
+The CLI does not load a custom component directory or tool manifest. Use the
+programmatic API when the Agent contract contains custom components or rich
+tool schemas.
+
+## 2. Programmatic usage
+
+Build the default prompt in server-side TypeScript:
+
+```ts
+import { buildOpenUiSystemPrompt } from '@lynx-js/genui/openui/prompt';
+
+const systemPrompt = buildOpenUiSystemPrompt();
+```
+
+Add application policy and tool descriptions:
+
+```ts
+import { buildOpenUiSystemPrompt } from '@lynx-js/genui/openui/prompt';
+
+const systemPrompt = buildOpenUiSystemPrompt({
+  appendix: [
+    'Prefer one-column mobile layouts.',
+    'Never invent tool names or arguments.',
+  ].join('\n'),
+  promptOptions: {
+    tools: [
+      {
+        name: 'list_orders',
+        description: 'List orders filtered by status.',
+        inputSchema: {
+          type: 'object',
+          properties: { status: { type: 'string' } },
+          required: ['status'],
+        },
+        outputSchema: {
+          type: 'object',
+          properties: {
+            rows: { type: 'array', items: { type: 'object' } },
+          },
+          required: ['rows'],
+        },
+        annotations: { readOnlyHint: true },
+      },
+    ],
+  },
+});
+```
+
+The client must expose a matching tool implementation:
+
+```tsx
+<OpenUiRenderer
+  response={response}
+  library={library}
+  toolProvider={{
+    list_orders: async ({ status }) => {
+      return await api.listOrders({ status: String(status) });
+    },
+  }}
+/>;
+```
+
+Tool schemas teach the model what it may call; `toolProvider` is the code that
+actually executes those calls. Do not put secrets or provider credentials in
+the prompt or browser-side tool arguments.
+
+## Prompt options
+
+`buildOpenUiSystemPrompt` accepts Library options, prompt feature flags, and an
+optional appendix:
+
+| Option                          | Purpose                                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `root`                          | Override the required root component name. The component must exist in the prompt Library and client Library. |
+| `components`                    | Append headless component definitions; later duplicate names replace defaults.                                |
+| `componentGroups`               | Append prompt grouping metadata.                                                                              |
+| `promptOptions.preamble`        | Replace or extend the product framing before language rules.                                                  |
+| `promptOptions.additionalRules` | Add rules after the built-in mobile/OpenUI constraints.                                                       |
+| `promptOptions.examples`        | Replace the default static examples.                                                                          |
+| `promptOptions.toolExamples`    | Provide examples used when tools are present.                                                                 |
+| `promptOptions.tools`           | Describe Query/Mutation tools by name or rich schema.                                                         |
+| `promptOptions.toolCalls`       | Enable or disable Query, Mutation, `@Run`, and tool workflow instructions.                                    |
+| `promptOptions.bindings`        | Enable or disable `$variables`, `@Set`, `@Reset`, and reactive filter instructions.                           |
+| `promptOptions.editMode`        | Teach the model to return only changed statements for incremental editing.                                    |
+| `promptOptions.inlineMode`      | Allow prose with optional fenced OpenUI instead of raw OpenUI-only output.                                    |
+| `appendix`                      | Append final deployment-specific instructions verbatim.                                                       |
+
+The Lynx OpenUI prompt builder enables `bindings` and `toolCalls` by default.
+Disable them explicitly for a static-only product surface:
+
+```ts
+const systemPrompt = buildOpenUiSystemPrompt({
+  promptOptions: {
+    bindings: false,
+    toolCalls: false,
+  },
+});
+```
+
+`inlineMode` is disabled by default. In the default mode, the model should
+return raw OpenUI Lang only—no explanation and no Markdown code fence—so the
+full response can go directly into `<OpenUiRenderer response={...}>`.
+
+## Custom component prompts
+
+Keep shared Zod schemas in a framework-neutral module. The client wraps the
+schema with the ReactLynx `defineComponent`; the server wraps the same schema
+with the headless `@openuidev/lang-core` definition.
+
+```ts
+// shared/bannerSchema.ts
+import { z } from 'zod/v4';
+
+export const bannerProps = z.object({
+  title: z.string(),
+  tone: z.enum(['info', 'success', 'warning']).optional(),
+});
+```
+
+```tsx
+// client/Banner.tsx
+import { defineComponent } from '@lynx-js/genui/openui';
+import { bannerProps } from '../shared/bannerSchema.js';
+
+export const Banner = defineComponent({
+  name: 'Banner',
+  description: 'Compact status banner with a title and tone.',
+  props: bannerProps,
+  component: ({ props }) => (
+    <view className={`Banner Banner-${props.tone ?? 'info'}`}>
+      <text className='BannerTitle'>{props.title}</text>
+    </view>
+  ),
+});
+```
+
+```ts
+// server/openuiPrompt.ts
+import { defineComponent } from '@openuidev/lang-core';
+import { buildOpenUiSystemPrompt } from '@lynx-js/genui/openui/prompt';
+import { bannerProps } from '../shared/bannerSchema.js';
+
+const PromptBanner = defineComponent({
+  name: 'Banner',
+  description: 'Compact status banner with a title and tone.',
+  props: bannerProps,
+  component: () => null,
+});
+
+export const systemPrompt = buildOpenUiSystemPrompt({
+  components: [PromptBanner],
+  componentGroups: [
+    { name: 'Product', components: ['Banner'] },
+  ],
+});
+```
+
+Install `@openuidev/lang-core` and `zod` as direct dependencies of the server
+workspace when it owns custom headless definitions. Keeping the prompt
+component renderer as `() => null` prevents server routes from importing
+ReactLynx, Lynx UI components, or component CSS.
+
+## Other prompt exports
+
+`@lynx-js/genui/openui/prompt` also exports:
+
+| Export                               | Purpose                                                                               |
+| ------------------------------------ | ------------------------------------------------------------------------------------- |
+| `createOpenUiPromptLibrary(options)` | Build the headless built-in Library for inspection or lower-level prompt composition. |
+| `OPENUI_SYSTEM_PROMPT`               | Prebuilt default prompt created with no options.                                      |
+| `openUiPromptActionPropSchema`       | Shared prompt schema for v0.5 action plans and legacy action objects.                 |
+
+Prefer `buildOpenUiSystemPrompt()` in application code so customization remains
+explicit and testable.
+
+## Backend integration pattern
+
+Send the generated prompt as the model's system instruction, preserve the raw
+text stream, and return that text to the client. The server does not need to
+parse the UI simply to forward it, but it should enforce its own model-output
+and tool policies.
+
+```ts
+const systemPrompt = buildOpenUiSystemPrompt({
+  promptOptions: { tools: toolSpecs },
+  appendix: productPolicy,
+});
+
+const stream = await model.generate({
+  system: systemPrompt,
+  messages,
+});
+
+return streamOpenUiText(stream);
+```
+
+On the client, append every received delta to one string. Pass that accumulated
+value to `response` and keep `isStreaming={true}` until the server signals
+completion. Use an `AbortController` to cancel an older generation before a new
+turn starts.
+
+When `onError` reports stable parser/runtime errors, an application may send a
+compact description back to the Agent for correction. Do not automatically
+retry forever; bound correction attempts and retain the original user request.
+
+## Choosing an approach
+
+Use the CLI when:
+
+- the built-in component contract is sufficient;
+- a checked-in or generated static prompt file is convenient;
+- deployment policy fits in an appendix.
+
+Use programmatic generation when:
+
+- tools have request- or deployment-specific schemas;
+- feature flags differ between products;
+- the Library contains custom or overridden components;
+- examples, groups, or policy are assembled from code.
+
+For the renderer-side contract, continue with
+[Libraries, built-ins, and custom components](./library-guide.md).

--- a/packages/genui/openui/docs/system-prompts_zh.md
+++ b/packages/genui/openui/docs/system-prompts_zh.md
@@ -1,0 +1,271 @@
+# System Prompts
+
+生成和定制用于指导 LLM 输出合法 OpenUI Lang 的指令；这些输出必须与 ReactLynx
+client 实际渲染的组件 Library 保持一致。
+
+内置 Library 和静态 prompt 文件已经满足需求时使用 CLI；当 backend 需要组合
+tools、feature flags、自定义组件或部署策略时，使用程序化 API。
+
+## 必须保持的 contract
+
+OpenUI system prompt 会描述：
+
+- 每行一个 assignment 的语言语法；
+- 必需的 `root` 入口和 top-down streaming 顺序；
+- 从有序 Zod schemas 推导出的组件签名；
+- 响应式 `$variables` 和 built-in functions；
+- Query/Mutation 与 Action 规则；
+- 传入时可用的工具名和 input/output schemas；
+- 保证输出可解析的示例与硬性约束。
+
+Prompt 侧 Library 与 client renderer Library 必须在每个组件名和位置 prop 顺序上
+保持一致。如果两者发生漂移，模型可能为其中一侧生成合法、却被另一侧拒绝的文本。
+
+## 1. CLI
+
+把默认内置 OpenUI prompt 生成到文件：
+
+```sh
+npx @lynx-js/genui openui generate prompt \
+  --out dist/openui-system-prompt.txt
+```
+
+输出到 stdout：
+
+```sh
+npx @lynx-js/genui openui generate prompt
+```
+
+追加部署侧规则：
+
+```sh
+npx @lynx-js/genui openui generate prompt \
+  --appendix "Prefer compact mobile layouts for booking flows." \
+  --out dist/openui-system-prompt.txt
+```
+
+CLI 使用内置 ReactLynx Library 的 headless 镜像。Prompt 生成命令支持：
+
+| Option              | 用途                                      |
+| ------------------- | ----------------------------------------- |
+| `--out <file>`      | 写入文件而不是 stdout；父目录会自动创建。 |
+| `--appendix <text>` | 追加应用侧特定指令。                      |
+| `--version`         | 输出包版本。                              |
+| `--help`            | 输出命令帮助。                            |
+
+CLI 不会加载自定义组件目录或 tool manifest。当 Agent contract 包含自定义组件或
+完整 tool schemas 时，请使用程序化 API。
+
+## 2. 程序化用法
+
+在 server-side TypeScript 中构建默认 prompt：
+
+```ts
+import { buildOpenUiSystemPrompt } from '@lynx-js/genui/openui/prompt';
+
+const systemPrompt = buildOpenUiSystemPrompt();
+```
+
+加入应用策略和工具描述：
+
+```ts
+import { buildOpenUiSystemPrompt } from '@lynx-js/genui/openui/prompt';
+
+const systemPrompt = buildOpenUiSystemPrompt({
+  appendix: [
+    'Prefer one-column mobile layouts.',
+    'Never invent tool names or arguments.',
+  ].join('\n'),
+  promptOptions: {
+    tools: [
+      {
+        name: 'list_orders',
+        description: 'List orders filtered by status.',
+        inputSchema: {
+          type: 'object',
+          properties: { status: { type: 'string' } },
+          required: ['status'],
+        },
+        outputSchema: {
+          type: 'object',
+          properties: {
+            rows: { type: 'array', items: { type: 'object' } },
+          },
+          required: ['rows'],
+        },
+        annotations: { readOnlyHint: true },
+      },
+    ],
+  },
+});
+```
+
+Client 必须提供匹配的工具实现：
+
+```tsx
+<OpenUiRenderer
+  response={response}
+  library={library}
+  toolProvider={{
+    list_orders: async ({ status }) => {
+      return await api.listOrders({ status: String(status) });
+    },
+  }}
+/>;
+```
+
+Tool schemas 告诉模型可以调用什么；`toolProvider` 才是真正执行调用的代码。不要把
+secrets 或 provider credentials 放进 prompt 或 browser-side tool arguments。
+
+## Prompt options
+
+`buildOpenUiSystemPrompt` 接受 Library options、prompt feature flags 和可选
+appendix：
+
+| Option                          | 用途                                                                                    |
+| ------------------------------- | --------------------------------------------------------------------------------------- |
+| `root`                          | 覆盖必需的 root component 名称；该组件必须同时存在于 prompt Library 和 client Library。 |
+| `components`                    | 追加 headless component definitions；后加入的同名 definition 覆盖默认值。               |
+| `componentGroups`               | 追加 prompt 分组 metadata。                                                             |
+| `promptOptions.preamble`        | 替换或扩展语言规则前的产品 framing。                                                    |
+| `promptOptions.additionalRules` | 在内置 mobile/OpenUI 约束后添加规则。                                                   |
+| `promptOptions.examples`        | 替换默认静态示例。                                                                      |
+| `promptOptions.toolExamples`    | 提供存在 tools 时使用的示例。                                                           |
+| `promptOptions.tools`           | 通过名称或完整 schema 描述 Query/Mutation tools。                                       |
+| `promptOptions.toolCalls`       | 启用或禁用 Query、Mutation、`@Run` 和 tool workflow 指令。                              |
+| `promptOptions.bindings`        | 启用或禁用 `$variables`、`@Set`、`@Reset` 和响应式 filter 指令。                        |
+| `promptOptions.editMode`        | 指导模型在增量编辑时只返回发生变化的 statements。                                       |
+| `promptOptions.inlineMode`      | 允许自然语言和可选 fenced OpenUI，而不要求只输出原始 OpenUI。                           |
+| `appendix`                      | 原样追加最终部署指令。                                                                  |
+
+Lynx OpenUI prompt builder 默认启用 `bindings` 和 `toolCalls`。纯静态产品界面应
+显式关闭：
+
+```ts
+const systemPrompt = buildOpenUiSystemPrompt({
+  promptOptions: {
+    bindings: false,
+    toolCalls: false,
+  },
+});
+```
+
+`inlineMode` 默认关闭。在默认模式下，模型应只返回原始 OpenUI Lang，不要附加解释
+或 Markdown code fence，这样完整 response 可以直接交给
+`<OpenUiRenderer response={...}>`。
+
+## 自定义组件 prompts
+
+把共享 Zod schemas 放进框架无关模块。Client 用 ReactLynx `defineComponent`
+包装 schema；server 使用 headless `@openuidev/lang-core` definition 包装同一份
+schema。
+
+```ts
+// shared/bannerSchema.ts
+import { z } from 'zod/v4';
+
+export const bannerProps = z.object({
+  title: z.string(),
+  tone: z.enum(['info', 'success', 'warning']).optional(),
+});
+```
+
+```tsx
+// client/Banner.tsx
+import { defineComponent } from '@lynx-js/genui/openui';
+import { bannerProps } from '../shared/bannerSchema.js';
+
+export const Banner = defineComponent({
+  name: 'Banner',
+  description: 'Compact status banner with a title and tone.',
+  props: bannerProps,
+  component: ({ props }) => (
+    <view className={`Banner Banner-${props.tone ?? 'info'}`}>
+      <text className='BannerTitle'>{props.title}</text>
+    </view>
+  ),
+});
+```
+
+```ts
+// server/openuiPrompt.ts
+import { defineComponent } from '@openuidev/lang-core';
+import { buildOpenUiSystemPrompt } from '@lynx-js/genui/openui/prompt';
+import { bannerProps } from '../shared/bannerSchema.js';
+
+const PromptBanner = defineComponent({
+  name: 'Banner',
+  description: 'Compact status banner with a title and tone.',
+  props: bannerProps,
+  component: () => null,
+});
+
+export const systemPrompt = buildOpenUiSystemPrompt({
+  components: [PromptBanner],
+  componentGroups: [
+    { name: 'Product', components: ['Banner'] },
+  ],
+});
+```
+
+自定义 headless definitions 由 server workspace 维护时，请把
+`@openuidev/lang-core` 和 `zod` 添加为直接 dependencies。让 prompt component
+renderer 保持为 `() => null`，可以避免 server routes 导入 ReactLynx、Lynx UI
+组件或 component CSS。
+
+## 其他 prompt exports
+
+`@lynx-js/genui/openui/prompt` 还导出：
+
+| Export                               | 用途                                                              |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| `createOpenUiPromptLibrary(options)` | 构建 headless 内置 Library，用于检查或底层 prompt 组合。          |
+| `OPENUI_SYSTEM_PROMPT`               | 不带 options 创建的预构建默认 prompt。                            |
+| `openUiPromptActionPropSchema`       | v0.5 action plans 与 legacy action objects 共用的 prompt schema。 |
+
+应用代码优先使用 `buildOpenUiSystemPrompt()`，让定制项保持显式且可测试。
+
+## Backend 接入模式
+
+把 generated prompt 作为模型 system instruction 发送，保留原始文本流，再把它返回
+给 client。Server 不必为了转发而解析 UI，但仍应执行自己的 model-output 和 tool
+策略。
+
+```ts
+const systemPrompt = buildOpenUiSystemPrompt({
+  promptOptions: { tools: toolSpecs },
+  appendix: productPolicy,
+});
+
+const stream = await model.generate({
+  system: systemPrompt,
+  messages,
+});
+
+return streamOpenUiText(stream);
+```
+
+Client 侧把每个 delta 追加到同一个字符串，将累计值传给 `response`，并在 server
+发出完成信号前保持 `isStreaming={true}`。新的 turn 开始前，用
+`AbortController` 取消旧 generation。
+
+当 `onError` 报告稳定 parser/runtime errors 时，应用可以把精简描述传回 Agent
+做 correction。不要无限自动重试；应限制修正次数，并保留原始用户请求。
+
+## 如何选择
+
+适合使用 CLI 的场景：
+
+- 内置 component contract 已经足够；
+- 适合使用已提交或生成的静态 prompt 文件；
+- 部署策略可以通过 appendix 表达。
+
+适合使用程序化生成的场景：
+
+- Tools 带有请求级或部署级 schemas；
+- 不同产品使用不同 feature flags；
+- Library 包含自定义或覆盖组件；
+- 需要通过代码组合 examples、groups 或 policy。
+
+Renderer 侧 contract 见
+[Libraries、内置组件与自定义组件](./library-guide_zh.md)。

--- a/packages/genui/package.json
+++ b/packages/genui/package.json
@@ -117,7 +117,8 @@
     "a2ui-catalog-extractor/README.md",
     "openui/dist",
     "openui/styles",
-    "openui/README.md",
+    "openui/*.md",
+    "openui/docs/*.md",
     "mcp-apps/dist"
   ],
   "scripts": {

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -17,7 +17,7 @@ import {
 import { camelCase } from 'change-case';
 
 import {
-  A2UI_EN_NAV_ITEMS,
+  GENUI_EN_NAV_ITEMS,
   createAPI,
   createChangelogs,
   createGenUIGuideReadmeDocs,
@@ -765,9 +765,7 @@ const config: UserConfig = defineConfig({
       },
       {
         text: 'GenUI',
-        link: '/genui',
-        activeMatch: '^/(genui|guide/genui/a2ui)',
-        items: A2UI_EN_NAV_ITEMS,
+        items: GENUI_EN_NAV_ITEMS,
       },
       {
         text: 'API',

--- a/website/sidebars/genui.ts
+++ b/website/sidebars/genui.ts
@@ -13,9 +13,21 @@ export function createGenUIGuideReadmeDocs(options: {
   en: SidebarGroup;
   zh: SidebarGroup;
 } {
+  const genuiPackageRoot = path.join(
+    options.repositoryRoot,
+    'packages/genui',
+  );
   const a2uiPackageRoot = path.join(
     options.repositoryRoot,
     'packages/genui/a2ui',
+  );
+  const a2uiCatalogExtractorPackageRoot = path.join(
+    options.repositoryRoot,
+    'packages/genui/a2ui-catalog-extractor',
+  );
+  const openuiPackageRoot = path.join(
+    options.repositoryRoot,
+    'packages/genui/openui',
   );
   const enGuideRoot = path.join(
     options.websiteRoot,
@@ -25,6 +37,15 @@ export function createGenUIGuideReadmeDocs(options: {
     options.websiteRoot,
     'docs/zh/guide/genui',
   );
+
+  syncDoc({
+    outFile: path.join(enGuideRoot, 'index.md'),
+    sourceFile: path.join(genuiPackageRoot, 'docs/overview.md'),
+  });
+  syncDoc({
+    outFile: path.join(zhGuideRoot, 'index.md'),
+    sourceFile: path.join(genuiPackageRoot, 'docs/overview_zh.md'),
+  });
 
   removeGeneratedDoc(path.join(enGuideRoot, 'a2ui'));
   removeGeneratedDoc(path.join(zhGuideRoot, 'a2ui'));
@@ -75,6 +96,73 @@ export function createGenUIGuideReadmeDocs(options: {
     replacements: A2UI_ZH_LINK_REPLACEMENTS,
     sourceFile: path.join(a2uiPackageRoot, 'docs/system-prompts_zh.md'),
   });
+  syncReadme({
+    languageSwitch:
+      'English | <a href="/zh/guide/genui/a2ui/catalog-extractor">简体中文</a>',
+    outFile: path.join(enGuideRoot, 'a2ui/catalog-extractor.md'),
+    sourceFile: path.join(a2uiCatalogExtractorPackageRoot, 'README.md'),
+    switchPattern: /^English \| \[简体中文\]\(\.\/readme\.zh_cn\.md\)$/m,
+  });
+  syncReadme({
+    languageSwitch:
+      '<a href="/guide/genui/a2ui/catalog-extractor">English</a> | 简体中文',
+    outFile: path.join(zhGuideRoot, 'a2ui/catalog-extractor.md'),
+    sourceFile: path.join(
+      a2uiCatalogExtractorPackageRoot,
+      'readme.zh_cn.md',
+    ),
+    switchPattern: /^\[English\]\(\.\/README\.md\) \| 简体中文$/m,
+  });
+
+  removeGeneratedDoc(path.join(enGuideRoot, 'openui'));
+  removeGeneratedDoc(path.join(zhGuideRoot, 'openui'));
+
+  syncReadme({
+    languageSwitch: 'English | <a href="/zh/guide/genui/openui">简体中文</a>',
+    outFile: path.join(enGuideRoot, 'openui.md'),
+    replacements: OPENUI_EN_LINK_REPLACEMENTS,
+    sourceFile: path.join(openuiPackageRoot, 'README.md'),
+    switchPattern: /^English \| \[简体中文\]\(\.\/README_zh\.md\)$/m,
+  });
+
+  syncReadme({
+    languageSwitch: '<a href="/guide/genui/openui">English</a> | 简体中文',
+    outFile: path.join(zhGuideRoot, 'openui.md'),
+    replacements: OPENUI_ZH_LINK_REPLACEMENTS,
+    sourceFile: path.join(openuiPackageRoot, 'README_zh.md'),
+    switchPattern: /^\[English\]\(\.\/README\.md\) \| 简体中文$/m,
+  });
+
+  syncDoc({
+    outFile: path.join(enGuideRoot, 'openui/overview.md'),
+    replacements: OPENUI_EN_LINK_REPLACEMENTS,
+    sourceFile: path.join(openuiPackageRoot, 'docs/overview.md'),
+  });
+  syncDoc({
+    outFile: path.join(zhGuideRoot, 'openui/overview.md'),
+    replacements: OPENUI_ZH_LINK_REPLACEMENTS,
+    sourceFile: path.join(openuiPackageRoot, 'docs/overview_zh.md'),
+  });
+  syncDoc({
+    outFile: path.join(enGuideRoot, 'openui/library-guide.md'),
+    replacements: OPENUI_EN_LINK_REPLACEMENTS,
+    sourceFile: path.join(openuiPackageRoot, 'docs/library-guide.md'),
+  });
+  syncDoc({
+    outFile: path.join(zhGuideRoot, 'openui/library-guide.md'),
+    replacements: OPENUI_ZH_LINK_REPLACEMENTS,
+    sourceFile: path.join(openuiPackageRoot, 'docs/library-guide_zh.md'),
+  });
+  syncDoc({
+    outFile: path.join(enGuideRoot, 'openui/system-prompts.md'),
+    replacements: OPENUI_EN_LINK_REPLACEMENTS,
+    sourceFile: path.join(openuiPackageRoot, 'docs/system-prompts.md'),
+  });
+  syncDoc({
+    outFile: path.join(zhGuideRoot, 'openui/system-prompts.md'),
+    replacements: OPENUI_ZH_LINK_REPLACEMENTS,
+    sourceFile: path.join(openuiPackageRoot, 'docs/system-prompts_zh.md'),
+  });
 
   removeGeneratedDoc(
     path.join(
@@ -94,8 +182,20 @@ export function createGenUIGuideReadmeDocs(options: {
       text: 'GenUI',
       items: [
         {
+          text: 'Overview',
+          link: '/guide/genui',
+        },
+        {
           text: 'A2UI',
           items: A2UI_EN_SIDEBAR_ITEMS,
+        },
+        {
+          text: 'OpenUI',
+          items: OPENUI_EN_SIDEBAR_ITEMS,
+        },
+        {
+          text: 'Playground',
+          link: '/genui',
         },
       ],
     },
@@ -103,8 +203,20 @@ export function createGenUIGuideReadmeDocs(options: {
       text: 'GenUI',
       items: [
         {
+          text: '概览',
+          link: '/zh/guide/genui',
+        },
+        {
           text: 'A2UI',
           items: A2UI_ZH_SIDEBAR_ITEMS,
+        },
+        {
+          text: 'OpenUI',
+          items: OPENUI_ZH_SIDEBAR_ITEMS,
+        },
+        {
+          text: 'Playground',
+          link: '/zh/genui',
         },
       ],
     },
@@ -128,10 +240,6 @@ export const A2UI_EN_NAV_ITEMS = [
     text: 'System Prompts',
     link: '/guide/genui/a2ui/system-prompts',
   },
-  {
-    text: 'Playground',
-    link: '/genui',
-  },
 ];
 
 export const A2UI_ZH_NAV_ITEMS = [
@@ -151,6 +259,61 @@ export const A2UI_ZH_NAV_ITEMS = [
     text: 'System Prompts',
     link: '/zh/guide/genui/a2ui/system-prompts',
   },
+];
+
+export const OPENUI_EN_NAV_ITEMS = [
+  {
+    text: 'Introduction README',
+    link: '/guide/genui/openui',
+  },
+  {
+    text: 'Overview & Architecture',
+    link: '/guide/genui/openui/overview',
+  },
+  {
+    text: 'Libraries & Components',
+    link: '/guide/genui/openui/library-guide',
+  },
+  {
+    text: 'System Prompts',
+    link: '/guide/genui/openui/system-prompts',
+  },
+];
+
+export const OPENUI_ZH_NAV_ITEMS = [
+  {
+    text: '简介 README',
+    link: '/zh/guide/genui/openui',
+  },
+  {
+    text: '概览与架构',
+    link: '/zh/guide/genui/openui/overview',
+  },
+  {
+    text: 'Libraries 与组件',
+    link: '/zh/guide/genui/openui/library-guide',
+  },
+  {
+    text: 'System Prompts',
+    link: '/zh/guide/genui/openui/system-prompts',
+  },
+];
+
+export const GENUI_EN_NAV_ITEMS = [
+  {
+    text: 'GenUI Overview',
+    link: '/guide/genui',
+  },
+  {
+    text: 'A2UI',
+    link: '/guide/genui/a2ui',
+    items: A2UI_EN_NAV_ITEMS.slice(1),
+  },
+  {
+    text: 'OpenUI',
+    link: '/guide/genui/openui',
+    items: OPENUI_EN_NAV_ITEMS.slice(1),
+  },
   {
     text: 'Playground',
     link: '/genui',
@@ -167,6 +330,16 @@ const A2UI_ZH_SIDEBAR_ITEMS = A2UI_ZH_NAV_ITEMS.map(item => ({
   text: item.text.replace(' README', ''),
 }));
 
+const OPENUI_EN_SIDEBAR_ITEMS = OPENUI_EN_NAV_ITEMS.map(item => ({
+  ...item,
+  text: item.text.replace(' README', ''),
+}));
+
+const OPENUI_ZH_SIDEBAR_ITEMS = OPENUI_ZH_NAV_ITEMS.map(item => ({
+  ...item,
+  text: item.text.replace(' README', ''),
+}));
+
 const A2UI_EN_LINK_REPLACEMENTS = [
   ['./docs/overview.md', '/guide/genui/a2ui/overview'],
   ['./docs/catalog-guide.md', '/guide/genui/a2ui/catalog-guide'],
@@ -176,7 +349,7 @@ const A2UI_EN_LINK_REPLACEMENTS = [
   ['./system-prompts.md', '/guide/genui/a2ui/system-prompts'],
   [
     '../../a2ui-catalog-extractor/README.md',
-    'https://github.com/lynx-family/lynx-stack/tree/main/packages/genui/a2ui-catalog-extractor#readme',
+    '/guide/genui/a2ui/catalog-extractor',
   ],
   ['../README.md', '/guide/genui/a2ui'],
 ] as const;
@@ -190,9 +363,29 @@ const A2UI_ZH_LINK_REPLACEMENTS = [
   ['./system-prompts_zh.md', '/zh/guide/genui/a2ui/system-prompts'],
   [
     '../../a2ui-catalog-extractor/readme.zh_cn.md',
-    'https://github.com/lynx-family/lynx-stack/blob/main/packages/genui/a2ui-catalog-extractor/readme.zh_cn.md',
+    '/zh/guide/genui/a2ui/catalog-extractor',
   ],
   ['../README_zh.md', '/zh/guide/genui/a2ui'],
+] as const;
+
+const OPENUI_EN_LINK_REPLACEMENTS = [
+  ['./docs/overview.md', '/guide/genui/openui/overview'],
+  ['./docs/library-guide.md', '/guide/genui/openui/library-guide'],
+  ['./docs/system-prompts.md', '/guide/genui/openui/system-prompts'],
+  ['./overview.md', '/guide/genui/openui/overview'],
+  ['./library-guide.md', '/guide/genui/openui/library-guide'],
+  ['./system-prompts.md', '/guide/genui/openui/system-prompts'],
+  ['../README.md', '/guide/genui/openui'],
+] as const;
+
+const OPENUI_ZH_LINK_REPLACEMENTS = [
+  ['./docs/overview_zh.md', '/zh/guide/genui/openui/overview'],
+  ['./docs/library-guide_zh.md', '/zh/guide/genui/openui/library-guide'],
+  ['./docs/system-prompts_zh.md', '/zh/guide/genui/openui/system-prompts'],
+  ['./overview_zh.md', '/zh/guide/genui/openui/overview'],
+  ['./library-guide_zh.md', '/zh/guide/genui/openui/library-guide'],
+  ['./system-prompts_zh.md', '/zh/guide/genui/openui/system-prompts'],
+  ['../README_zh.md', '/zh/guide/genui/openui'],
 ] as const;
 
 function syncReadme(options: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GenUI overview and navigation covering A2UI, OpenUI, and the Playground.
  * Added English and Simplified Chinese guides for OpenUI architecture, libraries, system prompts, runtime behavior, and integration.
  * Updated installation guidance for peer dependencies and optional OpenUI theme styles.
  * Added guidance for custom components, streaming, tools, state, actions, and parser behavior.
  * Improved cross-links and synchronized package documentation with the website.
* **Bug Fixes**
  * Corrected documentation links to use local website routes instead of external references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
