### PR TITLE
feat(preact-runtime): transform-free ReactLynx on vanilla preact, background-thread only

### DIFF
--- a/.changeset/gesture-transform-free-mts.md
+++ b/.changeset/gesture-transform-free-mts.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/gesture-runtime": patch
+---
+
+Accept plain functions as gesture callbacks when `globalThis.__TRANSFORM_FREE_MTS__` is set by a transform-free runtime.

--- a/benchmark/preact-runtime/cases/002-hello-preact/index.tsx
+++ b/benchmark/preact-runtime/cases/002-hello-preact/index.tsx
@@ -1,0 +1,27 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from '@lynx-js/preact-runtime';
+
+function RecursiveText(props: { text: string }) {
+  const { text } = props;
+  const sliced = [...text];
+  const [first, ...rest] = sliced;
+
+  return (
+    sliced.length > 0 && (
+      <text>
+        {first}
+        <RecursiveText text={rest.join('')} />
+      </text>
+    )
+  );
+}
+
+root.render(
+  <>
+    <RecursiveText text='Hello, preact-runtime 🎉!' />
+    <view id='stop-benchmark-true' />
+  </>,
+);

--- a/benchmark/preact-runtime/cases/007-four-layer-views-preact/index.tsx
+++ b/benchmark/preact-runtime/cases/007-four-layer-views-preact/index.tsx
@@ -1,0 +1,42 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from '@lynx-js/preact-runtime';
+
+function App() {
+  return (
+    <view className='root'>
+      {Array.from({ length: 3 }).map((_, a) => (
+        <view key={a} className='outer' style={{ backgroundColor: '#fa43e6' }}>
+          {Array.from({ length: 16 }).map((_, b) => (
+            <view
+              key={b}
+              className='block1'
+              style={{ backgroundColor: '#cccccc' }}
+            >
+              {Array.from({ length: 16 }).map((_, c) => (
+                <view
+                  key={c}
+                  className='block2'
+                  style={{ backgroundColor: '#333333' }}
+                >
+                  {Array.from({ length: 8 }).map((_, d) => (
+                    <view
+                      key={d}
+                      className='block3'
+                      style={{ backgroundColor: 'red' }}
+                    />
+                  ))}
+                </view>
+              ))}
+            </view>
+          ))}
+        </view>
+      ))}
+      <view id='stop-benchmark-true' />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/benchmark/preact-runtime/cases/008-many-use-state-preact/index.tsx
+++ b/benchmark/preact-runtime/cases/008-many-use-state-preact/index.tsx
@@ -1,0 +1,21 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/preact-runtime';
+
+function Item() {
+  const [counter] = useState(0);
+  return counter === 1 ? <text>{counter}</text> : null;
+}
+
+function App() {
+  return (
+    <view>
+      {Array.from({ length: 1000 }).map((_, i) => <Item key={i} />)}
+      <view id='stop-benchmark-true' />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/benchmark/preact-runtime/lynx.config.js
+++ b/benchmark/preact-runtime/lynx.config.js
@@ -1,0 +1,30 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { pluginPreactLynx } from '@lynx-js/preact-runtime/plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+// Benchmark cases mirroring benchmark/react scenarios on the transform-free
+// preact runtime, so benchx can compare the two implementations.
+export default defineConfig({
+  source: {
+    entry: {
+      '002-hello-preact': './cases/002-hello-preact/index.tsx',
+      '007-four-layer-views-preact':
+        './cases/007-four-layer-views-preact/index.tsx',
+      '008-many-use-state-preact':
+        './cases/008-many-use-state-preact/index.tsx',
+    },
+  },
+  output: {
+    filename: {
+      bundle: '[name].[platform].bundle',
+    },
+  },
+  plugins: [
+    pluginPreactLynx(),
+  ],
+  environments: {
+    lynx: {},
+  },
+});

--- a/benchmark/preact-runtime/package.json
+++ b/benchmark/preact-runtime/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@lynx-js/benchmark-preact-runtime",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "bench": "pnpm run --sequential --stream --aggregate-output '/^bench:.*/'",
+    "bench:002-hello-preact": "benchx_cli run dist/002-hello-preact.lynx.bundle --wait-for-id=stop-benchmark-true",
+    "bench:007-four-layer-views-preact": "benchx_cli run dist/007-four-layer-views-preact.lynx.bundle --wait-for-id=stop-benchmark-true",
+    "bench:008-many-use-state-preact": "benchx_cli run dist/008-many-use-state-preact.lynx.bundle --wait-for-id=stop-benchmark-true",
+    "build": "rspeedy build"
+  },
+  "dependencies": {
+    "@lynx-js/preact-runtime": "workspace:*",
+    "benchx_cli": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "workspace:*"
+  }
+}

--- a/benchmark/preact-runtime/tsconfig.json
+++ b/benchmark/preact-runtime/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedDeclarations": false,
+  },
+  "include": [
+    "lynx.config.js",
+    "cases",
+  ],
+}

--- a/benchmark/preact-runtime/turbo.json
+++ b/benchmark/preact-runtime/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": [
+        "//#build",
+        "^build"
+      ],
+      "cache": false
+    }
+  }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,6 +26,7 @@ coverage:
 
 ignore:
   - ".github/**"
+  - "benchmark/**"
   - "codecov.yml"
   - "packages/lynx/engine-bridge/tools/runtime_build.rs"
   - "packages/genui/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,6 +29,7 @@ ignore:
   - "codecov.yml"
   - "packages/lynx/engine-bridge/tools/runtime_build.rs"
   - "packages/genui/**"
+  - "packages/preact-runtime/**"
   - "pnpm-lock.yaml"
   - "rstest.config.ts"
   - "**/__test__/**/fixtures/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -33,6 +33,7 @@ ignore:
   - "pnpm-lock.yaml"
   - "rstest.config.ts"
   - "**/__test__/**/fixtures/**"
+  - "**/vitest.config.ts"
 
 fixes:
   - "/home/runner/_work/lynx-stack::"

--- a/examples/preact-ports-tailwind/lynx.config.js
+++ b/examples/preact-ports-tailwind/lynx.config.js
@@ -1,0 +1,25 @@
+import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss';
+
+import { pluginPreactLynx } from '@lynx-js/preact-runtime/plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+// Runs the original examples/tailwindcss sources on the transform-free
+// preact runtime.
+export default defineConfig({
+  source: {
+    entry: {
+      main: '../tailwindcss/src/index.tsx',
+    },
+  },
+  plugins: [
+    pluginPreactLynx(),
+    pluginTailwindCSS({
+      config: '../tailwindcss/tailwind.config.ts',
+      exclude: [/[\\/]node_modules[\\/]/],
+    }),
+  ],
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/preact-ports-tailwind/package.json
+++ b/examples/preact-ports-tailwind/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@lynx-js/example-preact-ports-tailwind",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "@lynx-js/preact-runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/tailwind-preset": "workspace:*",
+    "rsbuild-plugin-tailwindcss": "0.2.4",
+    "tailwindcss": "^3.4.19"
+  }
+}

--- a/examples/preact-ports/lynx.config.js
+++ b/examples/preact-ports/lynx.config.js
@@ -13,6 +13,9 @@ export default defineConfig({
       'react-main-thread-function':
         '../react-main-thread-function/src/index.tsx',
       'react-et-list': '../react-et-list/src/index.tsx',
+      'react-element-template': '../react-element-template/src/index.tsx',
+      'react-compiler': '../react-compiler/src/index.tsx',
+      'react-ui-sourcemap': '../react-ui-sourcemap/src/index.tsx',
     },
   },
   plugins: [

--- a/examples/preact-ports/lynx.config.js
+++ b/examples/preact-ports/lynx.config.js
@@ -1,0 +1,25 @@
+import { pluginPreactLynx } from '@lynx-js/preact-runtime/plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+// Each entry mounts an original example's source, unmodified, onto the
+// transform-free preact runtime (`@lynx-js/react` is aliased to the compat
+// layer by the plugin).
+export default defineConfig({
+  source: {
+    entry: {
+      'react': '../react/src/index.tsx',
+      'react-element': '../react-element/src/index.tsx',
+      'react-keyboard': '../react-keyboard/src/index.tsx',
+      'react-main-thread-function':
+        '../react-main-thread-function/src/index.tsx',
+      'react-et-list': '../react-et-list/src/index.tsx',
+    },
+  },
+  plugins: [
+    pluginPreactLynx(),
+  ],
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/preact-ports/lynx.config.js
+++ b/examples/preact-ports/lynx.config.js
@@ -21,6 +21,10 @@ export default defineConfig({
       'react-et-lazy-bundle': '../react-et-lazy-bundle/src/index.tsx',
       'react-externals': '../react-externals/src/index.tsx',
       'react-externals-web': '../react-externals-web/src/index.tsx',
+      'react-lazy-bundle-standalone': './src/react-lazy-bundle-standalone.ts',
+      'react-et-lazy-bundle-standalone':
+        './src/react-et-lazy-bundle-standalone.ts',
+      'react-debug-metadata': './src/react-debug-metadata.ts',
     },
   },
   plugins: [

--- a/examples/preact-ports/lynx.config.js
+++ b/examples/preact-ports/lynx.config.js
@@ -19,6 +19,8 @@ export default defineConfig({
       'react-et-mtf': '../react-et-mtf/src/index.tsx',
       'react-lazy-bundle': '../react-lazy-bundle/src/index.tsx',
       'react-et-lazy-bundle': '../react-et-lazy-bundle/src/index.tsx',
+      'react-externals': '../react-externals/src/index.tsx',
+      'react-externals-web': '../react-externals-web/src/index.tsx',
     },
   },
   plugins: [

--- a/examples/preact-ports/lynx.config.js
+++ b/examples/preact-ports/lynx.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
       'react-ui-sourcemap': '../react-ui-sourcemap/src/index.tsx',
       'react-et-mtf': '../react-et-mtf/src/index.tsx',
       'react-lazy-bundle': '../react-lazy-bundle/src/index.tsx',
+      'react-et-lazy-bundle': '../react-et-lazy-bundle/src/index.tsx',
     },
   },
   plugins: [

--- a/examples/preact-ports/lynx.config.js
+++ b/examples/preact-ports/lynx.config.js
@@ -16,6 +16,8 @@ export default defineConfig({
       'react-element-template': '../react-element-template/src/index.tsx',
       'react-compiler': '../react-compiler/src/index.tsx',
       'react-ui-sourcemap': '../react-ui-sourcemap/src/index.tsx',
+      'react-et-mtf': '../react-et-mtf/src/index.tsx',
+      'react-lazy-bundle': '../react-lazy-bundle/src/index.tsx',
     },
   },
   plugins: [

--- a/examples/preact-ports/lynx.config.js
+++ b/examples/preact-ports/lynx.config.js
@@ -25,6 +25,9 @@ export default defineConfig({
       'react-et-lazy-bundle-standalone':
         './src/react-et-lazy-bundle-standalone.ts',
       'react-debug-metadata': './src/react-debug-metadata.ts',
+      'gesture': '../gesture/src/index.tsx',
+      'motion-main': '../motion/src/index.tsx',
+      'motion-mini': '../motion/src/Mini/index.tsx',
     },
   },
   plugins: [

--- a/examples/preact-ports/package.json
+++ b/examples/preact-ports/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lynx-js/example-preact-ports",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "@lynx-js/preact-runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "workspace:*"
+  }
+}

--- a/examples/preact-ports/package.json
+++ b/examples/preact-ports/package.json
@@ -9,6 +9,8 @@
     "dev": "rspeedy dev"
   },
   "dependencies": {
+    "@lynx-js/gesture-runtime": "workspace:*",
+    "@lynx-js/motion": "workspace:*",
     "@lynx-js/preact-runtime": "workspace:*"
   },
   "devDependencies": {

--- a/examples/preact-ports/src/react-debug-metadata.ts
+++ b/examples/preact-ports/src/react-debug-metadata.ts
@@ -1,0 +1,19 @@
+// Port entry for the debug-metadata consumer app; see
+// react-lazy-bundle-standalone.ts for the approach. Debug-metadata asset
+// emission itself is a build-tooling feature outside this runtime.
+import { registerRemoteModule } from '@lynx-js/preact-runtime';
+
+registerRemoteModule(
+  'LazyComponent.lynx.bundle',
+  () => import('../../react-debug-metadata/src/LazyComponent.jsx'),
+);
+registerRemoteModule(
+  'add.lynx.bundle',
+  () => import('../../react-debug-metadata/src/utils/add.js'),
+);
+registerRemoteModule(
+  'dynamic.lynx.bundle',
+  () => import('../../react-debug-metadata/src/utils/dynamic.js'),
+);
+
+void import('../../react-debug-metadata/src/index.jsx');

--- a/examples/preact-ports/src/react-et-lazy-bundle-standalone.ts
+++ b/examples/preact-ports/src/react-et-lazy-bundle-standalone.ts
@@ -1,0 +1,18 @@
+// Port entry for the ET standalone consumer; see
+// react-lazy-bundle-standalone.ts for the approach.
+import { registerRemoteModule } from '@lynx-js/preact-runtime';
+
+registerRemoteModule(
+  'LazyComponent.lynx.bundle',
+  () => import('../../react-et-lazy-bundle-standalone/src/LazyComponent.jsx'),
+);
+registerRemoteModule(
+  'add.lynx.bundle',
+  () => import('../../react-et-lazy-bundle-standalone/src/utils/add.js'),
+);
+registerRemoteModule(
+  'dynamic.lynx.bundle',
+  () => import('../../react-et-lazy-bundle-standalone/src/utils/dynamic.js'),
+);
+
+void import('../../react-et-lazy-bundle-standalone/src/index.jsx');

--- a/examples/preact-ports/src/react-lazy-bundle-standalone.ts
+++ b/examples/preact-ports/src/react-lazy-bundle-standalone.ts
@@ -1,0 +1,32 @@
+// Port entry: register the producer modules locally, then run the original
+// consumer app. On the transform-free runtime the producer/consumer pair
+// shares one build; the import(url, { with }) surface still goes through
+// the runtime's remote-import path.
+import { registerRemoteModule } from '@lynx-js/preact-runtime';
+
+registerRemoteModule(
+  'LazyComponent.lynx.bundle',
+  () => import('../../react-lazy-bundle-standalone/src/LazyComponent.jsx'),
+);
+registerRemoteModule(
+  'LazyComponentSync.lynx.bundle',
+  () => import('../../react-lazy-bundle-standalone/src/LazyComponentSync.jsx'),
+);
+registerRemoteModule(
+  'LazyComponentAsync.lynx.bundle',
+  () => import('../../react-lazy-bundle-standalone/src/LazyComponentAsync.jsx'),
+);
+registerRemoteModule(
+  'add.lynx.bundle',
+  () => import('../../react-lazy-bundle-standalone/src/utils/add.js'),
+);
+registerRemoteModule(
+  'minus.lynx.bundle',
+  () => import('../../react-lazy-bundle-standalone/src/utils/minus.js'),
+);
+registerRemoteModule(
+  'dynamic.lynx.bundle',
+  () => import('../../react-lazy-bundle-standalone/src/utils/dynamic.js'),
+);
+
+void import('../../react-lazy-bundle-standalone/src/index.jsx');

--- a/examples/preact-ports/tsconfig.json
+++ b/examples/preact-ports/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022"],
+    "types": [],
+    "isolatedDeclarations": false,
+  },
+  "include": ["src", "lynx.config.js"],
+}

--- a/examples/preact/lynx.config.js
+++ b/examples/preact/lynx.config.js
@@ -1,0 +1,12 @@
+import { pluginPreactLynx } from '@lynx-js/preact-runtime/plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+export default defineConfig({
+  plugins: [
+    pluginPreactLynx(),
+  ],
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@lynx-js/rspeedy": "workspace:*",
-    "typescript": "~5.9.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@lynx-js/example-preact",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "@lynx-js/preact-runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "workspace:*",
+    "typescript": "~5.9.2"
+  }
+}

