### PR TITLE
fix(web-core): free the wasm context after each server render

### DIFF
--- a/.changeset/free-ssr-wasm-context.md
+++ b/.changeset/free-ssr-wasm-context.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Free the wasm context after each `executeTemplate` call. It builds its element tree inside the wasm linear memory, which the JS GC cannot reclaim, so every server render leaked memory proportional to the page size (~340KB for a 1000-element page) for the lifetime of the process.

--- a/packages/web-platform/web-core-e2e/server-tests/server-memory.test.ts
+++ b/packages/web-platform/web-core-e2e/server-tests/server-memory.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@rstest/core';
+import * as path from 'path';
+import * as fs from 'fs';
+import { executeTemplate } from '@lynx-js/web-core/server';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * `executeTemplate` builds its element tree inside the wasm linear memory,
+ * which the JS GC cannot reclaim. Before the context was freed explicitly each
+ * call retained its whole tree — ~340KB per render of `div-1000`, growing
+ * without bound in any long-running SSR process, and enough to make the
+ * benchmark of this same function swing by 20-30% run over run.
+ *
+ * `process.memoryUsage().external` counts the wasm memory, so a leak shows up
+ * as linear growth here. The threshold is deliberately loose: the regression
+ * this guards against was three orders of magnitude larger.
+ */
+test('executeTemplate should not retain wasm memory across calls', () => {
+  const buffer = fs.readFileSync(
+    path.resolve(__dirname, '../dist/basic-performance-div-1000.web.bundle'),
+  );
+
+  // Let the wasm instance reach its steady-state size first: the very first
+  // renders still grow the linear memory for allocator pages that get reused.
+  for (let i = 0; i < 20; i++) {
+    executeTemplate(buffer, {}, {}, {});
+  }
+
+  const before = process.memoryUsage().external;
+  const iterations = 50;
+  for (let i = 0; i < iterations; i++) {
+    executeTemplate(buffer, {}, {}, {});
+  }
+  const retainedPerCall = (process.memoryUsage().external - before)
+    / iterations;
+
+  // Leaking looked like ~340_000 bytes per call for this bundle.
+  expect(retainedPerCall).toBeLessThan(50_000);
+});

--- a/packages/web-platform/web-core/tests/deploy.spec.ts
+++ b/packages/web-platform/web-core/tests/deploy.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, rstest, beforeEach } from '@rstest/core';
+import * as vm from 'vm';
 import { executeTemplate } from '../ts/server/deploy.js';
 import * as decodeModule from '../ts/server/decode.js';
 import type { DecodedTemplate } from '../ts/server/decode.js';
