### PR TITLE
chore: run TypeScript 6 and TypeScript 7 side by side for Rslib builds

### DIFF
--- a/examples/gesture/package.json
+++ b/examples/gesture/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
-    "test:type": "tsc --noEmit"
+    "test:type": "tsc6 --noEmit"
   },
   "dependencies": {
     "@lynx-js/gesture-runtime": "workspace:*",

--- a/examples/react-et-mtf/package.json
+++ b/examples/react-et-mtf/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
-    "test:type": "tsc --noEmit"
+    "test:type": "tsc6 --noEmit"
   },
   "dependencies": {
     "@lynx-js/react": "workspace:*"

--- a/examples/react-main-thread-function/package.json
+++ b/examples/react-main-thread-function/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev",
-    "test:type": "tsc --noEmit"
+    "test:type": "tsc6 --noEmit"
   },
   "dependencies": {
     "@lynx-js/react": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc6 --build",
     "prepare": "husky && ts-patch install",
     "test": "vitest"
   },
@@ -38,7 +38,8 @@
     "@tsconfig/node22": "^22.0.5",
     "@tsconfig/strictest": "^2.0.8",
     "@types/node": "^24.13.3",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "@typescript/native": "npm:typescript@7.0.2",
+    "@typescript/typescript6": "6.0.2",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/eslint-plugin": "^1.6.23",
     "@vitest/ui": "^3.2.4",

