### PR TITLE
docs(plugin-config): generate full Lynx config field reference

### DIFF
--- a/.changeset/config-plugin-type-config-docs.md
+++ b/.changeset/config-plugin-type-config-docs.md
@@ -1,0 +1,6 @@
+---
+
+---
+
+Generate the full `@lynx-js/type-config` field reference alongside the
+`@lynx-js/config-rsbuild-plugin` API docs.

--- a/packages/rspeedy/plugin-config/package.json
+++ b/packages/rspeedy/plugin-config/package.json
@@ -32,7 +32,7 @@
     "README.md"
   ],
   "scripts": {
-    "api-extractor": "api-extractor run --verbose",
+    "api-extractor": "node scripts/api-extractor.mjs",
     "build": "rslib build",
     "test": "rstest",
     "test:type": "tsc6 --noEmit"
@@ -44,6 +44,7 @@
     "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/template-webpack-plugin": "workspace:*",
     "@lynx-js/test-tools": "workspace:*",
+    "@microsoft/api-extractor": "catalog:",
     "@rsbuild/core": "catalog:rsbuild",
     "@rspack/core": "catalog:rspack",
     "@rstest/core": "catalog:rstest",

--- a/packages/rspeedy/plugin-config/scripts/api-extractor.mjs
+++ b/packages/rspeedy/plugin-config/scripts/api-extractor.mjs
@@ -1,0 +1,98 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Runs the regular API Extractor for this package (forwarding CLI args such
+// as `--local`), then generates website/temp/type-config.api.json from the
+// installed `@lynx-js/type-config` package so that api-documenter renders the
+// full Lynx Config / CompilerOptions field reference alongside the
+// `@lynx-js/config-rsbuild-plugin` API docs: the plugin's `Config` interface
+// extends types from that package, and api-documenter can only resolve those
+// references when the package is part of the same doc model.
+//
+// The package is copied out of node_modules before extraction: API Extractor
+// treats files under a node_modules directory as external and refuses to
+// follow their internal `export *` chains, which would silently drop the
+// Config and CompilerOptions interfaces from the doc model.
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { Extractor, ExtractorConfig } from '@microsoft/api-extractor'
+
+const require = createRequire(import.meta.url)
+
+const forwardedArgs = process.argv.slice(2).filter(arg => arg !== '--')
+const apiExtractorBin = path.join(
+  path.dirname(require.resolve('@microsoft/api-extractor/package.json')),
+  'bin/api-extractor',
+)
+
+execFileSync(
+  process.execPath,
+  [apiExtractorBin, 'run', '--verbose', ...forwardedArgs],
+  { stdio: 'inherit' },
+)
+
+const typeConfigPkgJsonPath = require.resolve(
+  '@lynx-js/type-config/package.json',
+)
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '../../../..')
+const tempFolder = path.join(repoRoot, 'website/temp')
+const projectFolder = path.join(tempFolder, '.type-config-package')
+
+function copyDirSync(source, destination) {
+  fs.mkdirSync(destination, { recursive: true })
+  for (const entry of fs.readdirSync(source)) {
+    const sourcePath = path.join(source, entry)
+    const destinationPath = path.join(destination, entry)
+    if (fs.statSync(sourcePath).isDirectory()) {
+      copyDirSync(sourcePath, destinationPath)
+    } else {
+      fs.copyFileSync(sourcePath, destinationPath)
+    }
+  }
+}
+
+fs.rmSync(projectFolder, { recursive: true, force: true })
+copyDirSync(path.dirname(typeConfigPkgJsonPath), projectFolder)
+
+const extractorConfig = ExtractorConfig.prepare({
+  configObject: {
+    projectFolder,
+    mainEntryPointFilePath: path.join(projectFolder, 'index.d.ts'),
+    compiler: {
+      overrideTsconfig: {
+        compilerOptions: { types: [], lib: ['es2022'] },
+      },
+    },
+    apiReport: { enabled: false },
+    docModel: {
+      enabled: true,
+      apiJsonFilePath: path.join(tempFolder, 'type-config.api.json'),
+    },
+    dtsRollup: { enabled: false },
+    tsdocMetadata: { enabled: false },
+    messages: {
+      tsdocMessageReporting: { default: { logLevel: 'none' } },
+    },
+  },
+  configObjectFullPath: undefined,
+  packageJsonFullPath: path.join(projectFolder, 'package.json'),
+})
+
+const result = Extractor.invoke(extractorConfig, { localBuild: true })
+
+fs.rmSync(projectFolder, { recursive: true, force: true })
+
+if (!result.succeeded) {
+  throw new Error(
+    `API Extractor failed with ${result.errorCount} errors for @lynx-js/type-config`,
+  )
+}
+
+console.info('Generated website/temp/type-config.api.json')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1580,6 +1580,9 @@ importers:
       '@lynx-js/test-tools':
         specifier: workspace:*
         version: link:../../webpack/test-tools
+      '@microsoft/api-extractor':
+        specifier: 'catalog:'
+        version: 7.58.12(@types/node@24.13.3)
       '@rsbuild/core':
         specifier: catalog:rsbuild
         version: 2.1.7(core-js@3.49.0)

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -79,6 +79,16 @@ const SIDEBARS = {
     createAPI({
       name: 'config-rsbuild-plugin',
     }),
+    createAPI({
+      name: 'type-config',
+      text: '@lynx-js/type-config',
+      skips: [
+        'CompilerOptionsKeys',
+        'ConfigKeys',
+        'compilerOptionsKeys',
+        'configKeys',
+      ],
+    }),
   ],
   Webpack: [
     {
@@ -228,6 +238,17 @@ const SIDEBARS_ZH = {
     createAPI({
       base: 'zh/api',
       name: 'config-rsbuild-plugin',
+    }),
+    createAPI({
+      base: 'zh/api',
+      name: 'type-config',
+      text: '@lynx-js/type-config',
+      skips: [
+        'CompilerOptionsKeys',
+        'ConfigKeys',
+        'compilerOptionsKeys',
+        'configKeys',
+      ],
     }),
   ],
   Webpack: [


### PR DESCRIPTION
## Summary

The `config-rsbuild-plugin` API docs currently render `Config` as an empty interface: it extends types from `@lynx-js/type-config`, which API Extractor treats as external, so none of the config fields show up on the website.

This PR extracts the installed `@lynx-js/type-config` into a second doc model (`website/temp/type-config.api.json`) as part of the package's `api-extractor` script. api-documenter then renders every public `Config` / `CompilerOptions` field with its TSDoc (description, platform, since, default value), and the plugin's `Config` page cross-links to them. `@lynx-js/type-config` is also registered in the website API sidebar.

The package is copied out of node_modules before extraction because API Extractor refuses to follow `export *` chains of files under a node_modules directory (they are treated as external), which would silently drop the interfaces from the doc model.

## Changes

- `packages/rspeedy/plugin-config/scripts/api-extractor.mjs`: wraps the regular `api-extractor run` (forwarding CLI args) and generates `website/temp/type-config.api.json`
- `packages/rspeedy/plugin-config/package.json`: `api-extractor` script now runs the wrapper; add `@microsoft/api-extractor` devDependency
- `website/rspress.config.ts`: register `@lynx-js/type-config` in the en/zh API sidebars

Companion PR on lynx-website registers the package in `scripts/update-api-docs.sh` and syncs the regenerated pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `@lynx-js/type-config` API field reference documentation
  * Integrated API documentation into website navigation for both English and Chinese versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->