### PR TITLE
fix(react-webpack-plugin): avoid duplicate async asset wrappers

### DIFF
--- a/.changeset/silly-chairs-visit.md
+++ b/.changeset/silly-chairs-visit.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Avoid wrapping shared async main-thread assets more than once.

--- a/.github/react-webpack-assets.instructions.md
+++ b/.github/react-webpack-assets.instructions.md
@@ -3,3 +3,5 @@ applyTo: "packages/webpack/react-webpack-plugin/**/*"
 ---
 
 When mutating emitted assets while iterating `compilation.chunkGroups`, deduplicate by asset filename. A shared async chunk can belong to multiple chunk groups, so chunk-group iteration may otherwise update the same physical asset more than once.
+
+React webpack plugin tests load the plugin through its built `lib` package export. After changing `src`, rebuild through Turbo before interpreting test results.

--- a/.github/react-webpack-assets.instructions.md
+++ b/.github/react-webpack-assets.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/webpack/react-webpack-plugin/**/*"
+---
+
+When mutating emitted assets while iterating `compilation.chunkGroups`, deduplicate by asset filename. A shared async chunk can belong to multiple chunk groups, so chunk-group iteration may otherwise update the same physical asset more than once.

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -501,6 +501,8 @@ class ReactWebpackPlugin {
               + 1,
           },
           () => {
+            const wrappedFiles = new Set<string>();
+
             compilation.chunkGroups.forEach(chunkGroup => {
               const isDynamicImport = !chunkGroup.isInitial()
                 && chunkGroup.origins.every(
@@ -520,11 +522,17 @@ class ReactWebpackPlugin {
                     continue;
                   }
 
+                  // A shared async chunk can belong to multiple chunk groups.
+                  if (wrappedFiles.has(file)) {
+                    continue;
+                  }
+
                   const asset = compilation.getAsset(file);
                   if (!asset) {
                     continue;
                   }
 
+                  wrappedFiles.add(file);
                   compilation.updateAsset(
                     file,
                     old =>

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/first.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/first.js
@@ -1,0 +1,3 @@
+export function loadShared() {
+  return import('./shared.js');
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/index.jsx
@@ -1,0 +1,33 @@
+/// <reference types="vitest/globals" />
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+it('should load a shared async chunk from multiple async parents', async () => {
+  const [{ loadShared: loadFromFirst }, { loadShared: loadFromSecond }] =
+    await Promise.all([
+      import('./first.js'),
+      import('./second.js'),
+    ]);
+  const [first, second] = await Promise.all([
+    loadFromFirst(),
+    loadFromSecond(),
+  ]);
+
+  expect(first.value).toBe('shared');
+  expect(second.value).toBe('shared');
+});
+
+it('should wrap the nested shared main-thread asset once', async () => {
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/lazy-bundle/shared.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  const wrappers = tasmJSON.lepusCode.root.match(
+    /\(function \(globDynamicComponentEntry\) \{/g,
+  );
+  expect(wrappers).toHaveLength(1);
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/rspack.config.js
@@ -1,0 +1,28 @@
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { createConfig } from '../../../create-react-config.js';
+
+const config = createConfig();
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: import.meta.dirname,
+  ...config,
+  output: {
+    ...config.output,
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
+  },
+  plugins: [
+    ...config.plugins,
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: ['main__main-thread', 'main__background'],
+      filename: 'main/template.js',
+      intermediate: '.rspeedy/main',
+    }),
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/second.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/second.js
@@ -1,0 +1,3 @@
+export function loadShared() {
+  return import('./shared.js');
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/shared.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/shared.js
@@ -1,0 +1,1 @@
+export const value = 'shared';

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/nested-shared-async-chunk/test.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    // We do not run main-thread.js since the async chunks have been modified.
+    // 'main__main-thread.js',
+    'main__background.js',
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/same-file-different-paths/index.jsx
@@ -1,6 +1,6 @@
 /// <reference types="vitest/globals" />
 
-import { readdir } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { load } from './subdir/importer.js';
@@ -27,4 +27,18 @@ it('should generate a single lazy bundle inside the async directory', async () =
     name.endsWith('.bundle')
   );
   expect(escapedBundles).toHaveLength(0);
+});
+
+it('should wrap the shared main-thread asset once', async () => {
+  const tasmJSON = JSON.parse(
+    await readFile(
+      join(__dirname, '.rspeedy/lazy-bundle/foo.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  const wrappers = tasmJSON.lepusCode.root.match(
+    /\(function \(globDynamicComponentEntry\) \{/g,
+  );
+  expect(wrappers).toHaveLength(1);
 });

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/first.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/first.js
@@ -1,0 +1,3 @@
+export function loadShared() {
+  return import('./shared.js');
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/index.jsx
@@ -1,0 +1,31 @@
+/// <reference types="vitest/globals" />
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { loadShared as loadFromFirst } from './first.js';
+import { loadShared as loadFromSecond } from './second.js';
+
+it('should load a shared async chunk from multiple import sites', async () => {
+  const [first, second] = await Promise.all([
+    loadFromFirst(),
+    loadFromSecond(),
+  ]);
+
+  expect(first.value).toBe('shared');
+  expect(second.value).toBe('shared');
+});
+
+it('should wrap the shared main-thread asset once', async () => {
+  const tasmJSON = JSON.parse(
+    await readFile(
+      resolve(__dirname, '.rspeedy/lazy-bundle/shared.js/tasm.json'),
+      'utf-8',
+    ),
+  );
+
+  const wrappers = tasmJSON.lepusCode.root.match(
+    /\(function \(globDynamicComponentEntry\) \{/g,
+  );
+  expect(wrappers).toHaveLength(1);
+});

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/rspack.config.js
@@ -1,0 +1,28 @@
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { createConfig } from '../../../create-react-config.js';
+
+const config = createConfig();
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: import.meta.dirname,
+  ...config,
+  output: {
+    ...config.output,
+    chunkFilename: '.rspeedy/lazy-bundle/[name].js',
+  },
+  plugins: [
+    ...config.plugins,
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: ['main__main-thread', 'main__background'],
+      filename: 'main/template.js',
+      intermediate: '.rspeedy/main',
+    }),
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/second.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/second.js
@@ -1,0 +1,3 @@
+export function loadShared() {
+  return import('./shared.js');
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/shared.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/shared.js
@@ -1,0 +1,1 @@
+export const value = 'shared';

--- a/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/code-splitting/shared-async-chunk/test.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import("@lynx-js/test-tools").TConfigCaseConfig} */
+module.exports = {
+  bundlePath: [
+    // We do not run main-thread.js since the async chunk has been modified.
+    // 'main__main-thread.js',
+    'main__background.js',
+  ],
+};


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented shared asynchronous JavaScript assets from receiving duplicate runtime wrappers when the same async chunk is referenced from multiple chunk groups.
  * Improved correctness for nested shared async chunk loading so the wrapper is emitted only once.
* **Tests**
  * Added/extended coverage for shared and nested shared async chunks, including concurrent loading and verification via generated build artifacts.
  * Added an additional assertion to ensure the shared main-thread wrapper appears exactly once across related scenarios.
* **Documentation**
  * Added contributor guidance to deduplicate emitted assets when iterating chunk groups that may share async chunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #3280.

## Summary

- deduplicate main-thread wrapper injection by emitted asset filename
- add a regression fixture where two import sites share one async chunk
- document the asset-level deduplication requirement for future plugin changes

## Testing

- `pnpm turbo build`
- `pnpm --dir packages/webpack/react-webpack-plugin test`
- `pnpm turbo api-extractor -- --local`
- `pnpm dprint check`
- `pnpm biome check` on the changed source and fixture files
- `pnpm eslint packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts`

## Checklist

- [x] Tests updated
- [x] Documentation updated
- [x] Changeset added
