### PR TITLE
fix(renovate): group the `@rstest/*` packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,6 +94,23 @@
       "rangeStrategy": "pin",
     },
     {
+      // `@rstest/adapter-rsbuild` and `@rstest/coverage-istanbul` both peer on
+      // `@rstest/core`, so bumping one without the others fails
+      // `strictPeerDependencies` and Renovate cannot write the lock file —
+      // the PR then carries a catalog bump with no matching `pnpm-lock.yaml`.
+      "groupName": "Rstest",
+      "groupSlug": "Rstest",
+      "addLabels": ["upstream:rspack"],
+      "matchDepTypes": [
+        "devDependencies",
+        "dependencies",
+      ],
+      "matchPackageNames": [
+        "/@rstest/*/",
+      ],
+      "rangeStrategy": "pin",
+    },
+    {
       "groupName": "Rspress",
       "groupSlug": "Rspress",
       "matchDepTypes": [


### PR DESCRIPTION
`@rstest/adapter-rsbuild` and `@rstest/coverage-istanbul` both peer on `@rstest/core`, so bumping one alone leaves the catalog pinning an older core. Under `strictPeerDependencies` that install fails, Renovate cannot regenerate `pnpm-lock.yaml`, and the PR lands as a catalog bump with no matching lock file.

#3175 and #3177 are both in that state right now — `renovate/artifacts`, `sherif` and `code-style-check` all failing, no `pnpm-lock.yaml` in the diff — while #3176 (`@rstest/core` itself) updated cleanly. Grouping the three collapses them into one PR that installs.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling for Rstest packages.
  * Ensured related Rstest packages remain synchronized and use pinned versions to reduce update inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
