### PR TITLE
fix(react): keep cross-module `'main thread'` functions on the main thread

### DIFF
--- a/.changeset/cross-module-main-thread-functions.md
+++ b/.changeset/cross-module-main-thread-functions.md
@@ -2,8 +2,12 @@
 "@lynx-js/react": patch
 ---
 
-Fix cross-module `'main thread'` functions failing to hydrate.
+Keep cross-module `'main thread'` functions reachable on the main thread.
 
-A `'main thread'` function defined in a different module from the worklet that calls it is captured into the caller's closure (`this._c`) and resolved at hydration through `lynxWorkletImpl._workletMap[id]`. Its `registerWorkletInternal()` call lives in the _defining_ module, which reached the main-thread bundle only through the caller's named import — and that import is dropped by DCE once the surrounding background-only code (`useEffect`, `runOnMainThread`, ...) is shaken away. The defining module then never ran on the main thread, so `_workletMap[id]` was `undefined` and hydration threw `Cannot read properties of undefined (reading 'bind')`.
+A `'main thread'` function defined in a different module from the code that references it could throw at hydration with `Cannot read properties of undefined (reading 'bind')`.
 
-The worklet transform now re-adds a side-effect-only import for every module a worklet closure captures an identifier from, keeping the registration reachable on the main thread.
+The worklet id is content-addressed and target-independent, so both layers derive the same `_wkltId` — but the two halves of that symbol live in different bundles: the `registerWorkletInternal()` definition only in the main-thread bundle, the `{ _wkltId }` reference in either. The defining module reached the main-thread bundle solely through the referencing module's named import, and once the main-thread passes shook away the background-only code around the reference (`useEffect` and friends), that import became locally unused and was elided, taking the registration with it.
+
+The worklet transform now re-emits a side-effect-only import for every module a worklet closure captures an identifier from, so the defining module still reaches the main-thread bundle and registers its worklet. Import attributes (`with { type: 'json' }`) are carried over; type-only and `runtime: "shared"` imports are skipped; background output is unchanged.
+
+This is a targeted fix, not a complete one. It does not cover references the transform cannot see — `runOnMainThread(importedMtFn)()`, captures through a local alias, or references reachable only from background-only code — and the emitted import can still be elided when the consuming package declares `"sideEffects": false`. There are no build-time diagnostics for those cases yet.

--- a/.changeset/cross-module-main-thread-functions.md
+++ b/.changeset/cross-module-main-thread-functions.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/react": patch
+---
+
+Fix cross-module `'main thread'` functions failing to hydrate.
+
+A `'main thread'` function defined in a different module from the worklet that calls it is captured into the caller's closure (`this._c`) and resolved at hydration through `lynxWorkletImpl._workletMap[id]`. Its `registerWorkletInternal()` call lives in the _defining_ module, which reached the main-thread bundle only through the caller's named import — and that import is dropped by DCE once the surrounding background-only code (`useEffect`, `runOnMainThread`, ...) is shaken away. The defining module then never ran on the main thread, so `_workletMap[id]` was `undefined` and hydration threw `Cannot read properties of undefined (reading 'bind')`.
+
+The worklet transform now re-adds a side-effect-only import for every module a worklet closure captures an identifier from, keeping the registration reachable on the main thread.

--- a/codecov.yml
+++ b/codecov.yml
@@ -32,6 +32,9 @@ ignore:
   - "pnpm-lock.yaml"
   - "rstest.config.ts"
   - "**/__test__/**/fixtures/**"
+  # Expected output of the Rust `swc` transform tests, regenerated with
+  # `UPDATE=1 cargo test`. They are `.js` files but never executed.
+  - "**/__swc_snapshots__/**"
 
 fixes:
   - "/home/runner/_work/lynx-stack::"

--- a/packages/react/transform/__test__/fixture.spec.js
+++ b/packages/react/transform/__test__/fixture.spec.js
@@ -1945,6 +1945,68 @@ export function getCurrentDelta(event) {
     expect(code).not.toContain('_wkltId');
   });
 
