### PR TITLE
feat(genui): connect bench to ui judge service

### DIFF
--- a/.github/a2ui-bench.instructions.md
+++ b/.github/a2ui-bench.instructions.md
@@ -2,7 +2,11 @@
 applyTo: "packages/genui/server/service/a2ui-bench-*.ts,packages/genui/server/app/a2ui/bench/**,packages/genui/playground/src/pages/BenchPage.tsx,packages/genui/server/rslib.config.ts"
 ---
 
-A2UI bench jobs still run agent generation and validation in `genui-server`, but browser-backed render metrics and screenshots are disabled while that capability is split into a browser-capable service. Keep browser metrics marked as disabled in reports.
+A2UI bench jobs run agent generation and validation in `genui-server`, but browser-backed render metrics and screenshots remain disabled. Keep browser metrics marked as disabled in reports.
+
+UI Judge scoring may use only the independent Rust HTTP sidecar. Configure it with the private server environment variable `UI_JUDGE_SERVER_URL` and optionally set the server-owned `UI_JUDGE_BUNDLE_URL` for the `a2ui.lynx.js` bundle. Probe `GET /health` before a job and derive the report's Judge capability from that result. Send successful generated messages to `POST /judge` only as server-owned Lynx init data or global props; never accept the sidecar URL, bundle URL, or injected props from the Bench client.
+
+Never let model-generated Bench messages make the server-side headless renderer load resources. Remove `openUrl` from every Bench prompt catalog, replace `Image`, `LazyComponent`, `LineChart`, `McpApp`, and `PieChart` definitions with inert placeholders, downgrade Markdown `Text`, and reject recursive `openUrl` function calls before calling UI Judge. The headless resource callback can otherwise read `file://` paths, access arbitrary HTTP endpoints, load executable nested bundles, or block its single capture worker on an unbounded download.
 
 Do not add `@sparticuz/chromium` or `playwright-core` back to `packages/genui/server`. Keep the entire browser-backed implementation in `a2ui-bench-preview.ts` and its runner import and call sites commented until preview rendering moves to its dedicated service. Do not add a fallback preview implementation, capability flag, or configuration switch while it is disabled.
 

--- a/packages/genui/playground/README.md
+++ b/packages/genui/playground/README.md
@@ -48,8 +48,15 @@ append the endpoint override to the playground URL:
 | `OPENAI_API_KEY`                                                             | Agent model access (required for the Create tab)   | —                   |
 | `OPENAI_MODEL`                                                               | Model id                                           | `gpt-4o-mini`       |
 | `OPENAI_BASE_URL`                                                            | Custom OpenAI-compatible endpoint                  | OpenAI              |
+| `UI_JUDGE_SERVER_URL`                                                        | Rust UI Judge sidecar for Bench scoring            | disabled            |
+| `UI_JUDGE_BUNDLE_URL`                                                        | `a2ui.lynx.js` bundle rendered by UI Judge         | hosted GenUI bundle |
 | `SUPABASE_URL`, `SUPABASE_S3_ACCESS_KEY_ID`, `SUPABASE_S3_SECRET_ACCESS_KEY` | Short, shareable preview URLs via Supabase Storage | in-memory dev store |
 | `PEXELS_API_KEY`                                                             | Stock-image search in generated UIs                | —                   |
