### PR TITLE
feat(genui): add bilingual bench pages

### DIFF
--- a/packages/genui/playground/src/App.tsx
+++ b/packages/genui/playground/src/App.tsx
@@ -11,6 +11,11 @@ import {
 
 import { Button } from './components/Button.js';
 import { Moon, Sun } from './components/Icon.js';
+import {
+  readBenchLocale,
+  writeBenchLocale,
+} from './pages/bench/benchLocale.js';
+import type { BenchLocale } from './pages/bench/benchLocale.js';
 import { BenchResultPage } from './pages/bench/BenchResultPage.js';
 import { BenchRunnerPage } from './pages/bench/BenchRunnerPage.js';
 import { BenchShell } from './pages/bench/BenchShell.js';
@@ -118,6 +123,7 @@ export function App() {
   const [theme, setTheme] = useState<Theme>(() => {
     return getForcedTheme() ?? getInitialTheme();
   });
+  const [benchLocale, setBenchLocale] = useState<BenchLocale>(readBenchLocale);
   const embedded = useMemo(() => isEmbedded(), []);
   const forcedTheme = useMemo(() => getForcedTheme(), []);
 
@@ -143,6 +149,10 @@ export function App() {
       // Ignore localStorage errors.
     }
   }, [theme, forcedTheme]);
+
+  useEffect(() => {
+    writeBenchLocale(benchLocale);
+  }, [benchLocale]);
 
   useEffect(() => {
     const onHashChange = () => {
@@ -233,16 +243,25 @@ export function App() {
 
     switch (route.tab) {
       case 'bench': {
-        let benchPage = <BenchRunnerPage key='bench-runner' />;
+        let benchPage = (
+          <BenchRunnerPage key='bench-runner' locale={benchLocale} />
+        );
         switch (route.benchSlug) {
           case undefined:
           case 'runner':
             break;
           case 'phase-1':
-            benchPage = <BenchResultPage key='bench-phase-1' />;
+            benchPage = (
+              <BenchResultPage key='bench-phase-1' locale={benchLocale} />
+            );
             break;
           case 'phase-2':
-            benchPage = <PhaseTwoReportPage key='bench-phase-2-report' />;
+            benchPage = (
+              <PhaseTwoReportPage
+                key='bench-phase-2-report'
+                locale={benchLocale}
+              />
+            );
             break;
           default:
             break;
@@ -250,7 +269,9 @@ export function App() {
         return (
           <BenchShell
             activeSlug={route.benchSlug}
+            locale={benchLocale}
             theme={theme}
+            onChangeLocale={setBenchLocale}
             onToggleTheme={handleThemeToggle}
           >
             {benchPage}
@@ -293,6 +314,7 @@ export function App() {
     route.componentName,
     route.demoId,
     route.benchSlug,
+    benchLocale,
     theme,
     handleThemeToggle,
   ]);

--- a/packages/genui/playground/src/pages/BenchPage.tsx
+++ b/packages/genui/playground/src/pages/BenchPage.tsx
@@ -25,6 +25,7 @@ import {
 } from '../components/Icon.js';
 import { PageHeader } from '../components/PageHeader.js';
 import { copyToClipboard } from '../utils/clipboard.js';
+import type { BenchLocale } from './bench/benchLocale.js';
 
 type BenchRole = 'control' | 'experiment';
 type BenchProtocol = 'a2ui' | 'openui';
@@ -37,6 +38,192 @@ type BenchVariable =
   | 'custom';
 type BenchStatus = 'idle' | 'running' | 'complete' | 'failed' | 'cancelled';
 type BenchScreenshotState = 'captured' | 'failed' | 'missing';
+type BenchGroupSystemName =
+  | 'a2ui'
+  | 'baseline'
+  | 'core-catalog'
+  | 'default-prompt'
+  | 'new-baseline'
+  | 'new-comparison'
+  | 'openui'
+  | 'token-efficient';
+type BenchScenarioSystemText =
+  | 'custom'
+  | 'custom-prompt'
+  | 'custom-scenario'
+  | 'primary-action';
+type BenchRunMessage =
+  | { code: 'bench-cancelled' }
+  | { code: 'bench-complete'; failedRuns?: number }
+  | { code: 'bench-failed' }
+  | { code: 'bench-request-failed'; status: number }
+  | { code: 'cancellation-failed'; jobId: string }
+  | { code: 'complete-report-loaded' }
+  | { code: 'creating-job' }
+  | { code: 'defaults-confirmation-required' }
+  | { code: 'history-report-loaded'; failedRuns?: number }
+  | { code: 'job-queued'; jobId: string }
+  | { code: 'loading-report'; jobId: string }
+  | { code: 'preset-loaded' }
+  | { code: 'raw'; text: string }
+  | { code: 'ready' }
+  | { code: 'reconnecting' }
+  | { code: 'report-load-failed'; status: number }
+  | { code: 'report-loaded'; failedRuns?: number }
+  | {
+    code: 'run-progress';
+    group?: Pick<BenchGroup, 'name' | 'systemName'>;
+    phase: string;
+    repeatIndex: number;
+    scenario?: Pick<BenchScenario, 'name' | 'systemName'>;
+  }
+  | { code: 'run-config-required' }
+  | { code: 'running' }
+  | { code: 'setup-restored-loading-report' }
+  | { code: 'setup-restored-report-unavailable' }
+  | { code: 'stopping-previous-job' }
+  | { code: 'stream-disconnected' };
+
+function benchText(
+  locale: BenchLocale,
+  chinese: string,
+  english: string,
+): string {
+  return locale === 'en-US' ? english : chinese;
+}
+
+export function getBenchRunMessageText(
+  message: BenchRunMessage,
+  locale: BenchLocale,
+): string {
+  switch (message.code) {
+    case 'bench-cancelled':
+      return benchText(locale, 'Bench 任务已取消', 'Bench job cancelled');
+    case 'bench-complete':
+      return message.failedRuns
+        ? benchText(
+          locale,
+          `Bench 完成 · ${message.failedRuns} 个失败 Run`,
+          `Bench complete · ${message.failedRuns} failed runs`,
+        )
+        : benchText(locale, 'Bench 完成', 'Bench complete');
+    case 'bench-failed':
+      return benchText(locale, 'Bench 任务失败', 'Bench job failed');
+    case 'bench-request-failed':
+      return benchText(
+        locale,
+        `Bench 请求失败：${message.status}`,
+        `Bench request failed: ${message.status}`,
+      );
+    case 'cancellation-failed':
+      return benchText(
+        locale,
+        `Job ${message.jobId} 尚未取消，请再次重置重试`,
+        `Job ${message.jobId} was not cancelled. Reset again to retry.`,
+      );
+    case 'complete-report-loaded':
+      return benchText(
+        locale,
+        '完整 Report 已载入',
+        'Complete report loaded',
+      );
+    case 'creating-job':
+      return benchText(locale, '正在创建 Bench 任务…', 'Creating Bench job…');
+    case 'defaults-confirmation-required':
+      return benchText(
+        locale,
+        '请确认使用服务端默认配置',
+        'Confirm that you want to use the server defaults',
+      );
+    case 'history-report-loaded':
+      return message.failedRuns
+        ? benchText(
+          locale,
+          `历史 Report 已载入 · ${message.failedRuns} 个失败 Run`,
+          `Saved report loaded · ${message.failedRuns} failed runs`,
+        )
+        : benchText(locale, '历史 Report 已载入', 'Saved report loaded');
+    case 'job-queued':
+      return benchText(
+        locale,
+        `Job ${message.jobId} 已进入队列`,
+        `Job ${message.jobId} queued`,
+      );
+    case 'loading-report':
+      return benchText(
+        locale,
+        `正在载入 Report ${message.jobId}…`,
+        `Loading report ${message.jobId}…`,
+      );
+    case 'preset-loaded':
+      return benchText(locale, '已载入预设', 'Preset loaded');
+    case 'raw':
+      return message.text;
+    case 'ready':
+      return benchText(locale, '准备就绪', 'Ready');
+    case 'reconnecting':
+      return benchText(
+        locale,
+        '正在重连 Bench 数据流…',
+        'Reconnecting to the Bench event stream…',
+      );
+    case 'report-load-failed':
+      return benchText(
+        locale,
+        `Report 载入失败：${message.status}`,
+        `Failed to load report: ${message.status}`,
+      );
+    case 'report-loaded':
+      return message.failedRuns
+        ? benchText(
+          locale,
+          `Report 已载入 · ${message.failedRuns} 个失败 Run`,
+          `Report loaded · ${message.failedRuns} failed runs`,
+        )
+        : benchText(locale, 'Report 已载入', 'Report loaded');
+    case 'run-config-required':
+      return benchText(
+        locale,
+        '请先完成运行配置',
+        'Complete the run setup first',
+      );
+    case 'run-progress': {
+      const groupName = message.group
+        ? getBenchGroupDisplayName(message.group, locale)
+        : benchText(locale, '对比组', 'Comparison group');
+      const scenarioName = message.scenario
+        ? getBenchScenarioDisplayName(message.scenario, locale)
+        : benchText(locale, '场景', 'Scenario');
+      return `${groupName} · ${scenarioName} · #${message.repeatIndex} · ${message.phase}`;
+    }
+    case 'running':
+      return benchText(locale, 'Bench 运行中…', 'Bench running…');
+    case 'setup-restored-loading-report':
+      return benchText(
+        locale,
+        '配置已恢复，正在载入完整 Report…',
+        'Setup restored. Loading the complete report…',
+      );
+    case 'setup-restored-report-unavailable':
+      return benchText(
+        locale,
+        '配置已恢复 · 完整 Report 暂不可用',
+        'Setup restored · Complete report unavailable',
+      );
+    case 'stopping-previous-job':
+      return benchText(
+        locale,
+        '正在停止上一项 Bench 任务…',
+        'Stopping the previous Bench job…',
+      );
+    case 'stream-disconnected':
+      return benchText(
+        locale,
+        'Bench 数据流已断开',
+        'Bench event stream disconnected',
+      );
+  }
+}
 
 interface BenchEnv {
   apiKey: string;
@@ -55,6 +242,7 @@ interface BenchGroup {
   catalog: string;
   extraInstruction: string;
   enabled: boolean;
+  systemName?: BenchGroupSystemName;
 }
 
 interface BenchScenario {
@@ -64,6 +252,10 @@ interface BenchScenario {
   type: string;
   complexity: number;
   action: string;
+  systemAction?: BenchScenarioSystemText;
+  systemName?: BenchScenarioSystemText;
+  systemPrompt?: BenchScenarioSystemText;
+  systemType?: BenchScenarioSystemText;
 }
 
 interface BenchSettings {
@@ -165,6 +357,10 @@ interface BenchHealth {
   api?: 'chat' | 'responses';
 }
 
+type BenchHealthError =
+  | { kind: 'raw'; message: string }
+  | { kind: 'status'; status: number };
+
 interface BenchJobCreated {
   ok?: boolean;
   jobId?: string;
@@ -243,6 +439,145 @@ type BenchReportSettingsPayload = Partial<BenchSettings> & {
   renderMetricsEnabled?: boolean;
 };
 
+function getBenchGroupSystemNameText(
+  systemName: BenchGroupSystemName,
+  locale: BenchLocale,
+): string {
+  switch (systemName) {
+    case 'default-prompt':
+      return benchText(locale, '默认 Prompt', 'Default Prompt');
+    case 'token-efficient':
+      return benchText(locale, 'Token 精简', 'Token Efficient');
+    case 'new-baseline':
+      return benchText(locale, '新基准组', 'New baseline');
+    case 'new-comparison':
+      return benchText(locale, '新对比组', 'New comparison');
+    case 'a2ui':
+      return 'A2UI';
+    case 'baseline':
+      return 'Baseline';
+    case 'core-catalog':
+      return 'Core Catalog';
+    case 'openui':
+      return 'OpenUI';
+  }
+}
+
+export function getBenchGroupDisplayName(
+  group: Pick<BenchGroup, 'name' | 'systemName'>,
+  locale: BenchLocale,
+): string {
+  return group.systemName
+    ? getBenchGroupSystemNameText(group.systemName, locale)
+    : group.name;
+}
+
+function isBenchGroupSystemNameText(
+  value: string,
+  systemName: BenchGroupSystemName,
+): boolean {
+  return value === getBenchGroupSystemNameText(systemName, 'zh-CN')
+    || value === getBenchGroupSystemNameText(systemName, 'en-US');
+}
+
+function inferBenchGroupSystemName(
+  group: Pick<BenchGroup, 'id' | 'name' | 'systemName'>,
+): BenchGroupSystemName | undefined {
+  if (group.systemName) return group.systemName;
+  const byId: Record<string, BenchGroupSystemName> = {
+    'control-a2ui-matched': 'a2ui',
+    'control-default': 'default-prompt',
+    'control-empty': 'baseline',
+    'experiment-core': 'core-catalog',
+    'experiment-openui-matched': 'openui',
+    'experiment-token': 'token-efficient',
+  };
+  const idMatch = byId[group.id];
+  if (idMatch && isBenchGroupSystemNameText(group.name, idMatch)) {
+    return idMatch;
+  }
+  return ([
+    'new-baseline',
+    'new-comparison',
+  ] as const).find((systemName) =>
+    isBenchGroupSystemNameText(group.name, systemName)
+  );
+}
+
+function restoreBenchGroupSystemNames(groups: BenchGroup[]): BenchGroup[] {
+  return groups.map((group) => ({
+    ...group,
+    systemName: inferBenchGroupSystemName(group),
+  }));
+}
+
+function getBenchScenarioSystemText(
+  systemText: BenchScenarioSystemText,
+  locale: BenchLocale,
+): string {
+  switch (systemText) {
+    case 'custom':
+      return benchText(locale, '自定义', 'Custom');
+    case 'custom-prompt':
+      return benchText(
+        locale,
+        '描述需要生成和评测的 UI。',
+        'Describe the UI to generate and evaluate.',
+      );
+    case 'custom-scenario':
+      return benchText(locale, '自定义场景', 'Custom scenario');
+    case 'primary-action':
+      return benchText(locale, '主操作', 'Primary action');
+  }
+}
+
+function getBenchScenarioFieldText(
+  value: string,
+  systemText: BenchScenarioSystemText | undefined,
+  locale: BenchLocale,
+): string {
+  return systemText
+    ? getBenchScenarioSystemText(systemText, locale)
+    : value;
+}
+
+export function getBenchScenarioDisplayName(
+  scenario: Pick<BenchScenario, 'name' | 'systemName'>,
+  locale: BenchLocale,
+): string {
+  return getBenchScenarioFieldText(
+    scenario.name,
+    scenario.systemName,
+    locale,
+  );
+}
+
+function inferBenchScenarioSystemText(
+  value: string,
+  expected: BenchScenarioSystemText,
+): BenchScenarioSystemText | undefined {
+  return value === getBenchScenarioSystemText(expected, 'zh-CN')
+      || value === getBenchScenarioSystemText(expected, 'en-US')
+    ? expected
+    : undefined;
+}
+
+function restoreBenchScenarioSystemTexts(
+  scenarios: BenchScenario[],
+): BenchScenario[] {
+  return scenarios.map((scenario) => ({
+    ...scenario,
+    systemAction: scenario.systemAction
+      ?? inferBenchScenarioSystemText(scenario.action, 'primary-action'),
+    systemName: scenario.systemName
+      ?? inferBenchScenarioSystemText(scenario.name, 'custom-scenario'),
+    systemPrompt: scenario.systemPrompt
+      ?? inferBenchScenarioSystemText(scenario.prompt, 'custom-prompt'),
+    systemType: scenario.systemType
+      ?? inferBenchScenarioSystemText(scenario.type, 'custom'),
+  }));
+}
+
 const CATALOG_OPTIONS = [
   'Full Catalog',
   'Core Catalog',
@@ -293,6 +628,7 @@ const DEFAULT_GROUPS: BenchGroup[] = [
     catalog: 'Full Catalog',
     extraInstruction: '',
     enabled: true,
+    systemName: 'default-prompt',
   },
   {
     id: 'experiment-token',
@@ -306,6 +642,7 @@ const DEFAULT_GROUPS: BenchGroup[] = [
     extraInstruction:
       'Keep the A2UI message stream as short as possible while preserving all required content.',
     enabled: true,
+    systemName: 'token-efficient',
   },
   {
     id: 'experiment-core',
@@ -318,6 +655,7 @@ const DEFAULT_GROUPS: BenchGroup[] = [
     catalog: 'Core Catalog',
     extraInstruction: '',
     enabled: true,
+    systemName: 'core-catalog',
   },
 ];
 
@@ -333,6 +671,7 @@ const EMPTY_GROUPS: BenchGroup[] = [
     catalog: 'Full Catalog',
     extraInstruction: '',
     enabled: true,
+    systemName: 'baseline',
   },
 ];
 
@@ -348,6 +687,7 @@ const PROTOCOL_PAIR_GROUPS: BenchGroup[] = [
     catalog: 'Core Catalog',
     extraInstruction: '',
     enabled: true,
+    systemName: 'a2ui',
   },
   {
     id: 'experiment-openui-matched',
@@ -360,6 +700,7 @@ const PROTOCOL_PAIR_GROUPS: BenchGroup[] = [
     catalog: 'Core Catalog',
     extraInstruction: '',
     enabled: true,
+    systemName: 'openui',
   },
 ];
 
@@ -680,11 +1021,29 @@ function isProviderConfigured(env: BenchEnv): boolean {
 
 function getBenchHealthKeyLabel(
   health: BenchHealth | null,
-  healthError: string | null,
+  healthError: BenchHealthError | null,
+  locale: BenchLocale = 'zh-CN',
 ): string {
-  if (health) return health.hasKey ? '已配置' : '未配置';
-  if (healthError) return '状态未知';
-  return '检查中…';
+  if (health) {
+    return health.hasKey
+      ? benchText(locale, '已配置', 'Configured')
+      : benchText(locale, '未配置', 'Not configured');
+  }
+  if (healthError) return benchText(locale, '状态未知', 'Unknown');
+  return benchText(locale, '检查中…', 'Checking…');
+}
+
+function getBenchHealthErrorText(
+  error: BenchHealthError,
+  locale: BenchLocale,
+): string {
+  return error.kind === 'status'
+    ? benchText(
+      locale,
+      `Provider 状态检查失败：${error.status}`,
+      `Provider status check failed: ${error.status}`,
+    )
+    : error.message;
 }
 
 function formatMs(value: number): string {
@@ -702,6 +1061,36 @@ function cloneBenchGroups(groups: BenchGroup[]): BenchGroup[] {
 
 function cloneBenchScenarios(scenarios: BenchScenario[]): BenchScenario[] {
   return scenarios.map((scenario) => ({ ...scenario }));
+}
+
+function createBenchRequestGroups(
+  groups: BenchGroup[],
+): BenchGroup[] {
+  return groups.map((group) => ({
+    id: group.id,
+    role: group.role,
+    protocol: group.protocol,
+    profile: group.profile,
+    name: group.name,
+    variable: group.variable,
+    model: group.model,
+    catalog: group.catalog,
+    extraInstruction: group.extraInstruction,
+    enabled: group.enabled,
+  }));
+}
+
+function createBenchRequestScenarios(
+  scenarios: BenchScenario[],
+): BenchScenario[] {
+  return scenarios.map((scenario) => ({
+    id: scenario.id,
+    name: scenario.name,
+    prompt: scenario.prompt,
+    type: scenario.type,
+    complexity: scenario.complexity,
+    action: scenario.action,
+  }));
 }
 
 function cloneBenchSettings(settings: BenchSettings): BenchSettings {
@@ -731,7 +1120,14 @@ function createBenchPlanSignature(
       extraInstruction: group.extraInstruction,
       enabled: group.enabled,
     })),
-    scenarios,
+    scenarios: scenarios.map((scenario) => ({
+      id: scenario.id,
+      name: scenario.name,
+      prompt: scenario.prompt,
+      type: scenario.type,
+      complexity: scenario.complexity,
+      action: scenario.action,
+    })),
     settings,
     provider: {
       apiKeyConfigured: env.apiKey === undefined
@@ -822,7 +1218,9 @@ function createBenchGroupsFromReport(report: BenchReport): BenchGroup[] {
       enabled: readBoolean(item.enabled, true),
     };
   });
-  return groups.length > 0 ? groups : cloneBenchGroups(DEFAULT_GROUPS);
+  return groups.length > 0
+    ? restoreBenchGroupSystemNames(groups)
+    : cloneBenchGroups(getBenchGroupPreset('a2ui-variants'));
 }
 
 function createBenchScenariosFromReport(report: BenchReport): BenchScenario[] {
@@ -835,13 +1233,13 @@ function createBenchScenariosFromReport(report: BenchReport): BenchScenario[] {
       id: item.id ?? createId(`history-scenario-${index + 1}`),
       name: item.name ?? `Scenario ${index + 1}`,
       prompt: item.prompt ?? '',
-      type: item.type ?? '自定义',
+      type: item.type ?? 'Custom',
       complexity: readFiniteNumber(item.complexity, 1),
       action: item.action ?? '',
     };
   });
   return scenarios.length > 0
-    ? scenarios
+    ? restoreBenchScenarioSystemTexts(scenarios)
     : cloneBenchScenarios(DEFAULT_SCENARIOS);
 }
 
@@ -1094,10 +1492,13 @@ function deltaText(value: number, baseline: number, suffix = ''): string {
   return `${sign}${delta.toFixed(1)}%${suffix}`;
 }
 
-function getRunButtonText(status: BenchStatus): string {
-  if (status === 'running') return '运行中';
-  if (status === 'failed') return '重新运行';
-  return '运行 Bench';
+function getRunButtonText(
+  status: BenchStatus,
+  locale: BenchLocale = 'zh-CN',
+): string {
+  if (status === 'running') return benchText(locale, '运行中', 'Running');
+  if (status === 'failed') return benchText(locale, '重新运行', 'Run again');
+  return benchText(locale, '运行 Bench', 'Run Bench');
 }
 
 function getProgressWidth(
@@ -1113,23 +1514,41 @@ function getProgressWidth(
 function getRunMetaText(
   status: BenchStatus,
   progress: number,
-  runMessage: string,
+  runMessage: BenchRunMessage,
   runCount: number,
+  locale: BenchLocale = 'zh-CN',
 ): string {
   if (status === 'running') {
-    return `${Math.round(progress)}% · ${runMessage}`;
+    return `${Math.round(progress)}% · ${
+      getBenchRunMessageText(runMessage, locale)
+    }`;
   }
-  if (status === 'idle') return `计划运行 ${runCount} Runs`;
-  return runMessage;
+  if (status === 'idle') {
+    return benchText(
+      locale,
+      `计划运行 ${runCount} Runs`,
+      `${runCount} runs planned`,
+    );
+  }
+  return getBenchRunMessageText(runMessage, locale);
 }
 
 function getReportSubtitle(
   report: BenchReport | null,
   reportIsStale: boolean,
+  locale: BenchLocale = 'zh-CN',
 ): string {
-  if (!report) return '暂无报告';
-  if (reportIsStale) return '当前计划已变更 · 显示上次 Report';
-  return new Date(report.createdAt).toLocaleString();
+  if (!report) return benchText(locale, '暂无报告', 'No report yet');
+  if (reportIsStale) {
+    return benchText(
+      locale,
+      '当前计划已变更 · 显示上次 Report',
+      'Plan changed · Showing the previous report',
+    );
+  }
+  return new Date(report.createdAt).toLocaleString(
+    locale === 'en-US' ? 'en-US' : 'zh-CN',
+  );
 }
 
 function formatSummaryJudgeMetric(
@@ -1171,29 +1590,47 @@ function getScreenshotState(
 
 function getScreenshotStateLabelFromState(
   state: BenchScreenshotState,
+  locale: BenchLocale = 'zh-CN',
 ): string {
-  if (state === 'captured') return '已截图';
-  if (state === 'failed') return '运行失败';
-  return '无截图';
+  if (state === 'captured') return benchText(locale, '已截图', 'Captured');
+  if (state === 'failed') return benchText(locale, '运行失败', 'Run failed');
+  return benchText(locale, '无截图', 'No screenshot');
 }
 
-function getScreenshotPlaceholderText(result: BenchResult | null): string {
+function getScreenshotPlaceholderText(
+  result: BenchResult | null,
+  locale: BenchLocale = 'zh-CN',
+): string {
   if (!result) {
-    return '这个位置没有收到 Bench 结果。';
+    return benchText(
+      locale,
+      '这个位置没有收到 Bench 结果。',
+      'No Bench result was received for this slot.',
+    );
   }
   if (isBenchRunFailed(result)) {
     return result.error
       ?? result.errors?.[0]
-      ?? '截图前运行已失败。';
+      ?? benchText(
+        locale,
+        '截图前运行已失败。',
+        'The run failed before a screenshot was captured.',
+      );
   }
   return result.errors?.find((error) =>
     error.toLowerCase().includes('screenshot')
-  ) ?? '这次运行没有保存截图。';
+  ) ?? benchText(
+    locale,
+    '这次运行没有保存截图。',
+    'This run did not save a screenshot.',
+  );
 }
 
 function createBenchGroupsForMatrix(report: BenchReport): BenchGroup[] {
   const reportGroups = Array.isArray(report.groups) ? report.groups : [];
-  if (reportGroups.length > 0) return createBenchGroupsFromReport(report);
+  if (reportGroups.length > 0) {
+    return createBenchGroupsFromReport(report);
+  }
 
   const seen = new Set<string>();
   const groupsFromResults = report.results.flatMap((result) => {
@@ -1214,15 +1651,17 @@ function createBenchGroupsForMatrix(report: BenchReport): BenchGroup[] {
     }];
   });
   return groupsFromResults.length > 0
-    ? groupsFromResults
-    : cloneBenchGroups(DEFAULT_GROUPS);
+    ? restoreBenchGroupSystemNames(groupsFromResults)
+    : cloneBenchGroups(getBenchGroupPreset('a2ui-variants'));
 }
 
 function createBenchScenariosForMatrix(report: BenchReport): BenchScenario[] {
   const reportScenarios = Array.isArray(report.scenarios)
     ? report.scenarios
     : [];
-  if (reportScenarios.length > 0) return createBenchScenariosFromReport(report);
+  if (reportScenarios.length > 0) {
+    return createBenchScenariosFromReport(report);
+  }
 
   const seen = new Set<string>();
   const scenariosFromResults = report.results.flatMap((result) => {
@@ -1232,7 +1671,8 @@ function createBenchScenariosForMatrix(report: BenchReport): BenchScenario[] {
       id: result.scenarioId,
       name: result.scenarioName,
       prompt: '',
-      type: '自定义',
+      type: 'Custom',
+      systemType: 'custom' as const,
       complexity: 1,
       action: '',
     }];
@@ -1399,18 +1839,39 @@ export function getBenchRunBlockers(
   enabledControlCount: number,
   scenarioCount: number,
   repeats: number,
+  locale: BenchLocale = 'zh-CN',
 ): string[] {
   const issues: string[] = [];
   if (activeGroupCount === 0) {
-    issues.push('至少启用一个对比组。');
+    issues.push(
+      benchText(
+        locale,
+        '至少启用一个对比组。',
+        'Enable at least one comparison group.',
+      ),
+    );
   } else if (enabledControlCount === 0) {
-    issues.push('至少启用一个基准组。');
+    issues.push(
+      benchText(
+        locale,
+        '至少启用一个基准组。',
+        'Enable at least one baseline group.',
+      ),
+    );
   }
   if (scenarioCount === 0) {
-    issues.push('至少添加一个场景。');
+    issues.push(
+      benchText(locale, '至少添加一个场景。', 'Add at least one scenario.'),
+    );
   }
   if (repeats < 1) {
-    issues.push('Repeats 不能小于 1。');
+    issues.push(
+      benchText(
+        locale,
+        'Repeats 不能小于 1。',
+        'Repeats must be at least 1.',
+      ),
+    );
   }
   return issues;
 }
@@ -1505,10 +1966,14 @@ function BenchDropdown<T extends string>(props: {
 }
 
 interface BenchPageProps {
+  locale?: BenchLocale;
   showHeader?: boolean;
 }
 
-export function BenchPage({ showHeader = true }: BenchPageProps) {
+export function BenchPage({
+  locale = 'zh-CN',
+  showHeader = true,
+}: BenchPageProps) {
   const [env, setEnv] = useState<BenchEnv>(DEFAULT_ENV);
   const [groups, setGroups] = useState<BenchGroup[]>(EMPTY_GROUPS);
   const [scenarios, setScenarios] = useState<BenchScenario[]>(
@@ -1517,11 +1982,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
   const [settings, setSettings] = useState<BenchSettings>(DEFAULT_SETTINGS);
   const [status, setStatus] = useState<BenchStatus>('idle');
   const [progress, setProgress] = useState(0);
-  const [runMessage, setRunMessage] = useState('准备就绪');
+  const [runMessage, setRunMessage] = useState<BenchRunMessage>({
+    code: 'ready',
+  });
   const [configOpen, setConfigOpen] = useState(false);
   const [benchRunNoticeOpen, setBenchRunNoticeOpen] = useState(false);
   const [benchHealth, setBenchHealth] = useState<BenchHealth | null>(null);
-  const [benchHealthError, setBenchHealthError] = useState<string | null>(null);
+  const [benchHealthError, setBenchHealthError] = useState<
+    BenchHealthError | null
+  >(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [screenshotsOpen, setScreenshotsOpen] = useState(false);
   const [reportPaneWidth, setReportPaneWidth] = useState(
@@ -1613,8 +2082,18 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
     [report, settings],
   );
   const activeScenarioTypes = useMemo(
-    () => [...new Set(scenarios.map((scenario) => scenario.type))],
-    [scenarios],
+    () => [
+      ...new Set(
+        scenarios.map((scenario) =>
+          getBenchScenarioFieldText(
+            scenario.type,
+            scenario.systemType,
+            locale,
+          )
+        ),
+      ),
+    ],
+    [locale, scenarios],
   );
   const providerConfigured = useMemo(() => isProviderConfigured(env), [env]);
   const benchRunBlockers = useMemo(
@@ -1624,12 +2103,14 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         enabledControlGroupCount,
         scenarios.length,
         settings.repeats,
+        locale,
       ),
     [
       activeGroups.length,
       enabledControlGroupCount,
       scenarios.length,
       settings.repeats,
+      locale,
     ],
   );
 
@@ -1666,9 +2147,10 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
       }
     }
     if (notify && failedJobIds.length > 0) {
-      setRunMessage(
-        `Job ${failedJobIds[0].slice(0, 8)} 尚未取消，请再次重置重试`,
-      );
+      setRunMessage({
+        code: 'cancellation-failed',
+        jobId: failedJobIds[0].slice(0, 8),
+      });
     }
     return failedJobIds.length === 0;
   }, []);
@@ -1771,7 +2253,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
     historyReportAbortRef.current = controller;
     setStatus('running');
     setProgress(0);
-    setRunMessage(`正在载入 Report ${jobId.slice(0, 8)}…`);
+    setRunMessage({ code: 'loading-report', jobId: jobId.slice(0, 8) });
 
     void (async () => {
       try {
@@ -1783,11 +2265,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           | BenchReport
           | { error?: string };
         if (!response.ok || !('results' in payload)) {
-          throw new Error(
-            'error' in payload && payload.error
-              ? payload.error
-              : `Report 载入失败：${response.status}`,
-          );
+          if ('error' in payload && payload.error) {
+            throw new Error(payload.error);
+          }
+          setStatus('failed');
+          setRunMessage({
+            code: 'report-load-failed',
+            status: response.status,
+          });
+          return;
         }
         if (
           cancelled
@@ -1813,8 +2299,16 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           ),
         );
         setEnv(restoredEnv);
-        setGroups(cloneBenchGroups(historyEntry.config.groups));
-        setScenarios(cloneBenchScenarios(historyEntry.config.scenarios));
+        setGroups(
+          restoreBenchGroupSystemNames(
+            cloneBenchGroups(historyEntry.config.groups),
+          ),
+        );
+        setScenarios(
+          restoreBenchScenarioSystemTexts(
+            cloneBenchScenarios(historyEntry.config.scenarios),
+          ),
+        );
         setSettings(cloneBenchSettings(historyEntry.config.settings));
         setHistoryItems((current) => {
           const next = upsertBenchHistoryEntry(current, historyEntry);
@@ -1823,11 +2317,10 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         });
         setStatus(payload.status ?? 'complete');
         setProgress(100);
-        setRunMessage(
-          payload.summary && payload.summary.failedRuns > 0
-            ? `Report 已载入 · ${payload.summary.failedRuns} 个失败 Run`
-            : 'Report 已载入',
-        );
+        setRunMessage({
+          code: 'report-loaded',
+          failedRuns: payload.summary?.failedRuns,
+        });
       } catch (error) {
         if (
           cancelled
@@ -1839,7 +2332,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           return;
         }
         setStatus('failed');
-        setRunMessage(getErrorMessage(error));
+        setRunMessage({ code: 'raw', text: getErrorMessage(error) });
       } finally {
         if (historyReportAbortRef.current === controller) {
           historyReportAbortRef.current = null;
@@ -1873,12 +2366,17 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         role,
         protocol: 'a2ui',
         profile: 'native',
-        name: role === 'control' ? '新基准组' : '新对比组',
+        name: role === 'control'
+          ? 'New baseline'
+          : 'New comparison',
         variable: 'custom',
         model: env.model || DEFAULT_ENV.model,
         catalog: 'Full Catalog',
         extraInstruction: '',
         enabled: true,
+        systemName: role === 'control'
+          ? 'new-baseline'
+          : 'new-comparison',
       },
     ]);
   }, [env.model]);
@@ -1896,7 +2394,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
     setReportPlanSignature(null);
     setStatus('idle');
     setProgress(0);
-    setRunMessage('已载入预设');
+    setRunMessage({ code: 'preset-loaded' });
   }, [cancelActiveBenchJob]);
 
   const updateGroupProtocol = useCallback(
@@ -1974,11 +2472,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
       ...current,
       {
         id: createId('scenario'),
-        name: '自定义场景',
-        prompt: '描述需要生成和评测的 UI。',
-        type: '自定义',
+        name: 'Custom scenario',
+        prompt: 'Describe the UI to generate and evaluate.',
+        type: 'Custom',
         complexity: 1,
-        action: '主操作',
+        action: 'Primary action',
+        systemAction: 'primary-action',
+        systemName: 'custom-scenario',
+        systemPrompt: 'custom-prompt',
+        systemType: 'custom',
       },
     ]);
   }, []);
@@ -1999,7 +2501,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
     setSettings(DEFAULT_SETTINGS);
     setStatus('idle');
     setProgress(0);
-    setRunMessage('准备就绪');
+    setRunMessage({ code: 'ready' });
     setReport(null);
     setReportPlanSignature(null);
     setBenchHealth(null);
@@ -2015,11 +2517,18 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
       try {
         const response = await window.fetch(getA2UIBenchHealthEndpoint());
         if (!response.ok) {
-          throw new Error(`Provider 状态检查失败：${response.status}`);
+          setBenchHealthError({
+            kind: 'status',
+            status: response.status,
+          });
+          return;
         }
         setBenchHealth(await response.json() as BenchHealth);
       } catch (error) {
-        setBenchHealthError(getErrorMessage(error));
+        setBenchHealthError({
+          kind: 'raw',
+          message: getErrorMessage(error),
+        });
       }
     })();
   }, []);
@@ -2027,12 +2536,12 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
   const startBench = useCallback((confirmedServerDefaults = false) => {
     if (benchRunBlockers.length > 0 || runCount === 0) {
       setBenchRunNoticeOpen(true);
-      setRunMessage('请先完成运行配置');
+      setRunMessage({ code: 'run-config-required' });
       return;
     }
     if (!providerConfigured && !confirmedServerDefaults) {
       setBenchRunNoticeOpen(true);
-      setRunMessage('请确认使用服务端默认配置');
+      setRunMessage({ code: 'defaults-confirmation-required' });
       loadBenchHealth();
       return;
     }
@@ -2041,8 +2550,8 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
     setProgress(0);
     setRunMessage(
       activeJobIdRef.current || pendingCancellationJobIdsRef.current.size > 0
-        ? '正在停止上一项 Bench 任务…'
-        : '正在创建 Bench 任务…',
+        ? { code: 'stopping-previous-job' }
+        : { code: 'creating-job' },
     );
     setReport(null);
     setReportPlanSignature(null);
@@ -2065,7 +2574,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         return;
       }
 
-      setRunMessage('正在创建 Bench 任务…');
+      setRunMessage({ code: 'creating-job' });
       try {
         const jobsEndpoint = getA2UIBenchJobsEndpoint();
         const response = await window.fetch(jobsEndpoint, {
@@ -2086,8 +2595,8 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
               judgeEnabled: settings.judgeEnabled,
               renderMetricsEnabled: settings.collectLiveRenderMetrics,
             },
-            groups: runGroups,
-            scenarios,
+            groups: createBenchRequestGroups(runGroups),
+            scenarios: createBenchRequestScenarios(scenarios),
           }),
         });
 
@@ -2095,9 +2604,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           () => ({}),
         ) as BenchJobCreated;
         if (!response.ok || payload.ok === false || !payload.jobId) {
-          throw new Error(
-            payload.error ?? `Bench 请求失败：${response.status}`,
-          );
+          if (payload.error) throw new Error(payload.error);
+          setStatus('failed');
+          setRunMessage({
+            code: 'bench-request-failed',
+            status: response.status,
+          });
+          return;
         }
 
         if (
@@ -2124,8 +2637,8 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         pendingCancellationJobIdsRef.current.delete(payload.jobId);
         setRunMessage(
           payload.warnings && payload.warnings.length > 0
-            ? payload.warnings[0]
-            : `Job ${payload.jobId.slice(0, 8)} 已进入队列`,
+            ? { code: 'raw', text: payload.warnings[0] }
+            : { code: 'job-queued', jobId: payload.jobId.slice(0, 8) },
         );
 
         const eventsUrl = new URL(
@@ -2150,8 +2663,10 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           setProgress(total > 0 ? Math.min(100, (completed / total) * 100) : 0);
         };
 
-        const describeRun = (value: unknown): string => {
-          if (!value || typeof value !== 'object') return 'Bench 运行中…';
+        const describeRun = (value: unknown): BenchRunMessage => {
+          if (!value || typeof value !== 'object') {
+            return { code: 'running' };
+          }
           const record = value as Record<string, unknown>;
           const groupId = typeof record.groupId === 'string'
             ? record.groupId
@@ -2165,14 +2680,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           const phase = typeof record.phase === 'string'
             ? record.phase
             : 'agent';
-          const groupName = runGroups.find((group) => group.id === groupId)
-            ?.name ?? '对比组';
-          const scenarioName = scenarios.find((scenario) =>
-            scenario.id === scenarioId
-          )?.name ?? '场景';
-          return `${groupName} · ${scenarioName} · #${
-            repeatIndex ?? 1
-          } · ${phase}`;
+          return {
+            code: 'run-progress',
+            group: runGroups.find((group) => group.id === groupId),
+            phase,
+            repeatIndex: repeatIndex ?? 1,
+            scenario: scenarios.find((scenario) => scenario.id === scenarioId),
+          };
         };
 
         source.addEventListener('job', (event) => {
@@ -2184,11 +2698,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           if (snapshot.status === 'failed') {
             setStatus('failed');
             clearTerminalJob();
-            setRunMessage(snapshot.error ?? 'Bench 任务失败');
+            setRunMessage(
+              snapshot.error
+                ? { code: 'raw', text: snapshot.error }
+                : { code: 'bench-failed' },
+            );
           } else if (snapshot.status === 'cancelled') {
             setStatus('cancelled');
             clearTerminalJob();
-            setRunMessage('Bench 任务已取消');
+            setRunMessage({ code: 'bench-cancelled' });
           } else if (snapshot.status === 'complete') {
             clearTerminalJob();
             setProgress(100);
@@ -2233,11 +2751,10 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           setStatus(nextReport.status ?? 'complete');
           clearTerminalJob();
           setProgress(100);
-          setRunMessage(
-            nextReport.summary && nextReport.summary.failedRuns > 0
-              ? `Bench 完成 · ${nextReport.summary.failedRuns} 个失败 Run`
-              : 'Bench 完成',
-          );
+          setRunMessage({
+            code: 'bench-complete',
+            failedRuns: nextReport.summary?.failedRuns,
+          });
           source.close();
           if (eventSourceRef.current === source) eventSourceRef.current = null;
         });
@@ -2251,7 +2768,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
             !message
             && source.readyState !== EVENT_SOURCE_CLOSED_READY_STATE
           ) {
-            setRunMessage('正在重连 Bench 数据流…');
+            setRunMessage({ code: 'reconnecting' });
             return;
           }
           setStatus('failed');
@@ -2262,7 +2779,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           ) {
             clearTerminalJob();
           }
-          setRunMessage(message ?? 'Bench 数据流已断开');
+          setRunMessage(
+            message
+              ? { code: 'raw', text: message }
+              : { code: 'stream-disconnected' },
+          );
           source.close();
           if (eventSourceRef.current === source) eventSourceRef.current = null;
         });
@@ -2276,7 +2797,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           return;
         }
         setStatus('failed');
-        setRunMessage(getErrorMessage(error));
+        setRunMessage({ code: 'raw', text: getErrorMessage(error) });
       }
     })();
   }, [
@@ -2329,23 +2850,28 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
       restoredEnv,
     );
     setEnv(restoredEnv);
