### PR TITLE
fix(web-core): guard event errors at wasm boundary

### DIFF
--- a/.changeset/tough-wasps-guard.md
+++ b/.changeset/tough-wasps-guard.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Prevent event dispatch failures from escaping through the WebAssembly boundary.

--- a/.github/web-core-wasm-boundary.instructions.md
+++ b/.github/web-core-wasm-boundary.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-core/{src,ts,tests}/**/*,packages/web-platform/web-core-e2e/tests/**/*"
+---
+
+Treat potentially throwing Rust-to-JavaScript event dispatch imports made while a `MainThreadWasmContext` export is active as WebAssembly exception boundaries: declare them with `wasm-bindgen(catch)` and consume their `Result` so an exception cannot escape through the wasm frame and leave the context's borrow guard active. Keep this boundary independent of element event-listener registration and callback invocation. Add regression tests that throw from the real JavaScript binding and invoke another wasm context method afterward.

--- a/packages/web-platform/web-core/src/js_binding/mts_js_binding.rs
+++ b/packages/web-platform/web-core/src/js_binding/mts_js_binding.rs
@@ -10,7 +10,7 @@ use wasm_bindgen::prelude::*;
 extern "C" {
   pub type RustMainthreadContextBinding;
 
-  #[wasm_bindgen(method, js_name = "runWorklet")]
+  #[wasm_bindgen(method, catch, js_name = "runWorklet")]
   pub fn publish_mts_event(
     this: &RustMainthreadContextBinding,
     handler_name: &wasm_bindgen::JsValue,
@@ -19,7 +19,7 @@ extern "C" {
     target_dataset: &wasm_bindgen::JsValue,
     current_target_element_unique_id: usize,
     current_target_dataset: &wasm_bindgen::JsValue,
-  );
+  ) -> Result<(), JsValue>;
 
   /// Invokes a callback registered through `__AddEventListener`.
   #[wasm_bindgen(method, js_name = "runElementClosure")]
@@ -33,7 +33,7 @@ extern "C" {
     current_target_dataset: &wasm_bindgen::JsValue,
   );
 
-  #[wasm_bindgen(method, js_name = "publishEvent")]
+  #[wasm_bindgen(method, catch, js_name = "publishEvent")]
   pub fn publish_event(
     this: &RustMainthreadContextBinding,
     handler_name: &str,
@@ -43,7 +43,7 @@ extern "C" {
     target_dataset: &wasm_bindgen::JsValue,
     current_target_element_unique_id: usize,
     current_target_dataset: &wasm_bindgen::JsValue,
-  );
+  ) -> Result<(), JsValue>;
 
   #[wasm_bindgen(method, js_name = "addEventListener")]
   pub fn add_event_listener(this: &RustMainthreadContextBinding, event_name: &str);

--- a/packages/web-platform/web-core/src/main_thread/client/element_apis/event_apis.rs
+++ b/packages/web-platform/web-core/src/main_thread/client/element_apis/event_apis.rs
@@ -331,7 +331,7 @@ impl MainThreadWasmContext {
           };
           is_caught = catch_handler.is_some();
           for handler in [bind_handler, catch_handler].iter().flatten() {
-            self.mts_binding.publish_event(
+            let _ = self.mts_binding.publish_event(
               handler,
               current_target_parent_component_id.as_deref(),
               serialized_event,
@@ -352,7 +352,7 @@ impl MainThreadWasmContext {
         if bind_handler.is_some() || catch_handler.is_some() {
           is_caught = catch_handler.is_some();
           if let Some(handler) = bind_handler {
-            self.mts_binding.publish_mts_event(
+            let _ = self.mts_binding.publish_mts_event(
               &handler,
               serialized_event,
               target_unique_id,
@@ -362,7 +362,7 @@ impl MainThreadWasmContext {
             );
           }
           if let Some(handler) = catch_handler {
-            self.mts_binding.publish_mts_event(
+            let _ = self.mts_binding.publish_mts_event(
               &handler,
               serialized_event,
               target_unique_id,
@@ -475,7 +475,7 @@ impl MainThreadWasmContext {
               .and_then(|binding| binding.borrow().component_id.clone())
           }
         };
-        self.mts_binding.publish_event(
+        let _ = self.mts_binding.publish_event(
           &handler,
           current_target_parent_component_id.as_deref(),
           serialized_event,
@@ -489,7 +489,7 @@ impl MainThreadWasmContext {
       let run_worklet_handler = current_target_element_data
         .get_framework_run_worklet_event_handler(&event_name_lowercase, "global-bindevent");
       if let Some(handler) = run_worklet_handler {
-        self.mts_binding.publish_mts_event(
+        let _ = self.mts_binding.publish_mts_event(
           &handler,
           serialized_event,
           target_unique_id,

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -1676,6 +1676,73 @@ describe('Element APIs', () => {
     );
   });
 
+  test('cross-thread event errors do not escape the wasm boundary', () => {
+    const publishError = new DOMException(
+      'The object could not be cloned.',
+      'DataCloneError',
+    );
+    mtsBinding.lynxViewInstance.backgroundThread.publishEvent = rstest.fn(
+      () => {
+        throw publishError;
+      },
+    );
+
+    const page = mtsGlobalThis.__CreatePage('0', 0);
+    const target = mtsGlobalThis.__CreateView(0);
+    mtsGlobalThis.__AppendElement(page, target);
+    mtsGlobalThis.__SetID(target, 'publish-error-target');
+    mtsGlobalThis.__AddEvent(target, 'bindEvent', 'tap', 'handler');
+    mtsGlobalThis.__FlushElementTree();
+
+    expect(() => {
+      rootDom.querySelector('#publish-error-target')?.dispatchEvent(
+        new window.Event('click'),
+      );
+    }).not.toThrow();
+    expect(() => mtsGlobalThis.__CreateView(0)).not.toThrow();
+  });
+
+  test('worklet errors do not escape the wasm boundary', () => {
+    const workletError = {
+      name: 'TypeError',
+      message: 'worklet failed',
+      stack: 'TypeError: worklet failed\n    at worklet.js:1:1',
+    };
+    mtsBinding = new WASMJSBinding(
+      createTestLynxViewInstance(rootDom, {
+        runWorklet: () => {
+          throw workletError;
+        },
+      } as any),
+    );
+    mtsGlobalThis = createElementAPI(
+      rootDom,
+      mtsBinding,
+      true,
+      true,
+      true,
+    );
+
+    const page = mtsGlobalThis.__CreatePage('0', 0);
+    const target = mtsGlobalThis.__CreateView(0);
+    mtsGlobalThis.__AppendElement(page, target);
+    mtsGlobalThis.__SetID(target, 'worklet-error-target');
+    mtsGlobalThis.__AddEvent(
+      target,
+      'bindEvent',
+      'tap',
+      { value: 'worklet' } as any,
+    );
+    mtsGlobalThis.__FlushElementTree();
+
+    expect(() => {
+      rootDom.querySelector('#worklet-error-target')?.dispatchEvent(
+        new window.Event('click'),
+      );
+    }).not.toThrow();
+    expect(() => mtsGlobalThis.__CreateView(0)).not.toThrow();
+  });
+
   test('event with bubbles: false should not bubble to parent', () => {
     rstest.spyOn(mtsBinding, 'addEventListener');
     rstest.spyOn(mtsBinding, 'publishEvent');


### PR DESCRIPTION
## Summary

- Catch cross-thread event dispatch and main-thread worklet exceptions at the Rust-to-JavaScript WebAssembly boundary.
- Consume the binding results so JavaScript exceptions cannot escape an active `MainThreadWasmContext` frame.
- Keep element `addEventListener` registration and callback handling unchanged; those are covered by the XML template / element-listener implementation.

## Testing

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm turbo build` (70/70 tasks)
- [x] `pnpm --filter @lynx-js/web-core test` (356/356 tests)
- [x] `pnpm turbo api-extractor -- --local` (25/25 tasks)
- [x] `pnpm changeset status --since=upstream/main`
- [x] `pnpm dprint check ...`
- [x] `pnpm eslint --no-warn-ignored packages/web-platform/web-core/tests/element-apis.spec.ts`

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Changeset added.