### PR TITLE
fix(kitten-lynx): declare the `@types/node` dependency

### DIFF
--- a/packages/testing-library/kitten-lynx/package.json
+++ b/packages/testing-library/kitten-lynx/package.json
@@ -48,6 +48,7 @@
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/types": "4.0.0",
+    "@types/node": "^24.10.13",
     "@types/react": "^19.2.17",
     "execa": "^9.6.1",
     "jpeg-js": "^0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1919,6 +1919,9 @@ importers:
       '@lynx-js/types':
         specifier: 4.0.0
         version: 4.0.0
+      '@types/node':
+        specifier: ^24.10.13
+        version: 24.10.13
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17


### PR DESCRIPTION
`src/ElementNode.ts` and `src/KittenLynxView.ts` import `node:timers/promises` and `node:stream/web` and annotate a `Buffer`, but the package never declared `@types/node` and its tsconfig sets no `types` field. It has been resolving through whatever pnpm happened to expose, which holds only as long as nothing moves.

#3083 (`update types`) moves it, and `tsgo` then fails the declaration build:

```
[tsgo] src/ElementNode.ts:2:28 - error TS2591: Cannot find name 'node:timers/promises'.
[tsgo] src/KittenLynxView.ts:354:15 - error TS2591: Cannot find name 'Buffer'.
[tsgo] src/KittenLynxView.ts:355:45 - error TS2591: Cannot find name 'node:stream/web'.
```

The lock file change is three lines. `devDependencies` only, so no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Node.js type definitions for improved development and tooling support.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->