### PR TITLE
fix(create-lynx-library): align Rspeedy workspace version

### DIFF
--- a/.changeset/rspeedy-workspace-template.md
+++ b/.changeset/rspeedy-workspace-template.md
@@ -1,0 +1,5 @@
+---
+"create-lynx-library": patch
+---
+
+Keep the generated example's `@lynx-js/rspeedy` version aligned with the workspace release.

--- a/packages/lynx/create-lynx-library/package.json
+++ b/packages/lynx/create-lynx-library/package.json
@@ -39,6 +39,9 @@
     "@clack/prompts": "1.7.0",
     "@lynx-js/autolink-codegen": "workspace:^"
   },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "workspace:^"
+  },
   "engines": {
     "node": "^20 || ^22 || ^24"
   }

--- a/packages/lynx/create-lynx-library/template-common/example/package.json
+++ b/packages/lynx/create-lynx-library/template-common/example/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@lynx-js/react": "^0.123.0",
     "@lynx-js/react-rsbuild-plugin": "0.18.0",
-    "@lynx-js/rspeedy": "^0.16.0",
+    "@lynx-js/rspeedy": "workspace:*",
     "__PACKAGE_NAME__": "file:.."
   },
   "devDependencies": {

--- a/packages/lynx/create-lynx-library/test/create.test.ts
+++ b/packages/lynx/create-lynx-library/test/create.test.ts
@@ -77,6 +77,7 @@ describe('create-lynx-library', () => {
       serviceName: 'ButtonService',
       dependencyVersions: {
         '@lynx-js/autolink-codegen': '^0.123.0',
+        '@lynx-js/rspeedy': '^0.456.0',
       },
     });
 
@@ -172,6 +173,10 @@ describe('create-lynx-library', () => {
       '"@lynx-js/autolink-codegen": "^0.0.0"',
     );
     expect(read(dir, 'package.json')).not.toContain('workspace:');
+    expect(read(dir, 'example/package.json')).toContain(
+      '"@lynx-js/rspeedy": "^0.456.0"',
+    );
+    expect(read(dir, 'example/package.json')).not.toContain('workspace:');
     expect(read(dir, 'lynx.lib.json')).toContain(
       '"packageName": "com.example.button"',
     );
@@ -834,7 +839,9 @@ describe('create-lynx-library', () => {
       createLynxLibrary({
         dir,
         features: ['native-module'],
-        dependencyVersions: {},
+        dependencyVersions: {
+          '@lynx-js/rspeedy': '^0.456.0',
+        },
       })
     ).toThrow(
       /workspace dependencies without version mappings: @lynx-js\/autolink-codegen/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,6 +1085,10 @@ importers:
       '@lynx-js/autolink-codegen':
         specifier: workspace:^
         version: link:../autolink-codegen
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: workspace:^
+        version: link:../../rspeedy/core
 
   packages/lynx/gesture-runtime:
     devDependencies:


### PR DESCRIPTION
## Summary

- use `workspace:*` for `@lynx-js/rspeedy` in the generated example template
- carry the matching Rspeedy workspace version in `create-lynx-library` package metadata
- verify scaffold-time replacement and add a patch changeset

## Motivation

The example template pinned a published Rspeedy version directly, so Renovate opened updates independently of the workspace release. Keeping a workspace placeholder in the template lets `create-lynx-library` replace it with the version carried by its published package metadata.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo build --filter=create-lynx-library`
- `pnpm run test --project lynx/create-lynx-library`
- `pnpm biome check packages/lynx/create-lynx-library/package.json packages/lynx/create-lynx-library/template-common/example/package.json packages/lynx/create-lynx-library/test/create.test.ts`
- `pnpm eslint packages/lynx/create-lynx-library/test/create.test.ts`
- packed `create-lynx-library` and verified the generated example resolves `@lynx-js/rspeedy` to `^0.16.1` without workspace placeholders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated Lynx library templates to resolve the Rspeedy dependency consistently within workspace-based projects.
  * Improved dependency version handling when creating new Lynx libraries, including validation of generated package configuration.

* **Chores**
  * Added release tracking for this template update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->