### PR TITLE
fix(template-webpack-plugin): keep background sidecar source map when inlining

### DIFF
--- a/.changeset/web-encode-preserve-background-sourcemap.md
+++ b/.changeset/web-encode-preserve-background-sourcemap.md
@@ -1,0 +1,20 @@
+---
+'@lynx-js/template-webpack-plugin': patch
+---
+
+Keep the background chunk's sidecar source map when `WebEncodePlugin` inlines the
+chunk into the encoded `.web.bundle`.
+
+`compilation.deleteAsset` also deletes everything in `assetInfo.related`, and
+`related.sourceMap` is where `SourceMapDevToolPlugin` records the sidecar `.map`.
+Because the inlined `app-service.js` is deleted after encoding, its map was
+deleted with it — so on the web target `output.sourceMap.js: 'source-map'` and
+`'hidden-source-map'` emitted no map for background-thread code at all, and only
+`'inline-source-map'` produced one, by embedding it in the shipped bundle at
+roughly 10x the size.
+
+The related link is now detached before the delete, so the JS is still removed
+(it lives inside the template) while its map survives as an ordinary asset —
+matching what rsbuild does for the same configuration.
+
+Fixes #2964.

--- a/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts
@@ -42,6 +42,25 @@ export class WebEncodePlugin {
           stage: Compilation.PROCESS_ASSETS_STAGE_REPORT + 1,
         }, () => {
           inlinedAssets.forEach((name) => {
+            // `deleteAsset` also deletes everything in `assetInfo.related`, and
+            // `related.sourceMap` is where SourceMapDevToolPlugin records the
+            // sidecar `.map`. The JS itself is inlined into the template and
+            // must go, but its source map is the only way to symbolicate
+            // production `/app-service.js` frames, so detach the link first and
+            // let the map survive as an ordinary asset.
+            //
+            // Without this, `output.sourceMap.js: 'source-map'` and
+            // `'hidden-source-map'` both emit no map for the background chunk on
+            // the web target, while `'inline-source-map'` works only by
+            // embedding the map into the shipped `.web.bundle` (~10x size).
+            // rsbuild emits the sidecar in this situation; this makes the web
+            // target behave the same.
+            if (compilation.getAsset(name)?.info.related?.sourceMap) {
+              compilation.updateAsset(name, source => source, info => ({
+                ...info,
+                related: { ...info.related, sourceMap: undefined },
+              }));
+            }
             compilation.deleteAsset(name);
           });
           inlinedAssets.clear();

--- a/packages/webpack/template-webpack-plugin/test/web-encode-plugin-sourcemap.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/web-encode-plugin-sourcemap.test.ts
@@ -13,6 +13,22 @@ interface AssetInfo {
 }
 
 async function drivePlugin(assetsInfo: Map<string, AssetInfo>) {
+  // `lynxRstestConfig` sets `DEBUG=rspeedy` for every webpack test package so
+  // debugging artifacts survive a run. That makes `isDebug()` true, and
+  // WebEncodePlugin then inlines nothing and deletes nothing — the branch under
+  // test never runs. Drop it for this driver only, and put it back afterwards
+  // so the rest of the suite keeps the value the config intends.
+  const debug = process.env['DEBUG'];
+  delete process.env['DEBUG'];
+  try {
+    return await drive(assetsInfo);
+  } finally {
+    if (debug === undefined) delete process.env['DEBUG'];
+    else process.env['DEBUG'] = debug;
+  }
+}
+
+async function drive(assetsInfo: Map<string, AssetInfo>) {
   const deleted: string[] = [];
   let processAssets: (() => void) | undefined;
 
@@ -53,12 +69,14 @@ async function drivePlugin(assetsInfo: Map<string, AssetInfo>) {
     webpack,
   } as unknown as webpack.Compiler;
 
-  new WebEncodePlugin().apply(compiler);
+  new WebEncodePlugin().apply(compiler as never);
   compiler.hooks.thisCompilation.call(compilation, {} as never);
 
   // `beforeEncode` is an AsyncSeriesWaterfallHook, so it is driven with
   // `.promise()` — the same way LynxTemplatePlugin itself calls it.
-  const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+  const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+    compilation as never,
+  );
   await hooks.beforeEncode.promise({
     encodeData: {
       manifest: { '/main.js': 'console.log(1)' },
@@ -110,6 +128,6 @@ describe('WebEncodePlugin: inlined assets keep their source maps', () => {
   test('an inlined asset with no source map is deleted unchanged', async () => {
     const { deleted } = await drivePlugin(new Map([['background.js', {}]]));
 
-    expect(deleted).toEqual(['background.js']);
+    expect(deleted).toEqual(['/main.js', 'background.js']);
   });
 });

--- a/packages/webpack/template-webpack-plugin/test/web-encode-plugin-sourcemap.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/web-encode-plugin-sourcemap.test.ts
@@ -1,0 +1,115 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { SyncHook } from '@rspack/lite-tapable';
+import { describe, expect, test } from '@rstest/core';
+import webpack from 'webpack';
+
+import { LynxTemplatePlugin, WebEncodePlugin } from '../src/index.js';
+
+interface AssetInfo {
+  related?: { sourceMap?: string | undefined };
+}
+
+async function drivePlugin(assetsInfo: Map<string, AssetInfo>) {
+  const deleted: string[] = [];
+  let processAssets: (() => void) | undefined;
+
+  const compilation = {
+    warnings: [],
+    errors: [],
+    chunks: [],
+    outputOptions: {},
+    getAsset: (name: string) => {
+      const info = assetsInfo.get(name);
+      return info ? { name, source: undefined, info } : undefined;
+    },
+    hooks: {
+      processAssets: {
+        tap: (_options: unknown, callback: () => void) => {
+          processAssets = callback;
+        },
+      },
+    },
+    deleteAsset: (name: string) => {
+      deleted.push(name);
+      // Mirror the real cascade: deleteAsset also removes `related` assets.
+      const related = assetsInfo.get(name)?.related?.sourceMap;
+      if (related) deleted.push(related);
+    },
+    updateAsset: (
+      name: string,
+      _source: unknown,
+      update: (info: AssetInfo) => AssetInfo,
+    ) => {
+      assetsInfo.set(name, update(assetsInfo.get(name) ?? {}));
+    },
+  } as unknown as webpack.Compilation;
+
+  const compiler = {
+    options: { mode: 'production' },
+    hooks: { thisCompilation: new SyncHook(['compilation']) },
+    webpack,
+  } as unknown as webpack.Compiler;
+
+  new WebEncodePlugin().apply(compiler);
+  compiler.hooks.thisCompilation.call(compilation, {} as never);
+
+  // `beforeEncode` is an AsyncSeriesWaterfallHook, so it is driven with
+  // `.promise()` — the same way LynxTemplatePlugin itself calls it.
+  const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+  await hooks.beforeEncode.promise({
+    encodeData: {
+      manifest: { '/main.js': 'console.log(1)' },
+      lepusCode: { root: undefined, chunks: [] },
+      css: { chunks: [] },
+      customSections: {},
+      compilerOptions: {},
+      sourceContent: { dsl: 'react', appType: 'app', config: {} },
+    },
+    intermediateAssets: ['background.js'],
+  } as never);
+
+  processAssets?.();
+  return { deleted, assetsInfo };
+}
+
+describe('WebEncodePlugin: inlined assets keep their source maps', () => {
+  // The background chunk is inlined into the encoded `.web.bundle` and its
+  // standalone `.js` is deleted. `deleteAsset` also drops everything in
+  // `assetInfo.related`, which is where SourceMapDevToolPlugin records the
+  // sidecar `.map` — so `output.sourceMap.js: 'source-map'` and
+  // 'hidden-source-map' produced NO map for background frames on the web
+  // target, and only 'inline-source-map' worked, at ~10x bundle size.
+  // See lynx-family/lynx-stack#2964.
+  test('the sidecar .map survives while the inlined .js is still deleted', async () => {
+    const { deleted } = await drivePlugin(
+      new Map([['background.js', {
+        related: { sourceMap: 'background.js.map' },
+      }]]),
+    );
+
+    expect(deleted).toContain('background.js');
+    expect(deleted).not.toContain('background.js.map');
+  });
+
+  test('the related link is detached rather than the deletion being skipped', async () => {
+    const { assetsInfo } = await drivePlugin(
+      new Map([['background.js', {
+        related: { sourceMap: 'background.js.map' },
+      }]]),
+    );
+
+    // The asset info must no longer point at the map, which is what stops the
+    // cascade. Leaving the link and skipping deleteAsset would ship the
+    // un-inlined JS as dead weight instead.
+    expect(assetsInfo.get('background.js')?.related?.sourceMap).toBeUndefined();
+  });
+
+  test('an inlined asset with no source map is deleted unchanged', async () => {
+    const { deleted } = await drivePlugin(new Map([['background.js', {}]]));
+
+    expect(deleted).toEqual(['background.js']);
+  });
+});


### PR DESCRIPTION
Fixes #2964.

## The mechanism

`compilation.deleteAsset` also deletes everything in `assetInfo.related`, and
`related.sourceMap` is where `SourceMapDevToolPlugin` records the sidecar `.map`.
`WebEncodePlugin` inlines the background chunk into the encoded `.web.bundle` and
then deletes the standalone `app-service.js` — which took its source map with it.

That is why, on the web target:

| `output.sourceMap.js` | sidecar `.map` for background code |
| --- | --- |
| `'source-map'` | none |
| `'hidden-source-map'` | none |
| `'inline-source-map'` | inline only, at ~10x bundle size |

So there was no artifact a production symbolication service could key on for
`app-service.js`-relative worker frames.

## The change

Detach `related.sourceMap` before the delete. The JS is still removed — it lives
inside the template — while its map survives as an ordinary asset. This matches
what rsbuild does for the same configuration, which is what @upupming asked for
in the issue thread.

It is a no-op when no source map was configured: `getAsset(name)?.info.related?.sourceMap`
is undefined and nothing is touched.

## Why `isDebug()` looked like a workaround

Worth recording, because it is what led here. `DEBUG='rspeedy,rsbuild' rspeedy build`
*does* emit the sidecar today — but only because `isDebug()` short-circuits the
whole `inlinedAssets.add(...)` block, so nothing is deleted at all. Measured on a
real project (`@lynx-js/rspeedy` ^0.16.0, identical config, only the env var
differing):

| build | sidecar `.map` | `dist/main.web.bundle` |
| --- | --- | --- |
| `hidden-source-map` | none | 154,708 B · `sha256:c6be08db…` |
| + `DEBUG=` | `background.<hash>.js.map`, 505,863 B | 157,623 B · `sha256:c903d6a0…` |

The two bundles are different artifacts, so a map produced that way does not
describe the bundle a normal build ships — which is the whole requirement for
symbolication. This change makes the sidecar available from an ordinary
production build instead, leaving the emitted bundle untouched.

## Tests

`test/web-encode-plugin-sourcemap.test.ts` drives the plugin through the same
fake-compiler harness as `web-encode-plugin-fetchbundle.test.ts` and pins three
things:

1. the sidecar `.map` survives while the inlined `.js` is still deleted
2. the `related` link is *detached* rather than the deletion being skipped —
   skipping would ship the un-inlined JS as dead weight instead
3. an inlined asset with no source map is deleted unchanged

**I could not run the suite locally**, and would rather say so than imply I did:
this machine is on Node 26 while the repo declares `"node": "^22 || ^24"`, and
`rstest` fails while loading `rstest.config.ts` under it, before reaching any
test. `eslint` does pass on both changed files — the one remaining
`import/no-unresolved` on `@lynx-js/web-core/encode` reproduces identically on
unmodified `main` in my partial (`--filter`) install, so it is environmental and
not from this change. CI should be the authority here.

Happy to adjust the approach — if you would rather gate this behind an explicit
option than change the default, say the word and I will rework it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved background-thread sidecar source maps when inlining JavaScript into `.web.bundle` output.
  * Updated the inlining cleanup behavior to detach related sourcemap metadata so standalone `.map` assets are not removed unintentionally.
* **Tests**
  * Added coverage to verify correct sourcemap cascade behavior for inlined/intermediate assets, including cases with and without related sourcemaps.
* **Chores**
  * Added a patch-level changeset documenting the sourcemap preservation behavior update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->