--- a/examples/preact/src/App.tsx
+++ b/examples/preact/src/App.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useState } from '@lynx-js/preact-runtime';
+import { Suspense, lazy, useCallback, useState } from '@lynx-js/preact-runtime';
+
+const LazyThing = lazy(() => import('./LazyThing.js'));
 
 export function App() {
   const [count, setCount] = useState(0);
   const [items, setItems] = useState<string[]>([]);
+  const [showLazy, setShowLazy] = useState(false);
 
   const onTap = useCallback(() => {
     setCount((c) => c + 1);
@@ -47,6 +50,12 @@ export function App() {
       >
         MT: tap to turn green
       </text>
+      <view id='lazybtn' bindtap={() => setShowLazy((v) => !v)}>
+        <text id='lazylabel'>{showLazy ? 'hide lazy' : 'show lazy'}</text>
+      </view>
+      <Suspense fallback={<text>loading lazy...</text>}>
+        {showLazy ? <LazyThing /> : <text id='nolazy'>no panel</text>}
+      </Suspense>
       <list
         id='rows'
         style={{ height: '120px', width: '300px', marginTop: '10px' }}

--- a/examples/preact/src/App.tsx
+++ b/examples/preact/src/App.tsx
@@ -34,6 +34,31 @@ export function App() {
       {count % 2 === 0
         ? <text id='even'>even</text>
         : <text id='odd' style={{ color: 'red' }}>odd</text>}
+      <text
+        id='mt'
+        main-thread:bindtap={(e: {
+          currentTarget: {
+            setStyleProperty(name: string, value: string): void;
+          };
+        }) => {
+          e.currentTarget.setStyleProperty('color', 'green');
+          e.currentTarget.setStyleProperty('font-weight', 'bold');
+        }}
+      >
+        MT: tap to turn green
+      </text>
+      <list
+        id='rows'
+        style={{ height: '120px', width: '300px', marginTop: '10px' }}
+        list-type='single'
+        span-count={1}
+      >
+        {items.map((item) => (
+          <list-item item-key={item} key={item}>
+            <text>{`row of ${item}`}</text>
+          </list-item>
+        ))}
+      </list>
     </view>
   );
 }

--- a/examples/preact/src/App.tsx
+++ b/examples/preact/src/App.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useState } from '@lynx-js/preact-runtime';
+
+export function App() {
+  const [count, setCount] = useState(0);
+  const [items, setItems] = useState<string[]>([]);
+
+  const onTap = useCallback(() => {
+    setCount((c) => c + 1);
+  }, []);
+
+  const addItem = useCallback(() => {
+    setItems((list) => [...list, `item-${list.length}`]);
+  }, []);
+
+  const removeItem = useCallback(() => {
+    setItems((list) => list.slice(0, -1));
+  }, []);
+
+  return (
+    <view style={{ flexDirection: 'column', padding: '20px' }}>
+      <text id='title' style={{ fontSize: '24px', color: 'blue' }}>
+        Hello preact-runtime
+      </text>
+      <text id='count' data-count={count} bindtap={onTap}>
+        Count: {count}
+      </text>
+      <view style={{ flexDirection: 'row', marginTop: '10px' }}>
+        <text id='add' bindtap={addItem} style={{ marginRight: '20px' }}>
+          [+] add
+        </text>
+        <text id='del' bindtap={removeItem}>[-] remove</text>
+      </view>
+      {items.map((item) => <text key={item} className='item'>{item}</text>)}
+      {count % 2 === 0
+        ? <text id='even'>even</text>
+        : <text id='odd' style={{ color: 'red' }}>odd</text>}
+    </view>
+  );
+}

--- a/examples/preact/src/LazyThing.tsx
+++ b/examples/preact/src/LazyThing.tsx
@@ -1,0 +1,3 @@
+export default function LazyThing() {
+  return <text id='lazy-content'>lazy panel loaded</text>;
+}

--- a/examples/preact/src/index.tsx
+++ b/examples/preact/src/index.tsx
@@ -1,0 +1,5 @@
+import { root } from '@lynx-js/preact-runtime';
+
+import { App } from './App.js';
+
+root.render(<App />);

--- a/examples/preact/tsconfig.json
+++ b/examples/preact/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+  },
+  "include": ["src"],
+}

--- a/packages/lynx/gesture-runtime/__test__/is-worklet-object.test.ts
+++ b/packages/lynx/gesture-runtime/__test__/is-worklet-object.test.ts
@@ -75,6 +75,20 @@ describe('isWorkletObj', () => {
     expect(isWorkletObj(fn)).toBe(false);
   });
 
+  test('should return true for function when __TRANSFORM_FREE_MTS__ is set', () => {
+    const flagged = globalThis as { __TRANSFORM_FREE_MTS__?: boolean };
+    flagged.__TRANSFORM_FREE_MTS__ = true;
+
+    const fn = () => {};
+    const result = isWorkletObj(fn);
+    const nonFunction = isWorkletObj({});
+
+    delete flagged.__TRANSFORM_FREE_MTS__;
+
+    expect(result).toBe(true);
+    expect(nonFunction).toBe(false);
+  });
+
   test('should handle object with _wkltId as falsy value', () => {
     const worklet = {
       _wkltId: '',

--- a/packages/lynx/gesture-runtime/src/utils/isWorkletObject.ts
+++ b/packages/lynx/gesture-runtime/src/utils/isWorkletObject.ts
@@ -10,5 +10,13 @@ export function isWorkletObj(obj: unknown): boolean {
   if (!obj) {
     return false;
   }
+  // Transform-free runtimes (e.g. @lynx-js/preact-runtime) run main-thread
+  // functions on the background thread; plain functions are valid there.
+  if (
+    (globalThis as { __TRANSFORM_FREE_MTS__?: boolean }).__TRANSFORM_FREE_MTS__
+    && typeof obj === 'function'
+  ) {
+    return true;
+  }
   return typeof obj === 'object' && '_wkltId' in obj;
 }

--- a/packages/preact-runtime/loader/import-attributes-loader.cjs
+++ b/packages/preact-runtime/loader/import-attributes-loader.cjs
@@ -1,0 +1,26 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Rewrites the nonstandard `import(expr, { with: { ... } })` form (lazy /
+ * producer bundles) into a call to the runtime's `__preactRemoteImport`.
+ * This is a syntax-surface shim, not a code transform: standard dynamic
+ * imports pass through untouched.
+ */
+
+'use strict';
+
+const IMPORT_WITH_RE =
+  /\bimport\s*\(([^;{}]+),\s*\{\s*with\s*:\s*\{[^{}]*\}[\s,]*\}\s*\)/g;
+
+/** @type {import('@rspack/core').LoaderDefinitionFunction} */
+module.exports = function importAttributesLoader(source) {
+  if (!source.includes('with')) {
+    return source;
+  }
+  return source.replace(
+    IMPORT_WITH_RE,
+    (_match, expr) => `globalThis.__preactRemoteImport(${expr.trim()})`,
+  );
+};

--- a/packages/preact-runtime/package.json
+++ b/packages/preact-runtime/package.json
@@ -27,7 +27,11 @@
       "default": "./dist/plugin/index.js"
     },
     "./main-thread": "./dist/main-thread.js",
-    "./loader/import-attributes-loader": "./loader/import-attributes-loader.cjs"
+    "./loader/import-attributes-loader": "./loader/import-attributes-loader.cjs",
+    "./compat/worklet-bindings": {
+      "types": "./dist/compat/worklet-bindings.d.ts",
+      "default": "./dist/compat/worklet-bindings.js"
+    }
   },
   "files": [
     "dist",

--- a/packages/preact-runtime/package.json
+++ b/packages/preact-runtime/package.json
@@ -26,10 +26,12 @@
     "./plugin": {
       "default": "./dist/plugin/index.js"
     },
-    "./main-thread": "./dist/main-thread.js"
+    "./main-thread": "./dist/main-thread.js",
+    "./loader/import-attributes-loader": "./loader/import-attributes-loader.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "loader"
   ],
   "scripts": {
     "build": "rslib build"

--- a/packages/preact-runtime/package.json
+++ b/packages/preact-runtime/package.json
@@ -24,7 +24,6 @@
       "default": "./dist/compat/debug.js"
     },
     "./plugin": {
-      "types": "./dist/plugin/index.d.ts",
       "default": "./dist/plugin/index.js"
     },
     "./main-thread": "./dist/main-thread.js"

--- a/packages/preact-runtime/package.json
+++ b/packages/preact-runtime/package.json
@@ -15,6 +15,14 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./compat": {
+      "types": "./dist/compat/index.d.ts",
+      "default": "./dist/compat/index.js"
+    },
+    "./compat/debug": {
+      "types": "./dist/compat/debug.d.ts",
+      "default": "./dist/compat/debug.js"
+    },
     "./plugin": {
       "types": "./dist/plugin/index.d.ts",
       "default": "./dist/plugin/index.js"
@@ -28,6 +36,7 @@
     "build": "rslib build"
   },
   "dependencies": {
+    "@lynx-js/css-extract-webpack-plugin": "workspace:*",
     "@lynx-js/runtime-wrapper-webpack-plugin": "workspace:*",
     "@lynx-js/template-webpack-plugin": "workspace:*",
     "preact": "^10.29.1"

--- a/packages/preact-runtime/package.json
+++ b/packages/preact-runtime/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@lynx-js/preact-runtime",
+  "version": "0.0.1",
+  "private": true,
+  "description": "A transform-free ReactLynx runtime running vanilla preact purely on the background thread.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/preact-runtime"
+  },
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin/index.d.ts",
+      "default": "./dist/plugin/index.js"
+    },
+    "./main-thread": "./dist/main-thread.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rslib build"
+  },
+  "dependencies": {
+    "@lynx-js/runtime-wrapper-webpack-plugin": "workspace:*",
+    "@lynx-js/template-webpack-plugin": "workspace:*",
+    "preact": "^10.29.1"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "catalog:rsbuild",
+    "@rslib/core": "catalog:rslib"
+  }
+}

