### PR TITLE
fix(ci): stop re-downloading the Rust toolchain on every run

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -48,9 +48,11 @@ runs:
           toolchain="stable"
         fi
         printf 'toolchain=%s\n' "${toolchain}" >> "$GITHUB_OUTPUT"
+    # Restore unconditionally. `save-if` gates writing the cache, not reading
+    # it -- gating the restore too meant every pull request downloaded the
+    # toolchain from scratch, which is most of what `Setup Rust` spends time on.
     - name: Restore rustup cache
       id: restore
-      if: ${{ inputs.save-if == 'true' }}
       uses: lynx-infra/cache/restore@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
       with:
         path: ~/.rustup/toolchains

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,10 +105,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+      # `cargo fmt --check` itself takes a second; installing the toolchain took
+      # over eight minutes on a bad day and pushed this past `timeout-minutes`,
+      # which GitHub then reports as `cancelled` and `Done` reads as a failure.
+      # The local action restores a cached toolchain and installs the minimal
+      # component set.
+      - name: Setup Rust
+        uses: ./.github/actions/rustup
         with:
-          components: rustfmt
-          cache: false
+          key: lint
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Format
         run: cargo fmt --check
 
@@ -121,9 +127,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+      - name: Setup Rust
+        uses: ./.github/actions/rustup
         with:
-          components: clippy
-          cache: false
+          key: lint
+          save-if: ${{ github.ref_name == 'main' }}
       - name: Clippy
         run: cargo clippy --tests --all-features -- -D warnings


### PR DESCRIPTION
`rustfmt` and `clippy` install the toolchain through the upstream action with no cache, so a one-second check spends its entire budget downloading:

```
532s  Run actions-rust-lang/setup-rust-toolchain    (+458s inside "downloading 8 components")
  1s  Format                                        (cargo fmt --check)
```

`timeout-minutes` for these jobs is 10, so on a contended runner they do not finish. GitHub reports a timed-out job as `cancelled`, `Done` reads that as not-green, and the PR goes red with nothing wrong in it — #3208 and #3199 both hit this today at 10.3 and 10.2 minutes.

Raising the timeout would only hide it, so this uses the repo's own `./.github/actions/rustup` instead, which installs the minimal component set and restores a cached toolchain.

## The restore was gated on the wrong thing

```yaml
- name: Restore rustup cache
  if: ${{ inputs.save-if == 'true' }}      # <- removed
```

`save-if` is `github.ref_name == 'main'`, so **no pull request has ever restored this cache** — every PR build downloads the toolchain. `save-if` should gate writing the cache, not reading it; the save step keeps its own gate (plus `cache-hit != 'true'`).

Confirmed on a PR build today: `Setup Rust` logs `info: downloading 6 components` and there is no `Cache restored from key: rustup-cache-…` line, while the post-merge run on `main` does restore it.

This second part speeds up every job that uses the action, not just the two being fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust toolchain caching so cached toolchains are restored consistently, including when cache saving is disabled.
  * Updated code quality checks to use the standardized toolchain setup, improving reliability and reducing setup delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->