### PR TITLE
test(web): cover x-webview message event contract

### DIFF
--- a/.changeset/tidy-webviews-message.md
+++ b/.changeset/tidy-webviews-message.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Document and verify the `message` event forwarded from an `x-webview` iframe.

--- a/.github/web-core-e2e.instructions.md
+++ b/.github/web-core-e2e.instructions.md
@@ -3,3 +3,5 @@ applyTo: "packages/web-platform/web-core-e2e/**/*"
 ---
 
 When adding ReactLynx web-core-e2e cases that validate custom font faces, do not change `packages/web-platform/web-core/ts/client/decodeWorker/cssLoader.ts`; ReactLynx e2e fixtures are built into the binary template path by default. Keep `@font-face` declarations in the fixture CSS, and set font-related CSS properties directly on the `<text>` element so screenshot assertions cover text element font application instead of inherited wrapper styles.
+
+When testing ReactLynx `bind*` props against Web custom elements, use the developer-facing tag in the fixture and assert the complete ReactLynx event bridge. ReactLynx normalizes a prop such as `bindmessage` to the DOM event name `message`, so a custom element must emit the unprefixed event with `bubbles: true` and `composed: true`; a DOM-only test for a literal `bindmessage` event does not cover that contract.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -222,6 +222,13 @@ test.describe('reactlynx3 tests', () => {
       await wait(100);
       await expect(await target.getAttribute('style')).toContain('pink');
     });
+    test('basic-element-x-webview-bindmessage', async ({ page }, { title }) => {
+      test.skip(isSSR, 'x-webview iframe messaging runs on the client');
+      await goto(page, title);
+      await expect(page.locator('#webview-message')).toHaveText(
+        'hello from iframe',
+      );
+    });
     test('basic-event-target-id', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-webview-bindmessage/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-webview-bindmessage/index.jsx
@@ -1,0 +1,26 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useState } from '@lynx-js/react';
+
+function App() {
+  const [message, setMessage] = useState('waiting');
+
+  return (
+    <view>
+      <x-webview
+        html={`<script>
+          window.parent.postMessage(
+            { type: 'greeting', text: 'hello from iframe' },
+            '*',
+          );
+        </script>`}
+        bindmessage={event => setMessage(event.detail.msg.text)}
+        style={{ width: '300px', height: '120px' }}
+      />
+      <text id='webview-message'>{message}</text>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-elements/src/elements/XWebView/index.ts
+++ b/packages/web-platform/web-elements/src/elements/XWebView/index.ts
@@ -14,6 +14,8 @@
  * Events:
  * - `bindload`: Fired when the page loads. Detail: `{ url }`.
  * - `binderror`: Fired when an error occurs. Detail: `{ errorMsg }`.
+ * - `message`: Fired when the page posts a message to its parent. Detail:
+ *   `{ msg, data }`.
  * - `bindmessage`: Fired when a message is received from the page. Detail: `{ msg }`.
  *
  * Methods:

--- a/packages/web-platform/web-elements/tests/x-webview.spec.ts
+++ b/packages/web-platform/web-elements/tests/x-webview.spec.ts
@@ -89,4 +89,71 @@ test.describe('x-webview', () => {
     const data = await page.evaluate(() => window._bindmessage_data);
     expect(data.msg).toBe('hello from iframe');
   });
+
+  test('should forward iframe postMessage as message event', async ({ page }) => {
+    await goto(page, 'x-webview/basics');
+    const webview = page.locator('x-webview');
+
+    const messageEvent = await webview.evaluate(
+      el =>
+        new Promise(resolve => {
+          el.addEventListener(
+            'message',
+            event => {
+              const messageEvent = event as CustomEvent<{
+                msg: unknown;
+                data: unknown;
+              }>;
+              resolve({
+                bubbles: messageEvent.bubbles,
+                composed: messageEvent.composed,
+                detail: messageEvent.detail,
+              });
+            },
+            { once: true },
+          );
+          el.setAttribute(
+            'html',
+            `<script>
+              window.parent.postMessage(
+                { type: 'greeting', text: 'hello from iframe' },
+                '*',
+              );
+            </script>`,
+          );
+        }),
+    );
+
+    expect(messageEvent).toEqual({
+      bubbles: true,
+      composed: true,
+      detail: {
+        msg: { type: 'greeting', text: 'hello from iframe' },
+        data: { type: 'greeting', text: 'hello from iframe' },
+      },
+    });
+  });
+
+  test('should not forward messages from outside its iframe', async ({ page }) => {
+    await goto(page, 'x-webview/basics');
+    const webview = page.locator('x-webview');
+
+    const messageCount = await webview.evaluate(el => {
+      let messageCount = 0;
+      const handleMessage = () => messageCount++;
+      el.addEventListener('message', handleMessage);
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: 'message from parent window',
+          source: window,
+        }),
+      );
+
+      el.removeEventListener('message', handleMessage);
+      return messageCount;
+    });
+
+    expect(messageCount).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- document the `message` event emitted by `x-webview` when its iframe calls `window.parent.postMessage`
- add Web Component regression coverage for the forwarded `{ msg, data }` detail, bubbling/composed behavior, and iframe-source filtering
- add a ReactLynx E2E using the developer-facing `<x-webview bindmessage={...}>` API
- add a patch changeset for `@lynx-js/web-elements`

## Motivation

`x-webview` already performs source-filtered forwarding from its internal iframe. ReactLynx normalizes `bindmessage` to the underlying `message` event, so the unprefixed, bubbling, composed event is the relevant bridge contract. This PR makes that contract explicit and covers both the Web Component layer and the complete ReactLynx event path.

The iframe must post to its parent (`window.parent.postMessage(...)`); calling `window.postMessage(...)` inside the iframe targets the iframe itself.

## Validation

- `pnpm turbo build` (65/65 tasks passed)
- `pnpm --filter @lynx-js/web-elements exec playwright test tests/x-webview.spec.ts --project=chromium --reporter=line --workers=1` (7/7 passed)
- `pnpm --filter @lynx-js/web-core-e2e exec playwright test tests/reactlynx.spec.ts --project=chromium --reporter=line --workers=1 --grep=basic-element-x-webview-bindmessage` (1/1 passed)
- `pnpm dprint fmt .github/web-core-e2e.instructions.md packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-webview-bindmessage/index.jsx`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `x-webview` now forwards messages posted from its embedded page through a `message` event.
  * Message details include the message payload and associated data, with event propagation preserved.
  * ReactLynx `bindmessage` handlers can receive and respond to iframe messages.

* **Documentation**
  * Added documentation describing the `message` event and its payload format.

* **Tests**
  * Added coverage for forwarded iframe messages and filtering of unrelated parent-window messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->