### PR TITLE
fix(web-elements): correct 'mesaurement' typo to 'measurement'

### DIFF
--- a/.changeset/fix-measurement-typo.md
+++ b/.changeset/fix-measurement-typo.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Fix internal variable typo (`mesaurement` -> `measurement`). No behavior change.

--- a/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
@@ -461,11 +461,11 @@ class TextRenderingMeasureTool {
     if (lastRectInfo.node.nodeType === Node.TEXT_NODE) {
       const { rect, rectIndex } = lastRectInfo;
       const textNode = lastRectInfo.node as Text;
-      const mesaurementRange = document.createRange();
-      mesaurementRange.selectNode(textNode);
+      const measurementRange = document.createRange();
+      measurementRange.selectNode(textNode);
       for (let charIndex = 0; charIndex < textNode.data.length; charIndex++) {
-        mesaurementRange.setEnd(textNode, charIndex);
-        const targetRect = mesaurementRange.getClientRects().item(rectIndex);
+        measurementRange.setEnd(textNode, charIndex);
+        const targetRect = measurementRange.getClientRects().item(rectIndex);
         if (targetRect && targetRect.right === rect.right) {
           return charIndex;
         }


### PR DESCRIPTION
Pure variable rename (4 occurrences in `XTextTruncation.ts`, introduced in #2998). No behavior change — but this typo fails the required `test-typos` check on every PR whose CI runs against current main (all renovate PRs included), blocking the merge queue.

**Evidence** — #3068 (`chore(deps): update github-actions`, touches only `.github/workflows`, never this file) fails `test-typos` with exactly these 4 hits:

https://github.com/lynx-family/lynx-stack/actions/runs/29932953299/job/88967118223?pr=3068

```
error: `mesaurement` should be `measurement`
  --> ./packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts:465:9
  --> ./packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts:467:9
  --> ./packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts:468:28
Process completed with exit code 2.
```

PRs whose CI ran before #2998 landed on main still show `test-typos: pass`; any rerun or new PR from now on hits this deterministically (typos scans the whole repo on the merge ref).

No changeset: variable rename only, no observable change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an internal text measurement naming issue.
  * No user-visible behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->