### PR TITLE
fix(ci): run the Rust workflow after the build on main, not beside it

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -88,6 +88,12 @@ jobs:
     needs: build-all
     uses: ./.github/workflows/workflow-bundle-analysis.yml
     if: github.repository == 'lynx-family/lynx-stack'
+  test-rust:
+    needs: build-all
+    uses: ./.github/workflows/rust.yml
+    if: github.repository == 'lynx-family/lynx-stack'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   coverage:
     needs: build-all
     uses: ./.github/workflows/workflow-test.yml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,9 +1,8 @@
 name: Rust
 
 on:
-  push:
-    branches:
-      - main
+  # No `push` trigger: this needs the turbo cache the build job writes, and a
+  # standalone run races it. `deploy-main.yml` calls it after `build-all`.
   workflow_call:
     secrets:
       CODECOV_TOKEN:


### PR DESCRIPTION
`Rust / Test (Ubuntu)` has failed on **every** push to `main` since 2026-07-16 — 377 consecutive green runs, then 10 days of red:

```
Unable to find cache with primary key: turbo-v4-Linux-…-<main sha>
##[error]Failed to restore cache entry. Exiting as fail-on-cache-miss is set.
```

## It is an ordering bug, not a regression

The job needs the per-SHA turbo cache that `workflow-build.yml` writes. The two entry points disagree about ordering:

| | how it runs | build ordering | exact key |
|---|---|---|---|
| pull request | `test.yml` → `test-rust: needs: build` | guaranteed | hits |
| push to `main` | `rust.yml`'s own `on: push` | none — runs beside `deploy-main.yml`'s build | cannot hit |

On a push the key names a commit whose build is still running, so `fail-on-cache-miss: true` fails by construction. It was survivable for months only because runner contention held the job in the queue long enough for that build to finish:

| | conclusion | queued for |
|---|---|---|
| `2b5d83a4b` last green | success | **33.8 min** |
| `b6b809cdb` first red | failure | **0.2 min** |
| `5d056299d` today | failure | **0.1 min** |

The commit on the boundary is `chore: Release 2026-07-15 14:50:29` (#2921), which touched no workflow file — bisecting the diff finds nothing, because what changed was the timing. Two other suspects were ruled out on dates: #2987 (cache-key glob) merged 07-18, after the first failure, and #3206 (turbo cache) merged 07-26.

## The fix

Give both paths the same shape. Drop the self-trigger and let `deploy-main.yml` call the workflow after `build-all` — the way it already calls `workflow-test`, `bundle-analysis`, `bench` and `website`. `fail-on-cache-miss: true` then means what it says on both paths, and the cache block needs no change at all.

## Rejected alternative

Adding `restore-keys` so a miss falls back to some other commit's cache. It would stop the failure, but:

- On a push the exact key can never hit, so the fallback would run every time — and 19 of the last 30 commits on `main` changed `pnpm-lock.yaml`, which rehashes every task, so the restored cache would yield zero hits and cost only its download.
- This step uses the full `lynx-infra/cache` action, whose save key is the same one the build writes. Restoring through a loose prefix and then saving under `main`'s key is exactly the accumulation #3206 removed, and it would race the build for the write.

Ordering fixes the cause; a fallback would only paper over it.

Worth noting separately: for these 10 days the Rust test suite has produced no signal on `main` at all.
