### PR TITLE
chore(deps): align Typia with workspace TypeScript

### DIFF
--- a/.github/pnpm-11.instructions.md
+++ b/.github/pnpm-11.instructions.md
@@ -13,3 +13,5 @@ When bumping the `packageManager` pnpm version in package.json files, keep the `
 When adding Renovate npm minimum-release-age presets, mirror the delay in pnpm with `minimumReleaseAge` in `pnpm-workspace.yaml`; Renovate delegates lockfile maintenance to the package manager and does not enforce its own minimum release age for those updates.
 
 Do not add broad React or React DOM overrides in `pnpm-workspace.yaml`. Keep workspace React consumers on exact `react` and `react-dom` patch versions, and use scoped package metadata fixes when a tool package such as Rspress needs its internal React dependencies pinned to the same patch; Rspress SSG fails when pnpm resolves `react` and `react-dom` to different patch versions.
+
+When a tool's internal package imports TypeScript without declaring it, add an exact TypeScript dependency through a version-scoped `packageExtensions` entry. Do not override TypeScript globally, because tools such as `ts-blank-space` intentionally require an older TypeScript version.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sort-package-json": "^3.7.1",
     "ts-patch": "^4.0.1",
     "turbo": "^2.10.5",
-    "typescript": "^6.0.3",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.64.0",
     "vitest": "^3.2.4",
     "yaml": "^2.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ catalogs:
     '@microsoft/api-extractor':
       specifier: 7.58.12
       version: 7.58.12
+    typescript:
+      specifier: 6.0.3
+      version: 6.0.3
   lynxjs:
     preact:
       specifier: npm:@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c
@@ -50,7 +53,7 @@ overrides:
   '@rsdoctor/rspack-plugin>@rspack/core': 2.1.5
   '@rsdoctor/types>@rspack/core': 2.1.5
 
-packageExtensionsChecksum: sha256-BUwt5m2tRMyYg9pgFVHNTHCYEBuM0/o7IdJqk+vWTGs=
+packageExtensionsChecksum: sha256-Y9ZLHWMP51V1VaeUicx/UxFRX96fq7QFLXtege8aEOA=
 
 patchedDependencies:
   '@napi-rs/cli@2.18.4': ba947eb1c48b2a85834e99f92cbbae896722ce61fd5ae67507a3be9041959ebd
@@ -169,7 +172,7 @@ importers:
         specifier: ^2.10.5
         version: 2.10.5
       typescript:
-        specifier: ^6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.64.0
@@ -16640,6 +16643,7 @@ snapshots:
     dependencies:
       '@typia/interface': 12.1.1
       '@typia/utils': 12.1.1
+      typescript: 6.0.3
 
   '@typia/interface@12.1.1': {}
 
@@ -16648,6 +16652,7 @@ snapshots:
       '@typia/core': 12.1.1
       '@typia/interface': 12.1.1
       '@typia/utils': 12.1.1
+      typescript: 6.0.3
 
   '@typia/utils@12.1.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,6 +99,7 @@ peerDependencyRules:
 # Default catalogs
 catalog:
   "@microsoft/api-extractor": "7.58.12"
+  typescript: &typescript-version "6.0.3"
 
 catalogs:
   # Packages vendored from the Lynx toolchain.
@@ -150,6 +151,14 @@ overrides:
   "@rsdoctor/types>@rspack/core": "$@rspack/core"
 
 packageExtensions:
+  # Typia's internal packages import TypeScript without declaring it. Keep
+  # their TypeFlags aligned with the TypeScript instance used by the transformer.
+  "@typia/core@*":
+    dependencies:
+      typescript: *typescript-version
+  "@typia/transform@*":
+    dependencies:
+      typescript: *typescript-version
   "@rspack/test-tools@*":
     dependencies:
       wast-loader: ^1.14.1


### PR DESCRIPTION
## Summary

Make Typia validator generation deterministic for
`@lynx-js/react-rsbuild-plugin` across different pnpm installation layouts.

## Reproducibility Note

The invalid validator was observed in an existing workspace after incremental
dependency updates. In that workspace, `pnpm turbo build` generated a validator
that expected the complete plugin options object to be a string.

A fresh clone followed by the commands below did not reproduce the failure:

```bash
pnpm install --frozen-lockfile
pnpm turbo build
```

This indicates that the failure depended on the existing pnpm virtual-store
layout rather than being consistently reproducible from the current lockfile.

## Root Cause

Typia creates TypeScript type objects in its transformer and inspects them using
`TypeFlags` imported by its internal packages.

In the affected workspace:

- the transformer used TypeScript 6.0.3;
- `@typia/core` and `@typia/transform` resolved TypeScript 5.9.3 from pnpm's
  virtual store.

Because `TypeFlags` values are not compatible across these TypeScript versions,
Typia misclassified `PluginReactLynxOptions | undefined` and generated a
validator equivalent to:

```js
typeof input === 'string'
```

The resolution was fragile because `@typia/core` and `@typia/transform` import
TypeScript without declaring it themselves. A clean installation happened to
resolve a compatible TypeScript instance, while the existing installation did
not.

The Rslib build also loaded the package tsconfig containing the ts-patch Typia
transformer while registering `TypiaRspackPlugin`. This allowed Typia
transformation to occur through two build paths and made the published output
dependent on the same incidental dependency resolution.

## Changes

- Define the exact TypeScript 6.0.3 version in the default pnpm catalog.
- Reference the catalog from the root package.
- Use a YAML anchor to assign the same version to `@typia/core` and
  `@typia/transform`, because `packageExtensions` does not support `catalog:`.

These scoped package extensions do not affect packages that require TypeScript
5.9, such as `ts-blank-space`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @lynx-js/react-rsbuild-plugin test`
  - 190 passed, 1 skipped
- Targeted benchmark and React Compiler builds
- Full `pnpm turbo build`
  - 66/66 tasks passed
- Verified the published output:
  - accepts `undefined`;
  - accepts valid option objects;
  - rejects unknown properties.

Closes: #3353

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized development tooling configuration across the workspace.
  * Improved consistency and reliability for TypeScript-based build and validation processes.
  * Added guidance for maintaining compatible tooling configurations in future updates.
  * No user-facing functionality or interface changes were included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
