### PR TITLE
chore: upgrade Rslib to v1 beta

### DIFF
--- a/.changeset/upgrade-rslib-v1-beta.md
+++ b/.changeset/upgrade-rslib-v1-beta.md
@@ -1,0 +1,6 @@
+---
+
+---
+
+Upgrade the internal Rslib build toolchain to the v1 beta without changing
+published package behavior.

--- a/packages/genui/a2ui-catalog-extractor/rslib.config.ts
+++ b/packages/genui/a2ui-catalog-extractor/rslib.config.ts
@@ -1,12 +1,24 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { fileURLToPath } from 'node:url';
+
 import type { RslibConfig } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
 
 const config: RslibConfig = defineConfig({
   lib: [
-    { format: 'esm', syntax: 'es2022', dts: { bundle: true, tsgo: true } },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      dts: {
+        bundle: true,
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
+    },
   ],
   source: {
     entry: {

--- a/packages/genui/a2ui-prompt/rslib.config.ts
+++ b/packages/genui/a2ui-prompt/rslib.config.ts
@@ -1,12 +1,24 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { fileURLToPath } from 'node:url';
+
 import type { RslibConfig } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
 
 const config: RslibConfig = defineConfig({
   lib: [
-    { format: 'esm', syntax: 'es2022', dts: { bundle: true, tsgo: true } },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      dts: {
+        bundle: true,
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
+    },
   ],
   source: {
     entry: {

--- a/packages/genui/server/rslib.config.ts
+++ b/packages/genui/server/rslib.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2022',
       bundle: true,
-      autoExternal: false,
       dts: false,
       source: {
         entry: {
@@ -19,6 +18,7 @@ export default defineConfig({
       },
       output: {
         target: 'node',
+        autoExternal: false,
         externals: [/^@mastra\/core(?:\/.*)?$/u],
       },
     },

--- a/packages/lynx/autolink-codegen/rslib.config.ts
+++ b/packages/lynx/autolink-codegen/rslib.config.ts
@@ -1,12 +1,24 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { fileURLToPath } from 'node:url';
+
 import type { RslibConfig } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
 
 const config: RslibConfig = defineConfig({
   lib: [
-    { format: 'esm', syntax: 'es2022', dts: { bundle: true, tsgo: true } },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      dts: {
+        bundle: true,
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
+    },
   ],
   source: {
     entry: {

--- a/packages/lynx/create-lynx-library/rslib.config.ts
+++ b/packages/lynx/create-lynx-library/rslib.config.ts
@@ -1,12 +1,24 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { fileURLToPath } from 'node:url';
+
 import type { RslibConfig } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
 
 const config: RslibConfig = defineConfig({
   lib: [
-    { format: 'esm', syntax: 'es2022', dts: { bundle: true, tsgo: true } },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      dts: {
+        bundle: true,
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
+    },
   ],
   source: {
     entry: {

--- a/packages/react/testing-library/rslib.config.ts
+++ b/packages/react/testing-library/rslib.config.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from '@rslib/core';
 
@@ -59,6 +60,9 @@ export default defineConfig({
       dts: {
         bundle: true,
         tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
       },
       output: {
         filename: {
@@ -74,11 +78,9 @@ export default defineConfig({
   ],
   tools: {
     rspack(config, { appendRules }) {
-      // Rslib prefixes chunk names with `<libIndex>~` when a config has more
-      // than one `lib` entry. Vite refuses to load any path containing `~` on
-      // Windows (an 8.3 short-name guard), so `dist/pure.js` importing
-      // `./0~rslib-runtime.js` breaks every Windows consumer that runs it
-      // through Vite. Swap the separator for `-`.
+      // Rslib separates generated chunk names and their lib index with `~`.
+      // Vite refuses to load any path containing `~` on Windows (an 8.3
+      // short-name guard), so replace the separator for every generated name.
       if (typeof config.output?.chunkFilename === 'string') {
         config.output.chunkFilename = config.output.chunkFilename.replaceAll(
           '~',

--- a/packages/react/testing-library/rslib.config.ts
+++ b/packages/react/testing-library/rslib.config.ts
@@ -80,18 +80,10 @@ export default defineConfig({
     rspack(config, { appendRules }) {
       // Rslib separates generated chunk names and their lib index with `~`.
       // Vite refuses to load any path containing `~` on Windows (an 8.3
-      // short-name guard), so replace the separator for every generated name.
-      if (typeof config.output?.chunkFilename === 'string') {
-        config.output.chunkFilename = config.output.chunkFilename.replaceAll(
-          '~',
-          '-',
-        );
-      }
-      const runtimeChunk = config.optimization?.runtimeChunk;
-      if (
-        typeof runtimeChunk === 'object' && typeof runtimeChunk.name === 'string'
-      ) {
-        runtimeChunk.name = runtimeChunk.name.replaceAll('~', '-');
+      // short-name guard), so replace the separator in initial chunk names.
+      const filename = config.output?.filename;
+      if (typeof filename === 'function') {
+        config.output.filename = (pathData, assetInfo) => filename(pathData, assetInfo).replaceAll('~', '-');
       }
       appendRules({
         test: /\.jsx$/,

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -93,10 +93,6 @@ export const DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG: LibConfig = {
   format: 'cjs',
   syntax: 'es2015',
   autoExtension: false,
-  autoExternal: {
-    dependencies: false,
-    peerDependencies: false,
-  },
   shims: {
     cjs: {
       // Don't inject shim because Lynx don't support.
@@ -104,6 +100,10 @@ export const DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG: LibConfig = {
     },
   },
   output: {
+    autoExternal: {
+      dependencies: false,
+      peerDependencies: false,
+    },
     minify: process.env['NODE_ENV'] === 'development'
       ? false
       : DEFAULT_EXTERNAL_BUNDLE_MINIFY_CONFIG,

--- a/packages/rspeedy/plugin-qrcode/rslib.config.ts
+++ b/packages/rspeedy/plugin-qrcode/rslib.config.ts
@@ -1,8 +1,19 @@
+import { fileURLToPath } from 'node:url'
+
 import { defineConfig } from '@rslib/core'
 
 export default defineConfig({
   lib: [
-    { format: 'esm', syntax: 'es2022', dts: { tsgo: true } },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      dts: {
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
+    },
   ],
   source: {
     entry: {

--- a/packages/tailwind-preset/rslib.config.ts
+++ b/packages/tailwind-preset/rslib.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
@@ -9,7 +11,12 @@ export default defineConfig({
   },
   lib: [
     {
-      dts: { tsgo: true },
+      dts: {
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
       format: 'esm',
     },
     {

--- a/packages/testing-library/kitten-lynx/rslib.config.ts
+++ b/packages/testing-library/kitten-lynx/rslib.config.ts
@@ -1,9 +1,21 @@
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
 
 export default defineConfig({
   lib: [
-    { format: 'esm', syntax: 'es2022', dts: { bundle: true, tsgo: true } },
+    {
+      format: 'esm',
+      syntax: 'es2022',
+      dts: {
+        bundle: true,
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
+    },
   ],
   plugins: [
     pluginPublint(),

--- a/packages/testing-library/testing-environment/rslib.config.ts
+++ b/packages/testing-library/testing-environment/rslib.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
 
@@ -15,7 +17,12 @@ export default defineConfig({
       bundle: false,
       format: 'esm',
       syntax: 'es2021',
-      dts: { tsgo: true },
+      dts: {
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
     },
     {
       bundle: false,

--- a/packages/web-platform/web-rsbuild-plugin/rslib.config.ts
+++ b/packages/web-platform/web-rsbuild-plugin/rslib.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
@@ -5,7 +7,13 @@ export default defineConfig({
     {
       format: 'esm',
       syntax: 'es2022',
-      dts: { bundle: true, tsgo: true },
+      dts: {
+        bundle: true,
+        tsgo: true,
+        typescriptPath: fileURLToPath(
+          import.meta.resolve('@typescript/native-preview'),
+        ),
+      },
       source: {
         entry: {
           index: './src/index.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ catalogs:
       version: 2.1.7
   rslib:
     '@rslib/core':
-      specifier: 0.23.2
-      version: 0.23.2
+      specifier: 1.0.0-beta.1
+      version: 1.0.0-beta.1
   rspack:
     '@rspack/test-tools':
       specifier: 2.1.3
@@ -83,7 +83,7 @@ importers:
         version: 2.1.7(core-js@3.49.0)
       '@rslib/core':
         specifier: catalog:rslib
-        version: 0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@typescript/native-preview@7.0.0-dev.20260707.2)(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)
       '@rspack/core':
         specifier: 2.1.5
         version: 2.1.5(@swc/helpers@0.5.23)
@@ -1054,7 +1054,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: catalog:rslib
-        version: 0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@typescript/native-preview@7.0.0-dev.20260707.2)(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2))
@@ -1554,7 +1554,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rslib/core':
         specifier: catalog:rslib
-        version: 0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@typescript/native-preview@7.0.0-dev.20260707.2)(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2))
@@ -2104,7 +2104,7 @@ importers:
         version: 1.0.6(@rsbuild/core@2.1.7(core-js@3.49.0))
       '@rslib/core':
         specifier: catalog:rslib
-        version: 0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@typescript/native-preview@7.0.0-dev.20260707.2)(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2))
@@ -2161,7 +2161,7 @@ importers:
         version: 2.1.7(core-js@3.49.0)
       '@rslib/core':
         specifier: catalog:rslib
-        version: 0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@typescript/native-preview@7.0.0-dev.20260707.2)(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2))
@@ -5490,13 +5490,13 @@ packages:
   '@rsdoctor/utils@1.6.1':
     resolution: {integrity: sha512-Ll+X1nAE3eBq9BpBNZvAT+4hZZMQt/rxrBRzL/I8o6S3CBpo5Kh2A2JaYgCJLiYKh0kFQfuIWuOVpR3/yoFWJg==}
 
-  '@rslib/core@0.23.2':
-    resolution: {integrity: sha512-KxSp+/y0BJ1O4oKwxX4ydBY7/ZVeJCUpWAmQniCIct8mTxIQFPGO/ibKbKq2IxZYqRuRpM8g+Dtyq0VbEQf9HQ==}
+  '@rslib/core@1.0.0-beta.1':
+    resolution: {integrity: sha512-HHPZ+wTUKT/3bEhw2y0JB0O62wMuljkSHVZelLbSGhBflCaUt+D3LohBcIxYW6bhzPbUp4gkJXo1pdTpxiuNLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      typescript: ^5 || ^6 || ^7.0.1-0
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
@@ -10697,18 +10697,15 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rsbuild-plugin-dts@0.23.2:
-    resolution: {integrity: sha512-Ve8WOSPyTBjxH40O/6fChJtflL7yqcUtt5zbF0eHDM4hIt35jqLocRlSdCxFJdQm0blTjl6+hkmPa/vNI06ArA==}
+  rsbuild-plugin-dts@1.0.0-beta.1:
+    resolution: {integrity: sha512-hAEjOXhfIHR4erqjsqjRvA9Yqzc6Thry06tHheXDJUVwmR3VbN8BSMDC8kBZzyKdypDF0IJ98FmLQRiC194sMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      '@typescript/native-preview': ^7.0.0-0
-      typescript: ^5 || ^6 || ^7.0.1-0
+      '@rsbuild/core': ^2.0.0
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       '@microsoft/api-extractor':
-        optional: true
-      '@typescript/native-preview':
         optional: true
       typescript:
         optional: true
@@ -15659,16 +15656,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@typescript/native-preview@7.0.0-dev.20260707.2)(core-js@3.49.0)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.1.7(core-js@3.49.0)
-      rsbuild-plugin-dts: 0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
       - core-js
 
   '@rspack/binding-darwin-arm64@2.1.5':
@@ -21546,13 +21542,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
-  rsbuild-plugin-dts@0.23.2(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(@typescript/native-preview@7.0.0-dev.20260707.2)(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.7(core-js@3.49.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
-      '@typescript/native-preview': 7.0.0-dev.20260707.2
       typescript: 6.0.3
 
   rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@2.1.7(core-js@3.49.0))(i18next-cli@1.54.2(@swc/helpers@0.5.23)(@types/node@24.13.3)(i18next@26.3.6(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3))(rollup@4.62.2):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -122,7 +122,7 @@ catalogs:
 
   # Rslib monorepo packages
   rslib:
-    "@rslib/core": "0.23.2"
+    "@rslib/core": "1.0.0-beta.1"
 
   # Rspack monorepo packages
   rspack:


### PR DESCRIPTION
## Summary

- upgrade `@rslib/core` from 0.23.2 to 1.0.0-beta.1
- migrate deprecated `lib.autoExternal` settings to `output.autoExternal`
- explicitly configure `@typescript/native-preview` for declaration builds using `tsgo`

## Artifact compatibility

Compared all 670 Rslib outputs with 0.23.2. The differences are limited to internal chunk naming, compiler-generated identifiers, and bundle serialization. Declaration outputs and decoded Lynx executable sections are unchanged, with no behavior-affecting differences found.

## Suggestions

Some options explicitly configured in this repository are already defaults in Rslib v1, such as `format: 'esm'`, `bundle: true`, `dts: false`, and `output.target: 'node'`. We recommend removing these redundant explicit values in a follow-up cleanup to simplify the Rslib configurations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded internal library build tooling to the Rslib 1.0 beta.
  * Improved declaration generation across multiple packages using the native TypeScript preview implementation.
  * Standardized build configuration while preserving existing output formats and bundling behavior.
  * No changes were made to published package behavior.
* **Documentation**
  * Added a changeset documenting the tooling upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->