### PR TITLE
fix(renovate): give tsgo its own group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -242,6 +242,18 @@
       ],
     },
     {
+      // Anchoring the `types` group above only moved this package: it is a
+      // devDependency, so it fell into "dev minor & patch" instead and took
+      // #3179 down the same way it took #3083. Give it its own PR -- the
+      // preview compiler ships breaking declaration-emit changes under a date
+      // version, so it needs to be reviewed and rolled back on its own.
+      "groupName": "tsgo",
+      "groupSlug": "tsgo",
+      "matchPackageNames": [
+        "@typescript/native-preview",
+      ],
+    },
+    {
       "groupName": "Lynx Engine",
       "groupSlug": "lynx-engine",
       "matchManagers": ["custom.regex"],


### PR DESCRIPTION
`@typescript/native-preview` keeps riding along in grouped PRs and breaking them.

#3196 anchored the `types` group so it stopped matching (`/^@types/*/` is `@types` followed by any number of slashes, unanchored, so it also matched `@typescript/native-preview`). That only moved the problem: the package is a devDependency, so it landed in `dev minor & patch` instead, and took #3179 down the same way it took #3083.

The preview compiler ships breaking declaration-emit changes under a date version — the 20260212 to 20260707 jump produces `TS2591: Cannot find name 'node:timers/promises'` and friends in `kitten-lynx`. That needs to be reviewable and revertable on its own, not bundled with a dozen unrelated patch bumps.

Validated with `renovate-config-validator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings so TypeScript’s native preview package is handled independently from other type-related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->