### PR TITLE
fix(web): preserve cached bundles with override config

### DIFF
--- a/.changeset/preserve-override-blob-urls.md
+++ b/.changeset/preserve-override-blob-urls.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Reuse the first bundle loaded for a URL and ignore override configs from later requests without replacing or disposing the cached bundle.

--- a/.github/web-core-template-manager.instructions.md
+++ b/.github/web-core-template-manager.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/ts/client/{mainthread/TemplateManager.ts,decodeWorker/**},packages/web-platform/web-core/tests/template-manager.spec.ts"
+---
+
+Treat a bundle URL as identifying the first bundle loaded by `TemplateManager.fetchBundle`. When the same URL is requested again, including while its first load is still pending, reuse that load and ignore any later override config instead of comparing or applying it. Do not refetch, replace the cached bundle, free its stylesheet, or revoke its published Lepus/background Blob URLs. Continue disposing unpublished partial resources after a load error.

--- a/packages/web-platform/web-core/tests/template-manager.spec.ts
+++ b/packages/web-platform/web-core/tests/template-manager.spec.ts
@@ -307,6 +307,175 @@ describe('Template Manager', () => {
     );
   });
 
+  test('should reuse a bundle and ignore a later overrideConfig', async () => {
+    const templateUrl = 'http://example.com/template_override_blob_test';
+    const encoded = encode({
+      ...sampleTasm,
+      manifest: {
+        '/app-service.js': 'module.exports = "background";',
+      },
+    });
+
+    (globalThis.fetch as any).mockImplementation(() => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoded);
+          controller.close();
+        },
+      });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: stream,
+      });
+    });
+
+    await templateManager.fetchBundle(
+      templateUrl,
+      Promise.resolve(mockLynxViewInstance),
+      false,
+      false,
+      false,
+      {
+        cardType: 'first-card',
+        enableCSSSelector: 'true',
+      },
+    );
+
+    const oldBundle = templateManager.getBundle(templateUrl);
+    expect(Object.values(oldBundle?.lepusCode ?? {}).length).toBeGreaterThan(0);
+    expect(Object.values(oldBundle?.backgroundCode ?? {}).length)
+      .toBeGreaterThan(0);
+
+    const createBundleSpy = rstest.spyOn(templateManager, 'createBundle');
+    const revokeObjectURLSpy = rstest.spyOn(URL, 'revokeObjectURL');
+    try {
+      await templateManager.fetchBundle(
+        templateUrl,
+        Promise.resolve(mockLynxViewInstance),
+        false,
+        false,
+        false,
+        {
+          cardType: 'ignored-card',
+        },
+      );
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(templateManager.getBundle(templateUrl)).toBe(oldBundle);
+      expect(templateManager.getBundle(templateUrl)?.config?.cardType)
+        .toBe('first-card');
+      expect(createBundleSpy).not.toHaveBeenCalled();
+      expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+    } finally {
+      createBundleSpy.mockRestore();
+      revokeObjectURLSpy.mockRestore();
+    }
+  });
+
+  test('should not dispose a cached bundle for a later overrideConfig', async () => {
+    const templateUrl = 'http://example.com/template_override_conflict_test';
+    const encoded = encode(sampleTasm);
+
+    (globalThis.fetch as any).mockImplementation(() => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoded);
+          controller.close();
+        },
+      });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: stream,
+      });
+    });
+
+    await templateManager.fetchBundle(
+      templateUrl,
+      Promise.resolve(mockLynxViewInstance),
+      false,
+      false,
+      false,
+      { cardType: 'first-card' },
+    );
+
+    const oldBundle = templateManager.getBundle(templateUrl);
+    expect(oldBundle?.styleSheet).toBeDefined();
+    const createBundleSpy = rstest.spyOn(templateManager, 'createBundle');
+    const revokeObjectURLSpy = rstest.spyOn(URL, 'revokeObjectURL');
+    const freeStyleSheetSpy = rstest.spyOn(oldBundle!.styleSheet!, 'free');
+    try {
+      await templateManager.fetchBundle(
+        templateUrl,
+        Promise.resolve(mockLynxViewInstance),
+        false,
+        false,
+        false,
+        { cardType: 'ignored-card' },
+      );
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(templateManager.getBundle(templateUrl)).toBe(oldBundle);
+      expect(templateManager.getBundle(templateUrl)?.config?.cardType)
+        .toBe('first-card');
+      expect(createBundleSpy).not.toHaveBeenCalled();
+      expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+      expect(freeStyleSheetSpy).not.toHaveBeenCalled();
+    } finally {
+      createBundleSpy.mockRestore();
+      revokeObjectURLSpy.mockRestore();
+      freeStyleSheetSpy.mockRestore();
+    }
+  });
+
+  test('should ignore a later overrideConfig while the URL is loading', async () => {
+    const templateUrl =
+      'http://example.com/template_concurrent_override_conflict_test';
+    const encoded = encode(sampleTasm);
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      body: stream,
+    });
+
+    const firstLoad = templateManager.fetchBundle(
+      templateUrl,
+      Promise.resolve(mockLynxViewInstance),
+      false,
+      false,
+      false,
+      { cardType: 'first-card' },
+    );
+
+    const secondLoad = templateManager.fetchBundle(
+      templateUrl,
+      Promise.resolve(mockLynxViewInstance),
+      false,
+      false,
+      false,
+      { cardType: 'ignored-card' },
+    );
+
+    streamController.enqueue(encoded);
+    streamController.close();
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(templateManager.getBundle(templateUrl)?.config?.cardType)
+      .toBe('first-card');
+  });
+
   test('should load web-core.main-thread.json correctly', async () => {
     const jsonContent = {
       'styleInfo': {

--- a/packages/web-platform/web-core/ts/client/mainthread/TemplateManager.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/TemplateManager.ts
@@ -52,7 +52,7 @@ export class TemplateManager {
     transformREM: boolean,
     overrideConfig?: Record<string, string>,
   ): Promise<void> {
-    if (this.#bundles.has(url) && !overrideConfig) {
+    if (this.#bundles.has(url)) {
       return (async () => {
         const bundle = this.#bundles.get(url);
         const config = (bundle?.config || {}) as PageConfig;


### PR DESCRIPTION
## Summary

- reuse the first cached or in-flight bundle for a URL even when later requests provide `overrideConfig`
- ignore later override configs instead of refetching and replacing the cached bundle
- preserve the existing explicit `createBundle` replacement and cleanup behavior
- add regression coverage for Blob URLs, stylesheets, cached loads, and concurrent loads

## Why

`TemplateManager.fetchBundle` previously treated the presence of `overrideConfig` as a cache miss. A repeated request for the same URL could therefore call `createBundle`, revoke published Blob URLs, free the stylesheet, and replace the cached bundle. The URL should identify the first load; a later override config must not invalidate it.

## Impact

For the same URL, the first load and its config win. Later requests reuse that load without another fetch or disposal. Explicit bundle replacement and error cleanup remain unchanged.

## Validation

- `pnpm turbo build` — 65/65 tasks passed
- `pnpm --dir packages/web-platform/web-core test -- --run tests/template-manager.spec.ts` — 168/168 tests passed
- `pnpm dprint fmt ...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated bundle requests for the same URL now consistently reuse the first loaded bundle.
  * Later override settings no longer replace or recreate an existing bundle.
  * Concurrent requests share the initial load and avoid duplicate fetching, disposal, or resource revocation.

* **Tests**
  * Added coverage for cached bundle reuse, override handling, and concurrent loading scenarios.

* **Documentation**
  * Clarified the expected bundle-loading and resource-lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->