### PR TITLE
feat(react/transform): fold const literals into the static snapshot

### DIFF
--- a/.changeset/snapshot-fold-const-literals.md
+++ b/.changeset/snapshot-fold-const-literals.md
@@ -1,5 +1,5 @@
 ---
-"@lynx-js/react-transform": patch
+"@lynx-js/react": patch
 ---
 
 Fold compile-time constants into the static snapshot. A JSX expression that references a `const` binding with a literal initializer is now compiled as if the literal had been written inline, so `<view custom-attr={VALUE} />` becomes a static `__SetAttribute` instead of a dynamic value, and children that render nothing (`{null}`, `{true}`, `{false}`, or a `const` bound to one of them) no longer take up a slot.

--- a/.changeset/snapshot-fold-const-literals.md
+++ b/.changeset/snapshot-fold-const-literals.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-transform": patch
+---
+
+Fold compile-time constants into the static snapshot. A JSX expression that references a `const` binding with a literal initializer is now compiled as if the literal had been written inline, so `<view custom-attr={VALUE} />` becomes a static `__SetAttribute` instead of a dynamic value, and children that render nothing (`{null}`, `{true}`, `{false}`, or a `const` bound to one of them) no longer take up a slot.

--- a/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
@@ -1979,99 +1979,76 @@ mod tests {
     });
   }
 
-  fn transform_with_resolver(src: &str) -> String {
-    let mut output = String::new();
-
-    Tester::run(|tester| {
-      let top_level_mark = Mark::new();
-      let unresolved_mark = Mark::new();
-
-      let program = tester.apply_transform(
-        (
-          resolver(unresolved_mark, top_level_mark, true),
-          visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
-            super::JSXTransformerConfig {
-              preserve_jsx: true,
-              target: TransformTarget::MIXED,
-              ..Default::default()
-            },
-            None,
-            TransformMode::Test,
-            Some(tester.cm.clone()),
-          )),
-        ),
-        "input.js",
+  macro_rules! const_literal_test {
+    ($name:ident, $src:expr) => {
+      test!(
+        module,
         Syntax::Es(EsSyntax {
           jsx: true,
           ..Default::default()
         }),
-        Some(true),
-        src,
-      )?;
+        |t| {
+          let unresolved_mark = Mark::new();
+          let top_level_mark = Mark::new();
 
-      let comments = tester.comments.clone();
-      output = tester.print(&program, &comments);
-
-      Ok(())
-    });
-
-    output
+          (
+            resolver(unresolved_mark, top_level_mark, true),
+            visit_mut_pass(JSXTransformer::new(
+              super::JSXTransformerConfig {
+                preserve_jsx: true,
+                target: TransformTarget::MIXED,
+                ..Default::default()
+              },
+              Some(t.comments.clone()),
+              TransformMode::Test,
+              Some(t.cm.clone()),
+            )),
+          )
+        },
+        $name,
+        // Input codes
+        $src
+      );
+    };
   }
 
