### PR TITLE
fix(benchmark): give the 004-various-update setAttribute benchmarks more than one sample

### DIFF
--- a/benchmark/react/cases/004-various-update/index.tsx
+++ b/benchmark/react/cases/004-various-update/index.tsx
@@ -112,8 +112,20 @@ if (typeof Codspeed !== 'undefined' && __BACKGROUND__) {
   );
 }
 
+/**
+ * How many update passes to drive before ending the run.
+ *
+ * Each pass commits one `setAttribute` per attribute kind, and every one of
+ * those calls is a round of the corresponding benchmark. With a single pass the
+ * `setAttribute__*` benchmarks were single samples of a ~2us operation, which
+ * WallTime cannot resolve — they drifted in and out of CodSpeed's 5% threshold
+ * on unrelated commits. The measured operation is unchanged; only the number of
+ * rounds it is averaged over grows.
+ */
+const UPDATE_PASSES = 100;
+
 function F() {
-  const [stopBenchmark, setStopBenchmark] = useState(false);
+  const [pass, setPass] = useState(0);
   const [values, setValues] = useState(
     [
       'some-exposure-id' as string,
@@ -140,30 +152,35 @@ function F() {
   );
 
   useEffect(() => {
+    if (pass >= UPDATE_PASSES) {
+      return;
+    }
+    // Every value differs from the previous pass, so each pass really does
+    // reach `setAttribute` instead of being skipped as unchanged.
     setValues([
-      'some-other-exposure-id',
-      'some-other-dataset',
+      `some-other-exposure-id-${pass}`,
+      `some-other-dataset-${pass}`,
       () => {},
       () => {
         'main thread';
       },
-      'width: 200rpx; height: 100rpx; background-color: #FACE00;',
+      `width: ${200 + pass}rpx; height: 100rpx; background-color: #FACE00;`,
       {
-        width: '200rpx',
+        width: `${200 + pass}rpx`,
         height: '100rpx',
         backgroundColor: '#FACE00',
       },
-      'some-other-css-class',
-      'some-other-id',
+      `some-other-css-class-${pass}`,
+      `some-other-id-${pass}`,
       (_e: NodesRef) => {},
-      'some_other_lynx_timing_flag',
+      `some_other_lynx_timing_flag_${pass}`,
       (_e: MainThread.Element) => {
         'main thread';
       },
-      'some-other-item-key',
+      `some-other-item-key-${pass}`,
     ]);
-    setStopBenchmark(true);
-  }, []);
+    setPass(pass + 1);
+  }, [pass]);
 
   if (isMainThread) {
     return null;
@@ -222,7 +239,7 @@ function F() {
         }
       />
 
-      <view id={`stop-benchmark-${stopBenchmark}`} />
+      <view id={`stop-benchmark-${pass >= UPDATE_PASSES}`} />
     </view>
   );
 }


### PR DESCRIPTION
## Problem

`004-various-update` renders exactly one element per attribute kind and updates it once, so each `setAttribute__*` benchmark was **a single sample of a ~2us operation**. Measured locally by counting hook invocations:

```
1 ROUNDCOUNT Attr / Dataset / Class / Id / StyleString / StyleObject /
  TimingFlag / MT_Event / MT_Ref / Spread / ListItemPlatformInfo / ...
```

WallTime cannot resolve that — 5% of 2us is 80ns. These benchmarks drifted in and out of CodSpeed's 5% threshold on commits that could not possibly affect them (`004-various-update__main-thread-setAttribute__Dataset` moved 5.66% on a dependency bump).

## Change

Drive 100 update passes before signalling `stop-benchmark-true`, with per-pass distinct values so no pass is skipped as unchanged. The element tree, the measured operation, and the per-round work are unchanged — only the number of rounds each benchmark is averaged over. Verified locally with the same counter:

```
100 ROUNDCOUNT Attr / Dataset / Class / Id / StyleString / StyleObject / ...
```

## Expected effect on this PR's report

The 12 `setAttribute__*` benchmarks will change value: they used to report one cold call, now they report a mean over 100 mostly-warm rounds. Expect them to look like large "improvements" — that is the measurement changing, not the code.

`BatchedValues` stays at one round (its background hook keys off the stop sentinel) and is 113us, well clear of the noise floor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the benchmark to perform a defined number of attribute-update passes before completing.
  * Ensured the completion signal is emitted only after the final update pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->