### PR TITLE
fix(ci): start from an empty turbo cache on pushes to main

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -120,10 +120,49 @@ jobs:
       - name: Build
         id: build
         run: |
-          pnpm turbo build --summarize
+          # `benchx_cli` downloads an 86 MB binary only the benchmark job uses.
+          # `benchmark-*` goes with it -- it depends on `benchx_cli`, so
+          # excluding `benchx_cli` alone is a no-op. Same pair `deploy-main.yml`
+          # uses.
+          pnpm turbo build --summarize --filter '!benchx_cli' --filter '!@lynx-js/benchmark-*'
         env:
           NODE_OPTIONS: --max-old-space-size=32768
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # The restored cache carries every previous run's entries and this job
+      # saves the whole thing back, so it only ever grows -- past 5 GB the
+      # backend rejects the upload while still printing "Cache saved
+      # successfully", and every downstream job then dies on a cache miss:
+      # https://github.com/lynx-family/lynx-stack/actions/runs/30186830273/job/89752986590
+      #
+      # Keep only the hashes this commit produces. Downstream jobs run the same
+      # `turbo build` at the same SHA, so those are exactly the entries they
+      # look for; anything else is from another lockfile and can never be hit.
+      - name: Drop cache entries this commit cannot use
+        shell: bash
+        run: |
+          pnpm turbo build --dry=json --filter '!benchx_cli' --filter '!@lynx-js/benchmark-*' \
+            | sed -n '/^{/,$p' > /tmp/turbo-dry.json
+          node -e '
+            const fs = require("node:fs"), path = require("node:path");
+            const dir = ".turbo/cache";
+            if (!fs.existsSync(dir)) process.exit(0);
+            const keep = new Set(
+              JSON.parse(fs.readFileSync("/tmp/turbo-dry.json", "utf8")).tasks.map((t) => t.hash),
+            );
+            const mb = (b) => Math.round(b / 1048576);
+            let kept = 0, dropped = 0, keptBytes = 0, droppedBytes = 0;
+            for (const name of fs.readdirSync(dir)) {
+              const file = path.join(dir, name);
+              const size = fs.statSync(file).size;
+              if (keep.has(name.replace(/\.tar\.zst$|-meta\.json$|-manifest\.json$/, ""))) {
+                kept++; keptBytes += size;
+              } else {
+                fs.rmSync(file, { force: true });
+                dropped++; droppedBytes += size;
+              }
+            }
+            console.log(`turbo cache: kept ${kept} entries (${mb(keptBytes)} MB), dropped ${dropped} (${mb(droppedBytes)} MB)`);
+          '
       - name: Upload turbo summary
         if: runner.debug == '1'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -78,6 +78,9 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     needs: get-merge-base
+    env:
+      # `turbo-v4` matches the saved caches; anything else matches nothing.
+      TURBO_RESTORE_PREFIX: ${{ github.event_name == 'push' && 'turbo-no-restore' || 'turbo-v4' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -107,11 +110,23 @@ jobs:
           # We can restore caches from:
           #   1. Previous commit from base branch (merge base or base SHA)
           #   2. Any cache
+          #
+          # On a push to `main` (`deploy-main.yml`) the prefix below becomes one
+          # nothing is stored under, so this run starts from an empty cache and
+          # saves only what it built. Restoring there is what made the cache
+          # grow without bound: every PR restores main's cache through key 1, so
+          # main carrying the previous generation in and saving it back added a
+          # generation per merge -- 193 merges in three weeks, past the 5 GB the
+          # backend accepts, after which every save fails while still reporting
+          # success and downstream jobs die on a cache miss:
+          # https://github.com/lynx-family/lynx-stack/actions/runs/30186830273/job/89752986590
+          #
+          # The cold build this costs is on a post-merge run nobody waits on.
           restore-keys: |
-            turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ needs.get-merge-base.outputs.merge-base }}
-            turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
-            turbo-v4-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-
-            turbo-v4-${{ runner.os }}-
+            ${{ env.TURBO_RESTORE_PREFIX }}-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ needs.get-merge-base.outputs.merge-base }}
+            ${{ env.TURBO_RESTORE_PREFIX }}-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
+            ${{ env.TURBO_RESTORE_PREFIX }}-${{ runner.os }}-${{ hashFiles('packages/**/src/**/*.rs') }}-
+            ${{ env.TURBO_RESTORE_PREFIX }}-${{ runner.os }}-
       - name: Install
         uses: ./.github/actions/pnpm-install
         with:
