### PR TITLE
fix(web-elements): respect XList scroll orientation

### DIFF
--- a/.changeset/fuzzy-lists-scroll.md
+++ b/.changeset/fuzzy-lists-scroll.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Keep XList scroll offsets and automatic scrolling aligned with its configured orientation.

--- a/.github/web-elements-x-list.instructions.md
+++ b/.github/web-elements-x-list.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/web-elements/src/elements/XList/**,packages/web-platform/web-elements/tests/fixtures/x-list/**,packages/web-platform/web-elements/tests/web-elements.spec.ts"
+---
+
+Treat `scroll-orientation` as the single source of truth for XList axis behavior. Keep `scrollLeft` and `scrollTop` mapped to the matching internal scroll-container offsets, and make axis-sensitive methods such as `autoScroll` update only the configured axis. Do not restore `vertical-orientation`-based selectors as partial compatibility; either implement a complete legacy alias across layout and runtime behavior or keep the unsupported legacy attribute absent.

--- a/packages/web-platform/web-elements/src/elements/XList/XList.ts
+++ b/packages/web-platform/web-elements/src/elements/XList/XList.ts
@@ -40,7 +40,7 @@ export class XList extends HTMLElement {
   }
 
   override get scrollLeft() {
-    return this.#getListContainer().scrollTop;
+    return this.#getListContainer().scrollLeft;
   }
 
   override set scrollLeft(val: number) {
@@ -64,7 +64,7 @@ export class XList extends HTMLElement {
   }
 
   get __scrollLeft() {
-    return super.scrollTop;
+    return super.scrollLeft;
   }
 
   scrollToPosition(
@@ -129,17 +129,17 @@ export class XList extends HTMLElement {
     const scrollContainer = this.#getListContainer();
     const deltaTime = timestamp - this.#autoScrollOptions.lastTimestamp;
     const tickDistance = (deltaTime / 1000) * this.#autoScrollOptions.rate;
+    const isScrollVertical = (this.getAttribute('scroll-orientation')
+      || 'vertical') === 'vertical';
 
     scrollContainer.scrollBy({
-      left: tickDistance,
-      top: tickDistance,
+      left: isScrollVertical ? 0 : tickDistance,
+      top: isScrollVertical ? tickDistance : 0,
       // smooth might cause lag when scrolling.
       behavior: 'auto',
     });
 
     this.#autoScrollOptions.lastTimestamp = timestamp;
-    const isScrollVertical = (this.getAttribute('scroll-orientation')
-      || 'vertical') === 'vertical';
     const isContainerScrollable = isScrollVertical
       ? scrollContainer.scrollTop + scrollContainer.clientHeight
         >= scrollContainer.scrollHeight

--- a/packages/web-platform/web-elements/src/elements/XList/x-list.css
+++ b/packages/web-platform/web-elements/src/elements/XList/x-list.css
@@ -192,10 +192,6 @@ x-list::part(lower-threshold-observer) {
   flex-direction: column-reverse;
 }
 
-x-list[vertical-orientation="false"]::part(lower-threshold-observer) {
-  flex-direction: row-reverse;
-}
-
 /* list-type single */
 x-list {
   display: flex;

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -2291,6 +2291,26 @@ test.describe('web-elements test suite', () => {
         top: 0,
       }));
       expect(scrollByCalls['horizontal']!.left).toBeGreaterThan(0);
