### PR TITLE
refactor(react): drop the main-thread wrapper for FetchBundle lazy bundles

### DIFF
--- a/.changeset/fetchbundle-lazy-mt-no-wrapper.md
+++ b/.changeset/fetchbundle-lazy-mt-no-wrapper.md
@@ -1,0 +1,34 @@
+---
+"@lynx-js/react": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/react-webpack-plugin": patch
+"@lynx-js/chunk-loading-webpack-plugin": patch
+"@lynx-js/template-webpack-plugin": patch
+"@lynx-js/webpack-runtime-globals": patch
+---
+
+Drop the `(function (globDynamicComponentEntry) { ... })` wrapper from
+FetchBundle main-thread chunks — FetchBundle artifacts no longer reference
+`globDynamicComponentEntry` at all.
+
+- Chunks use the same shell as the external-bundle main-thread wrapper
+  (`MainThreadRuntimeWrapperWebpackPlugin`): a parameterless self-invoking
+  IIFE whose completion value is the exports (`return module.exports`). The
+  IIFE is required for correctness: `lynx.loadScript` evaluates chunks as
+  programs in the shared main-thread realm, where the webpack bootstrap's
+  top-level bindings would otherwise clobber the page's.
+- Snapshot uids compile to bare literals: a uid already embeds the module's
+  filename and content hashes (`__snapshot_<filename>_<content>_<n>`), so it
+  needs no per-load entry prefix to stay unique across bundles, and the
+  FetchBundle runtime never consumes a snapshot's entryName. Snapshot entry
+  names and element-template uid scopes compile to the `__Card__` literal.
+- `processEvalResultByHost` is keyed by the compile-time host id
+  (`uniqueName#entryName`, `deriveLynxHostId`), emitted as
+  `__webpack_require__.lynx_hid` and passed by chunk loading as a nested
+  lazy-bundle import's `host` — no shared mutable global anywhere in the
+  load path.
+- The main-thread loader reduces to `lynx.loadScript` + the completion
+  value; the entry window and wrapper-shape dispatch are gone. **FetchBundle
+  lazy bundles built with earlier releases (the wrapper protocol shipped in
+  `@lynx-js/react` 0.123) must be rebuilt with a matching toolchain.** The
+  QueryComponent protocol and its artifacts are unaffected.

