### PR TITLE
fix(docs-mcp-server): pin @modelcontextprotocol/sdk below 1.29

### DIFF
--- a/.changeset/pin-mcp-sdk.md
+++ b/.changeset/pin-mcp-sdk.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/docs-mcp-server": patch
+---
+
+Pin `@modelcontextprotocol/sdk` to 1.25.2. 1.29.0 added a `types` condition to
+its `./*` export wildcard, which resolves `server/mcp.js` to
+`dist/esm/server/mcp.js.d.ts` — a file that does not exist, the real one being
+`mcp.d.ts`. A caret range let any lockfile regeneration pull it in.

--- a/packages/mcp-servers/docs-mcp-server/package.json
+++ b/packages/mcp-servers/docs-mcp-server/package.json
@@ -17,7 +17,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "1.25.2",
     "commander": "^13.1.0",
     "debug": "^4.4.3",
     "empathic": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1104,7 +1104,7 @@ importers:
   packages/mcp-servers/docs-mcp-server:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.25.2
+        specifier: 1.25.2
         version: 1.25.2(hono@4.12.12)(supports-color@8.1.1)(zod@4.4.3)
       commander:
         specifier: ^13.1.0


### PR DESCRIPTION
1.29.0 added a `types` condition to its `./*` export wildcard:

```json
"./*": { "types": "./dist/esm/*.d.ts", "import": "./dist/esm/*" }
```

`server/mcp.js` substitutes into that as `dist/esm/server/mcp.js.d.ts`, which does not exist — the real file is `mcp.d.ts`. 1.20.2 carried no `types` condition on the wildcard, so type resolution fell back to the adjacent declaration and found it. Runtime resolution goes through `import` and is unaffected, so only `tsc` and `import/no-unresolved` see it:

```
packages/mcp-servers/docs-mcp-server/main.ts
  10:27  error  Unable to resolve path to module '@modelcontextprotocol/sdk/server/mcp.js'    import/no-unresolved
  11:38  error  Unable to resolve path to module '@modelcontextprotocol/sdk/server/stdio.js'  import/no-unresolved
```

The SDK's own documentation uses those `.js` subpaths, so this is upstream's to fix. Pinning holds the version until it is.

## Why a pin rather than a range

The caret meant this did not need the SDK's own Renovate PR (#3213) to land. `^1.25.2` admits 1.29.0, so **any** lockfile regeneration pulled it in — which is how #3210, a `@mastra/core` bump, ended up failing eslint on an unrelated package:

| | resolved version |
|---|---|
| `main` | 1.25.2 |
| #3210 branch (`@mastra/core` bump) | **1.29.0** |

Same reasoning as the exact pins added for `wasm-bindgen` and `napi` in #3178: a caret range lets the break come back on the next unrelated lockfile change.

Verified locally: `pnpm exec eslint packages/mcp-servers/docs-mcp-server/main.ts` reports nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Model Context Protocol SDK to version 1.25.2 for consistent dependency resolution.
  * Prevented automatic updates to newer SDK releases that may cause type declaration resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->