### PR TITLE
fix(ci): grant the Rust workflow the permission its jobs declare

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -92,6 +92,10 @@ jobs:
     needs: build-all
     uses: ./.github/workflows/rust.yml
     if: github.repository == 'lynx-family/lynx-stack'
+    # The called jobs declare `contents: read`; the workflow default here is
+    # `{}`, and a called workflow cannot request more than its caller grants.
+    permissions:
+      contents: read
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   coverage:


### PR DESCRIPTION
`main` is not publishing. #3231 made `deploy-main.yml` call `rust.yml`, and the whole Deploy workflow now ends in `startup_failure` with **zero jobs**:

```
Invalid workflow file: .github/workflows/deploy-main.yml#L91
The nested job 'test' is requesting 'contents: read', but is only allowed 'contents: none'.
The nested job 'rustfmt' is requesting 'contents: read', but is only allowed 'contents: none'.
```

This workflow defaults to `permissions: {}`, the calling job did not override it, and every job in `rust.yml` declares `contents: read`. A called workflow cannot request more than its caller grants.

Checked every reusable-workflow call in this file against what its jobs declare; `rust.yml` is the only one that asks for anything, which is why nothing else ever hit this:

| calling job | granted | called jobs need | |
|---|---|---|---|
| build-all | `{}` | `{}` | ok |
| benchmark | `{}` | `{}` | ok |
| bundle-analysis | `{}` | `{}` | ok |
| **test-rust** | **`contents: read`** | **`contents: read`** | **fixed here** |
| coverage | `{}` | `{}` | ok |
| coverage-web-elements | `{}` | `{}` | ok |
| coverage-web-core | `{}` | `{}` | ok |
| website-build | `{}` | `{}` | ok |

Not a flake: `startup_failure` has occurred twice in 400 Deploy runs, and the other one (`bcbaf2e6c`) changed only `renovate.json5`.

This cannot be validated before merging — `deploy-main.yml` only runs on push to `main` — so the check is the Deploy run this merge produces.