### PR TITLE
fix(renovate): constrain Tailwind CSS updates to v3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,10 +55,17 @@
       "rangeStrategy": "bump",
     },
     {
+      // The Lynx preset relies on Tailwind CSS v3 configuration and internal
+      // APIs. Tailwind CSS v4 requires a dedicated migration across the preset,
+      // integrations, examples, and website.
+      "matchPackageNames": ["tailwindcss"],
+      "allowedVersions": "<4",
+    },
+    {
       // Batch low-risk updates: all devDependencies minor/patch bumps share one
-      // rolling PR instead of one PR each. Kept FIRST on purpose -- the specific
-      // groups below (Rspack, types, linting, ...) match later and win, so they
-      // keep their own PRs; only otherwise-ungrouped dev deps land here.
+      // rolling PR instead of one PR each. Kept near the top on purpose -- the
+      // specific groups below (Rspack, types, linting, ...) match later and win,
+      // so they keep their own PRs; only otherwise-ungrouped dev deps land here.
       // dependencies and every major update keep individual PRs for precise
       // review and rollback.
       "matchDepTypes": ["devDependencies"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "files.associations": {
     "api-extractor.json": "jsonc",
     "renovate.json": "jsonc",
+    "renovate.json5": "jsonc",
     "*.mdx": "mdx",
     "*.snap.txt": "markdown",
   },


### PR DESCRIPTION
- **What**
  - Constrain Renovate `tailwindcss` updates to `<4` to stop v4 major bump PRs.
  - Associate `.github/renovate.json5` with `jsonc` in workspace settings to reduce noisy JSON5 auto-reformat diffs.
- **Why**
  - `@lynx-js/tailwind-preset` currently targets Tailwind CSS v3 and relies on v3 config semantics plus internal implementation details, so accepting v4 bumps would create unreviewable/incorrect upgrade PRs.
- **Follow-up**
  - Add a Tailwind v3 compile/integration test for `@lynx-js/tailwind-preset` to make the support boundary explicit in CI.
  - Revisit the `<4` constraint once the preset has a confirmed Tailwind v4 support plan (migration or compatibility layer).

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restricted Tailwind CSS updates to versions below 4.
  * Improved editor support for Renovate configuration files with JSONC syntax highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