-    setGroups(cloneBenchGroups(entry.config.groups));
-    setScenarios(cloneBenchScenarios(entry.config.scenarios));
+    setGroups(
+      restoreBenchGroupSystemNames(cloneBenchGroups(entry.config.groups)),
+    );
+    setScenarios(
+      restoreBenchScenarioSystemTexts(
+        cloneBenchScenarios(entry.config.scenarios),
+      ),
+    );
     setSettings(cloneBenchSettings(entry.config.settings));
     setReport(entry.report);
     setReportPlanSignature(restoredSignature);
     setStatus(entry.report.status ?? 'complete');
     setProgress(100);
-    setRunMessage(
-      entry.report.summary && entry.report.summary.failedRuns > 0
-        ? `历史 Report 已载入 · ${entry.report.summary.failedRuns} 个失败 Run`
-        : '历史 Report 已载入',
-    );
+    setRunMessage({
+      code: 'history-report-loaded',
+      failedRuns: entry.report.summary?.failedRuns,
+    });
     setHistoryOpen(false);
     const jobId = entry.report.jobId;
     if (!jobId) return;
 
-    setRunMessage('配置已恢复，正在载入完整 Report…');
+    setRunMessage({ code: 'setup-restored-loading-report' });
     const controller = new AbortController();
     historyReportAbortRef.current = controller;
     void (async () => {
@@ -2358,7 +2884,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           | BenchReport
           | { error?: string };
         if (!response.ok || !('results' in payload)) {
-          throw new Error('完整 Report 暂不可用');
+          throw new Error('complete report unavailable');
         }
         if (
           !shouldApplyBenchReportRequest(
@@ -2371,7 +2897,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         setReport(payload);
         setReportPlanSignature(restoredSignature);
         setStatus(payload.status ?? 'complete');
-        setRunMessage('完整 Report 已载入');
+        setRunMessage({ code: 'complete-report-loaded' });
       } catch {
         if (
           !shouldApplyBenchReportRequest(
@@ -2381,7 +2907,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         ) {
           return;
         }
-        setRunMessage('配置已恢复 · 完整 Report 暂不可用');
+        setRunMessage({ code: 'setup-restored-report-unavailable' });
       } finally {
         if (historyReportAbortRef.current === controller) {
           historyReportAbortRef.current = null;
@@ -2552,6 +3078,18 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
       screenshotMatrix.scenarios.length,
     ),
   } as CSSProperties;
+  const reportGroupsById = new Map(
+    report
+      ? createBenchGroupsFromReport(report).map((group) => [group.id, group])
+      : [],
+  );
+  const getReportGroupDisplayName = (summary: BenchGroupSummary | null) => {
+    if (!summary) return 'n/a';
+    const group = reportGroupsById.get(summary.groupId);
+    return group
+      ? getBenchGroupDisplayName(group, locale)
+      : summary.groupName;
+  };
 
   return (
     <div className='benchPage'>
@@ -2560,17 +3098,37 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           <PageHeader
             className='benchHeader'
             title='Bench Runner'
-            description='自由组合 Protocol、Model、Prompt 与 Catalog，并在同一份 Report 中查看结果。'
+            description={benchText(
+              locale,
+              '自由组合 Protocol、Model、Prompt 与 Catalog，并在同一份 Report 中查看结果。',
+              'Combine Protocol, Model, Prompt, and Catalog freely, then review the results in one report.',
+            )}
             topContent={
               <>
-                <span className='chip'>{activeGroups.length} 个对比组</span>
-                <span className='chip'>{scenarios.length} 个场景</span>
+                <span className='chip'>
+                  {benchText(
+                    locale,
+                    `${activeGroups.length} 个对比组`,
+                    `${activeGroups.length} comparison groups`,
+                  )}
+                </span>
+                <span className='chip'>
+                  {benchText(
+                    locale,
+                    `${scenarios.length} 个场景`,
+                    `${scenarios.length} scenarios`,
+                  )}
+                </span>
                 <span className='chip'>{runCount} Runs</span>
               </>
             }
           />
         )
-        : <h2 className='benchPageAccessibleTitle'>通用 Bench Runner</h2>}
+        : (
+          <h2 className='benchPageAccessibleTitle'>
+            {benchText(locale, '通用 Bench Runner', 'Universal Bench Runner')}
+          </h2>
+        )}
 
       <div
         className='benchBody'
@@ -2578,7 +3136,10 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         ref={benchBodyRef}
         style={benchBodyStyle}
       >
-        <main className='benchMain' aria-label='Bench 工作区'>
+        <main
+          className='benchMain'
+          aria-label={benchText(locale, 'Bench 工作区', 'Bench workspace')}
+        >
           <section className='benchOverviewBand'>
             <div className='benchRunPanel'>
               <div className='benchRunActions'>
@@ -2589,7 +3150,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   disabled={status === 'running'}
                   onClick={() => startBench()}
                 >
-                  {getRunButtonText(status)}
+                  {getRunButtonText(status, locale)}
                 </Button>
                 <Button
                   variant='secondary'
@@ -2598,22 +3159,38 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   disabled={planLocked}
                   onClick={() => setConfigOpen(true)}
                 >
-                  运行设置
+                  {benchText(locale, '运行设置', 'Run settings')}
                 </Button>
                 <Button
                   variant='secondary'
                   size='lg'
                   iconOnly
                   iconBefore={RotateCcw}
-                  aria-label={planLocked ? '停止并重置 Bench' : '重置 Bench'}
-                  title={planLocked ? '停止并重置 Bench' : '重置 Bench'}
+                  aria-label={planLocked
+                    ? benchText(
+                      locale,
+                      '停止并重置 Bench',
+                      'Stop and reset Bench',
+                    )
+                    : benchText(locale, '重置 Bench', 'Reset Bench')}
+                  title={planLocked
+                    ? benchText(
+                      locale,
+                      '停止并重置 Bench',
+                      'Stop and reset Bench',
+                    )
+                    : benchText(locale, '重置 Bench', 'Reset Bench')}
                   onClick={resetBench}
                 />
               </div>
               <div
                 className='benchProgressTrack'
                 role='progressbar'
-                aria-label='Bench 进度'
+                aria-label={benchText(
+                  locale,
+                  'Bench 进度',
+                  'Bench progress',
+                )}
                 aria-valuemin={0}
                 aria-valuemax={100}
                 aria-valuenow={Math.round(
@@ -2633,7 +3210,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                 role='status'
                 aria-live='polite'
               >
-                {getRunMetaText(status, progress, runMessage, runCount)}
+                {getRunMetaText(
+                  status,
+                  progress,
+                  runMessage,
+                  runCount,
+                  locale,
+                )}
               </div>
             </div>
             <div className='benchPlanSummary'>
@@ -2642,24 +3225,44 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                 <strong>
                   {activeProtocols.map((protocol) =>
                     protocol === 'a2ui' ? 'A2UI' : 'OpenUI'
-                  ).join(' + ') || '未选择'}
-                </strong>
-                <small>{activeGroups.length} 个对比组</small>
-              </div>
-              <div className='benchPlanItem'>
-                <span>运行参数</span>
-                <strong>
-                  重复 {settings.repeats} 次 / 并发 {settings.parallelism}
+                  ).join(' + ')
+                    || benchText(locale, '未选择', 'Not selected')}
                 </strong>
                 <small>
-                  UI Judge {settings.judgeEnabled ? '开启' : '关闭'} · Repair
-                  {' '}
-                  {settings.repairEnabled ? '开启' : '关闭'}
+                  {benchText(
+                    locale,
+                    `${activeGroups.length} 个对比组`,
+                    `${activeGroups.length} comparison groups`,
+                  )}
                 </small>
               </div>
               <div className='benchPlanItem'>
-                <span>场景</span>
-                <strong>{scenarios.length} 个 Prompt</strong>
+                <span>{benchText(locale, '运行参数', 'Run parameters')}</span>
+                <strong>
+                  {benchText(
+                    locale,
+                    `重复 ${settings.repeats} 次 / 并发 ${settings.parallelism}`,
+                    `${settings.repeats} repeats / ${settings.parallelism} concurrent`,
+                  )}
+                </strong>
+                <small>
+                  UI Judge {settings.judgeEnabled
+                    ? benchText(locale, '开启', 'on')
+                    : benchText(locale, '关闭', 'off')} · Repair{' '}
+                  {settings.repairEnabled
+                    ? benchText(locale, '开启', 'on')
+                    : benchText(locale, '关闭', 'off')}
+                </small>
+              </div>
+              <div className='benchPlanItem'>
+                <span>{benchText(locale, '场景', 'Scenarios')}</span>
+                <strong>
+                  {benchText(
+                    locale,
+                    `${scenarios.length} 个 Prompt`,
+                    `${scenarios.length} prompts`,
+                  )}
+                </strong>
                 <small>{activeScenarioTypes.join(' / ')}</small>
               </div>
             </div>
@@ -2672,14 +3275,22 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           >
             <div className='benchSectionHeader benchGroupsHeader'>
               <div>
-                <h3 className='benchSectionTitle'>对比组</h3>
+                <h3 className='benchSectionTitle'>
+                  {benchText(locale, '对比组', 'Comparison groups')}
+                </h3>
                 <p className='benchSectionSub'>
-                  每个组都是一条可组合的运行条件
+                  {benchText(
+                    locale,
+                    '每个组都是一条可组合的运行条件',
+                    'Each group is a composable run condition',
+                  )}
                 </p>
               </div>
               <div className='benchHeaderActions'>
                 <details className='benchTemplateMenu'>
-                  <summary>载入预设</summary>
+                  <summary>
+                    {benchText(locale, '载入预设', 'Load preset')}
+                  </summary>
                   <div>
                     <button
                       type='button'
@@ -2690,7 +3301,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         );
                       }}
                     >
