### PR TITLE
fix(react): skip destroying transferred lists

### DIFF
--- a/.changeset/quiet-lists-transfer.md
+++ b/.changeset/quiet-lists-transfer.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Prevent stale snapshot teardown from destroying list callbacks and recycling state after rendered elements are transferred to a new snapshot instance.

--- a/packages/react/runtime/__test__/snapshot/list.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/list.test.jsx
@@ -4884,3 +4884,35 @@ describe('clear __UpdateListCallbacks', () => {
     expect(listElement.componentAtIndexes()).toBeUndefined();
   });
 });
+
+describe('destroy list after element transfer', () => {
+  it('does not destroy a list after its elements are transferred', () => {
+    const parentSnapshot = __SNAPSHOT__(<view>{HOLE}</view>);
+    const childSnapshot = __SNAPSHOT__(<view>{HOLE}</view>);
+    const listSnapshot = __SNAPSHOT__(<list>{HOLE}</list>);
+
+    const parent = new SnapshotInstance(parentSnapshot, 101);
+    const child = new SnapshotInstance(childSnapshot, 102);
+    const list = new SnapshotInstance(listSnapshot, 103);
+    parent.ensureElements();
+    parent.insertBefore(child);
+    child.insertBefore(list);
+
+    const listElement = list.__elements[0];
+    const listID = __GetElementUniqueID(listElement);
+
+    const renderedOwner = parent.takeElements();
+    const transferredChild = renderedOwner.childNodes[0];
+    const transferredList = transferredChild.childNodes[0];
+
+    expect(list.__elements).toBeUndefined();
+    expect(transferredList.__elements[0]).toBe(listElement);
+    expect(() => parent.removeChild(child)).not.toThrow();
+    expect(gSignMap[listID]).toBeDefined();
+    expect(gRecycleMap[listID]).toBeDefined();
+
+    renderedOwner.removeChild(transferredChild);
+    expect(gSignMap[listID]).toBeUndefined();
+    expect(gRecycleMap[listID]).toBeUndefined();
+  });
+});

--- a/packages/react/runtime/src/snapshot/snapshot/list.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/list.ts
@@ -41,7 +41,14 @@ export function snapshotCreateList(
 
 export function snapshotDestroyList(si: SnapshotInstance): void {
   const [, elementIndex] = si.__snapshot_def.slot[0]!;
-  const list = si.__elements![elementIndex]!;
+  const list = si.__elements?.[elementIndex];
+  // `takeElements` and hydration transfer the rendered elements to a new
+  // SnapshotInstance while leaving the old instance tree available for
+  // teardown. Only the instance that still owns the list element may clean up
+  // its callbacks and recycling state.
+  if (list === undefined) {
+    return;
+  }
   const listID = __GetElementUniqueID(list);
 
   __UpdateListCallbacks(list, () => -1, () => {}, () => {});


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed list lifecycle handling when rendered elements move to a new snapshot.
  - Prevented stale cleanup from removing active list callbacks or recycling state prematurely.
  - Ensured transferred list elements remain usable until their container is removed.
- **Tests**
  - Added coverage for list ownership transfers and cleanup of associated lifecycle state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Skip list teardown when a stale `SnapshotInstance` no longer owns the rendered list element.
- Preserve callbacks and recycling state for the new snapshot owner after element transfer.
- Add a regression test covering teardown by both the stale owner and the current owner.
- Add a patch changeset for `@lynx-js/react`.

## Root cause

List reuse can transfer rendered elements from an old snapshot tree to a new `SnapshotInstance` while the old tree remains available for teardown. A later ancestor removal traversed that stale tree and `snapshotDestroyList` unconditionally accessed `si.__elements[elementIndex]`. Because the old owner had already relinquished its elements, this threw a `TypeError` and could abort the main-thread snapshot patch.

The missing element means this instance is no longer the list owner, so it must not clear callbacks or recycling maps that belong to the transferred list.

## User impact

This prevents main-thread exceptions during nested or asynchronous list reuse followed by subtree removal, including secondary `snapshotPatchApply failed: ctx not found` errors caused by the interrupted patch.

## Validation

- `fnm exec --using 24 pnpm turbo build` — 65/65 tasks passed.
- `fnm exec --using 24 pnpm --dir packages/react/runtime exec vitest run __test__/snapshot/list.test.jsx` — 45/45 tests passed.
- `fnm exec --using 24 pnpm changeset status --since=origin/main` — React patch changeset recognized.
- `pnpm dprint fmt` on all changed files and `git diff --check` passed.

## Checklist

- [x] Tests updated.
- [x] Documentation not required.
- [x] Changeset added; no breaking change.