### PR TITLE
fix(ci): resolve pnpm catalog entries when generating renovate changesets

### DIFF
--- a/.changeset/adb-catalog-bump.md
+++ b/.changeset/adb-catalog-bump.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/kitten-lynx-test-infra": patch
+---
+
+Update `@yume-chan/adb` from `^2.5.1` to `^2.6.0`

--- a/.github/scripts/generate-renovate-changeset.cjs
+++ b/.github/scripts/generate-renovate-changeset.cjs
@@ -13,6 +13,8 @@ const { createHash } = require('node:crypto');
 const { readFileSync, writeFileSync, existsSync } = require('node:fs');
 const { join } = require('node:path');
 
+const { parse: parseYaml } = require('yaml');
+
 const { isShallowEqual } = require('./check-dep-changes-have-changeset.cjs');
 
 // Two-dot `git diff <ref>` also picks up Renovate's not-yet-committed changes.
@@ -29,17 +31,67 @@ function gitShow(ref, path) {
   }
 }
 
-function changedPackageJsons() {
-  const out = execFileSync('git', ['diff', '--name-only', baseRef], {
+const WORKSPACE_FILE = 'pnpm-workspace.yaml';
+
+function gitChangedFiles() {
+  return execFileSync('git', ['diff', '--name-only', baseRef], {
     encoding: 'utf8',
-  });
-  return out
-    .split('\n')
+  }).split('\n');
+}
+
+// Every tracked `package.json`, used when the catalog moved: a catalog bump
+// changes the resolved version for its consumers without touching any of their
+// manifests, so the diff alone would show nothing to bump.
+function allPackageJsons() {
+  return execFileSync('git', ['ls-files', '*package.json'], {
+    encoding: 'utf8',
+  }).split('\n');
+}
+
+function changedPackageJsons() {
+  const changed = gitChangedFiles();
+  const files = changed.includes(WORKSPACE_FILE)
+    ? [...new Set([...changed, ...allPackageJsons()])]
+    : changed;
+  return files
     .filter((p) => p === 'package.json' || p.endsWith('/package.json'))
     // Scaffolding templates are not workspace members and their `name` is an
     // unsubstituted placeholder, so a changeset naming one makes
     // `changeset version` fail with "which is not in the workspace".
     .filter((p) => !p.split('/').includes('templates'));
+}
+
+// `catalog:` / `catalog:<name>` resolve through `pnpm-workspace.yaml`, so a
+// dependency can change version with no edit to the package that declares it.
+// Resolve both sides against their own copy of the workspace file and the
+// existing comparison then sees the bump.
+function readCatalogs(raw) {
+  if (raw === null) return null;
+  let doc;
+  try {
+    doc = parseYaml(raw);
+  } catch {
+    return null;
+  }
+  return { default: doc?.catalog ?? {}, named: doc?.catalogs ?? {} };
+}
+
+function resolveCatalogs(deps, catalogs) {
+  const out = {};
+  for (const [name, spec] of Object.entries(deps ?? {})) {
+    if (!catalogs || typeof spec !== 'string' || !spec.startsWith('catalog:')) {
+      out[name] = spec;
+      continue;
+    }
+    const which = spec.slice('catalog:'.length) || 'default';
+    const table = which === 'default'
+      ? catalogs.default
+      : catalogs.named?.[which];
+    // An unknown catalog name is left as-is rather than dropped, so a typo
+    // shows up as an unchanged spec instead of a phantom bump.
+    out[name] = table?.[name] ?? spec;
+  }
+  return out;
 }
 
 // Entries added, changed, or removed in `cur` vs `base` (removals have an
@@ -64,6 +116,10 @@ function changedEntries(cur, base) {
 function analyze() {
   const names = new Set();
   const deps = new Map(); // `${name}\0${from}\0${to}` -> { name, from, to }
+  const curCatalogs = readCatalogs(
+    existsSync(WORKSPACE_FILE) ? readFileSync(WORKSPACE_FILE, 'utf8') : null,
+  );
+  const baseCatalogs = readCatalogs(gitShow(baseRef, WORKSPACE_FILE));
   for (const file of changedPackageJsons()) {
     const baseRaw = gitShow(baseRef, file);
     if (baseRaw === null) continue;
@@ -76,16 +132,17 @@ function analyze() {
       continue;
     }
     if (cur.private || !cur.name) continue;
-    const depsChanged = !isShallowEqual(cur.dependencies, base.dependencies);
-    const peerChanged = !isShallowEqual(
-      cur.peerDependencies,
-      base.peerDependencies,
-    );
+    const curDeps = resolveCatalogs(cur.dependencies, curCatalogs);
+    const baseDeps = resolveCatalogs(base.dependencies, baseCatalogs);
+    const curPeer = resolveCatalogs(cur.peerDependencies, curCatalogs);
+    const basePeer = resolveCatalogs(base.peerDependencies, baseCatalogs);
+    const depsChanged = !isShallowEqual(curDeps, baseDeps);
+    const peerChanged = !isShallowEqual(curPeer, basePeer);
     if (!depsChanged && !peerChanged) continue;
     names.add(cur.name);
     const entries = [
-      ...changedEntries(cur.dependencies, base.dependencies),
-      ...changedEntries(cur.peerDependencies, base.peerDependencies),
+      ...changedEntries(curDeps, baseDeps),
+      ...changedEntries(curPeer, basePeer),
     ];
     for (const e of entries) deps.set(`${e.name}\0${e.from}\0${e.to}`, e);
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "turbo": "^2.10.5",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.64.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "yaml": "^2.9.0"
   },
   "packageManager": "pnpm@11.16.0+sha512.b767e9a98fc87aec0f42daefcd0e84941c2cdb45d73c4e1e68860fb2bdfdbe032ab592105479e5e05c237f740c8a5ffdbbb52385797ddc2296745a1bbb883e8d",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.7(@types/debug@4.1.12)(@types/node@24.10.13)(@vitest/ui@3.2.7)(jiti@2.6.1)(jsdom@27.4.0(supports-color@8.1.1))(less@4.6.4)(lightningcss@1.33.0)(sass-embedded@1.99.0)(sass@1.99.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.9.0)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   benchmark/react:
     dependencies:


### PR DESCRIPTION
Dependency versions for 40 packages live in `pnpm-workspace.yaml` under `catalog:` / `catalogs:`, and the manifests just say `catalog:<name>`. A Renovate bump edits the catalog and nothing else, so `git diff` shows no `package.json` change, the generator writes no changeset, and the dependency change ships with no version bump and no changelog entry.

Two publishable packages take **runtime** dependencies this way:

| package | dependency |
|---|---|
| `@lynx-js/rspeedy` | `@rsbuild/core` = `catalog:rsbuild` |
| `@lynx-js/kitten-lynx-test-infra` | `@yume-chan/adb`, `@yume-chan/adb-server-node-tcp` = `catalog:adb` |

`b429eef59` (#3093) bumped `@yume-chan/adb` `^2.5.1` → `^2.6.0` in the adb catalog and landed with no changeset. Its changeset is backfilled here.

Rather than special-case the workspace file, this resolves `catalog:` on both sides against their own copy of it before comparing — the existing dependency comparison then sees the bump by itself. When the catalog moved, every tracked manifest is considered, since a consumer's own file is untouched by definition.

Verified by bumping the adb catalog locally and running the script:

```
Wrote .changeset/renovate-415a9525.md bumping: @lynx-js/kitten-lynx-test-infra

---
"@lynx-js/kitten-lynx-test-infra": patch
---

Update `@yume-chan/adb` from `^2.6.0` to `^2.7.0`
```

`overrides:` is deliberately not covered: it applies only to this workspace's own install and is not part of a published package, so consumers never resolve through it and have nothing to be told about.

**#3180 needed no changeset.** `@rspack/core` is a `devDependency` in every publishable package, so skipping it was correct behaviour, not the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to detect package version changes managed through workspace catalogs.
  * Added automated patch release tracking when catalog-based updates affect publishable packages.
  * Added a Changeset entry to support the upcoming package release update.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
