### PR TITLE
fix(rspeedy): flatten multi-compiler stats for RelativeCI

### DIFF
--- a/packages/rspeedy/core/rslib.config.ts
+++ b/packages/rspeedy/core/rslib.config.ts
@@ -7,6 +7,7 @@ import { pluginPublint } from 'rsbuild-plugin-publint'
 import { TypiaRspackPlugin } from 'typia-rspack-plugin'
 
 import { BUNDLE_STATS_JSON_OPTIONS } from './src/plugins/statsJsonOptions.js'
+import { toSingleCompilerStats } from './rslib.stats.js'
 
 export default defineConfig({
   lib: [
@@ -124,7 +125,11 @@ function pluginStatsJson(): rsbuild.RsbuildPlugin {
         mkdirSync(api.context.distPath, { recursive: true })
         writeFileSync(
           path.join(api.context.distPath, 'stats.json'),
-          JSON.stringify(stats.toJson(BUNDLE_STATS_JSON_OPTIONS), null, 2),
+          JSON.stringify(
+            toSingleCompilerStats(stats.toJson(BUNDLE_STATS_JSON_OPTIONS)),
+            null,
+            2,
+          ),
         )
       })
     },

--- a/packages/rspeedy/core/rslib.stats.ts
+++ b/packages/rspeedy/core/rslib.stats.ts
@@ -1,0 +1,103 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export interface MultiCompilerStatsJson {
+  children?: SingleCompilerStatsJson[]
+  errors?: unknown[]
+  warnings?: unknown[]
+  errorsCount?: number
+  warningsCount?: number
+  [key: string]: unknown
+}
+
+export interface SingleCompilerStatsJson {
+  name?: string
+  assets?: unknown[]
+  chunks?: unknown[]
+  modules?: unknown[]
+  assetsByChunkName?: Record<string, unknown>
+  entrypoints?: Record<string, unknown>
+  namedChunkGroups?: Record<string, unknown>
+  errors?: unknown[]
+  warnings?: unknown[]
+  errorsCount?: number
+  warningsCount?: number
+  children?: unknown
+  [key: string]: unknown
+}
+
+/**
+ * Flatten Rspeedy core's multi-compiler stats into a single-compiler stats.
+ *
+ * `rslib.config.ts` builds several `lib` entries (the main library, the CLI,
+ * and the register hooks), so Rspack produces a `MultiCompiler` whose
+ * `stats.toJson()` is shaped as `{ children: [...] }` with no top-level
+ * `assets`/`chunks`/`modules`. RelativeCI's webpack stats extractor does not
+ * support multi-compiler stats and rejects it with "Invalid stats structure".
+ *
+ * We merge every child compilation into one single-compiler stats so the
+ * upload keeps the full published footprint (library + CLI + register bundles).
+ * This normalization lives here — alongside the config that owns the
+ * RelativeCI upload — rather than in the shared `lynx:stats-json` plugin, so
+ * that the `stats.json` emitted for regular Rspeedy projects is left untouched.
+ *
+ * @param statsJson - The raw stats object from `stats.toJson()`.
+ * @returns A single-compiler-shaped stats object accepted by RelativeCI.
+ */
+export function toSingleCompilerStats(
+  statsJson: MultiCompilerStatsJson,
+): SingleCompilerStatsJson {
+  const children = statsJson.children
+  if (!Array.isArray(children) || children.length === 0) {
+    return statsJson as SingleCompilerStatsJson
+  }
+
+  const [first] = children
+  const merged: SingleCompilerStatsJson = {
+    ...first,
+    assets: children.flatMap(child => child.assets ?? []),
+    chunks: children.flatMap(child => child.chunks ?? []),
+    modules: children.flatMap(child => child.modules ?? []),
+    assetsByChunkName: mergeRecords(
+      children.map(child => child.assetsByChunkName),
+    ),
+    entrypoints: mergeRecords(children.map(child => child.entrypoints)),
+    namedChunkGroups: mergeRecords(
+      children.map(child => child.namedChunkGroups),
+    ),
+    errors: children.flatMap(child => child.errors ?? []),
+    warnings: children.flatMap(child => child.warnings ?? []),
+    errorsCount: children.reduce(
+      (count, child) => count + (child.errorsCount ?? 0),
+      0,
+    ),
+    warningsCount: children.reduce(
+      (count, child) => count + (child.warningsCount ?? 0),
+      0,
+    ),
+  }
+
+  delete merged.name
+  delete merged.children
+
+  return merged
+}
+
+/**
+ * Shallow-merge a list of optional keyed maps into a single record.
+ *
+ * @param records - The per-child maps (any of which may be `undefined`).
+ * @returns A single record containing every entry.
+ */
+function mergeRecords(
+  records: Array<Record<string, unknown> | undefined>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const record of records) {
+    if (record) {
+      Object.assign(result, record)
+    }
+  }
+  return result
+}

