### PR TITLE
feat: print TASM encode timing output

### DIFF
--- a/.changeset/quiet-builds-trace.md
+++ b/.changeset/quiet-builds-trace.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Print TASM encode timing output for `DEBUG=rspeedy:template` and `DEBUG=rspeedy:*`.

--- a/packages/webpack/template-webpack-plugin/package.json
+++ b/packages/webpack/template-webpack-plugin/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.31",
     "@lynx-js/css-serializer": "workspace:*",
-    "@lynx-js/tasm": "0.0.48",
+    "@lynx-js/tasm": "0.0.49",
     "@lynx-js/web-core": "workspace:*",
     "@lynx-js/webpack-runtime-globals": "workspace:^",
     "@rspack/lite-tapable": "1.1.2",

--- a/packages/webpack/template-webpack-plugin/src/worker/encode.ts
+++ b/packages/webpack/template-webpack-plugin/src/worker/encode.ts
@@ -19,8 +19,28 @@ export default async function encode(
   const { getEncodeMode } =
     (await import(tasmPkg)) as typeof import('@lynx-js/tasm');
   // Napi will be used if supported
-  const encode = getEncodeMode(encodeBinary) as (
-    options: unknown,
-  ) => Promise<EncodeResult>;
-  return encode(encodeOptions);
+  const tasmEncode = getEncodeMode(encodeBinary);
+
+  if (!isDebug()) {
+    return tasmEncode(encodeOptions, false);
+  }
+
+  try {
+    return await tasmEncode(encodeOptions, true);
+  } finally {
+    // biome-ignore lint/suspicious/noConsoleLog: This is opt-in encode trace output.
+    console.log('[TASM Encode Trace] End!\n');
+  }
+}
+
+export function isDebug(): boolean {
+  if (!process.env['DEBUG']) {
+    return false;
+  }
+
+  const values = process.env['DEBUG'].toLocaleLowerCase().split(',');
+  return [
+    'rspeedy:*',
+    'rspeedy:template',
+  ].some(value => values.includes(value));
 }

