### PR TITLE
docs(ci): explain the turbo restore prefix

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -79,7 +79,8 @@ jobs:
     timeout-minutes: 45
     needs: get-merge-base
     env:
-      # `turbo-v4` matches the saved caches; anything else matches nothing.
+      # `turbo-v4` matches the saved caches; anything else matches nothing,
+      # which is how a push to `main` starts from an empty cache.
       TURBO_RESTORE_PREFIX: ${{ github.event_name == 'push' && 'turbo-no-restore' || 'turbo-v4' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Follow-up to #3206, and a live check that a PR now restores a small cache.

The post-merge run saved 29 MB against 5113 MB before, and the build job's restore went from 72s to 2s. This PR opens after that, so its `TurboCache` step should restore the 29 MB cache through the merge-base key rather than the 5 GB one.

Comment-only otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified build cache behavior for pushes to the main branch.
  * Documented that only the supported cache configuration matches saved caches; other values match none.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->