### PR TITLE
fix: `auto-height` for frame

### DIFF
--- a/.changeset/olive-hounds-invite.md
+++ b/.changeset/olive-hounds-invite.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+fix `auto-height` for frame

--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -110,7 +110,7 @@ Keep both `web` and `lynx` environments enabled when the same lazy demo should r
 
 LazyComponent demo data should contain complete `url` and `webUrl` values before it reaches preview rendering. Build those URLs at data construction time from the runtime playground base URL, with query and hash removed and file paths such as `render.html` collapsed to their containing directory. Keep this resolution in the demo data layer, not in `PreviewPanel`.
 
-Only demos backed by files copied to `dist/demos/*.json` should use `demoId` short links. Runtime-built demos such as `lazy-component` should remain known playground scenarios but pass inline `messages` into web preview and native QR preview links, because no `demos/lazy-component.json` file exists.
+Only demos backed by files copied to `dist/demos/*.json` should use `demoId` short links. Runtime-built demos such as `lazy-component` and `mcp-app` should remain known playground scenarios but pass inline `messages` into web preview and native QR preview links, because no corresponding `dist/demos/*.json` file exists.
 
 Keep `PreviewPanel` unaware of LazyComponent payload structure. It should choose between `demoId`, `messagesUrl`, and inline `messages/actionMocks`, then pass the selected payload through unchanged for web preview and QR/native preview paths.
 

--- a/packages/genui/playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/playground/src/components/PreviewPanel.tsx
@@ -33,6 +33,7 @@ import {
   buildOpenUIRenderUrl,
   buildRenderUrl,
   canInlineOpenUIRenderUrl,
+  hasShareableA2UIRenderPayload,
 } from '../utils/renderUrl.js';
 
 declare const __A2UI_PLAYGROUND_CLIENT_PAYLOAD_STORE__: boolean;
@@ -583,13 +584,9 @@ export function PreviewPanel(props: PreviewPanelProps) {
 
     if (previewSource.kind === 'a2ui') {
       const useClientPayloadStore = shouldUseClientPayloadStore();
-      const canSharePayload = !!previewSource.demoId
-        || !!previewSource.messagesUrl
+      const canSharePayload = hasShareableA2UIRenderPayload(previewSource)
         || useClientPayloadStore;
-      const hasInlineMessages = Array.isArray(previewSource.messages)
-        ? previewSource.messages.length > 0
-        : previewSource.messages !== undefined;
-      if (!canSharePayload && !hasInlineMessages) {
+      if (!canSharePayload) {
         setRenderUrl('');
         setRenderShareUrl('');
         setLynxDevUrl('');
@@ -920,8 +917,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
     }
 
     const showQrCode = previewSource.kind !== 'a2ui'
-      || !!previewSource.demoId
-      || !!previewSource.messagesUrl;
+      || hasShareableA2UIRenderPayload(previewSource);
 
     const cards: Array<{ key: string; item: PreviewQrItem }> = [];
     if (renderShareUrl) {

--- a/packages/genui/playground/src/utils/renderUrl.test.ts
+++ b/packages/genui/playground/src/utils/renderUrl.test.ts
@@ -9,7 +9,29 @@ import {
   buildMcpAppsRenderUrl,
   buildOpenUIRenderUrl,
   canInlineOpenUIRenderUrl,
+  hasShareableA2UIRenderPayload,
 } from './renderUrl.js';
+
+describe('A2UI render payloads', () => {
+  test('treats runtime-built inline messages as shareable', () => {
+    expect(hasShareableA2UIRenderPayload({
+      messages: [{ createSurface: { surfaceId: 'default' } }],
+    })).toBe(true);
+  });
+
+  test('requires content or an external payload reference', () => {
+    expect(hasShareableA2UIRenderPayload({ messages: [] })).toBe(false);
+    expect(hasShareableA2UIRenderPayload({ messages: undefined })).toBe(false);
+    expect(hasShareableA2UIRenderPayload({
+      demoId: 'mcp-app',
+      messages: [],
+    })).toBe(true);
+    expect(hasShareableA2UIRenderPayload({
+      messages: [],
+      messagesUrl: 'https://example.com/messages.json',
+    })).toBe(true);
+  });
+});
 
 describe('OpenUI render URLs', () => {
   test('marks oversized inline rawText URLs as unsafe', () => {

--- a/packages/genui/playground/src/utils/renderUrl.ts
+++ b/packages/genui/playground/src/utils/renderUrl.ts
@@ -50,6 +50,15 @@ export interface McpAppsRenderInit {
   theme?: 'light' | 'dark';
 }
 
+export function hasShareableA2UIRenderPayload(
+  init: Pick<RenderInit, 'demoId' | 'messages' | 'messagesUrl'>,
+): boolean {
+  if (init.demoId || init.messagesUrl) return true;
+  return Array.isArray(init.messages)
+    ? init.messages.length > 0
+    : init.messages !== undefined;
+}
+
 function buildRenderInitData(init: RenderInit): Record<string, unknown> {
   const initData: Record<string, unknown> = {
     protocol: init.protocol.name,

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -396,14 +396,17 @@ test.describe('reactlynx3 tests', () => {
 
     test('api-frame-auto-height', async ({ page }, { title }) => {
       await goto(page, title);
-      await expect(page.locator('#target')).toHaveAttribute(
+      const target = page.locator('#target');
+      await expect(target).toHaveAttribute(
         'auto-height',
         'true',
       );
-      await expect(page.locator('#target')).not.toHaveAttribute(
+      await expect(target).not.toHaveAttribute(
         'height',
         'auto',
       );
+      await expect(target).toHaveCSS('contain', 'content');
+      expect((await target.boundingBox())?.height).toBeGreaterThan(0);
     });
 
     test('api-frame-auto-width', async ({ page }, { title }) => {

--- a/packages/web-platform/web-core/css/index.css
+++ b/packages/web-platform/web-core/css/index.css
@@ -35,8 +35,10 @@ lynx-view[width="auto"] {
 }
 
 :host([height="auto"]),
+:host([auto-height]),
 :host([width="auto"]),
 lynx-view[height="auto"],
+lynx-view[auto-height],
 lynx-view[width="auto"] {
   contain: content;
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved sharing and QR preview availability for runtime-built A2UI content.
  * Added support for sharing previews with inline messages or external payloads.

* **Bug Fixes**
  * Fixed frame auto-height behavior, including sizing and content containment.

* **Documentation**
  * Clarified when demo links should use short IDs versus inline preview messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
