### PR TITLE
feat(tailwind-preset): expand uiVariants built-in states

### DIFF
--- a/.changeset/focused-states-expand.md
+++ b/.changeset/focused-states-expand.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/tailwind-preset": patch
+---
+
+Add `focused`, `complete`, `filled`, and `dragging` to the built-in `uiVariants` states, and clarify that only the `ui` prefix is enabled by default.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,5 +9,6 @@ packages/lynx/engine-bridge/** @pupiltong
 packages/rspeedy/plugin-react/** @upupming
 packages/react/** @hzy @HuJean @Yradex
 packages/react/transform/** @gaoachao
+packages/tailwind-preset/** @Dugyu @upupming
 packages/genui/** @pupiltong @Sherry-hue @gaoachao @HuJean @fzx2666-fz
 benchmark/react/** @hzy @HuJean @upupming

--- a/packages/tailwind-preset/README.md
+++ b/packages/tailwind-preset/README.md
@@ -131,4 +131,4 @@ createLynxPreset({
 
 #### Available Plugins
 
-- [uiVariants](https://github.com/lynx-family/lynx-stack/tree/main/packages/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md) — Class-based variants for expressing component state or structure using `ui-*` prefixes (e.g. `.ui-open:`, `.ui-side-left:`).
+- [uiVariants](https://github.com/lynx-family/lynx-stack/tree/main/packages/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md) — Class-based variants for expressing component state or structure using `ui-*` prefixes (for example, the default `.ui-open:` and opt-in `.ui-side-left:`).

--- a/packages/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
+++ b/packages/tailwind-preset/docs/plugins/lynx-ui/uiVariants.md
@@ -12,6 +12,7 @@ Before **v0.4.0**, `uiVariants` was **disabled by default** and had to be enable
 
 Starting with **v0.4.0**, `uiVariants` is **enabled by default**.
 You only need to configure it explicitly if you want to disable it or customize its options.
+With the default options, only the `ui` prefix is registered. The built-in `ui-side` and `ui-align` prefix value maps are available as explicit opt-ins.
 
 ## How to Customize
 
@@ -49,10 +50,9 @@ createLynxPreset({
 });
 ```
 
-> Tip: `uiVariants: {}` (empty object) and `uiVariants: true` both enable the plugin with default options.
-
+> Tip: `uiVariants: {}` (empty object) and `uiVariants: true` both enable the plugin with the default `ui` prefix.
 > Note: Passing an object replaces the default prefixes.
-> To extend/merge with defaults, use the function form shown below.
+> To extend or merge built-in prefix value maps, use the function form shown below.
 
 ### Customize Prefixes and Values
 
@@ -71,17 +71,17 @@ createLynxPreset({
 });
 ```
 
-### Advanced: Extend or Override Defaults Programmatically
+### Advanced: Extend or Override Built-ins Programmatically
 
-For full control while preserving built-in defaults, pass a function to prefixes. This allows extending, overriding, or merging prefix-value maps:
+For full control, pass a function to `prefixes`. The function receives all built-in prefix value maps, including the opt-in `ui-side` and `ui-align` maps. This allows enabling, extending, overriding, or merging them:
 
 ```ts
 createLynxPreset({
   lynxUIPlugins: {
     uiVariants: {
-      prefixes: (defaults) => ({
-        ...defaults,
-        ui: [...defaults.ui, 'expanded'], // extend existing
+      prefixes: (builtins) => ({
+        ...builtins, // explicitly enable all built-in prefixes
+        ui: [...builtins.ui, 'expanded'], // extend existing
         'ui-side': ['top', 'bottom'], // override
         'aria-expanded': ['true', 'false'], // add new prefix
       }),
@@ -92,9 +92,9 @@ createLynxPreset({
 
 This approach ensures forward compatibility while allowing you to tailor variants to your component system.
 
-### Default Prefixes and Values
+### Built-in Prefixes and Values
 
-When enabled with `true`, the plugin registers the following default variants:
+The plugin provides the following built-in prefix value maps:
 
 ```ts
 {
@@ -113,25 +113,45 @@ When enabled with `true`, the plugin registers the following default variants:
     'entering',
     'animating',
     'busy',
+    'focused',
+    'complete',
+    'filled',
+    'dragging',
   ],
   'ui-side': ['left', 'right', 'top', 'bottom'],
   'ui-align': ['start', 'end', 'center'],
 }
 ```
 
-These defaults are designed to support common component states and layout roles found in design systems and headless UI libraries.
+Only `ui` is registered by default. To register the other built-in prefixes, pass them explicitly:
+
+```ts
+createLynxPreset({
+  lynxUIPlugins: {
+    uiVariants: {
+      prefixes: ['ui', 'ui-side', 'ui-align'],
+    },
+  },
+});
+```
+
+These built-ins are designed to support common component states and optional layout roles found in design systems and headless UI libraries.
 
 ## Basic Usage Examples
 
 ```tsx
 // Generates: .ui-open:bg-blue-500
-<Popover className="ui-open:bg-blue-500" />
+<Popover className='ui-open:bg-blue-500' />;
+```
 
+The `ui-side` and `ui-align` examples require explicitly enabling their built-in prefixes as shown above:
+
+```tsx
 // Generates: .ui-side-left:border-l
-<Popover className="ui-side-left:border-l" />
+<Popover className='ui-side-left:border-l' />;
 
 // Generates: .ui-align-end:text-right
-<Popover className="ui-align-end:text-right" />
+<Popover className='ui-align-end:text-right' />;
 ```
 
 These variants enable component-aware styling by aligning Tailwind utilities with a component's runtime state or role in a scalable, declarative way.

--- a/packages/tailwind-preset/src/__tests__/plugins/lynx-ui/stateVariant.test.ts
+++ b/packages/tailwind-preset/src/__tests__/plugins/lynx-ui/stateVariant.test.ts
@@ -24,13 +24,15 @@ export function extractVariants(
 }
 
 describe('uiVariants plugin', () => {
-  it('registers variants with default prefix ui', () => {
+  it('registers only ui variants by default', () => {
     const plugin = uiVariants({});
     const { api } = runPlugin(plugin);
     const variants = extractVariants(vi.mocked(api.matchVariant));
 
-    expect(Object.keys(variants)).toEqual(
-      expect.arrayContaining(['ui']),
+    const keys = Object.keys(variants);
+    expect(keys).toHaveLength(4);
+    expect(keys).toEqual(
+      expect.arrayContaining(['ui', 'group-ui', 'peer-ui', 'parent-ui']),
     );
 
     const ui = variants['ui'];
@@ -38,6 +40,10 @@ describe('uiVariants plugin', () => {
     expect(ui?.('active', {})).toBe('&.ui-active');
     expect(ui?.('disabled', {})).toBe('&.ui-disabled');
     expect(ui?.('readonly', {})).toBe('&.ui-readonly');
+    expect(ui?.('focused', {})).toBe('&.ui-focused');
+    expect(ui?.('complete', {})).toBe('&.ui-complete');
+    expect(ui?.('filled', {})).toBe('&.ui-filled');
+    expect(ui?.('dragging', {})).toBe('&.ui-dragging');
   });
 
   it('registers group, peer, and parent variants', () => {
@@ -113,10 +119,10 @@ describe('uiVariants plugin', () => {
     expect(parent?.('active')).toBe('');
   });
 
-  it('allows function-based prefixes config with default inheritance', () => {
+  it('allows function-based prefixes config with built-in inheritance', () => {
     const plugin = uiVariants({
-      prefixes: (defaults) => ({
-        custom: [...defaults.ui, 'custom-state'],
+      prefixes: (builtins) => ({
+        custom: [...builtins.ui, 'custom-state'],
         'custom-side': ['left', 'right'],
       }),
     });

--- a/packages/tailwind-preset/src/core.ts
+++ b/packages/tailwind-preset/src/core.ts
@@ -250,7 +250,7 @@ export {
 // 'stroke'
 // 'strokeWidth'
 
-/** filter-related plugins, only gradyscale and blur are supported*/
+/** filter-related plugins, only grayscale and blur are supported */
 
 // 'brightness'
 // 'contrast'

