### PR TITLE
fix(tailwind-preset): declare the `@types/node` dependency

### DIFF
--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -36,6 +36,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
+    "@types/node": "^24.10.13",
     "tailwindcss": "^3.4.19"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1810,6 +1810,9 @@ importers:
 
   packages/tailwind-preset:
     devDependencies:
+      '@types/node':
+        specifier: ^24.10.13
+        version: 24.10.13
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19


### PR DESCRIPTION
The package's only declared devDependency is `tailwindcss`, yet `src/helpers.ts` reads `import.meta.url`, `src/lynx.ts` calls `console`, and the tests import `node:fs`, `node:path` and `node:url`. All of those come from `@types/node`, which it has been picking up transitively.

#3145 (vitest v4) rearranges that tree and `tsc --build` fails with 24 errors, every one of them inside this package:

```
TS2591  Cannot find name 'node:fs' / 'node:path' / 'node:url'
TS2584  Cannot find name 'console'
TS2339  Property 'url' does not exist on type 'ImportMeta'
```

Same shape as #3188 (`kitten-lynx`). The lock file change is three lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Node.js type definitions for development tooling in the Tailwind preset package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->