### PR TITLE
fix(renovate): give rkyv its own group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -257,6 +257,21 @@
       ],
     },
     {
+      // rkyv 0.8 renames the derive attributes (`#[archive(...)]` ->
+      // `#[rkyv(...)]`, and `with` / `omit_bounds` move with it), so the bump
+      // needs `packages/web-platform/web-core` migrated by hand. Grouped with
+      // the rest of the cargo crates it fails the whole PR -- #3129 carried
+      // ~20 harmless patch/minor bumps and only rkyv broke, with 32 errors in
+      // `web-core (lib)`. Give it its own PR so the others can land.
+      "groupName": "rkyv",
+      "groupSlug": "rkyv",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "rkyv",
+        "rkyv_derive",
+      ],
+    },
+    {
       "groupName": "SWC",
       "groupSlug": "swc",
       "matchManagers": ["cargo"],


### PR DESCRIPTION
rkyv 0.8 renames the derive attributes — `#[archive(...)]` becomes `#[rkyv(...)]`, and `with` / `omit_bounds` move with it — so the bump needs `packages/web-platform/web-core` migrated by hand.

Inside the "Rust Crates" group that failure takes the whole PR down with it. #3129 carries around twenty patch and minor bumps (serde, tokio, regex, indexmap, web-sys, …) and only rkyv breaks, with 32 errors in `web-core (lib)`:

```
error: cannot find attribute `with` in this scope
error: cannot find attribute `archive` in this scope
error: cannot find attribute `omit_bounds` in this scope
error: could not compile `web-core` (lib) due to 32 previous errors
```

Splitting it out lets the rest land while the migration gets its own PR. SWC majors are separated for the same reason.

**This does not do the migration.** rkyv stays on 0.7 until someone picks it up — the split just stops it blocking unrelated bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update organization for selected Rust crates.
  * Added clearer grouping and labeling for related update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->