-                      A2UI 变量对比
+                      {benchText(
+                        locale,
+                        'A2UI 变量对比',
+                        'A2UI variable comparison',
+                      )}
                       <small>Model / Prompt / Catalog</small>
                     </button>
                     <button
@@ -2702,7 +3317,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         );
                       }}
                     >
-                      Protocol 对照
+                      {benchText(
+                        locale,
+                        'Protocol 对照',
+                        'Protocol comparison',
+                      )}
                       <small>A2UI ↔ OpenUI · matched-core</small>
                     </button>
                     <button
@@ -2714,8 +3333,14 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         );
                       }}
                     >
-                      组合示例
-                      <small>把两类条件放进同一张 plan</small>
+                      {benchText(locale, '组合示例', 'Combined example')}
+                      <small>
+                        {benchText(
+                          locale,
+                          '把两类条件放进同一张 plan',
+                          'Put both condition types in one plan',
+                        )}
+                      </small>
                     </button>
                     <button
                       type='button'
@@ -2726,8 +3351,14 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         );
                       }}
                     >
-                      空白 plan
-                      <small>从一个 Baseline 开始</small>
+                      {benchText(locale, '空白 plan', 'Blank plan')}
+                      <small>
+                        {benchText(
+                          locale,
+                          '从一个 Baseline 开始',
+                          'Start from one baseline',
+                        )}
+                      </small>
                     </button>
                   </div>
                 </details>
@@ -2737,7 +3368,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   iconBefore={MessageSquarePlus}
                   onClick={() => addGroup('experiment')}
                 >
-                  添加对比组
+                  {benchText(
+                    locale,
+                    '添加对比组',
+                    'Add comparison group',
+                  )}
                 </Button>
               </div>
             </div>
@@ -2754,7 +3389,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                       <input
                         type='checkbox'
                         checked={group.enabled}
-                        aria-label={`启用 ${group.name}`}
+                        aria-label={benchText(
+                          locale,
+                          `启用 ${getBenchGroupDisplayName(group, locale)}`,
+                          `Enable ${getBenchGroupDisplayName(group, locale)}`,
+                        )}
                         onChange={(event) =>
                           updateGroup(
                             group.id,
@@ -2778,7 +3417,9 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                           onClick={() =>
                             updateGroup(group.id, groupPatch('role', role))}
                         >
-                          {role === 'control' ? '基准' : '对比'}
+                          {role === 'control'
+                            ? benchText(locale, '基准', 'Baseline')
+                            : benchText(locale, '对比', 'Comparison')}
                         </button>
                       ))}
                     </div>
@@ -2787,21 +3428,33 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                       size='sm'
                       iconOnly
                       iconBefore={Trash2}
-                      aria-label={`删除 ${group.name}`}
-                      title={`删除 ${group.name}`}
+                      aria-label={benchText(
+                        locale,
+                        `删除 ${getBenchGroupDisplayName(group, locale)}`,
+                        `Delete ${getBenchGroupDisplayName(group, locale)}`,
+                      )}
+                      title={benchText(
+                        locale,
+                        `删除 ${getBenchGroupDisplayName(group, locale)}`,
+                        `Delete ${getBenchGroupDisplayName(group, locale)}`,
+                      )}
                       disabled={groups.length <= 1}
                       onClick={() => removeGroup(group.id)}
                     />
                   </div>
                   <input
                     className='benchGroupName'
-                    value={group.name}
-                    aria-label='对比组名称'
+                    value={getBenchGroupDisplayName(group, locale)}
+                    aria-label={benchText(
+                      locale,
+                      '对比组名称',
+                      'Comparison group name',
+                    )}
                     onChange={(event) =>
-                      updateGroup(
-                        group.id,
-                        groupPatch('name', event.target.value),
-                      )}
+                      updateGroup(group.id, {
+                        name: event.target.value,
+                        systemName: undefined,
+                      })}
                   />
                   <div className='benchGroupSummary'>
                     <span data-protocol={group.protocol}>
@@ -2810,11 +3463,19 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     <span>{group.profile}</span>
                     <span>{group.model || env.model}</span>
                     {(groupDifferences.get(group.id) ?? []).length === 0
-                      ? <span data-baseline='true'>基准</span>
+                      ? (
+                        <span data-baseline='true'>
+                          {benchText(locale, '基准', 'Baseline')}
+                        </span>
+                      )
                       : (groupDifferences.get(group.id) ?? []).map(
                         (difference) => (
                           <span data-changed='true' key={difference}>
-                            {difference} 已变更
+                            {benchText(
+                              locale,
+                              `${difference} 已变更`,
+                              `${difference} changed`,
+                            )}
                           </span>
                         ),
                       )}
@@ -2822,24 +3483,44 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         && groupBaselines.get(group.id)
                       ? (
                         <span data-baseline='true'>
-                          相对 {groupBaselines.get(group.id)?.name}
+                          {benchText(
+                            locale,
+                            `相对 ${
+                              getBenchGroupDisplayName(
+                                groupBaselines.get(group.id)!,
+                                locale,
+                              )
+                            }`,
+                            `vs. ${
+                              getBenchGroupDisplayName(
+                                groupBaselines.get(group.id)!,
+                                locale,
+                              )
+                            }`,
+                          )}
                         </span>
                       )
                       : null}
                   </div>
                   <details className='benchGroupDetails'>
-                    <summary>配置</summary>
+                    <summary>{benchText(locale, '配置', 'Configure')}</summary>
                     <div className='benchGroupFields'>
                       <div className='benchField'>
                         <span className='benchFieldLabel'>Protocol</span>
                         <BenchDropdown
