### PR TITLE
fix(ci): repair main after the Babel 8 merge, and stop a cache abort failing the build

### DIFF
--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -51,8 +51,13 @@ runs:
     # Restore unconditionally. `save-if` gates writing the cache, not reading
     # it -- gating the restore too meant every pull request downloaded the
     # toolchain from scratch, which is most of what `Setup Rust` spends time on.
+    # A failed restore must not fail the job: the install step below handles a
+    # miss on its own. Without this a transient download abort inside the cache
+    # action ("Error: aborted" from an unhandled stream error) takes the whole
+    # build down, which is worse than the slow path it replaced.
     - name: Restore rustup cache
       id: restore
+      continue-on-error: true
       uses: lynx-infra/cache/restore@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
       with:
         path: ~/.rustup/toolchains

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,6 +63,11 @@ minimumReleaseAgeStrict: false
 
 peerDependencyRules:
   allowedVersions:
+    # `vite-plugin-babel` only calls `loadOptions`, `loadPartialConfig` and
+    # `transformAsync`, which all still exist in Babel 8; its `^7.0.0` range
+    # predates the release. Verified by building and testing the one package
+    # that uses it, `testing-library/examples/react-compiler`.
+    "vite-plugin-babel>@babel/core": "^7.0.0 || ^8.0.0"
     "@ai-sdk/provider-utils>zod": "^3.23.8 || ^4.0.0"
     "@ai-sdk/ui-utils>zod": "^3.23.8 || ^4.0.0"
     "@lynx-js/lynx-ui>@types/react": "^19.2.0"


### PR DESCRIPTION
Two regressions from today's merges, both in CI only.

## 1. `main` is red on `sherif`

#3224 moved the workspace to Babel 8 and `pnpm dedupe --check` now fails, which takes the `sherif` job down on every open PR:

```
ERR_PNPM_PEER_DEP_ISSUES
✕ unmet peer @babel/core
  Installed: 8.0.1
  Wanted:
    ^7.0.0:
      vite-plugin-babel@1.7.3
```

`vite-plugin-babel` calls exactly three Babel APIs — `loadOptions`, `loadPartialConfig` and `transformAsync` — and all three still exist in Babel 8. Its `^7.0.0` peer range was written before Babel 8 was released.

Verified rather than assumed, on the only package that depends on it (`packages/testing-library/examples/react-compiler`):

```
$ pnpm run build
ready   built in 0.47s
dist/main.lynx.bundle   84.6 kB

$ pnpm run test
Test Files  12 passed (12)
     Tests  20 passed (20)
```

`pnpm dedupe --check` is clean again with the allowance in place. Same shape as the entries already in `peerDependencyRules.allowedVersions`, with the reason recorded inline.

## 2. A failed rustup cache restore should not fail the build

#3225 made pull requests restore the toolchain cache — they never did before, because the restore step was gated on `save-if`, which is only true on `main`. That fixed a 532s toolchain download, but exposed a failure mode PRs did not previously have: a transient download abort inside the cache action throws an unhandled stream error and kills the step, taking `TurboCache`, `Install` and `Build` with it.

```
GET /caches%2Flynx-family%2Flynx-stack%2Frustup-cache-v3-Windows-1.92.0
Error: aborted
    Emitted 'error' event on Transform instance
```

https://github.com/lynx-family/lynx-stack/actions/runs/30197059929/job/89780596569

A restore failing is not worth stopping for — the `Install` step immediately below runs `rustup toolchain install` and handles a miss on its own. `continue-on-error` on the restore keeps the speed-up without letting a flaky download hard-fail the build.

Seen once so far, on `Build (Windows)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility checks for Babel 7 and Babel 8 integrations to better support the relevant build tooling versions.
  * Updated package configuration to explicitly allow the verified dependency range for the Babel plugin.
  * Improved CI reliability by tolerating failures when restoring the Rust toolchain cache, allowing builds to proceed via the normal installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->