+
+Bench probes `UI_JUDGE_SERVER_URL/health` once per job and reports Judge as
+enabled only when that sidecar is ready. See
+[`../ui-judge/README.md`](../ui-judge/README.md#http-server) for the Rust server
+startup and model environment.
 
 Conversation **share** links and Web / Native Preview reuse the Supabase Storage
 payload-publishing path — see [`examples/README.md`](./examples/README.md) for

--- a/packages/genui/playground/src/pages/BenchPage.tsx
+++ b/packages/genui/playground/src/pages/BenchPage.tsx
@@ -85,6 +85,8 @@ interface BenchResult {
   renderMs: number;
   attempts: number;
   judgeScore: number;
+  judgeStatus?: 'complete' | 'failed' | 'skipped';
+  judgeWarnings?: string[];
   messageCount?: number;
   outputChars?: number;
   errors?: string[];
@@ -105,6 +107,7 @@ interface BenchGroupSummary {
   avgTtiMs: number;
   avgRenderMs: number;
   avgJudgeScore: number;
+  judgeRunCount?: number;
   avgAttempts: number;
 }
 
@@ -846,9 +849,11 @@ function getRunMetaText(
 function formatReportJudgeMetric(report: BenchReport | null): string {
   if (report?.capabilities?.judge === 'disabled') return 'off';
   if (!report || report.summaries.length === 0) return 'n/a';
-  return `${
-    average(report.summaries.map((item) => item.avgJudgeScore)).toFixed(1)
-  }/5`;
+  const judged = report.summaries.filter((item) =>
+    item.judgeRunCount === undefined || item.judgeRunCount > 0
+  );
+  if (judged.length === 0) return 'n/a';
+  return `${average(judged.map((item) => item.avgJudgeScore)).toFixed(1)}/5`;
 }
 
 function formatSummaryJudgeMetric(
@@ -859,6 +864,7 @@ function formatSummaryJudgeMetric(
   if (!settings.judgeEnabled || report.capabilities?.judge === 'disabled') {
     return 'off';
   }
+  if (summary.judgeRunCount === 0) return 'n/a';
   return `${summary.avgJudgeScore.toFixed(1)}/5`;
 }
 
@@ -870,6 +876,8 @@ function formatRunJudgeMetric(
   if (!settings.judgeEnabled || report.capabilities?.judge === 'disabled') {
     return 'off';
   }
+  if (result.judgeStatus === 'failed') return 'error';
+  if (result.judgeStatus === 'skipped') return 'n/a';
   return `${result.judgeScore.toFixed(1)}/5`;
 }
 
@@ -1734,7 +1742,9 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
 
   const topJudge = useMemo(() => {
     if (!report || report.capabilities?.judge === 'disabled') return null;
-    return [...report.summaries].sort(
+    return report.summaries.filter((item) =>
+      item.judgeRunCount === undefined || item.judgeRunCount > 0
+    ).sort(
       (a, b) => b.avgJudgeScore - a.avgJudgeScore,
     )[0] ?? null;
   }, [report]);

--- a/packages/genui/server/AGENTS.md
+++ b/packages/genui/server/AGENTS.md
@@ -45,6 +45,36 @@ back to a deterministic Picsum URL.
 
 The hosting runtime must provide these variables before invoking the handler.
 
+To enable UI Judge scoring for A2UI Bench jobs, run the independent Rust UI
+Judge HTTP server and configure its private base URL:
+
+```bash
+export UI_JUDGE_SERVER_URL="http://127.0.0.1:8080"
+```
+
+The server probes `GET /health` for each Bench job and reports Judge as enabled
+only when the sidecar worker is ready. This is a shallow readiness check; model
+credentials, the configured bundle, and runtime resources are validated by the
+first `/judge` request. Successful A2UI generations are submitted to
+`POST /judge`; generated messages are injected through server-owned Lynx
+`globalProps` and cannot be supplied or overridden by Bench clients.
+
+Before rendering, the Bench integration replaces `Image`, `LazyComponent`,
+`LineChart`, `McpApp`, and `PieChart` definitions with inert loading
+placeholders, downgrades Markdown text, and rejects recursive `openUrl`
+function calls. Bench prompt catalogs also omit `openUrl` to avoid generating
+those calls in the first place. Keep this boundary in place: model output must
+not make the server-side headless resource loader fetch arbitrary URLs, read
+local files, or execute nested bundles.
+
+By default, Judge renders
+`https://lynx-stack.dev/genui/a2ui.lynx.js`. Override that server-owned bundle
+URL when running a local or pinned bundle:
+
+```bash
+export UI_JUDGE_BUNDLE_URL="http://127.0.0.1:3000/a2ui.lynx.js"
+```
+
 ## Security
 
 By default, request bodies submitted to `/a2ui/chat`, `/a2ui/stream`,

--- a/packages/genui/server/service/a2ui-bench-catalog.ts
+++ b/packages/genui/server/service/a2ui-bench-catalog.ts
@@ -44,7 +44,14 @@ function filterCatalog(
       }.`,
     ],
     examples: BASIC_CATALOG.examples,
+    functions: filterBenchFunctions(BASIC_CATALOG.functions),
   };
+}
+
+function filterBenchFunctions(
+  functions: A2UICatalog['functions'],
+): A2UICatalog['functions'] {
+  return functions?.filter((fn) => fn.name !== 'openUrl');
 }
 
 export function resolveBenchCatalog(label: BenchCatalogLabel): A2UICatalog {
@@ -54,5 +61,8 @@ export function resolveBenchCatalog(label: BenchCatalogLabel): A2UICatalog {
   if (label === 'Minimal Catalog') {
     return filterCatalog(label, MINIMAL_COMPONENTS);
   }
-  return BASIC_CATALOG;
+  return {
+    ...BASIC_CATALOG,
+    functions: filterBenchFunctions(BASIC_CATALOG.functions),
+  };
 }

--- a/packages/genui/server/service/a2ui-bench-judge.ts
+++ b/packages/genui/server/service/a2ui-bench-judge.ts
@@ -1,0 +1,406 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { BenchScenarioRequest } from './a2ui-bench-types';
+import type { A2UIMessage } from '../agent/a2ui-validator';
+
+const DEFAULT_A2UI_BUNDLE_URL = 'https://lynx-stack.dev/genui/a2ui.lynx.js';
+const HEALTH_TIMEOUT_MS = 3_000;
+const DEFAULT_OPERATION_TIMEOUT_MS = 60_000;
+
+type FetchLike = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface BenchUiJudgeSession {
+  bundleUrl: string;
+  judgeUrl: string;
+}
+
+export interface BenchUiJudgeCapability {
+  enabled: boolean;
+  reason?: string;
+  session?: BenchUiJudgeSession;
+}
+
+export interface BenchUiJudgeResult {
+  errors: string[];
+  reason?: string;
+  score: number;
+  status: 'complete' | 'failed';
+  summary?: string;
+  warnings: string[];
+}
+
+interface UiJudgeResponse {
+  error?: {
+    message?: unknown;
+  };
+  reason?: unknown;
+  score?: unknown;
+  summary?: unknown;
+}
+
+interface RunBenchUiJudgeOptions {
+  messages: A2UIMessage[];
+  scenario: BenchScenarioRequest;
+  session: BenchUiJudgeSession;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+const RESOURCE_COMPONENTS = new Set([
+  'Image',
+  'LazyComponent',
+  'LineChart',
+  'McpApp',
+  'PieChart',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeServerUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:')
+      || url.username
+      || url.password
+    ) {
+      return null;
+    }
+    url.hash = '';
+    url.search = '';
+    if (!url.pathname.endsWith('/')) url.pathname = `${url.pathname}/`;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeBundleUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (
+      !['file:', 'http:', 'https:'].includes(url.protocol)
+      || url.username
+      || url.password
+    ) {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readResponseError(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const error = value.error;
+  if (typeof error === 'string' && error.trim()) return error.trim();
+  if (!isRecord(error)) return undefined;
+  return typeof error.message === 'string' && error.message.trim()
+    ? error.message.trim()
+    : undefined;
+}
+
+function sanitizeMessagesForHeadless(
+  messages: A2UIMessage[],
+): { error?: string; messages: A2UIMessage[]; warnings: string[] } {
+  const replacements = new Map<string, number>();
+  const sanitized = messages.map((message): A2UIMessage => {
+    if (!('updateComponents' in message) || !message.updateComponents) {
+      return message;
+    }
+
+    let changed = false;
+    const components = message.updateComponents.components.map((component) => {
+      if (RESOURCE_COMPONENTS.has(component.component)) {
+        changed = true;
+        replacements.set(
+          component.component,
+          (replacements.get(component.component) ?? 0) + 1,
+        );
+        return {
+          component: 'Loading',
+          id: component.id,
+          variant: 'block',
+        };
+      }
+      if (component.component === 'Text' && component.variant === 'markdown') {
+        changed = true;
+        replacements.set(
+          'markdown Text',
+          (replacements.get('markdown Text') ?? 0) + 1,
+        );
+        return {
+          ...component,
+          variant: 'body',
+        };
+      }
+      return component;
+    });
+
+    return changed
+      ? {
+        ...message,
+        updateComponents: {
+          ...message.updateComponents,
+          components,
+        },
+      }
+      : message;
+  });
+  const warnings = [...replacements.entries()].map(
+    ([component, count]) =>
+      `ui-judge replaced ${count} ${component} component${
+        count === 1 ? '' : 's'
+      } to prevent untrusted resource loading.`,
+  );
+  return {
+    ...(containsOpenUrlCall(sanitized)
+      ? {
+        error:
+          'ui-judge rejected a model-generated openUrl function call to prevent server-side network access.',
+      }
+      : {}),
+    messages: sanitized,
+    warnings,
+  };
+}
+
+function containsOpenUrlCall(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (
+    isRecord(value)
+    && value.call === 'openUrl'
+  ) {
+    return true;
+  }
+  return Object.values(value).some((child) => containsOpenUrlCall(child, seen));
+}
+
+export async function probeBenchUiJudge(
+  options: {
+    env?: NodeJS.ProcessEnv;
+    fetch?: FetchLike;
+  } = {},
+): Promise<BenchUiJudgeCapability> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetch ?? fetch;
+  const rawServerUrl = env.UI_JUDGE_SERVER_URL?.trim();
+  if (!rawServerUrl) {
+    return {
+      enabled: false,
+      reason: 'UI_JUDGE_SERVER_URL is not configured.',
+    };
+  }
+
+  const serverUrl = normalizeServerUrl(rawServerUrl);
+  if (!serverUrl) {
+    return {
+      enabled: false,
+      reason: 'UI_JUDGE_SERVER_URL must be an HTTP(S) URL without credentials.',
+    };
+  }
+
+  const configuredBundleUrl = env.UI_JUDGE_BUNDLE_URL?.trim();
+  const rawBundleUrl = configuredBundleUrl !== undefined
+      && configuredBundleUrl.length > 0
+    ? configuredBundleUrl
+    : DEFAULT_A2UI_BUNDLE_URL;
+  const bundleUrl = normalizeBundleUrl(rawBundleUrl);
+  if (!bundleUrl) {
+    return {
+      enabled: false,
+      reason:
+        'UI_JUDGE_BUNDLE_URL must be a file, HTTP, or HTTPS URL without credentials.',
+    };
+  }
+
+  const healthUrl = new URL('health', serverUrl);
+  try {
+    const response = await fetchImpl(healthUrl, {
+      headers: { Accept: 'application/json' },
+      method: 'GET',
+      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return {
+        enabled: false,
+        reason: `UI Judge health check returned HTTP ${response.status}.`,
+      };
+    }
+    const body = await readJson(response);
+    if (!isRecord(body) || body.status !== 'ok') {
+      return {
+        enabled: false,
+        reason: 'UI Judge health check returned an invalid response.',
+      };
+    }
+  } catch (error) {
+    return {
+      enabled: false,
+      reason: `UI Judge health check failed: ${toErrorMessage(error)}`,
+    };
+  }
+
+  return {
+    enabled: true,
+    session: {
+      bundleUrl,
+      judgeUrl: new URL('judge', serverUrl).toString(),
+    },
+  };
+}
+
+export async function runBenchUiJudge(
+  options: RunBenchUiJudgeOptions,
+  fetchImpl: FetchLike = fetch,
+): Promise<BenchUiJudgeResult> {
+  const sanitized = sanitizeMessagesForHeadless(options.messages);
+  if (sanitized.error) {
+    return {
+      errors: [sanitized.error],
+      score: 0,
+      status: 'failed',
+      warnings: sanitized.warnings,
+    };
+  }
+  const operationTimeoutMs = options.timeoutMs
+    ?? DEFAULT_OPERATION_TIMEOUT_MS;
+  const requestTimeoutMs = operationTimeoutMs
+    * ((options.scenario.judgeSteps?.length ?? 0) + 4);
+  const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
+  const requestSignal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+  if (options.signal?.aborted) {
+    return {
+      errors: [],
+      score: 0,
+      status: 'failed',
+      warnings: sanitized.warnings,
+    };
+  }
+  const body = {
+    globalProps: {
+      instant: true,
+      messages: sanitized.messages,
+      speed: 0,
+      theme: 'light',
+    },
+    steps: options.scenario.judgeSteps ?? [],
+    task: options.scenario.judgeTask ?? options.scenario.prompt,
+    ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
+    url: options.session.bundleUrl,
+  };
+
+  let response: Response;
+  try {
+    response = await fetchImpl(options.session.judgeUrl, {
+      body: JSON.stringify(body),
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      signal: requestSignal,
+    });
+  } catch (error) {
+    if (options.signal?.aborted) {
+      return {
+        errors: [],
+        score: 0,
+        status: 'failed',
+        warnings: sanitized.warnings,
+      };
+    }
+    return {
+      errors: [`ui-judge request failed: ${toErrorMessage(error)}`],
+      score: 0,
+      status: 'failed',
+      warnings: sanitized.warnings,
+    };
+  }
+
+  const payload = await readJson(response);
+  if (!response.ok) {
+    const detail = readResponseError(payload);
+    return {
+      errors: [
+        `ui-judge request returned HTTP ${response.status}${
+          detail ? `: ${detail}` : ''
+        }`,
+      ],
+      score: 0,
+      status: 'failed',
+      warnings: sanitized.warnings,
+    };
+  }
+
+  if (!isRecord(payload)) {
+    return {
+      errors: ['ui-judge returned an invalid JSON response.'],
+      score: 0,
+      status: 'failed',
+      warnings: sanitized.warnings,
+    };
+  }
+  const result = payload as UiJudgeResponse;
+  const errors: string[] = [];
+  const responseError = readResponseError(payload);
+  if (responseError) errors.push(`ui-judge failed: ${responseError}`);
+
+  const score = typeof result.score === 'number'
+      && Number.isInteger(result.score)
+      && result.score >= 0
+      && result.score <= 5
+    ? result.score
+    : 0;
+  if (
+    typeof result.score !== 'number'
+    || !Number.isInteger(result.score)
+    || result.score < 0
+    || result.score > 5
+  ) {
+    errors.push('ui-judge returned an invalid score.');
+  }
+
+  const reason = typeof result.reason === 'string' && result.reason.trim()
+    ? result.reason.trim()
+    : undefined;
+  const summary = typeof result.summary === 'string' && result.summary.trim()
+    ? result.summary.trim()
+    : undefined;
+
+  return {
+    errors,
+    ...(reason ? { reason } : {}),
+    score: errors.length === 0 ? score : 0,
+    status: errors.length === 0 ? 'complete' : 'failed',
+    ...(summary ? { summary } : {}),
+    warnings: sanitized.warnings,
+  };
+}

--- a/packages/genui/server/service/a2ui-bench-runner.ts
+++ b/packages/genui/server/service/a2ui-bench-runner.ts
@@ -4,6 +4,11 @@
 
 import { getA2UIAgentService } from './a2ui-agent';
 import { resolveBenchCatalog } from './a2ui-bench-catalog';
+import { probeBenchUiJudge, runBenchUiJudge } from './a2ui-bench-judge';
+import type {
+  BenchUiJudgeCapability,
+  BenchUiJudgeResult,
+} from './a2ui-bench-judge';
 // import { runBenchPreview } from './a2ui-bench-preview';
 import { getBenchJobStore } from './a2ui-bench-store';
 import type {
@@ -148,6 +153,8 @@ async function runOne(
   jobId: string,
   request: BenchJobRequest,
   item: BenchRunItem,
+  judgeCapability: BenchUiJudgeCapability,
+  signal: AbortSignal,
 ): Promise<BenchRunResult> {
   const store = getBenchJobStore();
   const runId = `${item.group.id}-${item.scenario.id}-${item.repeatIndex}`;
@@ -185,6 +192,27 @@ async function runOne(
     emitRunPhase(jobId, item, 'validate');
     const agentMs = performance.now() - startedAt;
     const outputChars = result.text.length;
+    const judgeSession = judgeCapability.session;
+    const judge: BenchUiJudgeResult | {
+      errors: [];
+      score: 0;
+      status: 'skipped';
+      warnings: [];
+    } = result.ok
+        && request.settings.judgeEnabled
+        && judgeSession
+        && !signal.aborted
+      ? await (async () => {
+        emitRunPhase(jobId, item, 'judge');
+        return await runBenchUiJudge({
+          messages: result.messages,
+          scenario: item.scenario,
+          session: judgeSession,
+          signal,
+          timeoutMs: request.settings.timeoutMs,
+        });
+      })()
+      : { errors: [], score: 0, status: 'skipped', warnings: [] };
     /*
     const preview = result.ok
       ? await runBenchPreviewForItem(jobId, request, item, result.messages)
@@ -217,12 +245,20 @@ async function runOne(
       // renderMs: preview.renderMs,
       renderMs: 0,
       attempts: result.attempts,
-      // judgeScore: preview.judgeScore,
-      judgeScore: 0,
+      judgeScore: judge.score,
+      judgeStatus: judge.status,
+      ...('reason' in judge && judge.reason
+        ? { judgeReason: judge.reason }
+        : {}),
+      ...('summary' in judge && judge.summary
+        ? { judgeSummary: judge.summary }
+        : {}),
+      ...(judge.warnings.length > 0
+        ? { judgeWarnings: judge.warnings }
+        : {}),
       messageCount: result.messages.length,
       outputChars,
-      // errors: [...result.errors, ...preview.errors],
-      errors: result.errors,
+      errors: [...result.errors, ...judge.errors],
       finishReason: result.finishReason,
       usage: result.usage,
       messages: result.messages,
@@ -253,6 +289,7 @@ async function runOne(
       renderMs: 0,
       attempts: 0,
       judgeScore: 0,
+      judgeStatus: 'skipped',
       messageCount: 0,
       outputChars: 0,
       errors: [message],
@@ -308,13 +345,14 @@ async function runBenchPreviewForItem(
 }
 */
 
-function summarizeGroup(
+export function summarizeGroup(
   group: BenchGroupRequest,
   results: BenchRunResult[],
 ): BenchGroupSummary {
   const groupResults = results.filter((item) => item.groupId === group.id);
   const successful = groupResults.filter((item) => item.ok);
   const base = successful.length > 0 ? successful : groupResults;
+  const judged = base.filter((item) => item.judgeStatus === 'complete');
   const failedRuns = groupResults.filter((item) => !item.ok).length;
   return {
     groupId: group.id,
@@ -330,7 +368,8 @@ function summarizeGroup(
     avgFmpMs: average(base.map((item) => item.fmpMs)),
     avgTtiMs: average(base.map((item) => item.ttiMs)),
     avgRenderMs: average(base.map((item) => item.renderMs)),
-    avgJudgeScore: average(base.map((item) => item.judgeScore)),
+    avgJudgeScore: average(judged.map((item) => item.judgeScore)),
+    judgeRunCount: judged.length,
     avgAttempts: average(base.map((item) => item.attempts)),
   };
 }
@@ -358,6 +397,7 @@ function buildReport(
   results: BenchRunResult[],
   warnings: string[],
   status: BenchReport['status'],
+  judgeCapability: BenchUiJudgeCapability,
 ): BenchReport {
   const enabledGroups = request.groups.filter((group) => group.enabled);
   const summary = summarizeReport(results);
@@ -391,7 +431,9 @@ function buildReport(
       //   ? 'enabled'
       //   : 'disabled',
       renderMetrics: 'disabled',
-      judge: 'disabled',
+      judge: request.settings.judgeEnabled && judgeCapability.enabled
+        ? 'enabled'
+        : 'disabled',
     },
     warnings,
     groups: request.groups,
@@ -406,13 +448,36 @@ export function startBenchJob(jobId: string): void {
   void runBenchJob(jobId);
 }
 
-async function runBenchJob(jobId: string): Promise<void> {
+export async function runBenchJob(jobId: string): Promise<void> {
   const store = getBenchJobStore();
   const job = store.getJob(jobId);
   if (!job) return;
   const activeJob = job;
   const request = activeJob.request;
   const matrix = buildRunMatrix(request);
+  const judgeCapability = await probeBenchUiJudge();
+  if (
+    activeJob.abortController.signal.aborted
+    || activeJob.status === 'cancelled'
+  ) {
+    const report = buildReport(
+      jobId,
+      request,
+      activeJob.results,
+      activeJob.warnings,
+      'cancelled',
+      judgeCapability,
+    );
+    store.setReport(jobId, report);
+    return;
+  }
+  if (
+    request.settings.judgeEnabled
+    && !judgeCapability.enabled
+    && judgeCapability.reason
+  ) {
+    activeJob.warnings.push(`UI Judge disabled: ${judgeCapability.reason}`);
+  }
 
   store.updateStatus(jobId, 'running');
 
@@ -425,7 +490,14 @@ async function runBenchJob(jobId: string): Promise<void> {
       const item = matrix[index];
       if (!item) return;
 
-      const result = await runOne(jobId, request, item);
+      const result = await runOne(
+        jobId,
+        request,
+        item,
+        judgeCapability,
+        activeJob.abortController.signal,
+      );
+      if (activeJob.abortController.signal.aborted) return;
       const updated = store.addResult(jobId, result);
       if (!updated) return;
       const event = result.ok ? 'run-complete' : 'run-error';
@@ -446,12 +518,14 @@ async function runBenchJob(jobId: string): Promise<void> {
     if (
       latest.abortController.signal.aborted || latest.status === 'cancelled'
     ) {
+      store.updateStatus(jobId, 'cancelled');
       const report = buildReport(
         jobId,
         request,
         latest.results,
         latest.warnings,
         'cancelled',
+        judgeCapability,
       );
       store.setReport(jobId, report);
       return;
@@ -468,6 +542,7 @@ async function runBenchJob(jobId: string): Promise<void> {
       latest.results,
       latest.warnings,
       'complete',
+      judgeCapability,
     );
     store.setReport(jobId, report);
   } catch (error) {
@@ -480,6 +555,7 @@ async function runBenchJob(jobId: string): Promise<void> {
       latest.results,
       latest.warnings,
       'failed',
+      judgeCapability,
     );
     store.setReport(jobId, report);
   }

--- a/packages/genui/server/service/a2ui-bench-types.ts
+++ b/packages/genui/server/service/a2ui-bench-types.ts
@@ -106,6 +106,10 @@ export interface BenchRunResult {
   renderMs: number;
   attempts: number;
   judgeScore: number;
+  judgeReason?: string;
+  judgeStatus?: 'complete' | 'failed' | 'skipped';
+  judgeSummary?: string;
+  judgeWarnings?: string[];
   messageCount: number;
   outputChars: number;
   errors: string[];
@@ -130,6 +134,7 @@ export interface BenchGroupSummary {
   avgTtiMs: number;
   avgRenderMs: number;
   avgJudgeScore: number;
+  judgeRunCount: number;
   avgAttempts: number;
 }
 

--- a/packages/genui/server/test/a2ui-bench-catalog.test.ts
+++ b/packages/genui/server/test/a2ui-bench-catalog.test.ts
@@ -1,0 +1,21 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import { resolveBenchCatalog } from '../service/a2ui-bench-catalog.js';
+
+describe('resolveBenchCatalog', () => {
+  test.each(
+    [
+      'Full Catalog',
+      'Core Catalog',
+      'Minimal Catalog',
+    ] as const,
+  )('removes openUrl from %s', (label) => {
+    const catalog = resolveBenchCatalog(label);
+
+    expect(catalog.functions?.some((fn) => fn.name === 'openUrl')).toBe(false);
+  });
+});

--- a/packages/genui/server/test/a2ui-bench-judge.test.ts
+++ b/packages/genui/server/test/a2ui-bench-judge.test.ts
@@ -1,0 +1,408 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  probeBenchUiJudge,
+  runBenchUiJudge,
+} from '../service/a2ui-bench-judge.js';
+
+describe('probeBenchUiJudge', () => {
+  test('stays disabled without the private sidecar URL', async () => {
+    let called = false;
+    const capability = await probeBenchUiJudge({
+      env: {},
+      fetch: () => {
+        called = true;
+        throw new Error('unexpected fetch');
+      },
+    });
+
+    expect(called).toBe(false);
+    expect(capability).toEqual({
+      enabled: false,
+      reason: 'UI_JUDGE_SERVER_URL is not configured.',
+    });
+  });
+
+  test('enables Judge after a successful health probe', async () => {
+    let requestUrl = '';
+    let requestInit: RequestInit | undefined;
+    const capability = await probeBenchUiJudge({
+      env: {
+        UI_JUDGE_BUNDLE_URL: 'https://assets.test/a2ui.lynx.js',
+        UI_JUDGE_SERVER_URL: 'http://judge.test/internal',
+      },
+      fetch: (input, init) => {
+        requestUrl = input.toString();
+        requestInit = init;
+        return Promise.resolve(Response.json({ status: 'ok' }));
+      },
+    });
+
+    expect(requestUrl).toBe('http://judge.test/internal/health');
+    expect(requestInit?.method).toBe('GET');
+    expect(capability).toEqual({
+      enabled: true,
+      session: {
+        bundleUrl: 'https://assets.test/a2ui.lynx.js',
+        judgeUrl: 'http://judge.test/internal/judge',
+      },
+    });
+  });
+
+  test('keeps Judge disabled when the sidecar is not ready', async () => {
+    const capability = await probeBenchUiJudge({
+      env: {
+        UI_JUDGE_SERVER_URL: 'http://judge.test',
+      },
+      fetch: () =>
+        Promise.resolve(
+          Response.json(
+            { error: { message: 'not ready' } },
+            { status: 503 },
+          ),
+        ),
+    });
+
+    expect(capability).toEqual({
+      enabled: false,
+      reason: 'UI Judge health check returned HTTP 503.',
+    });
+  });
+});
+
+describe('runBenchUiJudge', () => {
+  test('injects generated messages as server-owned global props', async () => {
+    let requestUrl = '';
+    let requestBody: unknown;
+    const result = await runBenchUiJudge(
+      {
+        messages: [{
+          version: 'v0.9',
+          createSurface: {
+            catalogId: 'catalog',
+            surfaceId: 'surface',
+          },
+        }],
+        scenario: {
+          id: 'save',
+          judgeSteps: ['Tap Save'],
+          judgeTask: 'The saved state is visible',
+          name: 'Save card',
+          prompt: 'Build a save card',
+          type: 'Action',
+        },
+        session: {
+          bundleUrl: 'https://assets.test/a2ui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+        timeoutMs: 45_000,
+      },
+      (input, init) => {
+        requestUrl = input.toString();
+        if (typeof init?.body !== 'string') {
+          throw new Error('expected a JSON string request body');
+        }
+        requestBody = JSON.parse(init.body) as unknown;
+        return Promise.resolve(
+          Response.json({
+            reason: 'The saved state is clear.',
+            score: 4,
+            summary: 'Strong result.',
+          }),
+        );
+      },
+    );
+
+    expect(requestUrl).toBe('http://judge.test/judge');
+    expect(requestBody).toEqual({
+      globalProps: {
+        instant: true,
+        messages: [{
+          version: 'v0.9',
+          createSurface: {
+            catalogId: 'catalog',
+            surfaceId: 'surface',
+          },
+        }],
+        speed: 0,
+        theme: 'light',
+      },
+      steps: ['Tap Save'],
+      task: 'The saved state is visible',
+      timeoutMs: 45_000,
+      url: 'https://assets.test/a2ui.lynx.js',
+    });
+    expect(result).toEqual({
+      errors: [],
+      reason: 'The saved state is clear.',
+      score: 4,
+      status: 'complete',
+      summary: 'Strong result.',
+      warnings: [],
+    });
+  });
+
+  test('marks a completed Judge failure as an unavailable score', async () => {
+    const result = await runBenchUiJudge(
+      {
+        messages: [],
+        scenario: {
+          id: 'weather',
+          name: 'Weather',
+          prompt: 'Build a weather card',
+          type: 'Information',
+        },
+        session: {
+          bundleUrl: 'https://assets.test/a2ui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      () =>
+        Promise.resolve(
+          Response.json({
+            error: { message: 'capture failed' },
+            score: 0,
+          }),
+        ),
+    );
+
+    expect(result).toEqual({
+      errors: ['ui-judge failed: capture failed'],
+      score: 0,
+      status: 'failed',
+      warnings: [],
+    });
+  });
+
+  test('maps non-success HTTP responses to run errors', async () => {
+    const result = await runBenchUiJudge(
+      {
+        messages: [],
+        scenario: {
+          id: 'weather',
+          name: 'Weather',
+          prompt: 'Build a weather card',
+          type: 'Information',
+        },
+        session: {
+          bundleUrl: 'https://assets.test/a2ui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      () =>
+        Promise.resolve(
+          Response.json(
+            { error: { message: 'queue full' } },
+            { status: 503 },
+          ),
+        ),
+    );
+
+    expect(result).toEqual({
+      errors: ['ui-judge request returned HTTP 503: queue full'],
+      score: 0,
+      status: 'failed',
+      warnings: [],
+    });
+  });
+
+  test('replaces components that can load untrusted resources', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const result = await runBenchUiJudge(
+      {
+        messages: [{
+          version: 'v0.9',
+          updateComponents: {
+            components: [
+              {
+                component: 'Image',
+                id: 'image',
+                url: 'file:///etc/passwd',
+              },
+              {
+                component: 'LazyComponent',
+                id: 'lazy',
+                url: 'http://169.254.169.254/latest/meta-data',
+              },
+              {
+                component: 'McpApp',
+                id: 'mcp',
+                mcpAppData: {},
+                url: 'https://untrusted.test/app.lynx.js',
+              },
+              {
+                component: 'Text',
+                id: 'markdown',
+                text: '![remote](http://127.0.0.1/image.png)',
+                variant: 'markdown',
+              },
+              {
+                component: 'LineChart',
+                id: 'line-chart',
+                labels: ['A', 'B'],
+                series: [{
+                  color: 'url(http://127.0.0.1/paint)',
+                  name: 'unsafe',
+                  values: [1, 2],
+                }],
+              },
+              {
+                component: 'PieChart',
+                data: [{
+                  color: 'url(file:///etc/passwd)',
+                  name: 'unsafe',
+                  value: 1,
+                }],
+                id: 'pie-chart',
+              },
+            ],
+            surfaceId: 'surface',
+          },
+        }],
+        scenario: {
+          id: 'safe',
+          name: 'Safe',
+          prompt: 'Build a safe card',
+          type: 'Information',
+        },
+        session: {
+          bundleUrl: 'https://assets.test/a2ui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      (_input, init) => {
+        if (typeof init?.body !== 'string') {
+          throw new Error('expected a JSON string request body');
+        }
+        requestBody = JSON.parse(init.body) as Record<string, unknown>;
+        return Promise.resolve(Response.json({ score: 3 }));
+      },
+    );
+
+    const globalProps = requestBody?.globalProps as
+      | Record<string, unknown>
+      | undefined;
+    const messages = globalProps?.messages as
+      | Record<string, unknown>[]
+      | undefined;
+    const update = messages?.[0]?.updateComponents as
+      | Record<string, unknown>
+      | undefined;
+    expect(update?.components).toEqual([
+      { component: 'Loading', id: 'image', variant: 'block' },
+      { component: 'Loading', id: 'lazy', variant: 'block' },
+      { component: 'Loading', id: 'mcp', variant: 'block' },
+      {
+        component: 'Text',
+        id: 'markdown',
+        text: '![remote](http://127.0.0.1/image.png)',
+        variant: 'body',
+      },
+      { component: 'Loading', id: 'line-chart', variant: 'block' },
+      { component: 'Loading', id: 'pie-chart', variant: 'block' },
+    ]);
+    expect(result).toEqual({
+      errors: [],
+      score: 3,
+      status: 'complete',
+      warnings: [
+        'ui-judge replaced 1 Image component to prevent untrusted resource loading.',
+        'ui-judge replaced 1 LazyComponent component to prevent untrusted resource loading.',
+        'ui-judge replaced 1 McpApp component to prevent untrusted resource loading.',
+        'ui-judge replaced 1 markdown Text component to prevent untrusted resource loading.',
+        'ui-judge replaced 1 LineChart component to prevent untrusted resource loading.',
+        'ui-judge replaced 1 PieChart component to prevent untrusted resource loading.',
+      ],
+    });
+  });
+
+  test('rejects recursive openUrl calls before contacting the sidecar', async () => {
+    let called = false;
+    const result = await runBenchUiJudge(
+      {
+        messages: [{
+          version: 'v0.9',
+          updateDataModel: {
+            surfaceId: 'surface',
+            value: {
+              nested: {
+                args: { url: 'http://127.0.0.1/private' },
+                call: 'openUrl',
+                returnType: 'void',
+              },
+            },
+          },
+        }],
+        scenario: {
+          id: 'unsafe',
+          name: 'Unsafe',
+          prompt: 'Build a card',
+          type: 'Information',
+        },
+        session: {
+          bundleUrl: 'https://assets.test/a2ui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      () => {
+        called = true;
+        return Promise.resolve(Response.json({ score: 5 }));
+      },
+    );
+
+    expect(called).toBe(false);
+    expect(result).toEqual({
+      errors: [
+        'ui-judge rejected a model-generated openUrl function call to prevent server-side network access.',
+      ],
+      score: 0,
+      status: 'failed',
+      warnings: [],
+    });
+  });
+
+  test('aborts an in-flight Judge request when the job is cancelled', async () => {
+    const controller = new AbortController();
+    let requestSignal: AbortSignal | null | undefined;
+    const resultPromise = runBenchUiJudge(
+      {
+        messages: [],
+        scenario: {
+          id: 'cancel',
+          name: 'Cancel',
+          prompt: 'Build a card',
+          type: 'Information',
+        },
+        session: {
+          bundleUrl: 'https://assets.test/a2ui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+        signal: controller.signal,
+      },
+      (_input, init) => {
+        requestSignal = init?.signal;
+        return new Promise((_resolve, reject) => {
+          requestSignal?.addEventListener(
+            'abort',
+            () => reject(new Error('request aborted')),
+            { once: true },
+          );
+        });
+      },
+    );
+
+    controller.abort();
+
+    await expect(resultPromise).resolves.toEqual({
+      errors: [],
+      score: 0,
+      status: 'failed',
+      warnings: [],
+    });
+    expect(requestSignal?.aborted).toBe(true);
+  });
+});

--- a/packages/genui/server/test/a2ui-bench-runner.test.ts
+++ b/packages/genui/server/test/a2ui-bench-runner.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, rstest, test } from '@rstest/core';
+
+import { probeBenchUiJudge } from '../service/a2ui-bench-judge.js';
+import { runBenchJob, summarizeGroup } from '../service/a2ui-bench-runner.js';
+import { getBenchJobStore } from '../service/a2ui-bench-store.js';
+import type {
+  BenchGroupRequest,
+  BenchJobRequest,
+  BenchRunResult,
+} from '../service/a2ui-bench-types.js';
+
+rstest.mock('../service/a2ui-bench-judge.js', { mock: true });
+
+const group: BenchGroupRequest = {
+  enabled: true,
+  id: 'control',
+  name: 'Control',
+  role: 'control',
+  variable: 'custom',
+};
+
+function request(judgeEnabled = true): BenchJobRequest {
+  return {
+    groups: [group],
+    provider: {},
+    scenarios: [{
+      id: 'scenario',
+      name: 'Scenario',
+      prompt: 'Build a card',
+      type: 'Information',
+    }],
+    settings: {
+      judgeEnabled,
+      maxRepairAttempts: 0,
+      parallelism: 1,
+      renderMetricsEnabled: false,
+      repairEnabled: false,
+      repeats: 1,
+    },
+  };
+}
+
+function result(
+  id: string,
+  judgeStatus: BenchRunResult['judgeStatus'],
+  judgeScore: number,
+): BenchRunResult {
+  return {
+    agentMs: 10,
+    attempts: 1,
+    catalog: 'Full Catalog',
+    errors: [],
+    fmpMs: 0,
+    groupId: group.id,
+    groupName: group.name,
+    id,
+    judgeScore,
+    judgeStatus,
+    messageCount: 1,
+    model: 'test-model',
+    ok: true,
+    outputChars: 10,
+    renderMs: 0,
+    repeatIndex: 1,
+    role: group.role,
+    scenarioId: 'scenario',
+    scenarioName: 'Scenario',
+    status: 'complete',
+    tokens: 10,
+    ttiMs: 0,
+  };
+}
+
+describe('A2UI Bench UI Judge integration', () => {
+  test('does not restore a cancelled job to running after the health probe', async () => {
+    let resolveProbe:
+      | ((capability: Awaited<ReturnType<typeof probeBenchUiJudge>>) => void)
+      | undefined;
+    rstest.mocked(probeBenchUiJudge).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveProbe = resolve;
+        }),
+    );
+    const store = getBenchJobStore();
+    const job = store.createJob(request(), 1);
+
+    const running = runBenchJob(job.id);
+    store.cancelJob(job.id);
+    resolveProbe?.({
+      enabled: false,
+      reason: 'not ready',
+    });
+    await running;
+
+    const completed = store.getJob(job.id);
+    expect(completed?.status).toBe('cancelled');
+    expect(completed?.report?.status).toBe('cancelled');
+    expect(completed?.results).toEqual([]);
+  });
+
+  test('excludes failed and skipped Judge attempts from the average', () => {
+    const summary = summarizeGroup(group, [
+      result('complete', 'complete', 4),
+      result('failed', 'failed', 0),
+      result('skipped', 'skipped', 0),
+    ]);
+
+    expect(summary.avgJudgeScore).toBe(4);
+    expect(summary.judgeRunCount).toBe(1);
+  });
+});

--- a/packages/genui/ui-judge/README.md
+++ b/packages/genui/ui-judge/README.md
@@ -137,7 +137,10 @@ readiness check, `POST /judge` to evaluate a page, and `POST /compare` to
 compare two uploaded images without rendering a page or calling the VLM.
 
 The following request evaluates a local bundle. `url` and `task` are required.
-The other fields are optional.
+The other fields are optional. `initialData` and `globalProps` accept JSON
+objects and are forwarded only by the HTTP server to the headless Lynx
+navigation request; `null` is treated as omitted. The Rust library's public
+`JudgePageRequest` remains unchanged.
 
 ```bash
 curl --request POST http://127.0.0.1:8080/judge \
@@ -145,6 +148,11 @@ curl --request POST http://127.0.0.1:8080/judge \
   --data '{
     "url": "file:///absolute/path/to/dist/main.lynx.bundle",
     "task": "The saved state should be clear and visually correct",
+    "globalProps": {
+      "messages": [],
+      "instant": true,
+      "theme": "light"
+    },
     "reference": null,
     "referenceImage": null,
     "steps": ["Tap the Save button"],

--- a/packages/genui/ui-judge/src/headless.rs
+++ b/packages/genui/ui-judge/src/headless.rs
@@ -93,6 +93,12 @@ pub(crate) struct CapturedPage {
   url: String,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct PageLoadOptions {
+  pub(crate) global_props_json: Option<String>,
+  pub(crate) initial_data_json: Option<String>,
+}
+
 /// Captures the current software-renderer frame exposed by the existing
 /// headless runner.
 async fn capture_page_png(page: &Page, settle: Duration) -> Result<Vec<u8>, HeadlessPageError> {
@@ -174,6 +180,14 @@ pub(crate) async fn capture_prepared_page(
   client: &ModelClient,
   request: &JudgePageRequest,
 ) -> Result<CapturedPage, UiJudgeResult> {
+  capture_prepared_page_with_options(client, request, &PageLoadOptions::default()).await
+}
+
+pub(crate) async fn capture_prepared_page_with_options(
+  client: &ModelClient,
+  request: &JudgePageRequest,
+  load_options: &PageLoadOptions,
+) -> Result<CapturedPage, UiJudgeResult> {
   let lynx = match tokio::time::timeout(
     request.timeout,
     Lynx::connect(ConnectOptions {
@@ -192,7 +206,7 @@ pub(crate) async fn capture_prepared_page(
       ))
     }
   };
-  let capture = capture_with_lynx(&lynx, client, request).await;
+  let capture = capture_with_lynx(&lynx, client, request, load_options).await;
   lynx.close();
   capture
 }
@@ -201,6 +215,7 @@ async fn capture_with_lynx(
   lynx: &Lynx,
   client: &ModelClient,
   request: &JudgePageRequest,
+  load_options: &PageLoadOptions,
 ) -> Result<CapturedPage, UiJudgeResult> {
   let mut page = match lynx.new_page() {
     Ok(page) => page,
@@ -208,13 +223,7 @@ async fn capture_with_lynx(
   };
   let navigation = tokio::time::timeout(
     request.timeout,
-    page.goto(
-      &request.url,
-      GotoOptions {
-        timeout: Some(request.timeout),
-        ..GotoOptions::default()
-      },
-    ),
+    page.goto(&request.url, goto_options(request.timeout, load_options)),
   )
   .await;
   let navigation_error = match navigation {
@@ -227,6 +236,14 @@ async fn capture_with_lynx(
   }
 
   capture_loaded_page(client, &mut page, request).await
+}
+
+fn goto_options(timeout: Duration, load_options: &PageLoadOptions) -> GotoOptions {
+  GotoOptions {
+    global_props_json: load_options.global_props_json.clone(),
+    initial_data_json: load_options.initial_data_json.clone(),
+    timeout: Some(timeout),
+  }
 }
 
 async fn capture_loaded_page(
@@ -600,6 +617,32 @@ mod tests {
     assert!(prompt.contains(".class"));
     assert!(prompt.contains("swipe"));
     assert!(prompt.contains("unsupported"));
+  }
+
+  #[test]
+  fn page_load_options_are_forwarded_to_runner_navigation() {
+    let timeout = Duration::from_secs(9);
+    let options = goto_options(
+      timeout,
+      &PageLoadOptions {
+        global_props_json: Some(r#"{"messages":[]}"#.to_string()),
+        initial_data_json: Some(r#"{"theme":"light"}"#.to_string()),
+      },
+    );
+
+    assert_eq!(options.timeout, Some(timeout));
+    assert_eq!(
+      options.global_props_json.as_deref(),
+      Some(r#"{"messages":[]}"#)
+    );
+    assert_eq!(
+      options.initial_data_json.as_deref(),
+      Some(r#"{"theme":"light"}"#)
+    );
+
+    let defaults = goto_options(timeout, &PageLoadOptions::default());
+    assert!(defaults.global_props_json.is_none());
+    assert!(defaults.initial_data_json.is_none());
   }
 
   #[tokio::test(flavor = "current_thread")]

--- a/packages/genui/ui-judge/src/server.rs
+++ b/packages/genui/ui-judge/src/server.rs
@@ -27,7 +27,8 @@ use tokio::runtime::Runtime;
 use tokio::sync::{oneshot, watch};
 
 use crate::headless::{
-  capture_prepared_page, prepare_judge_page_request, score_captured_page, CapturedPage,
+  capture_prepared_page_with_options, prepare_judge_page_request, score_captured_page,
+  CapturedPage, PageLoadOptions,
 };
 use crate::model::ModelClient;
 use crate::visual::{
@@ -63,6 +64,10 @@ struct AppState {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct HttpJudgePageRequest {
+  #[serde(default, alias = "global_props")]
+  global_props: Option<Value>,
+  #[serde(default, alias = "initial_data")]
+  initial_data: Option<Value>,
   #[serde(default)]
   reference: Option<String>,
   #[serde(default, alias = "reference_image")]
@@ -75,6 +80,12 @@ struct HttpJudgePageRequest {
   #[serde(default, alias = "timeout_ms")]
   timeout_ms: Option<u64>,
   url: String,
+}
+
+#[derive(Debug)]
+struct HttpCaptureRequest {
+  load_options: PageLoadOptions,
+  request: JudgePageRequest,
 }
 
 #[derive(Debug, Serialize)]
@@ -104,7 +115,7 @@ impl From<ReferenceImageComparison> for HttpCompareImagesResponse {
 }
 
 impl HttpJudgePageRequest {
-  fn into_judge_request(self) -> Result<JudgePageRequest, ApiError> {
+  fn into_capture_request(self) -> Result<HttpCaptureRequest, ApiError> {
     let timeout_ms = self.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
     if timeout_ms == 0 {
       return Err(ApiError::new(
@@ -112,19 +123,38 @@ impl HttpJudgePageRequest {
         "timeoutMs must be greater than zero.",
       ));
     }
-    Ok(JudgePageRequest {
-      reference: self.reference,
-      reference_image: self.reference_image,
-      screenshot_settle: Duration::from_millis(
-        self
-          .screenshot_settle_ms
-          .unwrap_or(DEFAULT_SCREENSHOT_SETTLE_MS),
-      ),
-      steps: self.steps,
-      task: self.task,
-      timeout: Duration::from_millis(timeout_ms),
-      url: self.url,
+    let global_props_json = page_data_json("globalProps", self.global_props)?;
+    let initial_data_json = page_data_json("initialData", self.initial_data)?;
+    Ok(HttpCaptureRequest {
+      load_options: PageLoadOptions {
+        global_props_json,
+        initial_data_json,
+      },
+      request: JudgePageRequest {
+        reference: self.reference,
+        reference_image: self.reference_image,
+        screenshot_settle: Duration::from_millis(
+          self
+            .screenshot_settle_ms
+            .unwrap_or(DEFAULT_SCREENSHOT_SETTLE_MS),
+        ),
+        steps: self.steps,
+        task: self.task,
+        timeout: Duration::from_millis(timeout_ms),
+        url: self.url,
+      },
     })
+  }
+}
+
+fn page_data_json(name: &str, value: Option<Value>) -> Result<Option<String>, ApiError> {
+  match value {
+    Some(value @ Value::Object(_)) => Ok(Some(value.to_string())),
+    Some(_) => Err(ApiError::new(
+      StatusCode::BAD_REQUEST,
+      format!("{name} must be a JSON object."),
+    )),
+    None => Ok(None),
   }
 }
 
@@ -171,6 +201,7 @@ impl IntoResponse for ApiError {
 
 struct CaptureJob {
   client: ModelClient,
+  load_options: PageLoadOptions,
   request: JudgePageRequest,
   response: oneshot::Sender<CaptureResponse>,
 }
@@ -239,10 +270,12 @@ impl HeadlessExecutor {
     &self,
     request: JudgePageRequest,
     client: ModelClient,
+    load_options: PageLoadOptions,
   ) -> Result<CaptureResponse, ApiError> {
     let (response, response_receiver) = oneshot::channel();
     let job = CaptureJob {
       client,
+      load_options,
       request,
       response,
     };
@@ -314,7 +347,11 @@ fn run_headless_worker(runtime: Runtime, receiver: Receiver<CaptureJob>) {
     if job.response.is_closed() {
       continue;
     }
-    let capture = runtime.block_on(capture_prepared_page(&job.client, &job.request));
+    let capture = runtime.block_on(capture_prepared_page_with_options(
+      &job.client,
+      &job.request,
+      &job.load_options,
+    ));
     let _ = job.response.send(CaptureResponse {
       capture,
       client: job.client,
@@ -417,7 +454,10 @@ async fn judge(
   State(state): State<AppState>,
   Json(request): Json<HttpJudgePageRequest>,
 ) -> Result<Json<UiJudgeResult>, ApiError> {
-  let request = request.into_judge_request()?;
+  let HttpCaptureRequest {
+    load_options,
+    request,
+  } = request.into_capture_request()?;
   let (request, client) = match (state.prepare_request)(request) {
     Ok(prepared) => prepared,
     Err(result) => return Ok(Json(*result)),
@@ -426,7 +466,10 @@ async fn judge(
     capture,
     client,
     request,
-  } = state.headless.capture(request, client).await?;
+  } = state
+    .headless
+    .capture(request, client, load_options)
+    .await?;
   let result = match capture {
     Ok(capture) => score_captured_page(&client, &request, capture).await,
     Err(result) => result,
@@ -552,6 +595,8 @@ mod tests {
 
   fn http_request(url: &str) -> HttpJudgePageRequest {
     HttpJudgePageRequest {
+      global_props: None,
+      initial_data: None,
       reference: None,
       reference_image: None,
       screenshot_settle_ms: None,
@@ -631,12 +676,82 @@ mod tests {
 
   #[test]
   fn request_defaults_match_the_library_contract() {
-    let request = http_request("file:///tmp/main.lynx.bundle")
-      .into_judge_request()
+    let capture_request = http_request("file:///tmp/main.lynx.bundle")
+      .into_capture_request()
       .expect("valid HTTP request");
 
-    assert_eq!(request.screenshot_settle, Duration::from_millis(16));
-    assert_eq!(request.timeout, Duration::from_secs(60));
+    assert_eq!(
+      capture_request.request.screenshot_settle,
+      Duration::from_millis(16)
+    );
+    assert_eq!(capture_request.request.timeout, Duration::from_secs(60));
+    assert_eq!(capture_request.load_options, PageLoadOptions::default());
+  }
+
+  #[test]
+  fn accepts_camel_case_page_data_as_json() {
+    let request: HttpJudgePageRequest = serde_json::from_value(json!({
+      "globalProps": {
+        "instant": true,
+        "messages": [{"beginRendering": {"surfaceId": "main"}}],
+        "theme": "light"
+      },
+      "initialData": {
+        "messages": [{"surfaceUpdate": {"surfaceId": "main"}}]
+      },
+      "task": "Render the A2UI page",
+      "url": "file:///tmp/a2ui.lynx.bundle"
+    }))
+    .expect("deserialize HTTP request");
+    let capture_request = request.into_capture_request().expect("valid HTTP request");
+
+    assert_eq!(
+      capture_request
+        .load_options
+        .global_props_json
+        .as_deref()
+        .map(serde_json::from_str::<Value>)
+        .transpose()
+        .expect("parse forwarded global props"),
+      Some(json!({
+        "instant": true,
+        "messages": [{"beginRendering": {"surfaceId": "main"}}],
+        "theme": "light"
+      }))
+    );
+    assert_eq!(
+      capture_request
+        .load_options
+        .initial_data_json
+        .as_deref()
+        .map(serde_json::from_str::<Value>)
+        .transpose()
+        .expect("parse forwarded initial data"),
+      Some(json!({
+        "messages": [{"surfaceUpdate": {"surfaceId": "main"}}]
+      }))
+    );
+  }
+
+  #[test]
+  fn accepts_snake_case_page_data_aliases() {
+    let request: HttpJudgePageRequest = serde_json::from_value(json!({
+      "global_props": {"messages": []},
+      "initial_data": {"playbackMode": true},
+      "task": "Render the A2UI page",
+      "url": "file:///tmp/a2ui.lynx.bundle"
+    }))
+    .expect("deserialize aliased HTTP request");
+    let capture_request = request.into_capture_request().expect("valid HTTP request");
+
+    assert_eq!(
+      capture_request.load_options.global_props_json.as_deref(),
+      Some(r#"{"messages":[]}"#)
+    );
+    assert_eq!(
+      capture_request.load_options.initial_data_json.as_deref(),
+      Some(r#"{"playbackMode":true}"#)
+    );
   }
 
   #[test]
@@ -644,10 +759,22 @@ mod tests {
     let mut request = http_request("file:///tmp/main.lynx.bundle");
     request.timeout_ms = Some(0);
     let error = request
-      .into_judge_request()
+      .into_capture_request()
       .expect_err("zero timeout must fail");
 
     assert_eq!(error.status, StatusCode::BAD_REQUEST);
+  }
+
+  #[test]
+  fn rejects_non_object_page_data() {
+    let mut request = http_request("file:///tmp/main.lynx.bundle");
+    request.global_props = Some(json!(["not", "an", "object"]));
+    let error = request
+      .into_capture_request()
+      .expect_err("non-object global props must fail");
+
+    assert_eq!(error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error.message, "globalProps must be a JSON object.");
   }
 
   #[test]
@@ -727,16 +854,16 @@ mod tests {
 
   #[tokio::test]
   async fn handles_independent_http_requests_concurrently() {
-    let executed_urls = Arc::new(Mutex::new(Vec::new()));
-    let worker_urls = Arc::clone(&executed_urls);
+    let executed_requests = Arc::new(Mutex::new(Vec::new()));
+    let worker_requests = Arc::clone(&executed_requests);
     let headless = Arc::new(
       HeadlessExecutor::new_with_worker(move |_runtime, receiver| {
         while let Ok(job) = receiver.recv() {
           let url = job.request.url.clone();
-          worker_urls
+          worker_requests
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .push(url.clone());
+            .push((url.clone(), job.load_options.clone()));
           let _ = job.response.send(CaptureResponse {
             capture: Err(completed_result(url)),
             client: job.client,
@@ -750,10 +877,9 @@ mod tests {
       headless: Arc::clone(&headless),
       prepare_request: prepare_test_request,
     };
-    let first = judge(
-      State(state.clone()),
-      Json(http_request("file:///tmp/first.lynx.bundle")),
-    );
+    let mut first_request = http_request("file:///tmp/first.lynx.bundle");
+    first_request.global_props = Some(json!({ "messages": [], "theme": "light" }));
+    let first = judge(State(state.clone()), Json(first_request));
     let second = judge(
       State(state),
       Json(http_request("file:///tmp/second.lynx.bundle")),
@@ -765,12 +891,21 @@ mod tests {
     assert_eq!(first_result.url, "file:///tmp/first.lynx.bundle");
     assert_eq!(second_result.url, "file:///tmp/second.lynx.bundle");
     assert_eq!(
-      *executed_urls
+      *executed_requests
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()),
       vec![
-        "file:///tmp/first.lynx.bundle".to_string(),
-        "file:///tmp/second.lynx.bundle".to_string(),
+        (
+          "file:///tmp/first.lynx.bundle".to_string(),
+          PageLoadOptions {
+            global_props_json: Some(r#"{"messages":[],"theme":"light"}"#.to_string()),
+            initial_data_json: None,
+          },
+        ),
+        (
+          "file:///tmp/second.lynx.bundle".to_string(),
+          PageLoadOptions::default(),
+        ),
       ]
     );
     headless.shutdown().expect("stop mock headless worker");
@@ -792,10 +927,13 @@ mod tests {
       shutdown_sender,
     ));
     let request = http_request("file:///tmp/panic.lynx.bundle")
-      .into_judge_request()
+      .into_capture_request()
       .expect("valid panic request");
 
-    let error = match headless.capture(request, test_client()).await {
+    let error = match headless
+      .capture(request.request, test_client(), request.load_options)
+      .await
+    {
       Ok(_) => panic!("worker panic must fail the capture"),
       Err(error) => error,
     };


### PR DESCRIPTION
## Summary

- connect A2UI Bench jobs to the independent Rust UI Judge HTTP sidecar through server-owned `UI_JUDGE_SERVER_URL` / `UI_JUDGE_BUNDLE_URL` configuration and a per-job health probe
- let the Rust server forward server-only `initialData` / `globalProps` objects into headless Lynx navigation without changing the public library request API or worker model
- report Judge completion separately from generation success, exclude infrastructure failures from score averages, preserve cancellation, and render `off` / `n/a` / `error` states in the Bench UI
- prevent model-controlled server-side resource loading by filtering `openUrl`, replacing resource-bearing components, and downgrading Markdown before headless rendering

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo build` (65/65 tasks)
- `pnpm --filter a2ui-server test` (32/32 tests)
- `cargo test -p ui_judge --lib --all-features` (53/53 tests)
- `cargo fmt --all -- --check`
- `pnpm dprint check`
- targeted `pnpm biome check` for all changed TypeScript/TSX files
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint .` (0 errors; 15 existing warnings)
- `pnpm changeset status --since=origin/main` (no packages to bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional UI Judge scoring for benchmark runs, including readiness checks and judge results in reports.
  * Added judge score summaries, run counts, statuses, warnings, and unavailable-state handling in the benchmark interface.
  * Added support for forwarding benchmark data and global properties to headless judge evaluations.

* **Bug Fixes**
  * Improved benchmark safety by blocking untrusted navigation and resource-loading requests.
  * Excluded unsafe navigation actions from benchmark catalogs and prompts.

* **Documentation**
  * Documented UI Judge configuration, health checks, environment variables, and request examples.

* **Tests**
  * Added coverage for judge readiness, scoring, cancellation, safety filtering, and benchmark aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->