### PR TITLE
chore(ci): reduce Renovate memory usage

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Cap Renovate's Node child-process heap and limit pnpm to one worker so
+  // regenerating the shared lockfile across the workspace does not get killed
+  // by the kernel OOM killer.
+  // See: https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout--kernel-out-of-memory-limit-with-a-pnpmyarn-project
+  "env": {
+    "PNPM_MAX_WORKERS": "1",
+  },
+  "toolSettings": {
+    "nodeMaxMemory": 1536,
+  },
+
   "extends": [
     "config:recommended",
     ":maintainLockFilesWeekly",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings to limit resource usage during lockfile updates.
  * Reduced parallel processing and capped memory allocation to improve reliability and avoid timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

Ported from [rstackjs/rstack-examples#481](https://github.com/rstackjs/rstack-examples/pull/481).

The Renovate lockfile-maintenance job risks being killed by the kernel OOM killer when pnpm regenerates the shared lockfile across this large workspace (100+ projects).

This caps Renovate's Node child-process heap at 1536 MiB (`toolSettings.nodeMaxMemory`) and limits pnpm to a single worker (`PNPM_MAX_WORKERS=1`), leaving more memory available for the Renovate parent process and native allocations.

## Related Links

- https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout--kernel-out-of-memory-limit-with-a-pnpmyarn-project

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
