### PR TITLE
revert(renovate): drop all Mend 3 GB memory workarounds

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,30 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  // Mend-hosted gives the whole job 3 GB, shared by Renovate itself and the
-  // pnpm it spawns. Measured: Renovate alone reaches ~2.0 GB by the time it
-  // runs pnpm, and one `pnpm update --lockfile-only --recursive` across this
-  // workspace needs another ~1.1-2.6 GB -- hence `kernel-out-of-memory`.
-  // Everything below exists to keep that sum under 3 GB.
-  // See: https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout--kernel-out-of-memory-limit-with-a-pnpmyarn-project
-  "env": {
-    "PNPM_MAX_WORKERS": "1",
-  },
-  // Node auto-sizes its heap to 1536 MB inside a 3 GB cgroup, so this only has
-  // any effect below that. 1024 is the floor -- pnpm dies with "JavaScript heap
-  // out of memory" at 768.
-  "toolSettings": {
-    "nodeMaxMemory": 1024,
-  },
-
-  // Renovate holds every alert's full advisory text in memory, and these
-  // branches force `rangeStrategy: update-lockfile`, which is what spawns the
-  // pnpm run that gets OOM-killed. GitHub's own Dependabot alerts still fire;
-  // only Renovate's automatic security PRs are lost.
-  "vulnerabilityAlerts": {
-    "enabled": false,
-  },
-
   "extends": [
     "config:recommended",
     ":maintainLockFilesWeekly",
@@ -55,13 +31,13 @@
 
   "labels": ["bot:renovate"],
 
-  // Lowered from 20/4 (#2996). Renovate's own memory grows with every branch it
-  // works through -- measured 1.99 GB at 20 vs 1.54 GB at 5 -- and that 0.45 GB
-  // is what the pnpm run needs to survive. The cost is a longer triage queue:
-  // updates past the limit park as "Rate-Limited" on the Dependency Dashboard.
-  "prConcurrentLimit": 5,
-  "branchConcurrentLimit": 5,
-  "prHourlyLimit": 2,
+  // Raise the open-PR limits above Renovate's defaults (prConcurrentLimit: 10,
+  // prHourlyLimit: 2). This repo has enough active dependencies that a short
+  // triage lag lets the open-PR count reach 10, after which Renovate stops
+  // opening any new PR and parks every update as "Rate-Limited" on the
+  // Dependency Dashboard -- making it look like Renovate has stopped working.
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 4,
 
   "packageRules": [
     {
@@ -278,9 +254,9 @@
     },
   ],
 
-  // No `pnpmDedupe`: `pnpm dedupe` alone exhausts the 3 GB job budget even with
-  // the lockfile intact, and it runs right after every successful update.
-  "postUpdateOptions": [],
+  "postUpdateOptions": [
+    "pnpmDedupe",
+  ],
   "ignoreDeps": [
     // align Node.js version minimum requirements
     "node",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,11 +59,6 @@ minimumReleaseAgeExclude:
 # is available and skipped (with a warning) when it is not.
 minimumReleaseAgeStrict: false
 
-# Caps pnpm's concurrent registry fetches. Fewer in-flight packuments means a
-# lower peak: measured 2.56 -> 2.26 GB, which is what keeps the Renovate job
-# under Mend's 3 GB limit. Slower on a cold metadata cache, free on a warm one.
-networkConcurrency: 4
-
 peerDependencyRules:
   allowedVersions:
     "@lynx-js/lynx-ui>@types/react": "^19.2.0"


### PR DESCRIPTION
## What

Removes **all** Mend-3GB-specific memory workarounds from the Renovate config, restoring it to its pre-#3000 state:

- restore `postUpdateOptions: ["pnpmDedupe"]` — required by the `pnpm dedupe --check` gate in CI (`nodejs-dependencies.yml`); its removal in #3019 left every lockfile-touching renovate PR failing that check
- restore `vulnerabilityAlerts` (automatic security PRs re-enabled)
- restore `prConcurrentLimit: 20` / `prHourlyLimit: 4` (#2996), drop `branchConcurrentLimit`
- drop `env.PNPM_MAX_WORKERS` + `toolSettings.nodeMaxMemory` (#3000 / #3019)
- drop the pnpm `networkConcurrency` cap in `pnpm-workspace.yaml` (#3019)

## Why

Renovate is moving off Mend-hosted (3 GB / 30 min hard caps, measured impossible for this repo: renovate alone needs 1.3–2.0 GB and one recursive lockfile update needs another 1.1–2.6 GB) onto a **self-hosted runner** on internal CI with no such caps.

The self-hosted pipeline has been validated end-to-end with `--dry-run=full`: config validation passes, 585 updates / 123 branches computed, GitHub App auth works, zero writes. With no 3 GB ceiling, none of these mitigations are needed — and `pnpmDedupe` in particular must come back so renovate PRs pass CI.

`renovate-config-validator`: **Config validated successfully**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency updates by allowing more updates to be processed concurrently.
  * Dependency updates now include an automatic package deduplication step.
  * Restored vulnerability alert handling in automated dependency maintenance.
  * Increased package manager network concurrency to improve update throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->