### PR TITLE
fix(deps): resolve the preact peer to the vendored fork

### DIFF
--- a/.changeset/dedupe-preact-peer.md
+++ b/.changeset/dedupe-preact-peer.md
@@ -1,0 +1,3 @@
+---
+"@lynx-js/react": patch
+---

--- a/packages/genui/a2ui/package.json
+++ b/packages/genui/a2ui/package.json
@@ -170,7 +170,8 @@
     "@lynx-js/react": "workspace:*",
     "@lynx-js/types": "4.0.0",
     "@rstest/core": "catalog:rstest",
-    "@types/react": "^19.2.17"
+    "@types/react": "^19.2.17",
+    "preact": "catalog:lynxjs"
   },
   "peerDependencies": {
     "@lynx-js/lynx-ui": ">=3.133.0",

--- a/packages/genui/package.json
+++ b/packages/genui/package.json
@@ -142,7 +142,8 @@
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:^",
     "@lynx-js/react": "workspace:^",
     "@lynx-js/react-rsbuild-plugin": "workspace:^",
-    "@lynx-js/rspeedy": "workspace:^"
+    "@lynx-js/rspeedy": "workspace:^",
+    "preact": "catalog:lynxjs"
   },
   "peerDependencies": {
     "@lynx-js/lynx-ui": ">=3.133.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -224,7 +224,7 @@
     "build": "rslib build"
   },
   "dependencies": {
-    "preact": "npm:@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c"
+    "preact": "catalog:lynxjs"
   },
   "devDependencies": {
     "@lynx-js/types": "4.0.0",

--- a/packages/react/refresh/package.json
+++ b/packages/react/refresh/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@lynx-js/react": "workspace:*",
     "@prefresh/core": "^1.5.10",
-    "@prefresh/utils": "^1.2.1"
+    "@prefresh/utils": "^1.2.1",
+    "preact": "catalog:lynxjs"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,10 @@ catalogs:
     '@microsoft/api-extractor':
       specifier: 7.58.12
       version: 7.58.12
+  lynxjs:
+    preact:
+      specifier: npm:@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c
+      version: 10.29.1-20260519060144-e6da44c
   rsbuild:
     '@rsbuild/core':
       specifier: 2.1.7
@@ -776,7 +780,7 @@ importers:
         version: 0.2.9(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
       '@preact/signals':
         specifier: ^2.9.4
-        version: 2.9.4(preact@10.29.1)
+        version: 2.9.4(@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c)
       typedoc:
         specifier: ^0.28.20
         version: 0.28.20(typescript@6.0.3)
@@ -814,6 +818,9 @@ importers:
       '@lynx-js/rspeedy':
         specifier: workspace:^
         version: link:../rspeedy/core
+      preact:
+        specifier: catalog:lynxjs
+        version: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
 
   packages/genui/a2ui:
     dependencies:
@@ -822,7 +829,7 @@ importers:
         version: 0.10.5
       '@preact/signals':
         specifier: ^2.9.4
-        version: 2.9.4(preact@10.29.1)
+        version: 2.9.4(@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c)
     devDependencies:
       '@lynx-js/genui-cli':
         specifier: workspace:*
@@ -842,6 +849,9 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      preact:
+        specifier: catalog:lynxjs
+        version: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
 
   packages/genui/a2ui-catalog-extractor:
     dependencies:
@@ -1160,7 +1170,7 @@ importers:
   packages/react:
     dependencies:
       preact:
-        specifier: npm:@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c
+        specifier: catalog:lynxjs
         version: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
     devDependencies:
       '@lynx-js/types':
@@ -1198,10 +1208,13 @@ importers:
         version: link:..
       '@prefresh/core':
         specifier: ^1.5.10
-        version: 1.5.10(preact@10.29.1)
+        version: 1.5.10(@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c)
       '@prefresh/utils':
         specifier: ^1.2.1
         version: 1.2.1
+      preact:
+        specifier: catalog:lynxjs
+        version: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
 
   packages/react/runtime:
     devDependencies:
@@ -10200,9 +10213,6 @@ packages:
       rxjs:
         optional: true
 
-  preact@10.29.1:
-    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -14759,14 +14769,14 @@ snapshots:
 
   '@preact/signals-core@1.14.4': {}
 
-  '@preact/signals@2.9.4(preact@10.29.1)':
+  '@preact/signals@2.9.4(@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c)':
     dependencies:
       '@preact/signals-core': 1.14.4
-      preact: 10.29.1
+      preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
 
-  '@prefresh/core@1.5.10(preact@10.29.1)':
+  '@prefresh/core@1.5.10(@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c)':
     dependencies:
-      preact: 10.29.1
+      preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
 
   '@prefresh/utils@1.2.1': {}
 
@@ -20953,8 +20963,6 @@ snapshots:
       '@posthog/core': 1.45.0
     optionalDependencies:
       rxjs: 7.8.2
-
-  preact@10.29.1: {}
 
   prelude-ls@1.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -101,6 +101,10 @@ catalog:
   "@microsoft/api-extractor": "7.58.12"
 
 catalogs:
+  # Packages vendored from the Lynx toolchain.
+  lynxjs:
+    preact: "npm:@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c"
+
   adb:
     "@yume-chan/adb": ^2.6.0
     "@yume-chan/adb-scrcpy": ^2.3.2


### PR DESCRIPTION
## What

`@lynx-js/internal-preact` is preact republished under a different name, but its own sources still import from `'preact'`:

```
compat/src/memo.js:1       import { createElement } from 'preact';
compat/src/forwardRef.js:1 import { options } from 'preact';
hooks/src/index.d.ts       import { ... } from 'preact';
src/jsx.d.ts               import { ... } from 'preact';
```

After the rename that specifier no longer resolves to itself. It escapes the package and binds to whatever else in the tree happens to be named `preact`.

Something else is: `@prefresh/core` and `@preact/signals` peer-depend on `preact`, and the packages that pull them in — `packages/react/refresh`, `packages/genui`, `packages/genui/a2ui` — never declare `preact` themselves, so `autoInstallPeers` satisfies the peers with the public copy from the registry. A clean install has both:

```
node_modules/.pnpm/@lynx-js+internal-preact@10.29.1-20260519060144-e6da44c   ← the fork
node_modules/.pnpm/preact@10.29.1                                            ← for the peers
```

So the fork's `compat`, `hooks` and `jsx` bind to the public preact instead of to itself — a second module instance at runtime (its own `options` singleton, the hazard the existing `"@lynx-js/react": "workspace:*"` override already guards against for another package), and a second set of types at build time. `tsc --build` on `@lynx-js/react-runtime` then fails with:

```
src/element-template/index.ts(98,5): error TS2322: Type '<T>(defaultValue: T) => preact.Context<T>'
  is not assignable to type '<T>(defaultValue: T) =>
  import(".../@lynx-js/internal-preact/src/index").Context<T>'
```

TypeScript is structural, so this stays silent while the two versions happen to match — which is the case in this repo today, public `10.29.1` against fork `10.29.1-2026…` — and turns red downstream where the public copy resolves to an older version.

## Fix

Declare the alias on the three importers so their peers resolve to the fork, and pin it in a `lynxjs` catalog. After a clean install the public `preact` is gone from both the store and the lockfile, so the fork's self-reference resolves back to itself:

```
node_modules/.pnpm/@lynx-js+internal-preact@10.29.1-20260519060144-e6da44c
node_modules/.pnpm/@preact+signals@2.9.4_@lynx-js+internal-preact@10.29.1-20260519060144-e6da44c
node_modules/.pnpm/@prefresh+core@1.5.10_@lynx-js+internal-preact@10.29.1-20260519060144-e6da44c
```

`overrides` cannot do this — neither the bare form nor `"@prefresh/core>preact"` has any effect, because pnpm overrides do not apply to auto-installed peers. The importer has to declare the alias.

## Compatibility

Nothing changes for consumers: the alias is a `devDependency` on the three importers, and `packages/react` only moves the spec form of its existing `dependencies.preact` to `catalog:lynxjs`, which resolves to the same version at publish time. The changeset carries the resulting patch bump with no release note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package setup consistency by aligning the Preact dependency across the workspace, helping prevent duplicate runtime components and improving compatibility for supported integrations.

* **Chores**
  * Added a shared `lynxjs` catalog entry for Preact and updated package manifests to reference it consistently.
  * Applied a patch-level version bump for the React package to reflect the dependency alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->