### PR TITLE
ci(rust): fail when Cargo.lock is out of date

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,3 +134,26 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
       - name: Clippy
         run: cargo clippy --tests --all-features -- -D warnings
+
+  lockfile:
+    runs-on: lynx-ubuntu-26.04-medium
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        uses: ./.github/actions/rustup
+        with:
+          key: lint
+          save-if: ${{ github.ref_name == 'main' }}
+      # A `Cargo.toml` edit that is not reflected in `Cargo.lock` does not fail
+      # any build: the first cargo invocation silently rewrites the lock file.
+      # That leaves a dirty tree behind, which breaks anything downstream that
+      # expects a clean checkout after a build — `pnpm publish` aborts with
+      # `ERR_PNPM_GIT_UNCLEAN`. `cargo metadata --locked` resolves the graph
+      # without compiling and without writing, so it fails fast instead.
+      - name: Check Cargo.lock is up to date
+        run: cargo metadata --locked --format-version 1 > /dev/null

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,7 @@ name = "lynx"
 version = "0.1.0"
 dependencies = [
  "fs2",
+ "hex",
  "libloading 0.9.0",
  "sha2 0.11.0",
  "tempfile",


### PR DESCRIPTION
## Problem

`packages/lynx/engine-bridge/lynx/Cargo.toml` gained a `hex = { workspace = true }` build-dependency in #3129, but `Cargo.lock` was never updated to list `hex` under the `lynx` package. Nothing fails today — the first cargo invocation simply rewrites the lock file:

```diff
 name = "lynx"
 version = "0.1.0"
 dependencies = [
  "fs2",
+ "hex",
  "libloading 0.9.0",
```

The build succeeds, but the working tree is left dirty afterwards. That breaks anything downstream expecting a clean checkout after a build — an internal `pnpm --recursive publish` run aborted with `ERR_PNPM_GIT_UNCLEAN`, and the cause was far from obvious because the same commit published fine through a pipeline that happened to pass `--no-git-checks`.

## Change

A `lockfile` job running `cargo metadata --locked --format-version 1`. It resolves the dependency graph without compiling and without writing, so an out-of-date lock file fails fast and points straight at the real problem.

## Verification

This PR is deliberately split so CI proves both halves:

1. **First commit** adds the check only — the `lockfile` job is expected to **fail**, reproducing the issue on CI.
2. **Second commit** updates `Cargo.lock` — the job turns green.

Locally:

```console
$ cargo metadata --locked --format-version 1 > /dev/null   # before
error: the lock file .../Cargo.lock needs to be updated but --locked was passed to prevent this

$ cargo metadata --format-version 1 > /dev/null            # regenerate (adds only the one `hex` line)
$ cargo metadata --locked --format-version 1 > /dev/null   # after
$ echo $?
0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation to ensure the Rust dependency lockfile stays synchronized with project configuration.
  * Builds now fail early when the lockfile is outdated or inconsistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->