### PR TITLE
chore: remove bind cpusets for walltime check

### DIFF
--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -127,7 +127,7 @@ jobs:
           sync; echo 1 > /proc/sys/vm/drop_caches
           export HOME=/root
           . "$HOME/.cargo/env"
-          taskset -c 176-191 codspeed run --mode walltime -- pnpm -r run --workspace-concurrency=1 bench
+          codspeed run --mode walltime -- pnpm -r run --workspace-concurrency=1 bench
       - name: React benchmark - Run perfetto
         run: |
           pnpm -r run --workspace-concurrency=1 perfetto


### PR DESCRIPTION
remove bind cpusets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark execution to run without restricting the process to a fixed CPU range.
  * Preserved wall-time benchmark mode while allowing the environment to manage CPU allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->