@@ -128,41 +143,6 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=32768
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      # The restored cache carries every previous run's entries and this job
-      # saves the whole thing back, so it only ever grows -- past 5 GB the
-      # backend rejects the upload while still printing "Cache saved
-      # successfully", and every downstream job then dies on a cache miss:
-      # https://github.com/lynx-family/lynx-stack/actions/runs/30186830273/job/89752986590
-      #
-      # Keep only the hashes this commit produces. Downstream jobs run the same
-      # `turbo build` at the same SHA, so those are exactly the entries they
-      # look for; anything else is from another lockfile and can never be hit.
-      - name: Drop cache entries this commit cannot use
-        shell: bash
-        run: |
-          pnpm turbo build --dry=json --filter '!benchx_cli' --filter '!@lynx-js/benchmark-*' \
-            | sed -n '/^{/,$p' > /tmp/turbo-dry.json
-          node -e '
-            const fs = require("node:fs"), path = require("node:path");
-            const dir = ".turbo/cache";
-            if (!fs.existsSync(dir)) process.exit(0);
-            const keep = new Set(
-              JSON.parse(fs.readFileSync("/tmp/turbo-dry.json", "utf8")).tasks.map((t) => t.hash),
-            );
-            const mb = (b) => Math.round(b / 1048576);
-            let kept = 0, dropped = 0, keptBytes = 0, droppedBytes = 0;
-            for (const name of fs.readdirSync(dir)) {
-              const file = path.join(dir, name);
-              const size = fs.statSync(file).size;
-              if (keep.has(name.replace(/\.tar\.zst$|-meta\.json$|-manifest\.json$/, ""))) {
-                kept++; keptBytes += size;
-              } else {
-                fs.rmSync(file, { force: true });
-                dropped++; droppedBytes += size;
-              }
-            }
-            console.log(`turbo cache: kept ${kept} entries (${mb(keptBytes)} MB), dropped ${dropped} (${mb(droppedBytes)} MB)`);
-          '
       - name: Upload turbo summary
         if: runner.debug == '1'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -81,7 +81,10 @@ jobs:
         with:
           save-if: ${{ github.ref_name == 'main' }}
       - name: Build
-        run: pnpm turbo build --summarize
+        # Kept in step with the build workflow -- if only that one filtered
+        # `benchx_cli` out, every test job would download the 91 MB binary
+        # itself on the resulting cache miss.
+        run: pnpm turbo build --summarize --filter '!benchx_cli' --filter '!@lynx-js/benchmark-*'
       - name: Test # zizmor: ignore[template-injection] The inputs.run is provided by us.
         id: test
         env:


### PR DESCRIPTION
The turbo cache grew past the 5 GB the backend accepts. Over that, the save fails while the action still prints `Cache saved successfully`, so nothing is stored and every job with `fail-on-cache-miss: true` dies within seconds — a dozen unrelated PRs go red at once: https://github.com/lynx-family/lynx-stack/actions/runs/30186830273/job/89752986590

## Where it accumulates

`deploy-main.yml` runs this workflow on every push to `main`, and that run is the accumulator. From the most recent one:

```
restore-keys: turbo-v4-Linux-4ef85371…-upstream/
Cache Size: ~5070 MB
Cache restored from key: …turbo-v4-Linux-4ef85371…-6a0ad312a0e671c…
Cache Size: ~5113 MB
Cache saved with key:    turbo-v4-Linux-4ef85371…-70b038114…
```

