### PR TITLE
build: add repository build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+export CI="${CI:-1}"
+export TURBO_TELEMETRY_DISABLED="${TURBO_TELEMETRY_DISABLED:-1}"
+export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=32768}"
+
+if ! command -v corepack >/dev/null 2>&1; then
+  printf 'corepack is required to use the pnpm version pinned by package.json.\n' >&2
+  exit 1
+fi
+
+if [[ "${SKIP_INSTALL:-0}" != "1" ]]; then
+  corepack pnpm install --frozen-lockfile
+fi
+
+corepack pnpm turbo build --summarize


### PR DESCRIPTION
## Summary

- add an executable `build.sh` at the repository root
- install frozen pnpm dependencies by default, with `SKIP_INSTALL=1` support
- run the repository build through `pnpm turbo build --summarize`

## Why

Provide a single local entry point for the build portion of the `deploy-main` workflow without modifying CI configuration.

## Impact

Developers can run the repository build with `./build.sh`. Existing CI workflows and package behavior are unchanged.

## Validation

- `bash -n build.sh`
- verified executable file mode
- `git diff --check`
- `pnpm turbo build --summarize` completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a standardized build process with deterministic setup and consistent environment defaults.
  * Added dependency installation controls, including an option to skip installation.
  * Added validation for required build tooling and improved failure handling.
  * Enabled build summaries for clearer completion reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->