@@ -38,7 +39,7 @@ describe('executeTemplate', () => {
 
     mockCreateElementAPI.mockReturnValue({
       globalThisAPIs: {} as ElementPAPIs,
-      wasmContext: {} as MainThreadServerContext,
+      wasmContext: { free: rstest.fn() } as unknown as MainThreadServerContext,
     });
 
     const dummyBuffer = Buffer.from('test');
@@ -56,5 +57,33 @@ describe('executeTemplate', () => {
     expect(mockCreateElementAPI).toHaveBeenCalled();
     // 3rd arg is viewAttributes
     expect(mockCreateElementAPI.mock.calls[0][2]).toBe('my-view-attr="123"');
+  });
+
+  it('should free the wasm context, including when the root code throws', () => {
+    const mockDecodeTemplate = rstest.mocked(decodeModule.decodeTemplate);
+    const mockCreateElementAPI = rstest.mocked(
+      createElementAPIModule.createElementAPI,
+    );
+    const free = rstest.fn();
+
+    mockDecodeTemplate.mockReturnValue({
+      config: {},
+      lepusCode: { root: new TextEncoder().encode('void 0') },
+    } as unknown as DecodedTemplate);
+    mockCreateElementAPI.mockReturnValue({
+      globalThisAPIs: {} as ElementPAPIs,
+      wasmContext: { free } as unknown as MainThreadServerContext,
+    });
+
+    executeTemplate(Buffer.from('test'), {}, {}, () => {}, false, false);
+    expect(free).toHaveBeenCalledTimes(1);
+
+    rstest.mocked(vm.runInContext).mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    expect(() =>
+      executeTemplate(Buffer.from('test'), {}, {}, () => {}, false, false)
+    ).toThrow('boom');
+    expect(free).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web-platform/web-core/ts/server/deploy.ts
+++ b/packages/web-platform/web-core/ts/server/deploy.ts
@@ -26,7 +26,7 @@ export function executeTemplate(
   const config = result.config;
 
   const binding: SSRBinding = { ssrResult: '' };
-  const { globalThisAPIs: elementAPIs } = createElementAPI(
+  const { globalThisAPIs: elementAPIs, wasmContext } = createElementAPI(
     binding,
     result.styleInfo,
     viewAttributes ?? '',
@@ -65,13 +65,18 @@ export function executeTemplate(
 
   // Style Info block removed as it is passed to createElementAPI
 
-  // Lepus Code
-  const rootCodeBuf = result.lepusCode['root'];
-  if (rootCodeBuf) {
-    const rootCode = new TextDecoder('utf-8').decode(rootCodeBuf);
-    const isLazy = config['isLazy'] === 'true';
+  // `wasmContext` holds every element of this render inside the wasm linear
+  // memory. It is not reachable by the JS GC, so it has to be released
+  // explicitly once the html has been generated — otherwise each call retains
+  // its whole element tree for the lifetime of the process.
+  try {
+    // Lepus Code
+    const rootCodeBuf = result.lepusCode['root'];
+    if (rootCodeBuf) {
+      const rootCode = new TextDecoder('utf-8').decode(rootCodeBuf);
+      const isLazy = config['isLazy'] === 'true';
 
-    const wrappedCode = `
+      const wrappedCode = `
         (function() { 
           "use strict"; 
           const navigator = undefined;
@@ -82,25 +87,28 @@ export function executeTemplate(
         })()
       `;
 
-    // Execute root code
-    // This execution should trigger the assignment of globalThis.renderPage,
-    // which in turn triggers our setter, queues the microtask.
-    vm.runInContext(wrappedCode, context, {
-      filename: `root`,
-    });
-    const renderPageFunction = sandbox['renderPage'];
-    if (typeof renderPageFunction === 'function') {
-      const processData = sandbox['processData'];
-      const processedData = (config['enableJSDataProcessor'] !== 'true'
-          && config['enableJSDataProcessor'] !== true)
-          && processData
-        ? processData(initData)
-        : initData;
-      renderPageFunction(processedData);
-      elementAPIs.__FlushElementTree();
-      return binding.ssrResult;
+      // Execute root code
+      // This execution should trigger the assignment of globalThis.renderPage,
+      // which in turn triggers our setter, queues the microtask.
+      vm.runInContext(wrappedCode, context, {
+        filename: `root`,
+      });
+      const renderPageFunction = sandbox['renderPage'];
+      if (typeof renderPageFunction === 'function') {
+        const processData = sandbox['processData'];
+        const processedData = (config['enableJSDataProcessor'] !== 'true'
+            && config['enableJSDataProcessor'] !== true)
+            && processData
+          ? processData(initData)
+          : initData;
+        renderPageFunction(processedData);
+        elementAPIs.__FlushElementTree();
+        return binding.ssrResult;
+      }
     }
-  }
 
-  return undefined;
+    return undefined;
+  } finally {
+    wasmContext.free();
+  }
 }

--- a/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
+++ b/packages/web-platform/web-core/ts/server/elementAPIs/createElementAPI.ts
@@ -114,6 +114,10 @@ export function createElementAPI(
   if (styleInfo) {
     const resource = new StyleSheetResource(styleInfo, undefined);
     wasmContext.push_style_sheet(resource);
+    // `push_style_sheet` takes the resource by reference and clones it into the
+    // context's own map, so the wasm allocation behind this handle is ours to
+    // release. Without this it leaks for the lifetime of the wasm instance.
+    resource.free();
   }
 
   let pageElementId: number | undefined;


### PR DESCRIPTION
## Root cause

`executeTemplate` builds its element tree inside the wasm linear memory via `MainThreadServerContext`. wasm-bindgen handles are not reachable by the JS GC, and nothing called `free()` — `deploy.ts` discarded the `wasmContext` returned by `createElementAPI` entirely. `StyleSheetResource` leaked the same way (`push_style_sheet` takes it by reference and `style_manager_server.rs` clones it, so the JS handle is ours to release).

Measured per call, never reclaimed by GC:

| bundle | retained per `executeTemplate` |
| --- | --- |
| `basic-performance-div-100` | 38 KB |
| `basic-performance-div-1000` | 343 KB |
| `basic-performance-div-10000` | ~4 MB |

Rendering `div-10000` in a loop segfaults (exit 139) after ~11-20 iterations.

## Fix

Free `wasmContext` in a `finally`, and free the `StyleSheetResource` once the context has cloned it. After the fix all six benchmark bundles retain 0 KB per call and `div-10000` survives 100 iterations.

No throughput cost — interleaved A/B over 4 alternating rounds, `div-1000` p50: 2.70 ms (leaking) vs 2.67 ms (freed).

## Tests

- `server-memory.test.ts` asserts `external` memory does not grow across 50 renders; it fails on `main` and passes here.
- `deploy.spec.ts` asserts the context is freed, including when the root code throws.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side rendering memory leaks by releasing WebAssembly resources after each template render.
  * Ensured resources are freed even when rendering encounters an error or exits early.
  * Improved cleanup of stylesheet resources during rendering.

* **Tests**
  * Added coverage for repeated rendering and error scenarios to verify memory is released correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->