### PR TITLE
feat(motion): add multi-entry web examples

### DIFF
--- a/examples/motion/lynx.config.js
+++ b/examples/motion/lynx.config.js
@@ -5,15 +5,17 @@ import { defineConfig } from '@lynx-js/rspeedy';
 const enableBundleAnalysis = !!process.env['RSPEEDY_BUNDLE_ANALYSIS'];
 
 export default defineConfig({
-  environments: {
-    lynx: {},
-    web: {},
-  },
   source: {
     entry: {
-      main: './src/index.tsx',
+      basic: './src/Basic/index.tsx',
+      gesture: './src/iOSSlider/index.tsx',
       mini: './src/Mini/index.tsx',
+      'motion-value': './src/MotionValue/index.tsx',
+      spring: './src/Spring/index.tsx',
     },
+  },
+  output: {
+    filename: '[name].[platform].bundle',
   },
   plugins: [
     pluginReactLynx(),
@@ -24,6 +26,10 @@ export default defineConfig({
       },
     }),
   ],
+  environments: {
+    web: {},
+    lynx: {},
+  },
   performance: {
     profile: enableBundleAnalysis,
   },

--- a/examples/motion/src/Basic/index.tsx
+++ b/examples/motion/src/Basic/index.tsx
@@ -1,5 +1,10 @@
 import { animate } from '@lynx-js/motion';
-import { runOnMainThread, useEffect, useMainThreadRef } from '@lynx-js/react';
+import {
+  root,
+  runOnMainThread,
+  useEffect,
+  useMainThreadRef,
+} from '@lynx-js/react';
 import type { MainThread } from '@lynx-js/types';
 
 import './styles.css';
@@ -58,4 +63,10 @@ export default function Basic() {
       </view>
     </view>
   );
+}
+
+root.render(<Basic />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
 }

--- a/examples/motion/src/MotionValue/index.tsx
+++ b/examples/motion/src/MotionValue/index.tsx
@@ -1,6 +1,11 @@
 import { motionValue } from '@lynx-js/motion';
 import type { MotionValue } from '@lynx-js/motion';
-import { runOnMainThread, useEffect, useMainThreadRef } from '@lynx-js/react';
+import {
+  root,
+  runOnMainThread,
+  useEffect,
+  useMainThreadRef,
+} from '@lynx-js/react';
 import type { MainThread } from '@lynx-js/types';
 
 import './styles.css';
@@ -74,4 +79,10 @@ export default function Basic() {
       </view>
     </view>
   );
+}
+
+root.render(<Basic />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
 }

--- a/examples/motion/src/Spring/index.tsx
+++ b/examples/motion/src/Spring/index.tsx
@@ -1,5 +1,10 @@
 import { animate } from '@lynx-js/motion';
-import { runOnMainThread, useEffect, useMainThreadRef } from '@lynx-js/react';
+import {
+  root,
+  runOnMainThread,
+  useEffect,
+  useMainThreadRef,
+} from '@lynx-js/react';
 import type { MainThread } from '@lynx-js/types';
 
 import './styles.css';
@@ -49,4 +54,10 @@ export default function Spring() {
       </view>
     </view>
   );
+}
+
+root.render(<Spring />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
 }

--- a/examples/motion/src/iOSSlider/index.tsx
+++ b/examples/motion/src/iOSSlider/index.tsx
@@ -8,7 +8,12 @@ import {
   transformValue,
   useMotionValueRef,
 } from '@lynx-js/motion';
-import { runOnMainThread, useEffect, useMainThreadRef } from '@lynx-js/react';
+import {
+  root,
+  runOnMainThread,
+  useEffect,
+  useMainThreadRef,
+} from '@lynx-js/react';
 import type { MainThread } from '@lynx-js/types';
 
 import SunPng from './sun.png';
@@ -137,4 +142,10 @@ export default function Comp() {
       </view>
     </view>
   );
+}
+
+root.render(<Comp />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
 }


### PR DESCRIPTION
Expose Basic, Gesture, Mini, MotionValue, and Spring as standalone Motion example entries for both Lynx and Web previews. Align the example output naming with the platform-specific multi-entry layout used by lynx-examples.

Follow-up to #3295.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the motion examples with dedicated Basic, Gesture, Mini, Motion Value, and Spring demos.
  * Added separate build outputs for each motion example across supported platforms.
* **Improvements**
  * Motion examples now mount consistently and support smoother hot-reload behavior during development.
  * Existing web and Lynx targets remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->