### PR TITLE
fix(genui): support IPv6 agent connections

### DIFF
--- a/.github/genui-server.instructions.md
+++ b/.github/genui-server.instructions.md
@@ -14,7 +14,7 @@ Build `genui-server` as an executable ESM Hono server through `rslib.config.ts`.
 
 Read the server port from `LYNX_USE_PORT`, defaulting to `3000`; do not use `PORT` as a compatibility fallback.
 
-Bind the executable server to the IPv6 unspecified address `::` by default so Node accepts both IPv6 and IPv4 connections through its dual-stack listener. Preserve explicit `HOST` overrides, and format IPv6 addresses with brackets when logging HTTP URLs.
+Read the bind address from `LYNX_USE_HOST`, defaulting to the IPv6 unspecified address `::` so Node accepts both IPv6 and IPv4 connections through its dual-stack listener; do not use `HOST` as a compatibility fallback. Format IPv6 addresses with brackets when logging HTTP URLs.
 
 Derive CORS preflight and 405 `Allow` behavior from the composed Hono application's route table after mounting sub-applications. Do not maintain a second hand-written route and method inventory.
 

--- a/.github/genui-server.instructions.md
+++ b/.github/genui-server.instructions.md
@@ -14,6 +14,8 @@ Build `genui-server` as an executable ESM Hono server through `rslib.config.ts`.
 
 Read the server port from `LYNX_USE_PORT`, defaulting to `3000`; do not use `PORT` as a compatibility fallback.
 
+Bind the executable server to the IPv6 unspecified address `::` by default so Node accepts both IPv6 and IPv4 connections through its dual-stack listener. Preserve explicit `HOST` overrides, and format IPv6 addresses with brackets when logging HTTP URLs.
+
 Derive CORS preflight and 405 `Allow` behavior from the composed Hono application's route table after mounting sub-applications. Do not maintain a second hand-written route and method inventory.
 
 Every SSE route that starts model generation must propagate both `Request.signal` aborts and response-stream cancellation to the upstream model call. Guard enqueues and stream closure against reader cancellation, remove abort listeners during cleanup, and cover the disconnect path with a test.

--- a/packages/genui/server/AGENTS.md
+++ b/packages/genui/server/AGENTS.md
@@ -146,7 +146,7 @@ pnpm dev
 
 The server listens on `[::]:3000` by default. Node uses this IPv6 unspecified
 address as a dual-stack listener, accepting both IPv6 and IPv4 connections.
-Override the bind address and port with `HOST` and `LYNX_USE_PORT`.
+Override the bind address and port with `LYNX_USE_HOST` and `LYNX_USE_PORT`.
 
 Set `GENUI_HTTP2=1` to start a cleartext HTTP/2 (h2c) server instead of the
 default HTTP/1 server. HTTP transport adaptation, including HTTP/2
@@ -173,8 +173,8 @@ pnpm --filter a2ui-server start
 At the package root, `./start.sh` provides the production entry point. It
 checks for a supported Node.js 22 or 24 runtime and the built server artifact
 before launching the same `dist/index.js`. The launcher and server directly
-consume `HOST` and `LYNX_USE_PORT`, preserving direct overrides and the
-dual-stack `[::]:3000` default.
+consume `LYNX_USE_HOST` and `LYNX_USE_PORT`, preserving direct overrides and
+the dual-stack `[::]:3000` default.
 
 Each protocol module default-exports a Hono sub-application. `src/app.ts`
 assembles them, owns path and method matching, and supplies shared 404, 405,

