### PR TITLE
docs(plugin-config): fix usage example and drop dev-version link

### DIFF
--- a/.changeset/config-plugin-fix-example.md
+++ b/.changeset/config-plugin-fix-example.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/config-rsbuild-plugin": patch
+---
+
+Use a real exported config key (`alignMouseEventWithW3C`) in the usage
+examples, and drop the hard-coded link to the development-version config
+reference.

--- a/packages/rspeedy/plugin-config/src/index.ts
+++ b/packages/rspeedy/plugin-config/src/index.ts
@@ -15,7 +15,7 @@
  * export default defineConfig({
  *   plugins: [
  *     pluginLynxConfig({
- *       enableCheckExposureOptimize: false,
+ *       alignMouseEventWithW3C: true,
  *     }),
  *   ],
  * })

--- a/packages/rspeedy/plugin-config/src/pluginLynxConfig.ts
+++ b/packages/rspeedy/plugin-config/src/pluginLynxConfig.ts
@@ -27,8 +27,6 @@ const defaultUpgradeRspeedyLink =
 /**
  * A configuration interface for Lynx Config defined by `@lynx-js/type-config`.
  *
- * See all available options in {@link https://lynxjs.org/next/api/lynx-config/config-reference.html}.
- *
  * @public
  */
 export interface Config extends LynxConfig, LynxCompilerOptions {}
@@ -84,7 +82,7 @@ export interface Options {
  * export default defineConfig({
  *   plugins: [
  *     pluginLynxConfig({
- *       enableCheckExposureOptimize: false,
+ *       alignMouseEventWithW3C: true,
  *     }),
  *   ],
  * })


### PR DESCRIPTION
Follow-up to #3365, addressing two points from the lynx-website review (lynx-family/lynx-website#1269):

- The `pluginLynxConfig` usage examples used `enableCheckExposureOptimize`, which `@lynx-js/type-config` does not export; replace it with the real exported key `alignMouseEventWithW3C`.
- Remove the hard-coded `https://lynxjs.org/next/api/lynx-config/config-reference.html` link from the `Config` TSDoc: stable-version API pages should not send readers to development docs, and the interface now cross-links every field via its `type-config` doc-model pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin configuration examples to use the recommended `alignMouseEventWithW3C` setting.
  * Removed an outdated development-version reference link from the configuration documentation.
  * Added release notes documenting these documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->