It restores the previous cache and saves it back with its own entries added, so `main` gains a generation per merge — 193 merges in the last three weeks, against a generation measured at 58 MB. Every PR then restores that cache through the merge-base restore key, so the growth reaches all of CI.

Two details visible above are worth recording:

- The merge-base restore key evaluates to `…-upstream/` on a push. `github.base_ref` is empty for that event, so `git merge-base` and the `git rev-parse` fallback both fail and the literal `upstream/` is what reaches the key. It matches nothing.
- What actually matched is the bare-prefix key, which returned an unrelated commit's cache (`6a0ad312…`).

## What this does

Use a restore-key prefix nothing is stored under when the event is a push, so that run starts from an empty cache and saves exactly what it built. PR runs are untouched — same four keys, same fallbacks.

Removing only the bare-prefix keys would not be enough: on a push the second key degenerates into the same bare prefix, because `github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before` is null on all three branches. (`github.event.push.before` is not a real path — the push payload exposes `github.event.before` — but with this change all four keys are neutralized on a push anyway.) Those keys are also worth keeping for PRs, which need them whenever the Rust hash changes.

Only `deploy-main.yml` (push to `main` and `release/*`) and `test.yml` (`pull_request`, `merge_group`) call this workflow, so the condition selects exactly the post-merge run. Confirmed against real runs: a push to a PR branch reports `event=pull_request`, and the post-merge run reports `event=push`.

The cold build this costs lands on a run nobody waits on, and for the common case it costs close to nothing: the most recent post-merge build spent 385 s in `turbo build` *with* the 5 GB cache restored, because that merge changed `pnpm-lock.yaml` and `hashOfExternalDependencies` is a global cache input — every task rehashes, so the restore bought no hits and only cost its 72 s. `Build (Windows)` does not run on that workflow at all.

Measured on a real cache directory, for scale:

```
total                          539.0 MB / 1158 entries
each task counted once          57.9 MB /   73 entries
duplicates                          89.3%
```

## Also here

Stop building `benchx_cli` in PR CI. Its build downloads an 86 MB binary — the largest single entry in the cache at 13 MB compressed — and only the benchmark job uses it, which runs its own `turbo build` and tolerates a cache miss.

`benchmark-*` has to be excluded with it: it depends on `benchx_cli` via `workspace:*`, so filtering out `benchx_cli` alone is a no-op — turbo still builds it as a dependency of a selected package. `deploy-main.yml` and `copilot-setup-steps.yml` already use this same pair. The filter removes exactly two packages:

```
$ diff <(turbo build --dry=json)  <(turbo build --dry=json --filter '!benchx_cli' --filter '!@lynx-js/benchmark-*')
< @lynx-js/benchmark-react
< benchx_cli
```

Both workflows change together — filtering it out of the build alone would leave every test job downloading the binary itself on the resulting miss.

## Bootstrapping

This PR cannot go green on its own. It runs as a `pull_request`, so it still restores and saves the oversized cache and its downstream jobs still fail on the miss. The first post-merge run is what resets `main`'s cache; PRs opened after that restore a small one.

## Alternatives measured and rejected

- **Trimming `outputs`.** The two largest consumers already store only what they must. `benchx_cli`'s entry is one file. `web-core`'s bulk is debug wasm (9.1 MB against 227 KB for the release build), and `tests/loaders/debug-wasm-loader.mjs` rewrites imports to it, so the test job needs it.
- **`cacheMaxSize`.** turbo has one, and it works — a 30 MB limit took a test cache from 102 MB/551 files to 28 MB/68 files in a single run. But it evicts oldest-first, and `mtime` is when an entry was written, not when it was last used, so it drops live entries while still leaving GB of unusable ones.

## Not addressed

Remote caching is the real answer to the 71 s every job spends restoring this cache, across 18 jobs. Separate PR.