--- a/packages/preact-runtime/rslib.config.ts
+++ b/packages/preact-runtime/rslib.config.ts
@@ -18,6 +18,7 @@ const config: RslibConfig = defineConfig({
           index: './src/index.ts',
           'compat/index': './src/compat/index.ts',
           'compat/debug': './src/compat/debug.ts',
+          'compat/worklet-bindings': './src/compat/worklet-bindings.ts',
         },
       },
       output: {

--- a/packages/preact-runtime/rslib.config.ts
+++ b/packages/preact-runtime/rslib.config.ts
@@ -27,7 +27,9 @@ const config: RslibConfig = defineConfig({
       id: 'plugin',
       format: 'esm',
       syntax: 'es2022',
-      dts: true,
+      // The webpack helper packages this imports are built by the root
+      // `tsc --build`, which is not part of the turbo graph — skip dts.
+      dts: false,
       source: {
         entry: {
           'plugin/index': './src/plugin/index.ts',

--- a/packages/preact-runtime/rslib.config.ts
+++ b/packages/preact-runtime/rslib.config.ts
@@ -13,6 +13,7 @@ const config: RslibConfig = defineConfig({
       syntax: 'es2021',
       dts: true,
       source: {
+        tsconfigPath: './tsconfig.build.json',
         entry: {
           index: './src/index.ts',
           'compat/index': './src/compat/index.ts',

--- a/packages/preact-runtime/rslib.config.ts
+++ b/packages/preact-runtime/rslib.config.ts
@@ -15,6 +15,8 @@ const config: RslibConfig = defineConfig({
       source: {
         entry: {
           index: './src/index.ts',
+          'compat/index': './src/compat/index.ts',
+          'compat/debug': './src/compat/debug.ts',
         },
       },
       output: {

--- a/packages/preact-runtime/rslib.config.ts
+++ b/packages/preact-runtime/rslib.config.ts
@@ -1,0 +1,57 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@rslib/core';
+import type { RslibConfig } from '@rslib/core';
+
+const config: RslibConfig = defineConfig({
+  lib: [
+    {
+      id: 'background',
+      format: 'esm',
+      syntax: 'es2021',
+      dts: true,
+      source: {
+        entry: {
+          index: './src/index.ts',
+        },
+      },
+      output: {
+        externals: ['preact', 'preact/hooks', 'preact/compat'],
+      },
+    },
+    {
+      id: 'plugin',
+      format: 'esm',
+      syntax: 'es2022',
+      dts: true,
+      source: {
+        entry: {
+          'plugin/index': './src/plugin/index.ts',
+        },
+      },
+      output: {
+        target: 'node',
+      },
+    },
+    {
+      id: 'main-thread',
+      format: 'iife',
+      syntax: 'es2019',
+      source: {
+        entry: {
+          'main-thread': './src/main-thread/index.ts',
+        },
+      },
+      output: {
+        minify: false,
+        sourceMap: {
+          js: false,
+        },
+      },
+    },
+  ],
+});
+
+export default config;

--- a/packages/preact-runtime/src/channel.ts
+++ b/packages/preact-runtime/src/channel.ts
@@ -20,6 +20,12 @@ declare const lynx: {
   };
 };
 
+// PrimJS has no `queueMicrotask`; fall back to the promise job queue.
+const scheduleMicrotask: (cb: () => void) => void =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask
+    : (cb) => void Promise.resolve().then(cb);
+
 const queue: Op[] = [];
 let scheduled = false;
 
@@ -41,7 +47,7 @@ function scheduleFlush(): void {
     return;
   }
   scheduled = true;
-  queueMicrotask(flush);
+  scheduleMicrotask(flush);
 }
 
 export function flush(): void {

--- a/packages/preact-runtime/src/channel.ts
+++ b/packages/preact-runtime/src/channel.ts
@@ -1,0 +1,60 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * The background-thread side of the op channel: batches ops per microtask and
+ * sends them to the fixed main-thread runtime through `callLepusMethod`.
+ */
+
+import { PATCH_METHOD } from './ops.js';
+import type { Op } from './ops.js';
+
+declare const lynx: {
+  getNativeApp(): {
+    callLepusMethod(
+      name: string,
+      data: unknown,
+      callback?: (ret: unknown) => void,
+    ): void;
+  };
+};
+
+const queue: Op[] = [];
+let scheduled = false;
+
+/** Callbacks run right before a batch is sent (style/dataset serialization). */
+const preFlushCallbacks = new Set<() => void>();
+
+export function enqueueOp(op: Op): void {
+  queue.push(op);
+  scheduleFlush();
+}
+
+export function beforeFlush(cb: () => void): void {
+  preFlushCallbacks.add(cb);
+  scheduleFlush();
+}
+
+function scheduleFlush(): void {
+  if (scheduled) {
+    return;
+  }
+  scheduled = true;
+  queueMicrotask(flush);
+}
+
+export function flush(): void {
+  scheduled = false;
+  for (const cb of preFlushCallbacks) {
+    cb();
+  }
+  preFlushCallbacks.clear();
+  if (queue.length === 0) {
+    return;
+  }
+  const ops = queue.splice(0, queue.length);
+  lynx.getNativeApp().callLepusMethod(PATCH_METHOD, {
+    data: JSON.stringify(ops),
+  });
+}

--- a/packages/preact-runtime/src/compat/debug.ts
+++ b/packages/preact-runtime/src/compat/debug.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Alias target for the side-effect import `@lynx-js/react/debug`.
+ * Debugging integration is not part of the transform-free runtime yet.
+ */
+
+export {};

--- a/packages/preact-runtime/src/compat/index.ts
+++ b/packages/preact-runtime/src/compat/index.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * A drop-in surface of `@lynx-js/react` so existing example sources run on
+ * the transform-free runtime unmodified (the rspeedy plugin aliases
+ * `@lynx-js/react` here). Only the APIs the examples actually use are
+ * provided; compiler-bound APIs get explanatory stubs.
+ */
+
+import { useRef } from 'preact/hooks';
+
+export * from '../index.js';
+
+/**
+ * Main-thread refs need the compiler to move code across threads. On this
+ * runtime a plain ref object is returned; `main-thread:ref` is not wired.
+ *
+ * @public
+ */
+export function useMainThreadRef<T>(initValue?: T): { current: T | null } {
+  return useRef<T | null>(initValue ?? null);
+}
+
+/**
+ * `runOnBackground` is only meaningful inside main-thread functions, which
+ * are closure-free on this runtime — so a captured import can never reach
+ * the main thread. Calling the returned function on the background thread
+ * simply invokes the target directly.
+ *
+ * @public
+ */
+export function runOnBackground<Args extends unknown[], Ret>(
+  fn: (...args: Args) => Ret,
+): (...args: Args) => Promise<Ret> {
+  return (...args) => Promise.resolve(fn(...args));
+}
+
+/**
+ * No-op on this runtime: there is no main-thread first screen to hand over.
+ *
+ * @public
+ */
+export function markFirstScreenSyncReady(): void {
+  // noop
+}

--- a/packages/preact-runtime/src/compat/worklet-bindings.ts
+++ b/packages/preact-runtime/src/compat/worklet-bindings.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Alias target for `@lynx-js/react/worklet-runtime/bindings`. Without a
+ * compiler, "worklet ctx" values are plain functions running on the
+ * background thread, so running one is a direct call.
+ */
+
+export function runWorkletCtx(
+  ctx: unknown,
+  params?: unknown[],
+): unknown {
+  if (typeof ctx === 'function') {
+    return (ctx as (...args: unknown[]) => unknown)(...(params ?? []));
+  }
+  return undefined;
+}

--- a/packages/preact-runtime/src/document.ts
+++ b/packages/preact-runtime/src/document.ts
@@ -14,8 +14,8 @@
  */
 
 import { beforeFlush, enqueueOp } from './channel.js';
+import { BackgroundMainThreadElement } from './mainThreadElement.js';
 import * as Ops from './ops.js';
-import { registerWorklet } from './worklet.js';
 
 /** Matches ReactLynx event prop names, e.g. `bindtap`, `main-thread:bindtap`. */
 const eventRegExp =
@@ -178,7 +178,9 @@ export class RemoteElement extends RemoteNode {
   _tag: string;
   _children: RemoteNode[] = [];
   _listeners: Map<string, EventListenerFn> = new Map();
+  _mtListeners: Map<string, EventListenerFn> = new Map();
   _workletEvents: Map<string, number> = new Map();
+  _attributes: Map<string, unknown> = new Map();
   _dataset: Record<string, unknown> = {};
   _datasetDirty = false;
   _style: RemoteStyle | undefined;
@@ -306,6 +308,26 @@ export class RemoteElement extends RemoteNode {
     }
   }
 
+  _setMainThreadListener(
+    eventType: string,
+    eventName: string,
+    listener: EventListenerFn | null,
+  ): void {
+    const key = `${eventType}:${eventName}`;
+    const had = this._mtListeners.has(key);
+    if (listener) {
+      this._mtListeners.set(key, listener);
+      if (!had) {
+        enqueueOp([Ops.SetEvent, this._id, eventType, eventName, 1]);
+      }
+    } else if (had) {
+      this._mtListeners.delete(key);
+      if (!this._listeners.has(key)) {
+        enqueueOp([Ops.SetEvent, this._id, eventType, eventName, 0]);
+      }
+    }
+  }
+
   _setWorkletListener(
     eventType: string,
     eventName: string,
@@ -351,10 +373,13 @@ function routeProp(element: RemoteElement, name: string, value: unknown): void {
   if (match) {
     const [, prefix, type, eventName] = match;
     if (prefix === 'main-thread') {
-      const hash = typeof value === 'function'
-        ? registerWorklet(value as (...args: never[]) => unknown)
-        : 0;
-      element._setWorkletListener(eventTypeMap[type!]!, eventName!, hash);
+      // Without a compiler there is no closure extraction, so main-thread
+      // handlers run on the background thread against an op-backed Element.
+      element._setMainThreadListener(
+        eventTypeMap[type!]!,
+        eventName!,
+        typeof value === 'function' ? (value as EventListenerFn) : null,
+      );
       return;
     }
     const eventType = prefix === 'global'
@@ -365,6 +390,10 @@ function routeProp(element: RemoteElement, name: string, value: unknown): void {
       eventName!,
       typeof value === 'function' ? (value as EventListenerFn) : null,
     );
+    return;
+  }
+  if (name === 'main-thread:ref') {
+    assignMainThreadRef(element, value);
     return;
   }
   switch (name) {
@@ -396,12 +425,22 @@ function routeProp(element: RemoteElement, name: string, value: unknown): void {
     // Non-event function-valued props cannot cross the thread boundary.
     return;
   }
+  element._attributes.set(name, value === undefined ? null : value);
   enqueueOp([
     Ops.SetAttribute,
     element._id,
     name,
     value === undefined ? null : value,
   ]);
+}
+
+function assignMainThreadRef(element: RemoteElement, value: unknown): void {
+  const wrapped = new BackgroundMainThreadElement(element);
+  if (typeof value === 'function') {
+    (value as (el: unknown) => void)(wrapped);
+  } else if (value && typeof value === 'object') {
+    (value as { current: unknown }).current = wrapped;
+  }
 }
 
 /** Fields managed by {@link RemoteElement} itself; everything else that is

--- a/packages/preact-runtime/src/document.ts
+++ b/packages/preact-runtime/src/document.ts
@@ -1,0 +1,445 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * A minimal remote-DOM implementation for vanilla preact running in the
+ * background thread. Every mutation is recorded as an op and flushed to the
+ * fixed main-thread runtime, which applies it through the Element PAPI.
+ *
+ * Elements are wrapped in a `Proxy` whose `has` trap always returns `true`,
+ * so preact's `name in dom` check routes every non-special prop through the
+ * `set` trap, where Lynx event props (`bindtap`, `catchtap`, ...) and
+ * attributes are translated into ops.
+ */
+
+import { beforeFlush, enqueueOp } from './channel.js';
+import * as Ops from './ops.js';
+
+/** Matches ReactLynx event prop names, e.g. `bindtap`, `main-thread:bindtap`. */
+const eventRegExp =
+  /^(?:([A-Za-z-]*):)?(bind|catch|capture-bind|capture-catch|global-bind)([A-Za-z]+)$/;
+
+const eventTypeMap: Record<string, string> = {
+  bind: 'bindEvent',
+  catch: 'catchEvent',
+  'capture-bind': 'capture-bind',
+  'capture-catch': 'capture-catch',
+  'global-bind': 'global-bindEvent',
+};
+
+let nextId = Ops.PAGE_ID + 1;
+
+export const nodesById: Map<number, RemoteNode> = new Map();
+
+export class RemoteNode {
+  _id: number;
+  _parent: RemoteElement | null = null;
+
+  constructor(id: number = nextId++) {
+    this._id = id;
+    nodesById.set(this._id, this);
+  }
+
+  get parentNode(): RemoteElement | null {
+    return this._parent;
+  }
+
+  get nextSibling(): RemoteNode | null {
+    const parent = this._parent;
+    if (!parent) {
+      return null;
+    }
+    const index = parent._children.indexOf(this._self());
+    return parent._children[index + 1] ?? null;
+  }
+
+  remove(): void {
+    this._parent?.removeChild(this._self());
+  }
+
+  /**
+   * The identity preact sees: the proxy for elements, the instance for text.
+   */
+  _self(): RemoteNode {
+    return this;
+  }
+}
+
+export class RemoteText extends RemoteNode {
+  _data: string;
+
+  constructor(data: string) {
+    super();
+    this._data = data;
+    enqueueOp([Ops.CreateText, this._id, data]);
+  }
+
+  get data(): string {
+    return this._data;
+  }
+
+  set data(value: string) {
+    const text = String(value);
+    if (text !== this._data) {
+      this._data = text;
+      enqueueOp([Ops.SetText, this._id, text]);
+    }
+  }
+
+  get nodeValue(): string {
+    return this._data;
+  }
+
+  set nodeValue(value: string) {
+    this.data = value;
+  }
+}
+
+/** The style object surface preact interacts with. */
+export interface RemoteStyle {
+  cssText: string;
+  setProperty(name: string, value: string | null): void;
+  removeProperty(name: string): void;
+  [key: string]: unknown;
+}
+
+interface StyleState {
+  cssText: string;
+  props: Map<string, string>;
+  dirty: boolean;
+}
+
+function serializeStyle(state: StyleState): string {
+  let out = state.cssText;
+  for (const [key, value] of state.props) {
+    if (value === '') {
+      continue;
+    }
+    const name = key.startsWith('--')
+      ? key
+      : key.replace(/[A-Z]/g, (c) => '-' + c.toLowerCase());
+    out += `${out && !out.endsWith(';') ? ';' : ''}${name}:${value};`;
+  }
+  return out;
+}
+
+function createStyleProxy(element: RemoteElement): RemoteStyle {
+  const state: StyleState = { cssText: '', props: new Map(), dirty: false };
+  const markDirty = () => {
+    if (!state.dirty) {
+      state.dirty = true;
+      beforeFlush(() => {
+        state.dirty = false;
+        enqueueOp([Ops.SetStyle, element._id, serializeStyle(state)]);
+      });
+    }
+  };
+  const target = {
+    setProperty(name: string, value: string | null): void {
+      state.props.set(name, value == null ? '' : String(value));
+      markDirty();
+    },
+    removeProperty(name: string): void {
+      state.props.delete(name);
+      markDirty();
+    },
+  };
+  return new Proxy(target, {
+    get(t, prop) {
+      if (prop === 'cssText') {
+        return state.cssText;
+      }
+      if (prop in t) {
+        return Reflect.get(t, prop) as unknown;
+      }
+      return state.props.get(prop as string) ?? '';
+    },
+    set(t, prop, value) {
+      if (typeof prop === 'symbol') {
+        return Reflect.set(t, prop, value);
+      }
+      if (prop === 'cssText') {
+        state.cssText = value == null ? '' : String(value);
+        state.props.clear();
+      } else {
+        state.props.set(prop, value == null ? '' : String(value));
+      }
+      markDirty();
+      return true;
+    },
+  }) as unknown as RemoteStyle;
+}
+
+export type EventListenerFn = (event: unknown) => void;
+
+export class RemoteElement extends RemoteNode {
+  _tag: string;
+  _children: RemoteNode[] = [];
+  _listeners: Map<string, EventListenerFn> = new Map();
+  _dataset: Record<string, unknown> = {};
+  _datasetDirty = false;
+  _style: RemoteStyle | undefined;
+  _proxy: RemoteElement;
+
+  constructor(tag: string, id?: number) {
+    super(id);
+    this._tag = tag;
+    if (this._id !== Ops.PAGE_ID) {
+      enqueueOp([Ops.CreateElement, this._id, tag]);
+    }
+    this._proxy = wrapElement(this);
+    return this;
+  }
+
+  override _self(): RemoteNode {
+    return this._proxy;
+  }
+
+  get style(): RemoteStyle {
+    return (this._style ??= createStyleProxy(this));
+  }
+
+  get childNodes(): RemoteNode[] {
+    return this._children;
+  }
+
+  get firstChild(): RemoteNode | null {
+    return this._children[0] ?? null;
+  }
+
+  get className(): string {
+    return '';
+  }
+
+  set className(value: string) {
+    enqueueOp([Ops.SetClasses, this._id, value == null ? '' : String(value)]);
+  }
+
+  insertBefore(child: RemoteNode, ref?: RemoteNode | null): RemoteNode {
+    const childNode = child._self();
+    if (childNode._parent) {
+      childNode._parent._detach(childNode);
+    }
+    const refNode = ref?._self() ?? null;
+    const index = refNode ? this._children.indexOf(refNode) : -1;
+    if (index >= 0) {
+      this._children.splice(index, 0, childNode);
+    } else {
+      this._children.push(childNode);
+    }
+    childNode._parent = this._proxy ?? this;
+    enqueueOp([
+      Ops.InsertBefore,
+      this._id,
+      childNode._id,
+      index >= 0 && refNode ? refNode._id : 0,
+    ]);
+    return child;
+  }
+
+  appendChild(child: RemoteNode): RemoteNode {
+    return this.insertBefore(child, null);
+  }
+
+  removeChild(child: RemoteNode): RemoteNode {
+    this._detach(child._self());
+    enqueueOp([Ops.Remove, this._id, child._self()._id]);
+    return child;
+  }
+
+  _detach(child: RemoteNode): void {
+    const index = this._children.indexOf(child);
+    if (index >= 0) {
+      this._children.splice(index, 1);
+      child._parent = null;
+    } else if (child._parent && child._parent !== this._proxy) {
+      // A move initiated while the child belongs elsewhere.
+      child._parent._detach(child);
+    }
+  }
+
+  contains(node: RemoteNode | null): boolean {
+    while (node) {
+      if (node === this._proxy || (node as RemoteNode) === this) {
+        return true;
+      }
+      node = node._parent;
+    }
+    return false;
+  }
+
+  setAttribute(name: string, value: unknown): void {
+    routeProp(this, name, value);
+  }
+
+  removeAttribute(name: string): void {
+    routeProp(this, name, null);
+  }
+
+  addEventListener(type: string, listener: EventListenerFn): void {
+    // preact routes `onXxx` props here; treat them as `bindEvent`.
+    this._setListener('bindEvent', type, listener);
+  }
+
+  removeEventListener(type: string): void {
+    this._setListener('bindEvent', type, null);
+  }
+
+  _setListener(
+    eventType: string,
+    eventName: string,
+    listener: EventListenerFn | null,
+  ): void {
+    const key = `${eventType}:${eventName}`;
+    const had = this._listeners.has(key);
+    if (listener) {
+      this._listeners.set(key, listener);
+      if (!had) {
+        enqueueOp([Ops.SetEvent, this._id, eventType, eventName, 1]);
+      }
+    } else if (had) {
+      this._listeners.delete(key);
+      enqueueOp([Ops.SetEvent, this._id, eventType, eventName, 0]);
+    }
+  }
+
+  _setDataset(key: string, value: unknown): void {
+    if (value == null) {
+      delete this._dataset[key];
+    } else {
+      this._dataset[key] = value;
+    }
+    if (!this._datasetDirty) {
+      this._datasetDirty = true;
+      beforeFlush(() => {
+        this._datasetDirty = false;
+        enqueueOp([Ops.SetDataset, this._id, this._dataset]);
+      });
+    }
+  }
+
+  get dataset(): Record<string, unknown> {
+    return this._dataset;
+  }
+}
+
+function routeProp(element: RemoteElement, name: string, value: unknown): void {
+  // Note: event removal arrives as `''` because preact assigns
+  // `dom[name] = value == null ? '' : value` on the property path.
+  const match = eventRegExp.exec(name);
+  if (match) {
+    const [, prefix, type, eventName] = match;
+    if (prefix === 'main-thread') {
+      // TODO(mts): main-thread event handlers.
+      return;
+    }
+    const eventType = prefix === 'global'
+      ? 'global-bindEvent'
+      : eventTypeMap[type!]!;
+    element._setListener(
+      eventType,
+      eventName!,
+      typeof value === 'function' ? (value as EventListenerFn) : null,
+    );
+    return;
+  }
+  switch (name) {
+    case 'class':
+    case 'className':
+      element.className = value as string;
+      return;
+    case 'id':
+      enqueueOp([
+        Ops.SetId,
+        element._id,
+        value == null ? null : String(value as string | number),
+      ]);
+      return;
+    case 'style':
+      // Reached through setAttribute only (string form).
+      enqueueOp([Ops.SetStyle, element._id, value ?? '']);
+      return;
+    case 'dangerouslySetInnerHTML':
+      throw new Error('dangerouslySetInnerHTML is not supported in Lynx');
+    default:
+      break;
+  }
+  if (name.startsWith('data-')) {
+    element._setDataset(name.slice(5), value);
+    return;
+  }
+  if (typeof value === 'function') {
+    // Non-event function-valued props cannot cross the thread boundary.
+    return;
+  }
+  enqueueOp([
+    Ops.SetAttribute,
+    element._id,
+    name,
+    value === undefined ? null : value,
+  ]);
+}
+
+/** Fields managed by {@link RemoteElement} itself; everything else that is
+ * assigned by preact is routed as a prop. */
+function isInternalProp(prop: string): boolean {
+  return prop.startsWith('_');
+}
+
+function wrapElement(element: RemoteElement): RemoteElement {
+  return new Proxy(element, {
+    // Make `name in dom` true so preact assigns props as properties,
+    // letting the `set` trap route them (including function values, which
+    // preact would silently drop on the setAttribute path).
+    has() {
+      return true;
+    },
+    set(target, prop, value, receiver) {
+      if (typeof prop === 'symbol' || isInternalProp(prop)) {
+        return Reflect.set(target, prop, value, receiver);
+      }
+      const descriptor = findDescriptor(target, prop);
+      if (descriptor?.set) {
+        return Reflect.set(target, prop, value, receiver);
+      }
+      routeProp(target, prop, value);
+      return true;
+    },
+  });
+}
+
+function findDescriptor(
+  target: object,
+  prop: string,
+): PropertyDescriptor | undefined {
+  let proto: object | null = target;
+  while (proto) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, prop);
+    if (descriptor) {
+      return descriptor;
+    }
+    proto = Object.getPrototypeOf(proto) as object | null;
+  }
+  return undefined;
+}
+
+export class RemoteDocument {
+  createElement(tag: string): RemoteNode {
+    return new RemoteElement(tag)._self();
+  }
+
+  createElementNS(_ns: string, tag: string): RemoteNode {
+    return this.createElement(tag);
+  }
+
+  createTextNode(data: string): RemoteText {
+    return new RemoteText(String(data));
+  }
+}
+
+/** The root container mapped to the page element on the main thread. */
+export function createPageContainer(): RemoteElement {
+  const page = new RemoteElement('page', Ops.PAGE_ID);
+  return page._self() as RemoteElement;
+}

--- a/packages/preact-runtime/src/document.ts
+++ b/packages/preact-runtime/src/document.ts
@@ -15,6 +15,7 @@
 
 import { beforeFlush, enqueueOp } from './channel.js';
 import * as Ops from './ops.js';
+import { registerWorklet } from './worklet.js';
 
 /** Matches ReactLynx event prop names, e.g. `bindtap`, `main-thread:bindtap`. */
 const eventRegExp =
@@ -177,6 +178,7 @@ export class RemoteElement extends RemoteNode {
   _tag: string;
   _children: RemoteNode[] = [];
   _listeners: Map<string, EventListenerFn> = new Map();
+  _workletEvents: Map<string, number> = new Map();
   _dataset: Record<string, unknown> = {};
   _datasetDirty = false;
   _style: RemoteStyle | undefined;
@@ -304,6 +306,24 @@ export class RemoteElement extends RemoteNode {
     }
   }
 
+  _setWorkletListener(
+    eventType: string,
+    eventName: string,
+    hash: number,
+  ): void {
+    const key = `worklet:${eventType}:${eventName}`;
+    const prev = this._workletEvents.get(key) ?? 0;
+    if (prev === hash) {
+      return;
+    }
+    if (hash) {
+      this._workletEvents.set(key, hash);
+    } else {
+      this._workletEvents.delete(key);
+    }
+    enqueueOp([Ops.SetWorkletEvent, this._id, eventType, eventName, hash]);
+  }
+
   _setDataset(key: string, value: unknown): void {
     if (value == null) {
       delete this._dataset[key];
@@ -331,7 +351,10 @@ function routeProp(element: RemoteElement, name: string, value: unknown): void {
   if (match) {
     const [, prefix, type, eventName] = match;
     if (prefix === 'main-thread') {
-      // TODO(mts): main-thread event handlers.
+      const hash = typeof value === 'function'
+        ? registerWorklet(value as (...args: never[]) => unknown)
+        : 0;
+      element._setWorkletListener(eventTypeMap[type!]!, eventName!, hash);
       return;
     }
     const eventType = prefix === 'global'

--- a/packages/preact-runtime/src/index.ts
+++ b/packages/preact-runtime/src/index.ts
@@ -42,3 +42,4 @@ export { lazy, Suspense } from 'preact/compat';
 
 export { root } from './runtime.js';
 export { runOnMainThread } from './worklet.js';
+export { registerRemoteModule, registerSharedModule } from './remote.js';

--- a/packages/preact-runtime/src/index.ts
+++ b/packages/preact-runtime/src/index.ts
@@ -41,3 +41,4 @@ export {
 export { lazy, Suspense } from 'preact/compat';
 
 export { root } from './runtime.js';
+export { runOnMainThread } from './worklet.js';

--- a/packages/preact-runtime/src/index.ts
+++ b/packages/preact-runtime/src/index.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * @packageDocumentation
+ *
+ * A transform-free ReactLynx runtime: vanilla preact rendering purely on the
+ * background thread against a remote-DOM, with a fixed main-thread runtime
+ * applying element ops. No compile-time transform is required.
+ */
+
+export {
+  Component,
+  createContext,
+  createElement,
+  createElement as h,
+  cloneElement,
+  createRef,
+  Fragment,
+  isValidElement,
+  toChildArray,
+} from 'preact';
+export type { ComponentChild, ComponentType, JSX, VNode } from 'preact';
+
+export {
+  useCallback,
+  useContext,
+  useDebugValue,
+  useEffect,
+  useErrorBoundary,
+  useId,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'preact/hooks';
+
+export { lazy, Suspense } from 'preact/compat';
+
+export { root } from './runtime.js';

--- a/packages/preact-runtime/src/main-thread/index.ts
+++ b/packages/preact-runtime/src/main-thread/index.ts
@@ -200,11 +200,17 @@ class MainThreadElement {
   }
 }
 
+// PrimJS has no `queueMicrotask`; fall back to the promise job queue.
+const scheduleMicrotask: (cb: () => void) => void =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask
+    : (cb) => void Promise.resolve().then(cb);
+
 let workletFlushScheduled = false;
 function scheduleWorkletFlush(): void {
   if (!workletFlushScheduled) {
     workletFlushScheduled = true;
-    queueMicrotask(() => {
+    scheduleMicrotask(() => {
       workletFlushScheduled = false;
       __FlushElementTree();
     });
@@ -429,6 +435,11 @@ function applyOps(ops: Ops.Op[]): void {
 Object.assign(globalThis, {
   renderPage(_data: unknown): void {
     ensurePage();
+  },
+  // Native engines call `processData` while loading the template; there are
+  // no data processors in this runtime, so pass the data through unchanged.
+  processData(data: unknown): unknown {
+    return data;
   },
   updatePage(): void {/* noop */},
   updateGlobalProps(): void {/* noop */},

--- a/packages/preact-runtime/src/main-thread/index.ts
+++ b/packages/preact-runtime/src/main-thread/index.ts
@@ -395,6 +395,25 @@ function applyOps(ops: Ops.Op[]): void {
         );
         break;
       }
+      case Ops.AddInlineStyle: {
+        __AddInlineStyle(
+          elements.get(op[1] as number)!,
+          op[2] as string,
+          op[3],
+        );
+        break;
+      }
+      case Ops.ElementAnimate: {
+        __ElementAnimate(
+          elements.get(op[1] as number)!,
+          op[2] as unknown[],
+        );
+        break;
+      }
+      case Ops.ReportError: {
+        console.error('[preact-runtime BTS]', op[1]);
+        break;
+      }
       case Ops.RunWorklet: {
         runWorklet({ _wkltId: op[1] as number }, op[2] as unknown[]);
         break;

--- a/packages/preact-runtime/src/main-thread/index.ts
+++ b/packages/preact-runtime/src/main-thread/index.ts
@@ -6,7 +6,8 @@
  * The fixed main-thread runtime. It is identical for every app (no per-app
  * compilation): it registers the `renderPage`/`updatePage` entry points and
  * applies the op stream sent by the background thread through the Element
- * PAPI.
+ * PAPI. It also hosts the transform-free MTS support (worklet registry) and
+ * the `<list>` protocol.
  */
 
 import * as Ops from '../ops.js';
@@ -19,6 +20,18 @@ declare function __CreatePage(componentId: string, cssId: number): FiberElement;
 declare function __CreateElement(
   tag: string,
   parentComponentUniqueId: number,
+): FiberElement;
+declare function __CreateList(
+  parentComponentUniqueId: number,
+  componentAtIndex: (
+    list: FiberElement,
+    listID: number,
+    cellIndex: number,
+    operationID: number,
+    enableReuseNotification: boolean,
+  ) => number | undefined,
+  enqueueComponent: (list: FiberElement, listID: number, sign: number) => void,
+  info: Record<string, unknown>,
 ): FiberElement;
 declare function __CreateRawText(text: string): FiberElement;
 declare function __GetElementUniqueID(e: FiberElement): number;
@@ -40,6 +53,12 @@ declare function __SetAttribute(
   key: string,
   value: unknown,
 ): void;
+declare function __GetAttributeByName(e: FiberElement, key: string): unknown;
+declare function __AddInlineStyle(
+  e: FiberElement,
+  key: string | number,
+  value: unknown,
+): void;
 declare function __SetClasses(e: FiberElement, classes: string): void;
 declare function __SetInlineStyles(
   e: FiberElement,
@@ -53,6 +72,7 @@ declare function __AddEvent(
   eventName: string,
   event: string | Record<string, unknown> | undefined,
 ): void;
+declare function __ElementAnimate(e: FiberElement, args: unknown[]): void;
 declare function __FlushElementTree(
   element?: FiberElement,
   options?: Record<string, unknown>,
@@ -61,6 +81,172 @@ declare function __FlushElementTree(
 const elements = new Map<number, FiberElement>();
 let page: FiberElement | undefined;
 let pageId = 0;
+
+// ---------------------------------------------------------------------------
+// <list> support: items are created detached; `update-list-info` announces
+// positional changes and native/web pulls content back via componentAtIndex.
+// ---------------------------------------------------------------------------
+
+interface ListState {
+  list: FiberElement;
+  items: number[];
+  renderedCount: number;
+  dirty: boolean;
+}
+
+const listStates = new Map<number, ListState>();
+const dirtyLists: ListState[] = [];
+
+function componentAtIndexOf(
+  state: ListState,
+): (
+  list: FiberElement,
+  listID: number,
+  cellIndex: number,
+  operationID: number,
+  enableReuseNotification: boolean,
+) => number | undefined {
+  return (_list, _listID, cellIndex) => {
+    const itemId = state.items[cellIndex];
+    const item = itemId === undefined ? undefined : elements.get(itemId);
+    return item ? __GetElementUniqueID(item) : undefined;
+  };
+}
+
+function markListDirty(state: ListState): void {
+  if (!state.dirty) {
+    state.dirty = true;
+    dirtyLists.push(state);
+  }
+}
+
+function flushListUpdates(): void {
+  for (const state of dirtyLists) {
+    state.dirty = false;
+    // Full refresh: remove every rendered row, insert every current row.
+    // Correct (if not minimal) and enough for the recycling-free first cut.
+    const removeAction = Array.from(
+      { length: state.renderedCount },
+      (_, i) => i,
+    );
+    const insertAction = state.items.map((_, position) => ({ position }));
+    state.renderedCount = state.items.length;
+    __SetAttribute(state.list, 'update-list-info', {
+      insertAction,
+      removeAction,
+      updateAction: [],
+    });
+  }
+  dirtyLists.length = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Transform-free MTS: worklet registry + a minimal main-thread Element API.
+// ---------------------------------------------------------------------------
+
+const workletMap = new Map<number, (...args: unknown[]) => unknown>();
+let animationCount = 0;
+
+class MainThreadElement {
+  element: FiberElement;
+  dataset: unknown;
+  id: unknown;
+
+  constructor(element: FiberElement) {
+    this.element = element;
+  }
+
+  setAttribute(name: string, value: unknown): void {
+    __SetAttribute(this.element, name, value);
+    scheduleWorkletFlush();
+  }
+
+  getAttribute(name: string): unknown {
+    return __GetAttributeByName(this.element, name);
+  }
+
+  setStyleProperty(name: string, value: string): void {
+    __AddInlineStyle(this.element, name, value);
+    scheduleWorkletFlush();
+  }
+
+  setStyleProperties(styles: Record<string, string>): void {
+    for (const key in styles) {
+      __AddInlineStyle(this.element, key, styles[key]);
+    }
+    scheduleWorkletFlush();
+  }
+
+  animate(
+    keyframes: Record<string, unknown>[],
+    options?: number | Record<string, unknown>,
+  ): { cancel(): void; pause(): void; play(): void } {
+    const id = `__preact-runtime-animation-${animationCount++}`;
+    const normalized = typeof options === 'number'
+      ? { duration: options }
+      : options ?? {};
+    const element = this.element;
+    __ElementAnimate(element, [0, id, keyframes, normalized]);
+    scheduleWorkletFlush();
+    const operate = (op: number) => {
+      __ElementAnimate(element, [op, id]);
+      scheduleWorkletFlush();
+    };
+    return {
+      play: () => operate(1),
+      pause: () => operate(2),
+      cancel: () => operate(3),
+    };
+  }
+}
+
+let workletFlushScheduled = false;
+function scheduleWorkletFlush(): void {
+  if (!workletFlushScheduled) {
+    workletFlushScheduled = true;
+    queueMicrotask(() => {
+      workletFlushScheduled = false;
+      __FlushElementTree();
+    });
+  }
+}
+
+function wrapEventForWorklet(event: unknown): void {
+  if (!event || typeof event !== 'object') {
+    return;
+  }
+  const record = event as Record<string, unknown>;
+  for (const key of ['target', 'currentTarget']) {
+    const value = record[key] as
+      | { elementRefptr?: FiberElement; dataset?: unknown; id?: unknown }
+      | undefined;
+    if (value?.elementRefptr) {
+      const wrapped = new MainThreadElement(value.elementRefptr);
+      wrapped.dataset = value.dataset;
+      wrapped.id = value.id;
+      record[key] = wrapped;
+    }
+  }
+}
+
+function runWorklet(
+  ctx: { _wkltId?: number } | undefined,
+  params: unknown[] | undefined,
+): void {
+  const fn = ctx?._wkltId === undefined
+    ? undefined
+    : workletMap.get(ctx._wkltId);
+  if (!fn) {
+    return;
+  }
+  const args = params ?? [];
+  wrapEventForWorklet(args[0]);
+  fn(...args);
+}
+
+// ---------------------------------------------------------------------------
+// Op application
+// ---------------------------------------------------------------------------
 
 function ensurePage(): FiberElement {
   if (!page) {
@@ -77,7 +263,28 @@ function applyOps(ops: Ops.Op[]): void {
     const opcode = op[0] as number;
     switch (opcode) {
       case Ops.CreateElement: {
-        elements.set(op[1] as number, __CreateElement(op[2] as string, pageId));
+        const id = op[1] as number;
+        const tag = op[2] as string;
+        if (tag === 'list') {
+          const state: ListState = {
+            list: undefined as unknown as FiberElement,
+            items: [],
+            renderedCount: 0,
+            dirty: false,
+          };
+          state.list = __CreateList(
+            pageId,
+            componentAtIndexOf(state),
+            () => {
+              // Detach bookkeeping is driven by `update-list-info`.
+            },
+            {},
+          );
+          listStates.set(id, state);
+          elements.set(id, state.list);
+        } else {
+          elements.set(id, __CreateElement(tag, pageId));
+        }
         break;
       }
       case Ops.CreateText: {
@@ -89,9 +296,23 @@ function applyOps(ops: Ops.Op[]): void {
         break;
       }
       case Ops.InsertBefore: {
-        const parent = elements.get(op[1] as number)!;
-        const child = elements.get(op[2] as number)!;
-        const ref = op[3] ? elements.get(op[3] as number) : undefined;
+        const parentId = op[1] as number;
+        const childId = op[2] as number;
+        const refId = op[3] as number;
+        const listState = listStates.get(parentId);
+        if (listState) {
+          const index = refId ? listState.items.indexOf(refId) : -1;
+          if (index >= 0) {
+            listState.items.splice(index, 0, childId);
+          } else {
+            listState.items.push(childId);
+          }
+          markListDirty(listState);
+          break;
+        }
+        const parent = elements.get(parentId)!;
+        const child = elements.get(childId)!;
+        const ref = refId ? elements.get(refId) : undefined;
         if (ref) {
           __InsertElementBefore(parent, child, ref);
         } else {
@@ -100,9 +321,20 @@ function applyOps(ops: Ops.Op[]): void {
         break;
       }
       case Ops.Remove: {
+        const parentId = op[1] as number;
+        const childId = op[2] as number;
+        const listState = listStates.get(parentId);
+        if (listState) {
+          const index = listState.items.indexOf(childId);
+          if (index >= 0) {
+            listState.items.splice(index, 1);
+            markListDirty(listState);
+          }
+          break;
+        }
         __RemoveElement(
-          elements.get(op[1] as number)!,
-          elements.get(op[2] as number)!,
+          elements.get(parentId)!,
+          elements.get(childId)!,
         );
         break;
       }
@@ -115,10 +347,7 @@ function applyOps(ops: Ops.Op[]): void {
         break;
       }
       case Ops.SetStyle: {
-        __SetInlineStyles(
-          elements.get(op[1] as number)!,
-          op[2] as string,
-        );
+        __SetInlineStyles(elements.get(op[1] as number)!, op[2] as string);
         break;
       }
       case Ops.SetId: {
@@ -141,10 +370,40 @@ function applyOps(ops: Ops.Op[]): void {
         );
         break;
       }
+      case Ops.RegisterWorklet: {
+        const hash = op[1] as number;
+        const source = op[2] as string;
+        // The main-thread realm evaluates the shipped source once. This is
+        // the transform-free trade-off; see the package README.
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call
+        const fn = new Function(`return (${source});`)() as (
+          ...args: unknown[]
+        ) => unknown;
+        workletMap.set(hash, fn);
+        break;
+      }
+      case Ops.SetWorkletEvent: {
+        const id = op[1] as number;
+        const eventType = op[2] as string;
+        const eventName = op[3] as string;
+        const hash = op[4] as number;
+        __AddEvent(
+          elements.get(id)!,
+          eventType,
+          eventName,
+          hash ? { type: 'worklet', value: { _wkltId: hash } } : undefined,
+        );
+        break;
+      }
+      case Ops.RunWorklet: {
+        runWorklet({ _wkltId: op[1] as number }, op[2] as unknown[]);
+        break;
+      }
       default:
         break;
     }
   }
+  flushListUpdates();
   __FlushElementTree(page, {});
 }
 
@@ -158,6 +417,7 @@ Object.assign(globalThis, {
     return undefined;
   },
   removeComponents(): void {/* noop */},
+  runWorklet,
   [Ops.PATCH_METHOD](obj: { data: string }): void {
     applyOps(JSON.parse(obj.data) as Ops.Op[]);
   },

--- a/packages/preact-runtime/src/main-thread/index.ts
+++ b/packages/preact-runtime/src/main-thread/index.ts
@@ -1,0 +1,164 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * The fixed main-thread runtime. It is identical for every app (no per-app
+ * compilation): it registers the `renderPage`/`updatePage` entry points and
+ * applies the op stream sent by the background thread through the Element
+ * PAPI.
+ */
+
+import * as Ops from '../ops.js';
+
+interface FiberElement {
+  readonly __fiberElementBrand?: never;
+}
+
+declare function __CreatePage(componentId: string, cssId: number): FiberElement;
+declare function __CreateElement(
+  tag: string,
+  parentComponentUniqueId: number,
+): FiberElement;
+declare function __CreateRawText(text: string): FiberElement;
+declare function __GetElementUniqueID(e: FiberElement): number;
+declare function __AppendElement(
+  parent: FiberElement,
+  child: FiberElement,
+): FiberElement;
+declare function __InsertElementBefore(
+  parent: FiberElement,
+  child: FiberElement,
+  ref: FiberElement,
+): FiberElement;
+declare function __RemoveElement(
+  parent: FiberElement,
+  child: FiberElement,
+): FiberElement;
+declare function __SetAttribute(
+  e: FiberElement,
+  key: string,
+  value: unknown,
+): void;
+declare function __SetClasses(e: FiberElement, classes: string): void;
+declare function __SetInlineStyles(
+  e: FiberElement,
+  styles: string | Record<string, string>,
+): void;
+declare function __SetID(e: FiberElement, id: string | null): void;
+declare function __SetDataset(e: FiberElement, dataset: unknown): void;
+declare function __AddEvent(
+  e: FiberElement,
+  eventType: string,
+  eventName: string,
+  event: string | Record<string, unknown> | undefined,
+): void;
+declare function __FlushElementTree(
+  element?: FiberElement,
+  options?: Record<string, unknown>,
+): void;
+
+const elements = new Map<number, FiberElement>();
+let page: FiberElement | undefined;
+let pageId = 0;
+
+function ensurePage(): FiberElement {
+  if (!page) {
+    page = __CreatePage('0', 0);
+    pageId = __GetElementUniqueID(page);
+    elements.set(Ops.PAGE_ID, page);
+  }
+  return page;
+}
+
+function applyOps(ops: Ops.Op[]): void {
+  ensurePage();
+  for (const op of ops) {
+    const opcode = op[0] as number;
+    switch (opcode) {
+      case Ops.CreateElement: {
+        elements.set(op[1] as number, __CreateElement(op[2] as string, pageId));
+        break;
+      }
+      case Ops.CreateText: {
+        elements.set(op[1] as number, __CreateRawText(op[2] as string));
+        break;
+      }
+      case Ops.SetText: {
+        __SetAttribute(elements.get(op[1] as number)!, 'text', op[2]);
+        break;
+      }
+      case Ops.InsertBefore: {
+        const parent = elements.get(op[1] as number)!;
+        const child = elements.get(op[2] as number)!;
+        const ref = op[3] ? elements.get(op[3] as number) : undefined;
+        if (ref) {
+          __InsertElementBefore(parent, child, ref);
+        } else {
+          __AppendElement(parent, child);
+        }
+        break;
+      }
+      case Ops.Remove: {
+        __RemoveElement(
+          elements.get(op[1] as number)!,
+          elements.get(op[2] as number)!,
+        );
+        break;
+      }
+      case Ops.SetAttribute: {
+        __SetAttribute(elements.get(op[1] as number)!, op[2] as string, op[3]);
+        break;
+      }
+      case Ops.SetClasses: {
+        __SetClasses(elements.get(op[1] as number)!, op[2] as string);
+        break;
+      }
+      case Ops.SetStyle: {
+        __SetInlineStyles(
+          elements.get(op[1] as number)!,
+          op[2] as string,
+        );
+        break;
+      }
+      case Ops.SetId: {
+        __SetID(elements.get(op[1] as number)!, op[2] as string | null);
+        break;
+      }
+      case Ops.SetDataset: {
+        __SetDataset(elements.get(op[1] as number)!, op[2]);
+        break;
+      }
+      case Ops.SetEvent: {
+        const id = op[1] as number;
+        const eventType = op[2] as string;
+        const eventName = op[3] as string;
+        __AddEvent(
+          elements.get(id)!,
+          eventType,
+          eventName,
+          op[4] ? `${id}:${eventType}:${eventName}` : undefined,
+        );
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  __FlushElementTree(page, {});
+}
+
+Object.assign(globalThis, {
+  renderPage(_data: unknown): void {
+    ensurePage();
+  },
+  updatePage(): void {/* noop */},
+  updateGlobalProps(): void {/* noop */},
+  getPageData(): unknown {
+    return undefined;
+  },
+  removeComponents(): void {/* noop */},
+  [Ops.PATCH_METHOD](obj: { data: string }): void {
+    applyOps(JSON.parse(obj.data) as Ops.Op[]);
+  },
+});

--- a/packages/preact-runtime/src/mainThreadElement.ts
+++ b/packages/preact-runtime/src/mainThreadElement.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * The background-side stand-in for a main-thread `Element`: the API surface
+ * of the worklet-runtime Element, implemented as ops. Used when main-thread
+ * handlers fall back to background execution (closure-capturing handlers
+ * cannot be shipped across threads without a compiler).
+ */
+
+import { enqueueOp } from './channel.js';
+import type { RemoteElement } from './document.js';
+import * as Ops from './ops.js';
+
+let animationCount = 0;
+
+export class BackgroundMainThreadElement {
+  private readonly _node: RemoteElement;
+
+  constructor(node: RemoteElement) {
+    this._node = node;
+  }
+
+  get dataset(): Record<string, unknown> {
+    return this._node._dataset;
+  }
+
+  get id(): unknown {
+    return this._node._attributes.get('id');
+  }
+
+  setAttribute(name: string, value: unknown): void {
+    this._node._attributes.set(name, value);
+    enqueueOp([Ops.SetAttribute, this._node._id, name, value ?? null]);
+  }
+
+  getAttribute(name: string): unknown {
+    return this._node._attributes.get(name);
+  }
+
+  getAttributeNames(): string[] {
+    return [...this._node._attributes.keys()] as string[];
+  }
+
+  setStyleProperty(name: string, value: string): void {
+    enqueueOp([Ops.AddInlineStyle, this._node._id, name, value]);
+  }
+
+  setStyleProperties(styles: Record<string, string>): void {
+    for (const key in styles) {
+      enqueueOp([Ops.AddInlineStyle, this._node._id, key, styles[key]]);
+    }
+  }
+
+  animate(
+    keyframes: Record<string, unknown>[],
+    options?: number | Record<string, unknown>,
+  ): { cancel(): void; pause(): void; play(): void } {
+    const id = `__preact-runtime-bg-animation-${animationCount++}`;
+    const normalized = typeof options === 'number'
+      ? { duration: options }
+      : options ?? {};
+    enqueueOp([
+      Ops.ElementAnimate,
+      this._node._id,
+      [0, id, keyframes, normalized],
+    ]);
+    const operate = (op: number) => {
+      enqueueOp([Ops.ElementAnimate, this._node._id, [op, id]]);
+    };
+    return {
+      play: () => operate(1),
+      pause: () => operate(2),
+      cancel: () => operate(3),
+    };
+  }
+
+  invoke(): Promise<unknown> {
+    return Promise.reject(
+      new Error('Element.invoke is not supported on this runtime yet'),
+    );
+  }
+}

--- a/packages/preact-runtime/src/ops.ts
+++ b/packages/preact-runtime/src/ops.ts
@@ -35,6 +35,12 @@ export const RegisterWorklet = 12;
 export const SetWorkletEvent = 13;
 /** `[RunWorklet, hash, args]` */
 export const RunWorklet = 14;
+/** `[AddInlineStyle, id, key, value]` */
+export const AddInlineStyle = 15;
+/** `[ElementAnimate, id, args]` */
+export const ElementAnimate = 16;
+/** `[ReportError, message]` */
+export const ReportError = 17;
 
 export type Op = unknown[];
 

--- a/packages/preact-runtime/src/ops.ts
+++ b/packages/preact-runtime/src/ops.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * The flat op protocol between the background-thread renderer and the fixed
+ * main-thread runtime. Each op is a plain array: `[opcode, ...args]`.
+ */
+
+/** `[CreateElement, id, tag]` */
+export const CreateElement = 1;
+/** `[CreateText, id, text]` */
+export const CreateText = 2;
+/** `[SetText, id, text]` */
+export const SetText = 3;
+/** `[InsertBefore, parentId, childId, refId]` — `refId === 0` appends. */
+export const InsertBefore = 4;
+/** `[Remove, parentId, childId]` */
+export const Remove = 5;
+/** `[SetAttribute, id, key, value]` — `value === null` removes. */
+export const SetAttribute = 6;
+/** `[SetClasses, id, classes]` */
+export const SetClasses = 7;
+/** `[SetStyle, id, cssText]` */
+export const SetStyle = 8;
+/** `[SetId, id, idValue]` */
+export const SetId = 9;
+/** `[SetDataset, id, dataset]` */
+export const SetDataset = 10;
+/** `[SetEvent, id, eventType, eventName, enabled]` */
+export const SetEvent = 11;
+
+export type Op = unknown[];
+
+/** The id of the page (root container) element. */
+export const PAGE_ID = 1;
+
+/** The main-thread global invoked through `callLepusMethod`. */
+export const PATCH_METHOD = 'pLynxChange';

--- a/packages/preact-runtime/src/ops.ts
+++ b/packages/preact-runtime/src/ops.ts
@@ -29,6 +29,12 @@ export const SetId = 9;
 export const SetDataset = 10;
 /** `[SetEvent, id, eventType, eventName, enabled]` */
 export const SetEvent = 11;
+/** `[RegisterWorklet, hash, fnString]` */
+export const RegisterWorklet = 12;
+/** `[SetWorkletEvent, id, eventType, eventName, hash]` — `hash === 0` removes. */
+export const SetWorkletEvent = 13;
+/** `[RunWorklet, hash, args]` */
+export const RunWorklet = 14;
 
 export type Op = unknown[];
 

--- a/packages/preact-runtime/src/plugin/index.ts
+++ b/packages/preact-runtime/src/plugin/index.ts
@@ -67,6 +67,11 @@ export function pluginPreactLynx(): RsbuildPlugin {
     setup(api) {
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
         return mergeRsbuildConfig(config, {
+          output: {
+            // Route CSS through CssExtractRspackPlugin (replaced below with
+            // the Lynx-aware fork) instead of injecting <style> tags.
+            injectStyles: false,
+          },
           source: {
             define: {
               // The web BTS evaluates the chunk via
@@ -90,6 +95,48 @@ export function pluginPreactLynx(): RsbuildPlugin {
             },
           },
         });
+      });
+
+      // Swap rsbuild's CSS extraction for the Lynx-aware fork so `.css`
+      // assets become template style sections.
+      api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
+        const { CssExtractRspackPlugin } = await import(
+          '@lynx-js/css-extract-webpack-plugin'
+        );
+        const cssRules = [
+          CHAIN_ID.RULE.CSS,
+          CHAIN_ID.RULE.SASS,
+          CHAIN_ID.RULE.LESS,
+          CHAIN_ID.RULE.STYLUS,
+        ] as const;
+        cssRules
+          .filter((rule) => chain.module.rules.has(rule))
+          .forEach((ruleName) => {
+            const mainRuleName = ruleName === CHAIN_ID.RULE.CSS
+              ? CHAIN_ID.ONE_OF.CSS_MAIN
+              : ruleName;
+            const mainRule = chain.module.rule(ruleName).oneOf(mainRuleName);
+            if (mainRule.uses.has(CHAIN_ID.USE.LIGHTNINGCSS)) {
+              mainRule.uses.delete(CHAIN_ID.USE.LIGHTNINGCSS);
+            }
+            if (mainRule.uses.has(CHAIN_ID.USE.MINI_CSS_EXTRACT)) {
+              mainRule
+                .use(CHAIN_ID.USE.MINI_CSS_EXTRACT)
+                .loader(CssExtractRspackPlugin.loader);
+            }
+          });
+        if (chain.plugins.has(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)) {
+          chain
+            .plugin(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)
+            .init(
+              (_, args: unknown[]) =>
+                new CssExtractRspackPlugin(
+                  args[0] as ConstructorParameters<
+                    typeof CssExtractRspackPlugin
+                  >[0],
+                ),
+            );
+        }
       });
 
       api.modifyBundlerChain((chain, { environment, isDev }) => {
@@ -122,6 +169,28 @@ export function pluginPreactLynx(): RsbuildPlugin {
         ) {
           chain.resolve.alias.set(`${specifier}$`, require.resolve(specifier));
         }
+
+        // Let sources written against `@lynx-js/react` run unmodified.
+        chain.resolve.alias.set(
+          '@lynx-js/react$',
+          require.resolve('@lynx-js/preact-runtime/compat'),
+        );
+        chain.resolve.alias.set(
+          '@lynx-js/react/debug$',
+          require.resolve('@lynx-js/preact-runtime/compat/debug'),
+        );
+        chain.resolve.alias.set(
+          '@lynx-js/preact-devtools$',
+          require.resolve('@lynx-js/preact-runtime/compat/debug'),
+        );
+
+        // Example sources import './App.jsx' while the file is `App.tsx`.
+        chain.resolve.merge({
+          extensionAlias: {
+            '.js': ['.js', '.ts', '.tsx'],
+            '.jsx': ['.jsx', '.tsx'],
+          },
+        });
 
         const { hmr, liveReload } = environment.config.dev ?? {};
         const enabledHMR = isDev && hmr !== false;

--- a/packages/preact-runtime/src/plugin/index.ts
+++ b/packages/preact-runtime/src/plugin/index.ts
@@ -200,6 +200,10 @@ export function pluginPreactLynx(): RsbuildPlugin {
           require.resolve('@lynx-js/preact-runtime/compat'),
         );
         chain.resolve.alias.set(
+          '@lynx-js/react/worklet-runtime/bindings$',
+          require.resolve('@lynx-js/preact-runtime/compat/worklet-bindings'),
+        );
+        chain.resolve.alias.set(
           '@lynx-js/react/debug$',
           require.resolve('@lynx-js/preact-runtime/compat/debug'),
         );

--- a/packages/preact-runtime/src/plugin/index.ts
+++ b/packages/preact-runtime/src/plugin/index.ts
@@ -194,6 +194,11 @@ export function pluginPreactLynx(): RsbuildPlugin {
           '@lynx-js/react$',
           require.resolve('@lynx-js/preact-runtime/compat'),
         );
+        // ReactLynx also aliases bare `react` (externals examples use it).
+        chain.resolve.alias.set(
+          'react$',
+          require.resolve('@lynx-js/preact-runtime/compat'),
+        );
         chain.resolve.alias.set(
           '@lynx-js/react/debug$',
           require.resolve('@lynx-js/preact-runtime/compat/debug'),

--- a/packages/preact-runtime/src/plugin/index.ts
+++ b/packages/preact-runtime/src/plugin/index.ts
@@ -220,6 +220,20 @@ export function pluginPreactLynx(): RsbuildPlugin {
         // standalone lazy-bundle templates whose evaluation re-runs the app.
         chain.output.set('asyncChunks', false);
 
+        // `import(url, { with: { type: 'component' } })` → runtime loader.
+        chain.module
+          .rule('preact-remote-import')
+          .test(/\.(?:js|jsx|ts|tsx|mjs|cjs)$/)
+          .exclude.add(/[\\/]node_modules[\\/]/)
+          .end()
+          .enforce('pre')
+          .use('import-attributes')
+          .loader(
+            require.resolve(
+              '@lynx-js/preact-runtime/loader/import-attributes-loader',
+            ),
+          );
+
         const { hmr, liveReload } = environment.config.dev ?? {};
         const enabledHMR = isDev && hmr !== false;
         const enabledLiveReload = isDev && liveReload !== false;

--- a/packages/preact-runtime/src/plugin/index.ts
+++ b/packages/preact-runtime/src/plugin/index.ts
@@ -192,6 +192,10 @@ export function pluginPreactLynx(): RsbuildPlugin {
           },
         });
 
+        // Keep dynamic imports in the main chunk: async chunks would become
+        // standalone lazy-bundle templates whose evaluation re-runs the app.
+        chain.output.set('asyncChunks', false);
+
         const { hmr, liveReload } = environment.config.dev ?? {};
         const enabledHMR = isDev && hmr !== false;
         const enabledLiveReload = isDev && liveReload !== false;

--- a/packages/preact-runtime/src/plugin/index.ts
+++ b/packages/preact-runtime/src/plugin/index.ts
@@ -78,6 +78,25 @@ export function pluginPreactLynx(): RsbuildPlugin {
               // `new Function('document', ...)` with an undefined `document`
               // parameter that would shadow the worker global preact needs.
               document: 'globalThis.document',
+              // ReactLynx compile-time flags that example sources reference.
+              __DEV__: JSON.stringify(
+                process.env['NODE_ENV'] !== 'production',
+              ),
+              __BACKGROUND__: 'true',
+              __MAIN_THREAD__: 'false',
+              __LEPUS__: 'false',
+              __JS__: 'true',
+              __REACT_DEVTOOL__: 'false',
+              __PROFILE__: 'false',
+              __ALOG__: 'false',
+              __ALOG_ELEMENT_API__: 'false',
+              __EXTRACT_STR__: 'false',
+              __FIRST_SCREEN_SYNC_TIMING__: '"immediately"',
+              __GLOBAL_PROPS_MODE__: '"reactive"',
+              __ENABLE_SSR__: 'false',
+              __DISABLE_CREATE_SELECTOR_QUERY_INCOMPATIBLE_WARNING__: 'false',
+              __USE_ELEMENT_TEMPLATE__: 'false',
+              __LAZY_BUNDLE_FETCHER__: '"QueryComponent"',
             },
           },
           tools: {

--- a/packages/preact-runtime/src/plugin/index.ts
+++ b/packages/preact-runtime/src/plugin/index.ts
@@ -1,0 +1,222 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * @packageDocumentation
+ *
+ * The rspeedy/rsbuild plugin for the transform-free preact runtime.
+ *
+ * Unlike `pluginReactLynx`, there is no per-app main-thread build and no SWC
+ * transform: the main-thread chunk is a fixed prebuilt runtime shipped by
+ * `@lynx-js/preact-runtime/main-thread`, and user code is compiled once for
+ * the background thread with the standard preact JSX runtime.
+ */
+
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+
+import { RuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin';
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+  WebEncodePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+const DEFAULT_DIST_PATH_INTERMEDIATE = '.rspeedy';
+
+class MarkMainThreadAssetPlugin {
+  constructor(private mainThreadChunks: string[]) {}
+
+  apply(compiler: Rspack.Compiler): void {
+    compiler.hooks.thisCompilation.tap(
+      'MarkMainThreadAssetPlugin',
+      (compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: 'MarkMainThreadAssetPlugin',
+            stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+          },
+          () => {
+            for (const name of this.mainThreadChunks) {
+              const asset = compilation.getAsset(name);
+              if (asset) {
+                compilation.updateAsset(asset.name, asset.source, {
+                  ...asset.info,
+                  'lynx:main-thread': true,
+                });
+              }
+            }
+          },
+        );
+      },
+    );
+  }
+}
+
+/**
+ * Create the rsbuild plugin for the transform-free preact runtime.
+ *
+ * @public
+ */
+export function pluginPreactLynx(): RsbuildPlugin {
+  return {
+    name: 'lynx:preact',
+    setup(api) {
+      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+        return mergeRsbuildConfig(config, {
+          source: {
+            define: {
+              // The web BTS evaluates the chunk via
+              // `new Function('document', ...)` with an undefined `document`
+              // parameter that would shadow the worker global preact needs.
+              document: 'globalThis.document',
+            },
+          },
+          tools: {
+            swc: {
+              jsc: {
+                transform: {
+                  react: {
+                    runtime: 'automatic',
+                    importSource: 'preact',
+                  },
+                },
+              },
+            },
+          },
+        });
+      });
+
+      api.modifyBundlerChain((chain, { environment, isDev }) => {
+        const isRspeedy = api.context.callerName === 'rspeedy';
+        if (!isRspeedy) {
+          return;
+        }
+        const isLynx = environment.name === 'lynx'
+          || environment.name.startsWith('lynx-');
+        const isWeb = environment.name === 'web'
+          || environment.name.startsWith('web-');
+
+        const require = createRequire(import.meta.url);
+        const mainThreadRuntime = require.resolve(
+          '@lynx-js/preact-runtime/main-thread',
+        );
+
+        // Resolve preact from this package so apps do not need a direct
+        // dependency and the whole build shares a single copy.
+        for (
+          const specifier of [
+            'preact',
+            'preact/hooks',
+            'preact/compat',
+            'preact/jsx-runtime',
+            'preact/jsx-dev-runtime',
+            'preact/debug',
+            'preact/devtools',
+          ]
+        ) {
+          chain.resolve.alias.set(`${specifier}$`, require.resolve(specifier));
+        }
+
+        const { hmr, liveReload } = environment.config.dev ?? {};
+        const enabledHMR = isDev && hmr !== false;
+        const enabledLiveReload = isDev && liveReload !== false;
+
+        const entries = chain.entryPoints.entries() ?? {};
+        chain.entryPoints.clear();
+
+        const mainThreadChunks: string[] = [];
+
+        Object.entries(entries).forEach(([entryName, entryPoint]) => {
+          const imports = entryPoint.values().flatMap((item) => {
+            if (typeof item === 'string') {
+              return [item];
+            }
+            if (Array.isArray(item)) {
+              return item;
+            }
+            const importValue = (item as { import: string | string[] }).import;
+            return Array.isArray(importValue) ? importValue : [importValue];
+          });
+
+          const mainThreadEntry = `${entryName}__main-thread`;
+          const intermediate = isLynx ? DEFAULT_DIST_PATH_INTERMEDIATE : '';
+          const mainThreadName = path.posix.join(
+            intermediate,
+            `${entryName}/main-thread.js`,
+          );
+          const backgroundName = path.posix.join(
+            intermediate,
+            `${entryName}/background.js`,
+          );
+
+          mainThreadChunks.push(mainThreadName);
+
+          chain
+            .entry(mainThreadEntry)
+            .add({
+              import: [mainThreadRuntime],
+              filename: mainThreadName,
+            })
+            .end()
+            .entry(entryName)
+            .add({
+              import: imports,
+              filename: backgroundName,
+            })
+            .when(enabledHMR || enabledLiveReload, (entry) => {
+              // This is aliased in `@lynx-js/rspeedy`
+              entry.prepend('@lynx-js/webpack-dev-transport/client');
+            })
+            .end()
+            .plugin(`lynx:preact-template-${entryName}`)
+            .use(LynxTemplatePlugin, [{
+              ...LynxTemplatePlugin.defaultOptions,
+              dsl: 'react_nodiff',
+              chunks: [mainThreadEntry, entryName],
+              filename: `${entryName}.[platform].bundle`.replaceAll(
+                '[platform]',
+                environment.name,
+              ),
+              intermediate: path.posix.join(
+                DEFAULT_DIST_PATH_INTERMEDIATE,
+                entryName,
+              ),
+              enableRemoveCSSScope: true,
+              defaultDisplayLinear: true,
+            }])
+            .end();
+        });
+
+        chain
+          .plugin('lynx:preact-mark-main-thread')
+          .use(MarkMainThreadAssetPlugin, [mainThreadChunks])
+          .end();
+
+        if (isLynx) {
+          chain
+            .plugin('lynx:preact-runtime-wrapper')
+            .use(RuntimeWrapperWebpackPlugin, [{
+              targetSdkVersion: '3.2',
+              // Wrap all `.js` but not `main-thread.js`.
+              test: /^(?!.*main-thread(?:\.[A-Fa-f0-9]*)?\.js$).*\.js$/,
+            }])
+            .end()
+            .plugin(LynxEncodePlugin.name)
+            .use(LynxEncodePlugin, [{}])
+            .end();
+        }
+
+        if (isWeb) {
+          chain
+            .plugin('lynx:preact-web-encode')
+            .use(WebEncodePlugin, [])
+            .end();
+        }
+      });
+    },
+  };
+}

--- a/packages/preact-runtime/src/plugin/index.ts
+++ b/packages/preact-runtime/src/plugin/index.ts
@@ -82,6 +82,8 @@ export function pluginPreactLynx(): RsbuildPlugin {
                   react: {
                     runtime: 'automatic',
                     importSource: 'preact',
+                    // `main-thread:bindtap` etc. are namespaced JSX attributes.
+                    throwIfNamespace: false,
                   },
                 },
               },

--- a/packages/preact-runtime/src/remote.ts
+++ b/packages/preact-runtime/src/remote.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Runtime support for `import(url, { with: { type: 'component' } })`.
+ * The plugin rewrites such calls to `globalThis.__preactRemoteImport(url)`.
+ *
+ * Resolution order:
+ * 1. a module registered via {@link registerRemoteModule} (keyed by the URL's
+ *    trailing file name) — used by the example ports;
+ * 2. fetch + evaluate as a CommonJS module, with `require` resolving modules
+ *    registered via {@link registerSharedModule}.
+ */
+
+type ModuleLoader = () => Promise<unknown>;
+
+const registry = new Map<string, ModuleLoader>();
+const sharedModules = new Map<string, unknown>();
+
+/**
+ * Register a local module for a producer-bundle file name.
+ *
+ * @public
+ */
+export function registerRemoteModule(
+  fileName: string,
+  loader: ModuleLoader,
+): void {
+  registry.set(fileName, loader);
+}
+
+/** Make a module available to fetched producer bundles via `require`. */
+export function registerSharedModule(name: string, value: unknown): void {
+  sharedModules.set(name, value);
+}
+
+function shimRequire(specifier: string): unknown {
+  if (sharedModules.has(specifier)) {
+    return sharedModules.get(specifier);
+  }
+  throw new Error(
+    `__preactRemoteImport: producer bundle requires unknown module "${specifier}"`,
+  );
+}
+
+async function remoteImport(url: string): Promise<unknown> {
+  const fileName = url.split('?')[0]!.split('/').pop()!;
+  const registered = registry.get(fileName);
+  if (registered) {
+    return registered();
+  }
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- worker runtime
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `__preactRemoteImport: failed to load ${url}: ${response.status}`,
+    );
+  }
+  const source = await response.text();
+  const producerModule = { exports: {} as Record<string, unknown> };
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const evaluate = new Function('module', 'exports', 'require', source) as (
+    module: unknown,
+    exports: unknown,
+    require: unknown,
+  ) => void;
+  evaluate(producerModule, producerModule.exports, shimRequire);
+  return producerModule.exports;
+}
+
+(globalThis as Record<string, unknown>)['__preactRemoteImport'] = remoteImport;

--- a/packages/preact-runtime/src/runtime.ts
+++ b/packages/preact-runtime/src/runtime.ts
@@ -10,16 +10,49 @@
 import { render } from 'preact';
 import type { ComponentChild } from 'preact';
 
+import { enqueueOp } from './channel.js';
 import {
   RemoteDocument,
   RemoteElement,
   createPageContainer,
   nodesById,
 } from './document.js';
+import { BackgroundMainThreadElement } from './mainThreadElement.js';
+import * as Ops from './ops.js';
 
 declare const lynxCoreInject: {
   tt: Record<string, unknown>;
 };
+
+(globalThis as { __TRANSFORM_FREE_MTS__?: boolean }).__TRANSFORM_FREE_MTS__ =
+  true;
+
+const reportError = (message: string) => {
+  enqueueOp([Ops.ReportError, message]);
+};
+{
+  const target = globalThis as unknown as {
+    addEventListener?: (
+      type: string,
+      cb: (e: Record<string, unknown>) => void,
+    ) => void;
+  };
+  target.addEventListener?.('error', (e) => {
+    const error = e['error'] as Error | undefined;
+    const message = e['message'];
+    reportError(
+      error?.stack ?? error?.message
+        ?? (typeof message === 'string' ? message : ''),
+    );
+  });
+  target.addEventListener?.('unhandledrejection', (e) => {
+    reportError(`unhandledrejection: ${
+      String(
+        (e['reason'] as Error | undefined)?.stack ?? e['reason'],
+      )
+    }`);
+  });
+}
 
 let container: RemoteElement | undefined;
 
@@ -30,6 +63,19 @@ function dispatchEvent(handlerName: string, data: unknown): void {
   const key = handlerName.slice(first + 1);
   const node = nodesById.get(id);
   if (node instanceof RemoteElement) {
+    const mtListener = node._mtListeners.get(key);
+    if (mtListener) {
+      const wrapped = new BackgroundMainThreadElement(node);
+      const event = data && typeof data === 'object'
+        ? Object.assign({}, data, { currentTarget: wrapped, target: wrapped })
+        : data;
+      try {
+        mtListener(event);
+      } catch (error) {
+        (globalThis as { lynx?: { reportError?(e: unknown): void } }).lynx
+          ?.reportError?.(error);
+      }
+    }
     const listener = node._listeners.get(key);
     if (listener) {
       try {
@@ -74,6 +120,15 @@ function boot(): RemoteElement {
  */
 export const root = {
   render(vnode: ComponentChild): void {
-    render(vnode, boot() as unknown as HTMLElement);
+    const container = boot();
+    try {
+      render(vnode, container as unknown as HTMLElement);
+    } catch (error) {
+      enqueueOp([
+        Ops.ReportError,
+        String((error as Error | undefined)?.stack ?? error),
+      ]);
+      throw error;
+    }
   },
 };

--- a/packages/preact-runtime/src/runtime.ts
+++ b/packages/preact-runtime/src/runtime.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Background-thread bootstrap: installs the event bridge on
+ * `lynxCoreInject.tt` and exposes the root container for preact.
+ */
+
+import { render } from 'preact';
+import type { ComponentChild } from 'preact';
+
+import {
+  RemoteDocument,
+  RemoteElement,
+  createPageContainer,
+  nodesById,
+} from './document.js';
+
+declare const lynxCoreInject: {
+  tt: Record<string, unknown>;
+};
+
+let container: RemoteElement | undefined;
+
+function dispatchEvent(handlerName: string, data: unknown): void {
+  // handlerName format: `${id}:${eventType}:${eventName}`
+  const first = handlerName.indexOf(':');
+  const id = Number(handlerName.slice(0, first));
+  const key = handlerName.slice(first + 1);
+  const node = nodesById.get(id);
+  if (node instanceof RemoteElement) {
+    const listener = node._listeners.get(key);
+    if (listener) {
+      try {
+        listener(data);
+      } catch (error) {
+        (globalThis as { lynx?: { reportError?(e: unknown): void } }).lynx
+          ?.reportError?.(error);
+      }
+    }
+  }
+}
+
+function boot(): RemoteElement {
+  if (container) {
+    return container;
+  }
+
+  // Vanilla preact resolves `document` from the global scope.
+  (globalThis as { document?: unknown }).document ??= new RemoteDocument();
+
+  const tt = lynxCoreInject.tt;
+  tt['OnLifecycleEvent'] = () => {/* noop */};
+  tt['publishEvent'] = dispatchEvent;
+  tt['publicComponentEvent'] = (
+    _componentId: string,
+    handlerName: string,
+    data: unknown,
+  ) => dispatchEvent(handlerName, data);
+  tt['updateCardData'] = () => {/* noop */};
+  tt['updateGlobalProps'] = () => {/* noop */};
+  tt['processCardConfig'] = () => {/* noop */};
+  tt['callDestroyLifetimeFun'] = () => {/* noop */};
+
+  container = createPageContainer();
+  return container;
+}
+
+/**
+ * The page root, mirroring `root` from `@lynx-js/react`.
+ *
+ * @public
+ */
+export const root = {
+  render(vnode: ComponentChild): void {
+    render(vnode, boot() as unknown as HTMLElement);
+  },
+};

--- a/packages/preact-runtime/src/worklet.ts
+++ b/packages/preact-runtime/src/worklet.ts
@@ -33,7 +33,16 @@ export function registerWorklet(fn: AnyFunction): number {
  *
  * @public
  */
-export function runOnMainThread<Args extends unknown[]>(
+export function runOnMainThread<Args extends unknown[], Ret>(
+  fn: (...args: Args) => Ret,
+): (...args: Args) => Promise<Ret> {
+  // Background fallback: closure-capturing functions cannot cross threads
+  // without a compiler, so the function runs here against op-backed APIs.
+  return (...args) => Promise.resolve().then(() => fn(...args));
+}
+
+/** True main-thread execution for closure-free functions. */
+export function runOnMainThreadStrict<Args extends unknown[]>(
   fn: (...args: Args) => unknown,
 ): (...args: Args) => void {
   return (...args) => {

--- a/packages/preact-runtime/src/worklet.ts
+++ b/packages/preact-runtime/src/worklet.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Transform-free main-thread scripting: functions are stringified at runtime
+ * and evaluated once in the main-thread realm. They MUST be closure-free —
+ * without a compiler there is no closure extraction; everything a main-thread
+ * function needs must come through its arguments (e.g. the event object).
+ */
+
+import { enqueueOp } from './channel.js';
+import * as Ops from './ops.js';
+
+type AnyFunction = (...args: never[]) => unknown;
+
+let nextWorkletId = 1;
+const workletIds = new WeakMap<AnyFunction, number>();
+
+/** Ships the function source to the main thread once per identity. */
+export function registerWorklet(fn: AnyFunction): number {
+  let id = workletIds.get(fn);
+  if (id === undefined) {
+    id = nextWorkletId++;
+    workletIds.set(fn, id);
+    enqueueOp([Ops.RegisterWorklet, id, fn.toString()]);
+  }
+  return id;
+}
+
+/**
+ * Schedule a closure-free function to run on the main thread.
+ *
+ * @public
+ */
+export function runOnMainThread<Args extends unknown[]>(
+  fn: (...args: Args) => unknown,
+): (...args: Args) => void {
+  return (...args) => {
+    enqueueOp([Ops.RunWorklet, registerWorklet(fn as AnyFunction), args]);
+  };
+}

--- a/packages/preact-runtime/tsconfig.build.json
+++ b/packages/preact-runtime/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["src/plugin"],
+}

--- a/packages/preact-runtime/tsconfig.json
+++ b/packages/preact-runtime/tsconfig.json
@@ -7,5 +7,4 @@
     "types": [],
   },
   "include": ["src"],
-  "exclude": ["src/plugin"],
 }

--- a/packages/preact-runtime/tsconfig.json
+++ b/packages/preact-runtime/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "src",
+    "lib": ["ES2022"],
+    "types": [],
+  },
+  "include": ["src"],
+}

--- a/packages/preact-runtime/tsconfig.json
+++ b/packages/preact-runtime/tsconfig.json
@@ -7,4 +7,5 @@
     "types": [],
   },
   "include": ["src"],
+  "exclude": ["src/plugin"],
 }

--- a/packages/preact-runtime/turbo.json
+++ b/packages/preact-runtime/turbo.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "src/**",
+        "loader/**",
+        "rslib.config.ts",
+        "tsconfig.json",
+        "tsconfig.build.json"
+      ],
+      "outputs": [
+        "dist"
+      ]
+    }
+  }
+}

--- a/packages/react/runtime/__test__/element-template/vitest.config.ts
+++ b/packages/react/runtime/__test__/element-template/vitest.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from 'vitest/config';
 
 const require = createRequire(import.meta.url);
 const elementTemplateRuntimePkg = require.resolve('../../src/element-template/internal.ts');
+const internalPreactRoot = path.dirname(require.resolve('preact/package.json'));
 
 function transformReactLynxPlugin(): Plugin {
   return {
@@ -67,44 +68,82 @@ const config: UserConfigExport = defineConfig({
   ],
   resolve: {
     dedupe: ['preact'],
-    alias: {
-      '@lynx-js/react/compat': path.resolve(__dirname, '../../compat/index.js'),
-      '@lynx-js/react/worklet-runtime/bindings': path.resolve(
-        __dirname,
-        '../../src/worklet-runtime/bindings/index.ts',
-      ),
-      '@lynx-js/react/runtime-components': path.resolve(__dirname, '../../../components/src/index.ts'),
-      '@lynx-js/react/internal': path.resolve(__dirname, '../../src/element-template/internal.ts'),
+    alias: [
+      // Pin every preact entry point to the internal-preact copy resolved from
+      // this package. Without these aliases the externalized preact modules
+      // resolve bare `preact` imports through pnpm's hidden hoist
+      // (node_modules/.pnpm/node_modules/preact), whose winner is arbitrary
+      // once another real `preact` exists anywhere in the workspace — mixing
+      // two preact instances breaks hooks (`__H`) and Suspense.
+      { find: /^preact$/, replacement: path.join(internalPreactRoot, 'dist/preact.mjs') },
+      { find: /^preact\/compat$/, replacement: path.join(internalPreactRoot, 'compat/dist/compat.mjs') },
+      { find: /^preact\/hooks$/, replacement: path.join(internalPreactRoot, 'hooks/dist/hooks.mjs') },
+      {
+        find: /^preact\/jsx-dev-runtime$/,
+        replacement: path.join(internalPreactRoot, 'jsx-runtime/dist/jsxRuntime.mjs'),
+      },
+      { find: /^preact\/jsx-runtime$/, replacement: path.join(internalPreactRoot, 'jsx-runtime/dist/jsxRuntime.mjs') },
+      { find: '@lynx-js/react/compat', replacement: path.resolve(__dirname, '../../compat/index.js') },
+      {
+        find: '@lynx-js/react/worklet-runtime/bindings',
+        replacement: path.resolve(__dirname, '../../src/worklet-runtime/bindings/index.ts'),
+      },
+      {
+        find: '@lynx-js/react/runtime-components',
+        replacement: path.resolve(__dirname, '../../../components/src/index.ts'),
+      },
+      {
+        find: '@lynx-js/react/internal',
+        replacement: path.resolve(__dirname, '../../src/element-template/internal.ts'),
+      },
       // The ET vitest harness evaluates both background and main-thread flows in
       // a no-layer environment. Keep JSX creation on the shared runtime so the
       // background tree still receives the standard vnode shape it expects.
-      '@lynx-js/react/jsx-dev-runtime': path.resolve(__dirname, '../../jsx-dev-runtime/index.js'),
-      '@lynx-js/react/jsx-runtime': path.resolve(__dirname, '../../jsx-runtime/index.js'),
-      '@lynx-js/react/element-template/jsx-dev-runtime': path.resolve(
-        __dirname,
-        '../../src/element-template/jsx-dev-runtime/index.ts',
-      ),
-      '@lynx-js/react/element-template/jsx-runtime': path.resolve(
-        __dirname,
-        '../../src/element-template/jsx-runtime/index.ts',
-      ),
-      '@lynx-js/react/hooks': path.resolve(__dirname, '../../src/core/hooks/react.ts'),
-      '@lynx-js/react/lepus/hooks': path.resolve(
-        __dirname,
-        '../../src/core/hooks/mainThread.ts',
-      ),
-      '@lynx-js/react/lepus': path.resolve(__dirname, '../../lepus/index.js'),
-      '@lynx-js/react/legacy-react-runtime': path.resolve(
-        __dirname,
-        '../../src/core/compat/legacy-react-runtime.ts',
-      ),
-      '@lynx-js/react/element-template/internal': path.resolve(__dirname, '../../src/element-template/internal.ts'),
-      '@lynx-js/react/element-template': path.resolve(__dirname, '../../src/element-template/index.ts'),
-      '@lynx-js/react': path.resolve(__dirname, '../../src/element-template/index.ts'),
-    },
+      {
+        find: '@lynx-js/react/jsx-dev-runtime',
+        replacement: path.resolve(__dirname, '../../jsx-dev-runtime/index.js'),
+      },
+      { find: '@lynx-js/react/jsx-runtime', replacement: path.resolve(__dirname, '../../jsx-runtime/index.js') },
+      {
+        find: '@lynx-js/react/element-template/jsx-dev-runtime',
+        replacement: path.resolve(__dirname, '../../src/element-template/jsx-dev-runtime/index.ts'),
+      },
+      {
+        find: '@lynx-js/react/element-template/jsx-runtime',
+        replacement: path.resolve(__dirname, '../../src/element-template/jsx-runtime/index.ts'),
+      },
+      { find: '@lynx-js/react/hooks', replacement: path.resolve(__dirname, '../../src/core/hooks/react.ts') },
+      {
+        find: '@lynx-js/react/lepus/hooks',
+        replacement: path.resolve(__dirname, '../../src/core/hooks/mainThread.ts'),
+      },
+      { find: '@lynx-js/react/lepus', replacement: path.resolve(__dirname, '../../lepus/index.js') },
+      {
+        find: '@lynx-js/react/legacy-react-runtime',
+        replacement: path.resolve(__dirname, '../../src/core/compat/legacy-react-runtime.ts'),
+      },
+      {
+        find: '@lynx-js/react/element-template/internal',
+        replacement: path.resolve(__dirname, '../../src/element-template/internal.ts'),
+      },
+      {
+        find: '@lynx-js/react/element-template',
+        replacement: path.resolve(__dirname, '../../src/element-template/index.ts'),
+      },
+      { find: '@lynx-js/react', replacement: path.resolve(__dirname, '../../src/element-template/index.ts') },
+    ],
   },
   test: {
     name: 'react/runtime-et',
+    server: {
+      deps: {
+        // Keep internal-preact inside the vite module graph so its bare
+        // `preact` imports hit the aliases above instead of Node resolution
+        // (which would land on pnpm's hidden hoist and may load a second
+        // preact copy).
+        inline: [/@lynx-js[\\/]internal-preact/],
+      },
+    },
     include: ['**/__test__/element-template/**/*.{test,spec}.{js,ts,jsx,tsx}'],
     coverage: {
       include: ['src/element-template/**'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,19 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
 
+  benchmark/preact-runtime:
+    dependencies:
+      '@lynx-js/preact-runtime':
+        specifier: workspace:*
+        version: link:../../packages/preact-runtime
+      benchx_cli:
+        specifier: workspace:*
+        version: link:../../packages/lynx/benchx_cli
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+
   benchmark/react:
     dependencies:
       '@lynx-js/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,8 +299,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspeedy/core
       typescript:
-        specifier: ~5.9.2
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   examples/preact-ports:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,16 @@ importers:
         specifier: ~5.9.2
         version: 5.9.3
 
+  examples/preact-ports:
+    dependencies:
+      '@lynx-js/preact-runtime':
+        specifier: workspace:*
+        version: link:../../packages/preact-runtime
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+
   examples/react:
     dependencies:
       '@lynx-js/react':
@@ -1172,6 +1182,9 @@ importers:
 
   packages/preact-runtime:
     dependencies:
+      '@lynx-js/css-extract-webpack-plugin':
+        specifier: workspace:*
+        version: link:../webpack/css-extract-webpack-plugin
       '@lynx-js/runtime-wrapper-webpack-plugin':
         specifier: workspace:*
         version: link:../webpack/runtime-wrapper-webpack-plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,25 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspeedy/core
 
+  examples/preact-ports-tailwind:
+    dependencies:
+      '@lynx-js/preact-runtime':
+        specifier: workspace:*
+        version: link:../../packages/preact-runtime
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      '@lynx-js/tailwind-preset':
+        specifier: workspace:*
+        version: link:../../packages/tailwind-preset
+      rsbuild-plugin-tailwindcss:
+        specifier: 0.2.4
+        version: 0.2.4(@rsbuild/core@2.1.7(core-js@3.49.0))(tailwindcss@3.4.19)
+      tailwindcss:
+        specifier: ^3.4.19
+        version: 3.4.19
+
   examples/react:
     dependencies:
       '@lynx-js/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,12 @@ importers:
 
   examples/preact-ports:
     dependencies:
+      '@lynx-js/gesture-runtime':
+        specifier: workspace:*
+        version: link:../../packages/lynx/gesture-runtime
+      '@lynx-js/motion':
+        specifier: workspace:*
+        version: link:../../packages/motion
       '@lynx-js/preact-runtime':
         specifier: workspace:*
         version: link:../../packages/preact-runtime

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,19 @@ importers:
         specifier: ^19.2.17
         version: 19.2.17
 
+  examples/preact:
+    dependencies:
+      '@lynx-js/preact-runtime':
+        specifier: workspace:*
+        version: link:../../packages/preact-runtime
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      typescript:
+        specifier: ~5.9.2
+        version: 5.9.3
+
   examples/react:
     dependencies:
       '@lynx-js/react':
@@ -1156,6 +1169,25 @@ importers:
       rsbuild-plugin-publint:
         specifier: 1.0.0
         version: 1.0.0(@rsbuild/core@2.1.7(core-js@3.49.0))
+
+  packages/preact-runtime:
+    dependencies:
+      '@lynx-js/runtime-wrapper-webpack-plugin':
+        specifier: workspace:*
+        version: link:../webpack/runtime-wrapper-webpack-plugin
+      '@lynx-js/template-webpack-plugin':
+        specifier: workspace:*
+        version: link:../webpack/template-webpack-plugin
+      preact:
+        specifier: ^10.29.1
+        version: 10.29.1
+    devDependencies:
+      '@rsbuild/core':
+        specifier: catalog:rsbuild
+        version: 2.1.7(core-js@3.49.0)
+      '@rslib/core':
+        specifier: catalog:rslib
+        version: 0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@typescript/native-preview@7.0.0-dev.20260707.2)(core-js@3.49.0)(typescript@6.0.3)
 
   packages/react:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - benchmark/preact-runtime
   - benchmark/react
   - examples/*
   - packages/background-only

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
   - packages/i18n/*
   - packages/lynx/*
   - packages/mcp-servers/*
+  - packages/preact-runtime
   - packages/repl
   - packages/react
   - packages/react/refresh


### PR DESCRIPTION
## What

A new, fully independent ReactLynx implementation: **vanilla npm `preact`** renders purely on the **background thread** against a minimal remote-DOM; a **fixed, prebuilt main-thread runtime** (identical for every app — no per-app compilation, **no SWC/babel transform at all**) applies the op stream through the Element PAPI.

```
background thread                       main thread (fixed prebuilt chunk)
vanilla preact                          id → FiberElement map
  └─ RemoteDocument (fake DOM)  ──ops──▶ applies via __CreateElement /
     records mutations, batches         __SetAttribute / __AddEvent / ...
     per microtask                      __FlushElementTree
          ◀──────── publishEvent("id:type:name") ────────
```

- `@lynx-js/preact-runtime`: BTS runtime, fixed MT runtime (`./main-thread`), rspeedy plugin (`./plugin`), `@lynx-js/react` compat surface (`./compat`, aliased by the plugin so existing sources run unmodified)
- `examples/preact` demo; `examples/preact-ports`(+`-tailwind`) mount the original `examples/` sources on this runtime
- `benchmark/preact-runtime`: benchx cases mirroring `benchmark/react` for CodSpeed comparison

## Examples status: all 19 run (browser-verified on web)

react, react-element, react-keyboard, react-main-thread-function, react-et-list (list move/remove/select), react-element-template, react-compiler, react-ui-sourcemap (lazy/Suspense), tailwindcss, react-lazy-bundle, react-et-lazy-bundle (all lazy scenarios), react-externals, react-externals-web, react-lazy-bundle-standalone, react-et-lazy-bundle-standalone, react-debug-metadata, **react-et-mtf (6/6 checks pass)**, gesture (playground renders), motion (gallery renders).

## Key mechanisms

- **MTS without a compiler**: `main-thread:*` handlers run on the background thread against an op-backed `Element` (`setStyleProperty`/`animate`/`setAttribute`); closures work naturally — the only sound semantics without closure extraction. `runOnMainThread` falls back likewise (promise of result). True-MT stringified execution remains for closure-free functions (`runOnMainThreadStrict`).
- **Remote/producer bundles**: `import(url, { with: {...} })` is rewritten by a scope-limited pre-loader to a runtime remote-import (registry or fetch+eval with shared-module `require`).
- **gesture-runtime**: 3-line additive compat — accepts plain-function callbacks when the runtime signals `__TRANSFORM_FREE_MTS__`.
- **Diagnostics**: BTS errors are forwarded as ops and logged by the MT runtime.

## Known trade-offs

- No main-thread first screen (CSR-class first paint)
- MTS runs on the background thread by default (no MT-scheduling guarantee); true-MT path requires closure-free functions
- `<list>` v1: full-refresh `update-list-info`, no recycling
- `output.asyncChunks=false`: async chunks would otherwise become lazy-bundle templates whose evaluation re-runs the app

## benchx comparison (`benchmark/preact-runtime` vs `benchmark/react`)

Native engine (PrimJS), `benchx_cli run --wait-for-id=stop-benchmark-true`, end-to-end wall time (load → render → id found), local arm64 macOS, N=10 median:

| Case | preact-runtime | ReactLynx | Bundle size |
| --- | --- | --- | --- |
| 002-hello | **70.9 ms** | 92.7 ms | **40 KB** vs 246 KB |
| 007-four-layer-views (~6.9k elements) | 464.9 ms | **271.8 ms** | **41 KB** vs 251 KB |
| 008-many-use-state (1000 stateful comps) | **83.1 ms** | 88.5 ms | **40 KB** vs 252 KB |

Trace breakdown (perfetto) for 007: the preact pipeline is strictly serial — BTS renders the whole tree during script eval (`executeLoadedScript` 290 ms vs 112 ms), then ships ~6.9k ops as one JSON `CallLepusMethod` batch (170 ms) before the engine flushes; ReactLynx renders the first screen directly on the main thread and overlaps BTS hydration. Small/medium trees win on the 6× smaller bundle + no hydrate pass; big first-screen trees lose to the missing main-thread first screen (already listed in trade-offs).

Caveats: wall-clock on a laptop, not CodSpeed instrumentation; the preact cases emit no lynx profile markers yet, so CodSpeed's 244-benchmark suite does not include them (marker support is a TODO).

## TODO

- [ ] motion/gesture deep interaction verification (animations under BG fallback)
- [ ] recycling list protocol + platform-info passthrough
- [ ] lynx profile markers in preact-runtime so benchx/CodSpeed can instrument it