--- a/packages/rspeedy/core/test/rslib.stats.test.ts
+++ b/packages/rspeedy/core/test/rslib.stats.test.ts
@@ -1,0 +1,122 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core'
+
+import type { MultiCompilerStatsJson } from '../rslib.stats.js'
+import { toSingleCompilerStats } from '../rslib.stats.js'
+
+describe('toSingleCompilerStats', () => {
+  test('returns single-compiler stats unchanged', () => {
+    const stats = {
+      hash: 'abc',
+      assets: [{ name: 'index.js', size: 100 }],
+      chunks: [],
+      modules: [],
+    } satisfies MultiCompilerStatsJson
+
+    expect(toSingleCompilerStats(stats)).toBe(stats)
+  })
+
+  test('returns stats unchanged when children is empty', () => {
+    const stats = { children: [] } satisfies MultiCompilerStatsJson
+
+    expect(toSingleCompilerStats(stats)).toBe(stats)
+  })
+
+  test('flattens multi-compiler stats into single-compiler stats', () => {
+    const stats: MultiCompilerStatsJson = {
+      hash: 'multi',
+      errors: [],
+      warnings: [],
+      errorsCount: 0,
+      warningsCount: 0,
+      children: [
+        {
+          name: 'esm0',
+          hash: 'child0',
+          assets: [{ name: 'index.js', size: 100 }],
+          chunks: [{ id: 0 }],
+          modules: [{ name: './src/index.js' }],
+          assetsByChunkName: { index: ['index.js'] },
+          entrypoints: { index: { name: 'index' } },
+          namedChunkGroups: { index: { name: 'index' } },
+          errors: [],
+          warnings: ['w0'],
+          errorsCount: 0,
+          warningsCount: 1,
+        },
+        {
+          name: 'esm1',
+          assets: [{ name: 'cli/main.js', size: 200 }],
+          chunks: [{ id: 1 }],
+          modules: [{ name: './src/cli/main.js' }],
+          assetsByChunkName: { 'cli/main': ['cli/main.js'] },
+          entrypoints: { 'cli/main': { name: 'cli/main' } },
+          namedChunkGroups: { 'cli/main': { name: 'cli/main' } },
+          errors: ['e1'],
+          warnings: [],
+          errorsCount: 1,
+          warningsCount: 0,
+        },
+      ],
+    }
+
+    const result = toSingleCompilerStats(stats)
+
+    // Top-level `children`/`name` must be gone so RelativeCI's webpack stats
+    // extractor accepts it as a single-compiler stats.
+    expect(result).not.toHaveProperty('children')
+    expect(result).not.toHaveProperty('name')
+
+    // Every child's assets/chunks/modules are merged and kept.
+    expect(result.assets).toEqual([
+      { name: 'index.js', size: 100 },
+      { name: 'cli/main.js', size: 200 },
+    ])
+    expect(result.chunks).toEqual([{ id: 0 }, { id: 1 }])
+    expect(result.modules).toEqual([
+      { name: './src/index.js' },
+      { name: './src/cli/main.js' },
+    ])
+
+    // Keyed maps are merged.
+    expect(result.assetsByChunkName).toEqual({
+      'index': ['index.js'],
+      'cli/main': ['cli/main.js'],
+    })
+    expect(result.entrypoints).toEqual({
+      'index': { name: 'index' },
+      'cli/main': { name: 'cli/main' },
+    })
+    expect(result.namedChunkGroups).toEqual({
+      'index': { name: 'index' },
+      'cli/main': { name: 'cli/main' },
+    })
+
+    // Diagnostics are aggregated.
+    expect(result.errors).toEqual(['e1'])
+    expect(result.warnings).toEqual(['w0'])
+    expect(result.errorsCount).toBe(1)
+    expect(result.warningsCount).toBe(1)
+
+    // Non-list fields inherit from the first child.
+    expect(result['hash']).toBe('child0')
+  })
+
+  test('tolerates children missing optional fields', () => {
+    const stats: MultiCompilerStatsJson = {
+      children: [{ name: 'esm0' }, { name: 'esm1' }],
+    }
+
+    const result = toSingleCompilerStats(stats)
+
+    expect(result.assets).toEqual([])
+    expect(result.chunks).toEqual([])
+    expect(result.modules).toEqual([])
+    expect(result.errorsCount).toBe(0)
+    expect(result.warningsCount).toBe(0)
+    expect(result).not.toHaveProperty('children')
+    expect(result).not.toHaveProperty('name')
+  })
+})