-  #[test]
-  fn should_treat_const_literal_attr_as_static() {
-    let output = transform_with_resolver(r#"const V = "foo"; const a = <view custom-attr={V} />;"#);
+  // `custom-attr` is baked into the snapshot creator instead of the `values` array.
+  const_literal_test!(
+    const_literal_attr_is_static,
+    r#"
+    const V = "foo";
+    const a = <view custom-attr={V} />;
+    "#
+  );
 
-    assert!(
-      output.contains(r#"__SetAttribute(el, "custom-attr", "foo")"#),
-      "a const literal attr should be baked into the snapshot creator; output:\n{output}",
-    );
-    assert!(
-      !output.contains("values="),
-      "a const literal attr should not produce a dynamic value; output:\n{output}",
-    );
-  }
+  // `{HOLE}` renders nothing, so the snapshot stays fully static and takes no slot.
+  const_literal_test!(
+    const_literal_child_takes_no_slot,
+    r#"
+    const HOLE = null;
+    const a = <view>{HOLE}</view>;
+    "#
+  );
 
-  #[test]
-  fn should_not_treat_const_literal_child_as_slot() {
-    let output = transform_with_resolver(r#"const HOLE = null; const a = <view>{HOLE}</view>;"#);
+  // The parameter shadows the const, so `custom-attr` must stay dynamic.
+  const_literal_test!(
+    shadowed_const_literal_stays_dynamic,
+    r#"
+    const HOLE = null;
+    function App(HOLE) {
+      return <view custom-attr={HOLE} />;
+    }
+    "#
+  );
 
-    assert!(
-      !output.contains("$0="),
-      "a child that renders nothing should not take up a slot; output:\n{output}",
-    );
-    assert!(
-      !output.contains("DynamicPartSlot"),
-      "a child that renders nothing should leave the snapshot fully static; output:\n{output}",
-    );
-  }
-
-  #[test]
-  fn should_keep_shadowed_binding_dynamic() {
-    let output = transform_with_resolver(
-      r#"
-      const HOLE = null;
-      function App(HOLE) {
-        return <view custom-attr={HOLE} />;
-      }
-      "#,
-    );
-
-    assert!(
-      output.contains("values="),
-      "a parameter shadowing a const literal must stay dynamic; output:\n{output}",
-    );
-  }
-
-  #[test]
-  fn should_keep_mutable_binding_dynamic() {
-    let output = transform_with_resolver(r#"let V = "foo"; const a = <view custom-attr={V} />;"#);
-
-    assert!(
-      output.contains("values="),
-      "a `let` binding may be reassigned, so it must stay dynamic; output:\n{output}",
-    );
-  }
+  // `let` may be reassigned, so `custom-attr` must stay dynamic.
+  const_literal_test!(
+    mutable_binding_stays_dynamic,
+    r#"
+    let V = "foo";
+    const a = <view custom-attr={V} />;
+    "#
+  );
 
   test!(
     module,

--- a/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
@@ -17,7 +17,7 @@ use swc_core::{
   ecma::{
     ast::{JSXExpr, *},
     utils::{is_literal, prepend_stmt, private_ident},
-    visit::{VisitMut, VisitMutWith},
+    visit::{Visit, VisitMut, VisitMutWith, VisitWith},
   },
   quote, quote_expr,
 };
@@ -117,6 +117,70 @@ pub enum DynamicPart {
   Spread(Expr, i32, bool),
   Slot(Expr, i32),
   ListSlot(Expr, i32),
+}
+
+/// Collects `const` bindings whose initializer is a literal, so that JSX
+/// referencing one of them can be compiled as if the literal had been written
+/// inline. Keyed by the resolved binding id, so shadowed names stay distinct.
+#[derive(Default)]
+struct ConstLiteralCollector {
+  literals: HashMap<Id, Lit>,
+}
+
+impl Visit for ConstLiteralCollector {
+  fn visit_var_decl(&mut self, n: &VarDecl) {
+    n.visit_children_with(self);
+
+    if n.kind != VarDeclKind::Const {
+      return;
+    }
+
+    for decl in &n.decls {
+      if let (Pat::Ident(name), Some(init)) = (&decl.name, &decl.init) {
+        if let Expr::Lit(lit) = &**init {
+          self.literals.insert(name.id.to_id(), lit.clone());
+        }
+      }
+    }
+  }
+}
+
+/// Folds compile-time constants inside JSX before the snapshot is extracted:
+///
+/// - `{CONST}` becomes the literal it is bound to, so an attribute value ends
+///   up in the static snapshot instead of the `values` array.
+/// - `{null}` / `{true}` / `{false}` children render nothing, so they are
+///   dropped instead of taking up a slot.
+struct ConstLiteralFolder {
+  literals: HashMap<Id, Lit>,
+}
+
+impl VisitMut for ConstLiteralFolder {
+  fn visit_mut_jsx_expr_container(&mut self, n: &mut JSXExprContainer) {
+    n.visit_mut_children_with(self);
+
+    if let JSXExpr::Expr(expr) = &mut n.expr {
+      if let Expr::Ident(ident) = &**expr {
+        if let Some(lit) = self.literals.get(&ident.to_id()) {
+          **expr = Expr::Lit(lit.clone());
+        }
+      }
+    }
+  }
+
+  fn visit_mut_jsx_element_childs(&mut self, n: &mut Vec<JSXElementChild>) {
+    n.visit_mut_children_with(self);
+
+    n.retain(|child| {
+      !matches!(
+        child,
+        JSXElementChild::JSXExprContainer(JSXExprContainer {
+          expr: JSXExpr::Expr(expr),
+          ..
+        }) if matches!(&**expr, Expr::Lit(Lit::Null(_)) | Expr::Lit(Lit::Bool(_)))
+      )
+    });
+  }
 }
 
 pub fn i32_to_expr(i: &i32) -> Expr {
@@ -1724,6 +1788,12 @@ where
       self.css_id_value = Some(Expr::Lit(Lit::Num(0.into())));
     }
 
+    let mut collector = ConstLiteralCollector::default();
+    n.visit_with(&mut collector);
+    n.visit_mut_with(&mut ConstLiteralFolder {
+      literals: collector.literals,
+    });
+
     n.visit_mut_children_with(self);
 
     if let Expr::Ident(runtime_id) = &*self.runtime_id {
@@ -1907,6 +1977,100 @@ mod tests {
 
       Ok(())
     });
+  }
+
+  fn transform_with_resolver(src: &str) -> String {
+    let mut output = String::new();
+
+    Tester::run(|tester| {
+      let top_level_mark = Mark::new();
+      let unresolved_mark = Mark::new();
+
+      let program = tester.apply_transform(
+        (
+          resolver(unresolved_mark, top_level_mark, true),
+          visit_mut_pass(JSXTransformer::<&SingleThreadedComments>::new(
+            super::JSXTransformerConfig {
+              preserve_jsx: true,
+              target: TransformTarget::MIXED,
+              ..Default::default()
+            },
+            None,
+            TransformMode::Test,
+            Some(tester.cm.clone()),
+          )),
+        ),
+        "input.js",
+        Syntax::Es(EsSyntax {
+          jsx: true,
+          ..Default::default()
+        }),
+        Some(true),
+        src,
+      )?;
+
+      let comments = tester.comments.clone();
+      output = tester.print(&program, &comments);
+
+      Ok(())
+    });
+
+    output
+  }
+
+  #[test]
+  fn should_treat_const_literal_attr_as_static() {
+    let output = transform_with_resolver(r#"const V = "foo"; const a = <view custom-attr={V} />;"#);
+
+    assert!(
+      output.contains(r#"__SetAttribute(el, "custom-attr", "foo")"#),
+      "a const literal attr should be baked into the snapshot creator; output:\n{output}",
+    );
+    assert!(
+      !output.contains("values="),
+      "a const literal attr should not produce a dynamic value; output:\n{output}",
+    );
+  }
+
+  #[test]
+  fn should_not_treat_const_literal_child_as_slot() {
+    let output = transform_with_resolver(r#"const HOLE = null; const a = <view>{HOLE}</view>;"#);
+
+    assert!(
+      !output.contains("$0="),
+      "a child that renders nothing should not take up a slot; output:\n{output}",
+    );
+    assert!(
+      !output.contains("DynamicPartSlot"),
+      "a child that renders nothing should leave the snapshot fully static; output:\n{output}",
+    );
+  }
+
+  #[test]
+  fn should_keep_shadowed_binding_dynamic() {
+    let output = transform_with_resolver(
+      r#"
+      const HOLE = null;
+      function App(HOLE) {
+        return <view custom-attr={HOLE} />;
+      }
+      "#,
+    );
+
+    assert!(
+      output.contains("values="),
+      "a parameter shadowing a const literal must stay dynamic; output:\n{output}",
+    );
+  }
+
+  #[test]
+  fn should_keep_mutable_binding_dynamic() {
+    let output = transform_with_resolver(r#"let V = "foo"; const a = <view custom-attr={V} />;"#);
+
+    assert!(
+      output.contains("values="),
+      "a `let` binding may be reassigned, so it must stay dynamic; output:\n{output}",
+    );
   }
 
   test!(

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/const_literal_attr_is_static.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/const_literal_attr_is_static.js
@@ -1,0 +1,12 @@
+import * as ReactLynx from "@lynx-js/react";
+const V = "foo";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        __SetAttribute(el, "custom-attr", "foo");
+        return [
+            el
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+const a = <__snapshot_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/const_literal_child_takes_no_slot.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/const_literal_child_takes_no_slot.js
@@ -1,0 +1,11 @@
+import * as ReactLynx from "@lynx-js/react";
+const HOLE = null;
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, null, null, undefined, globDynamicComponentEntry, null, true);
+const a = <__snapshot_da39a_test_1/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/mutable_binding_stays_dynamic.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/mutable_binding_stays_dynamic.js
@@ -1,0 +1,19 @@
+import * as ReactLynx from "@lynx-js/react";
+let V = "foo";
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, [
+        function(ctx) {
+            if (ctx.__elements) {
+                __SetAttribute(ctx.__elements[0], "custom-attr", ctx.__values[0]);
+            }
+        }
+    ], null, undefined, globDynamicComponentEntry, null, true);
+const a = <__snapshot_da39a_test_1 values={[
+    V
+]}/>;

--- a/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/shadowed_const_literal_stays_dynamic.js
+++ b/packages/react/transform/crates/swc_plugin_snapshot/tests/__swc_snapshots__/lib.rs/shadowed_const_literal_stays_dynamic.js
@@ -1,0 +1,21 @@
+import * as ReactLynx from "@lynx-js/react";
+const HOLE = null;
+const __snapshot_da39a_test_1 = "__snapshot_da39a_test_1";
+ReactLynx.snapshotCreatorMap[__snapshot_da39a_test_1] = (__snapshot_da39a_test_1)=>ReactLynx.createSnapshot(__snapshot_da39a_test_1, function() {
+        const pageId = ReactLynx.__pageId;
+        const el = __CreateView(pageId);
+        return [
+            el
+        ];
+    }, [
+        function(ctx) {
+            if (ctx.__elements) {
+                __SetAttribute(ctx.__elements[0], "custom-attr", ctx.__values[0]);
+            }
+        }
+    ], null, undefined, globDynamicComponentEntry, null, true);
+function App(HOLE) {
+    return <__snapshot_da39a_test_1 values={[
+        HOLE
+    ]}/>;
+}


### PR DESCRIPTION
## What

`swc_plugin_snapshot` only ever treated an inline `Expr::Lit` as a static value. An identifier bound to a `const` literal went down the dynamic path, so this:

```tsx
const VALUE = 'foo';
<view custom-attr={VALUE} />
```

compiled to a snapshot with a `values` array and a runtime updater, instead of baking `__SetAttribute(el, "custom-attr", "foo")` into the creator.

This PR folds compile-time constants into the static snapshot:

- **Attributes** — `{CONST}` is replaced by the literal it is bound to, so the existing literal path takes over.
- **Children** — `{null}` / `{true}` / `{false}` render nothing, so they are dropped instead of taking up a slot. This covers `<view>{HOLE}</view>` with `const HOLE = null`, which previously produced a full `SlotV2` dynamic part.

Before / after for `const HOLE = null; <view>{HOLE}</view>`:

```js
- }, null, ReactLynx.__DynamicPartSlotV2_0, undefined, globDynamicComponentEntry, null, true);
- const a = <__snapshot_x $0={HOLE}/>;
+ }, null, null, undefined, globDynamicComponentEntry, null, true);
+ const a = <__snapshot_x/>;
```

## How

Two small passes run over the module in `JSXTransformer::visit_mut_module`, before JSX is visited:

- `ConstLiteralCollector` records `const` bindings with a literal initializer, keyed by resolved binding id (`resolver` already runs ahead of this plugin), so shadowed names and `let` stay dynamic.
- `ConstLiteralFolder` rewrites JSX expression containers and drops nothing-rendering children.

Because the folding happens on the AST before extraction, nothing downstream needed to change — `jsx_is_children_full_dynamic`, `legacy_slot.rs` and `swc_plugin_element_template` all see an already-normalized tree.

## Deliberately out of scope

String and number literal *children* are still dynamic. Making them static means synthesizing a `JSXText` node, which drags in JSX whitespace trimming, entity handling and WTF-8 round-tripping — worth its own PR rather than riding along here. Attribute values of every literal type are covered, since those never round-trip through JSX text.

## Test plan

- 4 new tests in `swc_plugin_snapshot`: const literal attr goes static, const `null` child leaves the snapshot fully static, a parameter shadowing a const stays dynamic, a `let` binding stays dynamic.
- `cargo test --workspace` green, with **zero churn in existing snapshots** — no committed fixture used a const literal inside JSX.
- `cargo fmt --check` and `cargo clippy` clean.

## Draft — JS-side tests not updated yet

Opening as a draft to watch CI. The JS suites are expected to fail: a lot of them use `const HOLE = null` with `<text>{HOLE}</text>` specifically to *manufacture* a slot (`packages/react/runtime/__test__/snapshot/basic.test.jsx` and friends), and those now compile to fully static snapshots. Those tests need rewriting to build slots from a genuinely dynamic expression; doing that is the next commit.
