### PR TITLE
fix(ci): fetch full history on the Ubuntu build

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -81,6 +81,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          # `changeset status --since` runs `git merge-base <ref> HEAD`, so the
+          # Ubuntu build -- the only job that publishes to pkg.pr.new -- needs
+          # real history. Growing it after a depth-1 checkout does not work:
+          # HEAD is `refs/pull/<n>/merge`, GitHub regenerates that ref whenever
+          # the base moves, and both `--depth <sha>` and `--deepen` then act on
+          # the ref's new tip while HEAD stays detached at the old commit.
+          # Ask for the history up front instead. Every other job, Windows
+          # included, keeps the shallow clone.
+          fetch-depth: ${{ inputs.runs-on == 'lynx-ubuntu-26.04-xlarge' && '0' || '1' }}
           persist-credentials: false
       - name: Disable local Git maintenance
         run: git config --local maintenance.auto false
@@ -138,22 +147,10 @@ jobs:
           github.event_name == 'pull_request'
         env:
           MERGE_BASE: ${{ needs.get-merge-base.outputs.merge-base }}
-        # `changeset status --since` runs `git merge-base <ref> HEAD`, so HEAD
-        # needs ancestry. `actions/checkout` clones at depth 1 and HEAD is
-        # `refs/pull/<n>/merge`, which is not a ref tip once GitHub regenerates
-        # that ref -- fetching it by SHA then deepens nothing. `--deepen` with
-        # no refspec grows the local shallow boundary instead, which is what
-        # HEAD sits on; it is the same call `@changesets/git` makes itself.
-        #
         # The merge base is already computed by the `get-merge-base` job, so
-        # pass it directly rather than deepening `origin/<base>` as well.
+        # pass that SHA straight to `--since` instead of resolving `origin/<base>`
+        # here. History comes from the `fetch-depth` above.
         run: |
-          depth=20
-          for _ in 1 2 3 4 5; do
-            git merge-base "$MERGE_BASE" HEAD >/dev/null 2>&1 && break
-            git fetch -q --deepen="$depth"
-            depth=$((depth * 2))
-          done
           pnpm changeset status --since="$MERGE_BASE" --output .changeset-status.json
           PACKAGE_DIRS=$(node .github/scripts/list-changeset-packages.cjs .changeset-status.json | tr '\n' ' ')
           if [ -z "$(echo "$PACKAGE_DIRS" | tr -d '[:space:]')" ]; then


### PR DESCRIPTION
Third attempt at this step, so the reasoning is worth writing down.

`changeset status --since` runs `git merge-base <ref> HEAD`, which needs HEAD to have ancestry. `actions/checkout` clones at depth 1 and HEAD is `refs/pull/<n>/merge`. GitHub regenerates that ref whenever the base branch moves, and the checkout stays detached at the commit the run started with — from then on the ref tip and HEAD are different commits.

Both earlier attempts grow history *through that ref*, so they act on the new tip while HEAD stays where it is:

| | approach | why it does nothing |
|---|---|---|
| #3178 | `--depth` on the pinned SHA | git already has that object, so the fetch is a no-op |
| #3187 | `--deepen` with no refspec | deepens the configured refspec — the merge ref, not the detached commit |

#3071 is failing on the second one right now. main moved four commits while its CI sat queued, and the step reports:

```
🦋 error Failed to find where HEAD diverged from "39f85bd291cd64c7d590e0e3f9a376e6709f107f".
```

Asking for the history at checkout has no ordering assumption to get wrong. Measured against a `--deepen` round trip it is also not slower for this repo — 11.0s versus 12.4s — and it applies only to the Ubuntu build, which is the one job that runs `changeset status`. Windows and everything else keep depth 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow reliability for changeset detection.
  * Ensured the build process has sufficient repository history when comparing changes.
  * Simplified automated package-change collection during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->