### PR TITLE
fix(testing-environment): model real ContextProxy routing across threads

### DIFF
--- a/.changeset/testing-env-context-proxy-routing.md
+++ b/.changeset/testing-env-context-proxy-routing.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/testing-environment": patch
+---
+
+Model the engine's real `ContextProxy` routing: each thread now owns its own `getCoreContext()`/`getJSContext()` proxy pair, and an event whose target equals the dispatching proxy's origin is delivered locally instead of crossing threads (matching `context_proxy.cc`). Previously both contexts shared one event bus, so wrong-direction dispatches (e.g. `lynx.getCoreContext().dispatchEvent(...)` from the main thread) still reached the other thread in tests while silently failing on real devices.

--- a/packages/testing-library/testing-environment/src/__tests__/context-proxy.test.js
+++ b/packages/testing-library/testing-environment/src/__tests__/context-proxy.test.js
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  lynxTestingEnv.reset();
+});
+
+// The real engine routes ContextProxy events by comparing the event target
+// with the dispatching proxy's origin (context_proxy.cc): equal means the
+// event is delivered locally on that proxy and never crosses threads.
+describe('ContextProxy routing', () => {
+  it('main thread getJSContext().dispatchEvent reaches background getCoreContext() listeners', () => {
+    const listener = vi.fn();
+
+    lynxTestingEnv.switchToBackgroundThread();
+    lynx.getCoreContext().addEventListener('ping', listener);
+
+    lynxTestingEnv.switchToMainThread();
+    lynx.getJSContext().dispatchEvent({ type: 'ping', data: { n: 1 } });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({
+      data: { n: 1 },
+      origin: 'CoreContext',
+    });
+  });
+
+  it('background getCoreContext().dispatchEvent reaches main thread getJSContext() listeners', () => {
+    const listener = vi.fn();
+
+    lynxTestingEnv.switchToMainThread();
+    lynx.getJSContext().addEventListener('pong', listener);
+
+    lynxTestingEnv.switchToBackgroundThread();
+    lynx.getCoreContext().dispatchEvent({ type: 'pong', data: { n: 2 } });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({
+      data: { n: 2 },
+      origin: 'JSContext',
+    });
+  });
+
+  it('main thread getCoreContext().dispatchEvent is a self-loop and never reaches the background thread', () => {
+    const backgroundListener = vi.fn();
+    const mainThreadListener = vi.fn();
+
+    lynxTestingEnv.switchToBackgroundThread();
+    lynx.getCoreContext().addEventListener('ping', backgroundListener);
+
+    lynxTestingEnv.switchToMainThread();
+    lynx.getCoreContext().addEventListener('ping', mainThreadListener);
+    lynx.getCoreContext().dispatchEvent({ type: 'ping', data: undefined });
+
+    expect(backgroundListener).not.toHaveBeenCalled();
+    expect(mainThreadListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('background getJSContext().dispatchEvent is a self-loop and never reaches the main thread', () => {
+    const mainThreadListener = vi.fn();
+    const backgroundListener = vi.fn();
+
+    lynxTestingEnv.switchToMainThread();
+    lynx.getJSContext().addEventListener('pong', mainThreadListener);
+
+    lynxTestingEnv.switchToBackgroundThread();
+    lynx.getJSContext().addEventListener('pong', backgroundListener);
+    lynx.getJSContext().dispatchEvent({ type: 'pong', data: undefined });
+
+    expect(mainThreadListener).not.toHaveBeenCalled();
+    expect(backgroundListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('listeners run with the receiving thread globals active, and the dispatching thread is restored', () => {
+    let mainThreadFlagInListener;
+
+    lynxTestingEnv.switchToBackgroundThread();
+    lynx.getCoreContext().addEventListener('ping', () => {
+      mainThreadFlagInListener = __MAIN_THREAD__;
+    });
+
+    lynxTestingEnv.switchToMainThread();
+    lynx.getJSContext().dispatchEvent({ type: 'ping', data: undefined });
+
+    expect(mainThreadFlagInListener).toBe(false);
+    expect(__MAIN_THREAD__).toBe(true);
+  });
+
+  it('removeEventListener detaches a listener', () => {
+    const listener = vi.fn();
+
+    lynxTestingEnv.switchToBackgroundThread();
+    lynx.getCoreContext().addEventListener('ping', listener);
+    lynx.getCoreContext().removeEventListener('ping', listener);
+
+    lynxTestingEnv.switchToMainThread();
+    lynx.getJSContext().dispatchEvent({ type: 'ping', data: undefined });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/testing-library/testing-environment/src/index.ts
+++ b/packages/testing-library/testing-environment/src/index.ts
@@ -209,12 +209,46 @@ function createPolyfills() {
     }),
   };
 
-  const ee = new EventEmitter();
-  // @ts-ignore
-  ee.dispatchEvent = ({
-    type,
-    data,
-  }) => {
+  // Model the engine's ContextProxy routing
+  // (`core/runtime/common/bindings/event/context_proxy.cc`): each thread owns
+  // its own proxy pair, and an event whose target equals the dispatching
+  // proxy's origin is delivered locally on that same proxy — it never crosses
+  // threads. A cross-thread event fires on the peer thread's proxy of the
+  // sender:
+  //
+  //   main thread `getJSContext().dispatchEvent`
+  //     -> background `getCoreContext()` listeners
+  //   background `getCoreContext().dispatchEvent`
+  //     -> main thread `getJSContext()` listeners
+  //   main thread `getCoreContext().dispatchEvent`
+  //     -> main thread `getCoreContext()` listeners (self-loop)
+  //   background `getJSContext().dispatchEvent`
+  //     -> background `getJSContext()` listeners (self-loop)
+  const createContextProxy = () => {
+    const ee = new EventEmitter();
+    // @ts-ignore
+    ee.addEventListener = ee.addListener;
+    // @ts-ignore
+    ee.removeEventListener = ee.removeListener;
+    return ee;
+  };
+
+  const mainThreadContexts = {
+    CoreContext: createContextProxy(),
+    JsContext: createContextProxy(),
+  };
+  const backgroundThreadContexts = {
+    CoreContext: createContextProxy(),
+    JsContext: createContextProxy(),
+  };
+
+  const deliverEvent = (
+    receiver: EventEmitter,
+    receiverThread: 'main' | 'background',
+    type: string,
+    data: unknown,
+    origin: 'CoreContext' | 'JSContext',
+  ) => {
     // Avoid ReferenceError: lynxTestingEnv is not defined
     // This error happens because worklet runtime may dispatch event
     // after the vitest environment is torn down
@@ -222,35 +256,60 @@ function createPolyfills() {
       return;
     }
 
-    const origin = __MAIN_THREAD__ ? 'CoreContext' : 'JSContext';
-    // Switch to another thread
-    if (origin === 'CoreContext') {
-      lynxTestingEnv.switchToBackgroundThread();
-    } else {
+    const wasMainThread = __MAIN_THREAD__;
+    // Ensure listeners run with the receiving thread's globals active
+    if (receiverThread === 'main') {
       lynxTestingEnv.switchToMainThread();
+    } else {
+      lynxTestingEnv.switchToBackgroundThread();
     }
 
-    // Ensure the code is running on the background thread
-    ee.emit(type, {
+    receiver.emit(type, {
       data: data,
       origin,
     });
 
     // Finish executing, restore the original thread state
-    if (origin === 'CoreContext') {
+    if (wasMainThread) {
       lynxTestingEnv.switchToMainThread();
     } else {
       lynxTestingEnv.switchToBackgroundThread();
     }
   };
-  // @ts-ignore
-  ee.addEventListener = ee.addListener;
-  // @ts-ignore
-  ee.removeEventListener = ee.removeListener;
 
-  const CoreContext = ee;
+  // Main thread proxies (origin: CoreContext)
+  // @ts-ignore
+  mainThreadContexts.CoreContext.dispatchEvent = ({ type, data }) =>
+    deliverEvent(
+      mainThreadContexts.CoreContext,
+      'main',
+      type,
+      data,
+      'CoreContext',
+    );
+  // @ts-ignore
+  mainThreadContexts.JsContext.dispatchEvent = ({ type, data }) =>
+    deliverEvent(
+      backgroundThreadContexts.CoreContext,
+      'background',
+      type,
+      data,
+      'CoreContext',
+    );
 
-  const JsContext = ee;
+  // Background thread proxies (origin: JSContext)
+  // @ts-ignore
+  backgroundThreadContexts.CoreContext.dispatchEvent = ({ type, data }) =>
+    deliverEvent(mainThreadContexts.JsContext, 'main', type, data, 'JSContext');
+  // @ts-ignore
+  backgroundThreadContexts.JsContext.dispatchEvent = ({ type, data }) =>
+    deliverEvent(
+      backgroundThreadContexts.JsContext,
+      'background',
+      type,
+      data,
+      'JSContext',
+    );
 
   function __LoadLepusChunk(
     chunkName: string,
@@ -277,8 +336,8 @@ function createPolyfills() {
   return {
     app,
     performance,
-    CoreContext,
-    JsContext,
+    mainThreadContexts,
+    backgroundThreadContexts,
     __LoadLepusChunk,
   };
 }
@@ -288,8 +347,7 @@ function injectMainThreadGlobals(target?: any, polyfills?: any) {
 
   const {
     performance,
-    CoreContext,
-    JsContext,
+    mainThreadContexts,
     __LoadLepusChunk,
   } = polyfills || {};
   if (typeof target === 'undefined') {
@@ -340,20 +398,21 @@ function injectMainThreadGlobals(target?: any, polyfills?: any) {
   target.lynx = {
     performance,
     getNative: () => native,
-    getCoreContext: (() => CoreContext),
     /*
-
-    background thread -> main thread:
+    receive events dispatched from the background thread:
     lynx.getJSContext().addEventListener("message", (e: Event) => {
       console.log('message', e)
-      });
-    main thread -> background thread:
-    lynx.getJSContext().postMessage({
+    });
+    send events to the background thread:
+    lynx.getJSContext().dispatchEvent({
       type: 'message',
       data: [3, 4, 5]
     });
+    (dispatching on getCoreContext() from the main thread is a self-loop
+    and never reaches the background thread, same as the real engine)
     */
-    getJSContext: (() => JsContext),
+    getCoreContext: (() => mainThreadContexts.CoreContext),
+    getJSContext: (() => mainThreadContexts.JsContext),
     reportError: (e: Error) => {
       throw e;
     },
@@ -434,8 +493,7 @@ function injectBackgroundThreadGlobals(target?: any, polyfills?: any) {
   const {
     app,
     performance,
-    CoreContext,
-    JsContext,
+    backgroundThreadContexts,
     __LoadLepusChunk,
   } = polyfills || {};
   if (typeof target === 'undefined') {
@@ -494,18 +552,20 @@ function injectBackgroundThreadGlobals(target?: any, polyfills?: any) {
       };
     }),
     /*
-    main thread -> background thread:
+    receive events dispatched from the main thread:
     lynx.getCoreContext().addEventListener("message", (e: Event) => {
       console.log('message', e)
     });
-    background thread -> main thread:
-    lynx.getCoreContext().postMessage({
+    send events to the main thread:
+    lynx.getCoreContext().dispatchEvent({
       type: 'message',
       data: [1, 2, 3]
     });
+    (dispatching on getJSContext() from the background thread is a self-loop
+    and never reaches the main thread, same as the real engine)
     */
-    getCoreContext: (() => CoreContext),
-    getJSContext: (() => JsContext),
+    getCoreContext: (() => backgroundThreadContexts.CoreContext),
+    getJSContext: (() => backgroundThreadContexts.JsContext),
     getJSModule: (moduleName) => {
       if (moduleName === 'GlobalEventEmitter') {
         return globalEventEmitter;


### PR DESCRIPTION
## Summary

`CoreContext` and `JsContext` were the same `EventEmitter`, so an event dispatched on either context from either thread always reached every listener. The real engine routes by proxy (`core/runtime/common/bindings/event/context_proxy.cc`): each thread owns its own proxy pair, and an event whose target equals the dispatching proxy's origin is delivered locally — it never crosses threads.

This made the environment more permissive than devices: wrong-direction dispatches like `lynx.getCoreContext().dispatchEvent(...)` from the main thread passed in tests while silently failing on real devices (see lynx-family/lynx-examples#390 for a bug of exactly this class that shipped undetected).

Now each thread gets its own `getCoreContext()`/`getJSContext()` pair with faithful routing:

- main thread `getJSContext().dispatchEvent` → background `getCoreContext()` listeners
- background `getCoreContext().dispatchEvent` → main thread `getJSContext()` listeners
- main thread `getCoreContext().dispatchEvent` → self-loop, stays on the main thread
- background `getJSContext().dispatchEvent` → self-loop, stays on the background thread

Listeners run with the receiving thread's globals active; the dispatching thread state is restored afterwards.

## Tests

- New `src/__tests__/context-proxy.test.js` covering all four routes, thread-global correctness, and `removeEventListener`.
- All existing consumers pass unchanged: `@lynx-js/testing-environment` (29), `@lynx-js/reactlynx-testing-library` (163), `@lynx-js/react` runtime (815).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event routing between main-thread and background-thread testing contexts.
  * Events targeting their originating context are now delivered locally.
  * Preserved thread-specific global state during event handling and teardown.
  * Updated event examples to use `dispatchEvent` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->