--- a/packages/rspeedy/core/tsconfig.json
+++ b/packages/rspeedy/core/tsconfig.json
@@ -11,6 +11,7 @@
     "test",
     "client.d.ts",
     "package.json",
+    "rslib.stats.ts",
     "rstest.config.ts",
   ],
   "exclude": [


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle analysis now produces a consolidated statistics report for multi-compiler builds.
  * Asset, chunk, module, warning, and error information is combined into a single, easier-to-consume output.

* **Bug Fixes**
  * Improved handling of builds with missing or optional statistics fields.

* **Tests**
  * Added coverage for single- and multi-compiler statistics, aggregation, and incomplete data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

The RelativeCI **Upload rspeedy** job fails with `Error: Invalid stats structure.` (e.g. [run #16851](https://github.com/lynx-family/lynx-stack/actions/runs/29736604423/job/88333302077)).

`packages/rspeedy/core` is built with **rslib**, which defines several `lib` entries (the main library, the CLI, and the register hooks). Rspack therefore produces a **MultiCompiler**, whose `stats.toJson()` is shaped as:

```jsonc
{ "children": [ /* esm0, esm1, esm2 */ ], "hash": "...", "errors": [], "warnings": [] }
```

with **no top-level `assets`/`chunks`/`modules`**. RelativeCI's webpack stats extractor (`@bundle-stats/plugin-webpack-validate`) does not support multi-compiler stats — its schema requires a non-empty top-level `assets` array — so it rejects the upload.

## Fix

Flatten the multi-compiler stats into a single-compiler stats in `rslib.config.ts` — the config that **owns** the RelativeCI upload — by merging every child compilation into one object (assets/chunks/modules concatenated, keyed maps merged, error/warning counts summed). This keeps the full published footprint (library + CLI + register bundles) in the report.

Per `.github/rspeedy-core-stats.instructions.md`, the normalization deliberately lives here rather than in the shared `lynx:stats-json` plugin, so the `stats.json` emitted for regular Rspeedy projects is left untouched.

The flattening logic is extracted to `rslib.stats.ts` and covered by unit tests in `test/rslib.stats.test.ts`.

## Verification

- Rebuilt `packages/rspeedy/core` with `RSPEEDY_BUNDLE_ANALYSIS=1`; the emitted `dist/stats.json` now has top-level `assets` (59), `chunks`, `modules` and no `children`.
- Ran the produced `stats.json` through RelativeCI's actual validator (`@bundle-stats/plugin-webpack-validate`): the old multi-compiler shape reports `Invalid ... Path: assets`; the new shape passes.
- `pnpm run test` (stats + new flatten tests), `pnpm run test:type`, `pnpm dprint check`, and `pnpm eslint` all pass.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required). — _Not required: only build config (`rslib.config.ts`), a build-only helper, tests, and `tsconfig` change; nothing under `src/**` (the changeset `changedFilePatterns`), and no published output changes._