--- a/packages/tailwind-preset/src/lynx.ts
+++ b/packages/tailwind-preset/src/lynx.ts
@@ -58,6 +58,8 @@ import { lynxTheme } from './theme.js';
  * // enable debug mode
  * createLynxPreset({ debug: true });
  *
+ * ```
+ *
  * @since 0.1.0
  */
 function createLynxPreset({

--- a/packages/tailwind-preset/src/plugins/lynx-ui/uiVariants.ts
+++ b/packages/tailwind-preset/src/plugins/lynx-ui/uiVariants.ts
@@ -28,10 +28,10 @@ import type { PluginWithOptions } from '../../helpers.js';
 import type { KeyValuePairOrList } from '../../types/plugin-types.js';
 
 /* -----------------------------------------------------------------------------
- * Default variant values per prefix
+ * Built-in variant values per prefix
  * -------------------------------------------------------------------------- */
 
-const DEFAULT_PREFIXES = {
+const BUILTIN_PREFIXES = {
   ui: [
     'active',
     'disabled',
@@ -47,17 +47,21 @@ const DEFAULT_PREFIXES = {
     'entering',
     'animating',
     'busy',
+    'focused',
+    'complete',
+    'filled',
+    'dragging',
   ],
   'ui-side': ['left', 'right', 'top', 'bottom'],
   'ui-align': ['start', 'end', 'center'],
 } as const;
 
-type DefaultPrefixMap = typeof DEFAULT_PREFIXES;
-type PrefixKey = keyof DefaultPrefixMap;
+type BuiltinPrefixMap = typeof BUILTIN_PREFIXES;
+type PrefixKey = keyof BuiltinPrefixMap;
 type PrefixConfig =
   | string[]
   | Record<string, KeyValuePairOrList>
-  | ((defaults: DefaultPrefixMap) => Record<string, KeyValuePairOrList>);
+  | ((builtins: BuiltinPrefixMap) => Record<string, KeyValuePairOrList>);
 
 interface UIVariantsOptions {
   /**
@@ -203,17 +207,17 @@ function normalizePrefixes(
   input?: PrefixConfig,
 ): Record<string, KeyValuePairOrList> {
   if (typeof input === 'function') {
-    return input(DEFAULT_PREFIXES);
+    return input(BUILTIN_PREFIXES);
   }
 
   if (Array.isArray(input)) {
     return Object.fromEntries(
       input.map((prefix) => [
         prefix,
-        DEFAULT_PREFIXES[prefix as PrefixKey] ?? [],
+        BUILTIN_PREFIXES[prefix as PrefixKey] ?? [],
       ]),
     );
   }
 
-  return input ?? { ui: DEFAULT_PREFIXES.ui };
+  return input ?? { ui: BUILTIN_PREFIXES.ui };
 }


### PR DESCRIPTION
## Motivation

Support the core state variants required by Input OTP and Slider, while
clarifying the default `uiVariants` prefix behavior.

## Changes

- Add `focused`, `complete`, and `filled` for Input OTP.
- Add `dragging` for Slider.
- Clarify that only `ui` is enabled by default; `ui-side` and `ui-align` are opt-in.
- Rename internal default-prefix terminology to built-in prefixes.
- Strengthen default registration and state coverage tests.
- Update documentation and add a patch changeset.
- Add CODEOWNERS for `tailwind-preset` and minor documentation cleanups.

## Validation

- `pnpm turbo build` — 66/66 tasks passed
- `pnpm run test --project tailwind-preset` — 26 files, 159 tests passed
- `pnpm dprint check` — passed
- `git diff --check` — passed

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `focused`, `complete`, `filled`, and `dragging` states to built-in UI variants.
  * Enabled the `ui` variant prefix by default, with optional `ui-side` and `ui-align` prefixes.
  * Added examples for enabling all built-in variant prefixes.

* **Documentation**
  * Clarified variant configuration and usage examples.
  * Improved wording and corrected minor formatting issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
