### PR TITLE
feat(genui): add protocol-aware bench jobs

### DIFF
--- a/.github/genui-server.instructions.md
+++ b/.github/genui-server.instructions.md
@@ -8,6 +8,8 @@ Keep protocol-neutral request infrastructure in `app/common`. Request-size enfor
 
 Keep shared agent-service contracts and helpers in `service/common`. `ChatMessage`, `ConversationContext`, generic provider options, provider agent caching, conversation assembly, model-message conversion, Mastra result extraction, and stream adaptation must not be imported from `service/a2ui-agent` by OpenUI or MCP Apps. Extend the generic options inside `service/a2ui-agent` only for A2UI-specific catalog and repair settings.
 
+Keep public provider integrations vendor-neutral. Do not commit deployment-only gateway rewrites, private hostnames, environment-specific authentication conventions, or credentials; inject those only through the deployment environment.
+
 Use `app/common/sse.ts` for standard SSE frames and response headers. Pass event IDs or additional headers through its options instead of cloning the SSE framing and header literals in individual functions.
 
 Build `genui-server` as an executable ESM Hono server through `rslib.config.ts`. Each protocol `route.ts` default-exports a Hono sub-application, `src/app.ts` composes the route tree and common HTTP fallbacks, and `src/index.ts` starts `@hono/node-server` and owns graceful process shutdown. Do not export endpoint request functions or add a custom router or Node/FaaS transport adapter. Keep business handlers based on standard Web `Request` and `Response` internally.

--- a/packages/genui/openui/src/openui-prompt/index.ts
+++ b/packages/genui/openui/src/openui-prompt/index.ts
@@ -26,6 +26,8 @@ export type OpenUiPromptLibrary = Library<HeadlessRenderer>;
 export interface CreateOpenUiPromptLibraryOptions {
   /** Override the root component name. Defaults to `'Stack'`. */
   root?: string;
+  /** Limit built-ins to these names. Custom `components` are still appended. */
+  componentNames?: readonly string[];
   /** Replace or extend the built-in component set. */
   components?: OpenUiPromptComponent[];
   /** Replace or extend the built-in component groups. */
@@ -575,16 +577,29 @@ const DEFAULT_EXAMPLES = [
   ].join('\n'),
 ];
 