+      await page.evaluate(() =>
+        new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      );
+      const changedScrollByCall = await page.evaluate(() => {
+        const list = document.querySelector('#vertical') as any;
+        list.setAttribute('scroll-orientation', 'horizontal');
+        const content = list.shadowRoot.querySelector('#content');
+        return new Promise<ScrollToOptions>((resolve) => {
+          content.scrollBy = (options: ScrollToOptions) => {
+            list.autoScroll({ rate: 100, start: false });
+            resolve(options);
+          };
+          list.autoScroll({ rate: 100, start: true });
+        });
+      });
+      expect(changedScrollByCall).toEqual(expect.objectContaining({
+        left: expect.any(Number),
+        top: 0,
+      }));
+      expect(changedScrollByCall.left).toBeGreaterThan(0);
     });
     test(
       'get-visible-cells',

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -2258,6 +2258,40 @@ test.describe('web-elements test suite', () => {
         await expect(scrolled).toBe(4);
       },
     );
+    test('auto-scroll-follows-orientation', async ({ page }) => {
+      await gotoWebComponentPage(page, 'x-list/scroll-orientation');
+      const scrollByCalls = await page.evaluate(() => {
+        const calls: Record<string, ScrollToOptions> = {};
+        return new Promise<Record<string, ScrollToOptions>>((resolve) => {
+          for (const id of ['vertical', 'horizontal']) {
+            const list = document.querySelector(`#${id}`) as any;
+            const content = list.shadowRoot.querySelector('#content');
+            content.scrollBy = (options: ScrollToOptions) => {
+              calls[id] = options;
+              if (Object.keys(calls).length !== 2) return;
+              for (const id of ['vertical', 'horizontal']) {
+                (document.querySelector(`#${id}`) as any).autoScroll({
+                  rate: 100,
+                  start: false,
+                });
+              }
+              resolve(calls);
+            };
+            list.autoScroll({ rate: 100, start: true });
+          }
+        });
+      });
+      expect(scrollByCalls['vertical']).toEqual(expect.objectContaining({
+        left: 0,
+        top: expect.any(Number),
+      }));
+      expect(scrollByCalls['vertical']!.top).toBeGreaterThan(0);
+      expect(scrollByCalls['horizontal']).toEqual(expect.objectContaining({
+        left: expect.any(Number),
+        top: 0,
+      }));
+      expect(scrollByCalls['horizontal']!.left).toBeGreaterThan(0);
+    });
     test(
       'get-visible-cells',
       async ({ page, browserName }, { titlePath }) => {
@@ -2320,7 +2354,7 @@ test.describe('web-elements test suite', () => {
           return (document.querySelector('x-list') as any)?.scrollWidth;
         });
         expect(
-          typeof info2 === 'object' && info2.scrollLeft === 200
+          typeof info2 === 'object' && info2.scrollLeft === 0
             && info2.scrollTop === 200 && info2.scrollHeight !== 0
             && info2.scrollWidth !== 0,
         ).toBeTruthy();
@@ -2328,6 +2362,20 @@ test.describe('web-elements test suite', () => {
         expect(scrollWidth2).toBe(info2.scrollWidth);
       },
     );
+    test('get-scroll-container-info-horizontal', async ({ page }) => {
+      await gotoWebComponentPage(page, 'x-list/scroll-orientation');
+      const info = await page.locator('#horizontal').evaluate(
+        (element: any) => {
+          const content = element.shadowRoot.querySelector('#content');
+          content.scrollLeft = 200;
+          return element.getScrollContainerInfo();
+        },
+      );
+      expect(info).toEqual(expect.objectContaining({
+        scrollLeft: 200,
+        scrollTop: 0,
+      }));
+    });
 
     test('recyclable-false', async ({ page }, { titlePath }) => {
       const title = getTitle(titlePath);


### PR DESCRIPTION
## Summary

- Report XList horizontal offsets from `scrollLeft` instead of incorrectly mirroring `scrollTop`.
- Make `autoScroll` advance only the axis selected by `scroll-orientation`.
- Remove the unreachable `vertical-orientation` CSS selector and add regressions for vertical and horizontal behavior.

## Testing

- [x] `pnpm turbo build`
- [x] Targeted XList tests on Chromium, Firefox, and WebKit (9/9)
- [x] `pnpm dprint check packages/web-platform/web-elements/src/elements/XList/XList.ts packages/web-platform/web-elements/src/elements/XList/x-list.css packages/web-platform/web-elements/tests/web-elements.spec.ts .changeset/fuzzy-lists-scroll.md .github/web-elements-x-list.instructions.md`
- [x] `pnpm changeset status --since=upstream/main`

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Changeset added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected horizontal and vertical scroll offsets in XList.
  * Updated automatic scrolling to follow the configured scroll orientation.
  * Improved horizontal list scrolling behavior and removed conflicting layout behavior.

* **Tests**
  * Added coverage for orientation-specific auto-scrolling and scroll offset values.
  * Verified horizontal and vertical scroll containers report accurate positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->