--- a/packages/genui/server/AGENTS.md
+++ b/packages/genui/server/AGENTS.md
@@ -144,8 +144,9 @@ Build, run, and restart the Hono server as sources change:
 pnpm dev
 ```
 
-The server listens on `0.0.0.0:3000` by default. Override the bind address and
-port with `HOST` and `LYNX_USE_PORT`.
+The server listens on `[::]:3000` by default. Node uses this IPv6 unspecified
+address as a dual-stack listener, accepting both IPv6 and IPv4 connections.
+Override the bind address and port with `HOST` and `LYNX_USE_PORT`.
 
 Set `GENUI_HTTP2=1` to start a cleartext HTTP/2 (h2c) server instead of the
 default HTTP/1 server. HTTP transport adaptation, including HTTP/2
@@ -173,7 +174,7 @@ At the package root, `./start.sh` provides the production entry point. It
 checks for a supported Node.js 22 or 24 runtime and the built server artifact
 before launching the same `dist/index.js`. The launcher and server directly
 consume `HOST` and `LYNX_USE_PORT`, preserving direct overrides and the
-`0.0.0.0:3000` default.
+dual-stack `[::]:3000` default.
 
 Each protocol module default-exports a Hono sub-application. `src/app.ts`
 assembles them, owns path and method matching, and supplies shared 404, 405,

--- a/packages/genui/server/app/common/cors.ts
+++ b/packages/genui/server/app/common/cors.ts
@@ -25,6 +25,8 @@ function isLocalDevOrigin(origin: string): boolean {
         hostname === 'localhost'
         || hostname === '127.0.0.1'
         || hostname === '0.0.0.0'
+        || hostname === '[::1]'
+        || hostname === '[::]'
         || hostname.startsWith('10.')
         || hostname.startsWith('192.168.')
         || /^172\.(?:1[6-9]|2\d|3[01])\./u.test(hostname)

--- a/packages/genui/server/src/index.ts
+++ b/packages/genui/server/src/index.ts
@@ -22,8 +22,9 @@ const server = serve(
   },
   ({ address, port }) => {
     const protocol = HTTP2_ENABLED ? 'HTTP/2' : 'HTTP/1';
+    const formattedAddress = address.includes(':') ? `[${address}]` : address;
     console.info(
-      `GenUI ${protocol} server listening on http://${address}:${port}`,
+      `GenUI ${protocol} server listening on http://${formattedAddress}:${port}`,
     );
   },
 );

--- a/packages/genui/server/src/listen-options.ts
+++ b/packages/genui/server/src/listen-options.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 const DEFAULT_PORT = 3_000;
-const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_HOST = '::';
 
 export interface ListenOptions {
   hostname: string;

--- a/packages/genui/server/src/listen-options.ts
+++ b/packages/genui/server/src/listen-options.ts
@@ -28,7 +28,7 @@ export function resolveListenOptions(
   env: Readonly<NodeJS.ProcessEnv>,
 ): ListenOptions {
   return {
-    hostname: env.HOST ?? DEFAULT_HOST,
+    hostname: env.LYNX_USE_HOST ?? DEFAULT_HOST,
     port: readPort(env.LYNX_USE_PORT, 'LYNX_USE_PORT'),
   };
 }

--- a/packages/genui/server/start.sh
+++ b/packages/genui/server/start.sh
@@ -28,7 +28,7 @@ if [[ ! -f "${SERVER_ENTRY}" ]]; then
   exit 1
 fi
 
-export HOST="${HOST:-::}"
+export LYNX_USE_HOST="${LYNX_USE_HOST:-::}"
 export LYNX_USE_PORT="${LYNX_USE_PORT:-3000}"
 
 cd "${SCRIPT_DIR}"

--- a/packages/genui/server/start.sh
+++ b/packages/genui/server/start.sh
@@ -28,7 +28,7 @@ if [[ ! -f "${SERVER_ENTRY}" ]]; then
   exit 1
 fi
 
-export HOST="${HOST:-0.0.0.0}"
+export HOST="${HOST:-::}"
 export LYNX_USE_PORT="${LYNX_USE_PORT:-3000}"
 
 cd "${SCRIPT_DIR}"

--- a/packages/genui/server/test/app.test.ts
+++ b/packages/genui/server/test/app.test.ts
@@ -27,6 +27,17 @@ describe('Hono application', () => {
     });
   });
 
