### PR TITLE
fix(web): include lynx-view styles in shadow roots

### DIFF
--- a/.changeset/web-core-shadow-host-css.md
+++ b/.changeset/web-core-shadow-host-css.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Include the `<lynx-view>` host and page baseline styles in its shadow root so client rendering and declarative Shadow DOM SSR do not depend on the outer document stylesheet.

--- a/.github/web-core-shadow-css.instructions.md
+++ b/.github/web-core-shadow-css.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/css/**,packages/web-platform/web-core/ts/client/**"
+---
+
+Keep the `<lynx-view>` host and page baseline styles available inside its shadow root by importing them through `css/in_shadow.css`. Until the public `client.prod.css` compatibility asset is removed, keep the shared rules valid in both contexts: pair `:host(...)` with `lynx-view...` for the host and pair shadow-local page selectors with `lynx-view::part(page)`.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { test, expect, swipe, dragAndHold } from '@lynx-js/playwright-fixtures';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import type { LynxViewElement } from '@lynx-js/web-core/client';
 const isSSR = !!process.env['ENABLE_SSR'];
 
@@ -53,6 +53,25 @@ const expectHasText = async (page: Page, text: string) => {
 
 const expectNoText = async (page: Page, text: string) => {
   await expect(page.getByText(text)).toHaveCount(0);
+};
+
+const getInShadowCSS = (locator: Locator) => {
+  return locator.evaluate(async (element) => {
+    const shadowRoot = element.shadowRoot!;
+    const inlineCSS = Array.from(
+      shadowRoot.querySelectorAll('style'),
+      style => style.textContent ?? '',
+    );
+    const linkedCSS = await Promise.all(
+      Array.from(
+        shadowRoot.querySelectorAll<HTMLLinkElement>(
+          'link[rel="stylesheet"]',
+        ),
+        link => fetch(link.href).then(response => response.text()),
+      ),
+    );
+    return inlineCSS.concat(linkedCSS).join('\n');
+  });
 };
 
 const goto = async (
@@ -337,6 +356,14 @@ test.describe('reactlynx3 tests', () => {
     test('api-frame-src', async ({ page }, { title }) => {
       await goto(page, title);
       await expect(page.locator('#frame-ready')).toHaveText('frame:ready');
+    });
+
+    test('api-frame-shadow-css', async ({ page }) => {
+      test.skip(isSSR, 'Nested frame source loading runs on the client');
+      await goto(page, 'api-frame-src');
+      await expect(page.locator('#frame-ready')).toHaveText('frame:ready');
+      const inShadowCSS = await getInShadowCSS(page.locator('#target'));
+      expect(inShadowCSS).toMatch(/:host\s*,\s*lynx-view\s*\{/);
     });
 
     test('api-frame-data', async ({ page }, { title }) => {
@@ -2479,6 +2506,14 @@ test.describe('reactlynx3 tests', () => {
   test.describe('elements', () => {
     test.describe('lynx-view', () => {
       const elementName = 'lynx-view';
+      test('lynx-view styles are included in its shadow root', async ({ page }) => {
+        await goto(page, 'basic-element-lynx-view-not-auto');
+        await wait(100);
+        const inShadowCSS = await getInShadowCSS(
+          page.locator('lynx-view'),
+        );
+        expect(inShadowCSS).toMatch(/:host\s*,\s*lynx-view\s*\{/);
+      });
       test('basic-element-lynx-view-not-auto', async ({ page }, { title }) => {
         await goto(page, title);
         await wait(100);

--- a/packages/web-platform/web-core/css/in_shadow.css
+++ b/packages/web-platform/web-core/css/in_shadow.css
@@ -1,3 +1,4 @@
+@import url("./index.css");
 @import url("@lynx-js/web-elements/index.css");
 
 [lynx-default-display-linear="false"] * {

--- a/packages/web-platform/web-core/css/index.css
+++ b/packages/web-platform/web-core/css/index.css
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 */
 
+:host,
 lynx-view {
   contain: strict;
   display: none;
@@ -16,25 +17,31 @@ lynx-view {
   --vh-unit: 1cqh;
 }
 
+:host([transform-vh]),
 lynx-view[transform-vh] {
   container-type: size;
 }
 
+:host([ssr]),
 lynx-view[ssr] {
   display: flex;
 }
 
+:host([width="auto"]),
 lynx-view[width="auto"] {
   --lynx-view-width: 100%;
   width: var(--lynx-view-width);
   inline-size: var(--lynx-view-width);
 }
 
+:host([height="auto"]),
+:host([width="auto"]),
 lynx-view[height="auto"],
 lynx-view[width="auto"] {
   contain: content;
 }
 
+[part="page"],
 lynx-view::part(page) {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
## Summary

- import the lynx-view baseline stylesheet from `in_shadow.css`
- make the shared host and page rules work both globally and inside shadow roots while preserving the existing `client.prod.css` compatibility asset
- add regressions for the top-level lynx-view and a nested frame (mapped to an inner lynx-view)
- add a patch changeset and a scoped maintenance instruction

## Why

The web elements stylesheet was already injected into each Lynx shadow root, but lynx-view's own host and page baseline styles only came from the outer document stylesheet. Nested frames and declarative Shadow DOM should receive those baseline rules from their own shadow root instead of depending on document-global CSS.

## Validation

- `pnpm turbo build` — 65/65 tasks passed
- `pnpm --filter @lynx-js/web-core test` — 165/165 tests passed
- `pnpm --filter @lynx-js/web-core-e2e test:server` — 17/17 tests passed
- Chromium CSR regressions for top-level lynx-view and nested frame — 2/2 passed
- Chromium SSR regression for top-level lynx-view — passed
- dprint and `git diff --check` — passed

The full-repository Biome check remains blocked by generated files under `examples/react-debug-metadata/dist-consumer`; web-platform files are excluded by the current Biome configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured `<lynx-view>` baseline and layout styles are available inside its shadow root.
  * Improved styling consistency for client rendering and declarative Shadow DOM SSR.
  * Updated conditional sizing, display, and containment styles to work correctly in shadow-root contexts.

* **Tests**
  * Added coverage verifying required CSS is included within shadow roots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->