-function withDefaultPromptOptions(options?: PromptOptions): PromptOptions {
+const RESTRICTED_COMPONENT_RULES = [
+  'Use only the components listed in this prompt; do not invent component names or named-argument syntax.',
+  'Prefer compact, mobile-friendly layouts built from the available layout and content components.',
+  'Return only OpenUI Lang code unless inlineMode is explicitly enabled.',
+];
+
+function withDefaultPromptOptions(
+  options?: PromptOptions,
+  restrictedComponents = false,
+): PromptOptions {
+  const defaultRules = restrictedComponents
+    ? RESTRICTED_COMPONENT_RULES
+    : DEFAULT_ADDITIONAL_RULES;
   return {
     bindings: true,
-    toolCalls: true,
+    toolCalls: !restrictedComponents,
     ...options,
     additionalRules: [
-      ...DEFAULT_ADDITIONAL_RULES,
+      ...defaultRules,
       ...(options?.additionalRules ?? []),
     ],
-    examples: options?.examples ?? DEFAULT_EXAMPLES,
+    examples: options?.examples
+      ?? (restrictedComponents ? [] : DEFAULT_EXAMPLES),
   };
 }
 
@@ -597,14 +612,32 @@ function withDefaultPromptOptions(options?: PromptOptions): PromptOptions {
 export function createOpenUiPromptLibrary(
   options: CreateOpenUiPromptLibraryOptions = {},
 ): OpenUiPromptLibrary {
+  const root = options.root ?? 'Stack';
+  const componentNames = options.componentNames
+    ? new Set([...options.componentNames, root])
+    : null;
+  const defaultComponents = componentNames
+    ? DEFAULT_COMPONENTS.filter((component) =>
+      componentNames.has(component.name)
+    )
+    : DEFAULT_COMPONENTS;
+  const defaultComponentGroups = componentNames
+    ? DEFAULT_COMPONENT_GROUPS
+      .map((group) => ({
+        ...group,
+        components: group.components.filter((name) => componentNames.has(name)),
+      }))
+      .filter((group) => group.components.length > 0)
+    : DEFAULT_COMPONENT_GROUPS;
+
   return createLibrary<HeadlessRenderer>({
-    root: options.root ?? 'Stack',
+    root,
     components: options.components
-      ? [...DEFAULT_COMPONENTS, ...options.components]
-      : DEFAULT_COMPONENTS,
+      ? [...defaultComponents, ...options.components]
+      : defaultComponents,
     componentGroups: options.componentGroups
-      ? [...DEFAULT_COMPONENT_GROUPS, ...options.componentGroups]
-      : DEFAULT_COMPONENT_GROUPS,
+      ? [...defaultComponentGroups, ...options.componentGroups]
+      : defaultComponentGroups,
   });
 }
 
@@ -618,6 +651,9 @@ export function buildOpenUiSystemPrompt(
   if (options.root !== undefined) {
     libraryOptions.root = options.root;
   }
+  if (options.componentNames !== undefined) {
+    libraryOptions.componentNames = options.componentNames;
+  }
   if (options.components !== undefined) {
     libraryOptions.components = options.components;
   }
@@ -626,7 +662,10 @@ export function buildOpenUiSystemPrompt(
   }
   const library = createOpenUiPromptLibrary(libraryOptions);
   const prompt = library.prompt(
-    withDefaultPromptOptions(options.promptOptions),
+    withDefaultPromptOptions(
+      options.promptOptions,
+      options.componentNames !== undefined,
+    ),
   );
   return options.appendix ? `${prompt}\n\n${options.appendix}` : prompt;
 }

--- a/packages/genui/playground/lynx-src/a2ui/App.tsx
+++ b/packages/genui/playground/lynx-src/a2ui/App.tsx
@@ -272,6 +272,9 @@ async function loadActionMocks(
 
 export function App() {
   const globalProps = useGlobalProps();
+  const benchMode = (
+    globalProps as Record<string, unknown> | null
+  )?.benchMode === true;
 
   const rawInitData = useInitData();
 
@@ -611,7 +614,7 @@ export function App() {
 
   return (
     <view
-      className={`page ${themeClassName}`}
+      className={`page ${themeClassName}${benchMode ? ' bench-page' : ''}`}
     >
       {error
         ? (

--- a/packages/genui/playground/lynx-src/a2ui/index.css
+++ b/packages/genui/playground/lynx-src/a2ui/index.css
@@ -17,6 +17,11 @@
   background-color: var(--canvas);
 }
 
+.bench-page {
+  padding: 10px;
+  background-color: var(--canvas);
+}
+
 .a2ui-root-container {
   flex: 1;
   min-height: 0;

--- a/packages/genui/playground/lynx-src/openui/App.tsx
+++ b/packages/genui/playground/lynx-src/openui/App.tsx
@@ -112,9 +112,11 @@ export function App() {
   const theme = useMemo<Theme>(() => {
     return readTheme(globalProps?.theme) ?? 'light';
   }, [globalProps]);
+  const benchMode = globalProps?.benchMode === true;
+  const layoutClassName = benchMode ? 'openui-bench' : 'openui-editorial';
   const themeClassName = theme === 'dark'
-    ? 'openui-page openui-editorial openui-dark luna-dark'
-    : 'openui-page openui-editorial openui-light luna-light';
+    ? `openui-page ${layoutClassName} openui-dark luna-dark`
+    : `openui-page ${layoutClassName} openui-light luna-light`;
 
   // Speed multiplier from globalProps (e.g. ?speed=2)
   const streamDelay = useMemo(() => {

--- a/packages/genui/playground/lynx-src/openui/index.css
+++ b/packages/genui/playground/lynx-src/openui/index.css
@@ -18,6 +18,17 @@
   background-color: transparent;
 }
 
+.openui-bench {
+  padding: 10px;
+  background-color: var(--canvas);
+}
+
+.openui-bench .OpenUIRenderer {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
 .openui-scroll {
   width: 100%;
   height: 100%;

--- a/packages/genui/server/agent/a2ui-validator.ts
+++ b/packages/genui/server/agent/a2ui-validator.ts
@@ -349,6 +349,7 @@ export function validateA2UIOutput(
       }
       const bucket = componentsBySurface.get(sId)
         ?? new Map<string, A2UIComponent>();
+      const idsInMessage = new Set<string>();
       for (const rawComponent of msg.updateComponents.components) {
         const comp = rawComponent as A2UIComponent;
         for (const fn of collectFunctionCalls(comp, `component.${comp.id}`)) {
@@ -376,11 +377,12 @@ export function validateA2UIOutput(
             }.`,
           );
         }
-        if (bucket.has(comp.id)) {
+        if (idsInMessage.has(comp.id)) {
           errors.push(
-            `Duplicate component id "${comp.id}" in surface "${sId}".`,
+            `Duplicate component id "${comp.id}" in one updateComponents message for surface "${sId}".`,
           );
         }
+        idsInMessage.add(comp.id);
         bucket.set(comp.id, comp);
         const componentPaths: string[] = [];
         collectPaths(comp, componentPaths);

--- a/packages/genui/server/agent/openui-agent.ts
+++ b/packages/genui/server/agent/openui-agent.ts
@@ -5,15 +5,22 @@
 import { Agent } from '@mastra/core/agent';
 
 import { buildOpenUiSystemPrompt } from '@lynx-js/genui-openui/openui-prompt';
+import type {
+  BuildOpenUiSystemPromptOptions,
+} from '@lynx-js/genui-openui/openui-prompt';
 
 import { createLLMProvider } from './openai-provider';
 import type { OpenAIProviderOptions } from './openai-provider';
 
 export interface OpenUIAgentOptions extends OpenAIProviderOptions {
+  promptComponentNames?: readonly string[] | undefined;
+  promptOptions?: BuildOpenUiSystemPromptOptions['promptOptions'];
+  promptRoot?: string | undefined;
   systemAppendix?: string | undefined;
 }
 
 interface OpenUIAgentRunOptions {
+  abortSignal?: AbortSignal | undefined;
   resourceId?: string | undefined;
 }
 
@@ -31,9 +38,18 @@ export interface OpenUIAgent {
 export function createOpenUIAgent(opts: OpenUIAgentOptions = {}) {
   const { buildModel, model } = createLLMProvider(opts);
   const instructions = buildOpenUiSystemPrompt(
-    opts.systemAppendix === undefined
-      ? {}
-      : { appendix: opts.systemAppendix },
+    {
+      ...(opts.promptComponentNames === undefined
+        ? {}
+        : { componentNames: opts.promptComponentNames }),
+      ...(opts.promptOptions === undefined
+        ? {}
+        : { promptOptions: opts.promptOptions }),
+      ...(opts.promptRoot === undefined ? {} : { root: opts.promptRoot }),
+      ...(opts.systemAppendix === undefined
+        ? {}
+        : { appendix: opts.systemAppendix }),
+    },
   );
 
   const agent = new Agent({

--- a/packages/genui/server/app/a2ui/bench/jobs/route.ts
+++ b/packages/genui/server/app/a2ui/bench/jobs/route.ts
@@ -42,11 +42,27 @@ async function postA2UIBenchJob(req: Request) {
   }
 
   const store = getBenchJobStore();
-  const job = store.createJob(
+  const admission = store.tryCreateJob(
     normalized.request,
     normalized.totalRuns,
     normalized.warnings,
   );
+  if (!admission.ok) {
+    return jsonWithCors(
+      req,
+      {
+        ok: false,
+        error: 'Bench active job capacity reached; retry later',
+        activeJobs: admission.activeJobs,
+        limit: admission.limit,
+      },
+      {
+        status: 503,
+        headers: { 'Retry-After': '5' },
+      },
+    );
+  }
+  const { job } = admission;
   startBenchJob(job.id);
 
   return jsonWithCors(req, {

--- a/packages/genui/server/package.json
+++ b/packages/genui/server/package.json
@@ -19,6 +19,7 @@
     "@lynx-js/genui-mcp-apps": "workspace:*",
     "@lynx-js/genui-openui": "workspace:*",
     "@mastra/core": "1.52.0",
+    "@openuidev/lang-core": "^0.2.9",
     "hono": "4.12.12",
     "zod": "^4.4.3"
   },

--- a/packages/genui/server/service/a2ui-agent.ts
+++ b/packages/genui/server/service/a2ui-agent.ts
@@ -40,6 +40,11 @@ import type {
 
 export interface A2UIChatOptions extends ChatOptions {
   catalog?: A2UICatalog | undefined;
+  /**
+   * Create an agent for this call without retaining request-scoped provider
+   * credentials in the shared provider cache.
+   */
+  disableAgentCache?: boolean | undefined;
   maxRepairAttempts?: number | undefined;
 }
 
@@ -71,13 +76,15 @@ export default class A2UIAgentService {
 
   private async getAgent(opts: A2UIChatOptions): Promise<A2UIAgent> {
     const catalog = opts.catalog ?? await loadBasicCatalog();
+    const createAgent = () =>
+      createA2UIAgent({
+        ...pickProviderConfig(opts),
+        catalog,
+      }).then(({ agent }) => agent);
+    if (opts.disableAgentCache) return createAgent();
     return this.agentCache.get(
       opts,
-      () =>
-        createA2UIAgent({
-          ...pickProviderConfig(opts),
-          catalog,
-        }).then(({ agent }) => agent),
+      createAgent,
       `${catalog.id}:${createStableValueHash(catalog)}`,
     );
   }

--- a/packages/genui/server/service/a2ui-bench-judge.ts
+++ b/packages/genui/server/service/a2ui-bench-judge.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { readBenchScreenshotDataUrl } from './a2ui-bench-screenshot';
 import type { BenchScenarioRequest } from './a2ui-bench-types';
 import type { A2UIMessage } from '../agent/a2ui-validator';
 
@@ -29,6 +30,7 @@ export interface BenchUiJudgeResult {
   errors: string[];
   reason?: string;
   score: number;
+  screenshotDataUrl?: string;
   status: 'complete' | 'failed';
   summary?: string;
   warnings: string[];
@@ -40,15 +42,37 @@ interface UiJudgeResponse {
   };
   reason?: unknown;
   score?: unknown;
+  screenshotDataUrl?: unknown;
   summary?: unknown;
+}
+
+export interface BenchUiJudgeScenario
+  extends Pick<BenchScenarioRequest, 'judgeSteps' | 'judgeTask' | 'prompt'>
+{
+  id?: string;
+  name?: string;
+  type?: string;
 }
 
 interface RunBenchUiJudgeOptions {
   messages: A2UIMessage[];
-  scenario: BenchScenarioRequest;
+  scenario: BenchUiJudgeScenario;
+  includeScreenshot?: boolean;
+  screenshotSettleMs?: number;
   session: BenchUiJudgeSession;
   signal?: AbortSignal;
   timeoutMs?: number;
+}
+
+export interface RunBenchUiJudgeRequestOptions {
+  globalProps: Record<string, unknown>;
+  scenario: BenchUiJudgeScenario;
+  includeScreenshot?: boolean;
+  screenshotSettleMs?: number;
+  session: BenchUiJudgeSession;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  warnings?: string[];
 }
 
 const RESOURCE_COMPONENTS = new Set([
@@ -203,7 +227,9 @@ function containsOpenUrlCall(
 
 export async function probeBenchUiJudge(
   options: {
+    bundleUrl?: string;
     env?: NodeJS.ProcessEnv;
+    expectedModel?: string;
     fetch?: FetchLike;
   } = {},
 ): Promise<BenchUiJudgeCapability> {
@@ -225,7 +251,8 @@ export async function probeBenchUiJudge(
     };
   }
 
-  const configuredBundleUrl = env.UI_JUDGE_BUNDLE_URL?.trim();
+  const configuredBundleUrl = options.bundleUrl?.trim()
+    ?? env.UI_JUDGE_BUNDLE_URL?.trim();
   const rawBundleUrl = configuredBundleUrl !== undefined
       && configuredBundleUrl.length > 0
     ? configuredBundleUrl
@@ -259,6 +286,19 @@ export async function probeBenchUiJudge(
         reason: 'UI Judge health check returned an invalid response.',
       };
     }
+    if (options.expectedModel) {
+      const actualModel = typeof body.model === 'string'
+        ? body.model.trim()
+        : '';
+      if (actualModel !== options.expectedModel) {
+        return {
+          enabled: false,
+          reason: actualModel
+            ? `UI Judge model mismatch: expected ${options.expectedModel}, received ${actualModel}.`
+            : `UI Judge health check did not report the required model ${options.expectedModel}.`,
+        };
+      }
+    }
   } catch (error) {
     return {
       enabled: false,
@@ -288,6 +328,34 @@ export async function runBenchUiJudge(
       warnings: sanitized.warnings,
     };
   }
+  return await runBenchUiJudgeRequest(
+    {
+      globalProps: {
+        benchMode: true,
+        instant: true,
+        messages: sanitized.messages,
+        speed: 0,
+        theme: 'light',
+      },
+      ...(options.includeScreenshot ? { includeScreenshot: true } : {}),
+      scenario: options.scenario,
+      ...(options.screenshotSettleMs === undefined
+        ? {}
+        : { screenshotSettleMs: options.screenshotSettleMs }),
+      session: options.session,
+      ...(options.signal ? { signal: options.signal } : {}),
+      ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
+      warnings: sanitized.warnings,
+    },
+    fetchImpl,
+  );
+}
+
+export async function runBenchUiJudgeRequest(
+  options: RunBenchUiJudgeRequestOptions,
+  fetchImpl: FetchLike = fetch,
+): Promise<BenchUiJudgeResult> {
+  const warnings = options.warnings ?? [];
   const operationTimeoutMs = options.timeoutMs
     ?? DEFAULT_OPERATION_TIMEOUT_MS;
   const requestTimeoutMs = operationTimeoutMs
@@ -301,16 +369,15 @@ export async function runBenchUiJudge(
       errors: [],
       score: 0,
       status: 'failed',
-      warnings: sanitized.warnings,
+      warnings,
     };
   }
   const body = {
-    globalProps: {
-      instant: true,
-      messages: sanitized.messages,
-      speed: 0,
-      theme: 'light',
-    },
+    globalProps: options.globalProps,
+    ...(options.includeScreenshot ? { includeScreenshot: true } : {}),
+    ...(options.screenshotSettleMs === undefined
+      ? {}
+      : { screenshotSettleMs: options.screenshotSettleMs }),
     steps: options.scenario.judgeSteps ?? [],
     task: options.scenario.judgeTask ?? options.scenario.prompt,
     ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
@@ -334,14 +401,14 @@ export async function runBenchUiJudge(
         errors: [],
         score: 0,
         status: 'failed',
-        warnings: sanitized.warnings,
+        warnings,
       };
     }
     return {
       errors: [`ui-judge request failed: ${toErrorMessage(error)}`],
       score: 0,
       status: 'failed',
-      warnings: sanitized.warnings,
+      warnings,
     };
   }
 
@@ -356,7 +423,7 @@ export async function runBenchUiJudge(
       ],
       score: 0,
       status: 'failed',
-      warnings: sanitized.warnings,
+      warnings,
     };
   }
 
@@ -365,7 +432,7 @@ export async function runBenchUiJudge(
       errors: ['ui-judge returned an invalid JSON response.'],
       score: 0,
       status: 'failed',
-      warnings: sanitized.warnings,
+      warnings,
     };
   }
   const result = payload as UiJudgeResponse;
@@ -394,13 +461,27 @@ export async function runBenchUiJudge(
   const summary = typeof result.summary === 'string' && result.summary.trim()
     ? result.summary.trim()
     : undefined;
+  const screenshotDataUrl = readBenchScreenshotDataUrl(
+    result.screenshotDataUrl,
+  );
+  const resultWarnings = [...warnings];
+  if (
+    options.includeScreenshot
+    && result.screenshotDataUrl !== undefined
+    && !screenshotDataUrl
+  ) {
+    resultWarnings.push(
+      'ui-judge returned an invalid screenshotDataUrl; the screenshot was discarded.',
+    );
+  }
 
   return {
     errors,
     ...(reason ? { reason } : {}),
     score: errors.length === 0 ? score : 0,
+    ...(screenshotDataUrl ? { screenshotDataUrl } : {}),
     status: errors.length === 0 ? 'complete' : 'failed',
     ...(summary ? { summary } : {}),
-    warnings: sanitized.warnings,
+    warnings: resultWarnings,
   };
 }

--- a/packages/genui/server/service/a2ui-bench-redaction.ts
+++ b/packages/genui/server/service/a2ui-bench-redaction.ts
@@ -1,0 +1,98 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { BenchProviderConfig } from './a2ui-bench-types';
+
+const PRIVATE_FIELD_NAMES = new Set([
+  'apikey',
+  'authorization',
+  'baseurl',
+]);
+const DIAGNOSTIC_FIELD_NAMES = new Set([
+  'error',
+  'errors',
+  'judgereason',
+  'judgesummary',
+  'judgewarnings',
+  'reason',
+  'summary',
+  'warning',
+  'warnings',
+]);
+
+function secretVariants(value: string | undefined): string[] {
+  if (!value) return [];
+  return [...new Set([value, encodeURIComponent(value)])]
+    .sort((left, right) => right.length - left.length);
+}
+
+export function redactBenchText(
+  value: string,
+  provider: BenchProviderConfig,
+): string {
+  let redacted = value;
+  for (
+    const secret of [
+      ...secretVariants(provider.apiKey),
+      ...secretVariants(provider.baseURL),
+    ]
+  ) {
+    redacted = redacted.replaceAll(secret, '[REDACTED]');
+  }
+  return redacted
+    .replace(/\bBearer\s+[^\s,;"']+/giu, 'Bearer [REDACTED]')
+    .replace(
+      /([?&](?:access_token|api[_-]?key|key|token)=)[^&#\s"'<>]*/giu,
+      '$1[REDACTED]',
+    );
+}
+
+export function redactBenchDiagnostic(
+  value: string,
+  provider: BenchProviderConfig,
+): string {
+  return redactBenchText(value, provider).replace(
+    /https?:\/\/[^\s"'<>]+/giu,
+    '[REDACTED_URL]',
+  );
+}
+
+function sanitizeDiagnosticValue(
+  value: unknown,
+  provider: BenchProviderConfig,
+  seen: WeakSet<object>,
+): unknown {
+  if (typeof value === 'string') return redactBenchDiagnostic(value, provider);
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeDiagnosticValue(item, provider, seen));
+  }
+  return sanitizeBenchPublicValue(value, provider, seen);
+}
+
+export function sanitizeBenchPublicValue(
+  value: unknown,
+  provider: BenchProviderConfig,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (typeof value === 'string') return redactBenchText(value, provider);
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeBenchPublicValue(item, provider, seen));
+  }
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, item]) => {
+      const normalizedKey = key.replace(/[^a-z]/giu, '').toLowerCase();
+      return PRIVATE_FIELD_NAMES.has(normalizedKey)
+        ? []
+        : [[
+          key,
+          DIAGNOSTIC_FIELD_NAMES.has(normalizedKey)
+            ? sanitizeDiagnosticValue(item, provider, seen)
+            : sanitizeBenchPublicValue(item, provider, seen),
+        ]];
+    }),
+  );
+}

--- a/packages/genui/server/service/a2ui-bench-request.ts
+++ b/packages/genui/server/service/a2ui-bench-request.ts
@@ -6,6 +6,8 @@ import type {
   BenchCatalogLabel,
   BenchGroupRequest,
   BenchJobRequest,
+  BenchProfile,
+  BenchProtocol,
   BenchRole,
   BenchScenarioRequest,
   BenchSettings,
@@ -18,6 +20,7 @@ const MAX_REPEATS = 10;
 const MAX_PARALLELISM = 4;
 const MAX_PROMPT_CHARS = 4_000;
 const MAX_TEXT_FIELD_CHARS = 1_000;
+const MAX_PLANNED_GENERATION_ATTEMPTS = 120;
 
 const CATALOG_LABELS = new Set<BenchCatalogLabel>([
   'Full Catalog',
@@ -26,10 +29,13 @@ const CATALOG_LABELS = new Set<BenchCatalogLabel>([
 ]);
 
 const ROLES = new Set<BenchRole>(['control', 'experiment']);
+const PROTOCOLS = new Set<BenchProtocol>(['a2ui', 'openui']);
+const PROFILES = new Set<BenchProfile>(['native', 'matched-core']);
 const VARIABLES = new Set<BenchVariable>([
   'model',
   'prompt',
   'catalog',
+  'protocol',
   'custom',
 ]);
 
@@ -89,6 +95,23 @@ function readVariable(value: unknown): BenchVariable {
   return 'custom';
 }
 
+function readProtocol(value: unknown): BenchProtocol {
+  if (typeof value === 'string' && PROTOCOLS.has(value as BenchProtocol)) {
+    return value as BenchProtocol;
+  }
+  return 'a2ui';
+}
+
+function readProfile(
+  value: unknown,
+  protocol: BenchProtocol,
+): BenchProfile {
+  if (typeof value === 'string' && PROFILES.has(value as BenchProfile)) {
+    return value as BenchProfile;
+  }
+  return protocol === 'openui' ? 'matched-core' : 'native';
+}
+
 function readStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const items = value
@@ -133,14 +156,20 @@ function normalizeGroups(
       const model = clientOverrideAccepted
         ? readOptionalString(item.model, 240)
         : undefined;
+      const protocol = readProtocol(item.protocol);
+      const profile = readProfile(item.profile, protocol);
       return {
         id,
         role: readRole(item.role),
         name,
         variable: readVariable(item.variable),
         enabled: item.enabled !== false,
+        protocol,
+        profile,
         ...(model ? { model } : {}),
-        catalog: readCatalog(item.catalog),
+        ...(protocol === 'a2ui' && profile === 'native'
+          ? { catalog: readCatalog(item.catalog) }
+          : {}),
         extraInstruction: readString(item.extraInstruction, '', 2_000),
       };
     })
@@ -207,6 +236,10 @@ export function normalizeBenchJobRequest(
       ?? providerRecord.api,
   );
   const clientOverrideAccepted = options.clientOverrideAccepted;
+  const requestedGroupModelOverride = Array.isArray(value.groups)
+    && value.groups.some((group) =>
+      isRecord(group) && readOptionalString(group.model, 240) !== undefined
+    );
   const api =
     providerRecord.api === 'chat' || providerRecord.api === 'responses'
       ? providerRecord.api
@@ -235,6 +268,17 @@ export function normalizeBenchJobRequest(
       error: 'at least one enabled group is required',
     };
   }
+  if (
+    enabledGroups.some((group) =>
+      group.protocol === 'openui' && group.profile !== 'matched-core'
+    )
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'openui groups require the "matched-core" profile',
+    };
+  }
 
   const scenarios = normalizeScenarios(value.scenarios);
   if (scenarios.length === 0) {
@@ -246,9 +290,34 @@ export function normalizeBenchJobRequest(
   }
 
   const settings = normalizeSettings(value.settings);
+  const mixedProtocols = new Set(enabledGroups.map((group) => group.protocol))
+    .size > 1;
   const totalRuns = enabledGroups.length * scenarios.length * settings.repeats;
+  const plannedGenerationAttempts = totalRuns
+    * (settings.maxRepairAttempts + 1);
+  if (
+    (settings.judgeEnabled
+      || enabledGroups.some((group) => group.profile === 'matched-core'))
+    && plannedGenerationAttempts > MAX_PLANNED_GENERATION_ATTEMPTS
+  ) {
+    return {
+      ok: false,
+      status: 422,
+      error:
+        `benchmark workload exceeds the ${MAX_PLANNED_GENERATION_ATTEMPTS} planned generation-attempt limit`,
+    };
+  }
   const warnings: string[] = [];
-  if (!clientOverrideAccepted && requestedProviderOverride) {
+  if (mixedProtocols && settings.parallelism !== 1) {
+    settings.parallelism = 1;
+    warnings.push(
+      'Mixed-protocol jobs run one sample at a time so benchmark arms remain paired; settings.parallelism was set to 1.',
+    );
+  }
+  if (
+    !clientOverrideAccepted
+    && (requestedProviderOverride || requestedGroupModelOverride)
+  ) {
     warnings.push(
       'Client provider overrides are disabled by server policy; using server environment provider settings.',
     );

--- a/packages/genui/server/service/a2ui-bench-runner.ts
+++ b/packages/genui/server/service/a2ui-bench-runner.ts
@@ -4,11 +4,12 @@
 
 import { getA2UIAgentService } from './a2ui-agent';
 import { resolveBenchCatalog } from './a2ui-bench-catalog';
-import { probeBenchUiJudge, runBenchUiJudge } from './a2ui-bench-judge';
+import { probeBenchUiJudge } from './a2ui-bench-judge';
 import type {
   BenchUiJudgeCapability,
   BenchUiJudgeResult,
 } from './a2ui-bench-judge';
+import { sanitizeBenchPublicValue } from './a2ui-bench-redaction';
 // import { runBenchPreview } from './a2ui-bench-preview';
 import { getBenchJobStore } from './a2ui-bench-store';
 import type {
@@ -16,6 +17,8 @@ import type {
   BenchGroupRequest,
   BenchGroupSummary,
   BenchJobRequest,
+  BenchProfile,
+  BenchProtocol,
   BenchReport,
   BenchReportSummary,
   BenchRunPhase,
@@ -23,12 +26,38 @@ import type {
   BenchScenarioRequest,
 } from './a2ui-bench-types';
 import type { ChatMessage } from './common/types';
+import { createA2UIBenchAdapter } from './genui-bench/a2ui-adapter';
+import type {
+  ProtocolBenchAdapter,
+  ProtocolBenchJudgePayload,
+} from './genui-bench/protocol-adapter';
+import type { ProtocolBenchScenario } from './genui-bench/types';
+import {
+  probeGenuiBenchUiJudge,
+  runGenuiBenchUiJudge,
+} from './genui-bench-judge';
+import { createOpenUIBenchAdapter } from './openui-bench-adapter';
+import {
+  formatErrorsForModel,
+  validateA2UIOutput,
+} from '../agent/a2ui-validator';
+import { resolveA2UIImageUrls } from '../agent/image-resolver';
 
 interface BenchRunItem {
   group: BenchGroupRequest;
   scenario: BenchScenarioRequest;
   repeatIndex: number;
 }
+
+interface BenchRunSample {
+  items: BenchRunItem[];
+}
+
+export interface BenchRunnerDependencies {
+  adapters?: Partial<Record<BenchProtocol, ProtocolBenchAdapter>>;
+}
+
+type BenchJudgeCapabilities = Map<string, BenchUiJudgeCapability>;
 
 interface UsageRecord {
   promptTokens?: unknown;
@@ -41,9 +70,9 @@ interface UsageRecord {
   total_tokens?: unknown;
 }
 
-function average(values: number[]): number {
-  if (values.length === 0) return 0;
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
+function averagePlanned(values: number[], plannedRuns: number): number {
+  if (plannedRuns === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / plannedRuns;
 }
 
 function pickNumber(record: UsageRecord, keys: (keyof UsageRecord)[]): number {
@@ -71,17 +100,43 @@ function parseTotalTokens(usage: unknown): number {
   return Math.round(totalTokens || promptTokens + completionTokens);
 }
 
-function buildRunMatrix(request: BenchJobRequest): BenchRunItem[] {
+function protocolForGroup(group: BenchGroupRequest): BenchProtocol {
+  return group.protocol ?? 'a2ui';
+}
+
+function profileForGroup(group: BenchGroupRequest): BenchProfile {
+  return group.profile
+    ?? (protocolForGroup(group) === 'openui' ? 'matched-core' : 'native');
+}
+
+function judgeCapabilityKey(group: BenchGroupRequest): string {
+  return `${protocolForGroup(group)}:${profileForGroup(group)}`;
+}
+
+function buildRunSamples(request: BenchJobRequest): BenchRunSample[] {
   const enabledGroups = request.groups.filter((group) => group.enabled);
-  return enabledGroups.flatMap((group) =>
-    request.scenarios.flatMap((scenario) =>
-      Array.from({ length: request.settings.repeats }, (_, index) => ({
-        group,
-        scenario,
-        repeatIndex: index + 1,
-      }))
-    )
-  );
+  const samples: BenchRunSample[] = [];
+  let sampleOrdinal = 0;
+  for (const scenario of request.scenarios) {
+    for (
+      let repeatIndex = 1;
+      repeatIndex <= request.settings.repeats;
+      repeatIndex++
+    ) {
+      const offset = enabledGroups.length === 0
+        ? 0
+        : sampleOrdinal % enabledGroups.length;
+      const groups = [
+        ...enabledGroups.slice(offset),
+        ...enabledGroups.slice(0, offset),
+      ];
+      samples.push({
+        items: groups.map((group) => ({ group, scenario, repeatIndex })),
+      });
+      sampleOrdinal++;
+    }
+  }
+  return samples;
 }
 
 function buildBenchPrompt(
@@ -115,10 +170,7 @@ function pickRunModel(
   request: BenchJobRequest,
   group: BenchGroupRequest,
 ): string | undefined {
-  if (group.variable === 'model' || group.variable === 'custom') {
-    return group.model ?? request.provider.model;
-  }
-  return request.provider.model;
+  return group.model ?? request.provider.model;
 }
 
 function pickRunCatalog(group: BenchGroupRequest): BenchCatalogLabel {
@@ -149,7 +201,92 @@ function emitRunPhase(
   });
 }
 
-async function runOne(
+async function generateA2UINative(
+  request: BenchJobRequest,
+  item: BenchRunItem,
+  runId: string,
+  messages: ChatMessage[],
+  catalog: ReturnType<typeof resolveBenchCatalog>,
+  model: string | undefined,
+  signal: AbortSignal,
+): Promise<{
+  attempts: number;
+  errors: string[];
+  finishReason?: unknown;
+  messages: NonNullable<BenchRunResult['messages']>;
+  ok: boolean;
+  text: string;
+  usage: unknown[];
+  warnings: string[];
+}> {
+  const conversation = [...messages];
+  const usage: unknown[] = [];
+  const maxAttempts = Math.min(
+    5,
+    Math.max(1, request.settings.maxRepairAttempts + 1),
+  );
+  let lastText = '';
+  let lastErrors: string[] = [];
+  let lastFinishReason: unknown;
+  let lastWarnings: string[] = [];
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    signal.throwIfAborted();
+    const generated = await getA2UIAgentService().generateRaw(
+      conversation,
+      {
+        resourceId: `bench:${item.group.id}:${runId}:attempt-${attempt}`,
+        apiKey: request.provider.apiKey,
+        baseURL: request.provider.baseURL,
+        model,
+        api: request.provider.api,
+        catalog,
+        disableAgentCache: true,
+        inheritReasoningEffort: false,
+      },
+      undefined,
+      signal,
+    );
+    usage.push(generated.usage);
+    lastText = generated.text;
+    lastFinishReason = generated.finishReason;
+    const validation = validateA2UIOutput(generated.text, catalog);
+    lastErrors = validation.errors;
+    lastWarnings = validation.warnings;
+    if (validation.ok) {
+      return {
+        attempts: attempt,
+        errors: [],
+        finishReason: lastFinishReason,
+        messages: await resolveA2UIImageUrls(validation.messages),
+        ok: true,
+        text: lastText,
+        usage,
+        warnings: lastWarnings,
+      };
+    }
+    if (attempt < maxAttempts) {
+      conversation.push({ role: 'assistant', content: generated.text });
+      conversation.push({
+        role: 'user',
+        content: formatErrorsForModel(validation.errors),
+      });
+    }
+  }
+
+  return {
+    attempts: maxAttempts,
+    errors: lastErrors,
+    finishReason: lastFinishReason,
+    messages: [],
+    ok: false,
+    text: lastText,
+    usage,
+    warnings: lastWarnings,
+  };
+}
+
+async function runA2UINativeOne(
   jobId: string,
   request: BenchJobRequest,
   item: BenchRunItem,
@@ -177,19 +314,13 @@ async function runOne(
   emitRunPhase(jobId, item, 'agent');
 
   try {
-    const result = await getA2UIAgentService().generateValidated(
+    const result = await generateA2UINative(
+      request,
+      item,
+      runId,
       messages,
-      {
-        resourceId: `bench:${jobId}:${runId}`,
-        apiKey: request.provider.apiKey,
-        baseURL: request.provider.baseURL,
-        model,
-        api: request.provider.api,
-        catalog,
-        maxRepairAttempts: request.settings.maxRepairAttempts,
-      },
-      undefined,
-      undefined,
+      catalog,
+      model,
       signal,
     );
     emitRunPhase(jobId, item, 'validate');
@@ -207,8 +338,11 @@ async function runOne(
         && !signal.aborted
       ? await (async () => {
         emitRunPhase(jobId, item, 'judge');
-        return await runBenchUiJudge({
-          messages: result.messages,
+        return await runGenuiBenchUiJudge({
+          artifact: {
+            protocol: 'a2ui',
+            messages: result.messages ?? [],
+          },
           scenario: item.scenario,
           session: judgeSession,
           signal,
@@ -227,11 +361,13 @@ async function runOne(
         ttiMs: 0,
       };
     */
-    return {
+    return sanitizeBenchPublicValue({
       id: runId,
       groupId: item.group.id,
       groupName: item.group.name,
       role: item.group.role,
+      protocol: 'a2ui',
+      profile: 'native',
       scenarioId: item.scenario.id,
       scenarioName: item.scenario.name,
       repeatIndex: item.repeatIndex,
@@ -239,7 +375,10 @@ async function runOne(
       ok: result.ok,
       model: model ?? process.env.OPENAI_MODEL ?? 'server default',
       catalog: catalogLabel,
-      tokens: parseTotalTokens(result.usage),
+      tokens: result.usage.reduce<number>(
+        (total, usage) => total + parseTotalTokens(usage),
+        0,
+      ),
       agentMs: Math.round(agentMs),
       // fmpMs: preview.fmpMs,
       fmpMs: 0,
@@ -256,8 +395,8 @@ async function runOne(
       ...('summary' in judge && judge.summary
         ? { judgeSummary: judge.summary }
         : {}),
-      ...(judge.warnings.length > 0
-        ? { judgeWarnings: judge.warnings }
+      ...([...result.warnings, ...judge.warnings].length > 0
+        ? { judgeWarnings: [...result.warnings, ...judge.warnings] }
         : {}),
       messageCount: result.messages.length,
       outputChars,
@@ -265,19 +404,21 @@ async function runOne(
       finishReason: result.finishReason,
       usage: result.usage,
       messages: result.messages,
-      // ...(preview.screenshotDataUrl
-      //   ? { screenshotDataUrl: preview.screenshotDataUrl }
-      //   : {}),
+      ...('screenshotDataUrl' in judge && judge.screenshotDataUrl
+        ? { screenshotDataUrl: judge.screenshotDataUrl }
+        : {}),
       text: result.text,
-    };
+    }, request.provider) as BenchRunResult;
   } catch (error) {
     const agentMs = performance.now() - startedAt;
     const message = error instanceof Error ? error.message : String(error);
-    return {
+    return sanitizeBenchPublicValue({
       id: runId,
       groupId: item.group.id,
       groupName: item.group.name,
       role: item.group.role,
+      protocol: 'a2ui',
+      profile: 'native',
       scenarioId: item.scenario.id,
       scenarioName: item.scenario.name,
       repeatIndex: item.repeatIndex,
@@ -297,8 +438,248 @@ async function runOne(
       outputChars: 0,
       errors: [message],
       error: message,
-    };
+    }, request.provider) as BenchRunResult;
   }
+}
+
+function adapterScenarioFor(
+  group: BenchGroupRequest,
+  scenario: BenchScenarioRequest,
+): ProtocolBenchScenario {
+  const prompt = group.extraInstruction
+    ? `${scenario.prompt}\n\nAdditional benchmark instruction:\n${group.extraInstruction}`
+    : scenario.prompt;
+  return {
+    id: scenario.id,
+    name: scenario.name,
+    prompt,
+    type: scenario.type,
+    complexity: Math.max(
+      1,
+      Math.min(3, Math.round(scenario.complexity ?? 1)),
+    ) as 1 | 2 | 3,
+    ...(scenario.action ? { action: scenario.action } : {}),
+    ...(scenario.judgeTask ? { judgeTask: scenario.judgeTask } : {}),
+    ...(scenario.judgeSteps ? { judgeSteps: [...scenario.judgeSteps] } : {}),
+  };
+}
+
+async function runProtocolAdapterOne(
+  jobId: string,
+  request: BenchJobRequest,
+  item: BenchRunItem,
+  judgeCapability: BenchUiJudgeCapability,
+  adapter: ProtocolBenchAdapter | undefined,
+  signal: AbortSignal,
+): Promise<BenchRunResult> {
+  const store = getBenchJobStore();
+  const runId = `${item.group.id}-${item.scenario.id}-${item.repeatIndex}`;
+  const protocol = protocolForGroup(item.group);
+  const profile = profileForGroup(item.group);
+  const model = pickRunModel(request, item.group);
+  const catalogLabel = profile === 'matched-core'
+    ? 'matched-core' as const
+    : pickRunCatalog(item.group);
+
+  store.emit(jobId, 'run-start', {
+    runId,
+    groupId: item.group.id,
+    protocol,
+    profile,
+    scenarioId: item.scenario.id,
+    repeatIndex: item.repeatIndex,
+    progress: store.getJob(jobId)?.progress,
+  });
+  emitRunPhase(jobId, item, 'agent');
+  const startedAt = performance.now();
+
+  try {
+    if (!adapter) {
+      throw new Error(
+        `No benchmark adapter is registered for ${protocol}/${profile}.`,
+      );
+    }
+    const artifact = await adapter.generate({
+      runId,
+      pairId: `${item.scenario.id}-repeat-${item.repeatIndex}`,
+      scenario: adapterScenarioFor(item.group, item.scenario),
+      repeatIndex: item.repeatIndex,
+      maxAttempts: Math.max(1, request.settings.maxRepairAttempts + 1),
+      provider: {
+        apiKey: request.provider.apiKey,
+        baseURL: request.provider.baseURL,
+        model,
+        api: request.provider.api,
+      },
+    }, signal);
+    emitRunPhase(jobId, item, 'validate');
+
+    const judgePayload: ProtocolBenchJudgePayload | undefined =
+      artifact.finalValid
+        ? artifact.judgePayload
+        : undefined;
+    const judge: BenchUiJudgeResult | {
+      errors: [];
+      score: 0;
+      status: 'skipped';
+      warnings: [];
+    } = request.settings.judgeEnabled
+        && judgeCapability.session
+        && judgePayload
+        && !signal.aborted
+      ? await (async () => {
+        emitRunPhase(jobId, item, 'judge');
+        return await runGenuiBenchUiJudge({
+          artifact: judgePayload.kind === 'a2ui-messages'
+            ? {
+              protocol: 'a2ui',
+              messages: judgePayload.messages as NonNullable<
+                BenchRunResult['messages']
+              >,
+            }
+            : { protocol: 'openui', rawText: judgePayload.rawText },
+          scenario: item.scenario,
+          session: judgeCapability.session!,
+          signal,
+          timeoutMs: request.settings.timeoutMs,
+        });
+      })()
+      : { errors: [], score: 0, status: 'skipped', warnings: [] };
+    const attempts = artifact.attempts;
+    const tokens = attempts.reduce(
+      (total, attempt) => total + attempt.totalTokens,
+      0,
+    );
+    const messages = judgePayload?.kind === 'a2ui-messages'
+      ? judgePayload.messages as NonNullable<BenchRunResult['messages']>
+      : undefined;
+    const judgeWarnings = [
+      ...(artifact.warnings ?? []),
+      ...judge.warnings,
+    ];
+    const agentMs = performance.now() - startedAt;
+    const result: BenchRunResult = {
+      id: runId,
+      groupId: item.group.id,
+      groupName: item.group.name,
+      role: item.group.role,
+      protocol,
+      profile,
+      scenarioId: item.scenario.id,
+      scenarioName: item.scenario.name,
+      repeatIndex: item.repeatIndex,
+      status: artifact.finalValid ? 'complete' : 'failed',
+      ok: artifact.finalValid,
+      model: model ?? process.env.OPENAI_MODEL ?? 'server default',
+      catalog: catalogLabel,
+      tokens,
+      agentMs: Math.round(agentMs),
+      fmpMs: 0,
+      ttiMs: 0,
+      renderMs: 0,
+      attempts: attempts.length,
+      judgeScore: judge.score,
+      judgeStatus: judge.status,
+      ...('reason' in judge && judge.reason
+        ? { judgeReason: judge.reason }
+        : {}),
+      ...('summary' in judge && judge.summary
+        ? { judgeSummary: judge.summary }
+        : {}),
+      ...(judgeWarnings.length > 0 ? { judgeWarnings } : {}),
+      messageCount: messages?.length ?? 0,
+      outputChars: artifact.finalText?.length
+        ?? attempts[attempts.length - 1]?.outputChars
+        ?? 0,
+      errors: [...artifact.finalErrors, ...judge.errors],
+      ...(artifact.finalValid
+        ? {}
+        : {
+          error: artifact.finalErrors.join('; ')
+            || `${protocol} output failed validation`,
+        }),
+      ...(attempts[attempts.length - 1]?.finishReason === undefined
+        ? {}
+        : {
+          finishReason: attempts[attempts.length - 1]?.finishReason,
+        }),
+      usage: { totalTokens: tokens },
+      ...(messages ? { messages } : {}),
+      ...('screenshotDataUrl' in judge && judge.screenshotDataUrl
+        ? { screenshotDataUrl: judge.screenshotDataUrl }
+        : {}),
+      ...(artifact.metadata
+        ? { adapterMetadata: artifact.metadata }
+        : {}),
+      ...(artifact.finalText ? { text: artifact.finalText } : {}),
+    };
+    return sanitizeBenchPublicValue(
+      result,
+      request.provider,
+    ) as BenchRunResult;
+  } catch (error) {
+    const agentMs = performance.now() - startedAt;
+    const message = error instanceof Error ? error.message : String(error);
+    return sanitizeBenchPublicValue({
+      id: runId,
+      groupId: item.group.id,
+      groupName: item.group.name,
+      role: item.group.role,
+      protocol,
+      profile,
+      scenarioId: item.scenario.id,
+      scenarioName: item.scenario.name,
+      repeatIndex: item.repeatIndex,
+      status: 'failed',
+      ok: false,
+      model: model ?? process.env.OPENAI_MODEL ?? 'server default',
+      catalog: catalogLabel,
+      tokens: 0,
+      agentMs: Math.round(agentMs),
+      fmpMs: 0,
+      ttiMs: 0,
+      renderMs: 0,
+      attempts: 0,
+      judgeScore: 0,
+      judgeStatus: 'skipped',
+      messageCount: 0,
+      outputChars: 0,
+      errors: [message],
+      error: message,
+    }, request.provider) as BenchRunResult;
+  }
+}
+
+async function runOne(
+  jobId: string,
+  request: BenchJobRequest,
+  item: BenchRunItem,
+  judgeCapabilities: BenchJudgeCapabilities,
+  adapters: Partial<Record<BenchProtocol, ProtocolBenchAdapter>>,
+  signal: AbortSignal,
+): Promise<BenchRunResult> {
+  const capability = judgeCapabilities.get(judgeCapabilityKey(item.group))
+    ?? { enabled: false };
+  if (
+    protocolForGroup(item.group) === 'a2ui'
+    && profileForGroup(item.group) === 'native'
+  ) {
+    return await runA2UINativeOne(
+      jobId,
+      request,
+      item,
+      capability,
+      signal,
+    );
+  }
+  return await runProtocolAdapterOne(
+    jobId,
+    request,
+    item,
+    capability,
+    adapters[protocolForGroup(item.group)],
+    signal,
+  );
 }
 
 /*
@@ -351,46 +732,77 @@ async function runBenchPreviewForItem(
 export function summarizeGroup(
   group: BenchGroupRequest,
   results: BenchRunResult[],
+  plannedRuns = results.filter((item) => item.groupId === group.id).length,
 ): BenchGroupSummary {
   const groupResults = results.filter((item) => item.groupId === group.id);
-  const successful = groupResults.filter((item) => item.ok);
-  const base = successful.length > 0 ? successful : groupResults;
-  const judged = base.filter((item) => item.judgeStatus === 'complete');
-  const failedRuns = groupResults.filter((item) => !item.ok).length;
+  const successfulRuns = groupResults.filter((item) => item.ok).length;
+  const judged = groupResults.filter((item) => item.judgeStatus === 'complete');
+  const failedRuns = Math.max(0, plannedRuns - successfulRuns);
   return {
     groupId: group.id,
     groupName: group.name,
     role: group.role,
+    protocol: protocolForGroup(group),
+    profile: profileForGroup(group),
+    plannedRuns,
     runCount: groupResults.length,
     failedRuns,
-    successRate: groupResults.length === 0
-      ? 0
-      : (groupResults.length - failedRuns) / groupResults.length,
-    avgTokens: average(base.map((item) => item.tokens)),
-    avgAgentMs: average(base.map((item) => item.agentMs)),
-    avgFmpMs: average(base.map((item) => item.fmpMs)),
-    avgTtiMs: average(base.map((item) => item.ttiMs)),
-    avgRenderMs: average(base.map((item) => item.renderMs)),
-    avgJudgeScore: average(judged.map((item) => item.judgeScore)),
+    successRate: plannedRuns === 0 ? 0 : successfulRuns / plannedRuns,
+    avgTokens: averagePlanned(
+      groupResults.map((item) => item.tokens),
+      plannedRuns,
+    ),
+    avgAgentMs: averagePlanned(
+      groupResults.map((item) => item.agentMs),
+      plannedRuns,
+    ),
+    avgFmpMs: averagePlanned(
+      groupResults.map((item) => item.fmpMs),
+      plannedRuns,
+    ),
+    avgTtiMs: averagePlanned(
+      groupResults.map((item) => item.ttiMs),
+      plannedRuns,
+    ),
+    avgRenderMs: averagePlanned(
+      groupResults.map((item) => item.renderMs),
+      plannedRuns,
+    ),
+    avgJudgeScore: averagePlanned(
+      judged.map((item) => item.judgeScore),
+      plannedRuns,
+    ),
     judgeRunCount: judged.length,
-    avgAttempts: average(base.map((item) => item.attempts)),
+    avgAttempts: averagePlanned(
+      groupResults.map((item) => item.attempts),
+      plannedRuns,
+    ),
   };
 }
 
-function summarizeReport(results: BenchRunResult[]): BenchReportSummary {
-  const failedRuns = results.filter((item) => !item.ok).length;
-  const successful = results.filter((item) => item.ok);
-  const base = successful.length > 0 ? successful : results;
+function summarizeReport(
+  results: BenchRunResult[],
+  plannedRuns: number,
+): BenchReportSummary {
+  const successfulRuns = results.filter((item) => item.ok).length;
+  const failedRuns = Math.max(0, plannedRuns - successfulRuns);
   return {
-    totalRuns: results.length,
+    totalRuns: plannedRuns,
     completedRuns: results.length,
     failedRuns,
-    successRate: results.length === 0
-      ? 0
-      : (results.length - failedRuns) / results.length,
-    avgTokens: average(base.map((item) => item.tokens)),
-    avgAgentMs: average(base.map((item) => item.agentMs)),
-    avgAttempts: average(base.map((item) => item.attempts)),
+    successRate: plannedRuns === 0 ? 0 : successfulRuns / plannedRuns,
+    avgTokens: averagePlanned(
+      results.map((item) => item.tokens),
+      plannedRuns,
+    ),
+    avgAgentMs: averagePlanned(
+      results.map((item) => item.agentMs),
+      plannedRuns,
+    ),
+    avgAttempts: averagePlanned(
+      results.map((item) => item.attempts),
+      plannedRuns,
+    ),
   };
 }
 
@@ -400,11 +812,16 @@ function buildReport(
   results: BenchRunResult[],
   warnings: string[],
   status: BenchReport['status'],
-  judgeCapability: BenchUiJudgeCapability,
+  judgeCapabilities: BenchJudgeCapabilities,
 ): BenchReport {
   const enabledGroups = request.groups.filter((group) => group.enabled);
-  const summary = summarizeReport(results);
-  return {
+  const plannedRuns = enabledGroups.length
+    * request.scenarios.length
+    * request.settings.repeats;
+  const plannedRunsPerGroup = request.scenarios.length
+    * request.settings.repeats;
+  const summary = summarizeReport(results, plannedRuns);
+  const report: BenchReport = {
     id: `bench-report-${jobId}`,
     jobId,
     createdAt: new Date().toISOString(),
@@ -412,21 +829,9 @@ function buildReport(
     status,
     settings: request.settings,
     env: {
-      apiKeyConfigured: Boolean(
-        request.provider.apiKey ?? process.env.OPENAI_API_KEY,
-      ),
-      baseURL: request.provider.baseURL
-        ?? process.env.OPENAI_BASE_URL
-        ?? 'https://api.openai.com/v1',
       model: request.provider.model
         ?? process.env.OPENAI_MODEL
         ?? 'server default',
-      clientOverrideAccepted: Boolean(
-        request.provider.apiKey
-          ?? request.provider.baseURL
-          ?? request.provider.model
-          ?? request.provider.api,
-      ),
     },
     capabilities: {
       agent: 'enabled',
@@ -434,84 +839,184 @@ function buildReport(
       //   ? 'enabled'
       //   : 'disabled',
       renderMetrics: 'disabled',
-      judge: request.settings.judgeEnabled && judgeCapability.enabled
+      judge: request.settings.judgeEnabled
+          && enabledGroups.some((group) =>
+            judgeCapabilities.get(judgeCapabilityKey(group))?.enabled === true
+          )
         ? 'enabled'
         : 'disabled',
     },
     warnings,
-    groups: request.groups,
+    groups: request.groups.map((group) => ({
+      ...group,
+      protocol: protocolForGroup(group),
+      profile: profileForGroup(group),
+    })),
     scenarios: request.scenarios,
     results,
-    summaries: enabledGroups.map((group) => summarizeGroup(group, results)),
+    summaries: enabledGroups.map((group) =>
+      summarizeGroup(group, results, plannedRunsPerGroup)
+    ),
     summary,
   };
+  return sanitizeBenchPublicValue(report, request.provider) as BenchReport;
 }
 
 export function startBenchJob(jobId: string): void {
   void runBenchJob(jobId);
 }
 
-export async function runBenchJob(jobId: string): Promise<void> {
+async function probeJudgeCapabilities(
+  request: BenchJobRequest,
+): Promise<BenchJudgeCapabilities> {
+  const capabilities: BenchJudgeCapabilities = new Map();
+  if (!request.settings.judgeEnabled) return capabilities;
+  const groups = request.groups.filter((group) => group.enabled);
+  const uniqueGroups = new Map(
+    groups.map((group) => [judgeCapabilityKey(group), group]),
+  );
+  await Promise.all([...uniqueGroups.entries()].map(async ([key, group]) => {
+    const capability = protocolForGroup(group) === 'a2ui'
+        && profileForGroup(group) === 'native'
+      ? await probeBenchUiJudge()
+      : await probeGenuiBenchUiJudge(protocolForGroup(group));
+    capabilities.set(key, capability);
+  }));
+  return capabilities;
+}
+
+function resolveProtocolAdapters(
+  request: BenchJobRequest,
+  overrides: BenchRunnerDependencies['adapters'],
+): Partial<Record<BenchProtocol, ProtocolBenchAdapter>> {
+  const protocols = new Set(
+    request.groups.filter((group) =>
+      group.enabled
+      && !(
+        protocolForGroup(group) === 'a2ui'
+        && profileForGroup(group) === 'native'
+      )
+    ).map((group) => protocolForGroup(group)),
+  );
+  const adapters: Partial<Record<BenchProtocol, ProtocolBenchAdapter>> = {};
+  for (const protocol of protocols) {
+    adapters[protocol] = overrides?.[protocol]
+      ?? (protocol === 'a2ui'
+        ? createA2UIBenchAdapter()
+        : createOpenUIBenchAdapter());
+  }
+  return adapters;
+}
+
+export async function runBenchJob(
+  jobId: string,
+  dependencies: BenchRunnerDependencies = {},
+): Promise<void> {
   const store = getBenchJobStore();
   const job = store.getJob(jobId);
   if (!job) return;
   const activeJob = job;
   const request = activeJob.request;
-  const matrix = buildRunMatrix(request);
-  const judgeCapability = await probeBenchUiJudge();
-  if (
-    activeJob.abortController.signal.aborted
-    || activeJob.status === 'cancelled'
-  ) {
-    const report = buildReport(
-      jobId,
-      request,
-      activeJob.results,
-      activeJob.warnings,
-      'cancelled',
-      judgeCapability,
-    );
-    store.setReport(jobId, report);
-    return;
-  }
-  if (
-    request.settings.judgeEnabled
-    && !judgeCapability.enabled
-    && judgeCapability.reason
-  ) {
-    activeJob.warnings.push(`UI Judge disabled: ${judgeCapability.reason}`);
-  }
-
-  store.updateStatus(jobId, 'running');
-
-  let nextIndex = 0;
-  const workerCount = Math.min(request.settings.parallelism, matrix.length);
-
-  async function worker(): Promise<void> {
-    while (!activeJob.abortController.signal.aborted) {
-      const index = nextIndex++;
-      const item = matrix[index];
-      if (!item) return;
-
-      const result = await runOne(
-        jobId,
-        request,
-        item,
-        judgeCapability,
-        activeJob.abortController.signal,
-      );
-      if (activeJob.abortController.signal.aborted) return;
-      const updated = store.addResult(jobId, result);
-      if (!updated) return;
-      const event = result.ok ? 'run-complete' : 'run-error';
-      store.emit(jobId, event, {
-        result,
-        progress: updated.progress,
-      });
-    }
-  }
+  const samples = buildRunSamples(request);
+  const totalRuns = samples.reduce(
+    (total, sample) => total + sample.items.length,
+    0,
+  );
+  let judgeCapabilities: BenchJudgeCapabilities = new Map();
 
   try {
+    if (
+      activeJob.abortController.signal.aborted
+      || store.getJob(jobId)?.status === 'cancelled'
+    ) {
+      const report = buildReport(
+        jobId,
+        request,
+        activeJob.results,
+        activeJob.warnings,
+        'cancelled',
+        judgeCapabilities,
+      );
+      store.setReport(jobId, report);
+      return;
+    }
+
+    store.updateStatus(jobId, 'running');
+    judgeCapabilities = await probeJudgeCapabilities(request);
+    const adapters = resolveProtocolAdapters(
+      request,
+      dependencies.adapters,
+    );
+
+    if (
+      activeJob.abortController.signal.aborted
+      || store.getJob(jobId)?.status === 'cancelled'
+    ) {
+      store.updateStatus(jobId, 'cancelled');
+      const report = buildReport(
+        jobId,
+        request,
+        activeJob.results,
+        activeJob.warnings,
+        'cancelled',
+        judgeCapabilities,
+      );
+      store.setReport(jobId, report);
+      return;
+    }
+    if (request.settings.judgeEnabled) {
+      for (const [key, capability] of judgeCapabilities) {
+        if (!capability.enabled && capability.reason) {
+          activeJob.warnings.push(
+            `UI Judge disabled for ${key}: ${capability.reason}`,
+          );
+        }
+      }
+    }
+
+    let nextIndex = 0;
+    const mixedProtocols = new Set(
+      request.groups.filter((group) => group.enabled).map((group) =>
+        protocolForGroup(group)
+      ),
+    ).size > 1;
+    const workerCount = Math.min(
+      mixedProtocols ? 1 : request.settings.parallelism,
+      samples.length,
+    );
+
+    async function worker(): Promise<void> {
+      while (!activeJob.abortController.signal.aborted) {
+        const index = nextIndex++;
+        const sample = samples[index];
+        if (!sample) return;
+
+        for (const item of sample.items) {
+          if (activeJob.abortController.signal.aborted) return;
+          const result = await runOne(
+            jobId,
+            request,
+            item,
+            judgeCapabilities,
+            adapters,
+            activeJob.abortController.signal,
+          );
+          if (activeJob.abortController.signal.aborted) return;
+          const updated = store.addResult(jobId, result);
+          if (!updated) return;
+          const storedResult = updated.results[updated.results.length - 1]
+            ?? result;
+          const eventResult = { ...storedResult };
+          delete eventResult.screenshotDataUrl;
+          const event = storedResult.ok ? 'run-complete' : 'run-error';
+          store.emit(jobId, event, {
+            result: eventResult,
+            progress: updated.progress,
+          });
+        }
+      }
+    }
+
     await Promise.all(
       Array.from({ length: workerCount }, () => worker()),
     );
@@ -528,7 +1033,7 @@ export async function runBenchJob(jobId: string): Promise<void> {
         latest.results,
         latest.warnings,
         'cancelled',
-        judgeCapability,
+        judgeCapabilities,
       );
       store.setReport(jobId, report);
       return;
@@ -536,7 +1041,7 @@ export async function runBenchJob(jobId: string): Promise<void> {
 
     latest.progress = {
       completedRuns: latest.results.length,
-      totalRuns: matrix.length,
+      totalRuns,
     };
     latest.status = 'complete';
     const report = buildReport(
@@ -545,7 +1050,7 @@ export async function runBenchJob(jobId: string): Promise<void> {
       latest.results,
       latest.warnings,
       'complete',
-      judgeCapability,
+      judgeCapabilities,
     );
     store.setReport(jobId, report);
   } catch (error) {
@@ -558,7 +1063,7 @@ export async function runBenchJob(jobId: string): Promise<void> {
       latest.results,
       latest.warnings,
       'failed',
-      judgeCapability,
+      judgeCapabilities,
     );
     store.setReport(jobId, report);
   }

--- a/packages/genui/server/service/a2ui-bench-screenshot.ts
+++ b/packages/genui/server/service/a2ui-bench-screenshot.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const BENCH_SCREENSHOT_DATA_URL_PREFIX = 'data:image/png;base64,';
+export const MAX_BENCH_SCREENSHOT_DECODED_BYTES = 2 * 1024 * 1024;
+export const MAX_BENCH_JOB_SCREENSHOT_DECODED_BYTES = 8 * 1024 * 1024;
+
+const MAX_BENCH_SCREENSHOT_ENCODED_CHARS = Math.ceil(
+  MAX_BENCH_SCREENSHOT_DECODED_BYTES / 3,
+) * 4;
+
+export function benchScreenshotDecodedBytes(
+  value: string,
+): number | null {
+  if (!value.startsWith(BENCH_SCREENSHOT_DATA_URL_PREFIX)) return null;
+  const encoded = value.slice(BENCH_SCREENSHOT_DATA_URL_PREFIX.length);
+  if (
+    encoded.length === 0
+    || encoded.length % 4 === 1
+    || !/^[A-Za-z0-9+/]+={0,2}$/u.test(encoded)
+  ) {
+    return null;
+  }
+  let padding = 0;
+  if (encoded.endsWith('==')) {
+    padding = 2;
+  } else if (encoded.endsWith('=')) {
+    padding = 1;
+  }
+  return Math.max(0, Math.floor(encoded.length * 3 / 4) - padding);
+}
+
+export function readBenchScreenshotDataUrl(
+  value: unknown,
+): string | undefined {
+  if (
+    typeof value !== 'string'
+    || !value.startsWith(BENCH_SCREENSHOT_DATA_URL_PREFIX)
+  ) {
+    return undefined;
+  }
+  const encodedLength = value.length - BENCH_SCREENSHOT_DATA_URL_PREFIX.length;
+  const decodedBytes = benchScreenshotDecodedBytes(value);
+  return decodedBytes !== null
+      && decodedBytes <= MAX_BENCH_SCREENSHOT_DECODED_BYTES
+      && encodedLength <= MAX_BENCH_SCREENSHOT_ENCODED_CHARS
+    ? value
+    : undefined;
+}

--- a/packages/genui/server/service/a2ui-bench-store.ts
+++ b/packages/genui/server/service/a2ui-bench-store.ts
@@ -4,6 +4,15 @@
 
 import { randomUUID } from 'node:crypto';
 
+import {
+  redactBenchDiagnostic,
+  sanitizeBenchPublicValue,
+} from './a2ui-bench-redaction';
+import {
+  MAX_BENCH_JOB_SCREENSHOT_DECODED_BYTES,
+  MAX_BENCH_SCREENSHOT_DECODED_BYTES,
+  benchScreenshotDecodedBytes,
+} from './a2ui-bench-screenshot';
 import type {
   BenchJobEvent,
   BenchJobRequest,
@@ -15,9 +24,27 @@ import type {
 } from './a2ui-bench-types';
 
 const MAX_EVENT_HISTORY = 500;
-const MAX_JOBS = 20;
+const MAX_RETAINED_JOBS = 20;
+
+export const MAX_ACTIVE_BENCH_JOBS = 2;
 
 type BenchEventListener = (event: BenchJobEvent) => void;
+
+export interface BenchJobStoreOptions {
+  maxActiveJobs?: number;
+  maxRetainedJobs?: number;
+}
+
+export type BenchJobAdmission =
+  | {
+    ok: true;
+    job: BenchJobRecord;
+  }
+  | {
+    ok: false;
+    activeJobs: number;
+    limit: number;
+  };
 
 export interface BenchJobRecord {
   id: string;
@@ -34,10 +61,11 @@ export interface BenchJobRecord {
   events: BenchJobEvent[];
   nextEventId: number;
   listeners: Set<BenchEventListener>;
+  workerActive: boolean;
 }
 
 function snapshotJob(job: BenchJobRecord): BenchJobSnapshot {
-  return {
+  return sanitizeBenchPublicValue({
     ok: true,
     jobId: job.id,
     status: job.status,
@@ -45,18 +73,47 @@ function snapshotJob(job: BenchJobRecord): BenchJobSnapshot {
     ...(job.report ? { summary: job.report.summary } : {}),
     ...(job.error ? { error: job.error } : {}),
     warnings: job.warnings,
-  };
+  }, job.request.provider) as BenchJobSnapshot;
 }
 
 export class BenchJobStore {
-  private jobs = new Map<string, BenchJobRecord>();
+  private readonly jobs = new Map<string, BenchJobRecord>();
+  private readonly maxActiveJobs: number;
+  private readonly maxRetainedJobs: number;
+
+  public constructor(options: BenchJobStoreOptions = {}) {
+    this.maxActiveJobs = options.maxActiveJobs ?? MAX_ACTIVE_BENCH_JOBS;
+    this.maxRetainedJobs = options.maxRetainedJobs ?? MAX_RETAINED_JOBS;
+  }
 
   public createJob(
     request: BenchJobRequest,
     totalRuns: number,
     warnings: string[] = [],
   ): BenchJobRecord {
+    const admission = this.tryCreateJob(request, totalRuns, warnings);
+    if (!admission.ok) {
+      throw new Error(
+        `Bench active job capacity reached (${admission.activeJobs}/${admission.limit})`,
+      );
+    }
+    return admission.job;
+  }
+
+  public tryCreateJob(
+    request: BenchJobRequest,
+    totalRuns: number,
+    warnings: string[] = [],
+  ): BenchJobAdmission {
     this.sweepOldJobs();
+    const activeJobs = this.countActiveJobs();
+    if (activeJobs >= this.maxActiveJobs) {
+      return {
+        ok: false,
+        activeJobs,
+        limit: this.maxActiveJobs,
+      };
+    }
     const now = new Date().toISOString();
     const job: BenchJobRecord = {
       id: randomUUID(),
@@ -69,15 +126,16 @@ export class BenchJobStore {
         totalRuns,
       },
       results: [],
-      warnings,
+      warnings: [...warnings],
       abortController: new AbortController(),
       events: [],
       nextEventId: 1,
       listeners: new Set(),
+      workerActive: true,
     };
     this.jobs.set(job.id, job);
     this.emit(job.id, 'job', snapshotJob(job));
-    return job;
+    return { ok: true, job };
   }
 
   public getJob(jobId: string): BenchJobRecord | undefined {
@@ -98,7 +156,9 @@ export class BenchJobStore {
     if (!job) return undefined;
     job.status = status;
     job.updatedAt = new Date().toISOString();
-    if (error) job.error = error;
+    if (error) {
+      job.error = redactBenchDiagnostic(error, job.request.provider);
+    }
     this.emit(jobId, 'job', snapshotJob(job));
     return job;
   }
@@ -123,7 +183,38 @@ export class BenchJobStore {
   ): BenchJobRecord | undefined {
     const job = this.jobs.get(jobId);
     if (!job) return undefined;
-    job.results.push(result);
+    let storedResult = result;
+    if (result.screenshotDataUrl) {
+      const screenshotBytes = benchScreenshotDecodedBytes(
+        result.screenshotDataUrl,
+      );
+      const existingScreenshotBytes = job.results.reduce(
+        (total, item) =>
+          total
+          + (item.screenshotDataUrl
+            ? benchScreenshotDecodedBytes(item.screenshotDataUrl) ?? 0
+            : 0),
+        0,
+      );
+      const overSingleLimit = screenshotBytes === null
+        || screenshotBytes > MAX_BENCH_SCREENSHOT_DECODED_BYTES;
+      const overJobLimit = screenshotBytes !== null
+        && existingScreenshotBytes + screenshotBytes
+          > MAX_BENCH_JOB_SCREENSHOT_DECODED_BYTES;
+      if (overSingleLimit || overJobLimit) {
+        const warning = overSingleLimit
+          ? `UI Judge screenshot for run ${result.id} exceeded the 2 MiB limit and was discarded.`
+          : `UI Judge screenshot for run ${result.id} exceeded the 8 MiB per-job limit and was discarded.`;
+        storedResult = { ...result };
+        delete storedResult.screenshotDataUrl;
+        storedResult.judgeWarnings = [
+          ...(storedResult.judgeWarnings ?? []),
+          warning,
+        ];
+        job.warnings.push(warning);
+      }
+    }
+    job.results.push(storedResult);
     job.progress.completedRuns = job.results.length;
     job.updatedAt = new Date().toISOString();
     return job;
@@ -135,10 +226,22 @@ export class BenchJobStore {
   ): BenchJobRecord | undefined {
     const job = this.jobs.get(jobId);
     if (!job) return undefined;
-    job.report = report;
+    const provider = job.request.provider;
+    job.error = job.error
+      ? redactBenchDiagnostic(job.error, provider)
+      : undefined;
+    job.warnings = job.warnings.map((warning) =>
+      redactBenchDiagnostic(warning, provider)
+    );
+    job.report = sanitizeBenchPublicValue(
+      report,
+      provider,
+    ) as BenchReport;
+    job.workerActive = false;
     job.updatedAt = new Date().toISOString();
-    this.emit(jobId, 'report', report);
+    this.emit(jobId, 'report', job.report);
     this.emit(jobId, 'job', snapshotJob(job));
+    job.request.provider = {};
     return job;
   }
 
@@ -162,7 +265,7 @@ export class BenchJobStore {
     const item: BenchJobEvent = {
       id: job.nextEventId++,
       event,
-      data,
+      data: sanitizeBenchPublicValue(data, job.request.provider),
     };
     job.events.push(item);
     if (job.events.length > MAX_EVENT_HISTORY) {
@@ -187,15 +290,26 @@ export class BenchJobStore {
   }
 
   private sweepOldJobs(): void {
-    if (this.jobs.size < MAX_JOBS) return;
+    if (this.jobs.size < this.maxRetainedJobs) return;
     const sorted = [...this.jobs.values()].sort(
       (a, b) =>
         new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime(),
     );
-    for (const job of sorted.slice(0, Math.max(1, sorted.length - MAX_JOBS))) {
-      if (job.status === 'running') continue;
+    const removeCount = Math.max(
+      1,
+      sorted.length - this.maxRetainedJobs + 1,
+    );
+    for (
+      const job of sorted.filter((candidate) =>
+        !candidate.workerActive && candidate.report
+      ).slice(0, removeCount)
+    ) {
       this.jobs.delete(job.id);
     }
+  }
+
+  private countActiveJobs(): number {
+    return [...this.jobs.values()].filter((job) => job.workerActive).length;
   }
 }
 

--- a/packages/genui/server/service/a2ui-bench-types.ts
+++ b/packages/genui/server/service/a2ui-bench-types.ts
@@ -5,7 +5,14 @@
 import type { A2UIMessage } from '../agent/a2ui-validator';
 
 export type BenchRole = 'control' | 'experiment';
-export type BenchVariable = 'model' | 'prompt' | 'catalog' | 'custom';
+export type BenchProtocol = 'a2ui' | 'openui';
+export type BenchProfile = 'native' | 'matched-core';
+export type BenchVariable =
+  | 'model'
+  | 'prompt'
+  | 'catalog'
+  | 'protocol'
+  | 'custom';
 export type BenchCatalogLabel =
   | 'Full Catalog'
   | 'Core Catalog'
@@ -52,6 +59,8 @@ export interface BenchGroupRequest {
   name: string;
   variable: BenchVariable;
   enabled: boolean;
+  protocol?: BenchProtocol;
+  profile?: BenchProfile;
   model?: string;
   catalog?: BenchCatalogLabel;
   extraInstruction?: string;
@@ -92,13 +101,15 @@ export interface BenchRunResult {
   groupId: string;
   groupName: string;
   role: BenchRole;
+  protocol: BenchProtocol;
+  profile: BenchProfile;
   scenarioId: string;
   scenarioName: string;
   repeatIndex: number;
   status: 'complete' | 'failed';
   ok: boolean;
   model: string;
-  catalog: BenchCatalogLabel;
+  catalog: BenchCatalogLabel | 'matched-core';
   tokens: number;
   agentMs: number;
   fmpMs: number;
@@ -118,6 +129,7 @@ export interface BenchRunResult {
   usage?: unknown;
   messages?: A2UIMessage[];
   screenshotDataUrl?: string;
+  adapterMetadata?: Record<string, unknown>;
   text?: string;
 }
 
@@ -125,6 +137,9 @@ export interface BenchGroupSummary {
   groupId: string;
   groupName: string;
   role: BenchRole;
+  protocol: BenchProtocol;
+  profile: BenchProfile;
+  plannedRuns: number;
   runCount: number;
   failedRuns: number;
   successRate: number;
@@ -156,10 +171,7 @@ export interface BenchReport {
   status: BenchJobStatus;
   settings: BenchSettings;
   env: {
-    apiKeyConfigured: boolean;
-    baseURL: string;
     model: string;
-    clientOverrideAccepted: boolean;
   };
   capabilities: {
     agent: 'enabled';

--- a/packages/genui/server/service/common/provider.ts
+++ b/packages/genui/server/service/common/provider.ts
@@ -131,8 +131,11 @@ function parseReasoningEffort(
 export function resolveReasoningEffort(
   opts: ChatOptions,
 ): OpenAIReasoningEffort | undefined {
-  return parseReasoningEffort(opts.reasoningEffort)
-    ?? parseReasoningEffort(process.env.OPENAI_REASONING_EFFORT);
+  const explicit = parseReasoningEffort(opts.reasoningEffort);
+  if (explicit !== undefined) return explicit;
+  return opts.inheritReasoningEffort === false
+    ? undefined
+    : parseReasoningEffort(process.env.OPENAI_REASONING_EFFORT);
 }
 
 export function buildResourceRunOptions(

--- a/packages/genui/server/service/common/types.ts
+++ b/packages/genui/server/service/common/types.ts
@@ -27,6 +27,11 @@ export interface ChatOptions {
   model?: string | undefined;
   api?: 'chat' | 'responses' | undefined;
   reasoningEffort?: OpenAIReasoningEffort | undefined;
+  /**
+   * Set to false for controlled runs that must not inherit the process-wide
+   * OPENAI_REASONING_EFFORT setting.
+   */
+  inheritReasoningEffort?: boolean | undefined;
   onPerformanceEvent?: (
     event: string,
     details?: Record<string, unknown>,

--- a/packages/genui/server/service/genui-bench-judge.ts
+++ b/packages/genui/server/service/genui-bench-judge.ts
@@ -1,0 +1,226 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import {
+  probeBenchUiJudge,
+  runBenchUiJudge,
+  runBenchUiJudgeRequest,
+} from './a2ui-bench-judge';
+import type {
+  BenchUiJudgeCapability,
+  BenchUiJudgeResult,
+} from './a2ui-bench-judge';
+import type { BenchScenarioRequest } from './a2ui-bench-types';
+import type { A2UIMessage } from '../agent/a2ui-validator';
+
+const DEFAULT_OPENUI_BUNDLE_URL = 'https://lynx-stack.dev/genui/openui.lynx.js';
+const DEFAULT_UI_JUDGE_ATTEMPT_COUNT = 2;
+const DEFAULT_UI_JUDGE_RETRY_DELAY_MS = 5_000;
+const SCREENSHOT_SETTLE_MS = 1_000;
+const UI_JUDGE_MODEL = 'gpt-5.5-2026-04-24';
+const UNSAFE_OPENUI_RESOURCE_URL =
+  /(?:^|[\s("'=])(?:data|file|https?):(?:\/\/)?/iu;
+const UNSAFE_OPENUI_HOST_CALL = /\bopenUrl\s*\(/u;
+
+export type GenuiBenchProtocol = 'a2ui' | 'openui';
+type FetchLike = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type GenuiBenchJudgeArtifact =
+  | { messages: A2UIMessage[]; protocol: 'a2ui' }
+  | { protocol: 'openui'; rawText: string };
+
+export interface RunGenuiBenchUiJudgeOptions {
+  artifact: GenuiBenchJudgeArtifact;
+  scenario: Pick<
+    BenchScenarioRequest,
+    'judgeSteps' | 'judgeTask' | 'prompt'
+  >;
+  session: NonNullable<BenchUiJudgeCapability['session']>;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  /**
+   * Test seam for the bounded sidecar retry. Values are clamped to 1–2.
+   */
+  attemptCount?: number;
+  /**
+   * Test seam for the retry backoff. Production callers use the 5s default.
+   */
+  retryDelayMs?: number;
+}
+
+function normalizedAttemptCount(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_UI_JUDGE_ATTEMPT_COUNT;
+  }
+  return Math.min(
+    DEFAULT_UI_JUDGE_ATTEMPT_COUNT,
+    Math.max(1, Math.floor(value)),
+  );
+}
+
+function normalizedRetryDelayMs(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_UI_JUDGE_RETRY_DELAY_MS;
+  }
+  return Math.min(
+    DEFAULT_UI_JUDGE_RETRY_DELAY_MS,
+    Math.max(0, Math.floor(value)),
+  );
+}
+
+async function waitForRetry(
+  delayMs: number,
+  signal: AbortSignal | undefined,
+): Promise<boolean> {
+  if (signal?.aborted) return false;
+  if (delayMs === 0) return true;
+
+  return await new Promise<boolean>((resolve) => {
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      resolve(false);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve(true);
+    }, delayMs);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function isLocalSafetyRejection(result: BenchUiJudgeResult): boolean {
+  return result.errors.some((error) => error.startsWith('ui-judge rejected '));
+}
+
+function isSafetyWarning(warning: string): boolean {
+  return warning.startsWith('ui-judge replaced ')
+    && warning.endsWith(' to prevent untrusted resource loading.');
+}
+
+async function runWithBoundedRetry(
+  options: Pick<
+    RunGenuiBenchUiJudgeOptions,
+    'attemptCount' | 'retryDelayMs' | 'signal'
+  >,
+  run: () => Promise<BenchUiJudgeResult>,
+): Promise<BenchUiJudgeResult> {
+  const attemptCount = normalizedAttemptCount(options.attemptCount);
+  const retryDelayMs = normalizedRetryDelayMs(options.retryDelayMs);
+  const safetyWarnings = new Set<string>();
+  let result = await run();
+  result.warnings.filter((warning) => isSafetyWarning(warning)).forEach((
+    warning,
+  ) => safetyWarnings.add(warning));
+
+  for (
+    let attempt = 1;
+    attempt < attemptCount && result.status === 'failed';
+    attempt++
+  ) {
+    if (isLocalSafetyRejection(result)) break;
+    if (!await waitForRetry(retryDelayMs, options.signal)) break;
+
+    result = await run();
+    result.warnings.filter((warning) => isSafetyWarning(warning)).forEach((
+      warning,
+    ) => safetyWarnings.add(warning));
+  }
+
+  return {
+    ...result,
+    warnings: [
+      ...safetyWarnings,
+      ...result.warnings.filter((warning) => !safetyWarnings.has(warning)),
+    ],
+  };
+}
+
+export async function probeGenuiBenchUiJudge(
+  protocol: GenuiBenchProtocol,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    fetch?: FetchLike;
+  } = {},
+): Promise<BenchUiJudgeCapability> {
+  const env = options.env ?? process.env;
+  const bundleUrl = protocol === 'a2ui'
+    ? env.UI_JUDGE_A2UI_BUNDLE_URL?.trim()
+      ?? env.UI_JUDGE_BUNDLE_URL?.trim()
+    : env.UI_JUDGE_OPENUI_BUNDLE_URL?.trim()
+      ?? DEFAULT_OPENUI_BUNDLE_URL;
+
+  return await probeBenchUiJudge({
+    ...(bundleUrl ? { bundleUrl } : {}),
+    env,
+    expectedModel: UI_JUDGE_MODEL,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+  });
+}
+
+export async function runGenuiBenchUiJudge(
+  options: RunGenuiBenchUiJudgeOptions,
+  fetchImpl: FetchLike = fetch,
+): Promise<BenchUiJudgeResult> {
+  if (options.artifact.protocol === 'a2ui') {
+    const messages = options.artifact.messages;
+    return await runWithBoundedRetry(
+      options,
+      () =>
+        runBenchUiJudge(
+          {
+            includeScreenshot: true,
+            messages,
+            scenario: options.scenario,
+            screenshotSettleMs: SCREENSHOT_SETTLE_MS,
+            session: options.session,
+            ...(options.signal ? { signal: options.signal } : {}),
+            ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
+          },
+          fetchImpl,
+        ),
+    );
+  }
+
+  const rawText = options.artifact.rawText;
+  if (
+    UNSAFE_OPENUI_RESOURCE_URL.test(rawText)
+    || UNSAFE_OPENUI_HOST_CALL.test(rawText)
+  ) {
+    return {
+      errors: [
+        'ui-judge rejected OpenUI output containing an external resource URL or openUrl call.',
+      ],
+      score: 0,
+      status: 'failed',
+      warnings: [],
+    };
+  }
+
+  return await runWithBoundedRetry(
+    options,
+    () =>
+      runBenchUiJudgeRequest(
+        {
+          globalProps: {
+            benchMode: true,
+            instant: true,
+            rawText,
+            speed: 0,
+            theme: 'light',
+          },
+          includeScreenshot: true,
+          scenario: options.scenario,
+          screenshotSettleMs: SCREENSHOT_SETTLE_MS,
+          session: options.session,
+          ...(options.signal ? { signal: options.signal } : {}),
+          ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
+        },
+        fetchImpl,
+      ),
+  );
+}

--- a/packages/genui/server/service/genui-bench/a2ui-adapter.ts
+++ b/packages/genui/server/service/genui-bench/a2ui-adapter.ts
@@ -1,0 +1,356 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { A2UICatalog } from '../../agent/a2ui-catalog';
+import {
+  formatErrorsForModel,
+  validateA2UIOutput,
+} from '../../agent/a2ui-validator';
+import { getA2UIAgentService } from '../a2ui-agent';
+import type { A2UIChatOptions } from '../a2ui-agent';
+import { resolveBenchCatalog } from '../a2ui-bench-catalog';
+import type {
+  ProtocolBenchAdapter,
+  ProtocolBenchAdapterInput,
+  ProtocolBenchRunArtifact,
+} from './protocol-adapter';
+import type { ProtocolBenchAttemptResult } from './types';
+import type { ChatMessage } from '../common/types';
+
+interface UsageRecord {
+  promptTokens?: unknown;
+  completionTokens?: unknown;
+  totalTokens?: unknown;
+  inputTokens?: unknown;
+  outputTokens?: unknown;
+  prompt_tokens?: unknown;
+  completion_tokens?: unknown;
+  total_tokens?: unknown;
+}
+
+export type A2UIBenchGenerateRaw = (
+  messages: ChatMessage[],
+  options: A2UIChatOptions,
+  signal?: AbortSignal,
+) => Promise<{ text: string; usage: unknown; finishReason: unknown }>;
+
+export type A2UIBenchRetrySleep = (
+  delayMs: number,
+  signal?: AbortSignal,
+) => Promise<void>;
+
+export interface A2UIBenchAdapterOptions {
+  generateRaw?: A2UIBenchGenerateRaw;
+  retryDelayMs?: number;
+  sleep?: A2UIBenchRetrySleep;
+}
+
+const DEFAULT_TRANSPORT_RETRY_DELAY_MS = 10_000;
+
+const MATCHED_CORE_COMPONENTS = new Set([
+  'Text',
+  'Row',
+  'Column',
+  'List',
+  'Card',
+  'Button',
+  'Divider',
+]);
+
+function createMatchedCoreCatalog(): A2UICatalog {
+  const base = resolveBenchCatalog('Full Catalog');
+  const components = base.components.filter((component) =>
+    MATCHED_CORE_COMPONENTS.has(component.name)
+  );
+  return {
+    ...base,
+    id: `${base.id}#matched-core`,
+    label: 'Lynx GenUI matched core',
+    components,
+    examples: [],
+    functions: [],
+    extraRules: [
+      ...(base.extraRules ?? []),
+      `Matched-core track: use only ${
+        components.map((component) => component.name).join(', ')
+      }. Image and protocol-native extension components are excluded.`,
+    ],
+  };
+}
+
+function pickToken(
+  usage: UsageRecord,
+  keys: (keyof UsageRecord)[],
+): number {
+  for (const key of keys) {
+    const value = usage[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(0, Math.round(value));
+    }
+  }
+  return 0;
+}
+
+function readUsage(usage: unknown): {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+} {
+  if (!usage || typeof usage !== 'object') {
+    return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  }
+  const record = usage as UsageRecord;
+  const inputTokens = pickToken(record, [
+    'promptTokens',
+    'inputTokens',
+    'prompt_tokens',
+  ]);
+  const outputTokens = pickToken(record, [
+    'completionTokens',
+    'outputTokens',
+    'completion_tokens',
+  ]);
+  const reportedTotal = pickToken(record, ['totalTokens', 'total_tokens']);
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: reportedTotal || inputTokens + outputTokens,
+  };
+}
+
+function normalizedAttemptLimit(maxAttempts: number): number {
+  if (!Number.isFinite(maxAttempts)) return 1;
+  return Math.min(4, Math.max(1, Math.floor(maxAttempts)));
+}
+
+function normalizedRetryDelayMs(retryDelayMs: number | undefined): number {
+  if (retryDelayMs === undefined || !Number.isFinite(retryDelayMs)) {
+    return DEFAULT_TRANSPORT_RETRY_DELAY_MS;
+  }
+  return Math.max(0, Math.floor(retryDelayMs));
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The operation was aborted.', 'AbortError');
+}
+
+const defaultRetrySleep: A2UIBenchRetrySleep = (
+  delayMs,
+  signal,
+) => {
+  signal?.throwIfAborted();
+  if (delayMs === 0) return Promise.resolve();
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+      reject(signal ? abortError(signal) : new Error('Retry was aborted.'));
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+};
+
+async function waitForTransportRetry(
+  sleep: A2UIBenchRetrySleep,
+  delayMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  if (!signal) {
+    await sleep(delayMs);
+    return;
+  }
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(abortError(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+
+  try {
+    await Promise.race([
+      Promise.resolve().then(() => sleep(delayMs, signal)),
+      aborted,
+    ]);
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+  }
+  signal.throwIfAborted();
+}
+
+function buildPrompt(input: ProtocolBenchAdapterInput): string {
+  return [
+    'Generate one Lynx UI for the benchmark scenario below.',
+    '',
+    `Scenario name: ${input.scenario.name}`,
+    `Scenario type: ${input.scenario.type}`,
+    `Scenario complexity: ${input.scenario.complexity}`,
+    input.scenario.action
+      ? `Required action: ${input.scenario.action}`
+      : undefined,
+    '',
+    'User request:',
+    input.scenario.prompt,
+    '',
+    'Return only valid A2UI v0.9 protocol messages using the selected catalog.',
+    'Do not include benchmark metadata in the generated UI.',
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join('\n');
+}
+
+function abortedArtifact(message: string): ProtocolBenchRunArtifact {
+  return {
+    attempts: [],
+    finalValid: false,
+    finalErrors: [message],
+  };
+}
+
+export function createA2UIBenchAdapter(
+  options: A2UIBenchAdapterOptions = {},
+): ProtocolBenchAdapter {
+  const generateRaw = options.generateRaw
+    ?? ((messages, chatOptions, signal) =>
+      getA2UIAgentService().generateRaw(
+        messages,
+        chatOptions,
+        undefined,
+        signal,
+      ));
+  const retryDelayMs = normalizedRetryDelayMs(options.retryDelayMs);
+  const sleep = options.sleep ?? defaultRetrySleep;
+  return {
+    protocol: 'a2ui',
+    async generate(input, signal) {
+      if (signal?.aborted) {
+        return abortedArtifact(
+          'A2UI generation was cancelled before it started.',
+        );
+      }
+
+      const catalog = createMatchedCoreCatalog();
+      const messages: ChatMessage[] = [{
+        role: 'user',
+        content: buildPrompt(input),
+      }];
+      const attempts: ProtocolBenchAttemptResult[] = [];
+      const warnings: string[] = [];
+      let finalText = '';
+      let finalErrors: string[] = [];
+      let finalMessages: unknown[] | undefined;
+      const maxAttempts = normalizedAttemptLimit(input.maxAttempts);
+
+      for (let index = 1; index <= maxAttempts; index++) {
+        if (signal?.aborted) {
+          finalErrors = ['A2UI generation was cancelled.'];
+          break;
+        }
+
+        const startedAt = performance.now();
+        try {
+          const generated = await generateRaw(
+            messages,
+            {
+              resourceId: `genui-bench:${input.runId}:attempt-${index}`,
+              apiKey: input.provider.apiKey,
+              baseURL: input.provider.baseURL,
+              model: input.provider.model,
+              api: input.provider.api,
+              catalog,
+              disableAgentCache: true,
+              inheritReasoningEffort: false,
+            },
+            signal,
+          );
+          const durationMs = Math.max(
+            0,
+            Math.round(performance.now() - startedAt),
+          );
+          finalText = generated.text;
+          const validation = validateA2UIOutput(generated.text, catalog);
+          finalErrors = validation.errors;
+          warnings.push(...validation.warnings);
+          const usage = readUsage(generated.usage);
+          attempts.push({
+            index,
+            durationMs,
+            ...usage,
+            valid: validation.ok,
+            validationErrors: [...validation.errors],
+            outputChars: generated.text.length,
+            finishReason: generated.finishReason,
+          });
+
+          if (validation.ok) {
+            finalMessages = validation.messages;
+            break;
+          }
+          if (index < maxAttempts) {
+            messages.push({ role: 'assistant', content: generated.text });
+            messages.push({
+              role: 'user',
+              content: formatErrorsForModel(validation.errors),
+            });
+          }
+        } catch (error) {
+          signal?.throwIfAborted();
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          finalErrors = [message];
+          attempts.push({
+            index,
+            durationMs: Math.max(
+              0,
+              Math.round(performance.now() - startedAt),
+            ),
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            valid: false,
+            validationErrors: [message],
+            outputChars: 0,
+          });
+          if (index < maxAttempts) {
+            await waitForTransportRetry(sleep, retryDelayMs, signal);
+            continue;
+          }
+          break;
+        }
+      }
+
+      return {
+        attempts,
+        finalValid: finalMessages !== undefined,
+        ...(finalText ? { finalText } : {}),
+        finalErrors,
+        warnings,
+        ...(finalMessages
+          ? {
+            judgePayload: {
+              kind: 'a2ui-messages' as const,
+              messages: finalMessages,
+            },
+          }
+          : {}),
+      };
+    },
+  };
+}

--- a/packages/genui/server/service/genui-bench/protocol-adapter.ts
+++ b/packages/genui/server/service/genui-bench/protocol-adapter.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type {
+  BenchProtocol,
+  ProtocolBenchAttemptResult,
+  ProtocolBenchJudgeResult,
+  ProtocolBenchProviderConfig,
+  ProtocolBenchRenderResult,
+  ProtocolBenchScenario,
+} from './types';
+
+export type { ProtocolBenchProviderConfig } from './types';
+
+export type ProtocolBenchJudgePayload =
+  | {
+    kind: 'a2ui-messages';
+    messages: unknown[];
+  }
+  | {
+    kind: 'openui-text';
+    rawText: string;
+  };
+
+export interface ProtocolBenchAdapterInput {
+  runId: string;
+  pairId: string;
+  scenario: ProtocolBenchScenario;
+  repeatIndex: number;
+  maxAttempts: number;
+  provider: ProtocolBenchProviderConfig;
+}
+
+/**
+ * Protocol adapters own protocol prompting, validation, and repair. The runner
+ * owns paired scheduling, aggregation, rendering, and judging.
+ */
+export interface ProtocolBenchRunArtifact {
+  attempts: ProtocolBenchAttemptResult[];
+  finalValid: boolean;
+  finalText?: string;
+  finalErrors: string[];
+  warnings?: string[];
+  judgePayload?: ProtocolBenchJudgePayload;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProtocolBenchAdapter {
+  protocol: BenchProtocol;
+  generate(
+    input: ProtocolBenchAdapterInput,
+    signal?: AbortSignal,
+  ): Promise<ProtocolBenchRunArtifact>;
+}
+
+export interface ProtocolBenchEvaluationInput {
+  runId: string;
+  pairId: string;
+  protocol: BenchProtocol;
+  scenario: ProtocolBenchScenario;
+  repeatIndex: number;
+  payload: ProtocolBenchJudgePayload;
+}
+
+export type ProtocolBenchRenderEvaluator = (
+  input: ProtocolBenchEvaluationInput,
+  signal?: AbortSignal,
+) => Promise<ProtocolBenchRenderResult>;
+
+export type ProtocolBenchJudgeEvaluator = (
+  input: ProtocolBenchEvaluationInput & { model: string },
+  signal?: AbortSignal,
+) => Promise<ProtocolBenchJudgeResult>;

--- a/packages/genui/server/service/genui-bench/types.ts
+++ b/packages/genui/server/service/genui-bench/types.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const BENCH_PROTOCOLS = ['a2ui', 'openui'] as const;
+
+export type BenchProtocol = (typeof BENCH_PROTOCOLS)[number];
+
+export interface ProtocolBenchProviderConfig {
+  apiKey?: string;
+  baseURL?: string;
+  model?: string;
+  api?: 'chat' | 'responses';
+}
+
+export interface ProtocolBenchScenario {
+  id: string;
+  name: string;
+  prompt: string;
+  type: string;
+  complexity: 1 | 2 | 3;
+  action?: string;
+  judgeTask?: string;
+  judgeSteps?: string[];
+}
+
+export interface ProtocolBenchAttemptResult {
+  index: number;
+  durationMs: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  valid: boolean;
+  validationErrors: string[];
+  outputChars: number;
+  finishReason?: unknown;
+}
+
+export type ProtocolBenchEvaluationStatus = 'passed' | 'failed' | 'not-run';
+
+export interface ProtocolBenchRenderResult {
+  status: ProtocolBenchEvaluationStatus;
+  durationMs: number;
+  reason?: string;
+  error?: string;
+  warnings?: string[];
+}
+
+export interface ProtocolBenchJudgeResult {
+  status: ProtocolBenchEvaluationStatus;
+  score: number;
+  model: string;
+  durationMs: number;
+  screenshotDataUrl?: string;
+  reason?: string;
+  summary?: string;
+  error?: string;
+  warnings?: string[];
+}

--- a/packages/genui/server/service/openui-agent.ts
+++ b/packages/genui/server/service/openui-agent.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { createOpenUIAgent } from '../agent/openui-agent';
-import type { OpenUIAgent } from '../agent/openui-agent';
+import type { OpenUIAgent, OpenUIAgentOptions } from '../agent/openui-agent';
 import {
   buildConversationMessages,
   sumContentChars,
@@ -12,6 +12,7 @@ import {
 import {
   ProviderAgentCache,
   buildResourceRunOptions,
+  createStableValueHash,
   pickProviderConfig,
 } from './common/provider';
 import {
@@ -27,6 +28,18 @@ import type {
   MastraStreamResult,
 } from './common/types';
 
+export interface OpenUIChatOptions extends ChatOptions {
+  /**
+   * Create an agent for this call without retaining request-scoped provider
+   * credentials in the shared provider cache.
+   */
+  disableAgentCache?: boolean | undefined;
+  promptComponentNames?: readonly string[] | undefined;
+  promptOptions?: OpenUIAgentOptions['promptOptions'];
+  promptRoot?: string | undefined;
+  systemAppendix?: string | undefined;
+}
+
 function buildDataModelSystemMessage(
   dataModel: Record<string, unknown>,
 ): ChatMessage {
@@ -41,16 +54,45 @@ function buildDataModelSystemMessage(
 export default class OpenUIAgentService {
   private readonly agentCache = new ProviderAgentCache<OpenUIAgent>();
 
-  private getAgent(opts: ChatOptions): Promise<OpenUIAgent> {
+  private getAgent(opts: OpenUIChatOptions): Promise<OpenUIAgent> {
+    const promptVariant = opts.promptComponentNames === undefined
+        && opts.promptOptions === undefined
+        && opts.promptRoot === undefined
+        && opts.systemAppendix === undefined
+      ? undefined
+      : createStableValueHash({
+        appendix: opts.systemAppendix,
+        componentNames: opts.promptComponentNames,
+        promptOptions: opts.promptOptions,
+        root: opts.promptRoot,
+      });
+    const createAgent = () =>
+      createOpenUIAgent({
+        ...pickProviderConfig(opts),
+        ...(opts.promptComponentNames === undefined
+          ? {}
+          : { promptComponentNames: opts.promptComponentNames }),
+        ...(opts.promptOptions === undefined
+          ? {}
+          : { promptOptions: opts.promptOptions }),
+        ...(opts.promptRoot === undefined
+          ? {}
+          : { promptRoot: opts.promptRoot }),
+        ...(opts.systemAppendix === undefined
+          ? {}
+          : { systemAppendix: opts.systemAppendix }),
+      }).agent;
+    if (opts.disableAgentCache) return Promise.resolve().then(createAgent);
     return this.agentCache.get(
       opts,
-      () => createOpenUIAgent(pickProviderConfig(opts)).agent,
+      createAgent,
+      promptVariant,
     );
   }
 
   public async stream(
     messages: ChatMessage[],
-    opts: ChatOptions = {},
+    opts: OpenUIChatOptions = {},
     abortSignal?: AbortSignal,
   ): Promise<MastraStreamResult> {
     abortSignal?.throwIfAborted();
@@ -79,7 +121,7 @@ export default class OpenUIAgentService {
 
   public async streamAsAsyncIterable(
     messages: ChatMessage[],
-    opts: ChatOptions = {},
+    opts: OpenUIChatOptions = {},
     conversation?: ConversationContext,
     abortSignal?: AbortSignal,
   ): Promise<{
@@ -120,14 +162,14 @@ export default class OpenUIAgentService {
 
   public async generateRaw(
     messages: ChatMessage[],
-    opts: ChatOptions = {},
+    opts: OpenUIChatOptions = {},
     conversation?: ConversationContext,
     abortSignal?: AbortSignal,
   ): Promise<{ text: string; usage: unknown; finishReason: unknown }> {
     abortSignal?.throwIfAborted();
     const agent = await this.getAgent(opts);
     abortSignal?.throwIfAborted();
-    const result = agent.generate(
+    const result = await agent.generate(
       toModelMessages(
         buildConversationMessages(
           messages,

--- a/packages/genui/server/service/openui-bench-adapter.ts
+++ b/packages/genui/server/service/openui-bench-adapter.ts
@@ -1,0 +1,548 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { ChatMessage } from './common/types';
+import type {
+  ProtocolBenchAdapter,
+  ProtocolBenchAdapterInput,
+  ProtocolBenchProviderConfig,
+  ProtocolBenchRunArtifact,
+} from './genui-bench/protocol-adapter';
+import type {
+  ProtocolBenchAttemptResult,
+  ProtocolBenchScenario,
+} from './genui-bench/types';
+import { getOpenUIAgentService } from './openui-agent';
+import type { OpenUIChatOptions } from './openui-agent';
+import {
+  OPENUI_BENCH_MATCHED_COMPONENTS,
+  OPENUI_BENCH_ROOT_COMPONENT,
+  createOpenUIBenchValidator,
+} from './openui-bench-validator';
+import type {
+  OpenUIBenchComplexity,
+  OpenUIBenchValidationError,
+  OpenUIBenchValidationResult,
+  OpenUIBenchValidator,
+} from './openui-bench-validator';
+
+export { OPENUI_BENCH_MATCHED_COMPONENTS, OPENUI_BENCH_ROOT_COMPONENT };
+
+export interface OpenUIBenchUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface OpenUIBenchGenerationResult {
+  text: string;
+  usage: unknown;
+  finishReason: unknown;
+}
+
+export type OpenUIBenchGenerateRaw = (
+  messages: ChatMessage[],
+  options: OpenUIChatOptions,
+  signal?: AbortSignal,
+) => Promise<OpenUIBenchGenerationResult>;
+
+export type OpenUIBenchRetrySleep = (
+  delayMs: number,
+  signal?: AbortSignal,
+) => Promise<void>;
+
+export interface OpenUIBenchGenerateAttemptInput {
+  index: number;
+  messages: ChatMessage[];
+  provider: ProtocolBenchProviderConfig;
+  resourceId: string;
+  signal?: AbortSignal;
+}
+
+export interface OpenUIBenchAttemptResult extends ProtocolBenchAttemptResult {
+  rawText: string;
+  usage: unknown;
+  normalizedUsage: OpenUIBenchUsage;
+  normalizedErrors: OpenUIBenchValidationError[];
+  warnings: string[];
+  complexity: OpenUIBenchComplexity;
+  generationFailed: boolean;
+}
+
+export interface OpenUIBenchRunArtifact extends ProtocolBenchRunArtifact {
+  attempts: OpenUIBenchAttemptResult[];
+  rawText: string;
+  normalizedErrors: OpenUIBenchValidationError[];
+  complexity: OpenUIBenchComplexity;
+  totalUsage: OpenUIBenchUsage;
+  totalLatencyMs: number;
+  attemptCount: number;
+  finalFinishReason?: unknown;
+}
+
+export interface OpenUIBenchAdapter extends ProtocolBenchAdapter {
+  readonly protocol: 'openui';
+  readonly componentNames: readonly string[];
+  validate(rawText: string): OpenUIBenchValidationResult;
+  generateAttempt(
+    input: OpenUIBenchGenerateAttemptInput,
+  ): Promise<OpenUIBenchAttemptResult>;
+  generate(
+    input: ProtocolBenchAdapterInput,
+    signal?: AbortSignal,
+  ): Promise<OpenUIBenchRunArtifact>;
+}
+
+export interface OpenUIBenchAdapterOptions {
+  generateRaw?: OpenUIBenchGenerateRaw;
+  now?: () => number;
+  retryDelayMs?: number;
+  sleep?: OpenUIBenchRetrySleep;
+  validator?: OpenUIBenchValidator;
+}
+
+const DEFAULT_TRANSPORT_RETRY_DELAY_MS = 10_000;
+
+export const OPENUI_BENCH_SYSTEM_APPENDIX = [
+  'Matched-core benchmark constraints (these override any broader catalog examples above):',
+  `- The root component is ${OPENUI_BENCH_ROOT_COMPONENT}.`,
+  `- Use only these components: ${OPENUI_BENCH_MATCHED_COMPONENTS.join(', ')}.`,
+  '- Do not use Query(), Mutation(), external tools, remote resources, or URL-opening actions.',
+  '- Return one complete OpenUI v0.5 program as plain text.',
+  '- Do not wrap the program in Markdown fences and do not add prose.',
+].join('\n');
+
+export const OPENUI_BENCH_CAPABILITY_PROFILE = 'matched-core-v1';
+
+export const OPENUI_BENCH_MATCHED_CAPABILITIES = Object.freeze(
+  [
+    'vertical-layout',
+    'horizontal-layout',
+    'list',
+    'card',
+    'text',
+    'button-action',
+    'divider',
+  ] as const,
+);
+
+export const OPENUI_BENCH_PROMPT_OPTIONS: NonNullable<
+  OpenUIChatOptions['promptOptions']
+> = {
+  bindings: false,
+  toolCalls: false,
+  examples: [],
+};
+
+interface UsageRecord {
+  promptTokens?: unknown;
+  completionTokens?: unknown;
+  totalTokens?: unknown;
+  inputTokens?: unknown;
+  outputTokens?: unknown;
+  prompt_tokens?: unknown;
+  completion_tokens?: unknown;
+  total_tokens?: unknown;
+  input_tokens?: unknown;
+  output_tokens?: unknown;
+}
+
+function pickTokenCount(
+  usage: UsageRecord,
+  keys: (keyof UsageRecord)[],
+): number {
+  for (const key of keys) {
+    const value = usage[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(0, Math.round(value));
+    }
+  }
+  return 0;
+}
+
+export function normalizeOpenUIBenchUsage(usage: unknown): OpenUIBenchUsage {
+  if (usage === null || typeof usage !== 'object' || Array.isArray(usage)) {
+    return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  }
+  const record = usage as UsageRecord;
+  const inputTokens = pickTokenCount(record, [
+    'inputTokens',
+    'promptTokens',
+    'input_tokens',
+    'prompt_tokens',
+  ]);
+  const outputTokens = pickTokenCount(record, [
+    'outputTokens',
+    'completionTokens',
+    'output_tokens',
+    'completion_tokens',
+  ]);
+  const reportedTotal = pickTokenCount(record, [
+    'totalTokens',
+    'total_tokens',
+  ]);
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: reportedTotal || inputTokens + outputTokens,
+  };
+}
+
+function sumUsage(attempts: OpenUIBenchAttemptResult[]): OpenUIBenchUsage {
+  return attempts.reduce<OpenUIBenchUsage>(
+    (total, attempt) => ({
+      inputTokens: total.inputTokens + attempt.normalizedUsage.inputTokens,
+      outputTokens: total.outputTokens + attempt.normalizedUsage.outputTokens,
+      totalTokens: total.totalTokens + attempt.normalizedUsage.totalTokens,
+    }),
+    { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+  );
+}
+
+export function buildOpenUIBenchPrompt(
+  scenario: ProtocolBenchScenario,
+): string {
+  return [
+    'Generate one OpenUI v0.5 UI for the following benchmark scenario.',
+    '',
+    `Scenario name: ${scenario.name}`,
+    `Scenario type: ${scenario.type}`,
+    `Scenario complexity: ${scenario.complexity}`,
+    scenario.action ? `Required action: ${scenario.action}` : undefined,
+    '',
+    'User request:',
+    scenario.prompt,
+    '',
+    'Benchmark constraints:',
+    `- Assign the renderable root to ${OPENUI_BENCH_ROOT_COMPONENT}.`,
+    `- Use only: ${OPENUI_BENCH_MATCHED_COMPONENTS.join(', ')}.`,
+    '- Return only a complete OpenUI v0.5 program.',
+    '- Do not use Query, Mutation, external tools, external URLs, or benchmark metadata.',
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join('\n');
+}
+
+export function formatOpenUIBenchError(
+  error: OpenUIBenchValidationError,
+): string {
+  const location = [
+    error.statementId ? `statement=${error.statementId}` : undefined,
+    error.component ? `component=${error.component}` : undefined,
+    error.path ? `path=${error.path}` : undefined,
+  ].filter((part): part is string => part !== undefined).join(' ');
+  return `[${error.code}]${location ? ` ${location}` : ''} ${error.message}${
+    error.hint ? ` Fix: ${error.hint}` : ''
+  }`;
+}
+
+export function formatOpenUIBenchRepairPrompt(
+  errors: OpenUIBenchValidationError[],
+): string {
+  return [
+    'Your previous response is not a valid matched-core OpenUI v0.5 program.',
+    'Return the entire corrected program, not a patch.',
+    'Output only plain OpenUI code without Markdown fences or commentary.',
+    '',
+    'Validation errors:',
+    ...errors.map((error) => `- ${formatOpenUIBenchError(error)}`),
+  ].join('\n');
+}
+
+function normalizedAttemptLimit(maxAttempts: number): number {
+  if (!Number.isFinite(maxAttempts)) return 1;
+  return Math.min(4, Math.max(1, Math.floor(maxAttempts)));
+}
+
+function normalizedRetryDelayMs(retryDelayMs: number | undefined): number {
+  if (retryDelayMs === undefined || !Number.isFinite(retryDelayMs)) {
+    return DEFAULT_TRANSPORT_RETRY_DELAY_MS;
+  }
+  return Math.max(0, Math.floor(retryDelayMs));
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The operation was aborted.', 'AbortError');
+}
+
+const defaultRetrySleep: OpenUIBenchRetrySleep = (
+  delayMs,
+  signal,
+) => {
+  signal?.throwIfAborted();
+  if (delayMs === 0) return Promise.resolve();
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+      reject(signal ? abortError(signal) : new Error('Retry was aborted.'));
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+};
+
+async function waitForTransportRetry(
+  sleep: OpenUIBenchRetrySleep,
+  delayMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  if (!signal) {
+    await sleep(delayMs);
+    return;
+  }
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(abortError(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+
+  try {
+    await Promise.race([
+      Promise.resolve().then(() => sleep(delayMs, signal)),
+      aborted,
+    ]);
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+  }
+  signal.throwIfAborted();
+}
+
+function redactMessage(
+  error: unknown,
+  secrets: (string | undefined)[],
+): string {
+  let message = error instanceof Error ? error.message : String(error);
+  for (const secret of secrets) {
+    if (secret) message = message.replaceAll(secret, '[REDACTED]');
+  }
+  return message.replace(/https?:\/\/[^\s"'<>]+/giu, '[REDACTED_URL]');
+}
+
+class DefaultOpenUIBenchAdapter implements OpenUIBenchAdapter {
+  public readonly protocol = 'openui' as const;
+  public readonly componentNames: readonly string[];
+
+  private readonly generateRaw: OpenUIBenchGenerateRaw;
+  private readonly now: () => number;
+  private readonly retryDelayMs: number;
+  private readonly sleep: OpenUIBenchRetrySleep;
+  private readonly validator: OpenUIBenchValidator;
+
+  public constructor(options: OpenUIBenchAdapterOptions) {
+    this.generateRaw = options.generateRaw
+      ?? ((messages, agentOptions, signal) =>
+        getOpenUIAgentService().generateRaw(
+          messages,
+          agentOptions,
+          undefined,
+          signal,
+        ));
+    this.now = options.now ?? (() => performance.now());
+    this.retryDelayMs = normalizedRetryDelayMs(options.retryDelayMs);
+    this.sleep = options.sleep ?? defaultRetrySleep;
+    this.validator = options.validator ?? createOpenUIBenchValidator();
+    this.componentNames = this.validator.componentNames;
+  }
+
+  public validate(rawText: string): OpenUIBenchValidationResult {
+    return this.validator.validate(rawText);
+  }
+
+  public async generateAttempt(
+    input: OpenUIBenchGenerateAttemptInput,
+  ): Promise<OpenUIBenchAttemptResult> {
+    input.signal?.throwIfAborted();
+    const startedAt = this.now();
+    let generated: OpenUIBenchGenerationResult;
+    try {
+      generated = await this.generateRaw(input.messages, {
+        ...input.provider,
+        disableAgentCache: true,
+        inheritReasoningEffort: false,
+        resourceId: input.resourceId,
+        promptComponentNames: OPENUI_BENCH_MATCHED_COMPONENTS,
+        promptOptions: OPENUI_BENCH_PROMPT_OPTIONS,
+        promptRoot: OPENUI_BENCH_ROOT_COMPONENT,
+        systemAppendix: OPENUI_BENCH_SYSTEM_APPENDIX,
+      }, input.signal);
+    } catch (error) {
+      input.signal?.throwIfAborted();
+      const durationMs = Math.max(0, this.now() - startedAt);
+      const normalizedError: OpenUIBenchValidationError = {
+        source: 'generation',
+        code: 'generation-error',
+        message: redactMessage(error, [input.provider.apiKey]),
+        hint:
+          'Retry the benchmark run after checking the configured model endpoint.',
+      };
+      const emptyValidation = this.validator.validate('');
+      return {
+        index: input.index,
+        durationMs,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        valid: false,
+        validationErrors: [formatOpenUIBenchError(normalizedError)],
+        outputChars: 0,
+        rawText: '',
+        usage: undefined,
+        normalizedUsage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+        normalizedErrors: [normalizedError],
+        warnings: [],
+        complexity: emptyValidation.complexity,
+        generationFailed: true,
+      };
+    }
+
+    input.signal?.throwIfAborted();
+    const durationMs = Math.max(0, this.now() - startedAt);
+    const validation = this.validator.validate(generated.text);
+    const normalizedUsage = normalizeOpenUIBenchUsage(generated.usage);
+    return {
+      index: input.index,
+      durationMs,
+      inputTokens: normalizedUsage.inputTokens,
+      outputTokens: normalizedUsage.outputTokens,
+      totalTokens: normalizedUsage.totalTokens,
+      valid: validation.valid,
+      validationErrors: validation.errors.map((error) =>
+        formatOpenUIBenchError(error)
+      ),
+      outputChars: generated.text.length,
+      ...(generated.finishReason === undefined
+        ? {}
+        : { finishReason: generated.finishReason }),
+      rawText: generated.text,
+      usage: generated.usage,
+      normalizedUsage,
+      normalizedErrors: validation.errors,
+      warnings: validation.warnings,
+      complexity: validation.complexity,
+      generationFailed: false,
+    };
+  }
+
+  public async generate(
+    input: ProtocolBenchAdapterInput,
+    signal?: AbortSignal,
+  ): Promise<OpenUIBenchRunArtifact> {
+    const attempts: OpenUIBenchAttemptResult[] = [];
+    const messages: ChatMessage[] = [{
+      role: 'user',
+      content: buildOpenUIBenchPrompt(input.scenario),
+    }];
+    const maxAttempts = normalizedAttemptLimit(input.maxAttempts);
+
+    for (let index = 1; index <= maxAttempts; index += 1) {
+      const attempt = await this.generateAttempt({
+        index,
+        messages,
+        provider: input.provider,
+        resourceId: `bench:${input.runId}:attempt:${index}`,
+        ...(signal ? { signal } : {}),
+      });
+      attempts.push(attempt);
+      if (attempt.valid) break;
+      if (attempt.generationFailed) {
+        if (index < maxAttempts) {
+          await waitForTransportRetry(
+            this.sleep,
+            this.retryDelayMs,
+            signal,
+          );
+          continue;
+        }
+        break;
+      }
+      if (index < maxAttempts) {
+        messages.push({ role: 'assistant', content: attempt.rawText });
+        messages.push({
+          role: 'user',
+          content: formatOpenUIBenchRepairPrompt(attempt.normalizedErrors),
+        });
+      }
+    }
+
+    const finalAttempt = attempts[attempts.length - 1];
+    if (!finalAttempt) {
+      throw new Error('OpenUI benchmark did not execute a generation attempt.');
+    }
+    const finalValid = finalAttempt.valid;
+    const totalUsage = sumUsage(attempts);
+    const totalLatencyMs = attempts.reduce(
+      (total, attempt) => total + attempt.durationMs,
+      0,
+    );
+    const finalErrors = finalAttempt.normalizedErrors.map(
+      (error) => formatOpenUIBenchError(error),
+    );
+
+    return {
+      attempts,
+      finalValid,
+      ...(finalAttempt.rawText ? { finalText: finalAttempt.rawText } : {}),
+      finalErrors,
+      warnings: finalAttempt.warnings,
+      ...(finalValid
+        ? {
+          judgePayload: {
+            kind: 'openui-text' as const,
+            rawText: finalAttempt.rawText,
+          },
+        }
+        : {}),
+      metadata: {
+        protocol: this.protocol,
+        rootComponent: OPENUI_BENCH_ROOT_COMPONENT,
+        matchedComponents: [...this.componentNames],
+        matchedCapabilities: [...OPENUI_BENCH_MATCHED_CAPABILITIES],
+        capabilityProfile: OPENUI_BENCH_CAPABILITY_PROFILE,
+        policy: 'resource-safe-matched-core',
+        attemptCount: attempts.length,
+        totalInputTokens: totalUsage.inputTokens,
+        totalOutputTokens: totalUsage.outputTokens,
+        totalTokens: totalUsage.totalTokens,
+        totalLatencyMs,
+        complexity: finalAttempt.complexity,
+      },
+      rawText: finalAttempt.rawText,
+      normalizedErrors: finalAttempt.normalizedErrors,
+      complexity: finalAttempt.complexity,
+      totalUsage,
+      totalLatencyMs,
+      attemptCount: attempts.length,
+      ...(finalAttempt.finishReason === undefined
+        ? {}
+        : { finalFinishReason: finalAttempt.finishReason }),
+    };
+  }
+}
+
+export function createOpenUIBenchAdapter(
+  options: OpenUIBenchAdapterOptions = {},
+): OpenUIBenchAdapter {
+  return new DefaultOpenUIBenchAdapter(options);
+}

--- a/packages/genui/server/service/openui-bench-validator.ts
+++ b/packages/genui/server/service/openui-bench-validator.ts
@@ -1,0 +1,366 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import {
+  createLibrary,
+  createParser,
+  enrichErrors,
+} from '@openuidev/lang-core';
+import type {
+  ElementNode,
+  LibraryJSONSchema,
+  OpenUIError,
+  ParseResult,
+  Parser,
+} from '@openuidev/lang-core';
+
+import { createOpenUiPromptLibrary } from '@lynx-js/genui-openui/openui-prompt';
+import type { OpenUiPromptLibrary } from '@lynx-js/genui-openui/openui-prompt';
+
+export const OPENUI_BENCH_ROOT_COMPONENT = 'Column';
+
+export const OPENUI_BENCH_MATCHED_COMPONENTS = Object.freeze(
+  [
+    'Column',
+    'Row',
+    'List',
+    'Card',
+    'Text',
+    'TextContent',
+    'Button',
+    'Divider',
+  ] as const,
+);
+
+export interface OpenUIBenchValidationError {
+  source: 'generation' | 'parser';
+  code: string;
+  message: string;
+  statementId?: string;
+  component?: string;
+  path?: string;
+  hint?: string;
+}
+
+export interface OpenUIBenchComplexity {
+  outputChars: number;
+  statementCount: number;
+  componentCount: number;
+  componentTypes: Record<string, number>;
+  maxComponentDepth: number;
+  partialComponentCount: number;
+  stateDeclarationCount: number;
+  queryCount: number;
+  mutationCount: number;
+  unresolvedReferenceCount: number;
+  orphanedStatementCount: number;
+  unknownComponentCount: number;
+}
+
+export interface OpenUIBenchValidationResult {
+  valid: boolean;
+  rawText: string;
+  parseResult: ParseResult | null;
+  errors: OpenUIBenchValidationError[];
+  warnings: string[];
+  complexity: OpenUIBenchComplexity;
+}
+
+export interface OpenUIBenchValidator {
+  readonly componentNames: readonly string[];
+  validate(rawText: string): OpenUIBenchValidationResult;
+}
+
+function emptyComplexity(rawText: string): OpenUIBenchComplexity {
+  return {
+    outputChars: rawText.length,
+    statementCount: 0,
+    componentCount: 0,
+    componentTypes: {},
+    maxComponentDepth: 0,
+    partialComponentCount: 0,
+    stateDeclarationCount: 0,
+    queryCount: 0,
+    mutationCount: 0,
+    unresolvedReferenceCount: 0,
+    orphanedStatementCount: 0,
+    unknownComponentCount: 0,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isElementNode(value: unknown): value is ElementNode {
+  return isRecord(value)
+    && value.type === 'element'
+    && typeof value.typeName === 'string'
+    && isRecord(value.props);
+}
+
+function measureComplexity(
+  rawText: string,
+  result: ParseResult,
+  errors: OpenUIBenchValidationError[],
+): OpenUIBenchComplexity {
+  const componentTypes = new Map<string, number>();
+  const seen = new WeakSet<object>();
+  let componentCount = 0;
+  let maxComponentDepth = 0;
+  let partialComponentCount = 0;
+
+  const visit = (value: unknown, depth: number): void => {
+    if (value === null || typeof value !== 'object') return;
+    if (seen.has(value)) return;
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, depth);
+      return;
+    }
+
+    if (isElementNode(value)) {
+      componentCount += 1;
+      maxComponentDepth = Math.max(maxComponentDepth, depth);
+      if (value.partial) partialComponentCount += 1;
+      componentTypes.set(
+        value.typeName,
+        (componentTypes.get(value.typeName) ?? 0) + 1,
+      );
+      visit(value.props, depth + 1);
+      return;
+    }
+
+    for (const nested of Object.values(value)) visit(nested, depth);
+  };
+
+  if (result.root) visit(result.root, 1);
+
+  return {
+    outputChars: rawText.length,
+    statementCount: result.meta.statementCount,
+    componentCount,
+    componentTypes: Object.fromEntries(
+      [...componentTypes.entries()].sort(([left], [right]) =>
+        left.localeCompare(right)
+      ),
+    ),
+    maxComponentDepth,
+    partialComponentCount,
+    stateDeclarationCount: Object.keys(result.stateDeclarations).length,
+    queryCount: result.queryStatements.length,
+    mutationCount: result.mutationStatements.length,
+    unresolvedReferenceCount: result.meta.unresolved.length,
+    orphanedStatementCount: result.meta.orphaned.length,
+    unknownComponentCount: errors.filter(
+      (error) => error.code === 'unknown-component',
+    ).length,
+  };
+}
+
+function normalizeParserError(error: OpenUIError): OpenUIBenchValidationError {
+  return {
+    source: 'parser',
+    code: error.code,
+    message: error.message,
+    ...(error.statementId ? { statementId: error.statementId } : {}),
+    ...(error.component ? { component: error.component } : {}),
+    ...(error.path ? { path: error.path } : {}),
+    ...(error.hint ? { hint: error.hint } : {}),
+  };
+}
+
+function syntheticError(
+  code: string,
+  message: string,
+  hint: string,
+): OpenUIBenchValidationError {
+  return {
+    source: 'parser',
+    code,
+    message,
+    hint,
+  };
+}
+
+function createOpenUIBenchLibrary(): OpenUiPromptLibrary {
+  const fullLibrary = createOpenUiPromptLibrary({
+    root: OPENUI_BENCH_ROOT_COMPONENT,
+  });
+  const components = OPENUI_BENCH_MATCHED_COMPONENTS.map((name) => {
+    const component = fullLibrary.components[name];
+    if (!component) {
+      throw new Error(
+        `OpenUI benchmark component "${name}" is missing from the prompt library.`,
+      );
+    }
+    return component;
+  });
+  return createLibrary({
+    root: OPENUI_BENCH_ROOT_COMPONENT,
+    components,
+    componentGroups: [{
+      name: 'Matched Core',
+      components: [...OPENUI_BENCH_MATCHED_COMPONENTS],
+    }],
+  });
+}
+
+function enrichParserErrors(
+  result: ParseResult,
+  schema: LibraryJSONSchema,
+  componentNames: string[],
+): OpenUIBenchValidationError[] {
+  try {
+    return enrichErrors(result.meta.errors, schema, componentNames).map(
+      (error) => normalizeParserError(error),
+    );
+  } catch {
+    return result.meta.errors.map((error) => ({
+      source: 'parser',
+      code: error.code,
+      message: error.message,
+      ...(error.statementId ? { statementId: error.statementId } : {}),
+      ...(error.component ? { component: error.component } : {}),
+      ...(error.path ? { path: error.path } : {}),
+    }));
+  }
+}
+
+class DefaultOpenUIBenchValidator implements OpenUIBenchValidator {
+  public readonly componentNames: readonly string[];
+
+  private readonly parser: Parser;
+  private readonly schema: LibraryJSONSchema;
+
+  public constructor(library: OpenUiPromptLibrary) {
+    this.schema = library.toJSONSchema();
+    this.componentNames = Object.freeze(Object.keys(library.components).sort());
+    this.parser = createParser(this.schema, library.root);
+  }
+
+  public validate(rawText: string): OpenUIBenchValidationResult {
+    if (!rawText.trim()) {
+      const error = syntheticError(
+        'empty-output',
+        'The model returned an empty OpenUI program.',
+        'Return one complete OpenUI v0.5 program whose renderable root is assigned to root.',
+      );
+      return {
+        valid: false,
+        rawText,
+        parseResult: null,
+        errors: [error],
+        warnings: [],
+        complexity: emptyComplexity(rawText),
+      };
+    }
+
+    let result: ParseResult;
+    try {
+      result = this.parser.parse(rawText);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const normalized = syntheticError(
+        'parse-exception',
+        `OpenUI parser crashed: ${message}`,
+        'Return plain OpenUI v0.5 code without Markdown fences or prose.',
+      );
+      return {
+        valid: false,
+        rawText,
+        parseResult: null,
+        errors: [normalized],
+        warnings: [],
+        complexity: emptyComplexity(rawText),
+      };
+    }
+
+    const errors = enrichParserErrors(
+      result,
+      this.schema,
+      [...this.componentNames],
+    );
+
+    if (result.meta.incomplete || result.root?.partial) {
+      errors.push(syntheticError(
+        'incomplete-output',
+        'The OpenUI program is incomplete or truncated.',
+        'Return the complete program and close every array, object, string, and component call.',
+      ));
+    }
+
+    if (result.meta.unresolved.length > 0) {
+      errors.push(syntheticError(
+        'unresolved-reference',
+        `Unresolved OpenUI references: ${result.meta.unresolved.join(', ')}.`,
+        'Define every referenced statement and include it in the complete response.',
+      ));
+    }
+
+    if (result.queryStatements.length > 0) {
+      errors.push(syntheticError(
+        'query-not-allowed',
+        'Query() is not allowed in the matched-core benchmark.',
+        'Inline deterministic content directly in the component tree.',
+      ));
+    }
+
+    if (result.mutationStatements.length > 0) {
+      errors.push(syntheticError(
+        'mutation-not-allowed',
+        'Mutation() is not allowed in the matched-core benchmark.',
+        'Use a local Button action or static content instead of external tools.',
+      ));
+    }
+
+    if (/https?:|file:|\/\//iu.test(rawText)) {
+      errors.push(syntheticError(
+        'external-url-not-allowed',
+        'External URLs are not allowed in the matched-core benchmark.',
+        'Do not use remote resources or OpenUrl actions. Only use content supplied by the benchmark scenario.',
+      ));
+    }
+
+    if (!result.root && errors.length === 0) {
+      errors.push(syntheticError(
+        'parse-failed',
+        'The program did not produce a renderable root component.',
+        'Assign a valid catalog component to root, for example root = Column([...]).',
+      ));
+    }
+
+    const warnings = result.meta.orphaned.length === 0
+      ? []
+      : [
+        `Orphaned OpenUI statements are not reachable from root: ${
+          result.meta.orphaned.join(', ')
+        }.`,
+      ];
+
+    return {
+      valid: errors.length === 0,
+      rawText,
+      parseResult: result,
+      errors,
+      warnings,
+      complexity: measureComplexity(rawText, result, errors),
+    };
+  }
+}
+
+export function createOpenUIBenchValidator(
+  library: OpenUiPromptLibrary = createOpenUIBenchLibrary(),
+): OpenUIBenchValidator {
+  return new DefaultOpenUIBenchValidator(library);
+}
+
+const defaultValidator = createOpenUIBenchValidator();
+
+export function validateOpenUIBenchOutput(
+  rawText: string,
+): OpenUIBenchValidationResult {
+  return defaultValidator.validate(rawText);
+}

--- a/packages/genui/server/test/a2ui-bench-judge.test.ts
+++ b/packages/genui/server/test/a2ui-bench-judge.test.ts
@@ -7,7 +7,26 @@ import { describe, expect, test } from '@rstest/core';
 import {
   probeBenchUiJudge,
   runBenchUiJudge,
+  runBenchUiJudgeRequest,
 } from '../service/a2ui-bench-judge.js';
+import {
+  BENCH_SCREENSHOT_DATA_URL_PREFIX,
+  MAX_BENCH_SCREENSHOT_DECODED_BYTES,
+} from '../service/a2ui-bench-screenshot.js';
+
+function screenshotDataUrlForBytes(bytes: number): string {
+  const encodedLength = Math.ceil(bytes / 3) * 4;
+  const remainder = bytes % 3;
+  let padding = '';
+  if (remainder === 1) {
+    padding = '==';
+  } else if (remainder === 2) {
+    padding = '=';
+  }
+  return BENCH_SCREENSHOT_DATA_URL_PREFIX
+    + 'A'.repeat(encodedLength - padding.length)
+    + padding;
+}
 
 describe('probeBenchUiJudge', () => {
   test('stays disabled without the private sidecar URL', async () => {
@@ -53,6 +72,25 @@ describe('probeBenchUiJudge', () => {
     });
   });
 
+  test('accepts a protocol-specific bundle override', async () => {
+    const capability = await probeBenchUiJudge({
+      bundleUrl: 'file:///tmp/openui.lynx.js',
+      env: {
+        UI_JUDGE_BUNDLE_URL: 'https://assets.test/a2ui.lynx.js',
+        UI_JUDGE_SERVER_URL: 'http://judge.test',
+      },
+      fetch: () => Promise.resolve(Response.json({ status: 'ok' })),
+    });
+
+    expect(capability).toEqual({
+      enabled: true,
+      session: {
+        bundleUrl: 'file:///tmp/openui.lynx.js',
+        judgeUrl: 'http://judge.test/judge',
+      },
+    });
+  });
+
   test('keeps Judge disabled when the sidecar is not ready', async () => {
     const capability = await probeBenchUiJudge({
       env: {
@@ -75,6 +113,107 @@ describe('probeBenchUiJudge', () => {
 });
 
 describe('runBenchUiJudge', () => {
+  test('supports protocol-neutral global props', async () => {
+    let requestBody: unknown;
+    const result = await runBenchUiJudgeRequest(
+      {
+        globalProps: {
+          instant: true,
+          rawText: 'root = TextContent("Hello")',
+          theme: 'light',
+        },
+        scenario: {
+          prompt: 'Build a greeting',
+        },
+        session: {
+          bundleUrl: 'https://assets.test/openui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      (_input, init) => {
+        const body = typeof init?.body === 'string' ? init.body : '';
+        requestBody = JSON.parse(body) as unknown;
+        return Promise.resolve(Response.json({ score: 5 }));
+      },
+    );
+
+    expect(requestBody).toEqual({
+      globalProps: {
+        instant: true,
+        rawText: 'root = TextContent("Hello")',
+        theme: 'light',
+      },
+      steps: [],
+      task: 'Build a greeting',
+      url: 'https://assets.test/openui.lynx.js',
+    });
+    expect(result).toEqual({
+      errors: [],
+      score: 5,
+      status: 'complete',
+      warnings: [],
+    });
+  });
+
+  test('returns an explicitly requested captured PNG', async () => {
+    let requestBody: unknown;
+    const screenshotDataUrl =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    const result = await runBenchUiJudgeRequest(
+      {
+        globalProps: { instant: true },
+        includeScreenshot: true,
+        scenario: { prompt: 'Build a greeting' },
+        session: {
+          bundleUrl: 'file:///tmp/openui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      (_input, init) => {
+        if (typeof init?.body !== 'string') {
+          throw new Error('expected a JSON string request body');
+        }
+        requestBody = JSON.parse(init.body) as unknown;
+        return Promise.resolve(
+          Response.json({ score: 4, screenshotDataUrl }),
+        );
+      },
+    );
+
+    expect(requestBody).toMatchObject({ includeScreenshot: true });
+    expect(result).toMatchObject({
+      screenshotDataUrl,
+      status: 'complete',
+    });
+  });
+
+  test('discards a captured PNG larger than 2 MiB', async () => {
+    const screenshotDataUrl = screenshotDataUrlForBytes(
+      MAX_BENCH_SCREENSHOT_DECODED_BYTES + 1,
+    );
+    const result = await runBenchUiJudgeRequest(
+      {
+        globalProps: { instant: true },
+        includeScreenshot: true,
+        scenario: { prompt: 'Build a greeting' },
+        session: {
+          bundleUrl: 'file:///tmp/openui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      () => Promise.resolve(Response.json({ score: 4, screenshotDataUrl })),
+    );
+
+    expect(result).toEqual({
+      errors: [],
+      score: 4,
+      status: 'complete',
+      warnings: [
+        'ui-judge returned an invalid screenshotDataUrl; the screenshot was discarded.',
+      ],
+    });
+  });
+
   test('injects generated messages as server-owned global props', async () => {
     let requestUrl = '';
     let requestBody: unknown;
@@ -120,6 +259,7 @@ describe('runBenchUiJudge', () => {
     expect(requestUrl).toBe('http://judge.test/judge');
     expect(requestBody).toEqual({
       globalProps: {
+        benchMode: true,
         instant: true,
         messages: [{
           version: 'v0.9',

--- a/packages/genui/server/test/a2ui-bench-request.test.ts
+++ b/packages/genui/server/test/a2ui-bench-request.test.ts
@@ -1,0 +1,217 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import { normalizeBenchJobRequest } from '../service/a2ui-bench-request.js';
+
+function body(groups: unknown[]) {
+  return {
+    provider: {},
+    settings: {
+      repeats: 1,
+      parallelism: 3,
+      maxRepairAttempts: 1,
+    },
+    groups,
+    scenarios: [{
+      id: 'scenario',
+      name: 'Scenario',
+      prompt: 'Build a card',
+      type: 'Information',
+    }],
+  };
+}
+
+describe('A2UI Bench request protocol groups', () => {
+  test('keeps legacy groups on the A2UI native profile', () => {
+    const normalized = normalizeBenchJobRequest(
+      body([{
+        id: 'legacy',
+        role: 'control',
+        name: 'Legacy',
+        variable: 'catalog',
+        enabled: true,
+        catalog: 'Core Catalog',
+      }]),
+      { clientOverrideAccepted: false },
+    );
+
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.request.groups[0]).toMatchObject({
+      protocol: 'a2ui',
+      profile: 'native',
+      catalog: 'Core Catalog',
+    });
+  });
+
+  test('removes group model overrides when client overrides are disabled', () => {
+    const normalized = normalizeBenchJobRequest(
+      body([
+        {
+          id: 'a2ui',
+          role: 'control',
+          name: 'A2UI',
+          variable: 'protocol',
+          enabled: true,
+          protocol: 'a2ui',
+          profile: 'matched-core',
+          model: 'model-a',
+        },
+        {
+          id: 'openui',
+          role: 'experiment',
+          name: 'OpenUI',
+          variable: 'protocol',
+          enabled: true,
+          protocol: 'openui',
+          model: 'model-b',
+        },
+      ]),
+      { clientOverrideAccepted: false },
+    );
+
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.request.groups).toEqual([
+      expect.objectContaining({
+        protocol: 'a2ui',
+        profile: 'matched-core',
+        variable: 'protocol',
+      }),
+      expect.objectContaining({
+        protocol: 'openui',
+        profile: 'matched-core',
+        variable: 'protocol',
+      }),
+    ]);
+    expect(normalized.request.groups[0]).not.toHaveProperty('model');
+    expect(normalized.request.groups[1]).not.toHaveProperty('model');
+    expect(normalized.request.groups[0]).not.toHaveProperty('catalog');
+    expect(normalized.request.groups[1]).not.toHaveProperty('catalog');
+    expect(normalized.request.settings.parallelism).toBe(1);
+    expect(normalized.warnings).toContain(
+      'Mixed-protocol jobs run one sample at a time so benchmark arms remain paired; settings.parallelism was set to 1.',
+    );
+    expect(normalized.warnings).toContain(
+      'Client provider overrides are disabled by server policy; using server environment provider settings.',
+    );
+  });
+
+  test('keeps group model overrides when client overrides are enabled', () => {
+    const normalized = normalizeBenchJobRequest(
+      body([
+        {
+          id: 'a2ui',
+          role: 'control',
+          name: 'A2UI',
+          variable: 'model',
+          enabled: true,
+          protocol: 'a2ui',
+          profile: 'matched-core',
+          model: 'model-a',
+        },
+        {
+          id: 'openui',
+          role: 'experiment',
+          name: 'OpenUI',
+          variable: 'model',
+          enabled: true,
+          protocol: 'openui',
+          model: 'model-b',
+        },
+      ]),
+      { clientOverrideAccepted: true },
+    );
+
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) return;
+    expect(normalized.request.groups).toEqual([
+      expect.objectContaining({ model: 'model-a' }),
+      expect.objectContaining({ model: 'model-b' }),
+    ]);
+  });
+
+  test('rejects an unsupported OpenUI native arm', () => {
+    const normalized = normalizeBenchJobRequest(
+      body([{
+        id: 'openui-native',
+        role: 'experiment',
+        name: 'OpenUI native',
+        variable: 'protocol',
+        enabled: true,
+        protocol: 'openui',
+        profile: 'native',
+      }]),
+      { clientOverrideAccepted: true },
+    );
+
+    expect(normalized).toEqual({
+      ok: false,
+      status: 400,
+      error: 'openui groups require the "matched-core" profile',
+    });
+  });
+
+  test('bounds adapter attempts without changing legacy A2UI admission', () => {
+    const legacy = body([{
+      id: 'legacy',
+      role: 'control',
+      name: 'Legacy',
+      variable: 'custom',
+      enabled: true,
+    }]);
+    legacy.settings.repeats = 10;
+    legacy.settings.maxRepairAttempts = 4;
+    legacy.scenarios = Array.from({ length: 3 }, (_, index) => ({
+      id: `scenario-${index}`,
+      name: `Scenario ${index}`,
+      prompt: 'Build a card',
+      type: 'Information',
+    }));
+
+    const legacyResult = normalizeBenchJobRequest(legacy, {
+      clientOverrideAccepted: false,
+    });
+    expect(legacyResult.ok).toBe(true);
+
+    const judgedLegacy = {
+      ...legacy,
+      settings: {
+        ...legacy.settings,
+        judgeEnabled: true,
+      },
+    };
+    expect(normalizeBenchJobRequest(judgedLegacy, {
+      clientOverrideAccepted: false,
+    })).toEqual({
+      ok: false,
+      status: 422,
+      error:
+        'benchmark workload exceeds the 120 planned generation-attempt limit',
+    });
+
+    const matched = {
+      ...legacy,
+      groups: [{
+        id: 'matched',
+        role: 'control',
+        name: 'Matched',
+        variable: 'protocol',
+        enabled: true,
+        protocol: 'a2ui',
+        profile: 'matched-core',
+      }],
+    };
+    expect(normalizeBenchJobRequest(matched, {
+      clientOverrideAccepted: false,
+    })).toEqual({
+      ok: false,
+      status: 422,
+      error:
+        'benchmark workload exceeds the 120 planned generation-attempt limit',
+    });
+  });
+});

--- a/packages/genui/server/test/a2ui-bench-runner.test.ts
+++ b/packages/genui/server/test/a2ui-bench-runner.test.ts
@@ -4,16 +4,33 @@
 
 import { describe, expect, rstest, test } from '@rstest/core';
 
+import { getA2UIAgentService } from '../service/a2ui-agent.js';
 import { probeBenchUiJudge } from '../service/a2ui-bench-judge.js';
 import { runBenchJob, summarizeGroup } from '../service/a2ui-bench-runner.js';
-import { getBenchJobStore } from '../service/a2ui-bench-store.js';
+import {
+  BENCH_SCREENSHOT_DATA_URL_PREFIX,
+  MAX_BENCH_SCREENSHOT_DECODED_BYTES,
+} from '../service/a2ui-bench-screenshot.js';
+import {
+  BenchJobStore,
+  getBenchJobStore,
+} from '../service/a2ui-bench-store.js';
 import type {
   BenchGroupRequest,
   BenchJobRequest,
   BenchRunResult,
 } from '../service/a2ui-bench-types.js';
+import type {
+  ProtocolBenchAdapter,
+} from '../service/genui-bench/protocol-adapter.js';
+import {
+  probeGenuiBenchUiJudge,
+  runGenuiBenchUiJudge,
+} from '../service/genui-bench-judge.js';
 
 rstest.mock('../service/a2ui-bench-judge.js', { mock: true });
+rstest.mock('../service/a2ui-agent.js', { mock: true });
+rstest.mock('../service/genui-bench-judge.js', { mock: true });
 
 const group: BenchGroupRequest = {
   enabled: true,
@@ -64,6 +81,8 @@ function result(
     model: 'test-model',
     ok: true,
     outputChars: 10,
+    profile: 'native',
+    protocol: 'a2ui',
     renderMs: 0,
     repeatIndex: 1,
     role: group.role,
@@ -73,6 +92,20 @@ function result(
     tokens: 10,
     ttiMs: 0,
   };
+}
+
+function screenshotDataUrlForBytes(bytes: number): string {
+  const encodedLength = Math.ceil(bytes / 3) * 4;
+  const remainder = bytes % 3;
+  let padding = '';
+  if (remainder === 1) {
+    padding = '==';
+  } else if (remainder === 2) {
+    padding = '=';
+  }
+  return BENCH_SCREENSHOT_DATA_URL_PREFIX
+    + 'A'.repeat(encodedLength - padding.length)
+    + padding;
 }
 
 describe('A2UI Bench UI Judge integration', () => {
@@ -103,14 +136,456 @@ describe('A2UI Bench UI Judge integration', () => {
     expect(completed?.results).toEqual([]);
   });
 
-  test('excludes failed and skipped Judge attempts from the average', () => {
+  test('uses the planned-run denominator for Judge averages', () => {
     const summary = summarizeGroup(group, [
       result('complete', 'complete', 4),
       result('failed', 'failed', 0),
       result('skipped', 'skipped', 0),
     ]);
 
-    expect(summary.avgJudgeScore).toBe(4);
+    expect(summary.avgJudgeScore).toBe(4 / 3);
     expect(summary.judgeRunCount).toBe(1);
+    expect(summary.plannedRuns).toBe(3);
+  });
+
+  test('runs mixed protocol arms serially and rotates their order per sample', async () => {
+    const order: string[] = [];
+    const adapter = (
+      protocol: 'a2ui' | 'openui',
+    ): ProtocolBenchAdapter => ({
+      protocol,
+      generate(input) {
+        order.push(`${input.repeatIndex}:${protocol}`);
+        return Promise.resolve({
+          attempts: [{
+            index: 1,
+            durationMs: 1,
+            inputTokens: 2,
+            outputTokens: 3,
+            totalTokens: 5,
+            valid: true,
+            validationErrors: [],
+            outputChars: 10,
+          }],
+          finalValid: true,
+          finalText: `${protocol} output`,
+          finalErrors: [],
+          judgePayload: protocol === 'a2ui'
+            ? { kind: 'a2ui-messages', messages: [] }
+            : { kind: 'openui-text', rawText: 'root = Text("ready")' },
+        });
+      },
+    });
+    const benchRequest = request(false);
+    benchRequest.groups = [
+      {
+        ...group,
+        id: 'a2ui',
+        name: 'A2UI',
+        protocol: 'a2ui',
+        profile: 'matched-core',
+        variable: 'protocol',
+      },
+      {
+        ...group,
+        id: 'openui',
+        name: 'OpenUI',
+        protocol: 'openui',
+        profile: 'matched-core',
+        variable: 'protocol',
+      },
+    ];
+    benchRequest.settings.repeats = 2;
+    benchRequest.settings.parallelism = 4;
+    const store = getBenchJobStore();
+    const job = store.createJob(benchRequest, 4);
+
+    await runBenchJob(job.id, {
+      adapters: {
+        a2ui: adapter('a2ui'),
+        openui: adapter('openui'),
+      },
+    });
+
+    expect(order).toEqual([
+      '1:a2ui',
+      '1:openui',
+      '2:openui',
+      '2:a2ui',
+    ]);
+    expect(store.getJob(job.id)?.report?.summary).toMatchObject({
+      totalRuns: 4,
+      completedRuns: 4,
+      failedRuns: 0,
+    });
+  });
+
+  test('uses each group model and stores the Judge scoring frame for both protocols', async () => {
+    const screenshotDataUrl =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    rstest.mocked(probeGenuiBenchUiJudge).mockResolvedValue({
+      enabled: true,
+      session: {
+        bundleUrl: 'https://bundle.example/bench.lynx.js',
+        judgeUrl: 'https://judge.example/judge',
+      },
+    });
+    rstest.mocked(runGenuiBenchUiJudge).mockResolvedValue({
+      errors: [],
+      score: 4,
+      screenshotDataUrl,
+      status: 'complete',
+      warnings: [],
+    });
+    const models = new Map<string, string | undefined>();
+    const adapter = (
+      protocol: 'a2ui' | 'openui',
+    ): ProtocolBenchAdapter => ({
+      protocol,
+      generate(input) {
+        models.set(protocol, input.provider.model);
+        return Promise.resolve({
+          attempts: [{
+            index: 1,
+            durationMs: 1,
+            inputTokens: 2,
+            outputTokens: 3,
+            totalTokens: 5,
+            valid: true,
+            validationErrors: [],
+            outputChars: 10,
+          }],
+          finalValid: true,
+          finalText: `${protocol} output`,
+          finalErrors: [],
+          judgePayload: protocol === 'a2ui'
+            ? { kind: 'a2ui-messages', messages: [] }
+            : { kind: 'openui-text', rawText: 'root = Text("ready")' },
+        });
+      },
+    });
+    const benchRequest = request();
+    benchRequest.provider.model = 'provider-model';
+    benchRequest.groups = [
+      {
+        ...group,
+        id: 'a2ui',
+        model: 'a2ui-group-model',
+        name: 'A2UI',
+        protocol: 'a2ui',
+        profile: 'matched-core',
+        variable: 'catalog',
+      },
+      {
+        ...group,
+        id: 'openui',
+        model: 'openui-group-model',
+        name: 'OpenUI',
+        protocol: 'openui',
+        profile: 'matched-core',
+        variable: 'custom',
+      },
+    ];
+    const store = getBenchJobStore();
+    const job = store.createJob(benchRequest, 2);
+
+    await runBenchJob(job.id, {
+      adapters: {
+        a2ui: adapter('a2ui'),
+        openui: adapter('openui'),
+      },
+    });
+
+    expect(Object.fromEntries(models)).toEqual({
+      a2ui: 'a2ui-group-model',
+      openui: 'openui-group-model',
+    });
+    expect(store.getJob(job.id)?.report?.results).toEqual([
+      expect.objectContaining({
+        protocol: 'a2ui',
+        screenshotDataUrl,
+      }),
+      expect.objectContaining({
+        protocol: 'openui',
+        screenshotDataUrl,
+      }),
+    ]);
+  });
+
+  test('maps an OpenUI matched-core result and redacts provider configuration from public output', async () => {
+    const secret = 'must-not-appear-in-report';
+    const providerUrl = `https://provider.example/v1?key=${secret}`;
+    rstest.mocked(probeGenuiBenchUiJudge).mockResolvedValueOnce({
+      enabled: true,
+      session: {
+        bundleUrl: 'https://bundle.example/openui.lynx.js',
+        judgeUrl: 'https://judge.example/judge',
+      },
+    });
+    rstest.mocked(runGenuiBenchUiJudge).mockResolvedValueOnce({
+      errors: [],
+      reason: `looks good ${secret}`,
+      score: 4.5,
+      screenshotDataUrl:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+      status: 'complete',
+      warnings: [],
+    });
+    let receivedMaxAttempts = 0;
+    const openui: ProtocolBenchAdapter = {
+      protocol: 'openui',
+      generate(input) {
+        receivedMaxAttempts = input.maxAttempts;
+        return Promise.resolve({
+          attempts: [
+            {
+              index: 1,
+              durationMs: 3,
+              inputTokens: 7,
+              outputTokens: 3,
+              totalTokens: 10,
+              valid: false,
+              validationErrors: ['repair'],
+              outputChars: 5,
+            },
+            {
+              index: 2,
+              durationMs: 4,
+              inputTokens: 11,
+              outputTokens: 4,
+              totalTokens: 15,
+              valid: true,
+              validationErrors: [],
+              outputChars: 12,
+            },
+          ],
+          finalValid: true,
+          finalText: 'root = Text("ready")',
+          finalErrors: [],
+          judgePayload: {
+            kind: 'openui-text',
+            rawText: 'root = Text("ready")',
+          },
+          metadata: { diagnostic: secret },
+        });
+      },
+    };
+    const benchRequest = request();
+    benchRequest.provider = {
+      apiKey: secret,
+      baseURL: providerUrl,
+      model: 'same-model',
+      api: 'chat',
+    };
+    benchRequest.groups = [{
+      ...group,
+      protocol: 'openui',
+      profile: 'matched-core',
+      variable: 'protocol',
+    }];
+    benchRequest.settings.maxRepairAttempts = 1;
+    const store = getBenchJobStore();
+    const job = store.createJob(benchRequest, 1);
+
+    await runBenchJob(job.id, { adapters: { openui } });
+
+    const finished = store.getJob(job.id);
+    const report = finished?.report;
+    expect(receivedMaxAttempts).toBe(2);
+    expect(report?.groups[0]).toMatchObject({
+      protocol: 'openui',
+      profile: 'matched-core',
+    });
+    expect(report?.results[0]).toMatchObject({
+      protocol: 'openui',
+      profile: 'matched-core',
+      catalog: 'matched-core',
+      tokens: 25,
+      attempts: 2,
+      judgeScore: 4.5,
+      judgeStatus: 'complete',
+      screenshotDataUrl:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+    });
+    expect(report?.summaries[0]).toMatchObject({
+      protocol: 'openui',
+      profile: 'matched-core',
+      plannedRuns: 1,
+    });
+    const publicOutput = JSON.stringify({
+      report,
+      snapshot: store.getSnapshot(job.id),
+      events: store.subscribe(job.id, () => undefined)?.events,
+    });
+    expect(publicOutput).not.toContain(secret);
+    expect(publicOutput).not.toContain(encodeURIComponent(secret));
+    expect(publicOutput).not.toContain('provider.example');
+    expect(publicOutput).not.toContain('"baseURL"');
+    expect(publicOutput).not.toContain('"apiKey"');
+    const runEvent = store.subscribe(job.id, () => undefined)?.events.find(
+      (event) => event.event === 'run-complete',
+    );
+    expect(runEvent).toBeDefined();
+    expect(runEvent?.data).not.toHaveProperty(
+      'result.screenshotDataUrl',
+    );
+    expect(report?.results[0]?.screenshotDataUrl).toBe(
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+    );
+    expect(finished?.request.provider).toEqual({});
+  });
+
+  test('finalizes a failed job and clears provider credentials when adapter initialization throws', async () => {
+    const benchRequest = request(false);
+    benchRequest.provider = {
+      apiKey: 'credential-that-must-be-cleared',
+      baseURL: 'https://provider.example/v1',
+    };
+    benchRequest.groups = [{
+      ...group,
+      protocol: 'openui',
+      profile: 'matched-core',
+      variable: 'protocol',
+    }];
+    const adapters = Object.create(null) as Partial<
+      Record<'a2ui' | 'openui', ProtocolBenchAdapter>
+    >;
+    Object.defineProperty(adapters, 'openui', {
+      get() {
+        throw new Error(
+          'adapter setup failed at https://provider.example/v1',
+        );
+      },
+    });
+    const store = getBenchJobStore();
+    const job = store.createJob(benchRequest, 1);
+
+    await runBenchJob(job.id, { adapters });
+
+    const finished = store.getJob(job.id);
+    expect(finished).toMatchObject({
+      status: 'failed',
+      workerActive: false,
+      request: { provider: {} },
+      report: { status: 'failed' },
+    });
+    expect(JSON.stringify({
+      report: finished?.report,
+      snapshot: store.getSnapshot(job.id),
+      events: store.subscribe(job.id, () => undefined)?.events,
+    })).not.toContain('provider.example');
+  });
+
+  test('rejects admission when the active-job capacity is full', () => {
+    const store = new BenchJobStore({ maxActiveJobs: 1 });
+    store.createJob(request(false), 1);
+
+    expect(store.tryCreateJob(request(false), 1)).toEqual({
+      ok: false,
+      activeJobs: 1,
+      limit: 1,
+    });
+  });
+
+  test('keeps report screenshots within the 8 MiB per-job budget', () => {
+    const store = new BenchJobStore();
+    const job = store.createJob(request(false), 5);
+    const screenshotDataUrl = screenshotDataUrlForBytes(
+      MAX_BENCH_SCREENSHOT_DECODED_BYTES,
+    );
+
+    for (let index = 0; index < 5; index++) {
+      store.addResult(job.id, {
+        ...result(`run-${index}`, 'complete', 4),
+        screenshotDataUrl,
+      });
+    }
+
+    const stored = store.getJob(job.id);
+    expect(
+      stored?.results.slice(0, 4).every((item) =>
+        item.screenshotDataUrl === screenshotDataUrl
+      ),
+    ).toBe(true);
+    expect(stored?.results[4]?.screenshotDataUrl).toBeUndefined();
+    expect(stored?.results[4]?.judgeWarnings).toContain(
+      'UI Judge screenshot for run run-4 exceeded the 8 MiB per-job limit and was discarded.',
+    );
+    expect(stored?.warnings).toContain(
+      'UI Judge screenshot for run run-4 exceeded the 8 MiB per-job limit and was discarded.',
+    );
+  });
+
+  test('aggregates native A2UI repair tokens and keeps its Judge screenshot', async () => {
+    rstest.mocked(probeBenchUiJudge).mockResolvedValueOnce({
+      enabled: true,
+      session: {
+        bundleUrl: 'https://bundle.example/a2ui.lynx.js',
+        judgeUrl: 'https://judge.example/judge',
+      },
+    });
+    rstest.mocked(runGenuiBenchUiJudge).mockResolvedValueOnce({
+      errors: [],
+      score: 4,
+      screenshotDataUrl:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+      status: 'complete',
+      warnings: [],
+    });
+    let callCount = 0;
+    rstest.mocked(getA2UIAgentService).mockReturnValue({
+      generateRaw(_messages: unknown, options: {
+        catalog?: { id?: string };
+      }) {
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.resolve({
+            text: 'invalid',
+            usage: { total_tokens: 5 },
+            finishReason: 'stop',
+          });
+        }
+        return Promise.resolve({
+          text: JSON.stringify([
+            {
+              version: 'v0.9',
+              createSurface: {
+                surfaceId: 'main',
+                catalogId: options.catalog?.id,
+              },
+            },
+            {
+              version: 'v0.9',
+              updateComponents: {
+                surfaceId: 'main',
+                components: [{
+                  id: 'root',
+                  component: 'Text',
+                  text: 'Ready',
+                  variant: 'body',
+                }],
+              },
+            },
+          ]),
+          usage: { total_tokens: 7 },
+          finishReason: 'stop',
+        });
+      },
+    } as unknown as ReturnType<typeof getA2UIAgentService>);
+    const benchRequest = request();
+    benchRequest.settings.maxRepairAttempts = 1;
+    const store = getBenchJobStore();
+    const job = store.createJob(benchRequest, 1);
+
+    await runBenchJob(job.id);
+
+    expect(store.getJob(job.id)?.report?.results[0]).toMatchObject({
+      protocol: 'a2ui',
+      profile: 'native',
+      tokens: 12,
+      attempts: 2,
+      screenshotDataUrl:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
+    });
   });
 });

--- a/packages/genui/server/test/agent-cache-policy.test.ts
+++ b/packages/genui/server/test/agent-cache-policy.test.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { beforeEach, describe, expect, rstest, test } from '@rstest/core';
+
+import { createA2UIAgent } from '../agent/a2ui-agent.js';
+import type { A2UICatalog } from '../agent/a2ui-catalog.js';
+import { createOpenUIAgent } from '../agent/openui-agent.js';
+import A2UIAgentService from '../service/a2ui-agent.js';
+import OpenUIAgentService from '../service/openui-agent.js';
+
+rstest.mock('../agent/a2ui-agent.js', { mock: true });
+rstest.mock('../agent/openui-agent.js', { mock: true });
+
+const catalog: A2UICatalog = {
+  id: 'cache-policy-test',
+  label: 'Cache policy test',
+  components: [],
+  examples: [],
+};
+
+function testAgent() {
+  return {
+    generate: () =>
+      Promise.resolve({
+        text: 'generated',
+        usage: {},
+        finishReason: 'stop',
+      }),
+    stream: () => ({ textStream: undefined }),
+  };
+}
+
+beforeEach(() => {
+  rstest.mocked(createA2UIAgent).mockReset();
+  rstest.mocked(createOpenUIAgent).mockReset();
+});
+
+describe('request-scoped provider agent policy', () => {
+  test('A2UI bypasses its cache for ephemeral credentials', async () => {
+    rstest.mocked(createA2UIAgent).mockImplementation(async () => ({
+      agent: testAgent(),
+      catalog,
+      model: 'test-model',
+    }));
+    const service = new A2UIAgentService();
+    const options = {
+      apiKey: 'request-scoped-key',
+      catalog,
+      disableAgentCache: true,
+    };
+
+    await service.generateRaw([], options);
+    await service.generateRaw([], options);
+
+    expect(createA2UIAgent).toHaveBeenCalledTimes(2);
+  });
+
+  test('OpenUI bypasses its cache for ephemeral credentials', async () => {
+    rstest.mocked(createOpenUIAgent).mockImplementation(() => ({
+      agent: testAgent(),
+      model: 'test-model',
+    }));
+    const service = new OpenUIAgentService();
+    const options = {
+      apiKey: 'request-scoped-key',
+      disableAgentCache: true,
+    };
+
+    const first = await service.generateRaw([], options);
+    const second = await service.generateRaw([], options);
+
+    expect(createOpenUIAgent).toHaveBeenCalledTimes(2);
+    expect(first.text).toBe('generated');
+    expect(second.text).toBe('generated');
+  });
+});

--- a/packages/genui/server/test/genui-bench-a2ui-adapter.test.ts
+++ b/packages/genui/server/test/genui-bench-a2ui-adapter.test.ts
@@ -1,0 +1,315 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import type { A2UIChatOptions } from '../service/a2ui-agent.js';
+import { createA2UIBenchAdapter } from '../service/genui-bench/a2ui-adapter.js';
+import type {
+  ProtocolBenchAdapterInput,
+} from '../service/genui-bench/protocol-adapter.js';
+
+function adapterInput(maxAttempts = 2): ProtocolBenchAdapterInput {
+  return {
+    runId: 'a2ui-run-1',
+    pairId: 'pair-1',
+    scenario: {
+      id: 'scenario-1',
+      name: 'Scenario',
+      prompt: 'Build a card.',
+      type: 'Information',
+      complexity: 1,
+    },
+    repeatIndex: 1,
+    maxAttempts,
+    provider: {
+      apiKey: 'request-scoped-key',
+      baseURL: 'https://provider.test/v1',
+      model: 'test-model',
+      api: 'chat',
+    },
+  };
+}
+
+function validA2UIOutput(catalogId: string | undefined): string {
+  return JSON.stringify([
+    {
+      version: 'v0.9',
+      createSurface: {
+        surfaceId: 'main',
+        catalogId,
+      },
+    },
+    {
+      version: 'v0.9',
+      updateComponents: {
+        surfaceId: 'main',
+        components: [{
+          id: 'root',
+          component: 'Text',
+          text: 'Ready',
+          variant: 'body',
+        }],
+      },
+    },
+  ]);
+}
+
+describe('A2UI matched-core bench adapter', () => {
+  test('uses an ephemeral agent and threads cancellation into generation', async () => {
+    const abortController = new AbortController();
+    let receivedOptions: A2UIChatOptions | undefined;
+    let receivedSignal: AbortSignal | undefined;
+    const adapter = createA2UIBenchAdapter({
+      generateRaw(_messages, options, signal) {
+        receivedOptions = options;
+        receivedSignal = signal;
+        return Promise.resolve({
+          text: 'not valid A2UI',
+          usage: {},
+          finishReason: 'stop',
+        });
+      },
+    });
+
+    await adapter.generate({
+      runId: 'a2ui-run-1',
+      pairId: 'pair-1',
+      scenario: {
+        id: 'scenario-1',
+        name: 'Scenario',
+        prompt: 'Build a card.',
+        type: 'Information',
+        complexity: 1,
+      },
+      repeatIndex: 1,
+      maxAttempts: 1,
+      provider: {
+        apiKey: 'request-scoped-key',
+        baseURL: 'https://provider.test/v1',
+        model: 'test-model',
+        api: 'chat',
+      },
+    }, abortController.signal);
+
+    expect(receivedOptions).toMatchObject({
+      apiKey: 'request-scoped-key',
+      disableAgentCache: true,
+      inheritReasoningEffort: false,
+    });
+    expect(receivedSignal).toBe(abortController.signal);
+    expect(receivedOptions?.catalog?.examples).toEqual([]);
+    expect(receivedOptions?.catalog?.functions).toEqual([]);
+  });
+
+  test('accepts a later updateComponents message that replaces an id', async () => {
+    const adapter = createA2UIBenchAdapter({
+      generateRaw(_messages, options) {
+        return Promise.resolve({
+          text: JSON.stringify([
+            {
+              version: 'v0.9',
+              createSurface: {
+                surfaceId: 'main',
+                catalogId: options.catalog?.id,
+              },
+            },
+            {
+              version: 'v0.9',
+              updateComponents: {
+                surfaceId: 'main',
+                components: [{
+                  id: 'root',
+                  component: 'Text',
+                  text: 'Loading',
+                  variant: 'body',
+                }],
+              },
+            },
+            {
+              version: 'v0.9',
+              updateComponents: {
+                surfaceId: 'main',
+                components: [{
+                  id: 'root',
+                  component: 'Text',
+                  text: 'Ready',
+                  variant: 'body',
+                }],
+              },
+            },
+          ]),
+          usage: {},
+          finishReason: 'stop',
+        });
+      },
+    });
+
+    const artifact = await adapter.generate({
+      runId: 'a2ui-replacement-run',
+      pairId: 'pair-1',
+      scenario: {
+        id: 'scenario-1',
+        name: 'Scenario',
+        prompt: 'Build a card.',
+        type: 'Information',
+        complexity: 1,
+      },
+      repeatIndex: 1,
+      maxAttempts: 1,
+      provider: {
+        apiKey: 'request-scoped-key',
+        baseURL: 'https://provider.test/v1',
+        model: 'test-model',
+        api: 'chat',
+      },
+    });
+
+    expect(artifact.finalValid).toBe(true);
+    expect(artifact.finalErrors).toEqual([]);
+  });
+
+  test('waits before retrying a transient generation failure', async () => {
+    const receivedMessages: string[][] = [];
+    const sleepCalls: number[] = [];
+    let releaseBackoff: (() => void) | undefined;
+    let markBackoffStarted: (() => void) | undefined;
+    const backoffStarted = new Promise<void>((resolve) => {
+      markBackoffStarted = resolve;
+    });
+    const backoff = new Promise<void>((resolve) => {
+      releaseBackoff = resolve;
+    });
+    let callCount = 0;
+    const adapter = createA2UIBenchAdapter({
+      generateRaw(messages, options) {
+        receivedMessages.push(messages.map((message) => message.content));
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.reject(new Error('provider temporarily unavailable'));
+        }
+        return Promise.resolve({
+          text: validA2UIOutput(options.catalog?.id),
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: 15,
+          },
+          finishReason: 'stop',
+        });
+      },
+      sleep(delayMs) {
+        sleepCalls.push(delayMs);
+        markBackoffStarted?.();
+        return backoff;
+      },
+    });
+
+    const generation = adapter.generate(adapterInput());
+    await backoffStarted;
+
+    expect(callCount).toBe(1);
+    expect(sleepCalls).toEqual([10_000]);
+    releaseBackoff?.();
+    const artifact = await generation;
+    expect(callCount).toBe(2);
+    expect(receivedMessages.map((messages) => messages.length)).toEqual([1, 1]);
+    expect(artifact.attempts.map((attempt) => attempt.valid)).toEqual([
+      false,
+      true,
+    ]);
+    expect(artifact.finalValid).toBe(true);
+    expect(artifact.finalErrors).toEqual([]);
+    expect(artifact.judgePayload).toMatchObject({
+      kind: 'a2ui-messages',
+    });
+  });
+
+  test('aborts during transport backoff without starting another request', async () => {
+    const abortController = new AbortController();
+    let markBackoffStarted: (() => void) | undefined;
+    const backoffStarted = new Promise<void>((resolve) => {
+      markBackoffStarted = resolve;
+    });
+    let callCount = 0;
+    const adapter = createA2UIBenchAdapter({
+      generateRaw() {
+        callCount += 1;
+        return Promise.reject(new Error('provider temporarily unavailable'));
+      },
+      sleep() {
+        markBackoffStarted?.();
+        return new Promise<void>(() => {
+          // Keep backoff pending so cancellation must win the race.
+        });
+      },
+    });
+
+    const generation = adapter.generate(
+      adapterInput(),
+      abortController.signal,
+    );
+    await backoffStarted;
+    abortController.abort();
+
+    await expect(generation).rejects.toMatchObject({ name: 'AbortError' });
+    expect(callCount).toBe(1);
+  });
+
+  test('repairs protocol validation failures without transport backoff', async () => {
+    const receivedMessages: string[][] = [];
+    const sleepCalls: number[] = [];
+    let callCount = 0;
+    const adapter = createA2UIBenchAdapter({
+      generateRaw(messages, options) {
+        receivedMessages.push(messages.map((message) => message.content));
+        callCount += 1;
+        return Promise.resolve({
+          text: callCount === 1
+            ? 'not valid A2UI'
+            : validA2UIOutput(options.catalog?.id),
+          usage: {},
+          finishReason: 'stop',
+        });
+      },
+      sleep(delayMs) {
+        sleepCalls.push(delayMs);
+        return Promise.resolve();
+      },
+    });
+
+    const artifact = await adapter.generate(adapterInput());
+
+    expect(callCount).toBe(2);
+    expect(sleepCalls).toEqual([]);
+    expect(receivedMessages.map((messages) => messages.length)).toEqual([1, 3]);
+    expect(artifact.finalValid).toBe(true);
+  });
+
+  test('bounds and exhausts repeated generation failures', async () => {
+    let callCount = 0;
+    const adapter = createA2UIBenchAdapter({
+      generateRaw() {
+        callCount += 1;
+        return Promise.reject(
+          new Error(`provider failure ${callCount}`),
+        );
+      },
+      retryDelayMs: 0,
+    });
+
+    const artifact = await adapter.generate(adapterInput(99));
+
+    expect(callCount).toBe(4);
+    expect(artifact.attempts.map((attempt) => attempt.index)).toEqual([
+      1,
+      2,
+      3,
+      4,
+    ]);
+    expect(artifact.finalValid).toBe(false);
+    expect(artifact.finalErrors).toEqual(['provider failure 4']);
+    expect(artifact.judgePayload).toBeUndefined();
+  });
+});

--- a/packages/genui/server/test/genui-bench-judge.test.ts
+++ b/packages/genui/server/test/genui-bench-judge.test.ts
@@ -1,0 +1,339 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  probeGenuiBenchUiJudge,
+  runGenuiBenchUiJudge,
+} from '../service/genui-bench-judge.js';
+
+describe('probeGenuiBenchUiJudge', () => {
+  test('selects the OpenUI bundle independently', async () => {
+    const capability = await probeGenuiBenchUiJudge('openui', {
+      env: {
+        UI_JUDGE_OPENUI_BUNDLE_URL: 'file:///tmp/openui.lynx.js',
+        UI_JUDGE_SERVER_URL: 'http://judge.test',
+      },
+      fetch: () =>
+        Promise.resolve(
+          Response.json({
+            model: 'gpt-5.5-2026-04-24',
+            status: 'ok',
+          }),
+        ),
+    });
+
+    expect(capability).toEqual({
+      enabled: true,
+      session: {
+        bundleUrl: 'file:///tmp/openui.lynx.js',
+        judgeUrl: 'http://judge.test/judge',
+      },
+    });
+  });
+
+  test('rejects a sidecar configured with a different judge model', async () => {
+    const capability = await probeGenuiBenchUiJudge('a2ui', {
+      env: {
+        UI_JUDGE_SERVER_URL: 'http://judge.test',
+      },
+      fetch: () =>
+        Promise.resolve(
+          Response.json({ model: 'another-model', status: 'ok' }),
+        ),
+    });
+
+    expect(capability).toEqual({
+      enabled: false,
+      reason:
+        'UI Judge model mismatch: expected gpt-5.5-2026-04-24, received another-model.',
+    });
+  });
+});
+
+describe('runGenuiBenchUiJudge', () => {
+  test('injects OpenUI source into the OpenUI bundle', async () => {
+    let body: unknown;
+    const result = await runGenuiBenchUiJudge(
+      {
+        artifact: {
+          protocol: 'openui',
+          rawText: 'root = TextContent("Hello")',
+        },
+        scenario: { prompt: 'Build a greeting' },
+        session: {
+          bundleUrl: 'file:///tmp/openui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      (_input, init) => {
+        const requestBody = typeof init?.body === 'string' ? init.body : '';
+        body = JSON.parse(requestBody) as unknown;
+        return Promise.resolve(Response.json({ score: 4 }));
+      },
+    );
+
+    expect(body).toEqual({
+      globalProps: {
+        benchMode: true,
+        instant: true,
+        rawText: 'root = TextContent("Hello")',
+        speed: 0,
+        theme: 'light',
+      },
+      includeScreenshot: true,
+      screenshotSettleMs: 1_000,
+      steps: [],
+      task: 'Build a greeting',
+      url: 'file:///tmp/openui.lynx.js',
+    });
+    expect(result).toEqual({
+      errors: [],
+      score: 4,
+      status: 'complete',
+      warnings: [],
+    });
+  });
+
+  test('lets the A2UI React effects settle before Phase 2 capture', async () => {
+    let body: unknown;
+    const result = await runGenuiBenchUiJudge(
+      {
+        artifact: {
+          messages: [{
+            createSurface: {
+              catalogId: 'matched-core-v1',
+              surfaceId: 'main',
+            },
+            version: 'v0.9',
+          }],
+          protocol: 'a2ui',
+        },
+        scenario: { prompt: 'Build a greeting' },
+        session: {
+          bundleUrl: 'file:///tmp/a2ui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      (_input, init) => {
+        const requestBody = typeof init?.body === 'string' ? init.body : '';
+        body = JSON.parse(requestBody) as unknown;
+        return Promise.resolve(Response.json({ score: 4 }));
+      },
+    );
+
+    expect(body).toEqual({
+      globalProps: {
+        benchMode: true,
+        instant: true,
+        messages: [{
+          createSurface: {
+            catalogId: 'matched-core-v1',
+            surfaceId: 'main',
+          },
+          version: 'v0.9',
+        }],
+        speed: 0,
+        theme: 'light',
+      },
+      includeScreenshot: true,
+      screenshotSettleMs: 1_000,
+      steps: [],
+      task: 'Build a greeting',
+      url: 'file:///tmp/a2ui.lynx.js',
+    });
+    expect(result).toEqual({
+      errors: [],
+      score: 4,
+      status: 'complete',
+      warnings: [],
+    });
+  });
+
+  test('retries the same safe artifact once after a sidecar failure', async () => {
+    let calls = 0;
+    const requestBodies: string[] = [];
+    const requestUrls: string[] = [];
+    const result = await runGenuiBenchUiJudge(
+      {
+        artifact: {
+          messages: [{
+            updateComponents: {
+              components: [{
+                component: 'Image',
+                id: 'hero',
+                url: 'https://untrusted.test/hero.png',
+              }],
+              surfaceId: 'main',
+            },
+            version: 'v0.9',
+          }],
+          protocol: 'a2ui',
+        },
+        retryDelayMs: 0,
+        scenario: { prompt: 'Build a greeting' },
+        session: {
+          bundleUrl: 'file:///tmp/a2ui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      (input, init) => {
+        calls++;
+        requestUrls.push(String(input));
+        requestBodies.push(
+          typeof init?.body === 'string' ? init.body : '',
+        );
+        return Promise.resolve(
+          calls === 1
+            ? Response.json(
+              { error: { message: 'temporarily unavailable' } },
+              { status: 503 },
+            )
+            : Response.json({
+              score: 5,
+              screenshotDataUrl: 'data:image/png;base64,iVBORw0KGgo=',
+            }),
+        );
+      },
+    );
+
+    expect(calls).toBe(2);
+    expect(requestUrls).toEqual([
+      'http://judge.test/judge',
+      'http://judge.test/judge',
+    ]);
+    expect(requestBodies[0]).toBe(requestBodies[1]);
+    expect(result).toEqual({
+      errors: [],
+      score: 5,
+      screenshotDataUrl: 'data:image/png;base64,iVBORw0KGgo=',
+      status: 'complete',
+      warnings: [
+        'ui-judge replaced 1 Image component to prevent untrusted resource loading.',
+      ],
+    });
+  });
+
+  test('returns the final result after both sidecar attempts fail', async () => {
+    let calls = 0;
+    const result = await runGenuiBenchUiJudge(
+      {
+        artifact: {
+          protocol: 'openui',
+          rawText: 'root = TextContent("Retry")',
+        },
+        attemptCount: 99,
+        retryDelayMs: 0,
+        scenario: { prompt: 'Build a greeting' },
+        session: {
+          bundleUrl: 'file:///tmp/openui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      () => {
+        calls++;
+        return Promise.resolve(
+          Response.json(
+            {
+              error: {
+                message: calls === 1
+                  ? 'first failure'
+                  : 'second failure',
+              },
+            },
+            { status: 503 },
+          ),
+        );
+      },
+    );
+
+    expect(calls).toBe(2);
+    expect(result).toEqual({
+      errors: ['ui-judge request returned HTTP 503: second failure'],
+      score: 0,
+      status: 'failed',
+      warnings: [],
+    });
+  });
+
+  test('stops an in-progress retry backoff when aborted', async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const startedAt = performance.now();
+    const resultPromise = runGenuiBenchUiJudge(
+      {
+        artifact: {
+          protocol: 'openui',
+          rawText: 'root = TextContent("Retry")',
+        },
+        attemptCount: 2,
+        retryDelayMs: 30_000,
+        scenario: { prompt: 'Build a greeting' },
+        session: {
+          bundleUrl: 'file:///tmp/openui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+        signal: controller.signal,
+      },
+      () => {
+        calls++;
+        setTimeout(() => controller.abort(), 0);
+        return Promise.resolve(
+          Response.json(
+            { error: { message: 'temporarily unavailable' } },
+            { status: 503 },
+          ),
+        );
+      },
+    );
+
+    const result = await resultPromise;
+
+    expect(calls).toBe(1);
+    expect(controller.signal.aborted).toBe(true);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+    expect(result).toEqual({
+      errors: [
+        'ui-judge request returned HTTP 503: temporarily unavailable',
+      ],
+      score: 0,
+      status: 'failed',
+      warnings: [],
+    });
+  });
+
+  test('does not let generated OpenUI load arbitrary resources', async () => {
+    let calls = 0;
+    const result = await runGenuiBenchUiJudge(
+      {
+        artifact: {
+          protocol: 'openui',
+          rawText: 'root = Image("file:///etc/passwd", "untrusted local file")',
+        },
+        attemptCount: 2,
+        retryDelayMs: 0,
+        scenario: { prompt: 'Build an image card' },
+        session: {
+          bundleUrl: 'file:///tmp/openui.lynx.js',
+          judgeUrl: 'http://judge.test/judge',
+        },
+      },
+      () => {
+        calls++;
+        return Promise.resolve(Response.json({ score: 5 }));
+      },
+    );
+
+    expect(calls).toBe(0);
+    expect(result).toEqual({
+      errors: [
+        'ui-judge rejected OpenUI output containing an external resource URL or openUrl call.',
+      ],
+      score: 0,
+      status: 'failed',
+      warnings: [],
+    });
+  });
+});

--- a/packages/genui/server/test/openui-bench-adapter.test.ts
+++ b/packages/genui/server/test/openui-bench-adapter.test.ts
@@ -1,0 +1,414 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import type {
+  ProtocolBenchAdapterInput,
+} from '../service/genui-bench/protocol-adapter.js';
+import type { ProtocolBenchScenario } from '../service/genui-bench/types.js';
+import type { OpenUIChatOptions } from '../service/openui-agent.js';
+import {
+  OPENUI_BENCH_CAPABILITY_PROFILE,
+  OPENUI_BENCH_MATCHED_COMPONENTS,
+  OPENUI_BENCH_PROMPT_OPTIONS,
+  createOpenUIBenchAdapter,
+} from '../service/openui-bench-adapter.js';
+import type {
+  OpenUIBenchGenerateRaw,
+} from '../service/openui-bench-adapter.js';
+import {
+  validateOpenUIBenchOutput,
+} from '../service/openui-bench-validator.js';
+
+const VALID_OPENUI = [
+  'root = Column([title, card], "start", "stretch", "m")',
+  'title = Text("Bench result", "h2")',
+  'card = Card([TextContent("Ready.", "default"), Button("Continue")], "card", "column", false, "s", "start", "start")',
+].join('\n');
+
+const scenario: ProtocolBenchScenario = {
+  id: 'information-card',
+  name: 'Information card',
+  prompt: 'Build a compact status card with a continue button.',
+  type: 'Information',
+  complexity: 2,
+  action: 'Continue',
+};
+
+function adapterInput(maxAttempts = 2): ProtocolBenchAdapterInput {
+  return {
+    runId: 'run-openui-1',
+    pairId: 'pair-1',
+    scenario,
+    repeatIndex: 1,
+    maxAttempts,
+    provider: {
+      api: 'responses',
+      baseURL: 'https://provider.test/v1',
+      model: 'test-model',
+    },
+  };
+}
+
+function sequenceNow(values: number[]): () => number {
+  let index = 0;
+  return () => values[index++] ?? values[values.length - 1] ?? 0;
+}
+
+describe('OpenUI Bench validator', () => {
+  test('parses matched-core output and measures component complexity', () => {
+    const result = validateOpenUIBenchOutput(VALID_OPENUI);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.complexity).toMatchObject({
+      componentCount: 5,
+      componentTypes: {
+        Button: 1,
+        Card: 1,
+        Column: 1,
+        Text: 1,
+        TextContent: 1,
+      },
+      maxComponentDepth: 3,
+      mutationCount: 0,
+      queryCount: 0,
+      statementCount: 3,
+      unknownComponentCount: 0,
+    });
+  });
+
+  test('rejects a nested unknown component even when a root still renders', () => {
+    const result = validateOpenUIBenchOutput([
+      'root = Column([known, missing])',
+      'known = Text("Still renderable")',
+      'missing = SecretWidget("must not disappear silently")',
+    ].join('\n'));
+
+    expect(result.parseResult?.root?.typeName).toBe('Column');
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'unknown-component',
+        component: 'SecretWidget',
+        statementId: 'missing',
+      }),
+    ]));
+    expect(result.complexity.unknownComponentCount).toBe(1);
+  });
+
+  test('hard-gates full-catalog components, tools, and external URLs', () => {
+    const disallowedComponent = validateOpenUIBenchOutput(
+      'root = Column([Icon("home")])',
+    );
+    const query = validateOpenUIBenchOutput([
+      'weather = Query("get_weather", {}, {})',
+      'root = Column([Text("Weather")])',
+    ].join('\n'));
+    const externalUrl = validateOpenUIBenchOutput(
+      'root = Column([Text("https://example.com")])',
+    );
+
+    expect(disallowedComponent.errors[0]).toMatchObject({
+      code: 'unknown-component',
+      component: 'Icon',
+    });
+    expect(query.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'query-not-allowed' }),
+    ]));
+    expect(externalUrl.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'external-url-not-allowed' }),
+    ]));
+  });
+});
+
+describe('OpenUI Bench adapter', () => {
+  test('returns a valid first attempt with normalized usage and latency', async () => {
+    let receivedOptions: OpenUIChatOptions | undefined;
+    const generateRaw: OpenUIBenchGenerateRaw = (_messages, options) => {
+      receivedOptions = options;
+      return Promise.resolve({
+        text: VALID_OPENUI,
+        usage: {
+          prompt_tokens: 13,
+          completion_tokens: 8,
+          total_tokens: 21,
+        },
+        finishReason: 'stop',
+      });
+    };
+    const adapter = createOpenUIBenchAdapter({
+      generateRaw,
+      now: sequenceNow([100, 125]),
+    });
+
+    const result = await adapter.generate(adapterInput());
+
+    expect(result.finalValid).toBe(true);
+    expect(result.rawText).toBe(VALID_OPENUI);
+    expect(result.attemptCount).toBe(1);
+    expect(result.totalLatencyMs).toBe(25);
+    expect(result.totalUsage).toEqual({
+      inputTokens: 13,
+      outputTokens: 8,
+      totalTokens: 21,
+    });
+    expect(result.attempts[0]).toMatchObject({
+      durationMs: 25,
+      inputTokens: 13,
+      outputTokens: 8,
+      totalTokens: 21,
+      valid: true,
+    });
+    expect(result.judgePayload).toEqual({
+      kind: 'openui-text',
+      rawText: VALID_OPENUI,
+    });
+    expect(result.metadata).toMatchObject({
+      capabilityProfile: OPENUI_BENCH_CAPABILITY_PROFILE,
+      rootComponent: 'Column',
+      policy: 'resource-safe-matched-core',
+    });
+    expect(result.metadata?.matchedComponents).toEqual(
+      [...OPENUI_BENCH_MATCHED_COMPONENTS].sort(),
+    );
+    expect(receivedOptions).toMatchObject({
+      api: 'responses',
+      baseURL: 'https://provider.test/v1',
+      disableAgentCache: true,
+      inheritReasoningEffort: false,
+      model: 'test-model',
+      promptRoot: 'Column',
+      promptOptions: OPENUI_BENCH_PROMPT_OPTIONS,
+    });
+    expect(receivedOptions?.systemAppendix).toContain(
+      'Matched-core benchmark',
+    );
+    expect(receivedOptions?.promptComponentNames).toEqual(
+      OPENUI_BENCH_MATCHED_COMPONENTS,
+    );
+    expect(OPENUI_BENCH_PROMPT_OPTIONS.examples).toEqual([]);
+  });
+
+  test('threads cancellation into generation and includes scenario complexity', async () => {
+    const abortController = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    let receivedPrompt = '';
+    const adapter = createOpenUIBenchAdapter({
+      generateRaw: (messages, _options, signal) => {
+        receivedSignal = signal;
+        receivedPrompt = messages[0]?.content ?? '';
+        return Promise.resolve({
+          text: VALID_OPENUI,
+          usage: {},
+          finishReason: 'stop',
+        });
+      },
+      now: sequenceNow([0, 1]),
+    });
+
+    await adapter.generate(adapterInput(), abortController.signal);
+
+    expect(receivedSignal).toBe(abortController.signal);
+    expect(receivedPrompt).toContain('Scenario complexity: 2');
+  });
+
+  test('repairs once without backoff and accumulates both attempt records', async () => {
+    const generated = [
+      {
+        text: 'root = Column([SecretWidget("bad")])',
+        usage: { inputTokens: 10, outputTokens: 4, totalTokens: 14 },
+        finishReason: 'stop',
+      },
+      {
+        text: VALID_OPENUI,
+        usage: { input_tokens: 15, output_tokens: 6, total_tokens: 21 },
+        finishReason: 'stop',
+      },
+    ];
+    const receivedMessages: string[][] = [];
+    const sleepCalls: number[] = [];
+    let callCount = 0;
+    const adapter = createOpenUIBenchAdapter({
+      generateRaw: (messages) => {
+        receivedMessages.push(messages.map((message) => message.content));
+        return Promise.resolve(generated[callCount++]!);
+      },
+      now: sequenceNow([0, 10, 10, 35]),
+      sleep(delayMs) {
+        sleepCalls.push(delayMs);
+        return Promise.resolve();
+      },
+    });
+
+    const result = await adapter.generate(adapterInput(99));
+
+    expect(callCount).toBe(2);
+    expect(result.finalValid).toBe(true);
+    expect(result.attemptCount).toBe(2);
+    expect(result.totalLatencyMs).toBe(35);
+    expect(result.totalUsage).toEqual({
+      inputTokens: 25,
+      outputTokens: 10,
+      totalTokens: 35,
+    });
+    expect(result.attempts.map((attempt) => attempt.valid)).toEqual([
+      false,
+      true,
+    ]);
+    expect(receivedMessages[1]).toHaveLength(3);
+    expect(receivedMessages[1]?.[1]).toContain('SecretWidget');
+    expect(receivedMessages[1]?.[2]).toContain('[unknown-component]');
+    expect(sleepCalls).toEqual([]);
+    expect(result.rawText).toBe(VALID_OPENUI);
+  });
+
+  test('honors the normalized attempt budget', async () => {
+    let callCount = 0;
+    const adapter = createOpenUIBenchAdapter({
+      generateRaw: () => {
+        callCount += 1;
+        return Promise.resolve({
+          text: `root = Column([Unknown${callCount}()])`,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          finishReason: 'stop',
+        });
+      },
+      now: sequenceNow([0, 1, 1, 2, 2, 3]),
+    });
+
+    const result = await adapter.generate(adapterInput(3));
+
+    expect(callCount).toBe(3);
+    expect(result.attemptCount).toBe(3);
+    expect(result.finalValid).toBe(false);
+    expect(result.judgePayload).toBeUndefined();
+    expect(result.finalErrors[0]).toContain('unknown-component');
+  });
+
+  test('waits before retrying a transient generation failure', async () => {
+    const receivedMessages: string[][] = [];
+    const sleepCalls: number[] = [];
+    let releaseBackoff: (() => void) | undefined;
+    let markBackoffStarted: (() => void) | undefined;
+    const backoffStarted = new Promise<void>((resolve) => {
+      markBackoffStarted = resolve;
+    });
+    const backoff = new Promise<void>((resolve) => {
+      releaseBackoff = resolve;
+    });
+    let callCount = 0;
+    const adapter = createOpenUIBenchAdapter({
+      generateRaw: (messages) => {
+        receivedMessages.push(messages.map((message) => message.content));
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.reject(new Error('provider temporarily unavailable'));
+        }
+        return Promise.resolve({
+          text: VALID_OPENUI,
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          finishReason: 'stop',
+        });
+      },
+      now: sequenceNow([0, 5, 5, 15]),
+      sleep(delayMs) {
+        sleepCalls.push(delayMs);
+        markBackoffStarted?.();
+        return backoff;
+      },
+    });
+
+    const generation = adapter.generate(adapterInput());
+    await backoffStarted;
+
+    expect(callCount).toBe(1);
+    expect(sleepCalls).toEqual([10_000]);
+    releaseBackoff?.();
+    const result = await generation;
+    expect(callCount).toBe(2);
+    expect(receivedMessages.map((messages) => messages.length)).toEqual([1, 1]);
+    expect(
+      result.attempts.map((attempt) => attempt.generationFailed),
+    ).toEqual([true, false]);
+    expect(result.attempts.map((attempt) => attempt.valid)).toEqual([
+      false,
+      true,
+    ]);
+    expect(result.finalValid).toBe(true);
+    expect(result.finalErrors).toEqual([]);
+    expect(result.judgePayload).toEqual({
+      kind: 'openui-text',
+      rawText: VALID_OPENUI,
+    });
+  });
+
+  test('aborts during transport backoff without starting another request', async () => {
+    const abortController = new AbortController();
+    let markBackoffStarted: (() => void) | undefined;
+    const backoffStarted = new Promise<void>((resolve) => {
+      markBackoffStarted = resolve;
+    });
+    let callCount = 0;
+    const adapter = createOpenUIBenchAdapter({
+      generateRaw: () => {
+        callCount += 1;
+        return Promise.reject(new Error('provider temporarily unavailable'));
+      },
+      now: sequenceNow([0, 5]),
+      sleep() {
+        markBackoffStarted?.();
+        return new Promise<void>(() => {
+          // Keep backoff pending so cancellation must win the race.
+        });
+      },
+    });
+
+    const generation = adapter.generate(
+      adapterInput(),
+      abortController.signal,
+    );
+    await backoffStarted;
+    abortController.abort();
+
+    await expect(generation).rejects.toMatchObject({ name: 'AbortError' });
+    expect(callCount).toBe(1);
+  });
+
+  test('redacts provider credentials and exhausts the transport retry budget', async () => {
+    const receivedMessages: string[][] = [];
+    let callCount = 0;
+    const adapter = createOpenUIBenchAdapter({
+      generateRaw: (messages) => {
+        receivedMessages.push(messages.map((message) => message.content));
+        callCount += 1;
+        return Promise.reject(
+          new Error('request failed for api-key-must-not-leak'),
+        );
+      },
+      now: sequenceNow([2, 7, 7, 12]),
+      retryDelayMs: 0,
+    });
+    const input = adapterInput();
+    input.provider.apiKey = 'api-key-must-not-leak';
+
+    const result = await adapter.generate(input);
+
+    expect(callCount).toBe(2);
+    expect(receivedMessages.map((messages) => messages.length)).toEqual([1, 1]);
+    expect(result.finalValid).toBe(false);
+    expect(result.attempts).toHaveLength(2);
+    expect(
+      result.attempts.every((attempt) => attempt.generationFailed),
+    ).toBe(true);
+    expect(JSON.stringify(result.attempts)).not.toContain(
+      'api-key-must-not-leak',
+    );
+    expect(result.finalErrors.join('\n')).not.toContain(
+      'api-key-must-not-leak',
+    );
+    expect(result.finalErrors[0]).toContain('[REDACTED]');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1033,6 +1033,9 @@ importers:
       '@mastra/core':
         specifier: 1.52.0
         version: 1.52.0(express@5.2.1(supports-color@10.2.2))(rxjs@7.8.2)(supports-color@10.2.2)(zod@4.4.3)
+      '@openuidev/lang-core':
+        specifier: ^0.2.9
+        version: 0.2.9(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
       hono:
         specifier: 4.12.12
         version: 4.12.12


### PR DESCRIPTION
## What

- add protocol-aware A2UI and OpenUI bench jobs for native and matched-core modes
- introduce shared adapters, validation, paired scheduling, judging, and screenshot capture
- add bounded admission, workload, screenshot, cache, and provider-override policies
- redact provider credentials and endpoints from reports, events, snapshots, warnings, and errors

## Why

This provides the protocol-neutral backend foundation for comparing A2UI and OpenUI under aligned workloads.

## Safety

- provider overrides are policy-gated
- credentials and provider endpoints are excluded from public job state
- screenshots are bounded per image and per job
- per-run SSE events omit screenshot payloads while final reports retain accepted captures

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo build` — 66/66 tasks
- `pnpm --filter a2ui-server test` — 17 files, 86 tests
- ESLint for server and changed TypeScript/TSX files
- scoped Biome checks
- `pnpm turbo api-extractor -- --local`

## Dependencies

Required by #3309.

Runtime depends on UI Judge #3310; #3310 should merge first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol-aware benchmarking for A2UI and OpenUI, including matched-core validation, retries, judging, screenshots, and richer reporting.
  * Added configurable OpenUI prompts, including component selection, root components, and prompt options.
  * Added benchmark capacity controls, workload limits, and protocol/profile support.
  * Added optional per-request agent cache bypassing and reasoning-effort inheritance controls.

* **Bug Fixes**
  * Corrected duplicate component ID validation across updates.
  * Improved screenshot validation, sensitive-data redaction, and benchmark failure handling.

* **Style**
  * Added dedicated benchmark layouts and styling to the playground.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->