### PR TITLE
fix(tailwind-preset): name `node` in tsconfig `types`

### DIFF
--- a/packages/tailwind-preset/tsconfig.build.json
+++ b/packages/tailwind-preset/tsconfig.build.json
@@ -11,6 +11,7 @@
     "emitDeclarationOnly": false,
     "isolatedDeclarations": true,
     "moduleResolution": "nodenext",
+    "types": ["node"],
   },
   "include": [
     "src",


### PR DESCRIPTION
`@types/node` is declared and installed, but TypeScript's automatic `@types` inclusion stops picking it up for this project once vitest moves to 4. The symptom is the whole node surface going missing at once:

```
TS2591  Cannot find name 'node:fs' / 'node:path' / 'node:url'
TS2584  Cannot find name 'console'
TS2339  Property 'url' does not exist on type 'ImportMeta'
```

24 errors, all inside `packages/tailwind-preset`.

**Only reproducible under `tsc --build --force`.** An incremental build reuses `.tsbuildinfo` and reports nothing — which is why this reads as a CI-only failure. I chased it three times locally on a warm build tree before forcing a clean one.

| | `--force` result |
|---|---|
| `main` | 0 errors |
| #3145 (vitest 4) | **24 errors** |
| #3145 + this change | 0 errors |
| `main` + this change | 0 errors |

Naming the package explicitly does not depend on resolution order, so it holds either way. This unblocks #3145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration so Node.js type definitions are available during compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->