### PR TITLE
fix(genui): respect asset prefix for bench screenshots

### DIFF
--- a/packages/genui/playground/src/pages/bench/PhaseTwoReportPage.test.ts
+++ b/packages/genui/playground/src/pages/bench/PhaseTwoReportPage.test.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { describe, expect, test } from '@rstest/core';
+import { afterEach, describe, expect, rstest, test } from '@rstest/core';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -14,12 +14,17 @@ import {
   buildThesis,
   collectFormalScreenshotEvidence,
   combinePublishedMetrics,
+  resolveFormalScreenshotAssetUrl,
   summarizePairedOutcomes,
   summarizePublishedSelection,
 } from './PhaseTwoReportPage.js';
 
 // Rstest compiles standalone TSX imports with the classic JSX runtime.
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+afterEach(() => {
+  rstest.unstubAllEnvs();
+});
 
 type PhaseTwoPublishedReport = typeof PHASE_TWO_PUBLISHED_REPORT;
 type PhaseTwoPublishedMetrics = PhaseTwoPublishedReport['summary'];
@@ -701,6 +706,7 @@ describe('Phase 2 report page integration', () => {
   });
 
   test('renders captured Judge screenshots in an accessible dialog', () => {
+    rstest.stubEnv('ASSET_PREFIX', '/genui/');
     const report = publishedFixture();
     report.sources = [{
       id: 'report',
@@ -743,6 +749,10 @@ describe('Phase 2 report page integration', () => {
       'run-a2ui',
       'run-openui',
     ]);
+    expect(evidence.map((item) => item.screenshotUrl)).toEqual([
+      '/genui/bench/phase-two/screenshots/run-a2ui.png?v=20260729T000100000Z',
+      '/genui/bench/phase-two/screenshots/run-openui.png?v=20260729T000100000Z',
+    ]);
     expect(evidence.every((item) => item.pairId === 'pair-1')).toBe(true);
     expect(html).toContain('查看 UI Judge 实际渲染结果');
     expect(html).toContain('<dialog');
@@ -750,6 +760,12 @@ describe('Phase 2 report page integration', () => {
     expect(html).toContain('role="tabpanel"');
     expect(html).toContain('run-a2ui.png');
     expect(html).toContain('run-openui.png');
+    expect(html).toContain(
+      'href="/genui/bench/phase-two/screenshots/run-a2ui.png',
+    );
+    expect(html).toContain(
+      'src="/genui/bench/phase-two/screenshots/run-openui.png',
+    );
     expect(html).not.toContain('run-a2ui-2.png');
     expect(html).toContain('Weather content is complete.');
     expect(html).toContain(
@@ -771,6 +787,27 @@ describe('Phase 2 report page integration', () => {
     );
     expect(englishHtml).toContain('A2UI Lynx render for Weather');
     expect(englishHtml).not.toContain('查看 UI Judge 实际渲染结果');
+  });
+
+  test('resolves formal screenshots against the Rsbuild asset prefix', () => {
+    const screenshotUrl =
+      '/bench/phase-two/screenshots/run-a2ui.png?v=20260729T000100000Z';
+
+    expect(resolveFormalScreenshotAssetUrl(screenshotUrl, '')).toBe(
+      screenshotUrl,
+    );
+    expect(resolveFormalScreenshotAssetUrl(screenshotUrl, '/')).toBe(
+      screenshotUrl,
+    );
+    expect(resolveFormalScreenshotAssetUrl(screenshotUrl, '/genui/')).toBe(
+      `/genui${screenshotUrl}`,
+    );
+    expect(
+      resolveFormalScreenshotAssetUrl(
+        screenshotUrl,
+        'https://static.example.com/genui/',
+      ),
+    ).toBe(`https://static.example.com/genui${screenshotUrl}`);
   });
 
   test('does not render untrusted or incomplete screenshot pairs', () => {

--- a/packages/genui/playground/src/pages/bench/PhaseTwoReportPage.tsx
+++ b/packages/genui/playground/src/pages/bench/PhaseTwoReportPage.tsx
@@ -739,6 +739,17 @@ function formalScreenshotVersion(completedAt: string): string | undefined {
   return instant.toISOString().replace(/[-:.]/gu, '');
 }
 
+export function resolveFormalScreenshotAssetUrl(
+  screenshotUrl: string,
+  assetPrefix = import.meta.env.ASSET_PREFIX ?? '',
+): string {
+  const normalizedPrefix = assetPrefix.replace(/\/+$/u, '');
+  const normalizedPath = screenshotUrl.startsWith('/')
+    ? screenshotUrl
+    : `/${screenshotUrl}`;
+  return `${normalizedPrefix}${normalizedPath}`;
+}
+
 function isFormalScreenshotUrl(
   run: PublishedRun,
   source: PublishedSource,
@@ -798,7 +809,7 @@ export function collectFormalScreenshotEvidence(
         scenarioName: pair.scenarioName,
         protocol: run.protocol,
         repeatIndex: pair.repeatIndex,
-        screenshotUrl: run.screenshotUrl,
+        screenshotUrl: resolveFormalScreenshotAssetUrl(run.screenshotUrl),
         judge: run.judge,
         totalTokens: run.totalTokens,
         generationMs: run.generationMs,

--- a/packages/genui/playground/tsconfig.json
+++ b/packages/genui/playground/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "target": "ES2020",
     "lib": ["ESNext", "DOM"],
-    "types": ["react", "react-dom"],
+    "types": ["react", "react-dom", "@rsbuild/core/types"],
     "noEmit": true,
     "skipLibCheck": true,
   },


### PR DESCRIPTION
## Summary

- Resolve Phase 02 UI Judge screenshot `href` and `src` values against Rsbuild's `ASSET_PREFIX` after canonical-path validation.
- Keep published `/bench/...` paths deployment-independent instead of hardcoding `/genui`.
- Add regression coverage for root, `/genui/`, and CDN asset prefixes.

## Root cause

The GenUI playground is deployed under `/genui/`, while the published screenshot URLs start at `/bench/...`. Because those root-relative strings bypassed Rsbuild's asset prefix, browsers requested the domain root and received 404 responses even though the PNG files existed under `/genui/bench/...`.

## Impact

Phase 02 screenshot evidence now works at the site root, under the production `/genui/` subpath, and with an absolute CDN asset prefix.

## Validation

- `pnpm --filter genui-playground test` — 151 tests passed.
- `ASSET_PREFIX=/genui/ pnpm --filter genui-playground build` — passed and compiled the runtime prefix as `/genui`.
- Targeted Biome and ESLint checks — passed.
- Full `pnpm turbo build` was attempted but stopped on unrelated, uncommitted local Phase 02 Bench Server type gaps; those files are not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed formal screenshot evidence to use browser-resolvable asset URLs.
  * Improved handling of empty, root, path-based, and absolute asset prefixes.
  * Updated screenshot rendering and collected evidence to include the correct asset prefix.

* **Tests**
  * Added coverage for screenshot URL resolution and improved test environment cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->