### PR TITLE
chore(deps): upgrade @lynx-js/type-config to 4.1.1

### DIFF
--- a/.changeset/upgrade-type-config-4.md
+++ b/.changeset/upgrade-type-config-4.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/config-rsbuild-plugin": minor
+---
+
+Upgrade `@lynx-js/type-config` to `4.1.1`

--- a/packages/rspeedy/plugin-config/package.json
+++ b/packages/rspeedy/plugin-config/package.json
@@ -38,7 +38,7 @@
     "test:type": "tsc --noEmit"
   },
   "dependencies": {
-    "@lynx-js/type-config": "3.6.0"
+    "@lynx-js/type-config": "4.1.1"
   },
   "devDependencies": {
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/plugin-config/test/cases/basic/compile-options/index.js
+++ b/packages/rspeedy/plugin-config/test/cases/basic/compile-options/index.js
@@ -3,11 +3,11 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-it('should override existing config', async () => {
+it('should not apply config to compiler options', async () => {
   const content = await readFile(path.join(__dirname, 'tasm.json'), 'utf-8')
   const { compilerOptions, sourceContent } = JSON.parse(content)
 
-  expect(compilerOptions).toHaveProperty('enableCSSSelector', false)
+  expect(compilerOptions).toHaveProperty('enableCSSSelector', true)
   expect(sourceContent.config).not.toHaveProperty('enableCSSSelector')
 })
 

--- a/packages/rspeedy/plugin-config/test/config.test-d.ts
+++ b/packages/rspeedy/plugin-config/test/config.test-d.ts
@@ -25,14 +25,14 @@ type UnionToTuple<U, T extends unknown[] = []> = [U] extends [T[number]] ? T
 describe('config length', () => {
   it('type config compiler option should have expected length', () => {
     expectTypeOf<UnionToTuple<keyof TypeConfig.CompilerOptions>['length']>()
-      .toEqualTypeOf<26>()
+      .toEqualTypeOf<0>()
   })
   it('type config config should have expected length', () => {
     expectTypeOf<UnionToTuple<keyof TypeConfig.Config>['length']>()
-      .toEqualTypeOf<120>()
+      .toEqualTypeOf<31>()
   })
   it('pluginLynxConfig config should have expected length', () => {
     expectTypeOf<UnionToTuple<keyof Config>['length']>()
-      .toEqualTypeOf<145>()
+      .toEqualTypeOf<31>()
   })
 })

--- a/packages/rspeedy/plugin-config/test/validate.test.ts
+++ b/packages/rspeedy/plugin-config/test/validate.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from '@rstest/core'
 import { validate } from '../src/validate.js'
 
 describe('validate', () => {
-  describe('compile options', () => {
+  describe('unsupported keys', () => {
     test('multiple errors', () => {
       expect(() =>
         validate({
@@ -28,7 +28,12 @@ describe('validate', () => {
         validate({
           debugInfoOutside: false,
         })
-      ).not.toThrow()
+      ).toThrowErrorMatchingInlineSnapshot(`
+        [Error: [pluginLynxConfig] Invalid configuration.
+
+          Unsupported configuration: \`$input.debugInfoOutside\`
+        ]
+      `)
     })
 
     test('defaultDisplayLinear', () => {
@@ -36,7 +41,12 @@ describe('validate', () => {
         validate({
           defaultDisplayLinear: false,
         })
-      ).not.toThrow()
+      ).toThrowErrorMatchingInlineSnapshot(`
+        [Error: [pluginLynxConfig] Invalid configuration.
+
+          Unsupported configuration: \`$input.defaultDisplayLinear\`
+        ]
+      `)
     })
 
     test('defaultOverflowVisible', () => {
@@ -44,7 +54,12 @@ describe('validate', () => {
         validate({
           defaultOverflowVisible: false,
         })
-      ).not.toThrow()
+      ).toThrowErrorMatchingInlineSnapshot(`
+        [Error: [pluginLynxConfig] Invalid configuration.
+
+          Unsupported configuration: \`$input.defaultOverflowVisible\`
+        ]
+      `)
     })
 
     test('enableCSSInvalidation', () => {
@@ -52,7 +67,12 @@ describe('validate', () => {
         validate({
           enableCSSInvalidation: false,
         })
-      ).not.toThrow()
+      ).toThrowErrorMatchingInlineSnapshot(`
+        [Error: [pluginLynxConfig] Invalid configuration.
+
+          Unsupported configuration: \`$input.enableCSSInvalidation\`
+        ]
+      `)
     })
 
     test('enableCSSSelector', () => {
@@ -60,7 +80,12 @@ describe('validate', () => {
         validate({
           enableCSSSelector: false,
         })
-      ).not.toThrow()
+      ).toThrowErrorMatchingInlineSnapshot(`
+        [Error: [pluginLynxConfig] Invalid configuration.
+
+          Unsupported configuration: \`$input.enableCSSSelector\`
+        ]
+      `)
     })
 
     test('enableRemoveCSSScope', () => {
@@ -68,7 +93,12 @@ describe('validate', () => {
         validate({
           enableRemoveCSSScope: false,
         })
-      ).not.toThrow()
+      ).toThrowErrorMatchingInlineSnapshot(`
+        [Error: [pluginLynxConfig] Invalid configuration.
+
+          Unsupported configuration: \`$input.enableRemoveCSSScope\`
+        ]
+      `)
     })
 
     test('targetSdkVersion', () => {
@@ -76,24 +106,14 @@ describe('validate', () => {
         validate({
           targetSdkVersion: '1.1.0',
         })
-      ).not.toThrow()
-
-      expect(() =>
-        validate({
-          targetSdkVersion: false,
-        })
       ).toThrowErrorMatchingInlineSnapshot(`
         [Error: [pluginLynxConfig] Invalid configuration.
 
-        Invalid config on \`$input.targetSdkVersion\`.
-          - Expect to be (string | undefined)
-          - Got: boolean
+          Unsupported configuration: \`$input.targetSdkVersion\`
         ]
       `)
     })
-  })
 
-  describe('invalid config', () => {
     test('customCSSInheritanceList', () => {
       expect(() =>
         validate({
@@ -102,13 +122,7 @@ describe('validate', () => {
       ).toThrowErrorMatchingInlineSnapshot(`
         [Error: [pluginLynxConfig] Invalid configuration.
 
-        Invalid config on \`$input.customCSSInheritanceList[0]\`.
-          - Expect to be string
-          - Got: number
-
-        Invalid config on \`$input.customCSSInheritanceList[1]\`.
-          - Expect to be string
-          - Got: number
+          Unsupported configuration: \`$input.customCSSInheritanceList\`
         ]
       `)
     })
@@ -131,10 +145,8 @@ describe('validate', () => {
     expect(() =>
       validate({
         enableAccessibilityElement: true,
-        customCSSInheritanceList: ['foo', 'bar'],
         enableCSSInheritance: true,
         enableNewGesture: true,
-        pipelineSchedulerConfig: 1,
       })
     ).not.toThrow()
   })

--- a/packages/rspeedy/plugin-react/test/config-plugin.test.ts
+++ b/packages/rspeedy/plugin-react/test/config-plugin.test.ts
@@ -10,14 +10,14 @@ import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
 import { pluginReactLynx } from '../src/pluginReactLynx.js'
 
 describe('config plugin', () => {
-  test('use targetSdkVersion from pluginLynxConfig', async () => {
+  test('use targetSdkVersion from pluginReactLynx', async () => {
     const rspeedy = await createRspeedy({
       rspeedyConfig: {
         plugins: [
-          pluginReactLynx(),
-          pluginLynxConfig({
+          pluginReactLynx({
             targetSdkVersion: '3.4',
           }),
+          pluginLynxConfig({}),
         ],
       },
       // eslint-disable-next-line n/no-unsupported-features/node-builtins
@@ -41,7 +41,7 @@ describe('config plugin', () => {
         plugins: [
           pluginReactLynx(),
           pluginLynxConfig({
-            enableCSSSelector: false,
+            enableCSSInheritance: true,
           }),
         ],
       },
@@ -57,7 +57,7 @@ describe('config plugin', () => {
 
     // @ts-expect-error private field
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(templatePlugin?.options.enableCSSSelector).toBe(false)
+    expect(templatePlugin?.options.enableCSSInheritance).toBe(true)
   })
 
   test('config in pluginLynxConfig should override user options', async () => {
@@ -65,10 +65,10 @@ describe('config plugin', () => {
       rspeedyConfig: {
         plugins: [
           pluginReactLynx({
-            enableCSSSelector: true,
+            enableCSSInheritance: false,
           }),
           pluginLynxConfig({
-            enableCSSSelector: false,
+            enableCSSInheritance: true,
           }),
         ],
       },
@@ -84,7 +84,7 @@ describe('config plugin', () => {
 
     // @ts-expect-error private field
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(templatePlugin?.options.enableCSSSelector).toBe(false)
+    expect(templatePlugin?.options.enableCSSInheritance).toBe(true)
   })
 
   test('should not throw when having extra config in pluginLynxConfig', async () => {
@@ -93,7 +93,7 @@ describe('config plugin', () => {
         plugins: [
           pluginReactLynx(),
           pluginLynxConfig({
-            defaultOverflowVisible: false,
+            enableNativeList: false,
           }),
         ],
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1537,8 +1537,8 @@ importers:
   packages/rspeedy/plugin-config:
     dependencies:
       '@lynx-js/type-config':
-        specifier: 3.6.0
-        version: 3.6.0
+        specifier: 4.1.1
+        version: 4.1.1
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: workspace:*
@@ -4466,8 +4466,8 @@ packages:
     resolution: {integrity: sha512-Zyl74cKi+BDggeXroLQG4frbBuiQ0DB0yH0C3pMkUHWv17abWTdJ2mw/H9Cd1QiIr+aQHn1U2SRtsrbkmWMtJw==}
     engines: {node: '>=18'}
 
-  '@lynx-js/type-config@3.6.0':
-    resolution: {integrity: sha512-XS+Wdbs77iWaVqrs1HKp3LyTLLHbu/AwLwy837BinmyNO28YunkgnOz0dmuzjnGGsbKJB3Alm7RoYrH/PAsVuQ==}
+  '@lynx-js/type-config@4.1.1':
+    resolution: {integrity: sha512-YuzuLkz71WoAgHnYEGkCgmocTW0mzcmQTDDF5zfvpNepD/Oxh4/yqxRhK+uaiJeJnPhTFM445ZRaFnBrSRTOag==}
 
   '@lynx-js/type-element-api@0.0.3':
     resolution: {integrity: sha512-e8+V1aU9VD6fmVJhS1VoE5ZxUD2udhEtTTsGBj2jlxYNscND2V6fyYFGF/dUPN+s9EwRiB80vUY/Im8tYSsMWA==}
@@ -13998,7 +13998,7 @@ snapshots:
     dependencies:
       immer: 10.2.0
 
-  '@lynx-js/type-config@3.6.0': {}
+  '@lynx-js/type-config@4.1.1': {}
 
   '@lynx-js/type-element-api@0.0.3': {}
 


### PR DESCRIPTION
## Summary

Upgrade `@lynx-js/type-config` from `3.6.0` to the first open-source release `4.1.1`.

The open-source package intentionally exposes only the essential Lynx config keys (31 in 4.1.1) and drops **compiler options** (`compilerOptionsKeys` is now empty). More keys will be added on demand.

## Changes

- `packages/rspeedy/plugin-config`: bump the `@lynx-js/type-config` dependency to `4.1.1`.
- Update tests to the trimmed key surface:
  - `test/config.test-d.ts`: expected key counts — `CompilerOptions` 26→0, `Config` 120→31.
  - `test/validate.test.ts`: former compiler-option keys (`debugInfoOutside`, `enableCSSSelector`, …) and removed config keys (`customCSSInheritanceList`, `pipelineSchedulerConfig`) are now rejected as unsupported.
  - `test/cases/basic/compile-options`: with an empty `compilerOptionsKeys`, config values no longer override compiler options.
  - `plugin-react/test/config-plugin.test.ts`: the config-bridge tests now use surviving keys; `targetSdkVersion` is set via `pluginReactLynx` (its supported path — it is deliberately not exposed as a Lynx config key).

## Notes

`compilerOptionsKeys` being empty means passing compiler options through `pluginLynxConfig` now throws a validation error. This matches the open-source package's current surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated configuration support to the latest type configuration release.
  * Added support for revised configuration option names and handling.

* **Bug Fixes**
  * Corrected configuration precedence and compiler option behavior.
  * Improved validation and reporting for unsupported configuration settings.

* **Tests**
  * Updated configuration and React plugin tests to reflect the revised options and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->