### PR TITLE
fix(repl): depend on the root build in turbo

### DIFF
--- a/packages/repl/turbo.json
+++ b/packages/repl/turbo.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      // `rsbuild` bundles `@lynx-js/web-core`'s `dist`, which imports
+      // `@lynx-js/web-worker-rpc`. That package has no build script of its own —
+      // its `dist` comes from the root `tsc --build`. Without this edge the two
+      // tasks race and the bundle fails to resolve it. Same reason
+      // `web-explorer`, which bundles the same thing, declares it.
+      "dependsOn": ["//#build", "^build"],
+      "inputs": ["scripts/**", "src/**", "*.ts", "*.json", "index.html"],
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
`@lynx-js/repl` has no `turbo.json`, so it inherits the root `build` task and waits only on `^build` — the packages it declares. Its bundle pulls in `@lynx-js/web-core`'s `dist`, which imports `@lynx-js/web-worker-rpc`, and that package has no build script of its own: its `dist` is emitted by the root `tsc --build`. Nothing orders the two, so turbo is free to start repl first.

This only surfaces on a cache miss for repl, which is why `main` never hits it and every PR that touches `packages/repl/package.json` does. #3182 (`lucide-react`), #3179 and #3083 are all failing this way:

```
Module not found: Can't resolve '@lynx-js/web-worker-rpc'
  in packages/web-platform/web-core/dist/client
```

`web-explorer` bundles the same thing and already declares `dependsOn: ["//#build", "^build"]`.

Graph after the change:

```
@lynx-js/repl#build
  dependencies: ['//#build', '@lynx-js/web-core#build', '@lynx-js/web-platform-rsbuild-plugin#build']
```

Also pins `inputs` and `outputs`, which the inherited task left unset — without `outputs` turbo caches nothing for repl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build task configuration for the REPL package.
  * Improved build sequencing and output tracking for more reliable package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->