### PR TITLE
docs: use @defaultValue tags for API defaults

### DIFF
--- a/.changeset/purple-feet-kneel.md
+++ b/.changeset/purple-feet-kneel.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Use @defaultValue tags for API default values.

--- a/packages/react/transform/crates/swc_plugin_compat/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_compat/lib.rs
@@ -111,8 +111,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Specifies the list of component package names that need compatibility processing
   ///
-  /// @remarks
-  /// Default value: `['@lynx-js/react-components']`
+  /// @defaultValue `['@lynx-js/react-components']`
   ///
   /// @example
   ///
@@ -134,8 +133,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Specifies the list of old runtime package names that need compatibility processing
   ///
-  /// @remarks
-  /// Default value: `['@lynx-js/react-runtime']`
+  /// @defaultValue `['@lynx-js/react-runtime']`
   ///
   /// @example
   ///
@@ -157,8 +155,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Specifies the new runtime package name
   ///
-  /// @remarks
-  /// Default value: `'@lynx-js/react'`
+  /// @defaultValue `'@lynx-js/react'`
   ///
   /// @example
   ///
@@ -180,10 +177,10 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Specifies additional component attributes list, these attributes will be passed to the wrapped `<view>` instead of the component.
   ///
+  /// @defaultValue `[]`
+  ///
   /// @remarks
   /// This only takes effect when {@link CompatVisitorConfig.addComponentElement} is enabled.
-  ///
-  /// Default value: `[]`
   ///
   /// @example
   ///
@@ -205,8 +202,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Controls whether to add wrapper elements for components
   ///
-  /// @remarks
-  /// Default value: `false`
+  /// @defaultValue `false`
   ///
   /// @example
   ///
