### PR TITLE
chore(renovate): group devDependencies minor/patch into one rolling PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,6 +47,18 @@
       "rangeStrategy": "bump",
     },
     {
+      // Batch low-risk updates: all devDependencies minor/patch bumps share one
+      // rolling PR instead of one PR each. Kept FIRST on purpose -- the specific
+      // groups below (Rspack, types, linting, ...) match later and win, so they
+      // keep their own PRs; only otherwise-ungrouped dev deps land here.
+      // dependencies and every major update keep individual PRs for precise
+      // review and rollback.
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev minor & patch",
+      "groupSlug": "dev-non-major",
+    },
+    {
       "groupName": "Rspack",
       "groupSlug": "Rspack",
       "addLabels": ["upstream:rspack"],


### PR DESCRIPTION
## What

Adds one `packageRules` entry that batches **devDependencies minor/patch** updates into a single rolling **"dev minor & patch"** PR, instead of one PR per dependency.

## Why

The self-hosted Renovate rollout opened ~56 individual PRs in one day. Steady-state volume will be much lower, but low-risk dev-dep bumps still don't each deserve a PR + CI run + review. This is the same pattern as the widely-used `group:allNonMajor` preset (1100+ repos on GitHub, incl. sveltejs/kit, redux-devtools, grafana/mcp-grafana), scoped down to the safest slice.

## Design notes

- **Rule is deliberately FIRST** in `packageRules`: the 15 specific groups below (Rspack, Rsbuild, Rspress, types, linting, …) match later and override `groupName`, so their behavior is unchanged. Only otherwise-ungrouped dev deps land in the batch.
- **Runtime `dependencies` and every `major` update keep individual PRs** — precise review and rollback where risk is real.
- **No `schedule` on the group (yet)**: a `schedule` here would leak into specific groups that don't set their own (packageRules merge field-by-field). Can be added later with explicit excludes if weekly batching is wanted.

`renovate-config-validator`: Config validated successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved maintenance automation by grouping routine, non-major development updates into consolidated rolling pull requests.
  * This reduces update noise and makes routine maintenance changes easier to review while preserving separate handling for major updates and explicitly grouped changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->