### PR TITLE
fix(web-elements): clamp setFoldExpanded offset and fill the foldview header width

### DIFF
--- a/.changeset/foldview-clamp-set-fold-expanded.md
+++ b/.changeset/foldview-clamp-set-fold-expanded.md
@@ -1,0 +1,9 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Clamp the `setFoldExpanded` offset of `<x-foldview-ng>` to the scrollable length.
+
+`setFoldExpanded` called the native `scrollTo`, bypassing the clamping done by the
+`scrollTop` setter. A page collapsing its header with a deliberately large offset
+(e.g. `offset: '99999px'`) scrolled past the end, which does not happen on native.

--- a/.changeset/foldview-header-width.md
+++ b/.changeset/foldview-header-width.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Give `<x-foldview-header-ng>` a `width: 100%`.
+
+The element is laid out with `position: absolute` but had no width, so it shrank to
+fit its content instead of filling the foldview.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -2981,6 +2981,31 @@ test.describe('reactlynx3 tests', () => {
           );
         },
       );
+      test(
+        'basic-element-x-foldview-ng-method-setFoldExpanded-overflow',
+        async ({ page }, {
+          title,
+        }) => {
+          await goto(page, title);
+          await page.locator('#tap').click();
+          await wait(100);
+          // the header is 400px and the toolbar is 200px, so the foldview can
+          // only be scrolled by 200px however large the requested offset is
+          const scrollTop = await page.locator('#foldview').evaluate((
+            element,
+          ) => element.scrollTop);
+          expect(scrollTop).toBe(200);
+        },
+      );
+      test(
+        'basic-element-x-foldview-ng-header-width',
+        async ({ page }, { title }) => {
+          await goto(page, title);
+          await wait(100);
+          // the header is out of flow, it still has to fill the foldview
+          await expect(page.locator('#header')).toHaveCSS('width', '300px');
+        },
+      );
     });
     test.describe('svg', () => {
       test('basic-element-svg-bindload', async ({ page }, { title }) => {

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-header-width/index.css
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-header-width/index.css
@@ -1,0 +1,8 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+view {
+  height: 100px;
+}

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-header-width/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-header-width/index.jsx
@@ -1,0 +1,30 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root } from '@lynx-js/react';
+import './index.css';
+function App() {
+  return (
+    <view style='width: 100%; height:600px; display:flex; flex-direction: column;'>
+      <x-foldview-ng
+        id='foldview'
+        style='width:300px; height:600px; background-color: wheat;display:flex; flex-direction: column;'
+      >
+        <x-foldview-toolbar-ng style='display:flex; width:100%; background-color: cadetblue;'>
+          <view style='height:200px;width:100%;'>
+          </view>
+        </x-foldview-toolbar-ng>
+        <x-foldview-header-ng
+          id='header'
+          style='height:400px; background-color: pink;'
+        >
+          <view style='background-color:aqua; width:100px;'></view>
+        </x-foldview-header-ng>
+        <x-foldview-slot-ng style='display:flex; width:100%; height:300px; flex-direction:column; background-color: salmon;'>
+          <view style='background-color:orange;'></view>
+        </x-foldview-slot-ng>
+      </x-foldview-ng>
+    </view>
+  );
+}
+root.render(<App></App>);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-method-setFoldExpanded-overflow/index.css
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-method-setFoldExpanded-overflow/index.css
@@ -1,0 +1,9 @@
+/*
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+*/
+view {
+  width: 100%;
+  height: 100px;
+}

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-method-setFoldExpanded-overflow/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-method-setFoldExpanded-overflow/index.jsx
@@ -1,0 +1,40 @@
+// Copyright 2023 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useCallback } from '@lynx-js/react';
+import './index.css';
+function App() {
+  const handleTap = useCallback(() => {
+    lynx.createSelectorQuery()
+      .select('#foldview')
+      .invoke({
+        method: 'setFoldExpanded',
+        params: {
+          offset: 99999,
+          smooth: false,
+        },
+      })
+      .exec();
+  }, []);
+  return (
+    <view style='width: 100%; height:600px; display:flex; flex-direction: column;'>
+      <x-foldview-ng
+        id='foldview'
+        style='width:80%; height:600px; background-color: wheat;display:flex; flex-direction: column;'
+      >
+        <x-foldview-toolbar-ng style='display:flex; width:70%; background-color: cadetblue;'>
+          <view style='height:200px;width:100%;'>
+          </view>
+        </x-foldview-toolbar-ng>
+        <x-foldview-header-ng style='position:absolute; width:80%; height:400px; background-color: pink;'>
+          <view style='background-color:aqua; width:95%;'></view>
+        </x-foldview-header-ng>
+        <x-foldview-slot-ng style='display:flex; width:90%; height:400px; flex-direction:column; background-color: salmon;'>
+          <view style='background-color:orange;' bindtap={handleTap} id='tap'>
+          </view>
+        </x-foldview-slot-ng>
+      </x-foldview-ng>
+    </view>
+  );
+}
+root.render(<App></App>);

--- a/packages/web-platform/web-elements/src/elements/XFoldViewNg/XFoldviewNg.ts
+++ b/packages/web-platform/web-elements/src/elements/XFoldViewNg/XFoldviewNg.ts
@@ -63,8 +63,10 @@ export class XFoldviewNg extends HTMLElement {
   setFoldExpanded(params: { offset: string; smooth: boolean }) {
     const { offset, smooth = true } = params;
     const offsetValue = parseFloat(offset);
+    // `scrollTo` is the native method and does not go through the `scrollTop`
+    // setter above, so the offset has to be clamped here as well.
     this.scrollTo({
-      top: offsetValue,
+      top: Math.min(Math.max(offsetValue, 0), this[scrollableLength]),
       behavior: smooth ? 'smooth' : 'instant',
     });
   }

--- a/packages/web-platform/web-elements/src/elements/XFoldViewNg/x-foldview-ng.css
+++ b/packages/web-platform/web-elements/src/elements/XFoldViewNg/x-foldview-ng.css
@@ -59,6 +59,8 @@ x-foldview-header-ng {
   order: 2;
   flex: 0 0 auto;
   position: absolute;
+  /* an out-of-flow box shrinks to fit its content without an explicit width */
+  width: 100%;
 }
 
 x-foldview-ng[header-over-slot] > x-foldview-slot-ng,


### PR DESCRIPTION
Two independent `<x-foldview-ng>` fixes, both making the web implementation behave the way the native one already does.

## Summary

- Clamp `setFoldExpanded` offsets to the measured collapsible header range.
- Make `x-foldview-header-ng` fill the foldview width by default.
- Keep the overflow regression fixture physically scrollable through the full 200px logical clamp range.

## Testing

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm turbo build` (70/70 tasks)
- [x] `pnpm --filter @lynx-js/web-core-e2e test --grep 'basic-element-x-foldview-ng-(method-setFoldExpanded-overflow|header-width)'` (6/6 across Chromium, Firefox, and WebKit)\n- [x] `pnpm turbo api-extractor -- --local` (25/25 tasks)\n- [x] `pnpm changeset status --since=upstream/main`\n- [x] `pnpm dprint check packages/web-platform/web-core-e2e/tests/reactlynx/basic-element-x-foldview-ng-method-setFoldExpanded-overflow/index.jsx`\n\n## Checklist\n\n- [x] Tests updated.\n- [x] Documentation updated.\n- [x] Changesets added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented foldview expansion from scrolling beyond the available content when given oversized offsets.
  * Updated foldview headers to span the full width of their container.

* **Tests**
  * Added coverage for scroll boundary handling and full-width foldview header rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->