### PR TITLE
chore(renovate): cap Node heap and pnpm workers to avoid OOM

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,19 @@
   "prConcurrentLimit": 20,
   "prHourlyLimit": 4,
 
+  // Keep the job inside Mend's hosted 3GB memory cap. Renovate was being killed
+  // by the kernel OOM killer while `pnpm install` regenerated `pnpm-lock.yaml`
+  // for this workspace (28 package definitions) during `updateArtifacts`.
+  // Capping the spawned Node heap and forcing pnpm to a single worker keeps
+  // peak RSS well under the limit.
+  // See https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout--kernel-out-of-memory-limit-with-a-pnpmyarn-project
+  "env": {
+    "PNPM_MAX_WORKERS": "1",
+  },
+  "toolSettings": {
+    "nodeMaxMemory": 1536,
+  },
+
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

Renovate has not opened a PR since 2026-06-27. The Mend-hosted job is being killed by the kernel OOM killer: every run ends at ~5 min with `Memory Used: 3.0GB (of 3.0GB limit)`.

The log pinpoints the kill site — `updateArtifacts` regenerating the lockfile:

```
Generating pnpm-lock.yaml for .
Spawning pnpm install to create pnpm-lock.yaml
Found pnpm workspace with 28 package definitions
Performing lockfileUpdate (pnpm)
Executing command        <- no "exec completed": killed here
```

This caps the spawned Node child-process heap at 1536 MiB and limits pnpm to a single worker, keeping peak RSS well under the hosted 3GB cap.

Same fix as https://github.com/rstackjs/rstack-examples/pull/481, per the official FAQ:
https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout--kernel-out-of-memory-limit-with-a-pnpmyarn-project

Note the OOM is unrelated to #2996 (PR-limit raise): the branch that dies is a vulnerability branch, which carries `prCreation: "immediate"` and is processed regardless of the PR backlog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update reliability by optimizing automated maintenance jobs.
  * Reduced the likelihood of resource-related failures during package installation and lockfile updates.
  * No user-facing product functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->