+  describe('cross-module main thread functions', () => {
+    // The caller worklet reads the captured `'main thread'` function back off
+    // `this._c`, so once the main-thread passes shake away the background-only
+    // code around it there is nothing left referencing the import. Without the
+    // side-effect import the defining module never reaches the main-thread
+    // bundle and `lynxWorkletImpl._workletMap[id]` is `undefined` at hydration.
+    const source = `\
+import { runOnMainThread, useEffect } from '@lynx-js/react';
+import { spin } from './spin.js';
+import { unrelated } from './unrelated.js';
+
+export function App(el) {
+  useEffect(() => {
+    runOnMainThread(() => {
+      "main thread";
+      spin(el, 45);
+    })();
+  }, []);
+  return unrelated;
+}
+`;
+
+    it('should keep the defining module reachable on the main thread', async () => {
+      const { code } = await transformReactLynx(source, {
+        ...lepusWorkletOptions,
+        shake: {
+          pkgName: ['@lynx-js/react'],
+          retainProp: [],
+          removeCall: ['useEffect'],
+          removeCallParams: [],
+        },
+      });
+
+      expect(code).toContain(`import './spin.js';`);
+      // `useEffect` is shaken away, so the worklet body is the only thing left
+      // mentioning `spin` — and it reads it off `this._c`, not off the import.
+      expect(code).not.toContain('useEffect');
+      expect(code).toContain(`let { spin, el } = this["_c"];`);
+      expect(code).toContain('registerWorkletInternal("main-thread"');
+      // Only modules a worklet captures from are re-imported for side effects.
+      expect(code).not.toContain(`import './unrelated.js';`);
+    });
+
+    it('should not add side-effect imports on the background thread', async () => {
+      const { code } = await transformReactLynx(source, {
+        ...lepusWorkletOptions,
+        defineDCE: { define: { __LEPUS__: 'false', __JS__: 'true' } },
+        shake: false,
+        worklet: {
+          target: 'JS',
+          filename: '',
+          runtimePkg: '@lynx-js/react',
+        },
+      });
+
+      // The background bundle still references the import through `_c`.
+      expect(code).toContain(`import { spin } from './spin.js';`);
+      expect(code.match(/from '\.\/spin\.js'/g)).toHaveLength(1);
+      expect(code).not.toContain(`import './spin.js';`);
+    });
+  });
+
   for (const target of ['LEPUS', 'JS', 'MIXED']) {
     it('member expression', async () => {
       const { code } = await transformReactLynx(

--- a/packages/react/transform/crates/swc_plugin_worklet/extract_ident.rs
+++ b/packages/react/transform/crates/swc_plugin_worklet/extract_ident.rs
@@ -79,6 +79,11 @@ impl ExtractingIdentsCollector {
     self.idents_to_extract.take()
   }
 
+  /// The identifiers captured into the worklet closure, without consuming them.
+  pub fn idents(&self) -> &[Ident] {
+    &self.idents_to_extract
+  }
+
   pub fn take_this_expr(&mut self) -> Box<Expr> {
     self.this_expr_to_extract.take()
   }

--- a/packages/react/transform/crates/swc_plugin_worklet/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_worklet/lib.rs
@@ -67,11 +67,22 @@ pub struct WorkletVisitor {
   /// Maps a local binding introduced by an `import` declaration to the module
   /// it comes from, so that we can tell whether an identifier captured into a
   /// worklet closure (`_c`) is defined in another module.
-  import_srcs: FxHashMap<Id, Box<Str>>,
+  import_srcs: FxHashMap<Id, CapturedImport>,
   /// The modules that own an identifier captured into a worklet closure. On the
   /// main thread these imports are the only thing that keeps a cross-module
   /// `'main thread'` function reachable, see [`WorkletVisitor::record_captured_imports`].
-  captured_import_srcs: Vec<Str>,
+  captured_imports: Vec<CapturedImport>,
+}
+
+/// A module a worklet closure captures an identifier from, along with the
+/// import attributes it was imported with. The attributes have to be carried
+/// over to the side-effect import we re-emit: `with { type: 'json' }` selects
+/// how the module is parsed, and importing the same module twice with
+/// mismatched attributes is an error.
+#[derive(Clone)]
+struct CapturedImport {
+  src: Box<Str>,
+  with: Option<Box<ObjectLit>>,
 }
 
 impl Default for WorkletVisitor {
@@ -562,9 +573,13 @@ impl VisitMut for WorkletVisitor {
           if is_shared_runtime {
             self.shared_identifiers.insert(local.to_id());
           } else if !import_decl.type_only {
-            self
-              .import_srcs
-              .insert(local.to_id(), import_decl.src.clone());
+            self.import_srcs.insert(
+              local.to_id(),
+              CapturedImport {
+                src: import_decl.src.clone(),
+                with: import_decl.with.clone(),
+              },
+            );
           }
         }
       }
@@ -658,18 +673,22 @@ impl VisitMut for WorkletVisitor {
     // import they came from is dropped by DCE once the surrounding
     // background-only code is shaken away, which would take a cross-module
     // `'main thread'` function's `registerWorkletInternal()` call with it.
-    if !self.captured_import_srcs.is_empty() {
+    if !self.captured_imports.is_empty() {
       let side_effect_imports = self
-        .captured_import_srcs
+        .captured_imports
         .drain(..)
-        .map(|src| {
+        .map(|captured| {
           ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
             span: DUMMY_SP,
+            // Always `Evaluation`: the point of this import is to run the
+            // module so its `registerWorkletInternal()` call happens. A
+            // deferred phase would defeat that, and a bare import cannot carry
+            // one anyway.
             phase: ImportPhase::Evaluation,
             specifiers: vec![],
-            src: Box::new(src),
+            src: captured.src,
             type_only: false,
-            with: None,
+            with: captured.with,
           }))
         })
         .collect::<Vec<_>>();
@@ -752,7 +771,7 @@ impl WorkletVisitor {
       worklet_runtime_loaded: false,
       worklet_runtime_loaded_ident: private_ident!("__workletRuntimeLoaded"),
       import_srcs: FxHashMap::default(),
-      captured_import_srcs: vec![],
+      captured_imports: vec![],
     }
   }
 
@@ -773,21 +792,28 @@ impl WorkletVisitor {
   fn record_captured_imports(&mut self, collector: &ExtractingIdentsCollector) {
     // The background bundle keeps the import: the captured identifier is still
     // referenced there, by the closure object literal (`_c`) itself.
+    //
+    // `MIXED` emits both that descriptor and the registration into one module,
+    // so its import is referenced too and the side-effect import we add is
+    // redundant. It is kept rather than skipped because it is harmless — ESM
+    // evaluates a module once — and because relying on the descriptor's
+    // reference would silently couple this pass to how `MIXED` is emitted. See
+    // `should_keep_captured_import_alive_mixed`.
     if self.cfg.target == TransformTarget::JS {
       return;
     }
     for ident in collector.idents() {
-      let Some(src) = self.import_srcs.get(&ident.to_id()) else {
+      let Some(captured) = self.import_srcs.get(&ident.to_id()) else {
         continue;
       };
       if self
-        .captured_import_srcs
+        .captured_imports
         .iter()
-        .any(|recorded| recorded.value == src.value)
+        .any(|recorded| recorded.src.value == captured.src.value)
       {
         continue;
       }
-      self.captured_import_srcs.push((**src).clone());
+      self.captured_imports.push(captured.clone());
     }
   }
 
@@ -905,6 +931,35 @@ function worklet(event: Event) {
     console.log(y1);
     console.log(this.y1);
     let a: object = y1;
+}
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      ..Default::default()
+    }),
+    |_| (
+      resolver(Mark::new(), Mark::new(), true),
+      visit_mut_pass(WorkletVisitor::new(
+        TransformMode::Test,
+        WorkletVisitorConfig {
+          filename: "index.js".into(),
+          target: TransformTarget::MIXED,
+          custom_global_ident_names: None,
+          runtime_pkg: "@lynx-js/react".into(),
+        }
+      )),
+      hygiene()
+    ),
+    should_keep_captured_import_alive_mixed,
+    r#"
+import { spin } from './spin.js';
+
+function worklet(event) {
+    "main thread";
+    spin(event.currentTarget, 45);
 }
     "#
   );
@@ -1275,6 +1330,35 @@ import { spin } from './spin.js';
 function worklet(event) {
     "main thread";
     spin(event.currentTarget, 45);
+}
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Typescript(TsSyntax {
+      ..Default::default()
+    }),
+    |_| (
+      resolver(Mark::new(), Mark::new(), true),
+      visit_mut_pass(WorkletVisitor::new(
+        TransformMode::Test,
+        WorkletVisitorConfig {
+          filename: "index.js".into(),
+          target: TransformTarget::LEPUS,
+          custom_global_ident_names: None,
+          runtime_pkg: "@lynx-js/react".into(),
+        }
+      )),
+      hygiene()
+    ),
+    should_keep_import_attributes_on_captured_import_lepus,
+    r#"
+import cfg from './config.json' with { type: 'json' };
+
+function worklet(event) {
+    "main thread";
+    event.currentTarget.setStyleProperty('color', cfg.color);
 }
     "#
   );

--- a/packages/react/transform/crates/swc_plugin_worklet/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_worklet/lib.rs
@@ -8,7 +8,7 @@ mod worklet_type;
 use extract_ident::{ExtractingIdentsCollector, ExtractingIdentsCollectorConfig};
 use gen_stmt::StmtGen;
 use hash::WorkletHash;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::vec;
@@ -64,6 +64,14 @@ pub struct WorkletVisitor {
   shared_identifiers: FxHashSet<Id>,
   worklet_runtime_loaded: bool,
   worklet_runtime_loaded_ident: Ident,
+  /// Maps a local binding introduced by an `import` declaration to the module
+  /// it comes from, so that we can tell whether an identifier captured into a
+  /// worklet closure (`_c`) is defined in another module.
+  import_srcs: FxHashMap<Id, Box<Str>>,
+  /// The modules that own an identifier captured into a worklet closure. On the
+  /// main thread these imports are the only thing that keeps a cross-module
+  /// `'main thread'` function reachable, see [`WorkletVisitor::record_captured_imports`].
+  captured_import_srcs: Vec<Str>,
 }
 
 impl Default for WorkletVisitor {
@@ -97,6 +105,7 @@ impl VisitMut for WorkletVisitor {
           shared_identifiers: Some(self.shared_identifiers.clone()),
         });
         n.visit_mut_with(&mut collector);
+        self.record_captured_imports(&collector);
 
         let should_use_getter = self.cfg.target == TransformTarget::JS
           && !n.as_method().unwrap().is_static
@@ -211,6 +220,7 @@ impl VisitMut for WorkletVisitor {
           shared_identifiers: Some(self.shared_identifiers.clone()),
         });
         value.visit_mut_with(&mut collector);
+        self.record_captured_imports(&collector);
 
         let function: Box<Function> = match value.as_ref() {
           Expr::Arrow(arrow) if arrow.body.is_block_stmt() => Box::new(Function {
@@ -316,6 +326,7 @@ impl VisitMut for WorkletVisitor {
       shared_identifiers: Some(self.shared_identifiers.clone()),
     });
     n.visit_mut_with(&mut collector);
+    self.record_captured_imports(&collector);
 
     let hash = self.hasher.gen(&self.cfg.filename, &self.content_hash);
     let (worklet_object_expr, register_worklet_stmt) = StmtGen::transform_worklet(
@@ -364,6 +375,7 @@ impl VisitMut for WorkletVisitor {
           shared_identifiers: Some(self.shared_identifiers.clone()),
         });
         n.visit_mut_with(&mut collector);
+        self.record_captured_imports(&collector);
 
         let hash = self.hasher.gen(&self.cfg.filename, &self.content_hash);
         let (worklet_object_expr, register_worklet_stmt) = StmtGen::transform_worklet(
@@ -420,6 +432,7 @@ impl VisitMut for WorkletVisitor {
           shared_identifiers: Some(self.shared_identifiers.clone()),
         });
         n.visit_mut_with(&mut collector);
+        self.record_captured_imports(&collector);
 
         let hash = self.hasher.gen(&self.cfg.filename, &self.content_hash);
         let (worklet_object_expr, register_worklet_stmt) = StmtGen::transform_worklet(
@@ -493,6 +506,7 @@ impl VisitMut for WorkletVisitor {
       .as_mut_fn_expr()
       .unwrap()
       .visit_mut_with(&mut collector);
+    self.record_captured_imports(&collector);
 
     let hash = self.hasher.gen(&self.cfg.filename, &self.content_hash);
     let (worklet_object_expr, register_worklet_stmt) = StmtGen::transform_worklet(
@@ -531,21 +545,26 @@ impl VisitMut for WorkletVisitor {
     // First process imports to detect shared-runtime modules
     for item in &n.body {
       if let ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) = item {
-        if is_shared_runtime_import(import_decl) {
-          for specifier in &import_decl.specifiers {
-            match specifier {
-              ImportSpecifier::Named(named) => {
-                self.shared_identifiers.insert(named.local.to_id());
+        let is_shared_runtime = is_shared_runtime_import(import_decl);
+        for specifier in &import_decl.specifiers {
+          let local = match specifier {
+            ImportSpecifier::Named(named) => {
+              if named.is_type_only {
+                continue;
               }
-              ImportSpecifier::Default(default) => {
-                self.shared_identifiers.insert(default.local.to_id());
-              }
-              ImportSpecifier::Namespace(ns) => {
-                self.shared_identifiers.insert(ns.local.to_id());
-              }
-              #[cfg(swc_ast_unknown)]
-              _ => panic!("unknown node"),
+              &named.local
             }
+            ImportSpecifier::Default(default) => &default.local,
+            ImportSpecifier::Namespace(ns) => &ns.local,
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unknown node"),
+          };
+          if is_shared_runtime {
+            self.shared_identifiers.insert(local.to_id());
+          } else if !import_decl.type_only {
+            self
+              .import_srcs
+              .insert(local.to_id(), import_decl.src.clone());
           }
         }
       }
@@ -635,6 +654,28 @@ impl VisitMut for WorkletVisitor {
         .into_iter(),
       );
     }
+    // Keep the modules that own a captured identifier reachable. The named
+    // import they came from is dropped by DCE once the surrounding
+    // background-only code is shaken away, which would take a cross-module
+    // `'main thread'` function's `registerWorkletInternal()` call with it.
+    if !self.captured_import_srcs.is_empty() {
+      let side_effect_imports = self
+        .captured_import_srcs
+        .drain(..)
+        .map(|src| {
+          ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+            span: DUMMY_SP,
+            phase: ImportPhase::Evaluation,
+            specifiers: vec![],
+            src: Box::new(src),
+            type_only: false,
+            with: None,
+          }))
+        })
+        .collect::<Vec<_>>();
+      prepend_stmts(&mut n.body, side_effect_imports.into_iter());
+    }
+
     // Add statements to insert at top level after processing all items
     n.body.extend(
       self
@@ -710,6 +751,43 @@ impl WorkletVisitor {
       shared_identifiers: FxHashSet::default(),
       worklet_runtime_loaded: false,
       worklet_runtime_loaded_ident: private_ident!("__workletRuntimeLoaded"),
+      import_srcs: FxHashMap::default(),
+      captured_import_srcs: vec![],
+    }
+  }
+
+  /// Remember every module a worklet closure captures an identifier from.
+  ///
+  /// A `'main thread'` function that lives in another module compiles down to a
+  /// `{ _wkltId }` descriptor that the caller captures into `this._c`, plus a
+  /// `registerWorkletInternal()` call in the *defining* module. The caller's
+  /// worklet body reads the identifier back off `this._c`, so after the
+  /// main-thread passes drop the background-only code around it (`useEffect`,
+  /// `runOnMainThread`, ...) nothing references the import any more and the DCE
+  /// pass removes the import declaration altogether. The defining module then
+  /// never makes it into the main-thread bundle, `_workletMap[id]` is
+  /// `undefined`, and hydrating the worklet throws on `.bind`.
+  ///
+  /// Recording the module here lets [`VisitMut::visit_mut_module`] re-add it as
+  /// a side-effect-only import, which survives DCE and keeps the registration.
+  fn record_captured_imports(&mut self, collector: &ExtractingIdentsCollector) {
+    // The background bundle keeps the import: the captured identifier is still
+    // referenced there, by the closure object literal (`_c`) itself.
+    if self.cfg.target == TransformTarget::JS {
+      return;
+    }
+    for ident in collector.idents() {
+      let Some(src) = self.import_srcs.get(&ident.to_id()) else {
+        continue;
+      };
+      if self
+        .captured_import_srcs
+        .iter()
+        .any(|recorded| recorded.value == src.value)
+      {
+        continue;
+      }
+      self.captured_import_srcs.push((**src).clone());
     }
   }
 
@@ -1138,6 +1216,97 @@ function worklet(event: Event) {
     console.log(sharedRuntime);
     console.log(this.y1);
     let a: object = y1;
+}
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      ..Default::default()
+    }),
+    |_| (
+      resolver(Mark::new(), Mark::new(), true),
+      visit_mut_pass(WorkletVisitor::new(
+        TransformMode::Test,
+        WorkletVisitorConfig {
+          filename: "index.js".into(),
+          target: TransformTarget::LEPUS,
+          custom_global_ident_names: None,
+          runtime_pkg: "@lynx-js/react".into(),
+        }
+      )),
+      hygiene()
+    ),
+    should_keep_captured_import_alive_lepus,
+    r#"
+import { spin } from './spin.js';
+import { unrelated } from './unrelated.js';
+
+function worklet(event) {
+    "main thread";
+    spin(event.currentTarget, 45);
+}
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Es(EsSyntax {
+      ..Default::default()
+    }),
+    |_| (
+      resolver(Mark::new(), Mark::new(), true),
+      visit_mut_pass(WorkletVisitor::new(
+        TransformMode::Test,
+        WorkletVisitorConfig {
+          filename: "index.js".into(),
+          target: TransformTarget::JS,
+          custom_global_ident_names: None,
+          runtime_pkg: "@lynx-js/react".into(),
+        }
+      )),
+      hygiene()
+    ),
+    should_not_add_side_effect_import_js,
+    r#"
+import { spin } from './spin.js';
+
+function worklet(event) {
+    "main thread";
+    spin(event.currentTarget, 45);
+}
+    "#
+  );
+
+  test!(
+    module,
+    Syntax::Typescript(TsSyntax {
+      ..Default::default()
+    }),
+    |_| (
+      resolver(Mark::new(), Mark::new(), true),
+      visit_mut_pass(WorkletVisitor::new(
+        TransformMode::Test,
+        WorkletVisitorConfig {
+          filename: "index.js".into(),
+          target: TransformTarget::LEPUS,
+          custom_global_ident_names: None,
+          runtime_pkg: "@lynx-js/react".into(),
+        }
+      )),
+      hygiene()
+    ),
+    should_not_keep_type_only_captured_import_lepus,
+    r#"
+import type { Spin } from './spin-types.js';
+import { type Deg, spin } from './spin.js';
+
+function worklet(event: Event) {
+    "main thread";
+    let s: Spin = spin;
+    let d: Deg = 45;
+    spin(event.currentTarget, d);
 }
     "#
   );

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_keep_captured_import_alive_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_keep_captured_import_alive_lepus.js
@@ -1,0 +1,18 @@
+import './spin.js';
+import { loadWorkletRuntime as __loadWorkletRuntime } from "@lynx-js/react";
+var loadWorkletRuntime = __loadWorkletRuntime;
+import { spin } from './spin.js';
+import { unrelated } from './unrelated.js';
+let worklet = {
+    _c: {
+        spin
+    },
+    _wkltId: "a77b:test:1"
+};
+const __workletRuntimeLoaded = loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry);
+__workletRuntimeLoaded && registerWorkletInternal("main-thread", "a77b:test:1", function(event) {
+    const worklet = lynxWorkletImpl._workletMap["a77b:test:1"].bind(this);
+    let { spin } = this["_c"];
+    "main thread";
+    spin(event.currentTarget, 45);
+});

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_keep_captured_import_alive_mixed.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_keep_captured_import_alive_mixed.js
@@ -1,0 +1,17 @@
+import './spin.js';
+import { loadWorkletRuntime as __loadWorkletRuntime } from "@lynx-js/react";
+var loadWorkletRuntime = __loadWorkletRuntime;
+import { spin } from './spin.js';
+let worklet = {
+    _c: {
+        spin
+    },
+    _wkltId: "a77b:test:1"
+};
+const __workletRuntimeLoaded = loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry);
+__workletRuntimeLoaded && registerWorkletInternal("main-thread", "a77b:test:1", function(event) {
+    const worklet = lynxWorkletImpl._workletMap["a77b:test:1"].bind(this);
+    let { spin } = this["_c"];
+    "main thread";
+    spin(event.currentTarget, 45);
+});

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_keep_import_attributes_on_captured_import_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_keep_import_attributes_on_captured_import_lepus.js
@@ -1,0 +1,23 @@
+import './config.json' with {
+    type: 'json'
+};
+import { loadWorkletRuntime as __loadWorkletRuntime } from "@lynx-js/react";
+var loadWorkletRuntime = __loadWorkletRuntime;
+import cfg from './config.json' with {
+    type: 'json'
+};
+let worklet = {
+    _c: {
+        cfg: {
+            color: cfg.color
+        }
+    },
+    _wkltId: "a77b:test:1"
+};
+const __workletRuntimeLoaded = loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry);
+__workletRuntimeLoaded && registerWorkletInternal("main-thread", "a77b:test:1", function(event) {
+    const worklet = lynxWorkletImpl._workletMap["a77b:test:1"].bind(this);
+    let { cfg } = this["_c"];
+    "main thread";
+    event.currentTarget.setStyleProperty('color', cfg.color);
+});

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_not_add_side_effect_import_js.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_not_add_side_effect_import_js.js
@@ -1,0 +1,7 @@
+import { spin } from './spin.js';
+let worklet = {
+    _c: {
+        spin
+    },
+    _wkltId: "a77b:test:1"
+};

--- a/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_not_keep_type_only_captured_import_lepus.js
+++ b/packages/react/transform/crates/swc_plugin_worklet/tests/__swc_snapshots__/lib.rs/should_not_keep_type_only_captured_import_lepus.js
@@ -1,0 +1,20 @@
+import './spin.js';
+import { loadWorkletRuntime as __loadWorkletRuntime } from "@lynx-js/react";
+var loadWorkletRuntime = __loadWorkletRuntime;
+import type { Spin } from './spin-types.js';
+import { type Deg, spin } from './spin.js';
+let worklet = {
+    _c: {
+        spin
+    },
+    _wkltId: "a77b:test:1"
+};
+const __workletRuntimeLoaded = loadWorkletRuntime(typeof globDynamicComponentEntry === 'undefined' ? undefined : globDynamicComponentEntry);
+__workletRuntimeLoaded && registerWorkletInternal("main-thread", "a77b:test:1", function(event: Event) {
+    const worklet = lynxWorkletImpl._workletMap["a77b:test:1"].bind(this);
+    let { spin } = this["_c"];
+    "main thread";
+    let s: Spin = spin;
+    let d: Deg = 45;
+    spin(event.currentTarget, d);
+});

--- a/packages/rspeedy/plugin-react/test/cross-module-worklet.test.ts
+++ b/packages/rspeedy/plugin-react/test/cross-module-worklet.test.ts
@@ -14,6 +14,9 @@ import { createStubRspeedy as createRspeedy } from './createRspeedy.js'
 const tempDirs: string[] = []
 
 afterAll(async () => {
+  // Runs even when a test fails, so the `NODE_ENV` stub below cannot leak into
+  // later suites sharing this worker.
+  rstest.unstubAllEnvs()
   await Promise.all(tempDirs.map(async (dir) => {
     await rm(dir, { recursive: true, force: true })
   }))

--- a/packages/rspeedy/plugin-react/test/cross-module-worklet.test.ts
+++ b/packages/rspeedy/plugin-react/test/cross-module-worklet.test.ts
@@ -1,0 +1,109 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { existsSync, readFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path, { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterAll, describe, expect, rstest, test } from '@rstest/core'
+
+import { createStubRspeedy as createRspeedy } from './createRspeedy.js'
+
+const tempDirs: string[] = []
+
+afterAll(async () => {
+  await Promise.all(tempDirs.map(async (dir) => {
+    await rm(dir, { recursive: true, force: true })
+  }))
+})
+
+const entry = fileURLToPath(
+  new URL('./fixtures/cross-module-worklet/index.tsx', import.meta.url),
+)
+
+/**
+ * A `'main thread'` function defined in another module is captured into the
+ * calling worklet's closure (`this._c`) and resolved at hydration through
+ * `lynxWorkletImpl._workletMap[id]`. The main-thread passes shake away the
+ * background-only code that surrounds the call site, so the named import is the
+ * only thing that could still pull the defining module in — and DCE drops it
+ * once it is unreferenced. When that happens the module never reaches the
+ * main-thread bundle, `_workletMap[id]` is `undefined`, and hydration throws
+ * `Cannot read properties of undefined (reading 'bind')`.
+ */
+describe('cross-module main thread functions', () => {
+  for (const environment of ['lynx', 'web']) {
+    test(`registers the worklet on the main thread (${environment})`, async () => {
+      rstest.stubEnv('NODE_ENV', 'production')
+      const { pluginReactLynx } = await import('../src/index.js')
+
+      const root = await mkdtemp(
+        path.join(tmpdir(), `rspeedy-react-cross-module-${environment}-`),
+      )
+      tempDirs.push(root)
+
+      const entryName = `cross-module-worklet-${environment}`
+      const rsbuild = await createRspeedy({
+        rspeedyConfig: {
+          source: { entry: { [entryName]: entry } },
+          output: {
+            distPath: { root },
+            filenameHash: false,
+            cleanDistPath: false,
+            minify: false,
+          },
+          environments: { [environment]: {} },
+          tools: {
+            rspack: {
+              context: dirname(fileURLToPath(import.meta.url)),
+              resolve: {
+                extensionAlias: {
+                  '.js': ['.ts', '.js'],
+                  '.jsx': ['.tsx', '.jsx'],
+                },
+              },
+            },
+          },
+          plugins: [pluginReactLynx()],
+        },
+      })
+
+      await rsbuild.build()
+
+      // The `lynx` environment hides the intermediate chunks under `.rspeedy`,
+      // the `web` one emits them next to the bundle.
+      const mainThreadPath = [
+        path.join(
+          rsbuild.context.distPath,
+          '.rspeedy',
+          entryName,
+          'main-thread.js',
+        ),
+        path.join(rsbuild.context.distPath, entryName, 'main-thread.js'),
+      ].find(candidate => existsSync(candidate))
+
+      if (!mainThreadPath) {
+        expect.fail('expected a main-thread output to exist')
+      }
+
+      const mainThreadCode = readFileSync(mainThreadPath, 'utf8')
+      const backgroundIds = [
+        ...readFileSync(
+          path.join(dirname(mainThreadPath), 'background.js'),
+          'utf8',
+        ).matchAll(/_wkltId:\s*"([^"]+)"/g),
+      ].map(([, id]) => id)
+
+      expect(backgroundIds.length).toBeGreaterThan(0)
+      for (const id of backgroundIds) {
+        expect(mainThreadCode).toContain(
+          `registerWorkletInternal("main-thread", "${id}"`,
+        )
+      }
+      // The defining module itself, not just the caller.
+      expect(mainThreadCode).toContain('setStyleProperty')
+    })
+  }
+})

--- a/packages/rspeedy/plugin-react/test/fixtures/cross-module-worklet/index.tsx
+++ b/packages/rspeedy/plugin-react/test/fixtures/cross-module-worklet/index.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  root,
+  runOnMainThread,
+  useEffect,
+  useMainThreadRef,
+} from '@lynx-js/react'
+
+import { spin } from './spin.js'
+
+function App() {
+  const boxRef = useMainThreadRef<unknown>(null)
+
+  useEffect(() => {
+    runOnMainThread(() => {
+      'main thread'
+      if (boxRef.current) {
+        spin(boxRef.current, 45)
+      }
+    })()
+  }, [])
+
+  return <view main-thread:ref={boxRef} />
+}
+
+root.render(
+  <page>
+    <App />
+  </page>,
+)

--- a/packages/rspeedy/plugin-react/test/fixtures/cross-module-worklet/spin.ts
+++ b/packages/rspeedy/plugin-react/test/fixtures/cross-module-worklet/spin.ts
@@ -1,0 +1,15 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// A `'main thread'` function living in its own module. Its
+// `registerWorkletInternal()` call is what puts it in
+// `lynxWorkletImpl._workletMap`, so this module has to reach the main-thread
+// bundle even though nothing on the main thread imports it by name.
+export function spin(el: unknown, deg: number): void {
+  'main thread'
+  ;(el as { setStyleProperty(k: string, v: string): void }).setStyleProperty(
+    'transform',
+    `rotate(${deg}deg)`,
+  )
+}


### PR DESCRIPTION
Fixes #3263.

> [!IMPORTANT]
> **This is a stopgap, not a complete fix, and the root-cause note in an earlier revision of this description was wrong.** Both are corrected below and analysed in depth in [this comment](https://github.com/lynx-family/lynx-stack/pull/3265#issuecomment-5097513609). Read the **Scope and known limitations** section before merging.

## Summary

A `'main thread'` function defined in a **different module** from the code that references it throws at hydration:

```
TypeError: Cannot read properties of undefined (reading 'bind')
```

### Root cause

The worklet id is content-addressed and target-independent (`crates/swc_plugin_worklet/hash.rs:12-20`), so the main-thread and background layers independently derive the *same* `_wkltId` for a given source file. The two halves of that symbol then land in different bundles:

- **definition** — main-thread bundle only: `registerWorkletInternal("main-thread", id, fn)` in the *defining* module
- **reference** — either bundle: the descriptor `{ _c: {…}, _wkltId: id }`

Resolution asserts they meet (`packages/react/runtime/src/worklet-runtime/workletRuntime.ts:185`):

```ts
obj[key] = lynxWorkletImpl._workletMap[(subObj as Worklet)._wkltId]!.bind(boundCtx);
```

That `!` is an unproven link condition — the crash is a linker error surfacing at runtime.

It breaks because the defining module reaches the main-thread bundle **only** through the referencing module's named import, and that import gets elided. In the reported shape the reference sits inside `useEffect`, which is on the main-thread `shake` pass's `removeCall` denylist (`packages/webpack/react-webpack-plugin/src/loaders/options.ts:312-319`); once it is shaken away, the imported binding is unreferenced.

**Correction to an earlier revision of this description.** It attributed the import's removal to the ReactLynx transform's own DCE pass (`preserve_imports_with_side_effects: false`). That is **wrong**, `VERIFIED` by instrumenting `packages/webpack/react-webpack-plugin/lib/loaders/main-thread.js` to dump `result.code` and comparing it with an `enforce: 'post'` loader capturing the end of the chain:

| stage | `import { spin } from './spin.js'` |
|---|---|
| ReactLynx main-thread loader output (`useEffect` already shaken away) | **present** |
| end of loader chain — what rspack's parser receives | **absent** |

The ReactLynx transform keeps the declaration; **rsbuild's `builtin:swc-loader`**, which runs after it in the same chain, elides it as a locally-unused import. Identical for `.tsx` and `.jsx`, so it is not TypeScript import elision. The module is therefore absent from the main-thread graph before rspack parses it — which is why the fix has to be an *emitted import* rather than a bundler-level hint.

Not web-specific: reproduced identically on `lynx` and `web`. The `main.lynx.bundle` main-thread section is QuickJS bytecode, but its string table likewise contains only the caller's ids, not the callee's.

### Fix

`WorkletVisitor` maps each `import` binding to its module (+ import attributes), records the modules whose identifiers a worklet closure captures, and re-emits those as side-effect-only imports (`import './spin.js';`). Bare imports survive both the transform and swc-loader, so the defining module reaches the main-thread bundle and registers its worklet.

Skips type-only imports and `with { runtime: 'shared' }` imports (whose identifiers go to `shared_identifiers` and are never extracted). Background output is unchanged — there the captured identifier is still referenced by the `_c` object literal, so nothing is emitted for `TransformTarget::JS`.

## Scope and known limitations

This closes the reported shape and the transitive chain, but **it is an instance-patch over a whole-program property**. `VERIFIED` by real builds of `examples/react-main-thread-function`:

| Reference shape | With this PR |
|---|---|
| imported MT fn captured into a worklet `_c` (the reported shape) | **OK** |
| MT→MT chain across two modules | **OK** |
| `main-thread:bindtap={importedMtFn}` | OK (ident survives in the retained `values:[…]` array) |
| app-local MT fn calling an imported MT fn | OK — *because `useCallback` is not on the `removeCall` denylist* |
| `runOnMainThread(importedMtFn)()` | **STILL BROKEN** — no enclosing worklet body, so the collector never runs |
| imported MT fn referenced only behind a plain helper called from `useEffect` | **STILL BROKEN** — same reason |
| captured through an alias (`const s = spin`) | **STILL BROKEN** — `import_srcs` is keyed on the import binding's `Id` |
| any of the OK rows when the package sets `"sideEffects": false` | **STILL BROKEN** — rspack elides the bare import |

Receipts:

```
# runOnMainThread(importedMtFn)() added to the repro
BROKEN (referenced, never registered): ['6d70:88525:1']

# "sideEffects": false added to the example's package.json
BROKEN with sideEffects:false -> ['2773:95f12:1', '6d70:88525:1', '7934:06539:1']
```

There are **no build-time diagnostics** for any of these — every one is a silent miscompile that surfaces as the `.bind` crash.

Merging this is still a strict improvement over the status quo, and the `import_srcs` map it introduces is the data a real fix needs. But it should be described as a stopgap. The recommended follow-ups — a link check in `LynxTemplatePlugin`'s `beforeEncode` hook (which `ReactWebpackPlugin.ts:453-475` already taps and already reads the MT chunk from), a strong anchor instead of a bare import to survive `sideEffects: false`, and module-level `'main thread'` as a root criterion — are laid out in [the design comment](https://github.com/lynx-family/lynx-stack/pull/3265#issuecomment-5097513609). Happy to split any of them out.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

### Tests

- `packages/rspeedy/plugin-react/test/cross-module-worklet.test.ts` — end-to-end build of a cross-module fixture for both the `lynx` and `web` environments, asserting every `_wkltId` in `background.js` has a matching `registerWorkletInternal("main-thread", …)` in `main-thread.js`. Confirmed failing on both environments without the transform change and passing with it.
- Four `swc_plugin_worklet` snapshot tests: the LEPUS side-effect import is added only for captured modules, is not added for the JS target, carries import attributes, and skips type-only imports; plus a MIXED-target case.
- Two `packages/react/transform/__test__/fixture.spec.js` cases covering the shake-then-elision path that produced the bug.

Suites green: `cargo test` for the transform workspace (63 worklet tests), `packages/react/transform` vitest (80), `packages/react/runtime` vitest (801), `packages/rspeedy/plugin-react` rstest (189), `packages/webpack/react-webpack-plugin` rstest.

### Note on the second issue

The `runtime: "shared"` / `motion-dom` circular-init problem mentioned at the end of #3263 is a separate subsystem and is not addressed here. In this repo's `examples/motion` built for web, every referenced `_wkltId` was already registered on the main thread both before and after this change, so that example does not exercise the path fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5pB7g321yx2psa7E3oj8Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hydration failures for main-thread worklet functions imported from other modules.
  * Preserved captured module references during optimization, including imports using JSON attributes.
  * Prevented unnecessary module retention for background and type-only imports.

* **Tests**
  * Added coverage for cross-module worklets across Lynx and web builds.
  * Added validation for worklet registration and main-thread bundle generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->