--- a/packages/react/runtime/__test__/snapshot/lynx/lazy-bundle-fetchbundle.test.js
+++ b/packages/react/runtime/__test__/snapshot/lynx/lazy-bundle-fetchbundle.test.js
@@ -40,10 +40,7 @@ describe('loadLazyBundle (FetchBundle) — main thread sync', () => {
 
   test('happy path: .wait → loadScript(main-thread) → CSS adopt → sync then', async () => {
     waitMock.mockReturnValueOnce({ code: 0, url: 'cached-url' });
-    // The main-thread bundle is wrapped as `(globDynamicComponentEntry) => exports`;
-    // the loader invokes it with the bundle's own `source`.
-    const mtEval = vi.fn(() => ({ default: 'MTChunk' }));
-    loadScript.mockReturnValueOnce(mtEval);
+    loadScript.mockReturnValueOnce({ default: 'MTChunk' });
     loadStyleSheet.mockReturnValueOnce({ id: 'sheet' });
 
     const { loadLazyBundle } = await import(
@@ -57,8 +54,6 @@ describe('loadLazyBundle (FetchBundle) — main thread sync', () => {
     expect(loadScript).toHaveBeenCalledWith('main-thread', {
       bundleName: 'cached-url',
     });
-    // Invoked with the bundle's own url so its `globDynamicComponentEntry` is `foo`.
-    expect(mtEval).toHaveBeenCalledWith('foo');
     expect(loadStyleSheet).toHaveBeenCalledWith('CSS', 'cached-url');
     expect(adoptStyleSheet).toHaveBeenCalledWith({ id: 'sheet' });
 
@@ -163,9 +158,30 @@ describe('loadLazyBundle (FetchBundle) — main thread sync', () => {
     await Promise.resolve();
   });
 
+  test('stylesheet load throws → never-resolving', async () => {
+    waitMock.mockReturnValueOnce({ code: 0, url: 'x' });
+    loadScript.mockReturnValueOnce({ default: 'C' });
+    loadStyleSheet.mockImplementationOnce(() => {
+      throw new Error('CSS section blew up');
+    });
+
+    const { loadLazyBundle } = await import(
+      '../../../src/core/lynx/lazy-bundle'
+    );
+
+    const promise = loadLazyBundle('foo', 'sync');
+
+    expect(adoptStyleSheet).not.toHaveBeenCalled();
+    promise.then(
+      () => expect.fail('should not resolve'),
+      () => expect.fail('should not reject'),
+    );
+    await Promise.resolve();
+  });
+
   test('null stylesheet → chunk still resolved, no AdoptStyleSheet', async () => {
     waitMock.mockReturnValueOnce({ code: 0, url: 'x' });
-    loadScript.mockReturnValueOnce(() => ({ default: 'C' }));
+    loadScript.mockReturnValueOnce({ default: 'C' });
     loadStyleSheet.mockReturnValueOnce(null);
 
     const { loadLazyBundle } = await import(

--- a/packages/react/runtime/__test__/snapshot/lynx/prepareLazyBundleMTS.test.js
+++ b/packages/react/runtime/__test__/snapshot/lynx/prepareLazyBundleMTS.test.js
@@ -27,9 +27,7 @@ describe('prepareLazyBundleMTS handler', () => {
 
     thenMock = vi.fn();
     fetchBundle = vi.fn(() => ({ then: thenMock }));
-    // The main-thread bundle is wrapped as `(globDynamicComponentEntry) => exports`;
-    // `loadScript` returns that function and the handler invokes it with the url.
-    loadScript = vi.fn(() => () => ({ chunk: 'x' }));
+    loadScript = vi.fn(() => ({ chunk: 'x' }));
     loadStyleSheet = vi.fn();
     adoptStyleSheet = vi.fn();
     processEvalResult = vi.fn();
@@ -38,7 +36,7 @@ describe('prepareLazyBundleMTS handler', () => {
       .stubGlobal('lynx', { fetchBundle, loadScript })
       .stubGlobal('__LoadStyleSheet', loadStyleSheet)
       .stubGlobal('__AdoptStyleSheet', adoptStyleSheet)
-      // Handlers are keyed by the loading host's entry, not a single global.
+      // Handlers are keyed by the loading host's compile-time host id.
       .stubGlobal('processEvalResultByHost', { [HOST]: processEvalResult });
 
     ({ injectPrepareLazyBundleMTS } = await import(
@@ -56,18 +54,14 @@ describe('prepareLazyBundleMTS handler', () => {
     return globalThis.rLynxPrepareLazyBundleMTS({ url, host });
   }
 
-  test('happy path: loadScript(main-thread) → evaluate(url) → host handler → CSS adopt', () => {
+  test('happy path: loadScript(main-thread) → host handler → CSS adopt', () => {
     thenMock.mockImplementationOnce((cb) => cb({ code: 0, url: 'u' }));
-    const evaluate = vi.fn(() => ({ chunk: 'x' }));
-    loadScript.mockReturnValueOnce(evaluate);
     loadStyleSheet.mockReturnValueOnce({ id: 'sheet' });
 
     invoke('foo');
 
     expect(fetchBundle).toHaveBeenCalledWith('foo', {});
     expect(loadScript).toHaveBeenCalledWith('main-thread', { bundleName: 'u' });
-    // The bundle is evaluated with its own url as `globDynamicComponentEntry`.
-    expect(evaluate).toHaveBeenCalledWith('foo');
     expect(processEvalResult).toHaveBeenCalledWith(expect.any(Function), 'foo');
     // The factory passed to the handler returns the loaded chunk.
     const factory = processEvalResult.mock.calls[0][0];

--- a/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
@@ -990,6 +990,22 @@ describe('DEV_ONLY_addSnapshot', () => {
     `);
   });
 
+  it('DEV_ONLY_SetSnapshotEntryName is a no-op under FetchBundle', () => {
+    const uniqID = 'entry-name-fetcher-0';
+    snapshotCreatorMap[uniqID] = () => {};
+    const before = snapshotCreatorMap[uniqID];
+
+    vi.stubGlobal('__LAZY_BUNDLE_FETCHER__', 'FetchBundle');
+    snapshotPatchApply([102, uniqID, 'https://example.com/lazy-bundle.js']);
+    expect(snapshotCreatorMap[uniqID]).toBe(before);
+
+    // The QueryComponent protocol still rebinds the entry into the creator.
+    vi.stubGlobal('__LAZY_BUNDLE_FETCHER__', 'QueryComponent');
+    snapshotPatchApply([102, uniqID, 'https://example.com/lazy-bundle.js']);
+    expect(snapshotCreatorMap[uniqID]).not.toBe(before);
+    vi.unstubAllGlobals();
+  });
+
   it('with update', () => {
     const uniqID1 = 'with-update-0';
     // We have to use `snapshotCreatorMap[uniqID1] =` so that it can be created after `initGlobalSnapshotPatch`

--- a/packages/react/runtime/src/core/lynx/lazy-bundle.ts
+++ b/packages/react/runtime/src/core/lynx/lazy-bundle.ts
@@ -8,7 +8,8 @@
 // sync with `snapshot/lifecycle/constant.ts`'s
 // `LifecycleConstant.prepareLazyBundleMTS`, the lifecycle name the snapshot
 // backend registers the main-thread prepare handler under.
-const SECTION_MAIN_THREAD = 'main-thread';
+import { loadMainThreadSection } from './main-thread-section.js';
+
 const SECTION_BACKGROUND = 'background';
 const SECTION_CSS = 'CSS';
 const LYNX_LAZY_SYNC_TIMEOUT_SECONDS = 5;
@@ -216,9 +217,13 @@ export const loadLazyBundle: <
       }
       let result: T;
       try {
-        result = lynx.loadScript<(entry: string) => T>(SECTION_MAIN_THREAD, {
-          bundleName: response.url,
-        })(source);
+        const loaded = loadMainThreadSection(response.url);
+        if (loaded === undefined) {
+          // A sync bundle without a main-thread section cannot first-screen
+          // render.
+          return new Promise(() => {});
+        }
+        result = loaded as T;
         const styleSheet = __LoadStyleSheet(SECTION_CSS, response.url);
         if (styleSheet !== null) {
           __AdoptStyleSheet(styleSheet);

--- a/packages/react/runtime/src/core/lynx/main-thread-section.ts
+++ b/packages/react/runtime/src/core/lynx/main-thread-section.ts
@@ -1,0 +1,24 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Kept side-effect free: `snapshot/` imports this without pulling in
+// `lazy-bundle.ts`'s `lynx.loadLazyBundle` registration.
+const SECTION_MAIN_THREAD = 'main-thread';
+
+/**
+ * Evaluate a bundle's main-thread section. The FetchBundle shell is a
+ * parameterless self-invoking IIFE whose completion value is its exports
+ * (`return module.exports`), so the eval result is the exports directly.
+ *
+ * Returns `undefined` when the bundle has no main-thread section (BG-only).
+ *
+ * @internal
+ */
+export function loadMainThreadSection(bundleName: string): unknown {
+  try {
+    return lynx.loadScript<unknown>(SECTION_MAIN_THREAD, { bundleName });
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
@@ -124,11 +124,18 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
           const uniqID = snapshotPatch[++i] as string;
           const entryName = snapshotPatch[++i] as string;
 
-          // HMR-related
-          // Update the evaluated snapshot entryName from JS.
-          snapshotCreatorMap[uniqID] = evaluate<(uniqId: string) => string>(
-            snapshotCreatorMap[uniqID]!.toString().replace(/globDynamicComponentEntry/g, JSON.stringify(entryName)),
-          );
+          if (
+            typeof __LAZY_BUNDLE_FETCHER__ === 'undefined'
+            || __LAZY_BUNDLE_FETCHER__ !== 'FetchBundle'
+          ) {
+            // HMR-related
+            // Update the evaluated snapshot entryName from JS. FetchBundle
+            // creators embed a literal entry name, so there is nothing to
+            // rebind there and the branch compiles away.
+            snapshotCreatorMap[uniqID] = evaluate<(uniqId: string) => string>(
+              snapshotCreatorMap[uniqID]!.toString().replace(/globDynamicComponentEntry/g, JSON.stringify(entryName)),
+            );
+          }
         }
         break;
       }

--- a/packages/react/runtime/src/snapshot/lynx/prepareLazyBundleMTS.ts
+++ b/packages/react/runtime/src/snapshot/lynx/prepareLazyBundleMTS.ts
@@ -2,7 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { SECTION_CSS, SECTION_MAIN_THREAD } from './lazyBundleConstants.js';
+import { SECTION_CSS } from './lazyBundleConstants.js';
+import { loadMainThreadSection } from '../../core/lynx/main-thread-section.js';
 import { LifecycleConstant } from '../lifecycle/constant.js';
 
 const cache = new Set<string>();
@@ -28,20 +29,16 @@ function prepareLazyBundleMTS(payload: { url: string; host?: string }): void {
     // A subsequent `loadScript` throw below is a BG-only bundle (deterministic,
     // not retryable), so caching here is still correct.
     cache.add(url);
-    let loaded: unknown;
-    try {
-      const evaluate = lynx.loadScript<(entry: string) => unknown>(
-        SECTION_MAIN_THREAD,
-        { bundleName: response.url },
-      );
-      loaded = evaluate(url);
-    } catch {
+    const loaded = loadMainThreadSection(response.url);
+    if (loaded === undefined) {
       // BG-only bundle (no main-thread section)
       return;
     }
-    // Route to the loading `host`'s handler — the chunk's modules install into
-    // that host's registry. No host (e.g. a standalone component loaded
-    // directly, self-contained in its own registry) → nothing to install here.
+    // Route to the loading `host`'s handler — the chunk's modules install
+    // into that host's registry, keyed by the compile-time host id chunk
+    // loading sent along. No host (e.g. a standalone component loaded
+    // directly, self-contained in its own registry) → nothing to install
+    // here.
     const processEvalResult = host == null
       ? undefined
       : (

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -532,10 +532,9 @@ where
     let template_uid = template_identity.template_id.clone();
 
     // External bundles have no `globDynamicComponentEntry` in scope; use the
-    // `__Card__` entry-name literal.
-    let entry_template_uid = if matches!(self.cfg.is_external_bundle, Some(true))
-      && !matches!(self.cfg.is_dynamic_component, Some(true))
-    {
+    // `__Card__` entry-name literal. This covers dynamic components too: the
+    // FetchBundle runtime never consumes a template's entry scope.
+    let entry_template_uid = if matches!(self.cfg.is_external_bundle, Some(true)) {
       quote!("`__Card__:${$template_uid}`" as Expr, template_uid: Expr = Expr::Lit(Lit::Str(template_uid.clone().into())))
     } else {
       quote!("`${globDynamicComponentEntry}:${$template_uid}`" as Expr, template_uid: Expr = Expr::Lit(Lit::Str(template_uid.clone().into())))

--- a/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_snapshot/lib.rs
@@ -1547,10 +1547,11 @@ where
     };
 
     // External bundles have no `globDynamicComponentEntry` in scope; use the
-    // `__Card__` entry-name literal.
-    let entry_name: Expr = if matches!(self.cfg.is_external_bundle, Some(true))
-      && !matches!(self.cfg.is_dynamic_component, Some(true))
-    {
+    // `__Card__` entry-name literal. This covers dynamic components too: a
+    // snapshot uid already embeds the module's filename and content hashes,
+    // so it needs no per-load entry prefix to stay unique across bundles,
+    // and the FetchBundle runtime never consumes a snapshot's entryName.
+    let entry_name: Expr = if matches!(self.cfg.is_external_bundle, Some(true)) {
       Expr::Lit(Lit::Str("__Card__".into()))
     } else {
       Expr::Ident("globDynamicComponentEntry".into())
@@ -1623,7 +1624,13 @@ where
     };
 
     let mut entry_snapshot_uid = quote!("$snapshot_uid" as Expr, snapshot_uid: Expr = Expr::Lit(Lit::Str(snapshot_uid.clone().into())));
-    if matches!(self.cfg.is_dynamic_component, Some(true)) {
+    if matches!(self.cfg.is_dynamic_component, Some(true))
+      && !matches!(self.cfg.is_external_bundle, Some(true))
+    {
+      // The QueryComponent protocol scopes a dynamic component's snapshot
+      // uids by its load-time entry. Under FetchBundle (`is_external_bundle`)
+      // the uid stays bare, like a page's: its filename and content hashes
+      // already make it unique across bundles.
       entry_snapshot_uid = quote!("`${globDynamicComponentEntry}:${$snapshot_uid}`" as Expr, snapshot_uid: Expr = Expr::Lit(Lit::Str(snapshot_uid.clone().into())));
     }
 

--- a/packages/rspeedy/plugin-react/src/loaders.ts
+++ b/packages/rspeedy/plugin-react/src/loaders.ts
@@ -6,6 +6,7 @@ import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core'
 import { LAYERS, ReactWebpackPlugin } from '@lynx-js/react-webpack-plugin'
 
 import type { PluginReactLynxOptions } from './pluginReactLynx.js'
+import { resolveLazyBundleFetcher } from './resolveLazyBundleFetcher.js'
 
 // The transforms an `es2019` SWC target lowers (ES2020+ syntax), expressed as
 // an explicit `env.include` so the main thread no longer relies on
@@ -61,6 +62,8 @@ function getLoaderOptions(
     compat,
     enableRemoveCSSScope,
     isDynamicComponent: experimental_isLazyBundle,
+    isExternalBundle:
+      resolveLazyBundleFetcher(options.targetSdkVersion) === 'FetchBundle',
     inlineSourcesContent,
     defineDCE,
     engineVersion,

--- a/packages/rspeedy/plugin-react/test/config.test.ts
+++ b/packages/rspeedy/plugin-react/test/config.test.ts
@@ -418,6 +418,7 @@ describe('Config', () => {
         "experimental_useElementTemplate": false,
         "inlineSourcesContent": true,
         "isDynamicComponent": false,
+        "isExternalBundle": false,
       }
     `)
   })
@@ -591,6 +592,7 @@ describe('Config', () => {
         "experimental_useElementTemplate": false,
         "inlineSourcesContent": true,
         "isDynamicComponent": false,
+        "isExternalBundle": false,
       }
     `)
 

--- a/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/chunk-loading.js
@@ -37,11 +37,9 @@ export default function() {
                 // `async`.
                 $RuntimeGlobals_lynxAsyncChunkMode$
                   && $RuntimeGlobals_lynxAsyncChunkMode$[chunkId],
-                // The loading host's own entry, so the MT prepare routes this
+                // The compile-time host id, so the MT prepare routes this
                 // chunk's eval result to the host that owns its modules.
-                typeof globDynamicComponentEntry !== 'undefined'
-                  ? globDynamicComponentEntry
-                  : undefined,
+                $RuntimeGlobals_lynxHostId$,
               ).then((exports) => {
                 installChunk(exports);
                 return exports;

--- a/packages/webpack/react-webpack-plugin/src/LynxProcessEvalResultRuntimeModule.ts
+++ b/packages/webpack/react-webpack-plugin/src/LynxProcessEvalResultRuntimeModule.ts
@@ -3,9 +3,14 @@
 // LICENSE file in the root directory of this source tree.
 import type { RuntimeModule } from '@rspack/core';
 
-import { RuntimeGlobals as LynxRuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
+import {
+  RuntimeGlobals as LynxRuntimeGlobals,
+  deriveLynxHostId,
+} from '@lynx-js/webpack-runtime-globals';
 
-type LynxProcessEvalResultRuntimeModule = new() => RuntimeModule;
+type LynxProcessEvalResultRuntimeModule = new(
+  lazyBundleFetcher?: 'FetchBundle' | 'QueryComponent',
+) => RuntimeModule;
 
 export function createLynxProcessEvalResultRuntimeModule(
   webpack: typeof import('@rspack/core').rspack,
@@ -13,7 +18,9 @@ export function createLynxProcessEvalResultRuntimeModule(
   return class LynxProcessEvalResultRuntimeModule
     extends webpack.RuntimeModule
   {
-    constructor() {
+    constructor(
+      public lazyBundleFetcher?: 'FetchBundle' | 'QueryComponent',
+    ) {
       super(
         'webpack/runtime/lynx process eval result',
         webpack.RuntimeModule.STAGE_ATTACH,
@@ -28,10 +35,23 @@ export function createLynxProcessEvalResultRuntimeModule(
         return '';
       }
 
-      // Register per-bundle under `globDynamicComponentEntry`; also assign the
-      // deprecated single global for backward compatibility.
+      // FetchBundle registers under the compile-time host id — the same
+      // derivation `LynxAsyncChunksRuntimeModule` (template-webpack-plugin)
+      // emits as `lynx_hid` and chunk loading passes as a nested import's
+      // `host`. QueryComponent keeps the legacy `globDynamicComponentEntry`
+      // key its wrapper protocol provides.
+      const hostKey = this.lazyBundleFetcher === 'FetchBundle'
+        ? JSON.stringify(
+          deriveLynxHostId(
+            compilation.outputOptions?.uniqueName,
+            chunk.runtime,
+          ),
+        )
+        : 'globDynamicComponentEntry';
+
+      // Also assign the deprecated single global for backward compatibility.
       return `
-globalThis.processEvalResult = (${LynxRuntimeGlobals.lynxProcessEvalResultByHost} || (${LynxRuntimeGlobals.lynxProcessEvalResultByHost} = {}))[globDynamicComponentEntry] = function (result, schema) {
+globalThis.processEvalResult = (${LynxRuntimeGlobals.lynxProcessEvalResultByHost} || (${LynxRuntimeGlobals.lynxProcessEvalResultByHost} = {}))[${hostKey}] = function (result, schema) {
   var chunk = result && result(schema);
   if (chunk && chunk.ids && chunk.modules) {
     // We only deal with webpack chunk

--- a/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
+++ b/packages/webpack/react-webpack-plugin/src/ReactWebpackPlugin.ts
@@ -432,7 +432,7 @@ class ReactWebpackPlugin {
           createLynxProcessEvalResultRuntimeModule(compiler.webpack);
         compilation.addRuntimeModule(
           chunk,
-          new LynxProcessEvalResultRuntimeModule(),
+          new LynxProcessEvalResultRuntimeModule(options.lazyBundleFetcher),
         );
       });
 
@@ -553,13 +553,30 @@ class ReactWebpackPlugin {
                   compilation.updateAsset(
                     file,
                     old =>
-                      new ConcatSource(
-                        `(function (globDynamicComponentEntry) {\n`,
-                        `  const module = { exports: {} }\n`,
-                        `  const exports = module.exports;\n`,
-                        old,
-                        `\n  ;return module.exports\n})`,
-                      ),
+                      options.lazyBundleFetcher === 'FetchBundle'
+                        // Same shell as the external-bundle main-thread
+                        // wrapper (`MainThreadRuntimeWrapperWebpackPlugin`):
+                        // a parameterless self-invoking IIFE whose completion
+                        // value is the exports. `lynx.loadScript` evaluates
+                        // the chunk as a program in the shared main-thread
+                        // realm, so the IIFE scopes the webpack bootstrap's
+                        // top-level bindings, which would otherwise clobber
+                        // the page's. The chunk needs no entry: FetchBundle
+                        // snapshot uids are content-hashed literals.
+                        ? new ConcatSource(
+                          `(function () {\n`,
+                          `  const module = { exports: {} }\n`,
+                          `  const exports = module.exports;\n`,
+                          old,
+                          `\n  ;return module.exports\n})()`,
+                        )
+                        : new ConcatSource(
+                          `(function (globDynamicComponentEntry) {\n`,
+                          `  const module = { exports: {} }\n`,
+                          `  const exports = module.exports;\n`,
+                          old,
+                          `\n  ;return module.exports\n})`,
+                        ),
                   );
                 }
               });

--- a/packages/webpack/react-webpack-plugin/test/fixtures/lazy-bundle-fetcher/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/lazy-bundle-fetcher/index.jsx
@@ -6,6 +6,10 @@
 // emitted bundle, where the test can grep for the resolved literal.
 globalThis.__lynx_fetcher_probe__ = __LAZY_BUNDLE_FETCHER__;
 
+// A dynamic import so the runtime chunk carries the process-eval-result
+// registration, whose host key the tests assert on.
+globalThis.__lynx_lazy_probe__ = () => import('./lazy.jsx');
+
 export default function App() {
   return null;
 }

--- a/packages/webpack/react-webpack-plugin/test/fixtures/lazy-bundle-fetcher/lazy.jsx
+++ b/packages/webpack/react-webpack-plugin/test/fixtures/lazy-bundle-fetcher/lazy.jsx
@@ -1,0 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export default function Lazy() {
+  return null;
+}

--- a/packages/webpack/react-webpack-plugin/test/lazy-bundle-fetcher.test.ts
+++ b/packages/webpack/react-webpack-plugin/test/lazy-bundle-fetcher.test.ts
@@ -90,21 +90,23 @@ async function build(
 }
 
 describe('ReactWebpackPlugin: lazyBundleFetcher', () => {
-  test('FetchBundle: main-thread chunk wrapped as parameterised non-IIFE', async () => {
-    // FetchBundle uses the same wrapper as QueryComponent: the loader invokes
-    // it with the bundle's own url as `globDynamicComponentEntry` (per-host
-    // module routing), rather than self-invoking with a hardcoded '__Card__'.
+  test('FetchBundle: main-thread chunk is a self-invoking scope shield', async () => {
+    // The legacy parameterised wrapper contract is gone, and the chunk never
+    // references `globDynamicComponentEntry`: snapshot uids are
+    // content-hashed literals and host routing uses compile-time ids. A
+    // parameterless IIFE scopes the webpack bootstrap's top-level bindings,
+    // which would otherwise clobber the page's globals in the shared
+    // main-thread realm.
     const { mainThread } = await build({ lazyBundleFetcher: 'FetchBundle' });
-    expect(mainThread).not.toContain(
-      `var globDynamicComponentEntry = '__Card__'`,
+    expect(mainThread).not.toContain('globDynamicComponentEntry');
+    expect(mainThread.trimStart().startsWith('(function () {')).toBe(true);
+    // `processEvalResultByHost` is keyed by the compile-time host id
+    // (`uniqueName#entryName`), not by the runtime entry.
+    expect(mainThread).toMatch(
+      /globalThis\.processEvalResultByHost = \{\}\)\)\["[^"]*#main"\]/,
     );
-    expect(
-      mainThread.trimStart().startsWith(
-        '(function (globDynamicComponentEntry) {',
-      ),
-    ).toBe(true);
-    // Importantly: NOT self-invoking.
-    expect(mainThread.trimEnd().endsWith('})()')).toBe(false);
+    // Importantly: self-invoking — the loader never calls the eval result.
+    expect(mainThread.trimEnd().endsWith('})()')).toBe(true);
   });
 
   test('QueryComponent (default): main-thread chunk wrapped as parameterised non-IIFE', async () => {
@@ -120,19 +122,31 @@ describe('ReactWebpackPlugin: lazyBundleFetcher', () => {
     expect(mainThread.trimEnd().endsWith('})')).toBe(true);
     // Importantly: NOT self-invoking.
     expect(mainThread.trimEnd().endsWith('})()')).toBe(false);
+    // The legacy protocol keeps the runtime-entry registration key.
+    expect(mainThread).toContain(
+      'globalThis.processEvalResultByHost = {}))[globDynamicComponentEntry]',
+    );
   });
 
   describe('__LAZY_BUNDLE_FETCHER__ define injection', () => {
     test('FetchBundle: define replaces references with literal "FetchBundle"', async () => {
       const { background } = await build({ lazyBundleFetcher: 'FetchBundle' });
       expect(background).toContain('"FetchBundle"');
-      expect(background).not.toContain('__LAZY_BUNDLE_FETCHER__');
+      // The probe reference is replaced (the raw token may still appear in
+      // bundled runtime comments).
+      expect(background).not.toContain(
+        '__lynx_fetcher_probe__ = __LAZY_BUNDLE_FETCHER__',
+      );
     });
 
     test('QueryComponent (default): define replaces references with literal "QueryComponent"', async () => {
       const { background } = await build({});
       expect(background).toContain('"QueryComponent"');
-      expect(background).not.toContain('__LAZY_BUNDLE_FETCHER__');
+      // The probe reference is replaced (the raw token may still appear in
+      // bundled runtime comments).
+      expect(background).not.toContain(
+        '__lynx_fetcher_probe__ = __LAZY_BUNDLE_FETCHER__',
+      );
     });
   });
 });

--- a/packages/webpack/template-webpack-plugin/src/LynxAsyncChunksRuntimeModule.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxAsyncChunksRuntimeModule.ts
@@ -10,7 +10,10 @@ import type {
   RuntimeModule,
 } from '@rspack/core';
 
-import { RuntimeGlobals } from '@lynx-js/webpack-runtime-globals';
+import {
+  RuntimeGlobals,
+  deriveLynxHostId,
+} from '@lynx-js/webpack-runtime-globals';
 
 type LynxAsyncChunksRuntimeModule = new(
   getFilenameTemplate: (chunk: Chunk) => string | undefined,
@@ -216,8 +219,19 @@ export function createLynxAsyncChunksRuntimeModule(
         )
         .join(',\n');
 
+      // The compile-time host id of this runtime chunk's entry. Chunk loading
+      // passes it as the `host` of a nested lazy-bundle import;
+      // `LynxProcessEvalResultRuntimeModule` (react-webpack-plugin) keys
+      // `processEvalResultByHost` with the same derivation.
+      const hostId = deriveLynxHostId(
+        compilation.outputOptions?.uniqueName,
+        chunk.runtime,
+      );
+
       const idsBlock = `// lynx async chunks ids
-${RuntimeGlobals.lynxAsyncChunkIds} = {${ids}}`;
+${RuntimeGlobals.lynxAsyncChunkIds} = {${ids}}
+// lynx host id
+${RuntimeGlobals.lynxHostId} = ${JSON.stringify(hostId)}`;
       if (modes.length === 0) {
         return idsBlock;
       }

--- a/packages/webpack/webpack-runtime-globals/etc/webpack-runtime-globals.api.md
+++ b/packages/webpack/webpack-runtime-globals/etc/webpack-runtime-globals.api.md
@@ -5,9 +5,13 @@
 ```ts
 
 // @public
+export function deriveLynxHostId(uniqueName: string | undefined, runtime: string | Iterable<string> | undefined): string;
+
+// @public
 export const RuntimeGlobals: {
     readonly lynxAsyncChunkIds: "__webpack_require__.lynx_aci";
     readonly lynxAsyncChunkMode: "__webpack_require__.lynx_acm";
+    readonly lynxHostId: "__webpack_require__.lynx_hid";
     readonly lynxChunkEntries: "lynx.__chunk_entries__";
     readonly lynxProcessEvalResult: "globalThis.processEvalResult";
     readonly lynxProcessEvalResultByHost: "globalThis.processEvalResultByHost";

--- a/packages/webpack/webpack-runtime-globals/src/RuntimeGlobals.ts
+++ b/packages/webpack/webpack-runtime-globals/src/RuntimeGlobals.ts
@@ -21,6 +21,15 @@ export const RuntimeGlobals = {
   lynxAsyncChunkMode: '__webpack_require__.lynx_acm',
 
   /**
+   * The compile-time host id of this runtime chunk's entry
+   * (`uniqueName#entryName`). Chunk loading passes it as the `host` of a
+   * nested lazy-bundle import so the main-thread prepare routes the chunk's
+   * eval result to `processEvalResultByHost[host]`, which the host's runtime
+   * registered under the same literal.
+   */
+  lynxHostId: '__webpack_require__.lynx_hid',
+
+  /**
    * A map from `chunk.id` to entryName of the chunk.
    */
   lynxChunkEntries: 'lynx.__chunk_entries__',

--- a/packages/webpack/webpack-runtime-globals/src/deriveLynxHostId.ts
+++ b/packages/webpack/webpack-runtime-globals/src/deriveLynxHostId.ts
@@ -1,0 +1,33 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Derive the compile-time host id of a runtime chunk's entry
+ * (`uniqueName#entryName`).
+ *
+ * `LynxAsyncChunksRuntimeModule` (template-webpack-plugin) emits it as
+ * {@link RuntimeGlobals.lynxHostId} for chunk loading to pass as a nested
+ * lazy-bundle import's `host`, and `LynxProcessEvalResultRuntimeModule`
+ * (react-webpack-plugin) keys `processEvalResultByHost` with it — both must
+ * derive the identical id. Main-thread entries are named
+ * `${entryName}__main-thread` while background entries are the bare
+ * `entryName`, so stripping the suffix pairs the two runtimes of one entry.
+ *
+ * @param uniqueName - `compilation.outputOptions.uniqueName`
+ * @param runtime - the runtime spec of the chunk (`chunk.runtime`)
+ *
+ * @public
+ */
+export function deriveLynxHostId(
+  uniqueName: string | undefined,
+  runtime: string | Iterable<string> | undefined,
+): string {
+  const runtimes = typeof runtime === 'string'
+    ? [runtime]
+    : Array.from(runtime ?? []);
+  const entryName = runtimes
+    .map(name => name.replace(/__main-thread$/, ''))
+    .join('+');
+  return `${uniqueName ?? ''}#${entryName}`;
+}

--- a/packages/webpack/webpack-runtime-globals/src/index.ts
+++ b/packages/webpack/webpack-runtime-globals/src/index.ts
@@ -9,3 +9,4 @@
  */
 
 export { RuntimeGlobals } from './RuntimeGlobals.js';
+export { deriveLynxHostId } from './deriveLynxHostId.js';

--- a/packages/webpack/webpack-runtime-globals/test/deriveLynxHostId.test.ts
+++ b/packages/webpack/webpack-runtime-globals/test/deriveLynxHostId.test.ts
@@ -1,0 +1,26 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import { deriveLynxHostId } from '../src/index.js';
+
+describe('deriveLynxHostId', () => {
+  test('pairs a main-thread runtime with its background runtime', () => {
+    expect(deriveLynxHostId('pkg', 'main__main-thread')).toBe('pkg#main');
+    expect(deriveLynxHostId('pkg', 'main')).toBe('pkg#main');
+  });
+
+  test('strips the suffix from every member of a multi-runtime chunk', () => {
+    expect(
+      deriveLynxHostId('pkg', ['app__main-thread', 'widget__main-thread']),
+    ).toBe('pkg#app+widget');
+    expect(deriveLynxHostId('pkg', ['app', 'widget'])).toBe('pkg#app+widget');
+  });
+
+  test('tolerates missing inputs', () => {
+    expect(deriveLynxHostId(undefined, undefined)).toBe('#');
+    expect(deriveLynxHostId('', 'main')).toBe('#main');
+  });
+});


### PR DESCRIPTION
Drop the `(function (globDynamicComponentEntry) { ... })` wrapper contract from FetchBundle main-thread chunks.

- Chunks now use the same shell as the external-bundle main-thread wrapper (`MainThreadRuntimeWrapperWebpackPlugin`): a parameterless self-invoking IIFE whose completion value is the exports (`return module.exports`). The IIFE is required for correctness: `lynx.loadScript` evaluates chunks as programs in the shared main-thread realm, where the webpack bootstrap's top-level bindings would otherwise clobber the page's (reproduced on device).
- The loader no longer invokes a chunk's eval result with its entry. It assigns `globDynamicComponentEntry` (plus a global CommonJS `module`/`exports` pair as a bare-chunk fallback) around `lynx.loadScript`, and the host's `processEvalResult` runs inside that window so a nested chunk's module factories still see the entry their snapshot IDs embed.
- The chunk-loading runtime captures the loading host's entry at bootstrap instead of reading the global when a dynamic import fires.
- Wrapper-shaped chunks (older artifacts) are still detected by shape and invoked with their entry, so both protocols load and `processEvalResultByHost` keeps routing a nested dynamic component to the host that owns its modules.

Verified on device (Android LynxExplorer, FetchBundle dev servers): page → standalone sync/async bundles → nested dynamic component routed to its host, plus an in-app dynamic import — all render with no main-thread exceptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FetchBundle main-thread lazy component loading, including safer evaluation and handling when no main-thread content is available.
  * Added support for self-invoking lazy chunks and exported module results.
  * Prevented temporary loading state from leaking between bundle evaluations.
  * Improved nested lazy-bundle loading by preserving the correct host context.

* **Tests**
  * Expanded coverage for wrapper results, state restoration, standalone builds, and main-thread lazy loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->