### PR TITLE
feat(ui-judge): expose judged screenshots and model identity

### DIFF
--- a/packages/genui/ui-judge/README.md
+++ b/packages/genui/ui-judge/README.md
@@ -136,9 +136,10 @@ from the caller's environment. Linux hosts must also provide the
 
 `LYNX_USE_PORT` defaults to `8080` and must be between `1` and `65535`. The
 process listens on both `0.0.0.0:{LYNX_USE_PORT}` and
-`[::]:{LYNX_USE_PORT}`. Use `GET /health` for a readiness check,
-`POST /judge` to evaluate a page, and `POST /compare` to compare two uploaded
-images without rendering a page or calling the VLM.
+`[::]:{LYNX_USE_PORT}`. Use `GET /health` for a readiness check and the
+non-secret configured model name, `POST /judge` to evaluate a page, and
+`POST /compare` to compare two uploaded images without rendering a page or
+calling the VLM.
 
 The following request evaluates a local bundle. `url` and `task` are required.
 The other fields are optional. `initialData` and `globalProps` accept JSON
@@ -159,6 +160,7 @@ curl --request POST http://127.0.0.1:8080/judge \
     },
     "reference": null,
     "referenceImage": null,
+    "includeScreenshot": true,
     "steps": ["Tap the Save button"],
     "screenshotSettleMs": 16,
     "timeoutMs": 60000
@@ -182,14 +184,17 @@ It normalizes and compares the uploads on the bounded visual worker pool; it
 does not enqueue headless capture, initialize a model client, render a Lynx
 page, or perform VLM scoring.
 
-The `/judge` response is a JSON-encoded `UiJudgeResult`. A completed evaluation
-returns HTTP `200`, including evaluation failures reported in the result's
-`error` field. Invalid HTTP input returns `400`, `413`, or `422`. The server
-returns `503` when its bounded capture queue is full or the headless worker is
-no longer available. A headless-worker panic makes readiness return `503`,
-initiates graceful shutdown, and is propagated as a server error after the
-worker is joined. Each uploaded comparison image is limited to 10 MiB. Request
-bodies are limited to 20 MiB plus 64 KiB of multipart overhead.
+The `/judge` response contains the JSON-encoded `UiJudgeResult`. When
+`includeScreenshot` is true and capture succeeds, it additionally contains the
+exact judged PNG as `screenshotDataUrl`; the field is omitted by default to
+avoid inflating ordinary responses. A completed evaluation returns HTTP `200`,
+including evaluation failures reported in the result's `error` field. Invalid
+HTTP input returns `400`, `413`, or `422`. The server returns `503` when its
+bounded capture queue is full or the headless worker is no longer available. A
+headless-worker panic makes readiness return `503`, initiates graceful
+shutdown, and is propagated as a server error after the worker is joined. Each
+uploaded comparison image is limited to 10 MiB. Request bodies are limited to
+20 MiB plus 64 KiB of multipart overhead.
 
 The server accepts connections concurrently. It keeps native Lynx capture on a
 dedicated current-thread runtime because the renderer is thread-bound. After a

--- a/packages/genui/ui-judge/src/headless.rs
+++ b/packages/genui/ui-judge/src/headless.rs
@@ -93,6 +93,12 @@ pub(crate) struct CapturedPage {
   url: String,
 }
 
