### PR TITLE
fix(renovate): stop the tsgo preview riding along in the types group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -230,9 +230,15 @@
     {
       "groupName": "types",
       "groupSlug": "types",
+      // Anchor on the scope separator. `^@types/*` is `@types` followed by any
+      // number of slashes and is not anchored at the end, so it also matched
+      // `@typescript/native-preview` -- the tsgo preview compiler rode along in
+      // every "update types" PR. Its 20260212 -> 20260707 jump breaks
+      // declaration emit for `kitten-lynx` (six `TS2591: Cannot find name
+      // 'node:timers/promises'` and friends), which took #3083 down with it.
       "matchPackageNames": [
-        "/^@tsconfig/*/",
-        "/^@types/*/",
+        "/^@tsconfig\\//",
+        "/^@types\\//",
       ],
     },
     {


### PR DESCRIPTION
`^@types/*` is `@types` followed by any number of slashes, and it is not anchored at the end — so it also matches `@typescript/native-preview`. The tsgo preview compiler has been bundled into every "update types" PR.

| package | old regex | new regex |
|---|---|---|
| `@types/node` | ✅ | ✅ |
| `@types/react` | ✅ | ✅ |
| `@typescript/native-preview` | ✅ ← unintended | ❌ |

That is what #3083 is failing on. It moves tsgo `7.0.0-dev.20260212.1` → `7.0.0-dev.20260707.2`, and the newer snapshot cannot resolve node builtins during declaration emit:

```
[tsgo] src/KittenLynxView.ts:5:28 - error TS2591:
       Cannot find name 'node:timers/promises'.
```

Note the code — **TS2591 is "cannot find name", not TS2307 "cannot find module"** — the compiler is reading the specifier as an identifier. Confirmed by swapping only that one version on `main`: `kitten-lynx` goes from a clean `turbo build` to six TS2591 errors with nothing else changed.

Anchoring on the scope separator lets the `@types/*` bumps land on their own and leaves the preview compiler to its own PR, where a broken dev snapshot blocks nothing else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated dependency grouping so TypeScript configuration and type packages are matched accurately.
  * Prevented unrelated packages from being included in the same update group, reducing the risk of problematic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->