### PR TITLE
fix(renovate): keep cross-dep-type packages in one PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,6 +67,26 @@
       "groupSlug": "dev-non-major",
     },
     {
+      // These packages are a `dependencies` of one workspace package and a
+      // `devDependencies` of another. The group above matches devDependencies
+      // only, so it splits such a package across two PRs — one for each half.
+      // `sherif` requires a single version across the workspace, so neither
+      // half can merge on its own and both sit red forever (seen with
+      // `@rsdoctor/rspack-plugin` in #3117 vs #3179). Ungroup them so each
+      // keeps the default single PR covering every occurrence.
+      "matchPackageNames": [
+        "@clack/prompts",
+        "@rsdoctor/rspack-plugin",
+        "commander",
+        "css-tree",
+        "eventemitter3",
+        "nyc",
+        "tiny-invariant",
+        "wasm-feature-detect",
+      ],
+      "groupName": null,
+    },
+    {
       "groupName": "Rspack",
       "groupSlug": "Rspack",
       "addLabels": ["upstream:rspack"],


### PR DESCRIPTION
Eight packages are a `dependencies` of one workspace package and a `devDependencies` of another. The "dev minor & patch" group matches devDependencies only, so it takes half of such a package and leaves the other half to its own PR.

`sherif` requires a single version across the workspace, so each half is inconsistent on its own and neither can merge. #3117 (`rspeedy/core`) and #3179 (`web-explorer`) are deadlocked on `@rsdoctor/rspack-plugin` right now — both fail with `Dependency @rsdoctor/rspack-plugin has multiple versions defined in the workspace`.

Ungrouping restores the default single PR per package, covering every occurrence at once.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to handle selected packages separately rather than grouping them with other development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