@@ -261,8 +257,7 @@ pub struct CompatVisitorConfig {
   ///
   /// Instead, use `background-only` on class methods for explicit and maintainable behavior
   ///
-  /// @remarks
-  /// Default value: `false`
+  /// @defaultValue `false`
   ///
   /// @example
   ///
@@ -289,8 +284,7 @@ pub struct CompatVisitorConfig {
   ///
   /// If your code depends on this switch, when distributing it to other projects through npm packages or other means, you'll also need to enable this switch. This will lead to the proliferation of switches, which is not conducive to code reuse between different projects.
   ///
-  /// @remarks
-  /// Default value: `None`
+  /// @defaultValue `undefined`
   ///
   /// @example
   ///
@@ -312,8 +306,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Whether to disable deprecated warnings
   ///
-  /// @remarks
-  /// Default value: `false`
+  /// @defaultValue `false`
   ///
   /// @example
   ///
@@ -338,8 +331,7 @@ pub struct CompatVisitorConfig {
   /// @deprecated
   /// Dark mode configuration
   ///
-  /// @remarks
-  /// Default value: `None`
+  /// @defaultValue `undefined`
   ///
   /// @example
   ///

--- a/packages/react/transform/crates/swc_plugin_compat/napi.rs
+++ b/packages/react/transform/crates/swc_plugin_compat/napi.rs
@@ -144,8 +144,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Specifies the list of component package names that need compatibility processing
   ///
-  /// @remarks
-  /// Default value: `['@lynx-js/react-components']`
+  /// @defaultValue `['@lynx-js/react-components']`
   ///
   /// @example
   ///
@@ -167,8 +166,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Specifies the list of old runtime package names that need compatibility processing
   ///
-  /// @remarks
-  /// Default value: `['@lynx-js/react-runtime']`
+  /// @defaultValue `['@lynx-js/react-runtime']`
   ///
   /// @example
   ///
@@ -190,8 +188,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Specifies the new runtime package name
   ///
-  /// @remarks
-  /// Default value: `'@lynx-js/react'`
+  /// @defaultValue `'@lynx-js/react'`
   ///
   /// @example
   ///
@@ -213,10 +210,10 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Specifies additional component attributes list, these attributes will be passed to the wrapped `<view>` instead of the component.
   ///
+  /// @defaultValue `[]`
+  ///
   /// @remarks
   /// This only takes effect when {@link CompatVisitorConfig.addComponentElement} is enabled.
-  ///
-  /// Default value: `[]`
   ///
   /// @example
   ///
@@ -238,8 +235,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Controls whether to add wrapper elements for components
   ///
-  /// @remarks
-  /// Default value: `false`
+  /// @defaultValue `false`
   ///
   /// @example
   ///
@@ -294,8 +290,7 @@ pub struct CompatVisitorConfig {
   ///
   /// Instead, use `background-only` on class methods for explicit and maintainable behavior
   ///
-  /// @remarks
-  /// Default value: `false`
+  /// @defaultValue `false`
   ///
   /// @example
   ///
@@ -322,8 +317,7 @@ pub struct CompatVisitorConfig {
   ///
   /// If your code depends on this switch, when distributing it to other projects through npm packages or other means, you'll also need to enable this switch. This will lead to the proliferation of switches, which is not conducive to code reuse between different projects.
   ///
-  /// @remarks
-  /// Default value: `None`
+  /// @defaultValue `undefined`
   ///
   /// @example
   ///
@@ -345,8 +339,7 @@ pub struct CompatVisitorConfig {
   /// @public
   /// Whether to disable deprecated warnings
   ///
-  /// @remarks
-  /// Default value: `false`
+  /// @defaultValue `false`
   ///
   /// @example
   ///
@@ -371,8 +364,7 @@ pub struct CompatVisitorConfig {
   /// @deprecated
   /// Dark mode configuration
   ///
-  /// @remarks
-  /// Default value: `None`
+  /// @defaultValue `undefined`
   ///
   /// @example
   ///

--- a/packages/react/transform/crates/swc_plugin_shake/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_shake/lib.rs
@@ -33,9 +33,11 @@ pub struct ShakeVisitorConfig {
   /// })
   /// ```
   ///
+  /// @defaultValue `['@lynx-js/react-runtime']`
+  ///
   /// @remarks
-  /// Default value: `['@lynx-js/react-runtime']`
   /// The provided values will be merged with the default values instead of replacing them.
+  ///
   /// @public
   pub pkg_name: Vec<String>,
 
@@ -57,8 +59,9 @@ pub struct ShakeVisitorConfig {
   /// })
   /// ```
   ///
+  /// @defaultValue `['constructor', 'render', 'getDerivedStateFromProps', 'state', 'defaultDataProcessor', 'dataProcessors', 'contextType', 'defaultProps']`
+  ///
   /// @remarks
-  /// Default value: `['constructor', 'render', 'getDerivedStateFromProps', 'state', 'defaultDataProcessor', 'dataProcessors', 'contextType', 'defaultProps']`
   /// The provided values will be merged with the default values instead of replacing them.
   ///
   /// @public
@@ -82,8 +85,9 @@ pub struct ShakeVisitorConfig {
   /// })
   /// ```
   ///
+  /// @defaultValue `['useEffect', 'useLayoutEffect', '__runInJS', 'useLynxGlobalEventListener', 'useImperativeHandle']`
+  ///
   /// @remarks
-  /// Default value: `['useEffect', 'useLayoutEffect', '__runInJS', 'useLynxGlobalEventListener', 'useImperativeHandle']`
   /// The provided values will be merged with the default values instead of replacing them.
   ///
   /// @public
@@ -107,8 +111,9 @@ pub struct ShakeVisitorConfig {
   /// })
   /// ```
   ///
+  /// @defaultValue `[]`
+  ///
   /// @remarks
-  /// Default value: `[]`
   /// The provided values will be merged with the default values instead of replacing them.
   ///
   /// @public

--- a/packages/react/transform/crates/swc_plugin_shake/napi.rs
+++ b/packages/react/transform/crates/swc_plugin_shake/napi.rs
@@ -26,9 +26,11 @@ pub struct ShakeVisitorConfig {
   /// })
   /// ```
   ///
+  /// @defaultValue `['@lynx-js/react-runtime']`
+  ///
   /// @remarks
-  /// Default value: `['@lynx-js/react-runtime']`
   /// The provided values will be merged with the default values instead of replacing them.
+  ///
   /// @public
   pub pkg_name: Vec<String>,
 
@@ -50,8 +52,9 @@ pub struct ShakeVisitorConfig {
   /// })
   /// ```
   ///
+  /// @defaultValue `['constructor', 'render', 'getDerivedStateFromProps', 'state', 'defaultDataProcessor', 'dataProcessors', 'contextType', 'defaultProps']`
+  ///
   /// @remarks
-  /// Default value: `['constructor', 'render', 'getDerivedStateFromProps', 'state', 'defaultDataProcessor', 'dataProcessors', 'contextType', 'defaultProps']`
   /// The provided values will be merged with the default values instead of replacing them.
   ///
   /// @public
@@ -75,8 +78,9 @@ pub struct ShakeVisitorConfig {
   /// })
   /// ```
   ///
+  /// @defaultValue `['useEffect', 'useLayoutEffect', '__runInJS', 'useLynxGlobalEventListener', 'useImperativeHandle']`
+  ///
   /// @remarks
-  /// Default value: `['useEffect', 'useLayoutEffect', '__runInJS', 'useLynxGlobalEventListener', 'useImperativeHandle']`
   /// The provided values will be merged with the default values instead of replacing them.
   ///
   /// @public
@@ -100,8 +104,9 @@ pub struct ShakeVisitorConfig {
   /// })
   /// ```
   ///
+  /// @defaultValue `[]`
+  ///
   /// @remarks
-  /// Default value: `[]`
   /// The provided values will be merged with the default values instead of replacing them.
   ///
   /// @public

--- a/packages/react/transform/index.d.ts
+++ b/packages/react/transform/index.d.ts
@@ -99,8 +99,7 @@ export interface CompatVisitorConfig {
    * @public
    * Specifies the list of component package names that need compatibility processing
    *
-   * @remarks
-   * Default value: `['@lynx-js/react-components']`
+   * @defaultValue `['@lynx-js/react-components']`
    *
    * @example
    *
@@ -124,8 +123,7 @@ export interface CompatVisitorConfig {
    * @public
    * Specifies the list of old runtime package names that need compatibility processing
    *
-   * @remarks
-   * Default value: `['@lynx-js/react-runtime']`
+   * @defaultValue `['@lynx-js/react-runtime']`
    *
    * @example
    *
@@ -149,8 +147,7 @@ export interface CompatVisitorConfig {
    * @public
    * Specifies the new runtime package name
    *
-   * @remarks
-   * Default value: `'@lynx-js/react'`
+   * @defaultValue `'@lynx-js/react'`
    *
    * @example
    *
@@ -174,10 +171,10 @@ export interface CompatVisitorConfig {
    * @public
    * Specifies additional component attributes list, these attributes will be passed to the wrapped `<view>` instead of the component.
    *
+   * @defaultValue `[]`
+   *
    * @remarks
    * This only takes effect when {@link CompatVisitorConfig.addComponentElement} is enabled.
-   *
-   * Default value: `[]`
    *
    * @example
    *
@@ -201,8 +198,7 @@ export interface CompatVisitorConfig {
    * @public
    * Controls whether to add wrapper elements for components
    *
-   * @remarks
-   * Default value: `false`
+   * @defaultValue `false`
    *
    * @example
    *
@@ -259,8 +255,7 @@ export interface CompatVisitorConfig {
    *
    * Instead, use `background-only` on class methods for explicit and maintainable behavior
    *
-   * @remarks
-   * Default value: `false`
+   * @defaultValue `false`
    *
    * @example
    *
@@ -288,8 +283,7 @@ export interface CompatVisitorConfig {
    *
    * If your code depends on this switch, when distributing it to other projects through npm packages or other means, you'll also need to enable this switch. This will lead to the proliferation of switches, which is not conducive to code reuse between different projects.
    *
-   * @remarks
-   * Default value: `None`
+   * @defaultValue `undefined`
    *
    * @example
    *
@@ -313,8 +307,7 @@ export interface CompatVisitorConfig {
    * @public
    * Whether to disable deprecated warnings
    *
-   * @remarks
-   * Default value: `false`
+   * @defaultValue `false`
    *
    * @example
    *
@@ -341,8 +334,7 @@ export interface CompatVisitorConfig {
    * @deprecated
    * Dark mode configuration
    *
-   * @remarks
-   * Default value: `None`
+   * @defaultValue `undefined`
    *
    * @example
    *
@@ -477,8 +469,7 @@ export interface ExtractStrConfig {
    * @public
    * The minimum length of string literals to be extracted.
    *
-   * @remarks
-   * Default value: `20`.
+   * @defaultValue `20`
    *
    * @example
    *
@@ -531,9 +522,11 @@ export interface ShakeVisitorConfig {
    * })
    * ```
    *
+   * @defaultValue `['@lynx-js/react-runtime']`
+   *
    * @remarks
-   * Default value: `['@lynx-js/react-runtime']`
    * The provided values will be merged with the default values instead of replacing them.
+   *
    * @public
    */
   pkgName: Array<string>
@@ -556,8 +549,9 @@ export interface ShakeVisitorConfig {
    * })
    * ```
    *
+   * @defaultValue `['constructor', 'render', 'getDerivedStateFromProps', 'state', 'defaultDataProcessor', 'dataProcessors', 'contextType', 'defaultProps']`
+   *
    * @remarks
-   * Default value: `['constructor', 'render', 'getDerivedStateFromProps', 'state', 'defaultDataProcessor', 'dataProcessors', 'contextType', 'defaultProps']`
    * The provided values will be merged with the default values instead of replacing them.
    *
    * @public
@@ -582,8 +576,9 @@ export interface ShakeVisitorConfig {
    * })
    * ```
    *
+   * @defaultValue `['useEffect', 'useLayoutEffect', '__runInJS', 'useLynxGlobalEventListener', 'useImperativeHandle']`
+   *
    * @remarks
-   * Default value: `['useEffect', 'useLayoutEffect', '__runInJS', 'useLynxGlobalEventListener', 'useImperativeHandle']`
    * The provided values will be merged with the default values instead of replacing them.
    *
    * @public
@@ -608,8 +603,9 @@ export interface ShakeVisitorConfig {
    * })
    * ```
    *
+   * @defaultValue `[]`
+   *
    * @remarks
-   * Default value: `[]`
    * The provided values will be merged with the default values instead of replacing them.
    *
    * @public

--- a/packages/react/transform/src/swc_plugin_extract_str/mod.rs
+++ b/packages/react/transform/src/swc_plugin_extract_str/mod.rs
@@ -17,8 +17,7 @@ pub struct ExtractStrConfig {
   /// @public
   /// The minimum length of string literals to be extracted.
   ///
-  /// @remarks
-  /// Default value: `20`.
+  /// @defaultValue `20`
   ///
   /// @example
   ///

--- a/packages/react/transform/swc-plugin-reactlynx-compat/index.d.ts
+++ b/packages/react/transform/swc-plugin-reactlynx-compat/index.d.ts
@@ -57,8 +57,7 @@ export interface CompatVisitorConfig {
    * @public
    * Specifies the list of component package names that need compatibility processing
    *
-   * @remarks
-   * Default value: `['@lynx-js/react-components']`
+   * @defaultValue `['@lynx-js/react-components']`
    *
    * @example
    *
@@ -82,8 +81,7 @@ export interface CompatVisitorConfig {
    * @public
    * Specifies the list of old runtime package names that need compatibility processing
    *
-   * @remarks
-   * Default value: `['@lynx-js/react-runtime']`
+   * @defaultValue `['@lynx-js/react-runtime']`
    *
    * @example
    *
@@ -107,8 +105,7 @@ export interface CompatVisitorConfig {
    * @public
    * Specifies the new runtime package name
    *
-   * @remarks
-   * Default value: `'@lynx-js/react'`
+   * @defaultValue `'@lynx-js/react'`
    *
    * @example
    *
@@ -132,10 +129,10 @@ export interface CompatVisitorConfig {
    * @public
    * Specifies additional component attributes list, these attributes will be passed to the wrapped `<view>` instead of the component.
    *
+   * @defaultValue `[]`
+   *
    * @remarks
    * This only takes effect when {@link CompatVisitorConfig.addComponentElement} is enabled.
-   *
-   * Default value: `[]`
    *
    * @example
    *
@@ -159,8 +156,7 @@ export interface CompatVisitorConfig {
    * @public
    * Controls whether to add wrapper elements for components
    *
-   * @remarks
-   * Default value: `false`
+   * @defaultValue `false`
    *
    * @example
    *
@@ -217,8 +213,7 @@ export interface CompatVisitorConfig {
    *
    * Instead, use `background-only` on class methods for explicit and maintainable behavior
    *
-   * @remarks
-   * Default value: `false`
+   * @defaultValue `false`
    *
    * @example
    *
@@ -246,8 +241,7 @@ export interface CompatVisitorConfig {
    *
    * If your code depends on this switch, when distributing it to other projects through npm packages or other means, you'll also need to enable this switch. This will lead to the proliferation of switches, which is not conducive to code reuse between different projects.
    *
-   * @remarks
-   * Default value: `None`
+   * @defaultValue `undefined`
    *
    * @example
    *
@@ -271,8 +265,7 @@ export interface CompatVisitorConfig {
    * @public
    * Whether to disable deprecated warnings
    *
-   * @remarks
-   * Default value: `false`
+   * @defaultValue `false`
    *
    * @example
    *
@@ -299,8 +292,7 @@ export interface CompatVisitorConfig {
    * @deprecated
    * Dark mode configuration
    *
-   * @remarks
-   * Default value: `None`
+   * @defaultValue `undefined`
    *
    * @example
    *

--- a/packages/react/transform/swc-plugin-reactlynx/index.d.ts
+++ b/packages/react/transform/swc-plugin-reactlynx/index.d.ts
@@ -69,9 +69,11 @@ export interface ShakeVisitorConfig {
    * })
    * ```
    *
+   * @defaultValue `['@lynx-js/react-runtime']`
+   *
    * @remarks
-   * Default value: `['@lynx-js/react-runtime']`
    * The provided values will be merged with the default values instead of replacing them.
+   *
    * @public
    */
   pkgName: Array<string>;
@@ -94,8 +96,9 @@ export interface ShakeVisitorConfig {
    * })
    * ```
    *
+   * @defaultValue `['constructor', 'render', 'getDerivedStateFromProps', 'state', 'defaultDataProcessor', 'dataProcessors', 'contextType', 'defaultProps']`
+   *
    * @remarks
-   * Default value: `['constructor', 'render', 'getDerivedStateFromProps', 'state', 'defaultDataProcessor', 'dataProcessors', 'contextType', 'defaultProps']`
    * The provided values will be merged with the default values instead of replacing them.
    *
    * @public
@@ -120,8 +123,9 @@ export interface ShakeVisitorConfig {
    * })
    * ```
    *
+   * @defaultValue `['useEffect', 'useLayoutEffect', '__runInJS', 'useLynxGlobalEventListener', 'useImperativeHandle']`
+   *
    * @remarks
-   * Default value: `['useEffect', 'useLayoutEffect', '__runInJS', 'useLynxGlobalEventListener', 'useImperativeHandle']`
    * The provided values will be merged with the default values instead of replacing them.
    *
    * @public
@@ -146,8 +150,9 @@ export interface ShakeVisitorConfig {
    * })
    * ```
    *
+   * @defaultValue `[]`
+   *
    * @remarks
-   * Default value: `[]`
    * The provided values will be merged with the default values instead of replacing them.
    *
    * @public

--- a/packages/rspeedy/core/src/config/output/source-map.ts
+++ b/packages/rspeedy/core/src/config/output/source-map.ts
@@ -76,9 +76,11 @@ export interface SourceMap {
   /**
    * Whether to generate CSS source maps.
    *
+   * @defaultValue `true`
+   *
    * @remarks
    *
-   * Defaults to `true`. In Lynx builds, all `.map` assets are removed before emit.
+   * In Lynx builds, all `.map` assets are removed before emit.
    *
    * @example
    *


### PR DESCRIPTION
## Summary

- Replace default values embedded in `@remarks` with dedicated `@defaultValue` tags across React transform and Rspeedy source-map APIs.
- Preserve non-default behavioral notes in `@remarks`.
- Sync generated TypeScript declarations and verify English and Chinese website API Markdown output.

## Validation

- `pnpm turbo build` (66/66 tasks)
- `pnpm turbo api-extractor -- --local` (25/25 tasks)
- `pnpm --dir website run docs`
- `pnpm dprint check`
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint .` (0 errors; existing warnings only)
- `pnpm changeset status --since=origin/main`

## Checklist

- [x] Tests updated (not required; documentation-only change).
- [x] Documentation updated.
- [x] Changeset added (empty changeset; documentation-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized configuration documentation to use `@defaultValue` annotations.
  * Clarified default values, including `undefined` for optional settings.
  * Improved documentation for source map behavior and CSS asset handling.
  * Preserved all existing configuration defaults and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->