### PR TITLE
fix(genui): expose bench for OpenUI

### DIFF
--- a/packages/genui/playground/src/App.tsx
+++ b/packages/genui/playground/src/App.tsx
@@ -45,17 +45,11 @@ interface TabDef {
   label: string;
 }
 
-const A2UI_TABS: TabDef[] = [
+const GENUI_TABS: TabDef[] = [
   { id: 'create', label: 'Create' },
   { id: 'examples', label: 'Examples' },
   { id: 'catalog', label: 'Catalog' },
   { id: 'bench', label: 'Bench' },
-];
-
-const OPENUI_TABS: TabDef[] = [
-  { id: 'create', label: 'Create' },
-  { id: 'examples', label: 'Examples' },
-  { id: 'catalog', label: 'Catalog' },
 ];
 
 const MCP_APPS_TABS: TabDef[] = [{ id: 'create', label: 'Create' }];
@@ -128,12 +122,7 @@ export function App() {
   const forcedTheme = useMemo(() => getForcedTheme(), []);
 
   const protocol = route.protocol;
-  let tabs = A2UI_TABS;
-  if (protocol.name === 'mcp-apps') {
-    tabs = MCP_APPS_TABS;
-  } else if (protocol.name === 'openui') {
-    tabs = OPENUI_TABS;
-  }
+  const tabs = protocol.name === 'mcp-apps' ? MCP_APPS_TABS : GENUI_TABS;
 
   useLayoutEffect(() => {
     ensureDefaultRouteHash();
@@ -176,11 +165,7 @@ export function App() {
       window.location.hash = buildRouteHash(name, 'create');
       return;
     }
-    // When switching to OpenUI and current tab is A2UI-only, fallback to examples.
-    const tab = name === 'openui' && route.tab === 'bench'
-      ? 'examples'
-      : route.tab;
-    window.location.hash = buildRouteHash(name, tab);
+    window.location.hash = buildRouteHash(name, route.tab);
   }, [route.tab]);
 
   const page = useMemo(() => {

--- a/packages/genui/playground/src/utils/appRoute.test.ts
+++ b/packages/genui/playground/src/utils/appRoute.test.ts
@@ -54,6 +54,7 @@ describe('app route hash', () => {
 
   test('uses the standalone bench root as the canonical runner route', () => {
     expect(buildRouteHash('a2ui', 'bench')).toBe('#/bench');
+    expect(buildRouteHash('openui', 'bench')).toBe('#/bench');
 
     expect(parseRouteHash('#/bench')).toMatchObject({
       protocol: { name: 'a2ui' },

--- a/packages/genui/playground/src/utils/appRoute.ts
+++ b/packages/genui/playground/src/utils/appRoute.ts
@@ -26,7 +26,7 @@ export function getRouteHash(hash: string): string {
 }
 
 export function buildRouteHash(protocolName: ProtocolName, tab: Tab): string {
-  if (protocolName === 'a2ui' && tab === 'bench') {
+  if (tab === 'bench') {
     return '#/bench';
   }
   return tab === 'create'


### PR DESCRIPTION
## Summary

- share the top-level GenUI tabs between A2UI and OpenUI so both expose Bench
- route Bench navigation from either protocol to the canonical protocol-neutral `#/bench`
- add regression coverage for OpenUI Bench route generation

## Root cause

The OpenUI tab list omitted Bench, and the route builder only canonicalized A2UI Bench navigation. Adding only the button would therefore have generated the unsupported `#/openui/bench` route instead of opening the shared Bench area.

## User impact

Users browsing the OpenUI playground can now open Bench directly from the top navigation, matching the A2UI experience.

## Validation

- `pnpm dprint fmt packages/genui/playground/src/App.tsx packages/genui/playground/src/utils/appRoute.ts packages/genui/playground/src/utils/appRoute.test.ts`
- `pnpm biome check packages/genui/playground/src/App.tsx packages/genui/playground/src/utils/appRoute.ts packages/genui/playground/src/utils/appRoute.test.ts`
- `pnpm eslint packages/genui/playground/src/App.tsx packages/genui/playground/src/utils/appRoute.ts packages/genui/playground/src/utils/appRoute.test.ts`
- `pnpm turbo build` — 66/66 tasks passed
- `pnpm -C packages/genui/playground test run src/utils/appRoute.test.ts` — 11/11 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protocol switching so the selected tab is preserved across non-MCP protocols.
  * OpenUI benchmark links now consistently use the canonical `#/bench` route.
  * Benchmark navigation works consistently regardless of the selected protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->