-                          ariaLabel={`${group.name} Protocol`}
+                          ariaLabel={`${
+                            getBenchGroupDisplayName(group, locale)
+                          } Protocol`}
                           value={group.protocol}
                           options={[
                             {
                               value: 'a2ui',
                               label: 'A2UI',
-                              description: '结构化消息流',
+                              description: benchText(
+                                locale,
+                                '结构化消息流',
+                                'Structured message stream',
+                              ),
                             },
                             {
                               value: 'openui',
@@ -2854,19 +3535,29 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                       <div className='benchField'>
                         <span className='benchFieldLabel'>Profile</span>
                         <BenchDropdown
-                          ariaLabel={`${group.name} Profile`}
+                          ariaLabel={`${
+                            getBenchGroupDisplayName(group, locale)
+                          } Profile`}
                           value={group.profile}
                           disabled={group.protocol === 'openui'}
                           options={[
                             {
                               value: 'native',
                               label: 'native',
-                              description: '使用完整协议能力',
+                              description: benchText(
+                                locale,
+                                '使用完整协议能力',
+                                'Use the full protocol capability set',
+                              ),
                             },
                             {
                               value: 'matched-core',
                               label: 'matched-core',
-                              description: '只使用公共能力子集',
+                              description: benchText(
+                                locale,
+                                '只使用公共能力子集',
+                                'Use only the shared capability subset',
+                              ),
                             },
                           ]}
                           onChange={(profile) =>
@@ -2877,9 +3568,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     {group.profile === 'matched-core'
                       ? (
                         <p className='benchProfileHint'>
-                          <strong>matched-core</strong>{' '}
-                          只使用 A2UI 与 OpenUI 都支持的公共能力，适合做同条件
-                          Protocol 对照。
+                          <strong>matched-core</strong> {benchText(
+                            locale,
+                            '只使用 A2UI 与 OpenUI 都支持的公共能力，适合做同条件 Protocol 对照。',
+                            'uses only capabilities shared by A2UI and OpenUI, making it suitable for a like-for-like Protocol comparison.',
+                          )}
                         </p>
                       )
                       : null}
@@ -2901,7 +3594,9 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                       <div className='benchField'>
                         <span className='benchFieldLabel'>Catalog</span>
                         <BenchDropdown
-                          ariaLabel={`${group.name} Catalog`}
+                          ariaLabel={`${
+                            getBenchGroupDisplayName(group, locale)
+                          } Catalog`}
                           value={group.catalog}
                           disabled={group.profile === 'matched-core'
                             || group.protocol === 'openui'}
@@ -2919,12 +3614,20 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     </div>
                     <label className='benchField'>
                       <span className='benchFieldLabel'>
-                        Prompt 附加指令
+                        {benchText(
+                          locale,
+                          'Prompt 附加指令',
+                          'Additional prompt instructions',
+                        )}
                       </span>
                       <textarea
                         className='benchTextarea'
                         value={group.extraInstruction}
-                        placeholder='只对这个对比组追加的 Prompt'
+                        placeholder={benchText(
+                          locale,
+                          '只对这个对比组追加的 Prompt',
+                          'Prompt appended only to this comparison group',
+                        )}
                         onChange={(event) =>
                           updateGroup(
                             group.id,
@@ -2945,11 +3648,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
           >
             <div className='benchSectionHeader'>
               <div>
-                <h3 className='benchSectionTitle'>共享场景</h3>
+                <h3 className='benchSectionTitle'>
+                  {benchText(locale, '共享场景', 'Shared scenarios')}
+                </h3>
                 <p className='benchSectionSub'>
-                  {activeGroups.length} 个对比组 × {scenarios.length} 个场景 ×
-                  {' '}
-                  重复 {settings.repeats} 次 = {runCount} Runs
+                  {benchText(
+                    locale,
+                    `${activeGroups.length} 个对比组 × ${scenarios.length} 个场景 × 重复 ${settings.repeats} 次 = ${runCount} Runs`,
+                    `${activeGroups.length} comparison groups × ${scenarios.length} scenarios × ${settings.repeats} repeats = ${runCount} runs`,
+                  )}
                 </p>
               </div>
               <Button
@@ -2959,13 +3666,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                 disabled={planLocked}
                 onClick={() => setConfigOpen(true)}
               >
-                编辑场景
+                {benchText(locale, '编辑场景', 'Edit scenarios')}
               </Button>
             </div>
             <div className='benchScenarioChips'>
               {scenarios.map((scenario) => (
                 <span className='benchScenarioChip' key={scenario.id}>
-                  {scenario.name}
+                  {getBenchScenarioDisplayName(scenario, locale)}
                 </span>
               ))}
             </div>
@@ -2975,7 +3682,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
         <div
           className='benchResizeHandle'
           role='separator'
-          aria-label='调整 Report 面板宽度'
+          aria-label={benchText(
+            locale,
+            '调整 Report 面板宽度',
+            'Resize report panel',
+          )}
           aria-orientation='vertical'
           aria-valuemin={REPORT_PANE_MIN_WIDTH}
           aria-valuemax={REPORT_PANE_MAX_WIDTH}
@@ -2995,7 +3706,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                 className='benchSectionSub'
                 data-stale={reportIsStale || undefined}
               >
-                {getReportSubtitle(report, reportIsStale)}
+                {getReportSubtitle(report, reportIsStale, locale)}
               </p>
             </div>
             <div className='benchReportActions'>
@@ -3005,7 +3716,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                 iconBefore={History}
                 onClick={() => setHistoryOpen(true)}
               >
-                历史
+                {benchText(locale, '历史', 'History')}
               </Button>
               <Button
                 variant='secondary'
@@ -3014,7 +3725,9 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                 disabled={!report}
                 onClick={() => void copyReport()}
               >
-                {copyState === 'copied' ? '已复制' : 'JSON'}
+                {copyState === 'copied'
+                  ? benchText(locale, '已复制', 'Copied')
+                  : 'JSON'}
               </Button>
             </div>
           </div>
@@ -3024,8 +3737,10 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
               <>
                 <div className='benchInsightGrid'>
                   <div className='benchInsight'>
-                    <span>Token 最低</span>
-                    <strong>{bestTokens?.groupName ?? 'n/a'}</strong>
+                    <span>
+                      {benchText(locale, 'Token 最低', 'Lowest tokens')}
+                    </span>
+                    <strong>{getReportGroupDisplayName(bestTokens)}</strong>
                     <small>
                       {bestTokens
                         ? formatNumber(bestTokens.avgTokens)
@@ -3033,8 +3748,10 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     </small>
                   </div>
                   <div className='benchInsight'>
-                    <span>Agent 最快</span>
-                    <strong>{fastestAgent?.groupName ?? 'n/a'}</strong>
+                    <span>
+                      {benchText(locale, 'Agent 最快', 'Fastest agent')}
+                    </span>
+                    <strong>{getReportGroupDisplayName(fastestAgent)}</strong>
                     <small>
                       {fastestAgent
                         ? formatMs(fastestAgent.avgAgentMs)
@@ -3042,8 +3759,10 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     </small>
                   </div>
                   <div className='benchInsight'>
-                    <span>Judge 最佳</span>
-                    <strong>{topJudge?.groupName ?? 'n/a'}</strong>
+                    <span>
+                      {benchText(locale, 'Judge 最佳', 'Best judge score')}
+                    </span>
+                    <strong>{getReportGroupDisplayName(topJudge)}</strong>
                     <small>
                       {topJudge
                         ? `${topJudge.avgJudgeScore.toFixed(1)}/5`
@@ -3056,7 +3775,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   <table className='benchReportTable'>
                     <thead>
                       <tr>
-                        <th>对比组</th>
+                        <th>
+                          {benchText(
+                            locale,
+                            '对比组',
+                            'Comparison group',
+                          )}
+                        </th>
                         <th>Tokens</th>
                         <th>Agent</th>
                         <th>FMP</th>
@@ -3079,7 +3804,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                   className={`benchRoleDot ${summary.role}`}
                                 />
                                 <span>
-                                  {summary.groupName}
+                                  {getReportGroupDisplayName(summary)}
                                   <small>
                                     {summary.protocol === 'openui'
                                       ? 'OpenUI'
@@ -3130,9 +3855,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                 <section className='benchScreenshotSection'>
                   <div className='benchSectionHeader'>
                     <div>
-                      <h3 className='benchSectionTitle'>运行截图</h3>
+                      <h3 className='benchSectionTitle'>
+                        {benchText(locale, '运行截图', 'Run screenshots')}
+                      </h3>
                       <p className='benchSectionSub'>
-                        每个 run 的实际渲染截图，失败位置也会保留
+                        {benchText(
+                          locale,
+                          '每个 run 的实际渲染截图，失败位置也会保留',
+                          'Actual render screenshots for every run, including failed slots',
+                        )}
                       </p>
                     </div>
                     <Button
@@ -3142,7 +3873,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                       disabled={screenshotMatrix.total === 0}
                       onClick={() => setScreenshotsOpen(true)}
                     >
-                      查看截图
+                      {benchText(locale, '查看截图', 'View screenshots')}
                     </Button>
                   </div>
                   <div className='benchScreenshotSummaryGrid'>
@@ -3151,17 +3882,17 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                       <strong>{formatNumber(screenshotMatrix.total)}</strong>
                     </div>
                     <div>
-                      <span>已截图</span>
+                      <span>{benchText(locale, '已截图', 'Captured')}</span>
                       <strong>
                         {formatNumber(screenshotMatrix.captured)}
                       </strong>
                     </div>
                     <div>
-                      <span>失败</span>
+                      <span>{benchText(locale, '失败', 'Failed')}</span>
                       <strong>{formatNumber(screenshotMatrix.failed)}</strong>
                     </div>
                     <div>
-                      <span>缺失</span>
+                      <span>{benchText(locale, '缺失', 'Missing')}</span>
                       <strong>{formatNumber(screenshotMatrix.missing)}</strong>
                     </div>
                   </div>
@@ -3169,8 +3900,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
 
                 <div className='benchReportNotes'>
                   <span>
-                    Agent、Token、Attempts 与校验数据由服务端采集；Render 或 UI
-                    Judge 不可用时会明确标记。
+                    {benchText(
+                      locale,
+                      'Agent、Token、Attempts 与校验数据由服务端采集；Render 或 UI Judge 不可用时会明确标记。',
+                      'Agent, token, attempts, and validation data are collected by the server. Unavailable Render or UI Judge data is explicitly marked.',
+                    )}
                   </span>
                 </div>
                 {report.warnings && report.warnings.length > 0
@@ -3187,8 +3921,20 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
             : (
               <div className='benchEmptyReport'>
                 <Sparkles size={28} strokeWidth={1.8} />
-                <strong>等待 Bench 数据</strong>
-                <span>运行当前计划后，这里会生成统一 Report。</span>
+                <strong>
+                  {benchText(
+                    locale,
+                    '等待 Bench 数据',
+                    'Waiting for Bench data',
+                  )}
+                </strong>
+                <span>
+                  {benchText(
+                    locale,
+                    '运行当前计划后，这里会生成统一 Report。',
+                    'Run the current plan to generate a unified report here.',
+                  )}
+                </span>
               </div>
             )}
         </aside>
@@ -3220,12 +3966,14 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     id='bench-screenshots-title'
                     className='benchConfigTitle'
                   >
-                    运行截图
+                    {benchText(locale, '运行截图', 'Run screenshots')}
                   </h2>
                   <p className='benchConfigSub'>
-                    {screenshotMatrix.rows.length} 个对比组 ×{' '}
-                    {screenshotMatrix.scenarios.length} 个场景 · 重复{' '}
-                    {screenshotMatrix.repeatCount} 次
+                    {benchText(
+                      locale,
+                      `${screenshotMatrix.rows.length} 个对比组 × ${screenshotMatrix.scenarios.length} 个场景 · 重复 ${screenshotMatrix.repeatCount} 次`,
+                      `${screenshotMatrix.rows.length} comparison groups × ${screenshotMatrix.scenarios.length} scenarios · ${screenshotMatrix.repeatCount} repeats`,
+                    )}
                   </p>
                 </div>
                 <Button
@@ -3233,8 +3981,16 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   size='sm'
                   iconOnly
                   iconBefore={X}
-                  aria-label='关闭截图'
-                  title='关闭截图'
+                  aria-label={benchText(
+                    locale,
+                    '关闭截图',
+                    'Close screenshots',
+                  )}
+                  title={benchText(
+                    locale,
+                    '关闭截图',
+                    'Close screenshots',
+                  )}
                   onClick={() => setScreenshotsOpen(false)}
                 />
               </header>
@@ -3246,15 +4002,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     <strong>{formatNumber(screenshotMatrix.total)}</strong>
                   </div>
                   <div>
-                    <span>已截图</span>
+                    <span>{benchText(locale, '已截图', 'Captured')}</span>
                     <strong>{formatNumber(screenshotMatrix.captured)}</strong>
                   </div>
                   <div>
-                    <span>失败</span>
+                    <span>{benchText(locale, '失败', 'Failed')}</span>
                     <strong>{formatNumber(screenshotMatrix.failed)}</strong>
                   </div>
                   <div>
-                    <span>缺失</span>
+                    <span>{benchText(locale, '缺失', 'Missing')}</span>
                     <strong>{formatNumber(screenshotMatrix.missing)}</strong>
                   </div>
                 </div>
@@ -3264,14 +4020,28 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     className='benchScreenshotMatrix'
                     style={screenshotMatrixStyle}
                   >
-                    <div className='benchScreenshotMatrixCorner'>对比组</div>
+                    <div className='benchScreenshotMatrixCorner'>
+                      {benchText(
+                        locale,
+                        '对比组',
+                        'Comparison group',
+                      )}
+                    </div>
                     {screenshotMatrix.scenarios.map((scenario) => (
                       <div
                         className='benchScreenshotScenarioHeader'
                         key={scenario.id}
                       >
-                        <strong>{scenario.name}</strong>
-                        <span>{scenario.type}</span>
+                        <strong>
+                          {getBenchScenarioDisplayName(scenario, locale)}
+                        </strong>
+                        <span>
+                          {getBenchScenarioFieldText(
+                            scenario.type,
+                            scenario.systemType,
+                            locale,
+                          )}
+                        </span>
                       </div>
                     ))}
                     {screenshotMatrix.rows.map((row) => (
@@ -3282,7 +4052,9 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                             aria-hidden='true'
                           />
                           <div>
-                            <strong>{row.group.name}</strong>
+                            <strong>
+                              {getBenchGroupDisplayName(row.group, locale)}
+                            </strong>
                             <span>
                               {row.group.protocol === 'openui'
                                 ? 'OpenUI'
@@ -3313,6 +4085,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                     >
                                       {getScreenshotStateLabelFromState(
                                         slot.state,
+                                        locale,
                                       )}
                                     </span>
                                   </div>
@@ -3320,7 +4093,17 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                     ? (
                                       <div className='benchScreenshotImageFrame'>
                                         <img
-                                          alt={`${cell.group.name} ${cell.scenario.name} #${slot.repeatIndex}`}
+                                          alt={`${
+                                            getBenchGroupDisplayName(
+                                              cell.group,
+                                              locale,
+                                            )
+                                          } ${
+                                            getBenchScenarioDisplayName(
+                                              cell.scenario,
+                                              locale,
+                                            )
+                                          } #${slot.repeatIndex}`}
                                           src={item.screenshotDataUrl}
                                         />
                                       </div>
@@ -3330,10 +4113,14 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                         <strong>
                                           {getScreenshotStateLabelFromState(
                                             slot.state,
+                                            locale,
                                           )}
                                         </strong>
                                         <span>
-                                          {getScreenshotPlaceholderText(item)}
+                                          {getScreenshotPlaceholderText(
+                                            item,
+                                            locale,
+                                          )}
                                         </span>
                                       </div>
                                     )}
@@ -3354,7 +4141,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                           </span>
                                         </>
                                       )
-                                      : <span>无结果</span>}
+                                      : (
+                                        <span>
+                                          {benchText(
+                                            locale,
+                                            '无结果',
+                                            'No result',
+                                          )}
+                                        </span>
+                                      )}
                                   </div>
                                 </article>
                               );
@@ -3373,13 +4168,17 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   size='sm'
                   onClick={() => setScreenshotsOpen(false)}
                 >
-                  完成
+                  {benchText(locale, '完成', 'Done')}
                 </Button>
               </footer>
               <div
                 className='benchScreenshotResizeHandle'
                 role='separator'
-                aria-label='调整截图弹窗宽度'
+                aria-label={benchText(
+                  locale,
+                  '调整截图弹窗宽度',
+                  'Resize screenshot dialog',
+                )}
                 aria-orientation='vertical'
                 aria-valuemin={SCREENSHOT_DIALOG_MIN_WIDTH}
                 aria-valuemax={SCREENSHOT_DIALOG_MAX_WIDTH}
@@ -3413,12 +4212,20 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
               <header className='benchConfigHeader'>
                 <div>
                   <h2 id='bench-history-title' className='benchConfigTitle'>
-                    Bench 历史
+                    {benchText(locale, 'Bench 历史', 'Bench history')}
                   </h2>
                   <p className='benchConfigSub'>
                     {historyItems.length > 0
-                      ? `已保存 ${historyItems.length} 次运行`
-                      : '还没有保存的运行'}
+                      ? benchText(
+                        locale,
+                        `已保存 ${historyItems.length} 次运行`,
+                        `${historyItems.length} saved runs`,
+                      )
+                      : benchText(
+                        locale,
+                        '还没有保存的运行',
+                        'No saved runs yet',
+                      )}
                   </p>
                 </div>
                 <Button
@@ -3426,8 +4233,16 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   size='sm'
                   iconOnly
                   iconBefore={X}
-                  aria-label='关闭 Bench 历史'
-                  title='关闭 Bench 历史'
+                  aria-label={benchText(
+                    locale,
+                    '关闭 Bench 历史',
+                    'Close Bench history',
+                  )}
+                  title={benchText(
+                    locale,
+                    '关闭 Bench 历史',
+                    'Close Bench history',
+                  )}
                   onClick={() => setHistoryOpen(false)}
                 />
               </header>
@@ -3451,7 +4266,9 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                               <div>
                                 <h3>{entry.title}</h3>
                                 <p>
-                                  {new Date(entry.savedAt).toLocaleString()}
+                                  {new Date(entry.savedAt).toLocaleString(
+                                    locale === 'en-US' ? 'en-US' : 'zh-CN',
+                                  )}
                                 </p>
                               </div>
                               <span
@@ -3459,8 +4276,12 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                 data-tone={failedRuns > 0 ? 'warn' : 'ok'}
                               >
                                 {failedRuns > 0
-                                  ? `${failedRuns} 个失败 Run`
-                                  : '通过'}
+                                  ? benchText(
+                                    locale,
+                                    `${failedRuns} 个失败 Run`,
+                                    `${failedRuns} failed runs`,
+                                  )
+                                  : benchText(locale, '通过', 'Passed')}
                               </span>
                             </div>
 
@@ -3470,7 +4291,9 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                 <strong>{formatNumber(totalRuns)}</strong>
                               </div>
                               <div>
-                                <span>成功率</span>
+                                <span>
+                                  {benchText(locale, '成功率', 'Success rate')}
+                                </span>
                                 <strong>
                                   {summary
                                     ? `${
@@ -3501,17 +4324,30 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                               <span>{entry.config.env.model}</span>
                               <span>
                                 {entry.config.env.apiKeyConfigured
-                                  ? 'API key 已配置'
-                                  : '无 API key'}
+                                  ? benchText(
+                                    locale,
+                                    'API key 已配置',
+                                    'API key configured',
+                                  )
+                                  : benchText(
+                                    locale,
+                                    '无 API key',
+                                    'No API key',
+                                  )}
                               </span>
                               <span>
-                                重复 {entry.config.settings.repeats} 次 / 并发
-                                {' '}
-                                {entry.config.settings.parallelism}
+                                {benchText(
+                                  locale,
+                                  `重复 ${entry.config.settings.repeats} 次 / 并发 ${entry.config.settings.parallelism}`,
+                                  `${entry.config.settings.repeats} repeats / ${entry.config.settings.parallelism} concurrent`,
+                                )}
                               </span>
                               <span>
-                                {entry.config.groups.length} 个对比组 ·{' '}
-                                {entry.config.scenarios.length} 个场景
+                                {benchText(
+                                  locale,
+                                  `${entry.config.groups.length} 个对比组 · ${entry.config.scenarios.length} 个场景`,
+                                  `${entry.config.groups.length} comparison groups · ${entry.config.scenarios.length} scenarios`,
+                                )}
                               </span>
                               {jobId
                                 ? <span>job {jobId.slice(0, 8)}</span>
@@ -3519,7 +4355,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                             </div>
 
                             <details className='benchHistoryDetails'>
-                              <summary>配置快照</summary>
+                              <summary>
+                                {benchText(
+                                  locale,
+                                  '配置快照',
+                                  'Setup snapshot',
+                                )}
+                              </summary>
                               <div className='benchHistorySnapshot'>
                                 {jobId
                                   ? (
@@ -3532,24 +4374,43 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                 {recoveryUrl
                                   ? (
                                     <div>
-                                      <span>恢复链接</span>
+                                      <span>
+                                        {benchText(
+                                          locale,
+                                          '恢复链接',
+                                          'Recovery link',
+                                        )}
+                                      </span>
                                       <strong>{recoveryUrl}</strong>
                                     </div>
                                   )
                                   : null}
                                 <div>
-                                  <span>对比组</span>
+                                  <span>
+                                    {benchText(
+                                      locale,
+                                      '对比组',
+                                      'Comparison groups',
+                                    )}
+                                  </span>
                                   <strong>
                                     {entry.config.groups.map((group) =>
-                                      `${group.name} (${group.model})`
+                                      `${
+                                        getBenchGroupDisplayName(group, locale)
+                                      } (${group.model})`
                                     ).join(', ')}
                                   </strong>
                                 </div>
                                 <div>
-                                  <span>场景</span>
+                                  <span>
+                                    {benchText(locale, '场景', 'Scenarios')}
+                                  </span>
                                   <strong>
                                     {entry.config.scenarios.map((scenario) =>
-                                      scenario.name
+                                      getBenchScenarioDisplayName(
+                                        scenario,
+                                        locale,
+                                      )
                                     ).join(', ')}
                                   </strong>
                                 </div>
@@ -3563,7 +4424,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                 iconBefore={RotateCcw}
                                 onClick={() => restoreHistoryEntry(entry)}
                               >
-                                恢复
+                                {benchText(locale, '恢复', 'Restore')}
                               </Button>
                               <div className='benchHistorySecondaryActions'>
                                 <Button
@@ -3575,8 +4436,12 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                     void copyHistoryRecoveryUrl(entry)}
                                 >
                                   {historyCopyId === entry.id
-                                    ? '已复制'
-                                    : '复制链接'}
+                                    ? benchText(locale, '已复制', 'Copied')
+                                    : benchText(
+                                      locale,
+                                      '复制链接',
+                                      'Copy link',
+                                    )}
                                 </Button>
                                 <Button
                                   variant='secondary'
@@ -3584,7 +4449,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                                   iconBefore={Trash2}
                                   onClick={() => deleteHistoryEntry(entry.id)}
                                 >
-                                  删除
+                                  {benchText(locale, '删除', 'Delete')}
                                 </Button>
                               </div>
                             </div>
@@ -3596,8 +4461,16 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   : (
                     <div className='benchEmptyReport benchHistoryEmpty'>
                       <History size={28} strokeWidth={1.8} />
-                      <strong>暂无历史</strong>
-                      <span>完成的 Bench 会自动保存在这里。</span>
+                      <strong>
+                        {benchText(locale, '暂无历史', 'No history yet')}
+                      </strong>
+                      <span>
+                        {benchText(
+                          locale,
+                          '完成的 Bench 会自动保存在这里。',
+                          'Completed Bench runs are saved here automatically.',
+                        )}
+                      </span>
                     </div>
                   )}
               </div>
@@ -3610,14 +4483,14 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   disabled={historyItems.length === 0}
                   onClick={clearHistory}
                 >
-                  清空历史
+                  {benchText(locale, '清空历史', 'Clear history')}
                 </Button>
                 <Button
                   variant='primary'
                   size='sm'
                   onClick={() => setHistoryOpen(false)}
                 >
-                  完成
+                  {benchText(locale, '完成', 'Done')}
                 </Button>
               </footer>
             </section>
@@ -3654,13 +4527,29 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                       className='benchConfigTitle'
                     >
                       {benchRunBlockers.length > 0
-                        ? '还不能运行 Bench'
-                        : '使用服务端默认配置？'}
+                        ? benchText(
+                          locale,
+                          '还不能运行 Bench',
+                          'Bench is not ready to run',
+                        )
+                        : benchText(
+                          locale,
+                          '使用服务端默认配置？',
+                          'Use the server defaults?',
+                        )}
                     </h2>
                     <p id='bench-run-notice-desc' className='benchConfigSub'>
                       {benchRunBlockers.length > 0
-                        ? '请先补全下面的必要配置。'
-                        : '当前没有填写自定义 Provider。'}
+                        ? benchText(
+                          locale,
+                          '请先补全下面的必要配置。',
+                          'Complete the required setup below first.',
+                        )
+                        : benchText(
+                          locale,
+                          '当前没有填写自定义 Provider。',
+                          'No custom Provider is configured.',
+                        )}
                     </p>
                   </div>
                 </div>
@@ -3669,8 +4558,12 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   size='md'
                   iconOnly
                   iconBefore={X}
-                  aria-label='关闭提示'
-                  title='关闭提示'
+                  aria-label={benchText(
+                    locale,
+                    '关闭提示',
+                    'Close notice',
+                  )}
+                  title={benchText(locale, '关闭提示', 'Close notice')}
                   onClick={() => setBenchRunNoticeOpen(false)}
                 />
               </header>
@@ -3687,8 +4580,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   : (
                     <>
                       <p className='benchRunNoticeText'>
-                        本次运行将使用服务端已配置的 Provider，浏览器不会发送
-                        Provider 密钥、地址或默认 Model。
+                        {benchText(
+                          locale,
+                          '本次运行将使用服务端已配置的 Provider，浏览器不会发送 Provider 密钥、地址或默认 Model。',
+                          'This run will use the Provider configured on the server. The browser will not send a Provider key, address, or default Model.',
+                        )}
                       </p>
                       <div className='benchRunHealthCard'>
                         <div>
@@ -3697,20 +4593,29 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                             {getBenchHealthKeyLabel(
                               benchHealth,
                               benchHealthError,
+                              locale,
                             )}
                           </strong>
                         </div>
                         <div>
                           <span>Model</span>
                           <strong>
-                            {benchHealth?.model ?? '服务端默认'}
+                            {benchHealth?.model
+                              ?? benchText(
+                                locale,
+                                '服务端默认',
+                                'Server default',
+                              )}
                           </strong>
                         </div>
                       </div>
                       {benchHealthError
                         ? (
                           <p className='benchRunNoticeError'>
-                            {benchHealthError}
+                            {getBenchHealthErrorText(
+                              benchHealthError,
+                              locale,
+                            )}
                           </p>
                         )
                         : null}
@@ -3724,7 +4629,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   size='md'
                   onClick={() => setBenchRunNoticeOpen(false)}
                 >
-                  关闭
+                  {benchText(locale, '关闭', 'Close')}
                 </Button>
                 <Button
                   variant={benchRunBlockers.length > 0
@@ -3737,7 +4642,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     setConfigOpen(true);
                   }}
                 >
-                  去配置
+                  {benchText(locale, '去配置', 'Open settings')}
                 </Button>
                 {benchRunBlockers.length === 0
                   ? (
@@ -3751,7 +4656,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         startBench(true);
                       }}
                     >
-                      使用默认配置运行
+                      {benchText(
+                        locale,
+                        '使用默认配置运行',
+                        'Run with defaults',
+                      )}
                     </Button>
                   )
                   : null}
@@ -3779,10 +4688,14 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
               <header className='benchConfigHeader'>
                 <div>
                   <h2 id='bench-config-title' className='benchConfigTitle'>
-                    运行设置
+                    {benchText(locale, '运行设置', 'Run settings')}
                   </h2>
                   <p className='benchConfigSub'>
-                    配置 Provider、运行参数与场景。
+                    {benchText(
+                      locale,
+                      '配置 Provider、运行参数与场景。',
+                      'Configure the Provider, run parameters, and scenarios.',
+                    )}
                   </p>
                 </div>
                 <Button
@@ -3790,8 +4703,16 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   size='md'
                   iconOnly
                   iconBefore={X}
-                  aria-label='关闭运行设置'
-                  title='关闭运行设置'
+                  aria-label={benchText(
+                    locale,
+                    '关闭运行设置',
+                    'Close run settings',
+                  )}
+                  title={benchText(
+                    locale,
+                    '关闭运行设置',
+                    'Close run settings',
+                  )}
                   onClick={() => setConfigOpen(false)}
                 />
               </header>
@@ -3807,7 +4728,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         </p>
                       </div>
                       <span className='benchStatusPill'>
-                        {env.apiKey.trim() ? 'Key 已配置' : '无 Key'}
+                        {env.apiKey.trim()
+                          ? benchText(
+                            locale,
+                            'Key 已配置',
+                            'Key configured',
+                          )
+                          : benchText(locale, '无 Key', 'No key')}
                       </span>
                     </div>
                     <label className='benchField'>
@@ -3839,7 +4766,11 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                     </label>
                     <label className='benchField'>
                       <span className='benchFieldLabel'>
-                        新建对比组的默认 Model
+                        {benchText(
+                          locale,
+                          '新建对比组的默认 Model',
+                          'Default Model for new comparison groups',
+                        )}
                       </span>
                       <input
                         className='benchInput'
@@ -3857,9 +4788,15 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   <section className='benchConfigSection'>
                     <div className='benchSectionHeader'>
                       <div>
-                        <h3 className='benchSectionTitle'>运行参数</h3>
+                        <h3 className='benchSectionTitle'>
+                          {benchText(locale, '运行参数', 'Run parameters')}
+                        </h3>
                         <p className='benchSectionSub'>
-                          Repeats、并发与检查项
+                          {benchText(
+                            locale,
+                            'Repeats、并发与检查项',
+                            'Repeats, concurrency, and checks',
+                          )}
                         </p>
                       </div>
                       <Zap size={15} strokeWidth={2} />
@@ -3885,7 +4822,9 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         />
                       </label>
                       <label className='benchField'>
-                        <span className='benchFieldLabel'>并发</span>
+                        <span className='benchFieldLabel'>
+                          {benchText(locale, '并发', 'Concurrency')}
+                        </span>
                         <input
                           className='benchInput'
                           type='number'
@@ -3914,7 +4853,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                             repairEnabled: event.target.checked,
                           }))}
                       />
-                      <span>启用 Repair attempts</span>
+                      <span>
+                        {benchText(
+                          locale,
+                          '启用 Repair attempts',
+                          'Enable Repair attempts',
+                        )}
+                      </span>
                     </label>
                     <label className='benchToggle'>
                       <input
@@ -3926,7 +4871,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                             judgeEnabled: event.target.checked,
                           }))}
                       />
-                      <span>启用 UI Judge</span>
+                      <span>
+                        {benchText(
+                          locale,
+                          '启用 UI Judge',
+                          'Enable UI Judge',
+                        )}
+                      </span>
                     </label>
                     <label className='benchToggle'>
                       <input
@@ -3938,7 +4889,13 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                             collectLiveRenderMetrics: event.target.checked,
                           }))}
                       />
-                      <span>采集实时 Render metrics</span>
+                      <span>
+                        {benchText(
+                          locale,
+                          '采集实时 Render metrics',
+                          'Collect live Render metrics',
+                        )}
+                      </span>
                     </label>
                   </section>
                 </div>
@@ -3946,8 +4903,16 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                 <section className='benchConfigSection benchConfigScenarios'>
                   <div className='benchSectionHeader'>
                     <div>
-                      <h3 className='benchSectionTitle'>场景</h3>
-                      <p className='benchSectionSub'>共享 Prompt 集合</p>
+                      <h3 className='benchSectionTitle'>
+                        {benchText(locale, '场景', 'Scenarios')}
+                      </h3>
+                      <p className='benchSectionSub'>
+                        {benchText(
+                          locale,
+                          '共享 Prompt 集合',
+                          'Shared prompt collection',
+                        )}
+                      </p>
                     </div>
                     <Button
                       variant='secondary'
@@ -3955,7 +4920,7 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                       iconBefore={MessageSquarePlus}
                       onClick={addScenario}
                     >
-                      添加
+                      {benchText(locale, '添加', 'Add')}
                     </Button>
                   </div>
                   <div className='benchScenarioList'>
@@ -3964,12 +4929,22 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         <div className='benchScenarioTop'>
                           <input
                             className='benchInlineInput benchScenarioName'
-                            value={scenario.name}
-                            aria-label='场景名称'
+                            value={getBenchScenarioDisplayName(
+                              scenario,
+                              locale,
+                            )}
+                            aria-label={benchText(
+                              locale,
+                              '场景名称',
+                              'Scenario name',
+                            )}
                             onChange={(event) =>
                               updateScenario(
                                 scenario.id,
-                                { name: event.target.value },
+                                {
+                                  name: event.target.value,
+                                  systemName: undefined,
+                                },
                               )}
                           />
                           <Button
@@ -3977,8 +4952,24 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                             size='sm'
                             iconOnly
                             iconBefore={Trash2}
-                            aria-label={`删除 ${scenario.name}`}
-                            title={`删除 ${scenario.name}`}
+                            aria-label={benchText(
+                              locale,
+                              `删除 ${
+                                getBenchScenarioDisplayName(scenario, locale)
+                              }`,
+                              `Delete ${
+                                getBenchScenarioDisplayName(scenario, locale)
+                              }`,
+                            )}
+                            title={benchText(
+                              locale,
+                              `删除 ${
+                                getBenchScenarioDisplayName(scenario, locale)
+                              }`,
+                              `Delete ${
+                                getBenchScenarioDisplayName(scenario, locale)
+                              }`,
+                            )}
                             disabled={scenarios.length <= 1}
                             onClick={() =>
                               removeScenario(scenario.id)}
@@ -3986,33 +4977,60 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                         </div>
                         <textarea
                           className='benchTextarea benchScenarioPrompt'
-                          value={scenario.prompt}
-                          aria-label={`${scenario.name} prompt`}
+                          value={getBenchScenarioFieldText(
+                            scenario.prompt,
+                            scenario.systemPrompt,
+                            locale,
+                          )}
+                          aria-label={`${
+                            getBenchScenarioDisplayName(scenario, locale)
+                          } prompt`}
                           onChange={(event) =>
                             updateScenario(
                               scenario.id,
-                              { prompt: event.target.value },
+                              {
+                                prompt: event.target.value,
+                                systemPrompt: undefined,
+                              },
                             )}
                         />
                         <div className='benchScenarioMetaRow'>
                           <input
                             className='benchInlineInput'
-                            value={scenario.type}
-                            aria-label={`${scenario.name} type`}
+                            value={getBenchScenarioFieldText(
+                              scenario.type,
+                              scenario.systemType,
+                              locale,
+                            )}
+                            aria-label={`${
+                              getBenchScenarioDisplayName(scenario, locale)
+                            } type`}
                             onChange={(event) =>
                               updateScenario(
                                 scenario.id,
-                                { type: event.target.value },
+                                {
+                                  type: event.target.value,
+                                  systemType: undefined,
+                                },
                               )}
                           />
                           <input
                             className='benchInlineInput'
-                            value={scenario.action}
-                            aria-label={`${scenario.name} action`}
+                            value={getBenchScenarioFieldText(
+                              scenario.action,
+                              scenario.systemAction,
+                              locale,
+                            )}
+                            aria-label={`${
+                              getBenchScenarioDisplayName(scenario, locale)
+                            } action`}
                             onChange={(event) =>
                               updateScenario(
                                 scenario.id,
-                                { action: event.target.value },
+                                {
+                                  action: event.target.value,
+                                  systemAction: undefined,
+                                },
                               )}
                           />
                         </div>
@@ -4029,14 +5047,14 @@ export function BenchPage({ showHeader = true }: BenchPageProps) {
                   iconBefore={RotateCcw}
                   onClick={resetBench}
                 >
-                  重置
+                  {benchText(locale, '重置', 'Reset')}
                 </Button>
                 <Button
                   variant='primary'
                   size='md'
                   onClick={() => setConfigOpen(false)}
                 >
-                  完成
+                  {benchText(locale, '完成', 'Done')}
                 </Button>
               </footer>
             </section>

--- a/packages/genui/playground/src/pages/bench/BenchResultPage.test.ts
+++ b/packages/genui/playground/src/pages/bench/BenchResultPage.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { BenchResultPage } from './BenchResultPage.js';
+
+// Rstest compiles standalone TSX imports with the classic JSX runtime.
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+describe('BenchResultPage', () => {
+  test('keeps Chinese as the default locale', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(BenchResultPage),
+    );
+
+    expect(markup).toContain('lang="zh-CN"');
+    expect(markup).toContain('一期测评结果');
+    expect(markup).toContain('关键结果');
+    expect(markup).toContain('实验对比');
+    expect(markup).toContain('gpt-5.5-2026-04-24');
+  });
+
+  test('renders English chrome and report copy without Chinese chrome', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(BenchResultPage, { locale: 'en-US' }),
+    );
+
+    expect(markup).toContain('lang="en-US"');
+    expect(markup).toContain('Phase 1 benchmark results');
+    expect(markup).toContain('Key results');
+    expect(markup).toContain('Experiment comparison');
+    expect(markup).toContain('Weather refresh card');
+    expect(markup).toContain('Before reading the results');
+    expect(markup).toContain('gpt-5.5-2026-04-24');
+    expect(markup).toContain('href="#/bench/phase-2"');
+    expect(markup).not.toContain('一期结论');
+    expect(markup).not.toContain('关键结果');
+    expect(markup).not.toContain('实验对比');
+    expect(markup).not.toContain('测试场景');
+    expect(markup).not.toMatch(/[\u3400-\u9fff]/u);
+  });
+});

--- a/packages/genui/playground/src/pages/bench/BenchResultPage.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchResultPage.tsx
@@ -4,8 +4,13 @@
 import type { KeyboardEvent } from 'react';
 import { useRef, useState } from 'react';
 
-import type { BenchComparison, BenchMetricKey } from './phaseOne.js';
-import { PHASE_ONE_BENCH } from './phaseOne.js';
+import type { BenchLocale } from './benchLocale.js';
+import type {
+  BenchComparison,
+  BenchMetricKey,
+  PhaseOneBench,
+} from './phaseOne.js';
+import { getPhaseOneBench } from './phaseOne.js';
 import './BenchResultPage.css';
 
 const MODEL_EVIDENCE_URL = new URL(
@@ -30,54 +35,250 @@ type DisplayMetric = Extract<
   'totalTokens' | 'agentMs' | 'judge'
 >;
 
-const METRIC_TABS = [
-  {
-    key: 'totalTokens',
-    label: 'Tokens',
-    description: 'Tokens 总量 · 越低越好',
+const UI_COPY = {
+  'zh-CN': {
+    metricTabs: [
+      {
+        key: 'totalTokens',
+        label: 'Tokens',
+        description: 'Tokens 总量 · 越低越好',
+      },
+      {
+        key: 'agentMs',
+        label: 'Agent 耗时',
+        description: 'Agent 生成耗时 · 越低越好',
+      },
+      {
+        key: 'judge',
+        label: 'UI Judge',
+        description: 'UI Judge 得分 · 越高越好',
+      },
+    ],
+    experimentLabels: {
+      models: 'A · 模型',
+      prompts: 'B · System Prompt',
+      catalogs: 'C · Catalog',
+    },
+    fullMetrics: '完整指标',
+    fullMetricsSummary: 'Tokens · Agent 耗时 · Runtime · UI Judge · 生成次数',
+    agentLatency: 'Agent 耗时',
+    generationAttempts: '生成次数',
+    viewEvidence: '查看生成结果拼图',
+    viewAllEvidence: '查看三组实验结果图',
+    evidenceKinds: '模型 · System Prompt · Catalog',
+    open: '打开',
+    evidenceDialogTitle: '三组实验结果图',
+    evidenceDialogHint: '点击图片可在新窗口查看原图。',
+    closeEvidenceAria: '关闭实验结果图',
+    close: '关闭',
+    chooseEvidenceAria: '选择实验结果图',
+    chooseExperimentAria: '选择实验',
+    chooseMetricAria: '选择指标',
+    currentExperiment: '当前实验',
+    fixedCondition: '固定条件',
+    scenarioAverage: (count: number) => `${count} 个场景的平均值`,
+    metricBest: '该指标最佳',
+    groupRecommendation: '本组建议 · 综合指标',
+    whyRecommended: '为什么推荐',
+    caveat: '需要注意',
+    dataRevision: (revision: number, runs: number) =>
+      `数据版本 Rev. ${revision} · ${runs} 次运行`,
+    phaseResults: '一期测评结果',
+    phaseConclusion: '一期结论',
+    scopeAria: '实验范围',
+    runs: '运行',
+    scenarios: '场景',
+    models: '模型',
+    evidenceBoundary: '证据边界',
+    evidenceBoundaryDetail:
+      '这不是已经验证的最优组合：推荐来自三组单变量实验，三者尚未一起测试。',
+    keyResults: '关键结果',
+    keyResultsDetail: (count: number) =>
+      `从模型、System Prompt 和 Catalog 三组实验中，摘取 ${count} 个关键结果。`,
+    experimentComparison: '实验对比',
+    experimentComparisonDetail:
+      '选择实验组和指标即可对比；完整指标与生成结果可按需展开。',
+    testScenarios: '测试场景',
+    testScenariosDetail:
+      '所有实验复用相同输入，覆盖信息卡、购买卡和长内容规划。',
+    complexitySuffix: '复杂度',
+    interaction: '交互',
+    methodIndex: '04 · 实验方法',
+    interpretation: '结果解读',
+    limitationsTitle: '阅读结果前，请注意',
   },
-  {
-    key: 'agentMs',
-    label: 'Agent 耗时',
-    description: 'Agent 生成耗时 · 越低越好',
-  },
-  {
-    key: 'judge',
-    label: 'UI Judge',
-    description: 'UI Judge 得分 · 越高越好',
-  },
-] as const satisfies readonly {
-  key: DisplayMetric;
-  label: string;
-  description: string;
-}[];
-
-const EXPERIMENT_LABELS = {
-  models: 'A · 模型',
-  prompts: 'B · System Prompt',
-  catalogs: 'C · Catalog',
-} as const satisfies Record<BenchComparison['id'], string>;
-
-const EVIDENCE = {
-  models: {
-    title: '模型对比结果拼图',
-    description: '3 个模型 × 3 个场景',
-    src: MODEL_EVIDENCE_URL,
-  },
-  prompts: {
-    title: 'System Prompt 对比结果拼图',
-    description: '3 个 Prompt × 3 个场景',
-    src: PROMPT_EVIDENCE_URL,
-  },
-  catalogs: {
-    title: 'Catalog 对比结果拼图',
-    description: '3 种 Catalog × 3 个场景',
-    src: CATALOG_EVIDENCE_URL,
+  'en-US': {
+    metricTabs: [
+      {
+        key: 'totalTokens',
+        label: 'Tokens',
+        description: 'Total tokens · lower is better',
+      },
+      {
+        key: 'agentMs',
+        label: 'Agent latency',
+        description: 'Agent generation latency · lower is better',
+      },
+      {
+        key: 'judge',
+        label: 'UI Judge',
+        description: 'UI Judge score · higher is better',
+      },
+    ],
+    experimentLabels: {
+      models: 'A · Model',
+      prompts: 'B · System Prompt',
+      catalogs: 'C · Catalog',
+    },
+    fullMetrics: 'Full metrics',
+    fullMetricsSummary:
+      'Tokens · Agent latency · Runtime · UI Judge · Attempts',
+    agentLatency: 'Agent latency',
+    generationAttempts: 'Attempts',
+    viewEvidence: 'View generated-result collage',
+    viewAllEvidence: 'View all three experiment result sets',
+    evidenceKinds: 'Model · System Prompt · Catalog',
+    open: 'Open',
+    evidenceDialogTitle: 'Three experiment result sets',
+    evidenceDialogHint: 'Open an image to view it at full size.',
+    closeEvidenceAria: 'Close experiment results',
+    close: 'Close',
+    chooseEvidenceAria: 'Choose experiment results',
+    chooseExperimentAria: 'Choose experiment',
+    chooseMetricAria: 'Choose metric',
+    currentExperiment: 'Current experiment',
+    fixedCondition: 'Fixed condition',
+    scenarioAverage: (count: number) => `Average across ${count} scenarios`,
+    metricBest: 'Best for this metric',
+    groupRecommendation: 'Group recommendation · overall',
+    whyRecommended: 'Why it is recommended',
+    caveat: 'What to consider',
+    dataRevision: (revision: number, runs: number) =>
+      `Data revision ${revision} · ${runs} runs`,
+    phaseResults: 'Phase 1 benchmark results',
+    phaseConclusion: 'Phase 1 conclusion',
+    scopeAria: 'Experiment scope',
+    runs: 'Runs',
+    scenarios: 'Scenarios',
+    models: 'Models',
+    evidenceBoundary: 'Evidence boundary',
+    evidenceBoundaryDetail:
+      'This is not a validated optimal combination. The recommendation comes from three single-variable experiments; the three choices have not yet been tested together.',
+    keyResults: 'Key results',
+    keyResultsDetail: (count: number) =>
+      `${count} key results from the Model, System Prompt, and Catalog experiments.`,
+    experimentComparison: 'Experiment comparison',
+    experimentComparisonDetail:
+      'Choose an experiment and metric to compare results; expand full metrics and generated results when needed.',
+    testScenarios: 'Test scenarios',
+    testScenariosDetail:
+      'Every experiment reuses the same inputs across an information card, a purchase card, and long-form planning.',
+    complexitySuffix: ' complexity',
+    interaction: 'Interaction',
+    methodIndex: '04 · Methodology',
+    interpretation: 'Interpreting the results',
+    limitationsTitle: 'Before reading the results',
   },
 } as const satisfies Record<
-  BenchComparison['id'],
-  { title: string; description: string; src: string }
+  BenchLocale,
+  {
+    metricTabs: readonly {
+      key: DisplayMetric;
+      label: string;
+      description: string;
+    }[];
+    experimentLabels: Record<BenchComparison['id'], string>;
+    fullMetrics: string;
+    fullMetricsSummary: string;
+    agentLatency: string;
+    generationAttempts: string;
+    viewEvidence: string;
+    viewAllEvidence: string;
+    evidenceKinds: string;
+    open: string;
+    evidenceDialogTitle: string;
+    evidenceDialogHint: string;
+    closeEvidenceAria: string;
+    close: string;
+    chooseEvidenceAria: string;
+    chooseExperimentAria: string;
+    chooseMetricAria: string;
+    currentExperiment: string;
+    fixedCondition: string;
+    scenarioAverage: (count: number) => string;
+    metricBest: string;
+    groupRecommendation: string;
+    whyRecommended: string;
+    caveat: string;
+    dataRevision: (revision: number, runs: number) => string;
+    phaseResults: string;
+    phaseConclusion: string;
+    scopeAria: string;
+    runs: string;
+    scenarios: string;
+    models: string;
+    evidenceBoundary: string;
+    evidenceBoundaryDetail: string;
+    keyResults: string;
+    keyResultsDetail: (count: number) => string;
+    experimentComparison: string;
+    experimentComparisonDetail: string;
+    testScenarios: string;
+    testScenariosDetail: string;
+    complexitySuffix: string;
+    interaction: string;
+    methodIndex: string;
+    interpretation: string;
+    limitationsTitle: string;
+  }
 >;
+
+function getEvidence(
+  locale: BenchLocale,
+  scope: PhaseOneBench['scope'],
+): Record<
+  BenchComparison['id'],
+  { description: string; src: string; title: string }
+> {
+  if (locale === 'en-US') {
+    return {
+      models: {
+        title: 'Model comparison result collage',
+        description: `${scope.models} models × ${scope.scenarios} scenarios`,
+        src: MODEL_EVIDENCE_URL,
+      },
+      prompts: {
+        title: 'System Prompt comparison result collage',
+        description: `${scope.prompts} Prompts × ${scope.scenarios} scenarios`,
+        src: PROMPT_EVIDENCE_URL,
+      },
+      catalogs: {
+        title: 'Catalog comparison result collage',
+        description:
+          `${scope.catalogs} Catalogs × ${scope.scenarios} scenarios`,
+        src: CATALOG_EVIDENCE_URL,
+      },
+    };
+  }
+
+  return {
+    models: {
+      title: '模型对比结果拼图',
+      description: `${scope.models} 个模型 × ${scope.scenarios} 个场景`,
+      src: MODEL_EVIDENCE_URL,
+    },
+    prompts: {
+      title: 'System Prompt 对比结果拼图',
+      description: `${scope.prompts} 个 Prompt × ${scope.scenarios} 个场景`,
+      src: PROMPT_EVIDENCE_URL,
+    },
+    catalogs: {
+      title: 'Catalog 对比结果拼图',
+      description: `${scope.catalogs} 种 Catalog × ${scope.scenarios} 个场景`,
+      src: CATALOG_EVIDENCE_URL,
+    },
+  };
+}
 
 function formatMetric(metric: DisplayMetric, value: number): string {
   if (metric === 'totalTokens') {
@@ -125,12 +326,17 @@ function moveTabFocus(event: KeyboardEvent<HTMLButtonElement>) {
   tabs[nextIndex]?.click();
 }
 
-function FullMetrics(props: { comparison: BenchComparison }) {
+function FullMetrics(props: {
+  comparison: BenchComparison;
+  locale: BenchLocale;
+}) {
+  const copy = UI_COPY[props.locale];
+
   return (
     <details className='benchStudyDisclosure'>
       <summary>
-        <span>完整指标</span>
-        <small>Tokens · Agent 耗时 · Runtime · UI Judge · 生成次数</small>
+        <span>{copy.fullMetrics}</span>
+        <small>{copy.fullMetricsSummary}</small>
       </summary>
       <div className='benchStudyMetricsTableWrap'>
         <table className='benchStudyMetricsTable'>
@@ -138,12 +344,12 @@ function FullMetrics(props: { comparison: BenchComparison }) {
             <tr>
               <th scope='col'>{props.comparison.variable}</th>
               <th scope='col'>Tokens</th>
-              <th scope='col'>Agent 耗时</th>
+              <th scope='col'>{copy.agentLatency}</th>
               <th scope='col'>Render</th>
               <th scope='col'>FMP</th>
               <th scope='col'>TTI</th>
               <th scope='col'>UI Judge</th>
-              <th scope='col'>生成次数</th>
+              <th scope='col'>{copy.generationAttempts}</th>
             </tr>
           </thead>
           <tbody>
@@ -168,8 +374,11 @@ function FullMetrics(props: { comparison: BenchComparison }) {
 
 function EvidenceDisclosure(props: {
   experimentId: BenchComparison['id'];
+  locale: BenchLocale;
+  scope: PhaseOneBench['scope'];
 }) {
-  const evidence = EVIDENCE[props.experimentId];
+  const copy = UI_COPY[props.locale];
+  const evidence = getEvidence(props.locale, props.scope)[props.experimentId];
 
   return (
     <details
@@ -177,13 +386,15 @@ function EvidenceDisclosure(props: {
       key={props.experimentId}
     >
       <summary>
-        <span>查看生成结果拼图</span>
+        <span>{copy.viewEvidence}</span>
         <small>{evidence.description}</small>
       </summary>
       <a href={evidence.src} target='_blank' rel='noreferrer'>
         <img
           src={evidence.src}
-          alt={`${evidence.title}: ${evidence.description}`}
+          alt={`${evidence.title}${
+            props.locale === 'zh-CN' ? '：' : ': '
+          }${evidence.description}`}
           loading='lazy'
         />
       </a>
@@ -191,10 +402,15 @@ function EvidenceDisclosure(props: {
   );
 }
 
-function ScenarioEvidenceGallery() {
+function ScenarioEvidenceGallery(props: {
+  locale: BenchLocale;
+  scope: PhaseOneBench['scope'];
+}) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [evidenceId, setEvidenceId] = useState<BenchComparison['id']>('models');
-  const evidence = EVIDENCE[evidenceId];
+  const copy = UI_COPY[props.locale];
+  const evidenceCollection = getEvidence(props.locale, props.scope);
+  const evidence = evidenceCollection[evidenceId];
 
   return (
     <>
@@ -204,10 +420,10 @@ function ScenarioEvidenceGallery() {
         onClick={() => dialogRef.current?.showModal()}
       >
         <span>
-          <strong>查看三组实验结果图</strong>
-          <small>模型 · System Prompt · Catalog</small>
+          <strong>{copy.viewAllEvidence}</strong>
+          <small>{copy.evidenceKinds}</small>
         </span>
-        <span aria-hidden='true'>打开</span>
+        <span aria-hidden='true'>{copy.open}</span>
       </button>
 
       <dialog
@@ -229,37 +445,41 @@ function ScenarioEvidenceGallery() {
         <div className='benchStudyEvidenceDialogPanel'>
           <header className='benchStudyEvidenceDialogHeader'>
             <div>
-              <h3 id='bench-study-evidence-title'>三组实验结果图</h3>
-              <p>点击图片可在新窗口查看原图。</p>
+              <h3 id='bench-study-evidence-title'>
+                {copy.evidenceDialogTitle}
+              </h3>
+              <p>{copy.evidenceDialogHint}</p>
             </div>
             <button
               type='button'
-              aria-label='关闭实验结果图'
+              aria-label={copy.closeEvidenceAria}
               onClick={() => dialogRef.current?.close()}
             >
-              关闭
+              {copy.close}
             </button>
           </header>
           <div
             className='benchStudyEvidenceDialogTabs'
             role='tablist'
-            aria-label='选择实验结果图'
+            aria-label={copy.chooseEvidenceAria}
           >
-            {(Object.keys(EVIDENCE) as BenchComparison['id'][]).map((id) => (
-              <button
-                id={`bench-study-evidence-${id}`}
-                type='button'
-                role='tab'
-                aria-controls='bench-study-evidence-panel'
-                aria-selected={evidenceId === id}
-                tabIndex={evidenceId === id ? 0 : -1}
-                onClick={() => setEvidenceId(id)}
-                onKeyDown={moveTabFocus}
-                key={id}
-              >
-                {EXPERIMENT_LABELS[id]}
-              </button>
-            ))}
+            {(Object.keys(evidenceCollection) as BenchComparison['id'][]).map(
+              (id) => (
+                <button
+                  id={`bench-study-evidence-${id}`}
+                  type='button'
+                  role='tab'
+                  aria-controls='bench-study-evidence-panel'
+                  aria-selected={evidenceId === id}
+                  tabIndex={evidenceId === id ? 0 : -1}
+                  onClick={() => setEvidenceId(id)}
+                  onKeyDown={moveTabFocus}
+                  key={id}
+                >
+                  {copy.experimentLabels[id]}
+                </button>
+              ),
+            )}
           </div>
           <figure
             className='benchStudyEvidenceDialogFigure'
@@ -270,7 +490,9 @@ function ScenarioEvidenceGallery() {
             <a href={evidence.src} target='_blank' rel='noreferrer'>
               <img
                 src={evidence.src}
-                alt={`${evidence.title}：${evidence.description}`}
+                alt={`${evidence.title}${
+                  props.locale === 'zh-CN' ? '：' : ': '
+                }${evidence.description}`}
                 loading='lazy'
               />
             </a>
@@ -287,7 +509,11 @@ function ScenarioEvidenceGallery() {
 
 function ExperimentComparator(props: {
   comparisons: readonly BenchComparison[];
+  locale: BenchLocale;
+  scope: PhaseOneBench['scope'];
 }) {
+  const copy = UI_COPY[props.locale];
+  const metricTabs = copy.metricTabs;
   const [experimentId, setExperimentId] = useState<
     BenchComparison['id']
   >('prompts');
@@ -297,8 +523,8 @@ function ExperimentComparator(props: {
   ) ?? props.comparisons[0];
   const winner = comparison.rows.find((row) => row.tone === 'positive')
     ?? comparison.rows[0];
-  const metricDefinition = METRIC_TABS.find((item) => item.key === metric)
-    ?? METRIC_TABS[0];
+  const metricDefinition = metricTabs.find((item) => item.key === metric)
+    ?? metricTabs[0];
   const values = comparison.rows.map((row) => row.metrics[metric]);
   const maximum = metric === 'judge' ? 5 : Math.max(...values);
   const bestValue = metric === 'judge'
@@ -311,7 +537,7 @@ function ExperimentComparator(props: {
         <div
           className='benchStudyTabs'
           role='tablist'
-          aria-label='选择实验'
+          aria-label={copy.chooseExperimentAria}
         >
           {props.comparisons.map((item) => (
             <button
@@ -325,16 +551,16 @@ function ExperimentComparator(props: {
               onKeyDown={moveTabFocus}
               key={item.id}
             >
-              {EXPERIMENT_LABELS[item.id]}
+              {copy.experimentLabels[item.id]}
             </button>
           ))}
         </div>
         <div
           className='benchStudyTabs benchStudyMetricTabs'
           role='tablist'
-          aria-label='选择指标'
+          aria-label={copy.chooseMetricAria}
         >
-          {METRIC_TABS.map((item) => (
+          {metricTabs.map((item) => (
             <button
               id={`bench-metric-${item.key}`}
               type='button'
@@ -360,11 +586,11 @@ function ExperimentComparator(props: {
       >
         <div className='benchStudyCompareHeader' aria-live='polite'>
           <div>
-            <span>当前实验</span>
+            <span>{copy.currentExperiment}</span>
             <h3>{comparison.title}</h3>
           </div>
           <p>
-            <small>固定条件</small>
+            <small>{copy.fixedCondition}</small>
             {comparison.fixedCondition}
           </p>
         </div>
@@ -372,7 +598,7 @@ function ExperimentComparator(props: {
         <div className='benchStudyBars' aria-live='polite'>
           <div className='benchStudyBarsHeading'>
             <span>{metricDefinition.description}</span>
-            <small>3 个场景的平均值</small>
+            <small>{copy.scenarioAverage(props.scope.scenarios)}</small>
           </div>
           {comparison.rows.map((row) => {
             const value = row.metrics[metric];
@@ -386,7 +612,7 @@ function ExperimentComparator(props: {
               >
                 <div className='benchStudyBarLabel'>
                   <strong>{row.name}</strong>
-                  {isBest ? <small>该指标最佳</small> : null}
+                  {isBest ? <small>{copy.metricBest}</small> : null}
                 </div>
                 <div className='benchStudyBarTrack' aria-hidden='true'>
                   <span style={{ width: `${width}%` }} />
@@ -399,63 +625,77 @@ function ExperimentComparator(props: {
 
         <aside className='benchStudyWinner' aria-live='polite'>
           <div className='benchStudyWinnerLead'>
-            <small>本组建议 · 综合指标</small>
+            <small>{copy.groupRecommendation}</small>
             <strong>{winner.name}</strong>
             <span>{winner.descriptor}</span>
           </div>
           <div>
-            <small>为什么推荐</small>
+            <small>{copy.whyRecommended}</small>
             <p>{winner.strength}</p>
           </div>
           <div>
-            <small>需要注意</small>
+            <small>{copy.caveat}</small>
             <p>{winner.risk}</p>
           </div>
         </aside>
       </div>
 
       <div className='benchStudyCompareDetails'>
-        <FullMetrics comparison={comparison} />
-        <EvidenceDisclosure experimentId={comparison.id} />
+        <FullMetrics comparison={comparison} locale={props.locale} />
+        <EvidenceDisclosure
+          experimentId={comparison.id}
+          locale={props.locale}
+          scope={props.scope}
+        />
       </div>
     </div>
   );
 }
 
-export function BenchResultPage() {
-  const report = PHASE_ONE_BENCH;
+export interface BenchResultPageProps {
+  locale?: BenchLocale;
+}
+
+export function BenchResultPage({
+  locale = 'zh-CN',
+}: BenchResultPageProps) {
+  const report = getPhaseOneBench(locale);
+  const copy = UI_COPY[locale];
 
   return (
-    <main className='benchStudyPage'>
+    <main className='benchStudyPage' lang={locale}>
       <section className='benchStudyHero'>
         <div className='benchStudyHeroTopline'>
           <span>{report.eyebrow}</span>
           <span>
-            数据版本 Rev. {report.sourceRevision} · {report.scope.runs} 次运行
+            {copy.dataRevision(
+              report.sourceRevision,
+              report.scope.runs,
+            )}
           </span>
         </div>
 
         <div className='benchStudyHeroLead'>
-          <p className='benchStudyEyebrow'>一期测评结果</p>
+          <p className='benchStudyEyebrow'>{copy.phaseResults}</p>
           <h1>{report.title}</h1>
           <div className='benchStudyConclusion'>
-            <span>一期结论</span>
+            <span>{copy.phaseConclusion}</span>
             <p>{report.conclusion}</p>
           </div>
           <p className='benchStudyHeroContext'>{report.description}</p>
         </div>
 
-        <dl className='benchStudyScope' aria-label='实验范围'>
+        <dl className='benchStudyScope' aria-label={copy.scopeAria}>
           <div>
-            <dt>运行</dt>
+            <dt>{copy.runs}</dt>
             <dd>{report.scope.runs}</dd>
           </div>
           <div>
-            <dt>场景</dt>
+            <dt>{copy.scenarios}</dt>
             <dd>{report.scope.scenarios}</dd>
           </div>
           <div>
-            <dt>模型</dt>
+            <dt>{copy.models}</dt>
             <dd>{report.scope.models}</dd>
           </div>
           <div>
@@ -466,7 +706,7 @@ export function BenchResultPage() {
 
         <div className='benchStudyRecommendation'>
           <div className='benchStudyRecommendationLead'>
-            <span>建议起始配置</span>
+            <span>{report.recommendation.title}</span>
             <p>{report.recommendation.summary}</p>
           </div>
           <ol>
@@ -478,8 +718,8 @@ export function BenchResultPage() {
             ))}
           </ol>
           <p className='benchStudyEvidenceBoundary'>
-            <strong>证据边界</strong>
-            这不是已经验证的最优组合：推荐来自三组单变量实验，三者尚未一起测试。
+            <strong>{copy.evidenceBoundary}</strong>
+            {copy.evidenceBoundaryDetail}
           </p>
         </div>
       </section>
@@ -488,10 +728,8 @@ export function BenchResultPage() {
         <header className='benchStudySectionHeader'>
           <span>01</span>
           <div>
-            <h2>关键结果</h2>
-            <p>
-              从模型、System Prompt 和 Catalog 三组实验中，摘取 4 个关键结果。
-            </p>
+            <h2>{copy.keyResults}</h2>
+            <p>{copy.keyResultsDetail(report.highlights.length)}</p>
           </div>
         </header>
         <div className='benchStudyFindingList'>
@@ -521,19 +759,23 @@ export function BenchResultPage() {
         <header className='benchStudySectionHeader'>
           <span>02</span>
           <div>
-            <h2>实验对比</h2>
-            <p>选择实验组和指标即可对比；完整指标与生成结果可按需展开。</p>
+            <h2>{copy.experimentComparison}</h2>
+            <p>{copy.experimentComparisonDetail}</p>
           </div>
         </header>
-        <ExperimentComparator comparisons={report.comparisons} />
+        <ExperimentComparator
+          comparisons={report.comparisons}
+          locale={locale}
+          scope={report.scope}
+        />
       </section>
 
       <section className='benchStudySection benchStudyScenarios'>
         <header className='benchStudySectionHeader'>
           <span>03</span>
           <div>
-            <h2>测试场景</h2>
-            <p>所有实验复用相同输入，覆盖信息卡、购买卡和长内容规划。</p>
+            <h2>{copy.testScenarios}</h2>
+            <p>{copy.testScenariosDetail}</p>
           </div>
         </header>
         <div className='benchStudyScenarioList'>
@@ -547,24 +789,25 @@ export function BenchResultPage() {
                 <div>
                   <h3>{scenario.name}</h3>
                   <small>
-                    {scenario.businessMode} · {scenario.complexity}复杂度
+                    {scenario.businessMode} · {scenario.complexity}
+                    {copy.complexitySuffix}
                   </small>
                 </div>
               </div>
               <p>{scenario.purpose}</p>
               <footer>
-                <span>交互</span>
+                <span>{copy.interaction}</span>
                 <b>{scenario.interaction}</b>
               </footer>
             </article>
           ))}
         </div>
-        <ScenarioEvidenceGallery />
+        <ScenarioEvidenceGallery locale={locale} scope={report.scope} />
       </section>
 
       <section className='benchStudySection benchStudyMethod'>
         <div className='benchStudyMethodColumn'>
-          <span className='benchStudySectionIndex'>04 · 实验方法</span>
+          <span className='benchStudySectionIndex'>{copy.methodIndex}</span>
           <h2>{report.methodology.title}</h2>
           <ol className='benchStudyMethodList'>
             {report.methodology.items.map((item, index) => (
@@ -579,8 +822,8 @@ export function BenchResultPage() {
           </ol>
         </div>
         <aside className='benchStudyLimitations'>
-          <span className='benchStudySectionIndex'>结果解读</span>
-          <h2>阅读结果前，请注意</h2>
+          <span className='benchStudySectionIndex'>{copy.interpretation}</span>
+          <h2>{copy.limitationsTitle}</h2>
           <ol>
             {report.limitations.map((limitation) => (
               <li key={limitation}>{limitation}</li>

--- a/packages/genui/playground/src/pages/bench/BenchRunnerPage.test.ts
+++ b/packages/genui/playground/src/pages/bench/BenchRunnerPage.test.ts
@@ -7,8 +7,11 @@ import { renderToStaticMarkup } from 'react-dom/server';
 
 import {
   createBenchJobCancellationRequestInit,
+  getBenchGroupDisplayName,
   getBenchJobCancellationDisposition,
   getBenchRunBlockers,
+  getBenchRunMessageText,
+  getBenchScenarioDisplayName,
   readBenchHistory,
   serializeBenchHistoryEntries,
   serializeBenchReport,
@@ -41,6 +44,55 @@ describe('BenchRunnerPage', () => {
     expect(markup).not.toContain('Phase 02');
     expect(markup).not.toContain('A2UI Bench');
     expect(markup).not.toContain('phase-2-runner');
+  });
+
+  test('renders the complete runner chrome in English', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(BenchRunnerPage, { locale: 'en-US' }),
+    );
+
+    expect(markup).toContain(
+      'Combine Protocol, Model, Prompt, and Catalog freely in one run plan.',
+    );
+    expect(markup).toContain('Comparison groups');
+    expect(markup).toContain('Load preset');
+    expect(markup).toContain('Run Bench');
+    expect(markup).toContain('Run settings');
+    expect(markup).toContain('Shared scenarios');
+    expect(markup).toContain('Waiting for Bench data');
+    expect(markup).not.toContain('对比组');
+    expect(markup).not.toContain('运行设置');
+    expect(markup).not.toMatch(/[\u3400-\u9fff]/u);
+  });
+
+  test('re-renders system state for a zh-CN to en-US locale switch', () => {
+    const message = { code: 'preset-loaded' } as const;
+    const group = {
+      name: '默认 Prompt',
+      systemName: 'default-prompt',
+    } as const;
+    const scenario = {
+      name: '自定义场景',
+      systemName: 'custom-scenario',
+    } as const;
+
+    expect(getBenchRunMessageText(message, 'zh-CN')).toBe('已载入预设');
+    expect(getBenchRunMessageText(message, 'en-US')).toBe('Preset loaded');
+    expect(getBenchGroupDisplayName(group, 'zh-CN')).toBe('默认 Prompt');
+    expect(getBenchGroupDisplayName(group, 'en-US')).toBe('Default Prompt');
+    expect(getBenchScenarioDisplayName(scenario, 'zh-CN')).toBe('自定义场景');
+    expect(getBenchScenarioDisplayName(scenario, 'en-US')).toBe(
+      'Custom scenario',
+    );
+
+    const userText = { code: 'raw', text: '用户自定义状态' } as const;
+    const customGroup = { name: '我的实验组' };
+    const customScenario = { name: '我的场景' };
+    expect(getBenchRunMessageText(userText, 'en-US')).toBe('用户自定义状态');
+    expect(getBenchGroupDisplayName(customGroup, 'en-US')).toBe('我的实验组');
+    expect(getBenchScenarioDisplayName(customScenario, 'en-US')).toBe(
+      '我的场景',
+    );
   });
 
   test('ignores stale and aborted report recovery requests', () => {
@@ -81,6 +133,9 @@ describe('BenchRunnerPage', () => {
     );
     expect(getBenchRunBlockers(1, 1, 1, 1)).not.toContain(
       '至少启用一个基准组。',
+    );
+    expect(getBenchRunBlockers(1, 0, 1, 1, 'en-US')).toContain(
+      'Enable at least one baseline group.',
     );
   });
 

--- a/packages/genui/playground/src/pages/bench/BenchRunnerPage.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchRunnerPage.tsx
@@ -2,23 +2,31 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { BenchPage } from '../BenchPage.js';
+import type { BenchLocale } from './benchLocale.js';
 import './BenchRunnerPage.css';
 
-export function BenchRunnerPage() {
+export function BenchRunnerPage(props: { locale?: BenchLocale }) {
+  const locale = props.locale ?? 'zh-CN';
+  const isEnglish = locale === 'en-US';
+
   return (
     <div className='benchRunnerPage'>
       <header className='benchRunnerHeader'>
         <div>
           <h1>Bench Runner</h1>
           <p>
-            在一份运行计划中自由组合 Protocol、Model、Prompt 与 Catalog。
+            {isEnglish
+              ? 'Combine Protocol, Model, Prompt, and Catalog freely in one run plan.'
+              : '在一份运行计划中自由组合 Protocol、Model、Prompt 与 Catalog。'}
           </p>
         </div>
-        <span>统一配置 · 实时报告</span>
+        <span>
+          {isEnglish ? 'Unified setup · Live report' : '统一配置 · 实时报告'}
+        </span>
       </header>
 
       <div className='benchRunnerWorkspace'>
-        <BenchPage showHeader={false} />
+        <BenchPage locale={locale} showHeader={false} />
       </div>
     </div>
   );

--- a/packages/genui/playground/src/pages/bench/BenchShell.css
+++ b/packages/genui/playground/src/pages/bench/BenchShell.css
@@ -141,6 +141,39 @@ html[data-theme="dark"] .benchShellBrandMark img {
   gap: 2px;
 }
 
+.benchShellLocale {
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  border: 1px solid var(--bench-line);
+  border-radius: 999px;
+}
+
+.benchShellLocale button {
+  min-width: 34px;
+  height: 22px;
+  padding: 0 7px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--bench-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.benchShellLocale button.active {
+  background: var(--bench-ink);
+  color: var(--bench-bg);
+}
+
+.benchShellLocale button:hover:not(.active) {
+  color: var(--bench-ink);
+}
+
 .benchShellUtility {
   min-width: 44px;
   min-height: 44px;
@@ -216,6 +249,10 @@ html[data-theme="dark"] .benchShellBrandMark img {
   .benchShellUtilities {
     grid-column: 2;
     grid-row: 1;
+  }
+
+  .benchShellLocale {
+    height: 26px;
   }
 
   .benchShellNav {

--- a/packages/genui/playground/src/pages/bench/BenchShell.test.ts
+++ b/packages/genui/playground/src/pages/bench/BenchShell.test.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { BenchShell } from './BenchShell.js';
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const noop = () => undefined;
+
+describe('BenchShell', () => {
+  test('renders a persistent bilingual language control', () => {
+    const chinese = renderToStaticMarkup(
+      React.createElement(
+        BenchShell,
+        {
+          activeSlug: 'runner',
+          locale: 'zh-CN',
+          theme: 'light',
+          onChangeLocale: noop,
+          onToggleTheme: noop,
+        },
+        React.createElement('span', null, 'Content'),
+      ),
+    );
+    const english = renderToStaticMarkup(
+      React.createElement(
+        BenchShell,
+        {
+          activeSlug: 'phase-1',
+          locale: 'en-US',
+          theme: 'dark',
+          onChangeLocale: noop,
+          onToggleTheme: noop,
+        },
+        React.createElement('span', null, 'Content'),
+      ),
+    );
+
+    expect(chinese).toContain('lang="zh-CN"');
+    expect(chinese).toContain('aria-label="语言"');
+    expect(chinese).toContain('aria-pressed="true"');
+    expect(chinese).toContain('中文');
+    expect(chinese).toContain('EN');
+
+    expect(english).toContain('lang="en"');
+    expect(english).toContain('aria-label="Language"');
+    expect(english).toContain('Switch to light mode');
+  });
+});

--- a/packages/genui/playground/src/pages/bench/BenchShell.tsx
+++ b/packages/genui/playground/src/pages/bench/BenchShell.tsx
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import type { ReactNode } from 'react';
 
+import type { BenchLocale } from './benchLocale.js';
 import { ChevronLeft, Moon, Sun } from '../../components/Icon.js';
 import './BenchShell.css';
 
@@ -16,7 +17,9 @@ type Theme = 'light' | 'dark';
 interface BenchShellProps {
   activeSlug?: string;
   children: ReactNode;
+  locale: BenchLocale;
   theme: Theme;
+  onChangeLocale: (locale: BenchLocale) => void;
   onToggleTheme: () => void;
 }
 
@@ -57,31 +60,37 @@ function isActiveItem(
 
 function ThemeButton(props: {
   className: string;
+  locale: BenchLocale;
   theme: Theme;
   onToggleTheme: () => void;
 }) {
   const Icon = props.theme === 'dark' ? Sun : Moon;
   const nextTheme = props.theme === 'dark' ? 'light' : 'dark';
+  const label = props.locale === 'en-US'
+    ? `Switch to ${nextTheme} mode`
+    : `切换到${nextTheme === 'dark' ? '深色' : '浅色'}模式`;
 
   return (
     <button
       type='button'
       className={props.className}
       onClick={props.onToggleTheme}
-      aria-label={`Switch to ${nextTheme} mode`}
-      title={`Switch to ${nextTheme} mode`}
+      aria-label={label}
+      title={label}
     >
       <Icon aria-hidden='true' />
       <span className='benchShellVisuallyHidden'>
-        Switch to {nextTheme} mode
+        {label}
       </span>
     </button>
   );
 }
 
 export function BenchShell(props: BenchShellProps) {
+  const isEnglish = props.locale === 'en-US';
+
   return (
-    <div className='benchShell'>
+    <div className='benchShell' lang={isEnglish ? 'en' : 'zh-CN'}>
       <header className='benchShellMasthead'>
         <a className='benchShellBrand' href='#/bench'>
           <span className='benchShellBrandMark'>
@@ -90,7 +99,10 @@ export function BenchShell(props: BenchShellProps) {
           <strong>Lynx GenUI Bench</strong>
         </a>
 
-        <nav className='benchShellNav' aria-label='Bench sections'>
+        <nav
+          className='benchShellNav'
+          aria-label={isEnglish ? 'Bench sections' : 'Bench 页面'}
+        >
           {BENCH_NAV_ITEMS.map((item) => (
             <a
               key={item.href}
@@ -112,8 +124,31 @@ export function BenchShell(props: BenchShellProps) {
             <ChevronLeft aria-hidden='true' />
             <span>Playground</span>
           </a>
+          <div
+            className='benchShellLocale'
+            role='group'
+            aria-label={isEnglish ? 'Language' : '语言'}
+          >
+            <button
+              type='button'
+              aria-pressed={!isEnglish}
+              className={isEnglish ? undefined : 'active'}
+              onClick={() => props.onChangeLocale('zh-CN')}
+            >
+              中文
+            </button>
+            <button
+              type='button'
+              aria-pressed={isEnglish}
+              className={isEnglish ? 'active' : undefined}
+              onClick={() => props.onChangeLocale('en-US')}
+            >
+              EN
+            </button>
+          </div>
           <ThemeButton
             className='benchShellUtility'
+            locale={props.locale}
             theme={props.theme}
             onToggleTheme={props.onToggleTheme}
           />

--- a/packages/genui/playground/src/pages/bench/PhaseTwoReportPage.test.ts
+++ b/packages/genui/playground/src/pages/bench/PhaseTwoReportPage.test.ts
@@ -607,6 +607,73 @@ describe('Phase 2 report page integration', () => {
     ).toHaveLength(1);
   });
 
+  test('renders the Phase 2 chrome in explicit Chinese and English locales', () => {
+    const report = publishedFixture();
+    const chineseHtml = renderToStaticMarkup(
+      React.createElement(PhaseTwoReportPage, {
+        locale: 'zh-CN',
+        report,
+      }),
+    );
+    const englishHtml = renderToStaticMarkup(
+      React.createElement(PhaseTwoReportPage, {
+        locale: 'en-US',
+        report,
+      }),
+    );
+
+    expect(chineseHtml).toContain('结论');
+    expect(chineseHtml).toContain('什么是 matched-core？');
+    expect(chineseHtml).toContain('缺少计划运行结果');
+    expect(chineseHtml).toContain('aria-label="报告筛选条件"');
+    expect(chineseHtml).not.toContain('What is matched-core?');
+
+    expect(englishHtml).toContain('Conclusion');
+    expect(englishHtml).toContain('What is matched-core?');
+    expect(englishHtml).toContain('Same task × model × repeat');
+    expect(englishHtml).toContain(
+      'Start with the overview, then inspect the delta',
+    );
+    expect(englishHtml).toContain('Final valid rate');
+    expect(englishHtml).toContain('Missing planned run result');
+    expect(englishHtml).toContain('aria-label="Report filters"');
+    expect(englishHtml).toContain(
+      'aria-label="Select a paired metric"',
+    );
+    expect(englishHtml).toContain('Evaluation methodology');
+    expect(englishHtml).toContain(
+      'Protocol differences should be grounded in paired evidence',
+    );
+    expect(englishHtml).not.toMatch(/[\u3400-\u9fff]/u);
+  });
+
+  test('localizes the checked-in report limitations without mutating report data', () => {
+    const originalLimitation = PHASE_TWO_PUBLISHED_REPORT.limitations[0];
+    const chineseHtml = renderToStaticMarkup(
+      React.createElement(PhaseTwoReportPage, {
+        locale: 'zh-CN',
+      }),
+    );
+    const englishHtml = renderToStaticMarkup(
+      React.createElement(PhaseTwoReportPage, {
+        locale: 'en-US',
+      }),
+    );
+
+    expect(originalLimitation).toContain('本轮只覆盖 3 个合成场景');
+    expect(chineseHtml).toContain(originalLimitation);
+    expect(englishHtml).toContain(
+      'This run covers only three synthetic scenarios',
+    );
+    expect(englishHtml).toContain(
+      'The independent Render evaluator was disabled',
+    );
+    expect(englishHtml).not.toMatch(/[\u3400-\u9fff]/u);
+    expect(PHASE_TWO_PUBLISHED_REPORT.limitations[0]).toBe(
+      originalLimitation,
+    );
+  });
+
   test('aligns the Phase 2 identity with Phase 1 and omits document links', () => {
     const report = publishedFixture();
     report.larkUrl = 'https://example.test/phase-two-report';
@@ -664,6 +731,12 @@ describe('Phase 2 report page integration', () => {
         report,
       }),
     );
+    const englishHtml = renderToStaticMarkup(
+      React.createElement(PhaseTwoReportPage, {
+        locale: 'en-US',
+        report,
+      }),
+    );
     const evidence = collectFormalScreenshotEvidence(report);
 
     expect(evidence.map((item) => item.id)).toEqual([
@@ -686,6 +759,18 @@ describe('Phase 2 report page integration', () => {
       'canonical report 未保存截图或完整协议输出',
     );
     expect(html).not.toMatch(/代表性复跑|证据复跑|不参与汇总指标/);
+    expect(englishHtml).toContain('View UI Judge render results');
+    expect(englishHtml).toContain(
+      'Each image comes from the same Lynx capture scored by UI Judge',
+    );
+    expect(englishHtml).toContain(
+      'aria-label="Close UI Judge render results"',
+    );
+    expect(englishHtml).toContain(
+      'aria-label="Select a UI Judge screenshot scenario"',
+    );
+    expect(englishHtml).toContain('A2UI Lynx render for Weather');
+    expect(englishHtml).not.toContain('查看 UI Judge 实际渲染结果');
   });
 
   test('does not render untrusted or incomplete screenshot pairs', () => {

--- a/packages/genui/playground/src/pages/bench/PhaseTwoReportPage.tsx
+++ b/packages/genui/playground/src/pages/bench/PhaseTwoReportPage.tsx
@@ -4,6 +4,8 @@
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 
+import { DEFAULT_BENCH_LOCALE } from './benchLocale.js';
+import type { BenchLocale } from './benchLocale.js';
 import { PHASE_TWO_PUBLISHED_REPORT } from './phaseTwoPublishedReport.js';
 import './PhaseTwoReportPage.css';
 
@@ -142,9 +144,102 @@ const METRICS = [
   },
 ] as const satisfies readonly MetricDefinition[];
 
+const ENGLISH_METRIC_COPY = {
+  finalValidRate: {
+    label: 'Final valid rate',
+    description: 'Final protocol validity across all planned runs',
+  },
+  passAt1Rate: {
+    label: 'First-pass rate',
+    description: 'Share of runs that pass protocol validation without a repair',
+  },
+  avgJudgeScoreAllRuns: {
+    label: 'UI Judge',
+    description:
+      'Average score from the fixed Judge model across all planned runs',
+  },
+  avgTokensAllRuns: {
+    label: 'Average total tokens',
+    description: 'Average total tokens per planned run (input + output)',
+  },
+  avgGenerationMsAllRuns: {
+    label: 'Average generation latency',
+    description: 'Average Agent latency from request to protocol output',
+  },
+  avgAttemptsAllRuns: {
+    label: 'Average attempts',
+    description:
+      'Average generation attempts, including protocol repair attempts',
+  },
+} as const satisfies Record<
+  MetricKey,
+  Pick<MetricDefinition, 'description' | 'label'>
+>;
+
+const ENGLISH_LIMITATION_COPY = new Map<string, string>([
+  [
+    '本轮只覆盖 3 个合成场景、单一生成模型与单一 UI Judge，未执行显著性检验。',
+    'This run covers only three synthetic scenarios, one generation model, and one UI Judge, with no significance testing.',
+  ],
+  [
+    '生成模型与 UI Judge 使用同一模型版本，Judge 结论可能存在同模型偏差。',
+    'The generation model and UI Judge use the same model version, so Judge conclusions may be subject to same-model bias.',
+  ],
+  [
+    'matched-core 统一场景、模型、运行环境与 Judge，但协议 schema、组件表达和适配 prompt 并不相同。',
+    'matched-core aligns the scenario, model, runtime environment, and Judge, but the protocol schemas, component expressions, and adaptation prompts still differ.',
+  ],
+  [
+    'UI Judge 只检查固定视口的静态 Lynx 截图，没有执行点击、滚动或其他交互步骤。',
+    'UI Judge inspects only static Lynx screenshots at a fixed viewport; it does not perform clicks, scrolling, or other interactions.',
+  ],
+  [
+    '未固定 temperature 或 seed；生成耗时包含外部模型服务波动与本机轻量任务影响，只适合方向性比较。',
+    'Temperature and seed were not fixed. Generation latency includes external model-service variance and light local-task effects, so it supports directional comparison only.',
+  ],
+  [
+    'Bench job store 为本地内存态，服务重启后不能从 API 恢复历史 job。',
+    'The Bench job store is local in-memory state; historical jobs cannot be restored from the API after a server restart.',
+  ],
+  [
+    '正式运行来自 dirty worktree；源码基线 commit 不能单独复现 bundle，需结合当时 diff 与飞书报告中的 bundle SHA-256。',
+    'The formal run came from a dirty worktree. The source baseline commit alone cannot reproduce the bundle; the contemporaneous diff and bundle SHA-256 in the Lark report are also required.',
+  ],
+  [
+    '独立 Render evaluator 未启用；本报告不能推导 Render、FMP 或 TTI。',
+    'The independent Render evaluator was disabled; this report cannot infer Render, FMP, or TTI.',
+  ],
+]);
+
 const NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 });
+
+function localize(
+  locale: BenchLocale,
+  zhCN: string,
+  enUS: string,
+): string {
+  return locale === 'en-US' ? enUS : zhCN;
+}
+
+function localizeMetric(
+  metric: MetricDefinition,
+  locale: BenchLocale,
+): MetricDefinition {
+  return locale === 'en-US'
+    ? { ...metric, ...ENGLISH_METRIC_COPY[metric.key] }
+    : metric;
+}
+
+function localizeLimitation(
+  limitation: string,
+  locale: BenchLocale,
+): string {
+  return locale === 'en-US'
+    ? (ENGLISH_LIMITATION_COPY.get(limitation) ?? limitation)
+    : limitation;
+}
 
 function protocolLabel(protocol: Protocol): string {
   return protocol === 'a2ui' ? 'A2UI' : 'OpenUI';
@@ -402,14 +497,22 @@ function describeDelta(
   metric: MetricDefinition,
   a2ui: number | null,
   openui: number | null,
+  locale: BenchLocale = DEFAULT_BENCH_LOCALE,
 ): string {
   const result = metricDelta(metric, a2ui, openui);
-  if (result.winner === null || result.delta === null) return '数据不足';
-  if (result.winner === 'tie') return '本轮持平';
+  if (result.winner === null || result.delta === null) {
+    return localize(locale, '数据不足', 'Insufficient data');
+  }
+  if (result.winner === 'tie') {
+    return localize(locale, '本轮持平', 'Tied in this run');
+  }
   const difference = Math.abs(result.delta);
-  return `${protocolLabel(result.winner)} ${
-    metric.direction === 'higher' ? '高' : '低'
-  } ${formatMetric(metric.key, difference)}`;
+  const direction = metric.direction === 'higher'
+    ? localize(locale, '高', 'is higher by')
+    : localize(locale, '低', 'is lower by');
+  return `${protocolLabel(result.winner)} ${direction} ${
+    formatMetric(metric.key, difference)
+  }`;
 }
 
 function hasIncompleteCoverage(metrics: PublishedMetrics): boolean {
@@ -440,16 +543,25 @@ export function buildThesis(
   openui: PublishedMetrics,
   pairCount: number,
   completePairs: number,
+  locale: BenchLocale = DEFAULT_BENCH_LOCALE,
 ): string {
   if (pairCount === 0) {
-    return '当前筛选范围没有完整的 paired 样本，暂时不能判断协议差异。';
+    return localize(
+      locale,
+      '当前筛选范围没有完整的 paired 样本，暂时不能判断协议差异。',
+      'No complete paired samples are available for the current filters, so protocol differences cannot yet be assessed.',
+    );
   }
   if (
     completePairs < pairCount
     || hasIncompleteCoverage(a2ui)
     || hasIncompleteCoverage(openui)
   ) {
-    return `本轮仅有 ${completePairs}/${pairCount} 个 pair 同时取得双协议结果，或 Judge / Render 覆盖不完整；当前只展示观测值，不形成协议优劣结论。`;
+    return localize(
+      locale,
+      `本轮仅有 ${completePairs}/${pairCount} 个 pair 同时取得双协议结果，或 Judge / Render 覆盖不完整；当前只展示观测值，不形成协议优劣结论。`,
+      `Only ${completePairs}/${pairCount} pairs produced results for both protocols, or Judge / Render coverage is incomplete. The report therefore shows observations without drawing a protocol-ranking conclusion.`,
+    );
   }
 
   const candidates = METRICS.flatMap((metric) => {
@@ -468,12 +580,20 @@ export function buildThesis(
 
   const strongest = candidates[0];
   if (!strongest || Math.abs(strongest.advantage ?? 0) < 0.02) {
-    return '本轮核心指标整体接近；协议选择应回到逐场景稳定性与产出成本，而不是只看总均值。';
+    return localize(
+      locale,
+      '本轮核心指标整体接近；协议选择应回到逐场景稳定性与产出成本，而不是只看总均值。',
+      'The core metrics are broadly similar in this run. Protocol selection should consider per-scenario stability and output cost rather than aggregate averages alone.',
+    );
   }
 
-  return `${
-    protocolLabel(strongest.winner as Protocol)
-  } 在${strongest.metric.label}上呈现本轮最明显的方向性优势；这不是显著性结论，仍需结合中轴差值与逐场景账本判断。`;
+  const winner = protocolLabel(strongest.winner as Protocol);
+  const metricLabel = localizeMetric(strongest.metric, locale).label;
+  return localize(
+    locale,
+    `${winner} 在${metricLabel}上呈现本轮最明显的方向性优势；这不是显著性结论，仍需结合中轴差值与逐场景账本判断。`,
+    `${winner} shows the clearest directional advantage in ${metricLabel}. This is not a statistical-significance claim; interpret it alongside the zero-axis delta and per-scenario ledger.`,
+  );
 }
 
 function moveTabFocus(
@@ -540,6 +660,7 @@ function ReportSelect(props: {
   label: string;
   onChange: (value: string) => void;
   options: readonly ReportSelectOption[];
+  placeholder: string;
   value: string;
 }) {
   const labelId = `${props.id}-label`;
@@ -560,7 +681,7 @@ function ReportSelect(props: {
             className='phaseTwoReportSelectTrigger'
             aria-labelledby={labelId}
           >
-            <SelectPrimitive.Value placeholder='暂无选项' />
+            <SelectPrimitive.Value placeholder={props.placeholder} />
             <SelectPrimitive.Icon
               className='phaseTwoReportSelectChevron'
               asChild
@@ -689,6 +810,7 @@ export function collectFormalScreenshotEvidence(
 
 function JudgeScreenshotGallery(props: {
   evidence: readonly FormalScreenshotEvidenceItem[];
+  locale: BenchLocale;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const scenarioIds = [
@@ -707,7 +829,8 @@ function JudgeScreenshotGallery(props: {
       ? 0
       : (left.protocol === 'a2ui' ? -1 : 1)
   );
-  const selectedName = selected[0]?.scenarioName ?? '渲染样本';
+  const selectedName = selected[0]?.scenarioName
+    ?? localize(props.locale, '渲染样本', 'Rendered sample');
 
   if (scenarioIds.length === 0) return null;
 
@@ -719,12 +842,24 @@ function JudgeScreenshotGallery(props: {
         onClick={() => dialogRef.current?.showModal()}
       >
         <span>
-          <strong>查看 UI Judge 实际渲染结果</strong>
+          <strong>
+            {localize(
+              props.locale,
+              '查看 UI Judge 实际渲染结果',
+              'View UI Judge render results',
+            )}
+          </strong>
           <small>
-            {scenarioIds.length} 个场景 · 正式 repeat 1 · A2UI / OpenUI
+            {localize(
+              props.locale,
+              `${scenarioIds.length} 个场景 · 正式 repeat 1 · A2UI / OpenUI`,
+              `${scenarioIds.length} scenarios · formal repeat 1 · A2UI / OpenUI`,
+            )}
           </small>
         </span>
-        <span aria-hidden='true'>打开</span>
+        <span aria-hidden='true'>
+          {localize(props.locale, '打开', 'Open')}
+        </span>
       </button>
 
       <dialog
@@ -747,26 +882,41 @@ function JudgeScreenshotGallery(props: {
           <header className='phaseTwoReportEvidenceDialogHeader'>
             <div>
               <h3 id='phase-two-report-evidence-title'>
-                UI Judge 实际渲染结果
+                {localize(
+                  props.locale,
+                  'UI Judge 实际渲染结果',
+                  'UI Judge render results',
+                )}
               </h3>
               <p>
-                图片来自正式 full Bench 中该 run 的 UI Judge 同一次 Lynx
-                capture；当前按每个场景 repeat 1 抽样展示。
+                {localize(
+                  props.locale,
+                  '图片来自正式 full Bench 中该 run 的 UI Judge 同一次 Lynx capture；当前按每个场景 repeat 1 抽样展示。',
+                  'Each image comes from the same Lynx capture scored by UI Judge for that run in the formal full Bench. The gallery shows repeat 1 for each scenario.',
+                )}
               </p>
             </div>
             <button
               type='button'
-              aria-label='关闭 UI Judge 实际渲染结果'
+              aria-label={localize(
+                props.locale,
+                '关闭 UI Judge 实际渲染结果',
+                'Close UI Judge render results',
+              )}
               onClick={() => dialogRef.current?.close()}
             >
-              关闭
+              {localize(props.locale, '关闭', 'Close')}
             </button>
           </header>
 
           <div
             className='phaseTwoReportEvidenceDialogTabs'
             role='tablist'
-            aria-label='选择 UI Judge 截图场景'
+            aria-label={localize(
+              props.locale,
+              '选择 UI Judge 截图场景',
+              'Select a UI Judge screenshot scenario',
+            )}
           >
             {scenarioIds.map((scenarioId) => {
               const name = props.evidence.find((item) =>
@@ -798,7 +948,13 @@ function JudgeScreenshotGallery(props: {
           >
             <header>
               <strong>{selectedName}</strong>
-              <span>同任务 · 同模型 · 同一正式 pair</span>
+              <span>
+                {localize(
+                  props.locale,
+                  '同任务 · 同模型 · 同一正式 pair',
+                  'Same task · same model · same formal pair',
+                )}
+              </span>
             </header>
             <div className='phaseTwoReportEvidenceGrid'>
               {selected.map((item) => (
@@ -813,9 +969,15 @@ function JudgeScreenshotGallery(props: {
                   >
                     <img
                       src={item.screenshotUrl}
-                      alt={`${item.scenarioName} 的 ${
-                        protocolLabel(item.protocol)
-                      } Lynx 实际渲染截图`}
+                      alt={localize(
+                        props.locale,
+                        `${item.scenarioName} 的 ${
+                          protocolLabel(item.protocol)
+                        } Lynx 实际渲染截图`,
+                        `${
+                          protocolLabel(item.protocol)
+                        } Lynx render for ${item.scenarioName}`,
+                      )}
                       loading='lazy'
                     />
                   </a>
@@ -846,6 +1008,7 @@ function JudgeScreenshotGallery(props: {
 function MetricBeam(props: {
   a2ui: PublishedMetrics;
   completePairs: number;
+  locale: BenchLocale;
   metric: MetricDefinition;
   openui: PublishedMetrics;
   outcomes: PairedOutcomeSummary;
@@ -868,21 +1031,34 @@ function MetricBeam(props: {
       <div className='phaseTwoReportBeamHeader'>
         <div>
           <span>{props.metric.description}</span>
-          <strong>{describeDelta(props.metric, a2uiValue, openuiValue)}</strong>
+          <strong>
+            {describeDelta(
+              props.metric,
+              a2uiValue,
+              openuiValue,
+              props.locale,
+            )}
+          </strong>
         </div>
         <small>
-          {props.completePairs}/{props.pairCount} complete / planned pairs ·
-          {' '}
-          {props.metric.direction === 'higher'
-            ? '越高越好'
-            : '越低越好'}
+          {props.completePairs}/{props.pairCount} {localize(
+            props.locale,
+            'complete / planned pairs',
+            'complete / planned pairs',
+          )} · {props.metric.direction === 'higher'
+            ? localize(props.locale, '越高越好', 'higher is better')
+            : localize(props.locale, '越低越好', 'lower is better')}
         </small>
       </div>
 
       <div
         className='phaseTwoReportPairRecord'
         role='group'
-        aria-label={`${props.metric.label}的 A2UI 配对结果：${props.outcomes.a2uiWins} 胜，${props.outcomes.ties} 平，${props.outcomes.a2uiLosses} 负；${props.outcomes.comparablePairs} 个可比较 pair`}
+        aria-label={localize(
+          props.locale,
+          `${props.metric.label}的 A2UI 配对结果：${props.outcomes.a2uiWins} 胜，${props.outcomes.ties} 平，${props.outcomes.a2uiLosses} 负；${props.outcomes.comparablePairs} 个可比较 pair`,
+          `${props.metric.label}, paired results from the A2UI perspective: ${props.outcomes.a2uiWins} wins, ${props.outcomes.ties} ties, ${props.outcomes.a2uiLosses} losses; ${props.outcomes.comparablePairs} comparable pairs`,
+        )}
       >
         <span aria-hidden='true'>A2UI W / T / L</span>
         <strong aria-hidden='true'>
@@ -893,7 +1069,11 @@ function MetricBeam(props: {
           <b data-outcome='loss'>{props.outcomes.a2uiLosses}</b>
         </strong>
         <small aria-hidden='true'>
-          {props.outcomes.comparablePairs} comparable pairs · A2UI perspective
+          {props.outcomes.comparablePairs} {localize(
+            props.locale,
+            'comparable pairs · A2UI perspective',
+            'comparable pairs · A2UI perspective',
+          )}
         </small>
       </div>
 
@@ -940,19 +1120,20 @@ function MetricBeam(props: {
 }
 
 function ProtocolOverview(props: {
+  locale: BenchLocale;
   metrics: PublishedMetrics;
   protocol: Protocol;
 }) {
   const rows = [
     [
-      '最终有效率',
+      localize(props.locale, '最终有效率', 'Final valid rate'),
       formatMetric(
         'finalValidRate',
         displayMetric(props.metrics, 'finalValidRate'),
       ),
     ],
     [
-      '首轮通过率',
+      localize(props.locale, '首轮通过率', 'First-pass rate'),
       formatMetric('passAt1Rate', displayMetric(props.metrics, 'passAt1Rate')),
     ],
     [
@@ -963,14 +1144,18 @@ function ProtocolOverview(props: {
       ),
     ],
     [
-      '平均总 Tokens',
+      localize(props.locale, '平均总 Tokens', 'Average total tokens'),
       formatMetric(
         'avgTokensAllRuns',
         displayMetric(props.metrics, 'avgTokensAllRuns'),
       ),
     ],
     [
-      '平均生成耗时',
+      localize(
+        props.locale,
+        '平均生成耗时',
+        'Average generation latency',
+      ),
       formatMetric(
         'avgGenerationMsAllRuns',
         displayMetric(props.metrics, 'avgGenerationMsAllRuns'),
@@ -989,7 +1174,13 @@ function ProtocolOverview(props: {
         </span>
         <div>
           <h3>{protocolLabel(props.protocol)}</h3>
-          <p>{props.metrics.plannedRuns} planned protocol runs</p>
+          <p>
+            {props.metrics.plannedRuns} {localize(
+              props.locale,
+              'planned protocol runs',
+              'planned protocol runs',
+            )}
+          </p>
         </div>
       </header>
       <dl>
@@ -1001,8 +1192,13 @@ function ProtocolOverview(props: {
         ))}
       </dl>
       <footer>
-        <span>完成 {props.metrics.completedRuns}</span>
-        <span>失败 {props.metrics.failedRuns}</span>
+        <span>
+          {localize(props.locale, '完成', 'Completed')}{' '}
+          {props.metrics.completedRuns}
+        </span>
+        <span>
+          {localize(props.locale, '失败', 'Failed')} {props.metrics.failedRuns}
+        </span>
         <span>
           Judge coverage {Math.round(props.metrics.judgeCoverageRate * 100)}%
         </span>
@@ -1011,16 +1207,25 @@ function ProtocolOverview(props: {
   );
 }
 
-function formatMethodologyValue(value: unknown): string {
+function formatMethodologyValue(
+  value: unknown,
+  locale: BenchLocale,
+): string {
   if (Array.isArray(value)) {
-    return value.map((item) => formatMethodologyValue(item)).join(' · ');
+    return value.map((item) => formatMethodologyValue(item, locale)).join(
+      ' · ',
+    );
   }
   if (value && typeof value === 'object') {
     return Object.entries(value as Record<string, unknown>)
-      .map(([key, item]) => `${key}: ${formatMethodologyValue(item)}`)
+      .map(([key, item]) => `${key}: ${formatMethodologyValue(item, locale)}`)
       .join(' · ');
   }
-  if (typeof value === 'boolean') return value ? 'enabled' : 'disabled';
+  if (typeof value === 'boolean') {
+    return value
+      ? localize(locale, 'enabled', 'enabled')
+      : localize(locale, 'disabled', 'disabled');
+  }
   if (typeof value === 'string' || typeof value === 'number') {
     return String(value);
   }
@@ -1037,6 +1242,7 @@ function methodologyLabel(value: string): string {
 function collectScenarioDiagnostics(
   pairs: readonly PublishedPair[],
   scenarioId: string,
+  locale: BenchLocale,
 ): ScenarioDiagnostic[] {
   const diagnostics = new Map<string, ScenarioDiagnostic>();
   const add = (
@@ -1061,13 +1267,28 @@ function collectScenarioDiagnostics(
     for (const protocol of ['a2ui', 'openui'] as const) {
       const run = pair.runs[protocol];
       if (!run) {
-        add(pair, protocol, 'error', '缺少计划运行结果');
+        add(
+          pair,
+          protocol,
+          'error',
+          localize(
+            locale,
+            '缺少计划运行结果',
+            'Missing planned run result',
+          ),
+        );
         continue;
       }
       const errors = [...run.errors];
       const warnings = [...run.warnings];
       if (run.status === 'failed' && errors.length === 0) {
-        errors.push('运行失败，未提供错误详情');
+        errors.push(
+          localize(
+            locale,
+            '运行失败，未提供错误详情',
+            'The run failed without error details',
+          ),
+        );
       }
       for (const message of errors) add(pair, protocol, 'error', message);
       for (const message of warnings) add(pair, protocol, 'warning', message);
@@ -1076,7 +1297,7 @@ function collectScenarioDiagnostics(
   return [...diagnostics.values()];
 }
 
-function MatchedCoreExplainer() {
+function MatchedCoreExplainer(props: { locale: BenchLocale }) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -1138,35 +1359,66 @@ function MatchedCoreExplainer() {
       >
         <header>
           <div>
-            <small>评测口径</small>
+            <small>
+              {localize(props.locale, '评测口径', 'Evaluation scope')}
+            </small>
             <strong id='phase-two-report-matched-core-title'>
-              什么是 matched-core？
+              {localize(
+                props.locale,
+                '什么是 matched-core？',
+                'What is matched-core?',
+              )}
             </strong>
             <p>
-              它表示在可对齐的核心条件下做成对比较：同一任务、模型和重复轮次，
-              分别生成 A2UI 与 OpenUI，再进入同一套 Lynx 渲染与 UI Judge。
+              {localize(
+                props.locale,
+                '它表示在可对齐的核心条件下做成对比较：同一任务、模型和重复轮次，分别生成 A2UI 与 OpenUI，再进入同一套 Lynx 渲染与 UI Judge。',
+                'It compares the protocols in pairs under aligned core conditions: the same task, model, and repeat generate A2UI and OpenUI outputs, which then enter the same Lynx rendering and UI Judge pipeline.',
+              )}
             </p>
           </div>
           <button
             type='button'
-            aria-label='收起 matched-core 说明'
+            aria-label={localize(
+              props.locale,
+              '收起 matched-core 说明',
+              'Collapse the matched-core explanation',
+            )}
             onClick={closeAndRestoreFocus}
           >
-            收起
+            {localize(props.locale, '收起', 'Collapse')}
           </button>
         </header>
 
         <div
           className='phaseTwoReportMatchedCoreFlow'
-          aria-label='matched-core 配对评测流程'
+          aria-label={localize(
+            props.locale,
+            'matched-core 配对评测流程',
+            'matched-core paired evaluation flow',
+          )}
         >
           <div>
-            <small>01 · 配对输入</small>
-            <strong>同一 task × model × repeat</strong>
+            <small>
+              {localize(props.locale, '01 · 配对输入', '01 · Paired input')}
+            </small>
+            <strong>
+              {localize(
+                props.locale,
+                '同一 task × model × repeat',
+                'Same task × model × repeat',
+              )}
+            </strong>
           </div>
           <span aria-hidden='true'>→</span>
           <div>
-            <small>02 · 协议分流</small>
+            <small>
+              {localize(
+                props.locale,
+                '02 · 协议分流',
+                '02 · Protocol split',
+              )}
+            </small>
             <p>
               <b data-protocol='a2ui'>A2UI</b>
               <b data-protocol='openui'>OpenUI</b>
@@ -1174,26 +1426,52 @@ function MatchedCoreExplainer() {
           </div>
           <span aria-hidden='true'>→</span>
           <div>
-            <small>03 · 同一把尺</small>
+            <small>
+              {localize(
+                props.locale,
+                '03 · 同一把尺',
+                '03 · Shared measure',
+              )}
+            </small>
             <strong>Lynx capture + UI Judge</strong>
           </div>
         </div>
 
         <dl className='phaseTwoReportMatchedCoreNotes'>
           <div>
-            <dt>固定一致</dt>
-            <dd>生成模型、场景任务、重复轮次、运行环境、截图与 Judge 口径。</dd>
-          </div>
-          <div>
-            <dt>保留差异</dt>
+            <dt>
+              {localize(props.locale, '固定一致', 'Held constant')}
+            </dt>
             <dd>
-              协议 schema、组件表达和适配 prompt 保持各自实现，不强行抹平。
+              {localize(
+                props.locale,
+                '生成模型、场景任务、重复轮次、运行环境、截图与 Judge 口径。',
+                'Generation model, scenario task, repeat, runtime environment, screenshot, and Judge criteria.',
+              )}
             </dd>
           </div>
           <div>
-            <dt>如何解读</dt>
+            <dt>
+              {localize(props.locale, '保留差异', 'Kept distinct')}
+            </dt>
             <dd>
-              适合看相近条件下的配对方向，不代表统计显著或任何场景下的绝对优劣。
+              {localize(
+                props.locale,
+                '协议 schema、组件表达和适配 prompt 保持各自实现，不强行抹平。',
+                'Each protocol retains its own schema, component expression, and adaptation prompt instead of forcing artificial equivalence.',
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt>
+              {localize(props.locale, '如何解读', 'How to interpret it')}
+            </dt>
+            <dd>
+              {localize(
+                props.locale,
+                '适合看相近条件下的配对方向，不代表统计显著或任何场景下的绝对优劣。',
+                'Use it to inspect paired direction under similar conditions, not as proof of statistical significance or absolute superiority in every scenario.',
+              )}
             </dd>
           </div>
         </dl>
@@ -1203,11 +1481,15 @@ function MatchedCoreExplainer() {
 }
 
 export function PhaseTwoReportPage(props: {
+  locale?: BenchLocale;
   report?: PublishedReport;
 }) {
+  const locale = props.locale ?? DEFAULT_BENCH_LOCALE;
   const report = props.report ?? REPORT;
   const evidence = collectFormalScreenshotEvidence(report);
-  const limitations = report.limitations;
+  const limitations = report.limitations.map((item) =>
+    localizeLimitation(item, locale)
+  );
   const modelOptions = useMemo(
     () => [
       ...new Set([
@@ -1234,7 +1516,9 @@ export function PhaseTwoReportPage(props: {
     () => summarizePublishedSelection(report),
     [report],
   );
-  const metric = METRICS.find((item) => item.key === metricKey) ?? METRICS[0];
+  const localizedMetrics = METRICS.map((item) => localizeMetric(item, locale));
+  const metric = localizedMetrics.find((item) => item.key === metricKey)
+    ?? localizedMetrics[0];
   const pairedOutcomes = useMemo(
     () => summarizePairedOutcomes(report.pairs, metric.key, model, scenario),
     [metric.key, model, report.pairs, scenario],
@@ -1244,6 +1528,7 @@ export function PhaseTwoReportPage(props: {
     overall.openui,
     overall.pairCount,
     overall.completePairs,
+    locale,
   );
   const visibleScenarios = report.scenarios.filter((item) =>
     scenario === 'all' || item.id === scenario
@@ -1258,6 +1543,7 @@ export function PhaseTwoReportPage(props: {
         diagnostics: collectScenarioDiagnostics(
           modelFilteredPairs,
           item.id,
+          locale,
         ),
         item,
         summary,
@@ -1265,14 +1551,32 @@ export function PhaseTwoReportPage(props: {
       : [];
   });
   const methodology = [
-    ['执行模式', report.methodology.modes],
-    ['能力口径', report.methodology.capabilityProfiles],
-    ['协议版本', report.methodology.protocolVersions],
+    [
+      localize(locale, '执行模式', 'Execution modes'),
+      report.methodology.modes,
+    ],
+    [
+      localize(locale, '能力口径', 'Capability profiles'),
+      report.methodology.capabilityProfiles,
+    ],
+    [
+      localize(locale, '协议版本', 'Protocol versions'),
+      report.methodology.protocolVersions,
+    ],
     ['Provider API', report.methodology.providerApis],
-    ['Judge 模型', report.methodology.judgeModels],
-    ['重复轮次', report.methodology.repeats],
-    ['最大尝试次数', report.methodology.maxAttempts],
-    ['超时时间（ms）', report.methodology.timeoutMs],
+    [
+      localize(locale, 'Judge 模型', 'Judge models'),
+      report.methodology.judgeModels,
+    ],
+    [localize(locale, '重复轮次', 'Repeats'), report.methodology.repeats],
+    [
+      localize(locale, '最大尝试次数', 'Maximum attempts'),
+      report.methodology.maxAttempts,
+    ],
+    [
+      localize(locale, '超时时间（ms）', 'Timeout (ms)'),
+      report.methodology.timeoutMs,
+    ],
     ['Render', report.methodology.renderEnabled],
     ['Judge', report.methodology.judgeEnabled],
   ] as const;
@@ -1282,7 +1586,7 @@ export function PhaseTwoReportPage(props: {
       <header className='phaseTwoReportHero'>
         <div className='phaseTwoReportHeroMeta'>
           <span>Lynx A2UI Bench · Phase 02</span>
-          <MatchedCoreExplainer />
+          <MatchedCoreExplainer locale={locale} />
         </div>
         <div className='phaseTwoReportHeroGrid'>
           <div className='phaseTwoReportHeroLead'>
@@ -1291,7 +1595,7 @@ export function PhaseTwoReportPage(props: {
             </p>
             <h1>{report.title}</h1>
             <div className='phaseTwoReportThesis'>
-              <span>结论</span>
+              <span>{localize(locale, '结论', 'Conclusion')}</span>
               <p>{thesis}</p>
             </div>
           </div>
@@ -1320,10 +1624,13 @@ export function PhaseTwoReportPage(props: {
           </dl>
         </div>
         <div className='phaseTwoReportRunStrip'>
-          <span>口径</span>
+          <span>{localize(locale, '口径', 'Scope')}</span>
           <p>
-            相同模型、相同任务、相同重复轮次，分别生成 A2UI 与 OpenUI，
-            并以全部计划运行作为失败、缺失和取消样本的统一分母。
+            {localize(
+              locale,
+              '相同模型、相同任务、相同重复轮次，分别生成 A2UI 与 OpenUI，并以全部计划运行作为失败、缺失和取消样本的统一分母。',
+              'A2UI and OpenUI are generated with the same model, task, and repeat. All planned runs form the shared denominator, including failed, missing, and cancelled samples.',
+            )}
           </p>
         </div>
       </header>
@@ -1336,27 +1643,52 @@ export function PhaseTwoReportPage(props: {
           index='01'
           label='Protocol overview'
           id='phase-two-report-overview'
-          title='先看全局，再进入差值'
-          description='两侧指标独立按同一计划运行口径聚合；颜色只标识协议，不表达优劣。'
+          title={localize(
+            locale,
+            '先看全局，再进入差值',
+            'Start with the overview, then inspect the delta',
+          )}
+          description={localize(
+            locale,
+            '两侧指标独立按同一计划运行口径聚合；颜色只标识协议，不表达优劣。',
+            'Both sides aggregate metrics over the same planned-run scope. Color identifies the protocol; it does not imply rank.',
+          )}
         />
         {overall.pairCount > 0
           ? (
             <div className='phaseTwoReportProtocolPair'>
-              <ProtocolOverview protocol='a2ui' metrics={overall.a2ui} />
+              <ProtocolOverview
+                locale={locale}
+                protocol='a2ui'
+                metrics={overall.a2ui}
+              />
               <div className='phaseTwoReportProtocolSpine' aria-hidden='true'>
                 <span />
                 <b>PAIR</b>
                 <span />
               </div>
-              <ProtocolOverview protocol='openui' metrics={overall.openui} />
+              <ProtocolOverview
+                locale={locale}
+                protocol='openui'
+                metrics={overall.openui}
+              />
             </div>
           )
           : (
             <div className='phaseTwoReportEmptyState' role='status'>
-              <strong>尚无可发布的 paired evidence</strong>
+              <strong>
+                {localize(
+                  locale,
+                  '尚无可发布的 paired evidence',
+                  'No publishable paired evidence yet',
+                )}
+              </strong>
               <p>
-                当前 artifact 不包含计划 pair。完成 Phase 2 运行并发布 canonical
-                report 后，此处才会展示协议结论。
+                {localize(
+                  locale,
+                  '当前 artifact 不包含计划 pair。完成 Phase 2 运行并发布 canonical report 后，此处才会展示协议结论。',
+                  'This artifact contains no planned pairs. Protocol conclusions appear after a Phase 2 run is completed and its canonical report is published.',
+                )}
               </p>
             </div>
           )}
@@ -1370,18 +1702,37 @@ export function PhaseTwoReportPage(props: {
           index='02'
           label='Paired delta instrument'
           id='phase-two-report-delta'
-          title='把差异放回同一条零轴'
-          description='中轴不是排行榜：左侧表示 A2UI 占优，右侧表示 OpenUI 占优，横梁长度按两侧均值的相对差异缩放。'
+          title={localize(
+            locale,
+            '把差异放回同一条零轴',
+            'Place each difference on a shared zero axis',
+          )}
+          description={localize(
+            locale,
+            '中轴不是排行榜：左侧表示 A2UI 占优，右侧表示 OpenUI 占优，横梁长度按两侧均值的相对差异缩放。',
+            'The axis is not a leaderboard: left favors A2UI, right favors OpenUI, and beam length scales with the relative difference between their means.',
+          )}
         />
 
-        <div className='phaseTwoReportFilters' aria-label='报告筛选条件'>
+        <div
+          className='phaseTwoReportFilters'
+          aria-label={localize(
+            locale,
+            '报告筛选条件',
+            'Report filters',
+          )}
+        >
           <ReportSelect
             id='phase-two-report-model-filter'
             label='Generation model'
+            placeholder={localize(locale, '暂无选项', 'No options')}
             value={model}
             disabled={modelOptions.length === 0}
             options={[
-              { label: '全部模型', value: 'all' },
+              {
+                label: localize(locale, '全部模型', 'All models'),
+                value: 'all',
+              },
               ...modelOptions.map((item) => ({ label: item, value: item })),
             ]}
             onChange={setModel}
@@ -1389,10 +1740,14 @@ export function PhaseTwoReportPage(props: {
           <ReportSelect
             id='phase-two-report-scenario-filter'
             label='Scenario'
+            placeholder={localize(locale, '暂无选项', 'No options')}
             value={scenario}
             disabled={report.scenarios.length === 0}
             options={[
-              { label: '全部场景', value: 'all' },
+              {
+                label: localize(locale, '全部场景', 'All scenarios'),
+                value: 'all',
+              },
               ...report.scenarios.map((item) => ({
                 disabled: model !== 'all'
                   && !scenarioIdsForModel.has(item.id),
@@ -1420,9 +1775,13 @@ export function PhaseTwoReportPage(props: {
               <div
                 className='phaseTwoReportMetricTabs'
                 role='tablist'
-                aria-label='选择配对指标'
+                aria-label={localize(
+                  locale,
+                  '选择配对指标',
+                  'Select a paired metric',
+                )}
               >
-                {METRICS.map((item) => (
+                {localizedMetrics.map((item) => (
                   <button
                     type='button'
                     role='tab'
@@ -1440,6 +1799,7 @@ export function PhaseTwoReportPage(props: {
                         item,
                         displayMetric(selection.a2ui, item.key),
                         displayMetric(selection.openui, item.key),
+                        locale,
                       )}
                     </small>
                   </button>
@@ -1449,6 +1809,7 @@ export function PhaseTwoReportPage(props: {
               <MetricBeam
                 a2ui={selection.a2ui}
                 completePairs={selection.completePairs}
+                locale={locale}
                 metric={metric}
                 openui={selection.openui}
                 outcomes={pairedOutcomes}
@@ -1458,10 +1819,19 @@ export function PhaseTwoReportPage(props: {
           )
           : (
             <div className='phaseTwoReportEmptyState' role='status'>
-              <strong>此筛选暂无 paired evidence</strong>
+              <strong>
+                {localize(
+                  locale,
+                  '此筛选暂无 paired evidence',
+                  'No paired evidence for these filters',
+                )}
+              </strong>
               <p>
-                当前模型与场景没有共同计划运行，因此不显示 0
-                值或“持平”结论。请选择其他筛选条件。
+                {localize(
+                  locale,
+                  '当前模型与场景没有共同计划运行，因此不显示 0 值或“持平”结论。请选择其他筛选条件。',
+                  'The selected model and scenario have no shared planned runs, so the report does not show a zero value or tie. Choose different filters.',
+                )}
               </p>
             </div>
           )}
@@ -1475,12 +1845,26 @@ export function PhaseTwoReportPage(props: {
           index='03'
           label='Scenario ledger'
           id='phase-two-report-ledger'
-          title='逐场景核对方向是否一致'
-          description='Ledger 跟随模型与场景筛选。均值差异只能说明本轮方向，不代表跨任务的统计显著性。'
+          title={localize(
+            locale,
+            '逐场景核对方向是否一致',
+            'Check whether the direction holds per scenario',
+          )}
+          description={localize(
+            locale,
+            'Ledger 跟随模型与场景筛选。均值差异只能说明本轮方向，不代表跨任务的统计显著性。',
+            'The ledger follows the model and scenario filters. Mean differences show direction for this run, not statistical significance across tasks.',
+          )}
         />
         <div className='phaseTwoReportLedgerWrap'>
           <table className='phaseTwoReportLedger'>
-            <caption>A2UI 与 OpenUI 的逐场景 paired 聚合</caption>
+            <caption>
+              {localize(
+                locale,
+                'A2UI 与 OpenUI 的逐场景 paired 聚合',
+                'Per-scenario paired aggregates for A2UI and OpenUI',
+              )}
+            </caption>
             <thead>
               <tr>
                 <th scope='col'>Scenario</th>
@@ -1523,14 +1907,15 @@ export function PhaseTwoReportPage(props: {
                       </td>
                       <td>
                         {describeDelta(
-                          METRICS[3],
+                          localizedMetrics[3],
                           displayMetric(summary.a2ui, 'avgTokensAllRuns'),
                           displayMetric(summary.openui, 'avgTokensAllRuns'),
+                          locale,
                         )}
                       </td>
                       <td>
                         {describeDelta(
-                          METRICS[4],
+                          localizedMetrics[4],
                           displayMetric(
                             summary.a2ui,
                             'avgGenerationMsAllRuns',
@@ -1539,11 +1924,12 @@ export function PhaseTwoReportPage(props: {
                             summary.openui,
                             'avgGenerationMsAllRuns',
                           ),
+                          locale,
                         )}
                       </td>
                       <td>
                         {describeDelta(
-                          METRICS[2],
+                          localizedMetrics[2],
                           displayMetric(
                             summary.a2ui,
                             'avgJudgeScoreAllRuns',
@@ -1552,6 +1938,7 @@ export function PhaseTwoReportPage(props: {
                             summary.openui,
                             'avgJudgeScoreAllRuns',
                           ),
+                          locale,
                         )}
                       </td>
                     </tr>
@@ -1560,7 +1947,11 @@ export function PhaseTwoReportPage(props: {
                         <td colSpan={7}>
                           <details>
                             <summary>
-                              {diagnostics.length} 条场景诊断
+                              {localize(
+                                locale,
+                                `${diagnostics.length} 条场景诊断`,
+                                `${diagnostics.length} scenario diagnostics`,
+                              )}
                             </summary>
                             <ul>
                               {diagnostics.map((diagnostic) => (
@@ -1585,14 +1976,18 @@ export function PhaseTwoReportPage(props: {
                 : (
                   <tr className='phaseTwoReportLedgerEmptyRow'>
                     <td colSpan={7}>
-                      当前筛选没有计划 pair，无法生成逐场景 ledger。
+                      {localize(
+                        locale,
+                        '当前筛选没有计划 pair，无法生成逐场景 ledger。',
+                        'The current filters contain no planned pairs, so a per-scenario ledger cannot be generated.',
+                      )}
                     </td>
                   </tr>
                 )}
             </tbody>
           </table>
         </div>
-        <JudgeScreenshotGallery evidence={evidence} />
+        <JudgeScreenshotGallery evidence={evidence} locale={locale} />
       </section>
 
       <section
@@ -1603,20 +1998,30 @@ export function PhaseTwoReportPage(props: {
           index='04'
           label='Methodology & boundaries'
           id='phase-two-report-method'
-          title='结果成立的条件'
-          description='先确认匹配条件、覆盖率与失败分母，再把结果用于协议决策。'
+          title={localize(
+            locale,
+            '结果成立的条件',
+            'Conditions behind the results',
+          )}
+          description={localize(
+            locale,
+            '先确认匹配条件、覆盖率与失败分母，再把结果用于协议决策。',
+            'Confirm matching conditions, coverage, and the failure denominator before using the results for protocol decisions.',
+          )}
         />
         <div className='phaseTwoReportMethodGrid'>
           <article>
             <header>
               <span>METHOD</span>
-              <h3>实验口径</h3>
+              <h3>
+                {localize(locale, '实验口径', 'Evaluation methodology')}
+              </h3>
             </header>
             <dl>
               {methodology.map(([key, value]) => (
                 <div key={key}>
                   <dt>{methodologyLabel(key)}</dt>
-                  <dd>{formatMethodologyValue(value)}</dd>
+                  <dd>{formatMethodologyValue(value, locale)}</dd>
                 </div>
               ))}
             </dl>
@@ -1624,7 +2029,9 @@ export function PhaseTwoReportPage(props: {
           <article>
             <header>
               <span>LIMITS</span>
-              <h3>解读边界</h3>
+              <h3>
+                {localize(locale, '解读边界', 'Interpretation boundaries')}
+              </h3>
             </header>
             {limitations.length > 0
               ? (
@@ -1632,10 +2039,24 @@ export function PhaseTwoReportPage(props: {
                   {limitations.map((item) => <li key={item}>{item}</li>)}
                 </ul>
               )
-              : <p className='phaseTwoReportEmpty'>当前报告未声明额外限制。</p>}
+              : (
+                <p className='phaseTwoReportEmpty'>
+                  {localize(
+                    locale,
+                    '当前报告未声明额外限制。',
+                    'This report declares no additional limitations.',
+                  )}
+                </p>
+              )}
             {report.warnings.length > 0 && (
               <details>
-                <summary>{report.warnings.length} 条运行告警</summary>
+                <summary>
+                  {localize(
+                    locale,
+                    `${report.warnings.length} 条运行告警`,
+                    `${report.warnings.length} run warnings`,
+                  )}
+                </summary>
                 <ul>
                   {report.warnings.map((item) => <li key={item}>{item}</li>)}
                 </ul>
@@ -1648,7 +2069,13 @@ export function PhaseTwoReportPage(props: {
       <footer className='phaseTwoReportFooter'>
         <div>
           <span>Lynx A2UI Bench · Phase 02</span>
-          <p>协议差异应从 paired evidence 出发，而不是从单次截图出发。</p>
+          <p>
+            {localize(
+              locale,
+              '协议差异应从 paired evidence 出发，而不是从单次截图出发。',
+              'Protocol differences should be grounded in paired evidence, not a single screenshot.',
+            )}
+          </p>
         </div>
       </footer>
     </main>

--- a/packages/genui/playground/src/pages/bench/benchLocale.test.ts
+++ b/packages/genui/playground/src/pages/bench/benchLocale.test.ts
@@ -1,0 +1,16 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { DEFAULT_BENCH_LOCALE, parseBenchLocale } from './benchLocale.js';
+
+describe('bench locale', () => {
+  test('accepts only supported locale values', () => {
+    expect(parseBenchLocale('zh-CN')).toBe('zh-CN');
+    expect(parseBenchLocale('en-US')).toBe('en-US');
+    expect(parseBenchLocale('en')).toBeNull();
+    expect(parseBenchLocale(null)).toBeNull();
+    expect(DEFAULT_BENCH_LOCALE).toBe('zh-CN');
+  });
+});

--- a/packages/genui/playground/src/pages/bench/benchLocale.ts
+++ b/packages/genui/playground/src/pages/bench/benchLocale.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export type BenchLocale = 'en-US' | 'zh-CN';
+
+export const DEFAULT_BENCH_LOCALE: BenchLocale = 'zh-CN';
+export const BENCH_LOCALE_STORAGE_KEY = 'lynx-genui-bench-locale';
+
+export function parseBenchLocale(value: unknown): BenchLocale | null {
+  return value === 'en-US' || value === 'zh-CN' ? value : null;
+}
+
+export function readBenchLocale(): BenchLocale {
+  try {
+    return parseBenchLocale(
+      window.localStorage.getItem(BENCH_LOCALE_STORAGE_KEY),
+    ) ?? DEFAULT_BENCH_LOCALE;
+  } catch {
+    return DEFAULT_BENCH_LOCALE;
+  }
+}
+
+export function writeBenchLocale(locale: BenchLocale): void {
+  try {
+    window.localStorage.setItem(BENCH_LOCALE_STORAGE_KEY, locale);
+  } catch {
+    // Ignore localStorage errors and keep the in-memory preference.
+  }
+}

--- a/packages/genui/playground/src/pages/bench/phaseOne.ts
+++ b/packages/genui/playground/src/pages/bench/phaseOne.ts
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { BenchLocale } from './benchLocale.js';
+
 export type BenchMetricKey =
   | 'totalTokens'
   | 'agentMs'
@@ -67,7 +69,7 @@ export interface BenchScenario {
   id: string;
   name: string;
   businessMode: string;
-  complexity: '低' | '中' | '高';
+  complexity: 'High' | 'Low' | 'Medium' | '低' | '中' | '高';
   interaction: string;
   prompt: string;
   purpose: string;
@@ -83,7 +85,7 @@ export interface BenchRecommendation {
   title: string;
   summary: string;
   combination: readonly {
-    dimension: '模型' | 'Prompt' | 'Catalog';
+    dimension: 'Catalog' | 'Model' | 'Prompt' | '模型';
     comparisonId: string;
     label: string;
   }[];
@@ -517,3 +519,288 @@ export const PHASE_ONE_BENCH = {
     'UI Judge 由模型自动评分，只适合横向比较与基础合理性检查，不能替代人工 UI 评审。',
   ],
 } as const satisfies PhaseOneBench;
+
+type PhaseOneHighlightId = typeof PHASE_ONE_BENCH.highlights[number]['id'];
+type PhaseOneMethodItemId =
+  typeof PHASE_ONE_BENCH.methodology.items[number]['id'];
+type PhaseOneScenarioId = typeof PHASE_ONE_BENCH.scenarios[number]['id'];
+
+interface ComparisonCopy {
+  fixedCondition: string;
+  rows: Record<
+    string,
+    {
+      descriptor: string;
+      risk: string;
+      strength: string;
+    }
+  >;
+  title: string;
+  variable: string;
+}
+
+const ENGLISH_HIGHLIGHTS = {
+  'lowest-model-cost': {
+    title: 'Model: lowest average token usage',
+    metricLabel: 'Average tokens',
+    detail:
+      'Used the fewest average tokens in the model comparison and tied for the highest UI Judge score.',
+  },
+  'fastest-model': {
+    title: 'Model: lowest agent latency',
+    metricLabel: 'Average agent latency',
+    detail:
+      'Recorded the lowest average agent latency in the model comparison, but used more tokens than gpt-5.5.',
+  },
+  'best-prompt': {
+    title: 'System Prompt: best overall',
+    metricLabel: 'UI Judge score',
+    detail:
+      'Averaged 8.3k tokens and 24.4s of agent latency, outperforming the baseline on all three primary metrics.',
+  },
+  'best-catalog': {
+    title: 'Catalog: best token usage and UI Judge score',
+    metricLabel: 'UI Judge score',
+    detail:
+      'Averaged 7.9k tokens with a six-component Catalog, although agent latency was not the lowest in the group.',
+  },
+} as const satisfies Record<
+  PhaseOneHighlightId,
+  {
+    detail: string;
+    metricLabel: string;
+    title: string;
+  }
+>;
+
+const ENGLISH_COMPARISONS: Record<
+  BenchComparison['id'],
+  ComparisonCopy
+> = {
+  models: {
+    title: 'Experiment A · Model comparison',
+    variable: 'Model',
+    fixedCondition:
+      'Default A2UI Prompt as the System Prompt and the full base Catalog.',
+    rows: {
+      'deepseek-coder': {
+        descriptor: 'Lowest agent latency',
+        strength:
+          'Average agent latency was 13.9s, the lowest in the model group.',
+        risk:
+          'Average token usage was 15.4k, higher than gpt-5.5; the UI Judge score was 3.0/5.',
+      },
+      'gemini-3-pro': {
+        descriptor: 'Tied UI Judge score, highest token usage and latency',
+        strength:
+          'Averaged 3.0/5 on UI Judge, tied for the highest score in the model group.',
+        risk:
+          'Averaged 22.9k tokens, 61.1s of agent latency, and 2.0 generation attempts.',
+      },
+      'gpt-5-5': {
+        descriptor: 'Lowest token usage, tied for highest UI Judge score',
+        strength:
+          'Averaged 9.3k tokens and 3.0/5 on UI Judge; all three scenarios completed in one attempt.',
+        risk:
+          'Average agent latency was 37.8s. When low latency is the priority, deepseek-coder is faster.',
+      },
+    },
+  },
+  prompts: {
+    title: 'Experiment B · System Prompt comparison',
+    variable: 'System Prompt',
+    fixedCondition:
+      'gpt-5.5-2026-04-24 as the model and the full base Catalog.',
+    rows: {
+      baseline: {
+        descriptor: 'Default A2UI Prompt',
+        strength:
+          'Averaged 3.0/5 on UI Judge and provides a useful default baseline.',
+        risk:
+          'Averaged 12.6k tokens, 41.3s of agent latency, and 1.3 attempts; some runs triggered Repair.',
+      },
+      'token-efficient': {
+        descriptor: 'Best overall result in this round',
+        strength:
+          'Averaged 4.0/5 on UI Judge while reducing token usage to 8.3k and agent latency to 24.4s.',
+        risk:
+          'The output is more restrained. For richer visual expression, restore visual constraints one at a time and revalidate.',
+      },
+      'visual-polish': {
+        descriptor: 'Lower UI Judge score after adding visual requirements',
+        strength:
+          'Averaged 9.7k tokens, and all three scenarios completed in one attempt.',
+        risk:
+          'Averaged only 1.7/5 on UI Judge while agent latency rose to 40.7s.',
+      },
+    },
+  },
+  catalogs: {
+    title: 'Experiment C · Catalog comparison',
+    variable: 'Catalog',
+    fixedCondition:
+      'gpt-5.5-2026-04-24 as the model and Default A2UI Prompt as the System Prompt.',
+    rows: {
+      'full-catalog': {
+        descriptor: '19 components · full base Catalog',
+        strength:
+          'Includes all 19 base components, and all three scenarios completed in one attempt.',
+        risk:
+          'Averaged 9.2k tokens and 3.0/5 on UI Judge; agent latency was 35.3s, lower than Minimal Catalog.',
+      },
+      'core-catalog': {
+        descriptor: '9 components · core capability set',
+        strength: 'Averaged 3.3/5 on UI Judge, higher than Full Catalog.',
+        risk:
+          'Averaged 13.5k tokens, 63.8s of agent latency, and 2.0 generation attempts.',
+      },
+      'minimal-catalog': {
+        descriptor: '6 components · best token usage and UI Judge score',
+        strength:
+          'Averaged 7.9k tokens, the lowest in the group, and 3.7/5 on UI Judge, the highest in the group.',
+        risk:
+          'Average agent latency was 43.7s, higher than Full Catalog. Its six components require separate validation for complex scenarios.',
+      },
+    },
+  },
+};
+
+const ENGLISH_SCENARIOS = {
+  'weather-refresh-card': {
+    name: 'Weather refresh card',
+    businessMode: 'Information lookup',
+    complexity: 'Low',
+    interaction: 'Read + refresh',
+    purpose:
+      'Tests whether the model can control component count in a lightweight information card and avoid overdesign.',
+  },
+  'product-purchase-card': {
+    name: 'Product purchase card',
+    businessMode: 'E-commerce conversion',
+    complexity: 'Medium',
+    interaction: 'Select + convert',
+    purpose:
+      'Tests whether purchase actions, pricing, and variant details form a clear hierarchy.',
+  },
+  'kyoto-trip-planner': {
+    name: 'Kyoto trip planner',
+    businessMode: 'Long-form browsing',
+    complexity: 'High',
+    interaction: 'Browse + save',
+    purpose:
+      'Tests token overhead and structural correctness in long-form flows with deep nesting.',
+  },
+} as const satisfies Record<
+  PhaseOneScenarioId,
+  {
+    businessMode: string;
+    complexity: BenchScenario['complexity'];
+    interaction: string;
+    name: string;
+    purpose: string;
+  }
+>;
+
+const ENGLISH_METHOD_ITEMS = {
+  generation: {
+    title: 'A2UI generation',
+    detail:
+      'Each experiment uses its corresponding A2UI System Prompt and the same project Validator. When validation fails, Repair follows the Runner configuration; attempt count records the actual number of calls.',
+  },
+  rendering: {
+    title: 'A2UI rendering',
+    detail:
+      'Every result is rendered in the same Lynx4Web Playground Preview Runtime, with metrics collected under one consistent definition.',
+  },
+  metrics: {
+    title: 'Metric definitions',
+    detail:
+      'Agent latency is model wall time including Repair. Render, FMP, and TTI are collected by the Preview Runtime. FCP is collected but is not a primary metric in this report.',
+  },
+  judge: {
+    title: 'UI Judge scoring',
+    detail:
+      'UI Judge assigns a 0–5 visual-correctness score. The judge model is gpt-5.5-2026-04-24.',
+  },
+} as const satisfies Record<
+  PhaseOneMethodItemId,
+  {
+    detail: string;
+    title: string;
+  }
+>;
+
+export const PHASE_ONE_BENCH_EN = {
+  ...PHASE_ONE_BENCH,
+  title: 'How should you choose a model, System Prompt, and Catalog?',
+  description:
+    'The benchmark covers three mobile A2UI scenarios. Each experiment changes one variable at a time and uses the same metrics for generation cost, latency, stability, and visual correctness.',
+  conclusion:
+    'In the model group, gpt-5.5 used the fewest average tokens. In the Prompt group, Token Efficient delivered the best balance. In the Catalog group, Minimal Catalog led in token usage and UI Judge score, but not in agent latency.',
+  metricDefinitions: PHASE_ONE_BENCH.metricDefinitions.map((definition) => ({
+    ...definition,
+    label: {
+      totalTokens: 'Tokens',
+      agentMs: 'Agent latency',
+      renderMs: 'Render',
+      fmpMs: 'FMP',
+      ttiMs: 'TTI',
+      judge: 'UI Judge',
+      attempts: 'Generation attempts',
+      success: 'Success',
+    }[definition.key],
+  })),
+  highlights: PHASE_ONE_BENCH.highlights.map((highlight) => ({
+    ...highlight,
+    ...ENGLISH_HIGHLIGHTS[highlight.id],
+  })),
+  recommendation: {
+    title: 'Recommended starting configuration',
+    summary:
+      'Use this configuration as a baseline, then add components gradually for each real-world scenario.',
+    combination: [
+      {
+        ...PHASE_ONE_BENCH.recommendation.combination[0],
+        dimension: 'Model',
+      },
+      PHASE_ONE_BENCH.recommendation.combination[1],
+      PHASE_ONE_BENCH.recommendation.combination[2],
+    ],
+  },
+  comparisons: PHASE_ONE_BENCH.comparisons.map((comparison) => {
+    const copy = ENGLISH_COMPARISONS[comparison.id];
+    return {
+      ...comparison,
+      title: copy.title,
+      variable: copy.variable,
+      fixedCondition: copy.fixedCondition,
+      rows: comparison.rows.map((row) => ({
+        ...row,
+        ...copy.rows[row.id],
+      })),
+    };
+  }),
+  scenarios: PHASE_ONE_BENCH.scenarios.map((scenario) => ({
+    ...scenario,
+    ...ENGLISH_SCENARIOS[scenario.id],
+  })),
+  methodology: {
+    title: 'Methodology and metric definitions',
+    sequence: ['Choose a model', 'Tune the Prompt', 'Reduce the Catalog'],
+    items: PHASE_ONE_BENCH.methodology.items.map((item) => ({
+      ...item,
+      ...ENGLISH_METHOD_ITEMS[item.id],
+    })),
+  },
+  limitations: [
+    'Token counts come from model-provider usage. If Repair is triggered, the total includes the initial generation and every Repair; attempt count is reported separately.',
+    'Render, FMP, and TTI reflect only the local Lynx4Web Preview and do not represent real mobile performance.',
+    'UI Judge is model-based automation intended for relative comparison and basic plausibility checks; it does not replace human UI review.',
+  ],
+} satisfies PhaseOneBench;
+
+export function getPhaseOneBench(
+  locale: BenchLocale = 'zh-CN',
+): PhaseOneBench {
+  return locale === 'en-US' ? PHASE_ONE_BENCH_EN : PHASE_ONE_BENCH;
+}


### PR DESCRIPTION
## Summary

- add a persistent `中文 / EN` switch shared by the Bench Runner, Phase 01, and Phase 02 routes
- localize page chrome, report copy, filters, dialogs, accessibility labels, and the checked-in Phase 02 report limitations
- keep Runner system messages, presets, generated groups, scenarios, and restored history locale-responsive while preserving user-authored text and locale-independent Bench request semantics
- add SSR and locale-switch regression coverage for all three Bench pages

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo build` — 66/66 tasks passed
- `pnpm --filter genui-playground test` — 116/116 tests passed
- targeted dprint, Biome, and ESLint checks
- browser smoke test across `#/bench`, `#/bench/phase-1`, and `#/bench/phase-2`, including an EN → 中文 → EN preset-state switch

## Dependency

Depends on #3312. This PR intentionally targets `p/gcc/fix-phase1-model-count` so the bilingual diff does not duplicate the Phase 01 model-count and evidence-image correction. After #3312 merges, this PR can be retargeted to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English and Chinese language support across benchmark runner, results, reports, navigation, accessibility labels, and status messages.
  * Added a language selector with saved preferences and automatic document language updates.
  * Localized benchmark data, metrics, scenarios, recommendations, evidence, diagnostics, and limitations.
  * Preserved benchmark history and reports while improving restoration of legacy records.

* **Bug Fixes**
  * Improved error and validation messaging for benchmark health checks and runs.

* **Tests**
  * Added coverage for bilingual rendering, locale persistence, accessibility labels, reports, and benchmark content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->