+  test('allows IPv6 loopback origins during local development', async () => {
+    const response = await app.request('/a2ui/health', {
+      headers: { Origin: 'http://[::1]:3000' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+      'http://[::1]:3000',
+    );
+  });
+
   test('extracts dynamic job parameters', async () => {
     const response = await app.request('/a2ui/bench/jobs/missing');
 

--- a/packages/genui/server/test/listen-options.test.ts
+++ b/packages/genui/server/test/listen-options.test.ts
@@ -7,9 +7,9 @@ import { describe, expect, test } from '@rstest/core';
 import { resolveListenOptions } from '../src/listen-options.js';
 
 describe('resolveListenOptions', () => {
-  test('reads HOST and LYNX_USE_PORT', () => {
+  test('reads LYNX_USE_HOST and LYNX_USE_PORT', () => {
     expect(resolveListenOptions({
-      HOST: '127.0.0.1',
+      LYNX_USE_HOST: '127.0.0.1',
       LYNX_USE_PORT: '4321',
     })).toEqual({
       hostname: '127.0.0.1',
@@ -26,9 +26,18 @@ describe('resolveListenOptions', () => {
 
   test('accepts an explicit IPv6 host', () => {
     expect(resolveListenOptions({
-      HOST: '::1',
+      LYNX_USE_HOST: '::1',
     })).toEqual({
       hostname: '::1',
+      port: 3_000,
+    });
+  });
+
+  test('does not use HOST as a compatibility fallback', () => {
+    expect(resolveListenOptions({
+      HOST: '127.0.0.1',
+    })).toEqual({
+      hostname: '::',
       port: 3_000,
     });
   });

--- a/packages/genui/server/test/listen-options.test.ts
+++ b/packages/genui/server/test/listen-options.test.ts
@@ -19,7 +19,16 @@ describe('resolveListenOptions', () => {
 
   test('uses the server defaults when no listen environment is provided', () => {
     expect(resolveListenOptions({})).toEqual({
-      hostname: '0.0.0.0',
+      hostname: '::',
+      port: 3_000,
+    });
+  });
+
+  test('accepts an explicit IPv6 host', () => {
+    expect(resolveListenOptions({
+      HOST: '::1',
+    })).toEqual({
+      hostname: '::1',
       port: 3_000,
     });
   });


### PR DESCRIPTION
## Summary

- read the A2UI agent server bind address from `LYNX_USE_HOST` instead of `HOST`
- bind to the IPv6 unspecified address `::` by default, giving Node a dual-stack listener for both IPv6 and IPv4 clients
- format IPv6 listen addresses correctly in startup URLs
- allow IPv6 loopback and unspecified origins in local-development CORS handling
- update launcher defaults, tests, and server guidance for the new host variable and dual-stack behavior

## Why

The previous `0.0.0.0` default only accepted IPv4 connections. Agent clients may connect over IPv6, so the server should expose both address families without requiring deployment-specific host configuration.

The Lynx server environment contract also uses Lynx-specific variable names. The bind address should therefore use `LYNX_USE_HOST`, matching `LYNX_USE_PORT`, instead of the generic `HOST` variable.

## Impact

The default listen address changes from `0.0.0.0` to `::`. On Node this acts as a dual-stack listener, accepting connections through both IPv6 and IPv4.

Deployments must provide `LYNX_USE_HOST` when overriding the bind address. `HOST` is no longer used as a compatibility fallback.

## Validation

- `pnpm turbo build` (66/66 tasks)
- `pnpm turbo build --filter=a2ui-server` (16/16 tasks)
- `pnpm --filter a2ui-server test` (47 tests)
- `pnpm dprint check`
- `pnpm biome check` on modified TypeScript files
- `pnpm eslint` on modified TypeScript files
- `bash -n packages/genui/server/start.sh`
- launched the production `start.sh` with `LYNX_USE_HOST=::1 LYNX_USE_PORT=0` and verified `/a2ui/health` through `[::1]`
- verified the default dual-stack listener through both `127.0.0.1` and `[::1]`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The server now supports dual-stack listening for IPv6 and IPv4 by default.
  * Added support for configuring the server host with `LYNX_USE_HOST`.
  * Local development CORS now permits IPv6 loopback origins.
* **Bug Fixes**
  * Server logs now display IPv6 URLs correctly with bracketed addresses.
  * Updated startup and development defaults to use IPv6-compatible addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->