### PR TITLE
perf(debug-metadata): cache chunk release keys and halve git spawns

### DIFF
--- a/.changeset/debug-metadata-plugin-perf.md
+++ b/.changeset/debug-metadata-plugin-perf.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+---
+
+Reduce build-time overhead: memoize the chunk release key, and read the commit and worktree root in one `git rev-parse` spawn instead of two.

--- a/packages/rspeedy/plugin-debug-metadata/src/collectors/git.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/collectors/git.ts
@@ -69,9 +69,10 @@ export function normalizeRemoteUrl(remoteUrl: string | null): string | null {
  * should omit the `meta.git` field entirely.
  */
 export function collectGitMetadata(cwd: string): GitMetadata | null {
-  const commit = tryRunGit(cwd, ['rev-parse', 'HEAD'])
+  // One spawn for both: each `git` costs ~20ms on the compile critical path.
+  const revParse = tryRunGit(cwd, ['rev-parse', 'HEAD', '--show-toplevel'])
+  const [commit, rootDir = null] = revParse?.split(/\r?\n/) ?? []
   if (!commit) return null
-  const rootDir = tryRunGit(cwd, ['rev-parse', '--show-toplevel'])
   const remoteUrl = normalizeRemoteUrl(
     tryRunGit(cwd, ['config', '--get', 'remote.origin.url']),
   )

--- a/packages/rspeedy/plugin-debug-metadata/src/release-banner.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/release-banner.ts
@@ -35,6 +35,9 @@ export function computeChunkReleaseKey(
   chunkGraph: Rspack.Compilation['chunkGraph'],
   chunk: Rspack.Chunk,
 ): string {
+  const cached = releaseKeyCache.get(chunk)
+  if (cached !== undefined) return cached
+
   const moduleIds: string[] = []
   for (const module of chunkGraph.getChunkModules(chunk)) {
     moduleIds.push(module.identifier())
@@ -42,8 +45,20 @@ export function computeChunkReleaseKey(
   // `getChunkModules` order is not guaranteed stable; sort so the key is
   // deterministic for a given module set.
   moduleIds.sort()
-  return computeReleaseKey(chunk.name ?? '', chunk.hash ?? '', ...moduleIds)
+  const key = computeReleaseKey(
+    chunk.name ?? '',
+    chunk.hash ?? '',
+    ...moduleIds,
+  )
+  releaseKeyCache.set(chunk, key)
+  return key
 }
+
+/**
+ * The same chunk is keyed once for the banner plus once per mappable file per
+ * template. `Chunk` is per-compilation, so entries drop with it.
+ */
+const releaseKeyCache = new WeakMap<Rspack.Chunk, string>()
 
 export const RELEASE_DEFINE = '__DEBUG_METADATA_RELEASE__'
 

--- a/packages/rspeedy/plugin-debug-metadata/test/git.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/git.test.ts
@@ -66,11 +66,10 @@ describe('collectGitMetadata', () => {
     expect(collectGitMetadata('/no/repo')).toBeNull()
   })
 
-  test('assembles GitMetadata from the four git commands', () => {
+  test('assembles GitMetadata from the git commands', () => {
     mockExecFileSync.mockReset()
     mockExecFileSync
-      .mockReturnValueOnce('abc123\n')
-      .mockReturnValueOnce('/repo\n')
+      .mockReturnValueOnce('abc123\n/repo\n')
       .mockReturnValueOnce('git@github.com:owner/repo.git\n')
 
     expect(collectGitMetadata('/repo')).toEqual({
@@ -81,11 +80,40 @@ describe('collectGitMetadata', () => {
     })
   })
 
+  test('CRLF output does not leak into the commit hash', () => {
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('abc123\r\n/repo\r\n')
+      .mockReturnValueOnce('git@github.com:owner/repo.git\n')
+
+    expect(collectGitMetadata('/repo')).toEqual({
+      commit: 'abc123',
+      rootDir: '/repo',
+      remoteUrl: 'https://github.com/owner/repo',
+      commitUrl: 'https://github.com/owner/repo/commit/abc123',
+    })
+  })
+
+  test('commit and rootDir come from a single `rev-parse` spawn', () => {
+    mockExecFileSync.mockReset()
+    mockExecFileSync
+      .mockReturnValueOnce('abc123\n/repo\n')
+      .mockReturnValueOnce('git@github.com:owner/repo.git\n')
+
+    collectGitMetadata('/repo')
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2)
+    expect(mockExecFileSync.mock.calls[0]?.[1]).toEqual([
+      'rev-parse',
+      'HEAD',
+      '--show-toplevel',
+    ])
+  })
+
   test('omits commitUrl when no remote URL is configured', () => {
     mockExecFileSync.mockReset()
     mockExecFileSync
-      .mockReturnValueOnce('abc123\n')
-      .mockReturnValueOnce('/repo\n')
+      .mockReturnValueOnce('abc123\n/repo\n')
       .mockImplementationOnce(() => {
         throw new Error('no remote')
       })


### PR DESCRIPTION
## Summary

Two contained wins in `@lynx-js/debug-metadata-rsbuild-plugin`, both found by profiling a real build (`node --cpu-prof` over `examples/react-debug-metadata`) rather than by reading the code.

**1. Memoize `computeChunkReleaseKey`**

The release key materializes every module identifier in a chunk, sorts them and SHA-1s the lot — O(modules in chunk). It is computed once per chunk for the release banner, then again per mappable file for every template whose chunk groups contain that chunk.

Measured on the example: **21 calls over 10 distinct chunks**. A `WeakMap<Chunk, string>` cuts that to 10 actual hashes. Chunk identity was verified to be stable across `compilation.chunks` and `chunkGroup.chunks` (probe: 11 hits / 10 misses), and `Chunk` is per-compilation so entries drop with it rather than leaking across watch rebuilds. Both call sites run after seal, where `chunk.hash` and the module set are fixed.

Cost per call, by chunk size: 500 modules 0.12ms, 2000 modules 0.50ms, 5000 modules 1.10ms.

**2. One `git rev-parse` instead of two**

`collectGitMetadata` ran three synchronous `execFileSync('git', ...)` calls on the compile critical path. In the profile this was the single largest attributable JS cost in the whole build (52.8ms of a 1.18s build). `rev-parse HEAD --show-toplevel` answers both queries on two lines.

Median of 15 rounds: **3 spawns 105ms → 2 spawns 50.8ms (−52%)**.

Net: plugin-inclusive CPU **62.5ms → 43.2ms (−31%)** on the example.

## Not included

Two further candidates were prototyped and dropped:

- **Emitting `debug-metadata.json` only in `beforeEmit`** (skipping the serialize → parse → serialize round trip). This breaks the contract that the asset exists during `beforeEncode`: downstream plugins read it back there to augment it and hash its content. Verified with a probe plugin — with the change, `getAsset()` at `beforeEncode` returns `undefined` for every template, silently.
- **Skipping the `beforeEmit` re-parse when the asset is untouched**, detected by comparing the `Source` instance. Rspack's napi layer does not return the same JS `Source` object that was passed to `emitAsset` (probe: 0 same / 5 different), so identity cannot detect modification.

## Verification

- 108 unit tests pass (107 + one new assertion that `collectGitMetadata` spawns twice)
- 42 `error-remapping` end-to-end tests pass
- `tsc -b`, eslint clean
- **Output equivalence**: the emitted `debug-metadata.json` for all 5 templates is byte-identical to a baseline built from `main`, excluding the encoder's `debugInfo` subtree — which was shown to be nondeterministic run-to-run with identical code (3 runs, 2 distinct hashes), so it is not a regression from this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced build-time overhead when collecting repository metadata.
  * Improved release metadata generation by caching chunk release-key calculations and avoiding repeated work.

* **Bug Fixes**
  * Streamlined Git metadata capture to derive commit and repository root from a single command.
  * More reliably handles cases where the commit value is unavailable.

* **Tests**
  * Updated Git metadata tests to reflect the new command shape and added checks for CRLF-safe commit hashing and expected invocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->