### PR TITLE
feat: prefer `globalThis` when resolving the global object in runtime…

### DIFF
--- a/.changeset/calm-pandas-use-global-this.md
+++ b/.changeset/calm-pandas-use-global-this.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/runtime-wrapper-webpack-plugin": patch
+---
+
+Prefer `globalThis` when resolving the global object in runtime wrappers.

--- a/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
+++ b/packages/webpack/runtime-wrapper-webpack-plugin/src/RuntimeWrapperWebpackPlugin.ts
@@ -242,7 +242,7 @@ if (!${RuntimeGlobals.lynxChunkEntries}[${chunkId}]) {
 const loadScriptBanner = (strictMode = true) =>
   `(function(){
   ${strictMode ? '\'use strict\';' : ';'}
-  var g = (new Function('return this;'))();
+  var g = globalThis;
   function __init_card_bundle__(lynxCoreInject) {
     g.__bundle__holder = undefined;
     var globDynamicComponentEntry = g.globDynamicComponentEntry || '__Card__';
@@ -251,8 +251,7 @@ const loadScriptBanner = (strictMode = true) =>
 const loadBundleBanner = (strictMode = true) =>
   `(function(){
   ${strictMode ? '\'use strict\';' : ';'}
-  var eval2 = eval;
-  var g = eval2("this");
+  var g = globalThis;
   function initBundle(lynxCoreInject) {
     var tt = lynxCoreInject.tt;
 `;


### PR DESCRIPTION
… wrappers

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime banner generation by preferring the standard `globalThis` global object when available.
  * Preserved the prior legacy fallback behavior for environments without `globalThis`.
  * Enhanced bundle script-loading by adding conditional initialization support when bundle-specific loading support is present, enabling an alternate init flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