--- a/packages/webpack/template-webpack-plugin/test/encode-worker.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/encode-worker.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterEach, describe, expect, rs, test } from '@rstest/core';
+
+import encode from '../src/worker/encode.js';
+
+const context = path.dirname(new URL(import.meta.url).pathname);
+const tasmPkg = pathToFileURL(
+  path.join(context, 'fixtures/mock-tasm.mjs'),
+).href;
+const encodeOptions = {
+  compilerOptions: { targetSdkVersion: '3.2' },
+  sourceContent: {
+    dsl: 'react_nodiff',
+    appType: 'card',
+    config: {},
+  },
+  css: {
+    cssMap: {},
+    cssSource: {},
+  },
+  lepusCode: { lepusChunk: {} },
+  manifest: {},
+  customSections: {},
+};
+
+interface EncodeTraceRow {
+  name: string;
+  duration_us: number;
+  duration_ms: number;
+}
+
+function isEncodeTraceRow(value: unknown): value is EncodeTraceRow {
+  return typeof value === 'object'
+    && value !== null
+    && 'name' in value
+    && typeof value.name === 'string'
+    && 'duration_us' in value
+    && typeof value.duration_us === 'number'
+    && 'duration_ms' in value
+    && typeof value.duration_ms === 'number';
+}
+
+describe('encode worker trace configuration', () => {
+  afterEach(() => {
+    rs.restoreAllMocks();
+    rs.unstubAllEnvs();
+  });
+
+  test.each(
+    [
+      ['rspeedy:template', true],
+      ['rspeedy:*', true],
+      ['rspeedy', false],
+      ['*', false],
+      ['other', false],
+    ] as const,
+  )(
+    'passes DEBUG=%s as trace=%s to the TASM encoder',
+    async (debugEnv, expected) => {
+      rs.stubEnv('DEBUG', debugEnv);
+      rs.spyOn(console, 'log').mockImplementation(() => void 0);
+      const result = await encode({
+        encodeOptions: {},
+        tasmPkg,
+      });
+
+      expect(result.lepus_code).toBe(String(expected));
+    },
+  );
+
+  test('prints the TASM encode trace when enabled', async () => {
+    rs.stubEnv('DEBUG', 'rspeedy:template');
+    const log = rs.spyOn(console, 'log').mockImplementation(() => void 0);
+    const table = rs.spyOn(console, 'table').mockImplementation(() => void 0);
+
+    await encode({
+      encodeOptions,
+    });
+
+    expect(log.mock.calls).toEqual([
+      ['[TASM Encode Trace]'],
+      ['[TASM Encode Trace] End!\n'],
+    ]);
+    expect(table).toHaveBeenCalledTimes(1);
+    const tableOutput: unknown = table.mock.calls[0]?.[0];
+    const traceRows = Array.isArray(tableOutput)
+      ? tableOutput.filter(row => isEncodeTraceRow(row))
+      : [];
+    const encodeRow = traceRows.find(row => row.name === 'Encode');
+
+    expect(typeof encodeRow?.duration_us).toBe('number');
+    expect(typeof encodeRow?.duration_ms).toBe('number');
+    expect(traceRows.some(row => row.name === 'ParseEncodeOptions')).toBe(true);
+  });
+
+  test('does not print the TASM encode trace when disabled', async () => {
+    rs.stubEnv('DEBUG', 'rspeedy');
+    const log = rs.spyOn(console, 'log').mockImplementation(() => void 0);
+    const table = rs.spyOn(console, 'table').mockImplementation(() => void 0);
+
+    await encode({
+      encodeOptions,
+    });
+
+    expect(log).not.toHaveBeenCalled();
+    expect(table).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webpack/template-webpack-plugin/test/fixtures/mock-tasm.mjs
+++ b/packages/webpack/template-webpack-plugin/test/fixtures/mock-tasm.mjs
@@ -1,0 +1,16 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { Buffer } from 'node:buffer';
+
+export function getEncodeMode() {
+  return (_options, enableTrace) => ({
+    buffer: Buffer.alloc(0),
+    error_msg: '',
+    lepus_code: String(enableTrace),
+    lepus_debug: '',
+    section_size: '',
+    status: 0,
+    trace: '',
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2434,8 +2434,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/css-serializer
       '@lynx-js/tasm':
-        specifier: 0.0.48
-        version: 0.0.48
+        specifier: 0.0.49
+        version: 0.0.49
       '@lynx-js/web-core':
         specifier: workspace:*
         version: link:../../web-platform/web-core
@@ -4325,6 +4325,10 @@ packages:
 
   '@lynx-js/tasm@0.0.48':
     resolution: {integrity: sha512-6JeySjqS9A424+KdBhI08Km6tdbZ/eLEpqbbLOjzwmY8VhitHOeWoU1bOpfafxYWmEpie/ip7F3IaN/6K3mmjw==}
+    hasBin: true
+
+  '@lynx-js/tasm@0.0.49':
+    resolution: {integrity: sha512-sI+xmLXaMvXWFN5n47kYNHFEMIEpkrz/bVvU2GwvhB26lXfYPdSNedE3bh85vfW/vAmYsB/TbKwtiNhXgN3LDw==}
     hasBin: true
 
   '@lynx-js/trace-processor@0.0.1':
@@ -14409,6 +14413,8 @@ snapshots:
       - react-dom
 
   '@lynx-js/tasm@0.0.48': {}
+
+  '@lynx-js/tasm@0.0.49': {}
 
   '@lynx-js/trace-processor@0.0.1':
     dependencies:


### PR DESCRIPTION
… output

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional TASM encoding timing output when debugging is enabled with `DEBUG=rspeedy:template` or `DEBUG=rspeedy:*`.
  * Debug output includes encoding trace details and timing information.

* **Bug Fixes**
  * Ensured the trace completion message is logged even when encoding encounters an error.

* **Tests**
  * Added coverage for enabled and disabled debug tracing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