--- a/packages/genui/a2ui-catalog-extractor/package.json
+++ b/packages/genui/a2ui-catalog-extractor/package.json
@@ -32,8 +32,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
-    "build:api": "tsc --project tsconfig.build.json",
+    "build": "tsc6 --project tsconfig.build.json",
+    "build:api": "tsc6 --project tsconfig.build.json",
     "test": "rstest"
   },
   "dependencies": {

--- a/packages/genui/a2ui-catalog-extractor/rslib.config.ts
+++ b/packages/genui/a2ui-catalog-extractor/rslib.config.ts
@@ -13,9 +13,8 @@ const config: RslibConfig = defineConfig({
       syntax: 'es2022',
       dts: {
         bundle: true,
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
     },

--- a/packages/genui/a2ui-prompt/rslib.config.ts
+++ b/packages/genui/a2ui-prompt/rslib.config.ts
@@ -13,9 +13,8 @@ const config: RslibConfig = defineConfig({
       syntax: 'es2022',
       dts: {
         bundle: true,
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
     },

--- a/packages/genui/a2ui/package.json
+++ b/packages/genui/a2ui/package.json
@@ -155,8 +155,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json && npm run build:catalog",
-    "build:api": "tsc --project tsconfig.build.json",
+    "build": "tsc6 --project tsconfig.build.json && npm run build:catalog",
+    "build:api": "tsc6 --project tsconfig.build.json",
     "build:catalog": "genui a2ui generate catalog --catalog-dir src/catalog --out-dir dist --catalog-id https://unpkg.com/@lynx-js/genui/a2ui/dist/catalog.json && node scripts/writeBasicFunctionCatalogs.js dist && node scripts/writeCatalogManifestIndex.js",
     "test": "rstest"
   },

--- a/packages/genui/cli/package.json
+++ b/packages/genui/cli/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc6 --project tsconfig.build.json",
     "test": "rstest"
   },
   "dependencies": {

--- a/packages/genui/mcp-apps/package.json
+++ b/packages/genui/mcp-apps/package.json
@@ -36,7 +36,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "pnpm run clean && tsc --project tsconfig.build.json && cp src/render/styles.css dist/render/styles.css",
+    "build": "pnpm run clean && tsc6 --project tsconfig.build.json && cp src/render/styles.css dist/render/styles.css",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true});\"",
     "test": "rstest"
   },

--- a/packages/genui/openui/package.json
+++ b/packages/genui/openui/package.json
@@ -36,8 +36,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && cp src/core/renderer.css dist/core/renderer.css",
-    "build:api": "tsc -p tsconfig.build.json"
+    "build": "tsc6 -p tsconfig.build.json && cp src/core/renderer.css dist/core/renderer.css",
+    "build:api": "tsc6 -p tsconfig.build.json"
   },
   "dependencies": {
     "@openuidev/lang-core": "^0.2.9",

--- a/packages/genui/package.json
+++ b/packages/genui/package.json
@@ -122,7 +122,7 @@
     "mcp-apps/dist"
   ],
   "scripts": {
-    "build": "pnpm run clean && tsc --project tsconfig.build.json",
+    "build": "pnpm run clean && tsc6 --project tsconfig.build.json",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true});\""
   },
   "dependencies": {

--- a/packages/genui/server/package.json
+++ b/packages/genui/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc --noEmit && rslib build",
+    "build": "tsc6 --noEmit && rslib build",
     "dev": "pnpm build && pnpm run --parallel \"/^dev:(build|server)$/\"",
     "dev:build": "rslib build --watch",
     "dev:server": "node --watch dist/index.js",

--- a/packages/lynx/autolink-codegen/rslib.config.ts
+++ b/packages/lynx/autolink-codegen/rslib.config.ts
@@ -13,9 +13,8 @@ const config: RslibConfig = defineConfig({
       syntax: 'es2022',
       dts: {
         bundle: true,
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
     },

--- a/packages/lynx/create-lynx-library/rslib.config.ts
+++ b/packages/lynx/create-lynx-library/rslib.config.ts
@@ -13,9 +13,8 @@ const config: RslibConfig = defineConfig({
       syntax: 'es2022',
       dts: {
         bundle: true,
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
     },

--- a/packages/mcp-servers/docs-mcp-server/package.json
+++ b/packages/mcp-servers/docs-mcp-server/package.json
@@ -14,7 +14,7 @@
     "main.ts"
   ],
   "scripts": {
-    "build": "tsc"
+    "build": "tsc6"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.25.2",

--- a/packages/react/runtime/package.json
+++ b/packages/react/runtime/package.json
@@ -15,7 +15,7 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc6 --build",
     "test": "pnpm run test:snapshot && pnpm run test:core && pnpm run test:et",
     "test:core": "vitest run __test__/core",
     "test:et": "vitest run -c __test__/element-template/vitest.config.ts --coverage",

--- a/packages/react/testing-library/rslib.config.ts
+++ b/packages/react/testing-library/rslib.config.ts
@@ -59,9 +59,8 @@ export default defineConfig({
       format: 'esm',
       dts: {
         bundle: true,
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
       output: {

--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -51,7 +51,7 @@
     "api-extractor": "api-extractor run --verbose",
     "build": "rslib build",
     "test": "rstest",
-    "test:type": "tsc --noEmit"
+    "test:type": "tsc6 --noEmit"
   },
   "dependencies": {
     "@lynx-js/debug-metadata-rsbuild-plugin": "workspace:^",

--- a/packages/rspeedy/plugin-config/package.json
+++ b/packages/rspeedy/plugin-config/package.json
@@ -35,7 +35,7 @@
     "api-extractor": "api-extractor run --verbose",
     "build": "rslib build",
     "test": "rstest",
-    "test:type": "tsc --noEmit"
+    "test:type": "tsc6 --noEmit"
   },
   "dependencies": {
     "@lynx-js/type-config": "4.1.3"

--- a/packages/rspeedy/plugin-lynx/package.json
+++ b/packages/rspeedy/plugin-lynx/package.json
@@ -35,7 +35,7 @@
     "api-extractor": "api-extractor run --verbose",
     "build": "rslib build",
     "test": "rstest run",
-    "test:type": "tsc --noEmit"
+    "test:type": "tsc6 --noEmit"
   },
   "dependencies": {
     "@lynx-js/cache-events-webpack-plugin": "workspace:^",

--- a/packages/rspeedy/plugin-qrcode/rslib.config.ts
+++ b/packages/rspeedy/plugin-qrcode/rslib.config.ts
@@ -8,9 +8,8 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2022',
       dts: {
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
     },

--- a/packages/tailwind-preset/rslib.config.ts
+++ b/packages/tailwind-preset/rslib.config.ts
@@ -12,9 +12,8 @@ export default defineConfig({
   lib: [
     {
       dts: {
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
       format: 'esm',

--- a/packages/testing-library/kitten-lynx/rslib.config.ts
+++ b/packages/testing-library/kitten-lynx/rslib.config.ts
@@ -10,9 +10,8 @@ export default defineConfig({
       syntax: 'es2022',
       dts: {
         bundle: true,
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
     },

--- a/packages/testing-library/testing-environment/rslib.config.ts
+++ b/packages/testing-library/testing-environment/rslib.config.ts
@@ -18,9 +18,8 @@ export default defineConfig({
       format: 'esm',
       syntax: 'es2021',
       dts: {
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
     },

--- a/packages/web-platform/web-rsbuild-plugin/rslib.config.ts
+++ b/packages/web-platform/web-rsbuild-plugin/rslib.config.ts
@@ -9,9 +9,8 @@ export default defineConfig({
       syntax: 'es2022',
       dts: {
         bundle: true,
-        tsgo: true,
         typescriptPath: fileURLToPath(
-          import.meta.resolve('@typescript/native-preview'),
+          import.meta.resolve('@typescript/native'),
         ),
       },
       source: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1557,7 +1557,7 @@ importers:
         version: 7.58.12(@types/node@24.13.3)
       '@rslib/core':
         specifier: catalog:rslib
-        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@7.0.2)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2))
@@ -2107,7 +2107,7 @@ importers:
         version: 1.0.6(@rsbuild/core@2.1.7(core-js@3.49.0))
       '@rslib/core':
         specifier: catalog:rslib
-        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@7.0.2)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2))
@@ -2164,7 +2164,7 @@ importers:
         version: 2.1.7(core-js@3.49.0)
       '@rslib/core':
         specifier: catalog:rslib
-        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@7.0.2)
       '@rstest/core':
         specifier: catalog:rstest
         version: 0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2))
@@ -15799,6 +15799,17 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(core-js@3.49.0)(typescript@7.0.2)':
+    dependencies:
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(typescript@7.0.2)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - core-js
+
   '@rspack/binding-darwin-arm64@2.1.5':
     optional: true
 
@@ -21746,6 +21757,14 @@ snapshots:
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       typescript: 6.0.3
+
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(typescript@7.0.2):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
+      typescript: 7.0.2
 
   rsbuild-plugin-i18next-extractor@0.2.1(@rsbuild/core@2.1.7(core-js@3.49.0))(i18next-cli@1.54.2(@swc/helpers@0.5.23)(@types/node@24.13.3)(i18next@26.3.6(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3))(rollup@4.62.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,12 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260707.2
-        version: 7.0.0-dev.20260707.2
+      '@typescript/native':
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
+      '@typescript/typescript6':
+        specifier: 6.0.2
+        version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.7(supports-color@10.2.2)(vitest@3.2.7)
@@ -6373,6 +6376,130 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
+
   '@typia/core@12.1.1':
     resolution: {integrity: sha512-SfyugTNTCJa75pVwSXwfx6SwvS5YcNOCBg8VjxqykhSgCyoAXkZtc2PsWEkeeaB8EPut1JRBCrzlWtsXo1EZ8Q==}
 
@@ -11655,6 +11782,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   typia-rspack-plugin@3.0.1:
     resolution: {integrity: sha512-QejxXofRkakQJwmUukpXyhtLi7M37ZIA5CkwcHWqTdjL2rFMB8WroNSGPdMaWxfFd3+DwI6yO9aQ5S6VYdYxNA==}
     engines: {node: '>=18'}
@@ -16631,6 +16763,71 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
+    optional: true
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@typia/core@12.1.1':
     dependencies:
@@ -22505,6 +22702,29 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   typia-rspack-plugin@3.0.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@6.0.3)(typia@12.1.1(typescript@6.0.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Keep the existing pipeline on TypeScript 6 via `@typescript/typescript6` and `tsc6`. Run TypeScript 7 alongside it as `@typescript/native` for Rslib declaration generation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and type-checking workflows to use TypeScript 6 tooling.
  * Replaced the TypeScript native preview integration with the stable native integration.
  * Simplified declaration-generation configuration by removing the deprecated TypeScript option.
  * No user-facing API or functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->