+impl CapturedPage {
+  pub(crate) fn screenshot_data_url(&self) -> String {
+    png_data_url(&self.png)
+  }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct PageLoadOptions {
   pub(crate) global_props_json: Option<String>,

--- a/packages/genui/ui-judge/src/model.rs
+++ b/packages/genui/ui-judge/src/model.rs
@@ -162,6 +162,13 @@ impl ModelOptions {
   }
 }
 
+pub(crate) fn configured_model_name() -> String {
+  ModelOptions::from_env()
+    .ok()
+    .and_then(|options| options.model)
+    .unwrap_or_else(|| DEFAULT_MODEL.to_string())
+}
+
 #[derive(Clone)]
 pub struct ModelClient {
   mock_response: Option<String>,
@@ -357,15 +364,25 @@ impl LlmProvider for OpenAiCompatibleProvider {
     };
     let mut reply = self.post_json(&body).await?;
 
-    // A number of otherwise OpenAI-compatible gateways predate JSON-schema
-    // wire constraints. Keep the SDK's local validation while retrying once
-    // without that optional wire constraint when the gateway says so.
-    if reply.status.is_client_error()
-      && has_structured_format(self.api, &body)
-      && response_format_is_unsupported(&reply.body)
-    {
-      remove_structured_format(self.api, &mut body);
-      reply = self.post_json(&body).await?;
+    // Some OpenAI-compatible models accept only their default temperature,
+    // while older gateways may reject JSON-schema wire constraints. Keep the
+    // SDK's local structured validation and retry only after an explicit
+    // compatibility error, removing at most one optional field per retry.
+    for _ in 0..2 {
+      if !reply.status.is_client_error() {
+        break;
+      }
+      if body.get("temperature").is_some() && temperature_is_unsupported(&reply.body) {
+        remove_temperature(&mut body);
+        reply = self.post_json(&body).await?;
+        continue;
+      }
+      if has_structured_format(self.api, &body) && response_format_is_unsupported(&reply.body) {
+        remove_structured_format(self.api, &mut body);
+        reply = self.post_json(&body).await?;
+        continue;
+      }
+      break;
     }
 
     http_reply_to_outcome(reply, &self.model, self.api)
@@ -753,6 +770,12 @@ fn remove_structured_format(api: ModelApi, body: &mut Value) {
   }
 }
 
+fn remove_temperature(body: &mut Value) {
+  if let Some(object) = body.as_object_mut() {
+    object.remove("temperature");
+  }
+}
+
 fn wire_message(message: &Message) -> Value {
   json!({
     "role": match message.role {
@@ -1113,6 +1136,14 @@ fn family_avoids_openai_response_format(family: &str) -> bool {
 fn response_format_is_unsupported(body: &str) -> bool {
   let body = body.to_ascii_lowercase();
   body.contains("response_format") || body.contains("json_schema")
+}
+
+fn temperature_is_unsupported(body: &str) -> bool {
+  let body = body.to_ascii_lowercase();
+  body.contains("temperature")
+    && (body.contains("unsupported")
+      || body.contains("does not support")
+      || body.contains("only the default"))
 }
 
 fn parse_retry_after_seconds(value: &str) -> Option<Duration> {
@@ -1504,5 +1535,16 @@ mod tests {
     assert!(!response_format_is_unsupported(
       r#"{"error":"unknown model"}"#
     ));
+  }
+
+  #[test]
+  fn marks_only_temperature_compatibility_errors_for_retry() {
+    assert!(temperature_is_unsupported(
+      r#"{"error":"Unsupported value: temperature only supports the default"}"#
+    ));
+    assert!(temperature_is_unsupported(
+      r#"{"error":"temperature does not support 0.0"}"#
+    ));
+    assert!(!temperature_is_unsupported(r#"{"error":"unknown model"}"#));
   }
 }

--- a/packages/genui/ui-judge/src/server.rs
+++ b/packages/genui/ui-judge/src/server.rs
@@ -30,7 +30,7 @@ use crate::headless::{
   capture_prepared_page_with_options, prepare_judge_page_request, score_captured_page,
   CapturedPage, PageLoadOptions,
 };
-use crate::model::ModelClient;
+use crate::model::{configured_model_name, ModelClient};
 use crate::visual::{
   compare_uploaded_images, ReferenceImageComparison, VisualEvaluationError, MAX_IMAGE_BYTES,
 };
@@ -58,6 +58,7 @@ pub enum ServerError {
 #[derive(Clone)]
 struct AppState {
   headless: Arc<HeadlessExecutor>,
+  model_name: Arc<str>,
   prepare_request: PrepareJudgePageRequest,
 }
 
@@ -66,6 +67,8 @@ struct AppState {
 struct HttpJudgePageRequest {
   #[serde(default, alias = "global_props")]
   global_props: Option<Value>,
+  #[serde(default, alias = "include_screenshot")]
+  include_screenshot: bool,
   #[serde(default, alias = "initial_data")]
   initial_data: Option<Value>,
   #[serde(default)]
@@ -84,8 +87,18 @@ struct HttpJudgePageRequest {
 
 #[derive(Debug)]
 struct HttpCaptureRequest {
+  include_screenshot: bool,
   load_options: PageLoadOptions,
   request: JudgePageRequest,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HttpJudgePageResponse {
+  #[serde(flatten)]
+  result: UiJudgeResult,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  screenshot_data_url: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -126,6 +139,7 @@ impl HttpJudgePageRequest {
     let global_props_json = page_data_json("globalProps", self.global_props)?;
     let initial_data_json = page_data_json("initialData", self.initial_data)?;
     Ok(HttpCaptureRequest {
+      include_screenshot: self.include_screenshot,
       load_options: PageLoadOptions {
         global_props_json,
         initial_data_json,
@@ -370,6 +384,7 @@ pub async fn serve(port: &str) -> Result<(), ServerError> {
   let worker_failure = headless.take_failure_receiver();
   let state = AppState {
     headless: Arc::clone(&headless),
+    model_name: configured_model_name().into(),
     prepare_request: prepare_judge_page_request,
   };
   let app = Router::new()
@@ -441,7 +456,10 @@ fn configure_listener(socket: Socket, address: SocketAddr) -> io::Result<TcpList
 
 async fn health(State(state): State<AppState>) -> Result<Json<Value>, ApiError> {
   if state.headless.is_healthy() {
-    Ok(Json(json!({ "status": "ok" })))
+    Ok(Json(json!({
+      "model": state.model_name.as_ref(),
+      "status": "ok"
+    })))
   } else {
     Err(ApiError::new(
       StatusCode::SERVICE_UNAVAILABLE,
@@ -453,14 +471,20 @@ async fn health(State(state): State<AppState>) -> Result<Json<Value>, ApiError> 
 async fn judge(
   State(state): State<AppState>,
   Json(request): Json<HttpJudgePageRequest>,
-) -> Result<Json<UiJudgeResult>, ApiError> {
+) -> Result<Json<HttpJudgePageResponse>, ApiError> {
   let HttpCaptureRequest {
+    include_screenshot,
     load_options,
     request,
   } = request.into_capture_request()?;
   let (request, client) = match (state.prepare_request)(request) {
     Ok(prepared) => prepared,
-    Err(result) => return Ok(Json(*result)),
+    Err(result) => {
+      return Ok(Json(HttpJudgePageResponse {
+        result: *result,
+        screenshot_data_url: None,
+      }))
+    }
   };
   let CaptureResponse {
     capture,
@@ -470,11 +494,20 @@ async fn judge(
     .headless
     .capture(request, client, load_options)
     .await?;
-  let result = match capture {
-    Ok(capture) => score_captured_page(&client, &request, capture).await,
-    Err(result) => result,
+  let (result, screenshot_data_url) = match capture {
+    Ok(capture) => {
+      let screenshot_data_url = include_screenshot.then(|| capture.screenshot_data_url());
+      (
+        score_captured_page(&client, &request, capture).await,
+        screenshot_data_url,
+      )
+    }
+    Err(result) => (result, None),
   };
-  Ok(Json(result))
+  Ok(Json(HttpJudgePageResponse {
+    result,
+    screenshot_data_url,
+  }))
 }
 
 async fn compare(mut multipart: Multipart) -> Result<Json<HttpCompareImagesResponse>, ApiError> {
@@ -596,6 +629,7 @@ mod tests {
   fn http_request(url: &str) -> HttpJudgePageRequest {
     HttpJudgePageRequest {
       global_props: None,
+      include_screenshot: false,
       initial_data: None,
       reference: None,
       reference_image: None,
@@ -734,6 +768,38 @@ mod tests {
   }
 
   #[test]
+  fn screenshot_capture_is_opt_in_and_supports_snake_case() {
+    let default_request = http_request("file:///tmp/a2ui.lynx.bundle")
+      .into_capture_request()
+      .expect("valid default request");
+    assert!(!default_request.include_screenshot);
+
+    let request: HttpJudgePageRequest = serde_json::from_value(json!({
+      "include_screenshot": true,
+      "task": "Render the A2UI page",
+      "url": "file:///tmp/a2ui.lynx.bundle"
+    }))
+    .expect("deserialize screenshot opt-in");
+    let capture_request = request.into_capture_request().expect("valid request");
+    assert!(capture_request.include_screenshot);
+  }
+
+  #[test]
+  fn screenshot_response_flattens_the_existing_result_contract() {
+    let response = HttpJudgePageResponse {
+      result: completed_result("file:///tmp/a2ui.lynx.bundle".to_string()),
+      screenshot_data_url: Some("data:image/png;base64,iVBORw0KGgo=".to_string()),
+    };
+    let value = serde_json::to_value(response).expect("serialize response");
+
+    assert_eq!(value["score"], 5);
+    assert_eq!(
+      value["screenshotDataUrl"],
+      "data:image/png;base64,iVBORw0KGgo="
+    );
+  }
+
+  #[test]
   fn accepts_snake_case_page_data_aliases() {
     let request: HttpJudgePageRequest = serde_json::from_value(json!({
       "global_props": {"messages": []},
@@ -793,12 +859,16 @@ mod tests {
     );
     let response = health(State(AppState {
       headless: Arc::clone(&headless),
+      model_name: "judge-model".into(),
       prepare_request: prepare_test_request,
     }))
     .await
     .expect("healthy worker must pass readiness");
 
-    assert_eq!(response.0, json!({ "status": "ok" }));
+    assert_eq!(
+      response.0,
+      json!({ "model": "judge-model", "status": "ok" })
+    );
     headless.shutdown().expect("stop mock headless worker");
   }
 
@@ -875,6 +945,7 @@ mod tests {
     );
     let state = AppState {
       headless: Arc::clone(&headless),
+      model_name: "judge-model".into(),
       prepare_request: prepare_test_request,
     };
     let mut first_request = http_request("file:///tmp/first.lynx.bundle");
@@ -888,8 +959,8 @@ mod tests {
     let first_result = first.expect("first response").0;
     let second_result = second.expect("second response").0;
 
-    assert_eq!(first_result.url, "file:///tmp/first.lynx.bundle");
-    assert_eq!(second_result.url, "file:///tmp/second.lynx.bundle");
+    assert_eq!(first_result.result.url, "file:///tmp/first.lynx.bundle");
+    assert_eq!(second_result.result.url, "file:///tmp/second.lynx.bundle");
     assert_eq!(
       *executed_requests
         .lock()
@@ -948,6 +1019,7 @@ mod tests {
     assert!(!headless.is_healthy());
     let health_error = health(State(AppState {
       headless: Arc::clone(&headless),
+      model_name: "judge-model".into(),
       prepare_request: prepare_test_request,
     }))
     .await


### PR DESCRIPTION
## Summary

- add an opt-in `includeScreenshot` request flag that returns the exact judged PNG as `screenshotDataUrl` without changing the default response shape
- expose the configured, non-secret model name from `/health`
- retry standard OpenAI-compatible requests without `temperature` only after an explicit unsupported/default-temperature error
- document the HTTP contract while preserving `LYNX_USE_PORT`

## Safety

- preserves existing endpoint and authentication behavior
- adds no deployment-specific provider URL, query-auth convention, or internal service reference

## Dependencies

No merge dependency. Follow-up GenUI Bench work can consume the opt-in screenshot and health model fields after this lands.

## Validation

- `fnm exec --using=24.11.1 -- pnpm install --frozen-lockfile`
- `fnm exec --using=24.11.1 -- pnpm turbo build` — 66/66 tasks passed
- `pnpm dprint check` on all changed files
- `cargo fmt -p ui_judge -- --check`
- `cargo test -p ui_judge --lib --tests --all-features` — 56 unit tests and the environment-gated headless e2e harness passed
- `cargo clippy -p ui_judge --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional screenshot capture for UI Judge requests, returned as a data URL when enabled and successful.
  - Health checks now report the configured model name alongside service status.

- **Bug Fixes**
  - Improved compatibility with providers that reject unsupported temperature or structured response settings by retrying with adjusted requests.
  - Clarified screenshot and request-size behavior in the server documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->