### PR TITLE
fix(react): type createPortal as ReactNode and document its contract

### DIFF
--- a/.changeset/portal-reactnode-return.md
+++ b/.changeset/portal-reactnode-return.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Type `createPortal` as returning `ReactNode` instead of Preact's `VNode<any> | null`, matching the rest of the public surface, and document its behavioral contract.

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -39,7 +39,6 @@ import { useReducer } from 'react';
 import { useRef } from 'react';
 import { useState } from 'react';
 import { useSyncExternalStore } from 'react';
-import type { VNode } from 'preact';
 
 // @public
 export const Children: ReactLynxChildren;
@@ -66,7 +65,7 @@ export interface CreateElement {
 export const createElement: CreateElement;
 
 // @public
-export function createPortal(vnode: ComponentChild, container: NodesRef): VNode<any> | null;
+export function createPortal(vnode: ComponentChild, container: NodesRef): ReactNode;
 
 export { createRef }
 

--- a/packages/react/runtime/src/snapshot/lynx/portals.ts
+++ b/packages/react/runtime/src/snapshot/lynx/portals.ts
@@ -4,6 +4,7 @@
 
 import { createElement, render } from 'preact';
 import type { Component, ComponentChild, ComponentChildren, ContainerNode, RenderableProps, VNode } from 'preact';
+import type { ReactNode } from 'react';
 
 import type { NodesRef } from '@lynx-js/types';
 
@@ -156,14 +157,30 @@ function Portal(this: PortalThis, props: PortalProps): ComponentChildren {
 }
 
 /**
- * Create a `Portal` to continue rendering the vnode tree at a different DOM node.
+ * Renders `vnode` into `container` instead of the current component's position
+ * in the element tree, while keeping it in the React tree.
+ *
+ * `container` is a `NodesRef`, obtained either from a callback `ref` or from
+ * `lynx.createSelectorQuery().select(...)`.
+ *
+ * @remarks
+ * Context still flows across the portal boundary, and state updates inside the
+ * portal behave like they do in any other component. A few behaviors differ
+ * from `react-dom`:
+ *
+ * - Events do not bubble along the React tree. ReactLynx follows Preact's
+ *   approach, which has no synthetic event system, so events follow the actual
+ *   element structure of the page.
+ * - The portaled subtree renders on the background thread only, and does not
+ *   participate in main-thread first-screen rendering.
+ * - Mounting across pages or across native containers is not supported.
  *
  * @public
  */
 export function createPortal(
   vnode: ComponentChild,
   container: NodesRef,
-): VNode<any> | null {
+): ReactNode {
   // Main-thread bundle never renders Portal — the JSX is run only on the
   // background thread. Bail early so the rest of the module (preact's
   // `render` / `createElement`, the BSI cast, etc.) tree-shakes out of
@@ -175,5 +192,7 @@ export function createPortal(
     _container: container,
   });
   (el as VNode<any> & { containerInfo?: NodesRef }).containerInfo = container;
-  return el;
+  // preact's `VNode` and React's `ReactNode` describe the same runtime value
+  // here; the public signature speaks React types like the rest of the surface.
+  return el as unknown as ReactNode;
 }

--- a/packages/react/runtime/src/snapshot/lynx/portals.ts
+++ b/packages/react/runtime/src/snapshot/lynx/portals.ts
@@ -175,6 +175,11 @@ function Portal(this: PortalThis, props: PortalProps): ComponentChildren {
  *   participate in main-thread first-screen rendering.
  * - Mounting across pages or across native containers is not supported.
  *
+ * @param vnode - The React node to render into `container`.
+ * @param container - The `NodesRef` target to render into.
+ * @returns A `ReactNode` placeholder to include in the JSX at the call site;
+ * the rendered output goes into `container`.
+ *
  * @public
  */
 export function createPortal(


### PR DESCRIPTION
`createPortal` was the only public API returning Preact's `VNode<any>` while the rest of the surface speaks React types. Callers had to write `as unknown as ReactNode`, and TypeDoc could not resolve `VNode` from the documented entry point, so the generated API page rendered the return type as an unrelated symbol (`useErrorBoundary<any> | null`).

Also moves the behavioral contract into TSDoc — event bubbling, background-thread-only rendering, and no cross-page mounting — since TypeDoc reads the original declaration, not the re-export in `react.docs.d.ts`.

Verified by running TypeDoc against the rebuilt package: the return type now resolves to an external `React.ReactNode` reference, and `@remarks` / `@example` render as their own sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `createPortal` to return a `ReactNode`, aligning its type with React expectations and improving compatibility for portal consumers.

* **Documentation**
  * Clarified portal usage, return behavior, limitations, and supported platform details.
  * Added guidance on how portal content behaves across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->