### PR TITLE
fix(debug-metadata): skip emission on local production builds

### DIFF
--- a/.changeset/debug-metadata-local-prod-gate.md
+++ b/.changeset/debug-metadata-local-prod-gate.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+Skip `debug-metadata.json` emission on local production builds — nothing reads it there, but collecting it walks every source map. Production builds now emit it only on an automated build, detected via `CI`, `CI_REPO_NAME` or `BUILD_VERSION`; `DEBUG=rspeedy` opts back in. Dev builds are unaffected.

--- a/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
@@ -15,18 +15,22 @@ import type { CompilerHandle } from './middleware.js'
 
 const PLUGIN_NAME = 'lynx:debug-metadata'
 
-/**
- * `DEBUG=rspeedy` (and friends) — mirrors `isDebug()` in
- * `@lynx-js/template-webpack-plugin`, replicated here to avoid widening that
- * package's public API for a single env check.
- */
 function isDebugMode(): boolean {
   const debug = process.env['DEBUG']
   if (!debug) return false
   const values = debug.toLocaleLowerCase().split(',')
-  return ['rspeedy', '*', 'rspeedy:*', 'rspeedy:template'].some((key) =>
-    values.includes(key)
-  )
+  return ['rspeedy', 'rsbuild', '*', 'rspeedy:*', 'rspeedy:template'].some((
+    key,
+  ) => values.includes(key))
+}
+
+function isAutomatedBuild(): boolean {
+  const { CI, CI_REPO_NAME, BUILD_VERSION } = process.env
+  return [BUILD_VERSION, CI_REPO_NAME, CI].some(Boolean)
+}
+
+function isLocalProductionBuild(isProd: boolean): boolean {
+  return isProd && !isAutomatedBuild() && !isDebugMode()
 }
 
 /**
@@ -152,12 +156,14 @@ export function pluginLynxDebugMetadata(): RsbuildPlugin {
         stripDebugMetadataFromOutput(compiler)
       })
 
-      api.modifyBundlerChain((chain, { environment }) => {
+      api.modifyBundlerChain((chain, { environment, isProd }) => {
         // biome `useHookAtTopLevel` lint doesn't trip — it's an rsbuild
         // API, not a React hook, but the name prefix matches.
         const exposed = api.useExposed<LynxTemplatePluginExposure>(
           Symbol.for('LynxTemplatePlugin'),
         )
+
+        if (isLocalProductionBuild(isProd)) return
 
         // Non-lynx envs (e.g. the `web` env in a multi-env build) share
         // the same `intermediate` dir with the lynx env in rspeedy's

--- a/packages/rspeedy/plugin-debug-metadata/test/local-prod-gate.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/local-prod-gate.test.ts
@@ -1,0 +1,102 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { RsbuildPlugin } from '@rsbuild/core'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { pluginLynxDebugMetadata } from '../src/pluginLynxDebugMetadata.js'
+
+interface ChainUtils {
+  environment: { name: string, entry: unknown }
+  isProd: boolean
+}
+
+function noop(): void {
+  return
+}
+
+function runChain(utils: ChainUtils): string[] {
+  const registered: string[] = []
+  const chain = {
+    plugin(name: string) {
+      registered.push(name)
+      return { use: noop }
+    },
+  }
+  const api = {
+    onAfterCreateCompiler: noop,
+    onBeforeStartDevServer: noop,
+    useExposed: () => ({ LynxTemplatePlugin: class {} }),
+    getNormalizedConfig: () => ({ dev: { assetPrefix: '' } }),
+    context: {},
+    modifyBundlerChain: (
+      callback: (chain: typeof chain, utils: ChainUtils) => void,
+    ) => {
+      callback(chain, utils)
+    },
+  } as unknown as Parameters<RsbuildPlugin['setup']>[0]
+
+  void pluginLynxDebugMetadata().setup(api)
+  return registered
+}
+
+const LYNX_PROD: ChainUtils = {
+  environment: { name: 'lynx', entry: {} },
+  isProd: true,
+}
+
+beforeEach(() => {
+  vi.stubEnv('DEBUG', '')
+  vi.stubEnv('CI', '')
+  vi.stubEnv('CI_REPO_NAME', '')
+  vi.stubEnv('BUILD_VERSION', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('pluginLynxDebugMetadata production gate', () => {
+  test('emits on a CI production build', () => {
+    vi.stubEnv('CI', 'true')
+
+    expect(runChain(LYNX_PROD)).toContain('lynx:debug-metadata')
+  })
+
+  test('emits on a release pipeline that sets BUILD_VERSION but not CI', () => {
+    vi.stubEnv('BUILD_VERSION', '1.0.0.50')
+
+    expect(runChain(LYNX_PROD)).toContain('lynx:debug-metadata')
+  })
+
+  test('emits on a pipeline that sets CI_REPO_NAME but not CI', () => {
+    vi.stubEnv('CI_REPO_NAME', 'lynx-stack')
+
+    expect(runChain(LYNX_PROD)).toContain('lynx:debug-metadata')
+  })
+
+  test('skips a local production build', () => {
+    expect(runChain(LYNX_PROD)).not.toContain('lynx:debug-metadata')
+  })
+
+  test('emits on a local production build when DEBUG=rspeedy', () => {
+    vi.stubEnv('DEBUG', 'rspeedy')
+
+    expect(runChain(LYNX_PROD)).toContain('lynx:debug-metadata')
+  })
+
+  test('emits on a dev build regardless of CI (the middleware serves it)', () => {
+    expect(
+      runChain({ environment: { name: 'lynx', entry: {} }, isProd: false }),
+    )
+      .toContain('lynx:debug-metadata')
+  })
+
+  test('still skips a non-lynx environment on CI', () => {
+    vi.stubEnv('CI', 'true')
+
+    expect(runChain({ environment: { name: 'web', entry: {} }, isProd: true }))
+      .not.toContain('lynx:debug-metadata')
+  })
+})


### PR DESCRIPTION
## Summary

`pluginLynxDebugMetadata` emitted `debug-metadata.json` on every production build. Nothing consumes it on a developer's local `build` — it is read either by an uploader (which runs on automated builds) or by the dev-server middleware (dev builds) — but collecting it still walks every source map and serialises several MB.

Production emission is now gated on the build being automated:

```diff
-api.modifyBundlerChain((chain, { environment }) => {
+api.modifyBundlerChain((chain, { environment, isProd }) => {
   const exposed = api.useExposed<LynxTemplatePluginExposure>(
     Symbol.for('LynxTemplatePlugin'),
   )
+
+  if (isLocalProductionBuild(isProd)) return
```

```ts
function isAutomatedBuild(): boolean {
  const { CI, CI_REPO_NAME, BUILD_VERSION } = process.env
  return [BUILD_VERSION, CI_REPO_NAME, CI].some(Boolean)
}

function isLocalProductionBuild(isProd: boolean): boolean {
  return isProd && !isAutomatedBuild() && !isDebugMode()
}
```

`CI` alone is not enough: some release pipelines set `BUILD_VERSION` or `CI_REPO_NAME` and neither `CI`, and those are exactly the builds whose output gets uploaded. Treating them as local would silently drop the metadata from every release.

Dev builds are unaffected, so the middleware endpoints keep working. `DEBUG=rspeedy` (the same switch `stripDebugMetadataFromOutput` already honours) forces emission back on for a local production build, which is what `examples/react-debug-metadata` uses.

`isDebugMode` also gains the `rsbuild` key, matching what downstream uploaders accept. This widens `stripDebugMetadataFromOutput` too: `DEBUG=rsbuild` now keeps the asset in the output, as `DEBUG=rspeedy` already did.

## Notes

`isLocalProductionBuild` is checked *after* `api.useExposed`, not before, so biome's `useHookAtTopLevel` rule stays happy — the same reason the existing `isLynx` / `exposed` early returns sit where they do.

`isAutomatedBuild` uses `.some(Boolean)` rather than a `||` chain because `@typescript-eslint/prefer-nullish-coalescing` rejects the latter, and `??` would be wrong — an empty-string env var has to fall through, not win.

## Test plan

New `test/local-prod-gate.test.ts` drives `modifyBundlerChain` with a recording chain:

- CI production build → registers
- production build with only `BUILD_VERSION` → registers
- production build with only `CI_REPO_NAME` → registers
- local production build → does not register
- local production build with `DEBUG=rspeedy` → registers
- dev build (no CI) → registers
- non-lynx environment on CI → still skipped

`packages/rspeedy/plugin-debug-metadata`: 114 tests pass. `packages/rspeedy/plugin-react` `release-order` + `sourcemap`: 6 tests pass (the latter already stubs `DEBUG=rspeedy`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Debug metadata emission for local production-like builds is now skipped by default unless re-enabled via `DEBUG=rspeedy` (also recognized via `DEBUG=rsbuild`).
  * Metadata generation continues for automated/CI production builds (detected via `CI`, `CI_REPO_NAME`, or `BUILD_VERSION`) and for development builds.
  * Non-Lynx environments won’t receive debug-metadata wiring even when CI signals are present.
* **Tests**
  * Added Vitest coverage to verify conditional metadata registration across CI, local production, dev, and non-Lynx scenarios.
* **Documentation**
  * Documented the new CI-vs-local behavior in a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->