### PR TITLE
ci: guard against a second preact instance in the lockfile

### DIFF
--- a/.changeset/dedupe-preact-peer.md
+++ b/.changeset/dedupe-preact-peer.md
@@ -1,3 +1,5 @@
 ---
 "@lynx-js/react": patch
 ---
+
+Resolve the `preact` peer dependency to the vendored `@lynx-js/internal-preact`, preventing duplicate preact copies in the dependency tree.

--- a/.github/scripts/check-single-preact-instance.cjs
+++ b/.github/scripts/check-single-preact-instance.cjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+const { readFileSync } = require('node:fs');
+
+const lockfile = readFileSync('pnpm-lock.yaml', 'utf8');
+const found = lockfile.match(/^ {2}'?preact@[^:]*:/gm) ?? [];
+
+if (found.length > 0) {
+  console.error(
+    `A standalone \`preact\` package appeared in pnpm-lock.yaml:\n\n${
+      found.map((line) => `  ${line.trim()}`).join('\n')
+    }\n\nEvery \`preact\` specifier must resolve to the vendored`
+      + ' `@lynx-js/internal-preact` (the `lynxjs` catalog in'
+      + ' pnpm-workspace.yaml), or two preact module instances exist at'
+      + ' runtime. Alias `preact: "catalog:lynxjs"` in the package that'
+      + ' pulled it in.',
+  );
+  throw new Error(
+    `${found.length} standalone preact instance(s) in pnpm-lock.yaml.`,
+  );
+}
+
+console.info('All preact specifiers resolve to @lynx-js/internal-preact.');

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,8 @@ jobs:
           pnpm biome check
       - name: Package Metadata Check
         run: pnpm --package=@pnpm/meta-updater@2.0.6 dlx meta-updater --test
+      - name: Preact Dedupe Check
+        run: node .github/scripts/check-single-preact-instance.cjs
       - name: API Check
         run: pnpm turbo api-extractor
       - name: Changeset Check


### PR DESCRIPTION
Follow-up to #3276.

- Fill in the empty `dedupe-preact-peer` changeset so it does not become an empty CHANGELOG entry (raised in https://github.com/lynx-family/lynx-stack/pull/3283#discussion_r3679713984).
- Add a CI check that fails when a standalone `preact` package reappears in pnpm-lock.yaml — every `preact` specifier must resolve to the vendored `@lynx-js/internal-preact`, otherwise two preact module instances exist at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate Preact instances by ensuring dependencies use the vendored Preact implementation.
  * Added automated validation to detect multiple Preact instances and prevent related runtime issues.
* **Chores**
  * Updated the React package with a patch release.
* **Tests**
  * Added a code-style workflow step that runs a Preact deduplication check during CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->