### PR TITLE
fix: x-text inline view truncation

### DIFF
--- a/.changeset/fix-x-text-inline-view-truncation.md
+++ b/.changeset/fix-x-text-inline-view-truncation.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Fix x-text custom truncation when inline x-view elements are included in the measured text.

--- a/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
@@ -21,6 +21,50 @@ type NodeInfo = {
 type RectInfo = { rect: DOMRect; rectIndex: number } & NodeInfo;
 type RawLineInfo = RectInfo[];
 type LynxLineInfo = { start: number; end: number };
+type RangePosition = { container: Node; offset: number };
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const getSiblingIndex = (node: Node) => {
+  let index = 0;
+  let previousNode = node.previousSibling;
+  while (previousNode) {
+    index++;
+    previousNode = previousNode.previousSibling;
+  }
+  return index;
+};
+
+const getRangePosition = (
+  nodeInfo: NodeInfo,
+  offsetInNode: number,
+): RangePosition => {
+  const { node } = nodeInfo;
+  if (node.nodeType === Node.TEXT_NODE) {
+    return {
+      container: node,
+      offset: clamp(offsetInNode, 0, (node as Text).data.length),
+    };
+  }
+
+  // Elements are one virtual character, while DOM Range offsets address child
+  // indexes. Use the parent's before/after-element boundary instead.
+  const elementOffset = offsetInNode > 0 ? 1 : 0;
+  const parentNode = node.parentNode;
+  if (!parentNode) {
+    return {
+      container: node,
+      offset: clamp(elementOffset, 0, node.childNodes.length),
+    };
+  }
+
+  return {
+    container: parentNode,
+    offset: getSiblingIndex(node) + elementOffset,
+  };
+};
+
 export class XTextTruncation
   implements InstanceType<AttributeReactiveClass<typeof XText>>
 {
@@ -163,17 +207,28 @@ export class XTextTruncation
           let currentNodeInfo: NodeInfo | undefined = measure
             .getNodeInfoByCharIndex(maxLineEndAt)!;
           const endCharInNodeIndex = end - currentNodeInfo.start;
-          range.setEnd(currentNodeInfo.node, endCharInNodeIndex);
-          range.setStart(currentNodeInfo.node, endCharInNodeIndex);
+          const initialRangePosition = getRangePosition(
+            currentNodeInfo,
+            endCharInNodeIndex,
+          );
+          range.setEnd(
+            initialRangePosition.container,
+            initialRangePosition.offset,
+          );
+          range.setStart(
+            initialRangePosition.container,
+            initialRangePosition.offset,
+          );
           while (
             range.getBoundingClientRect().width < inlineTruncationWidth
             && (maxLineEndAt -= 1)
             && (currentNodeInfo = measure.getNodeInfoByCharIndex(maxLineEndAt))
           ) {
-            range.setStart(
-              currentNodeInfo.node,
+            const rangePosition = getRangePosition(
+              currentNodeInfo,
               maxLineEndAt - currentNodeInfo.start,
             );
+            range.setStart(rangePosition.container, rangePosition.offset);
           }
         } else {
           maxLineEndAt = start;

--- a/packages/web-platform/web-elements/tests/fixtures/x-text/text-maxline-with-inline-view-and-custom-truncation.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-text/text-maxline-with-inline-view-and-custom-truncation.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>web playground</title>
+    <meta content="yes" name="apple-mobile-web-app-capable">
+    <meta content="default" name="apple-mobile-web-app-status-bar-style">
+    <meta content="telephone=no" name="format-detection">
+    <meta content="portrait" name="screen-orientation">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <meta content="portrait" name="x5-orientation" />
+    <link
+      href="/main.css"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <script src="/main.js" defer></script>
+    <x-text
+      class="quote-text"
+      text-maxline="2"
+      text-overflow="ellipsis"
+      tag-v="02dc4"
+      tag-e="e540c"
+      data-tag="text"
+      kit-uid="text-0"
+      can-use-linear-container=""
+      style="width: 100%; font-size: 15px; font-weight: 400; line-height: 23px; color: rgba(22, 24, 35, 0.6); background-clip: initial; --lynx-text-bg-color: initial; --lynx-color: rgba(22, 24, 35, 0.6)"
+      x-show-inline-truncation=""
+    ><x-view
+        class="avatar-slot"
+        clip-radius="true"
+        tag-v="02dc4"
+        tag-e="e540c"
+        data-tag="view"
+        kit-uid="view-0"
+        can-use-linear-container=""
+        style="position: relative; display: inline-flex; width: 18px; height: 18px; margin-right: 7px; align-items: center; vertical-align: middle; overflow: hidden; border-radius: 50%; --justify-content: center; background-color: rgba(22, 24, 35, 0.03)"
+      ><x-view
+          class="avatar-placeholder"
+          tag-v="02dc4"
+          tag-e="e540c"
+          data-tag="view"
+          kit-uid="view-0"
+          can-use-linear-container=""
+          style="width: 18px; height: 18px; border-radius: 50%"
+        ></x-view><x-view
+          class="avatar-border"
+          tag-v="02dc4"
+          tag-e="e540c"
+          data-tag="view"
+          kit-uid="view-0"
+          can-use-linear-container=""
+          style="position: absolute; inset: 0px; border-radius: 50%; border: 1px solid rgba(22, 24, 35, 0.12)"
+        ></x-view></x-view>零跑C10开了17000公里，8295车机流畅，智享版辅助驾驶完全够用，没必要硬上顶配。<x-view
+        class="quote-mark-slot"
+        tag-v="02dc4"
+        tag-e="e540c"
+        data-tag="view"
+        kit-uid="view-0"
+        can-use-linear-container=""
+        style="width: 17px; height: 17px; align-items: center; vertical-align: top; display: flex; --lynx-display-toggle: var(--lynx-display-flex); --lynx-display: flex; --justify-content: center; margin-left: -2px"
+      ><x-view
+          src="/tests/fixtures/resources/firefox-logo.png"
+          class="quote-mark"
+          mode="aspectFit"
+          skip-redirection="true"
+          tag-v="02dc4"
+          tag-e="e540c"
+          data-tag="image"
+          kit-uid="image-0"
+          can-use-linear-container=""
+          classname="quote-mark"
+          style="width: 17px; height: 17px"
+        ><img
+            src="/tests/fixtures/resources/firefox-logo.png"
+            style="width: 100%; height: 100%; object-fit: contain; object-position: center center; transition: opacity 0.3s; opacity: 1; pointer-events: none"
+          ></x-view></x-view><inline-truncation
+        _componentuuid="_com_1___undefined_0___"
+        containerwidth="375"
+        tag-v="02dc4"
+        tag-e="e540c"
+        data-tag="inline-truncation"
+        kit-uid="inline-truncation-0"
+        can-use-linear-container=""
+        slot="inline-truncation"
+      ><x-text
+          class="ellipsis-text"
+          tag-v="02dc4"
+          tag-e="e540c"
+          data-tag="text"
+          kit-uid="text-0"
+          can-use-linear-container=""
+          style="margin-left: -4px; font-size: 15px; font-weight: 400; line-height: 23px; color: rgba(22, 24, 35, 0.6); background-clip: initial; --lynx-text-bg-color: initial; --lynx-color: rgba(22, 24, 35, 0.6)"
+        >...</x-text><x-view
+          class="quote-mark-slot"
+          tag-v="02dc4"
+          tag-e="e540c"
+          data-tag="view"
+          kit-uid="view-0"
+          can-use-linear-container=""
+          style="width: 17px; height: 17px; align-items: center; vertical-align: top; display: flex; --lynx-display-toggle: var(--lynx-display-flex); --lynx-display: flex; --justify-content: center; margin-left: 4px"
+        ><x-view
+            src="/tests/fixtures/resources/firefox-logo.png"
+            class="quote-mark"
+            mode="aspectFit"
+            skip-redirection="true"
+            tag-v="02dc4"
+            tag-e="e540c"
+            data-tag="image"
+            kit-uid="image-0"
+            can-use-linear-container=""
+            classname="quote-mark"
+            style="width: 17px; height: 17px"
+          ><img
+              src="/tests/fixtures/resources/firefox-logo.png"
+              style="width: 100%; height: 100%; object-fit: contain; object-position: center center; transition: opacity 0.3s; opacity: 1; pointer-events: none"
+            ></x-view></x-view></inline-truncation></x-text>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -299,6 +299,24 @@ test.describe('web-elements test suite', () => {
         page.locator('#target'),
       ).not.toHaveAttribute('x-show-inline-truncation', '');
     });
+    test(
+      'x-text/text-maxline-with-inline-view-and-custom-truncation',
+      async ({ page }, { title }) => {
+        const errors: string[] = [];
+        page.on('pageerror', (error) => {
+          errors.push(error.message);
+        });
+        page.on('console', (message) => {
+          if (message.type() === 'error') {
+            errors.push(message.text());
+          }
+        });
+
+        await gotoWebComponentPage(page, title);
+        await wait(500);
+        expect(errors).toEqual([]);
+      },
+    );
 
     test('x-text/text-overflow-inherit', async ({ page }, { title }) => {
       await gotoWebComponentPage(page, title);


### PR DESCRIPTION
## Summary

- Fix custom `x-text` truncation when inline `x-view` elements participate in text measurement.
- Convert virtual element-character offsets into DOM `Range` parent boundaries before calling `setStart`/`setEnd`.
- Add a regression fixture and Playwright assertion for the inline view + custom truncation case.
- Add a patch changeset for `@lynx-js/web-elements`.

## Root Cause

The truncation measurement treats non-text elements as one virtual character in the text stream. That virtual offset was previously passed directly to DOM `Range#setStart`/`setEnd`, but element Range offsets are child-node indexes. Empty inline elements could therefore throw `IndexSizeError` when offset `1` was used.

## Validation

- `pnpm dprint fmt .changeset/fix-x-text-inline-view-truncation.md packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts packages/web-platform/web-elements/tests/web-elements.spec.ts packages/web-platform/web-elements/tests/fixtures/x-text/text-maxline-with-inline-view-and-custom-truncation.html`
- `pnpm exec playwright test tests/web-elements.spec.ts --project=chromium -g "x-text/(text-maxline-with-custom-truncation|inline-truncation-with-inline-image|truncation-first-element-is-image|text-maxline-with-inline-view-and-custom-truncation|view-flex-in-text)"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text truncation for `x-text` elements containing inline `x-view` elements.
  * Improved inline ellipsis handling with custom truncation content.

* **Tests**
  * Added coverage for multi-line truncation with inline views, images, and custom ellipses.
  * Verified the scenario renders without browser or console errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->