### PR TITLE
fix(web-core): wait for lazy component evaluation

### DIFF
--- a/.changeset/calm-badgers-wait.md
+++ b/.changeset/calm-badgers-wait.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Wait for main-thread lazy-component evaluation before invoking background callbacks.

--- a/.github/web-core-query-component.instructions.md
+++ b/.github/web-core-query-component.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/ts/client/{background/background-apis/createNativeApp.ts,mainthread/{Background.ts,LynxViewInstance.ts}},packages/web-platform/web-core/tests/create-native-app.spec.ts"
+---
+
+For background `queryComponent`, do not use `templateCache` to decide callback readiness. Always wait for the main-thread `queryComponent` RPC and forward its `{ code, detail }` response, because that promise covers loading the main-thread chunk and running `processEvalResult`. Keep `templateCache` only for resolving background chunk URLs in `readScript`, `loadScript`, and `loadScriptAsync`.

--- a/packages/web-platform/web-core/tests/create-native-app.spec.ts
+++ b/packages/web-platform/web-core/tests/create-native-app.spec.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, rstest, test } from '@rstest/core';
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+import {
+  queryComponentEndpoint,
+  updateBTSChunkEndpoint,
+} from '../ts/client/endpoints.js';
+import { createNativeApp } from '../ts/client/background/background-apis/createNativeApp.js';
+import type { TimingSystem } from '../ts/client/background/background-apis/createTimingSystem.js';
+
+type RpcHandler = (...args: unknown[]) => unknown;
+type QueryComponentResponse = {
+  code: number;
+  detail: {
+    schema: string;
+  };
+};
+
+function createMainThreadRpc(
+  queryComponent: (url: string) => Promise<QueryComponentResponse>,
+): {
+  rpc: Rpc;
+  handlers: Map<string, RpcHandler>;
+} {
+  const handlers = new Map<string, RpcHandler>();
+  const noOpCall = rstest.fn(() => Promise.resolve(undefined));
+
+  return {
+    rpc: {
+      createCall: rstest.fn((endpoint: { name: string }) => {
+        return endpoint.name === queryComponentEndpoint.name
+          ? queryComponent
+          : noOpCall;
+      }),
+      createCallbackify: rstest.fn(() => rstest.fn()),
+      registerHandler: rstest.fn((
+        endpoint: { name: string },
+        handler: RpcHandler,
+      ) => {
+        handlers.set(endpoint.name, handler);
+      }),
+      invoke: rstest.fn(() => Promise.resolve(undefined)),
+    } as unknown as Rpc,
+    handlers,
+  };
+}
+
+const timingSystem = {
+  registerGlobalEmitter: rstest.fn(),
+  markTimingInternal: rstest.fn(),
+  pipelineIdToTimingFlags: new Map<string, string[]>(),
+} as TimingSystem;
+
+describe('createNativeApp', () => {
+  test('waits for the main-thread query when the background chunk is cached', async () => {
+    const source = '/lazy-component.web.bundle';
+    const query = Promise.withResolvers<QueryComponentResponse>();
+    const queryComponent = rstest.fn(() => query.promise);
+    const { rpc, handlers } = createMainThreadRpc(queryComponent);
+    const nativeApp = await createNativeApp(
+      rpc,
+      timingSystem,
+      {},
+      '/main.web.bundle',
+      'react',
+    );
+    handlers.get(updateBTSChunkEndpoint.name)?.(
+      source,
+      { '/app-service.js': 'blob:background-chunk' },
+    );
+    const callback = rstest.fn();
+
+    nativeApp.queryComponent(source, callback);
+
+    expect(queryComponent).toHaveBeenCalledWith(source);
+    expect(callback).not.toHaveBeenCalled();
+
+    const response = {
+      code: 0,
+      detail: { schema: source },
+    };
+    query.resolve(response);
+    await query.promise;
+    await Promise.resolve();
+
+    expect(callback).toHaveBeenCalledWith(response);
+  });
+
+  test('forwards the main-thread response for an uncached component', async () => {
+    const source = '/lazy-component.web.bundle';
+    const response: QueryComponentResponse = {
+      code: 0,
+      detail: { schema: source },
+    };
+    const queryComponent = rstest.fn(() => Promise.resolve(response));
+    const { rpc } = createMainThreadRpc(queryComponent);
+    const nativeApp = await createNativeApp(
+      rpc,
+      timingSystem,
+      {},
+      '/main.web.bundle',
+      'react',
+    );
+    const callback = rstest.fn();
+
+    nativeApp.queryComponent(source, callback);
+    await Promise.resolve();
+
+    expect(callback).toHaveBeenCalledWith(response);
+  });
+});

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createNativeApp.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createNativeApp.ts
@@ -148,13 +148,9 @@ export async function createNativeApp(
     __SetSourceMapRelease: (err: Error) => release = err.message,
     __GetSourceMapRelease: (_url: string) => release,
     queryComponent: (source, callback) => {
-      if (templateCache.has(source)) {
-        callback({ __hasReady: true });
-      } else {
-        queryComponent(source).then(res => {
-          callback?.(res);
-        });
-      }
+      queryComponent(source).then(res => {
+        callback?.(res);
+      });
     },
   };
   return nativeApp;


### PR DESCRIPTION
## Summary

- always route background `queryComponent` calls through the main-thread RPC, even when the BTS chunk is already present in `templateCache`
- forward the main-thread `{ code, detail }` response after `LynxViewInstance.queryComponent` finishes loading and processing the lazy component
- add regression coverage for cached and uncached background chunks

## Root cause

The background `templateCache` only indicates that the BTS chunk is available. The cached path treated it as proof that the lazy component was also ready on the main thread and synchronously returned `__hasReady`, bypassing the existing `mtsRealm.loadScript()` and `processEvalResult()` barrier.

That allowed the background render to emit element patches before the main thread registered the lazy chunk's snapshot creators, intermittently causing `Snapshot not found` and a blank page.

## Impact

Cached and uncached `QueryComponent` loads now use the same main-thread readiness barrier, preventing background patches from racing main-thread lazy-component evaluation.

## Validation

- `pnpm turbo build` — 65/65 tasks passed
- `pnpm --filter @lynx-js/web-core test -- create-native-app.spec.ts` — 170/170 tests passed
- `pnpm dprint check` on changed files
- `git diff --check`

Fixes #3184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed component queries so callbacks wait for main-thread lazy-component evaluation to complete.
  * Ensured query results are consistently returned after required loading and processing, including when content is already cached.

* **Tests**
  * Added coverage for cached and uncached component-query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->