### PR TITLE
fix(rspeedy): minify stats.json to avoid invalid string length

### DIFF
--- a/.changeset/tidy-planes-shave.md
+++ b/.changeset/tidy-planes-shave.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Minify `stats.json` to avoid invalid string length when building large projects

--- a/.changeset/tidy-planes-shave.md
+++ b/.changeset/tidy-planes-shave.md
@@ -2,4 +2,4 @@
 "@lynx-js/rspeedy": patch
 ---
 
-Minify `stats.json` to avoid invalid string length when building large projects
+Minify `stats.json` and exclude module `reasons` to avoid invalid string length when building large projects

--- a/packages/rspeedy/core/src/plugins/statsJson.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/statsJson.plugin.ts
@@ -26,7 +26,7 @@ export function pluginStatsJson(config: Config): RsbuildPlugin {
         await mkdir(path.dirname(statsPath), { recursive: true })
         await writeFile(
           statsPath,
-          JSON.stringify(stats.toJson(BUNDLE_STATS_JSON_OPTIONS), null, 2),
+          JSON.stringify(stats.toJson(BUNDLE_STATS_JSON_OPTIONS)),
         )
       })
     },

--- a/packages/rspeedy/core/src/plugins/statsJsonOptions.ts
+++ b/packages/rspeedy/core/src/plugins/statsJsonOptions.ts
@@ -8,4 +8,8 @@ export const BUNDLE_STATS_JSON_OPTIONS = {
   modules: true,
   entrypoints: true,
   chunkGroups: true,
+  // `reasons` grows with the number of module edges and can push `stats.json`
+  // beyond V8's maximum string length on large projects, while bundle-analysis
+  // consumers only need module names and sizes.
+  reasons: false,
 } as const


### PR DESCRIPTION
Similar to #2966, but in `pluginStatsJson`: with `performance.profile` enabled (e.g. `DEBUG=rspeedy`), building a large project crashes after artifacts are emitted:

```
error   RangeError: Invalid string length
    at JSON.stringify (<anonymous>)
    at .../dist/0~statsJson.plugin.js:21:49
```

Measured on a real-world project (7872 top-level modules, 14562 including concatenated-module children), the stringified stats break down as:

| field | minified size |
|---|---|
| `modules[].reasons` (aggregated) | 414.8 MB |
| `modules[].issuerPath` (aggregated) | 86.5 MB |
| everything else | ~45 MB |

Dropping the `null, 2` indent alone is not enough — the minified string still exceeds V8's maximum string length (~512 MiB). `reasons` grows with the number of module edges, and bundle-analysis consumers (e.g. RelativeCI / bundle-stats) only need module names and sizes.

This PR:

1. removes the pretty-print indent, mirroring #2966;
2. adds `reasons: false` to `BUNDLE_STATS_JSON_OPTIONS` (this also drops the `issuer*` fields).

Verified on the same project: the build now completes and emits a 137 MB `stats.json`, and `npx bundle-stats` consumes it successfully.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generation of build statistics for large projects by reducing unnecessary data and producing a more compact `stats.json` file.
  * Helped prevent invalid string length errors during builds while preserving essential module and size information.

* **Release**
  * Prepared a patch release for the build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->