### PR TITLE
feat(web): add devtool event bridge

### DIFF
--- a/.changeset/web-devtool-events.md
+++ b/.changeset/web-devtool-events.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Add a bidirectional per-card devtool event channel. Background scripts can use `lynx.getDevtool()` to dispatch events to a `devtoolMessage` event on `<lynx-view>` and listen for events sent through `lynxView.sendDevtoolEvent()`.

--- a/.github/web-core-devtool-events.instructions.md
+++ b/.github/web-core-devtool-events.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/ts/client/{background,mainthread}/**,packages/web-platform/web-core/ts/client/endpoints.ts"
+---
+
+Keep the Web devtool event bridge per `LynxViewInstance` by routing it through that instance's `BackgroundThread` RPC. Preserve the native context-proxy shape on BTS: `lynx.getDevtool().dispatchEvent({ type, data })` emits a `devtoolMessage` `CustomEvent` whose `detail` is the full `{ type, data }` object, while `lynxView.sendDevtoolEvent(type, data)` reaches listeners registered with `lynx.getDevtool().addEventListener(type, listener)`.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -2043,6 +2043,33 @@ test.describe('reactlynx3 tests', () => {
         'rgb(0, 128, 0)',
       ); // green;
     });
+    test('api-devtool-event', async ({ page }, { title }) => {
+      await goto(page, title);
+      const target = page.locator('#target');
+      await expect(target).toHaveText('ready');
+
+      const data = JSON.stringify({ key: 'value' });
+      const detail = await page.evaluate((data) => {
+        const lynxView = document.querySelector(
+          'lynx-view',
+        ) as LynxViewElement;
+        const devtoolMessage = new Promise((resolve) => {
+          lynxView.addEventListener(
+            'devtoolMessage',
+            (event) => resolve((event as CustomEvent).detail),
+            { once: true },
+          );
+        });
+        lynxView.sendDevtoolEvent('eventname', data);
+        return devtoolMessage;
+      }, data);
+
+      await expect(target).toHaveText(data);
+      expect(detail).toEqual({
+        type: 'PreactDevtools',
+        data,
+      });
+    });
     test('api-invoke-success', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/api-devtool-event/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/api-devtool-event/index.jsx
@@ -1,0 +1,28 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useEffect, useState } from '@lynx-js/react';
+
+function App() {
+  const [message, setMessage] = useState('waiting');
+
+  useEffect(() => {
+    const devtool = lynx.getDevtool();
+    const handleMessage = (event) => {
+      setMessage(event.data);
+      devtool.dispatchEvent({
+        type: 'PreactDevtools',
+        data: event.data,
+      });
+    };
+    devtool.addEventListener('eventname', handleMessage);
+    setMessage('ready');
+    return () => {
+      devtool.removeEventListener('eventname', handleMessage);
+    };
+  }, []);
+
+  return <text id='target'>{message}</text>;
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core/ts/client/LynxCrossThreadContext.ts
+++ b/packages/web-platform/web-core/ts/client/LynxCrossThreadContext.ts
@@ -2,9 +2,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { dispatchCoreContextOnBackgroundEndpoint } from './endpoints.js';
-import type { LynxContextEventTarget } from '../types/index.js';
-import type { Rpc } from '@lynx-js/web-worker-rpc';
+import type {
+  ContextCrossThreadEvent,
+  LynxContextEventTarget,
+} from '../types/index.js';
+import type { Rpc, RpcEndpoint } from '@lynx-js/web-worker-rpc';
 
 export const DispatchEventResult = {
   // Event was not canceled by event handler or default event handler.
@@ -27,8 +29,8 @@ export const DispatchEventResult = {
 
 type LynxCrossThreadContextConfig = {
   rpc: Rpc;
-  receiveEventEndpoint: typeof dispatchCoreContextOnBackgroundEndpoint;
-  sendEventEndpoint: typeof dispatchCoreContextOnBackgroundEndpoint;
+  receiveEventEndpoint: RpcEndpoint<[ContextCrossThreadEvent], void>;
+  sendEventEndpoint: RpcEndpoint<[ContextCrossThreadEvent], void>;
 };
 export class LynxCrossThreadContext extends EventTarget
   implements LynxContextEventTarget

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
@@ -4,6 +4,8 @@
 
 import {
   dispatchCoreContextOnBackgroundEndpoint,
+  dispatchDevtoolEventOnBackgroundEndpoint,
+  dispatchDevtoolEventOnMainThreadEndpoint,
   dispatchJSContextOnMainThreadEndpoint,
   fetchExternalBundleEndpoint,
   reloadEndpoint,
@@ -25,6 +27,11 @@ export function createBackgroundLynx(
     receiveEventEndpoint: dispatchCoreContextOnBackgroundEndpoint,
     sendEventEndpoint: dispatchJSContextOnMainThreadEndpoint,
   });
+  const devtoolContext = new LynxCrossThreadContext({
+    rpc: mainThreadRpc,
+    receiveEventEndpoint: dispatchDevtoolEventOnBackgroundEndpoint,
+    sendEventEndpoint: dispatchDevtoolEventOnMainThreadEndpoint,
+  });
   const fetchExternalBundle = mainThreadRpc.createCall(
     fetchExternalBundleEndpoint,
   );
@@ -37,6 +44,9 @@ export function createBackgroundLynx(
     },
     getCoreContext() {
       return coreContext;
+    },
+    getDevtool() {
+      return devtoolContext;
     },
     getCustomSectionSync(key: string) {
       return customSections[key];

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createNativeApp.ts
@@ -131,6 +131,7 @@ export async function createNativeApp(
       );
       timingSystem.registerGlobalEmitter(tt.GlobalEventEmitter);
       (tt.lynx.getCoreContext() as LynxCrossThreadContext).__start();
+      (tt.lynx.getDevtool() as LynxCrossThreadContext).__start();
       nativeApp.tt = tt;
     },
     triggerComponentEvent,

--- a/packages/web-platform/web-core/ts/client/endpoints.ts
+++ b/packages/web-platform/web-core/ts/client/endpoints.ts
@@ -10,6 +10,7 @@ import type {
   InvokeCallbackRes,
   ElementAnimationOptions,
   ExternalBundleResponse,
+  ContextCrossThreadEvent,
   UpdateDataOptions,
   TimingEntry,
 } from '../types/index.js';
@@ -179,6 +180,16 @@ export const dispatchJSContextOnMainThreadEndpoint = createRpcEndpoint<
   }],
   void
 >('dispatchJSContextOnMainThread', false, false);
+
+export const dispatchDevtoolEventOnBackgroundEndpoint = createRpcEndpoint<
+  [ContextCrossThreadEvent],
+  void
+>('dispatchDevtoolEventOnBackground', false, false);
+
+export const dispatchDevtoolEventOnMainThreadEndpoint = createRpcEndpoint<
+  [ContextCrossThreadEvent],
+  void
+>('dispatchDevtoolEventOnMainThread', false, false);
 
 export const triggerElementMethodEndpoint = createRpcEndpoint<
   [

--- a/packages/web-platform/web-core/ts/client/mainthread/Background.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/Background.ts
@@ -7,6 +7,8 @@
 import { Rpc, type RpcCallType } from '@lynx-js/web-worker-rpc';
 import {
   dispatchCoreContextOnBackgroundEndpoint,
+  dispatchDevtoolEventOnBackgroundEndpoint,
+  dispatchDevtoolEventOnMainThreadEndpoint,
   dispatchJSContextOnMainThreadEndpoint,
   disposeEndpoint,
   markTimingEndpoint,
@@ -75,6 +77,9 @@ export class BackgroundThread implements AsyncDisposable {
 
   readonly postTimingFlags: RpcCallType<typeof postTimingFlagsEndpoint>;
   readonly sendGlobalEvent: RpcCallType<typeof sendGlobalEventEndpoint>;
+  readonly sendDevtoolEvent: RpcCallType<
+    typeof dispatchDevtoolEventOnBackgroundEndpoint
+  >;
   readonly publicComponentEvent: RpcCallType<
     typeof publicComponentEventEndpoint
   >;
@@ -114,6 +119,9 @@ export class BackgroundThread implements AsyncDisposable {
     this.#batchSendTimingInfo = this.#rpc.createCall(markTimingEndpoint);
     this.postTimingFlags = this.#rpc.createCall(postTimingFlagsEndpoint);
     this.sendGlobalEvent = this.#rpc.createCall(sendGlobalEventEndpoint);
+    this.sendDevtoolEvent = this.#rpc.createCall(
+      dispatchDevtoolEventOnBackgroundEndpoint,
+    );
     this.publicComponentEvent = this.#rpc.createCall(
       publicComponentEventEndpoint,
     );
@@ -218,6 +226,19 @@ export class BackgroundThread implements AsyncDisposable {
         this.#lynxViewInstance.rootDom.dispatchEvent(
           new CustomEvent(eventType, {
             detail,
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+          }),
+        );
+      },
+    );
+    this.#rpc.registerHandler(
+      dispatchDevtoolEventOnMainThreadEndpoint,
+      (event) => {
+        this.#lynxViewInstance.parentDom.dispatchEvent(
+          new CustomEvent('devtoolMessage', {
+            detail: event,
             bubbles: true,
             cancelable: true,
             composed: true,

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
@@ -48,6 +48,7 @@ export interface BrowserConfig {
  *
  * @event error lynx card fired an error
  * @event i18nResourceMissed i18n resource cache miss
+ * @event devtoolMessage a devtool event dispatched by the background thread
  *
  * @example
  * HTML Example
@@ -370,6 +371,19 @@ export class LynxViewElement extends HTMLElement {
    */
   sendGlobalEvent(eventName: string, params: Cloneable[]) {
     this.#instance?.backgroundThread.sendGlobalEvent(eventName, params);
+  }
+
+  /**
+   * @public
+   * @method
+   * send a devtool event to the background thread, which can be listened to
+   * using `lynx.getDevtool().addEventListener()`
+   */
+  sendDevtoolEvent(eventName: string, data: string) {
+    this.#instance?.backgroundThread.sendDevtoolEvent({
+      type: eventName,
+      data,
+    });
   }
 
   /**

--- a/packages/web-platform/web-core/ts/types/NativeApp.ts
+++ b/packages/web-platform/web-core/ts/types/NativeApp.ts
@@ -39,6 +39,7 @@ export type NativeLynx = {
   getJSModule(_moduleName: string): unknown;
   getNativeApp(): NativeApp;
   getCoreContext(): LynxContextEventTarget;
+  getDevtool(): LynxContextEventTarget;
   getCustomSectionSync(key: string): CloneableObject;
   getCustomSection(key: string): Promise<CloneableObject>;
 };


### PR DESCRIPTION
## Summary

- expose the native-compatible `lynx.getDevtool()` event target in BTS
- route BTS `dispatchEvent({ type, data })` calls to a `devtoolMessage` event on the owning `<lynx-view>`
- add `lynxView.sendDevtoolEvent(type, data)` for sending host events to BTS listeners
- reuse the existing per-view RPC event bridge and add a Chromium round-trip test
- add a minor changeset for `@lynx-js/web-core`

## Why

Web devtools integrations need a per-card, bidirectional channel compatible with the native Lynx DevTool API. Keeping the channel on each `BackgroundThread` prevents messages from leaking across LynxView instances.

## Validation

- `pnpm turbo build` — 65/65 tasks passed
- `pnpm --filter @lynx-js/web-core test` — 165/165 tests passed
- `pnpm --filter @lynx-js/web-core-e2e test --grep api-devtool-event --project chromium` — passed
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint .` — 0 errors
- `pnpm dprint check` — passed
- `pnpm turbo api-extractor -- --local` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bidirectional devtool event communication between Lynx views and background scripts.
  - Added `lynx.getDevtool()` for registering listeners and dispatching devtool events.
  - Added `lynxView.sendDevtoolEvent()` and the `devtoolMessage` event for receiving messages on `<lynx-view>`.
- **Tests**
  - Added end-to-end coverage validating event delivery and payloads.
- **Documentation**
  - Documented the new devtool event channel and usage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->