### PR TITLE
fix: require @rslib/core as a peer dependency

### DIFF
--- a/.changeset/rslib-peer-rspack-v2.md
+++ b/.changeset/rslib-peer-rspack-v2.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": patch
+---
+
+Require `@rslib/core` 0.22.0 or later to ensure the Rspack v2 toolchain is used.

--- a/.changeset/rslib-peer-rspack-v2.md
+++ b/.changeset/rslib-peer-rspack-v2.md
@@ -2,4 +2,5 @@
 "@lynx-js/lynx-bundle-rslib-config": patch
 ---
 
-Require `@rslib/core` 0.22.0 or later to ensure the Rspack v2 toolchain is used.
+Require `@rslib/core` 0.22.0 or later and consume Rspack types through Rslib so
+the Rspack v2 toolchain is used without a separate `@rspack/core` dependency.

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -4,10 +4,9 @@
 
 ```ts
 
-import type { BannerPluginArgument } from '@rspack/core';
-import type { Compiler } from '@rspack/core';
 import type { LibConfig } from '@rslib/core';
 import type { RslibConfig } from '@rslib/core';
+import type { Rspack } from '@rslib/core';
 
 // @public
 export const builtInExternalsPresetDefinitions: ExternalsPresetDefinitions;
@@ -37,7 +36,7 @@ export interface ExternalBundleLibConfig extends LibConfig {
 export class ExternalBundleWebpackPlugin {
     constructor(options: ExternalBundleWebpackPluginOptions);
     // (undocumented)
-    apply(compiler: Compiler): void;
+    apply(compiler: Rspack.Compiler): void;
 }
 
 // @public
@@ -83,12 +82,12 @@ export type ExternalsPresetValue = boolean | {
 export class MainThreadRuntimeWrapperWebpackPlugin {
     constructor(options?: Partial<MainThreadRuntimeWrapperWebpackPluginOptions>);
     // (undocumented)
-    apply(compiler: Compiler): void;
+    apply(compiler: Rspack.Compiler): void;
 }
 
 // @public
 export interface MainThreadRuntimeWrapperWebpackPluginOptions {
-    test: Extract<BannerPluginArgument, {
+    test: Extract<Rspack.BannerPluginArgument, {
         banner: unknown;
     }>['test'];
 }

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -47,7 +47,6 @@
     "@lynx-js/test-tools": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rslib/core": "catalog:rslib",
-    "@rspack/core": "catalog:rspack",
     "@rstest/core": "catalog:rstest"
   },
   "peerDependencies": {

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -50,6 +50,9 @@
     "@rspack/core": "catalog:rspack",
     "@rstest/core": "catalog:rstest"
   },
+  "peerDependencies": {
+    "@rslib/core": ">=0.22.0"
+  },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   }

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { Asset, Compilation, Compiler } from '@rspack/core'
+import type { Rspack } from '@rslib/core'
 
 import { cssChunksToMap } from '@lynx-js/css-serializer'
 import type { LynxStyleNode } from '@lynx-js/css-serializer'
@@ -80,7 +80,7 @@ const isDebug = (): boolean => {
 export class ExternalBundleWebpackPlugin {
   constructor(private options: ExternalBundleWebpackPluginOptions) {}
 
-  apply(compiler: Compiler): void {
+  apply(compiler: Rspack.Compiler): void {
     compiler.hooks.thisCompilation.tap(
       ExternalBundleWebpackPlugin.name,
       (compilation) => {
@@ -107,8 +107,8 @@ export class ExternalBundleWebpackPlugin {
   }
 
   async #generateExternalBundle(
-    compiler: Compiler,
-    compilation: Compilation,
+    compiler: Rspack.Compiler,
+    compilation: Rspack.Compilation,
   ): Promise<void> {
     const assets = compilation.getAssets()
     // `rslib build` always compiles with rspack mode `production`, so the
@@ -140,7 +140,10 @@ export class ExternalBundleWebpackPlugin {
     }
   }
 
-  async #encode(assets: readonly Asset[], enableJsBytecode: boolean) {
+  async #encode(
+    assets: readonly Rspack.Asset[],
+    enableJsBytecode: boolean,
+  ) {
     const customSections = assets
       .reduce<
         Record<string, {

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/MainThreadRuntimeWrapperWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/MainThreadRuntimeWrapperWebpackPlugin.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { BannerPluginArgument, Compiler } from '@rspack/core'
+import type { Rspack } from '@rslib/core'
 
 const PLUGIN_NAME = 'MainThreadRuntimeWrapperWebpackPlugin'
 
@@ -18,7 +18,7 @@ export interface MainThreadRuntimeWrapperWebpackPluginOptions {
    *
    * @public
    */
-  test: Extract<BannerPluginArgument, { banner: unknown }>['test']
+  test: Extract<Rspack.BannerPluginArgument, { banner: unknown }>['test']
 }
 /**
  * The main-thread runtime wrapper for external bundle.
@@ -30,7 +30,7 @@ export class MainThreadRuntimeWrapperWebpackPlugin {
     private options: Partial<MainThreadRuntimeWrapperWebpackPluginOptions> = {},
   ) {}
 
-  apply(compiler: Compiler): void {
+  apply(compiler: Rspack.Compiler): void {
     const { BannerPlugin } = compiler.webpack
     new BannerPlugin({
       test: this.options.test ?? /\.js$/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1520,9 +1520,6 @@ importers:
       '@rslib/core':
         specifier: catalog:rslib
         version: 0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@typescript/native-preview@7.0.0-dev.20260707.2)(core-js@3.49.0)(typescript@6.0.3)
-      '@rspack/core':
-        specifier: 2.1.5
-        version: 2.1.5(@swc/helpers@0.5.23)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2))


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Updated bundling configuration to use Rslib-provided Rspack v2 types and tooling.
  - Requires `@rslib/core` version 0.22.0 or later.
  - Removes the need for a separate Rspack core dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
