### PR TITLE
fix(renovate): keep Mend job under its 3 GB memory limit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,15 +1,28 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  // Cap Renovate's Node child-process heap and limit pnpm to one worker so
-  // regenerating the shared lockfile across the workspace does not get killed
-  // by the kernel OOM killer.
+  // Mend-hosted gives the whole job 3 GB, shared by Renovate itself and the
+  // pnpm it spawns. Measured: Renovate alone reaches ~2.0 GB by the time it
+  // runs pnpm, and one `pnpm update --lockfile-only --recursive` across this
+  // workspace needs another ~1.1-2.6 GB -- hence `kernel-out-of-memory`.
+  // Everything below exists to keep that sum under 3 GB.
   // See: https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout--kernel-out-of-memory-limit-with-a-pnpmyarn-project
   "env": {
     "PNPM_MAX_WORKERS": "1",
   },
+  // Node auto-sizes its heap to 1536 MB inside a 3 GB cgroup, so this only has
+  // any effect below that. 1024 is the floor -- pnpm dies with "JavaScript heap
+  // out of memory" at 768.
   "toolSettings": {
-    "nodeMaxMemory": 1536,
+    "nodeMaxMemory": 1024,
+  },
+
+  // Renovate holds every alert's full advisory text in memory, and these
+  // branches force `rangeStrategy: update-lockfile`, which is what spawns the
+  // pnpm run that gets OOM-killed. GitHub's own Dependabot alerts still fire;
+  // only Renovate's automatic security PRs are lost.
+  "vulnerabilityAlerts": {
+    "enabled": false,
   },
 
   "extends": [
@@ -42,13 +55,13 @@
 
   "labels": ["bot:renovate"],
 
-  // Raise the open-PR limits above Renovate's defaults (prConcurrentLimit: 10,
-  // prHourlyLimit: 2). This repo has enough active dependencies that a short
-  // triage lag lets the open-PR count reach 10, after which Renovate stops
-  // opening any new PR and parks every update as "Rate-Limited" on the
-  // Dependency Dashboard -- making it look like Renovate has stopped working.
-  "prConcurrentLimit": 20,
-  "prHourlyLimit": 4,
+  // Lowered from 20/4 (#2996). Renovate's own memory grows with every branch it
+  // works through -- measured 1.99 GB at 20 vs 1.54 GB at 5 -- and that 0.45 GB
+  // is what the pnpm run needs to survive. The cost is a longer triage queue:
+  // updates past the limit park as "Rate-Limited" on the Dependency Dashboard.
+  "prConcurrentLimit": 5,
+  "branchConcurrentLimit": 5,
+  "prHourlyLimit": 2,
 
   "packageRules": [
     {
@@ -265,9 +278,9 @@
     },
   ],
 
-  "postUpdateOptions": [
-    "pnpmDedupe",
-  ],
+  // No `pnpmDedupe`: `pnpm dedupe` alone exhausts the 3 GB job budget even with
+  // the lockfile intact, and it runs right after every successful update.
+  "postUpdateOptions": [],
   "ignoreDeps": [
     // align Node.js version minimum requirements
     "node",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,11 @@ minimumReleaseAgeExclude:
 # is available and skipped (with a warning) when it is not.
 minimumReleaseAgeStrict: false
 
+# Caps pnpm's concurrent registry fetches. Fewer in-flight packuments means a
+# lower peak: measured 2.56 -> 2.26 GB, which is what keeps the Renovate job
+# under Mend's 3 GB limit. Slower on a cold metadata cache, free on a warm one.
+networkConcurrency: 4
+
 peerDependencyRules:
   allowedVersions:
     "@lynx-js/lynx-ui>@types/react": "^19.2.0"


### PR DESCRIPTION
## Problem

The Mend-hosted Renovate job has been failing with `kernel-out-of-memory` — three consecutive jobs, all with the identical signature: die after ~3m40s, `3.0GB of 3.0GB` used, killed while running the **single** package-manager command on the `renovate/npm-vitest-vulnerability` branch.

Mend gives the whole job one **3 GB cgroup**, shared by the Renovate process *and* the pnpm it spawns. Previous fix ([#3000](https://github.com/lynx-family/lynx-stack/pull/3000)) set `nodeMaxMemory: 1536` + `PNPM_MAX_WORKERS: 1`, but the job in the OOM log ran *with those already in place* and still died.

## What I measured

Reproduced in a real 3 GB cgroup (`docker run --memory 3g --memory-swap 3g`, `/sys/fs/cgroup/memory.max` verified = exactly 3 GiB), running the actual renovate image with `--dry-run=full` (executes pnpm, blocks all writes):

| half of the budget | measured |
|---|---|
| Renovate's own RSS by the time it spawns pnpm | **1.32 – 2.02 GiB** (median 1.56) |
| one `pnpm update --lockfile-only --recursive` | **1.1 – 2.6 GiB** depending on cache warmth |

The two sum past 3 GB → the kernel kills it. `nodeMaxMemory: 1536` is a **no-op** in a 3 GB cgroup because Node already auto-sizes its heap to 1536 MB there (byte-identical `heap_size_limit` with and without the flag).

## The fix — shrink *both* halves

| change | effect (measured) |
|---|---|
| `vulnerabilityAlerts: { enabled: false }` | Renovate holds every advisory's full text in memory; self-RSS 1.99 → ~1.5 GiB. These branches also force the `update-lockfile` pnpm run that gets killed. |
| `prConcurrentLimit`/`branchConcurrentLimit` → 5 (from 20) | Renovate's memory grows per branch processed: 1.99 GiB at 20 vs 1.54 GiB at 5 |
| drop `pnpmDedupe` | `pnpm dedupe` alone saturates the 3 GB budget, and runs after every successful update |
| `nodeMaxMemory` 1536 → 1024 | 1536 is inert here; 1024 saves ~0.22 GiB (768 dies with V8 heap OOM, so 1024 is the floor) |
| `networkConcurrency: 4` | fewer concurrent packument fetches: pnpm peak 2.56 → 2.26 GiB |

**Verification:** with all of the above, a real `dry-run=full` in a 3 GB cgroup exits **0 with zero OOM-kill events**; without them the same run is **exit 137 (SIGKILL)**.

## Trade-offs (deliberate)

- **`vulnerabilityAlerts: false`** — Renovate no longer opens security-update PRs automatically. GitHub's Dependabot alerts still fire; they just need manual triage.
- **Lower concurrency limits** — updates past 5 park as "Rate-Limited" on the Dependency Dashboard; the triage queue is longer.

## Caveats

- Peak still *touches* 3.00 GiB (survives via kernel reclaim), so headroom is thin — further dependency growth could bring it back.
- `networkConcurrency` was measured on the pnpm command in isolation; I could not inject `pnpm-workspace.yaml` into Renovate's own clone without merging first, so its effect inside the full pipeline is inferred, not end-to-end verified.

## Separate issues found (not fixed here)

- Lock file maintenance additionally fails with `ERR_PNPM_PEER_DEP_ISSUES`: `react-i18next@17.0.10` wants `i18next >= 26.2.0`, lockfile has 26.0.6.
- pnpm has an upstream memory regression tracked in [pnpm/pnpm#12868](https://github.com/pnpm/pnpm/issues/12868); 11.15.1 (current) contains the main fix ([#13133](https://github.com/pnpm/pnpm/pull/13133)) — do **not** downgrade pnpm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced automated dependency update activity to limit concurrent pull requests and registry requests.
  * Disabled vulnerability alert processing and automatic package deduplication during updates.
  * Improved resource management for automated dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->