### PR TITLE
chore(benchx): bump benchx_cli to release build (benchx_cli-202607240911)

### DIFF
--- a/packages/lynx/benchx_cli/scripts/build_unix.sh
+++ b/packages/lynx/benchx_cli/scripts/build_unix.sh
@@ -13,7 +13,7 @@ if [ ! -f "package.json" ] || ! grep -q '"name": "benchx_cli"' package.json; the
   exit 1
 fi
 
-LOCKED_VERSION="benchx_cli-202607011810"
+LOCKED_VERSION="benchx_cli-202607240911"
 
 # Check if binary is up to date
 if [ -f "./dist/bin/benchx_cli" ] && [ -f "./dist/bin/benchx_cli.version" ]; then


### PR DESCRIPTION
## Summary

Bumps the pinned `benchx_cli` binary (`LOCKED_VERSION` in `packages/lynx/benchx_cli/scripts/build_unix.sh`) from `benchx_cli-202607011810` to `benchx_cli-202607240911`.

The old binary was a **debug** build (`is_debug=true` → `-O0` across the whole engine, plus a debug-mode `mimalloc` with padding/canary/asserts). CodSpeed's simulation counts instructions, so that debug overhead inflated every benchmark. The new binary is a **release** build:

- `is_debug=false` `symbol_level=1` — the whole engine is `-O2` (`compile_commands` went from ~1265 TUs at `-O0` to release), symbols kept so callgrind/flamegraphs stay symbolicated (lynx-community/benchx_cli #12).
- `mimalloc` compiled release + optimized — `MI_DEBUG=0`, `NDEBUG`, `-O2` (benchx_cli #11).
- `-UNVALGRIND` for the benchx target so the CodSpeed simulation markers survive the optimized build (benchx_cli #13); walltime is unchanged.

## Impact

Isolated on the ReactLynx bench (codspeed-valgrind fork, same bundle, `MI_DEBUG` alone): whole-process estimated_cycles **−59%**; the full release build (engine `-O2` too) reduces it further. LoadScript and background-thread regions drop the most. This is a benchmark-harness correctness change — a shipped app runs against a release binary, so the numbers now reflect real optimized cost rather than debug-mode overhead.

## Validation

- The release Linux binary carries function symbols and runs a fully-symbolicated callgrind (no anonymous runtime frames).
- `codspeed run --mode simulation`: benchmark region markers present (verified: 10 markers + Metadata on 006, was 0 before the `-UNVALGRIND` fix).
- `--mode walltime`: unchanged, valid results (9 benchmarks on 006).

`benchx_cli` is a private package, so no changeset. `turbo.json` already lists `scripts/build_unix.sh` as a build input, so the bump invalidates the cache and forces a re-download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Unix build process to use the latest locked `benchx_cli` release.
  - Subsequent builds can automatically download and extract the newer prebuilt binary when an update is detected.
  - No changes were made to the public API or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->