### PR TITLE
chore(deps): upgrade @lynx-js/type-config to 4.1.3

### DIFF
--- a/.changeset/upgrade-type-config-4-1-3.md
+++ b/.changeset/upgrade-type-config-4-1-3.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/config-rsbuild-plugin": patch
+---
+
+Upgrade `@lynx-js/type-config` to `4.1.3`, which adds `enableEventHandleRefactor` and `alignMouseEventWithW3C` to the supported Lynx config keys.

--- a/packages/rspeedy/plugin-config/package.json
+++ b/packages/rspeedy/plugin-config/package.json
@@ -38,7 +38,7 @@
     "test:type": "tsc --noEmit"
   },
   "dependencies": {
-    "@lynx-js/type-config": "4.1.1"
+    "@lynx-js/type-config": "4.1.3"
   },
   "devDependencies": {
     "@lynx-js/rspeedy": "workspace:*",

--- a/packages/rspeedy/plugin-config/test/config.test-d.ts
+++ b/packages/rspeedy/plugin-config/test/config.test-d.ts
@@ -29,10 +29,10 @@ describe('config length', () => {
   })
   it('type config config should have expected length', () => {
     expectTypeOf<UnionToTuple<keyof TypeConfig.Config>['length']>()
-      .toEqualTypeOf<31>()
+      .toEqualTypeOf<33>()
   })
   it('pluginLynxConfig config should have expected length', () => {
     expectTypeOf<UnionToTuple<keyof Config>['length']>()
-      .toEqualTypeOf<31>()
+      .toEqualTypeOf<33>()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,8 +1530,8 @@ importers:
   packages/rspeedy/plugin-config:
     dependencies:
       '@lynx-js/type-config':
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.1.3
+        version: 4.1.3
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: workspace:*
@@ -4321,8 +4321,8 @@ packages:
     resolution: {integrity: sha512-Zyl74cKi+BDggeXroLQG4frbBuiQ0DB0yH0C3pMkUHWv17abWTdJ2mw/H9Cd1QiIr+aQHn1U2SRtsrbkmWMtJw==}
     engines: {node: '>=18'}
 
-  '@lynx-js/type-config@4.1.1':
-    resolution: {integrity: sha512-YuzuLkz71WoAgHnYEGkCgmocTW0mzcmQTDDF5zfvpNepD/Oxh4/yqxRhK+uaiJeJnPhTFM445ZRaFnBrSRTOag==}
+  '@lynx-js/type-config@4.1.3':
+    resolution: {integrity: sha512-r5YZFwXMQ9DY7du7idsTocRfzAff86ktKLwZ6k/i6kmF0dCCo7+5/d/FvmPtcg3PDuXV5vUSmAd8GnJrbdA/1w==}
 
   '@lynx-js/type-element-api@0.0.3':
     resolution: {integrity: sha512-e8+V1aU9VD6fmVJhS1VoE5ZxUD2udhEtTTsGBj2jlxYNscND2V6fyYFGF/dUPN+s9EwRiB80vUY/Im8tYSsMWA==}
@@ -14407,7 +14407,7 @@ snapshots:
     dependencies:
       immer: 10.2.0
 
-  '@lynx-js/type-config@4.1.1': {}
+  '@lynx-js/type-config@4.1.3': {}
 
   '@lynx-js/type-element-api@0.0.3': {}
 


### PR DESCRIPTION
## Summary

Upgrade `@lynx-js/type-config` from `4.1.1` to `4.1.3`.

`4.1.2` and `4.1.3` are additive patches — two new keys in `Config` and `configKeys`:

- `enableEventHandleRefactor` (4.1.2)
- `alignMouseEventWithW3C` (4.1.3)

## Changes

- `packages/rspeedy/plugin-config`: bump the dependency.
- `test/config.test-d.ts`: expected `Config` key count 31 → 33.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new Lynx configuration options: `enableEventHandleRefactor` and `alignMouseEventWithW3C`.

* **Bug Fixes**
  * Updated configuration tooling to recognize the latest supported settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->