### PR TITLE
feat(web-core): add the engine context proxy

### DIFF
--- a/.changeset/engine-context-proxy.md
+++ b/.changeset/engine-context-proxy.md
@@ -1,0 +1,27 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Add `lynx.getEngine()`, the main-thread Engine context proxy.
+
+This is the web counterpart of the engine's `kEngine` context proxy. A card
+subscribes to it to receive the engine lifecycle events `__RenderPage`,
+`__UpdatePage`, `__DestroyLifetime` and `__UpdateGlobalProps`, which is how a
+card built directly from the Element PAPIs drives its own first paint, updates
+and cleanup.
+
+Listeners receive a plain `{ type, data }` object rather than a DOM event,
+matching what the engine hands scripts. For `__RenderPage` and `__UpdatePage`,
+`data` holds the call's positional arguments as an array.
+
+Existing bundles are unaffected. Each of these events keeps the engine's own
+fallback rule: if the card registered a listener the event is dispatched,
+otherwise the corresponding `globalThis.renderPage` / `updatePage` call happens
+exactly as before. Server-side rendering always reports no listener, so it stays
+on the direct path.
+
+Card teardown no longer requires a framework lifetime hook. A card that runs its
+own background script never installs `tt.callDestroyLifetimeFun`, and the
+resulting error previously propagated far enough to skip `destroyCard`, leaving
+the card registered after its view was gone. The hook is now optional, while a
+hook that exists and fails is still reported.

--- a/packages/web-platform/web-core/tests/cross-thread-context.spec.ts
+++ b/packages/web-platform/web-core/tests/cross-thread-context.spec.ts
@@ -1,0 +1,364 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import './jsdom.js';
+import { beforeEach, describe, expect, rstest, test } from '@rstest/core';
+import {
+  DispatchEventResult,
+  LynxCrossThreadContext,
+} from '../ts/client/LynxCrossThreadContext.js';
+import {
+  dispatchCoreContextOnBackgroundEndpoint,
+  dispatchJSContextOnMainThreadEndpoint,
+} from '../ts/client/endpoints.js';
+import type { Rpc, RpcEndpoint } from '@lynx-js/web-worker-rpc';
+import type { ContextCrossThreadEvent } from '../ts/types/index.js';
+
+type AnyEndpoint = RpcEndpoint<any[], any>;
+
+/**
+ * Stands in for `Rpc`, which otherwise needs a real `MessagePort` pair and a
+ * second worker. Only the two members `LynxCrossThreadContext` touches are
+ * modelled: `invoke` (outbound) and `registerHandler` (inbound). `deliver`
+ * plays the role of the peer thread posting a message.
+ */
+class FakeRpc {
+  readonly invocations: { endpoint: string; args: unknown[] }[] = [];
+  readonly handlers = new Map<string, (...args: any[]) => unknown>();
+
+  invoke(endpoint: AnyEndpoint, args: unknown[]): void {
+    this.invocations.push({ endpoint: endpoint.name, args });
+  }
+
+  registerHandler(
+    endpoint: AnyEndpoint,
+    handler: (...args: any[]) => unknown,
+  ): void {
+    this.handlers.set(endpoint.name, handler);
+  }
+
+  /**
+   * Simulates the peer thread invoking `endpoint` on us. Throws when nothing is
+   * registered so that a context which never wires up its handler fails loudly
+   * instead of silently swallowing the delivery.
+   */
+  deliver(endpoint: AnyEndpoint, ...args: unknown[]): void {
+    const handler = this.handlers.get(endpoint.name);
+    if (!handler) {
+      throw new Error(
+        `no handler registered for rpc endpoint "${endpoint.name}"`,
+      );
+    }
+    handler(...args);
+  }
+
+  asRpc(): Rpc {
+    return this as unknown as Rpc;
+  }
+}
+
+// The real wiring, from `createBackgroundLynx`: the background thread receives
+// on `dispatchCoreContextOnBackground` and sends on
+// `dispatchJSContextOnMainThread`. Keeping the production endpoints (rather
+// than ad-hoc ones) means a swap of the two config fields shows up here.
+const receiveEventEndpoint = dispatchCoreContextOnBackgroundEndpoint;
+const sendEventEndpoint = dispatchJSContextOnMainThreadEndpoint;
+
+describe('LynxCrossThreadContext (lynx.getJSContext / getCoreContext)', () => {
+  let rpc: FakeRpc;
+  let context: LynxCrossThreadContext;
+
+  beforeEach(() => {
+    rstest.resetAllMocks();
+    rpc = new FakeRpc();
+    context = new LynxCrossThreadContext({
+      rpc: rpc.asRpc(),
+      receiveEventEndpoint,
+      sendEventEndpoint,
+    });
+  });
+
+  // Outbound: unlike a normal `EventTarget`, `dispatchEvent` is a *send*. It
+  // must hand the event to the peer thread and deliberately not run any local
+  // listener, because the two directions are separate RPC endpoints.
+  describe('dispatchEvent forwards over rpc', () => {
+    test('invokes the send endpoint with the event', () => {
+      const event: ContextCrossThreadEvent = {
+        type: 'my-event',
+        data: { hello: 'world' },
+      };
+
+      context.dispatchEvent(event);
+
+      expect(rpc.invocations).toHaveLength(1);
+      expect(rpc.invocations[0]!.endpoint).toBe(sendEventEndpoint.name);
+      // The event travels as a single-element parameter tuple.
+      expect(rpc.invocations[0]!.args).toStrictEqual([event]);
+    });
+
+    test('sends on the send endpoint, never the receive endpoint', () => {
+      context.dispatchEvent({ type: 'my-event', data: {} });
+      expect(rpc.invocations[0]!.endpoint).not.toBe(receiveEventEndpoint.name);
+    });
+
+    test('does not invoke local listeners', () => {
+      const listener = rstest.fn();
+      context.addEventListener('my-event', listener);
+
+      context.dispatchEvent({ type: 'my-event', data: {} });
+
+      // Local delivery would double-handle the event: the peer thread echoes
+      // back through `receiveEventEndpoint` when it wants us to see it.
+      expect(listener).not.toHaveBeenCalled();
+      expect(rpc.invocations).toHaveLength(1);
+    });
+
+    test('returns CanceledBeforeDispatch', () => {
+      const result = context.dispatchEvent({ type: 'my-event', data: {} });
+      expect(result).toBe(DispatchEventResult.CanceledBeforeDispatch);
+      expect(result).not.toBe(DispatchEventResult.NotCanceled);
+    });
+
+    test('forwards each dispatch in order', () => {
+      context.dispatchEvent({ type: 'first', data: 1 });
+      context.dispatchEvent({ type: 'second', data: 2 });
+
+      expect(rpc.invocations).toHaveLength(2);
+      expect(rpc.invocations.map((i) => (i.args[0] as { type: string }).type))
+        .toStrictEqual(['first', 'second']);
+    });
+
+    test('forwards without requiring __start()', () => {
+      // Sending is independent of the inbound handler registration.
+      context.dispatchEvent({ type: 'my-event', data: {} });
+      expect(rpc.invocations).toHaveLength(1);
+    });
+  });
+
+  // Inbound: `__start()` registers the RPC handler that turns a `{ type, data }`
+  // payload from the peer thread into a local `MessageEvent`.
+  describe('__start registers the receive handler', () => {
+    test('no handler is registered before __start()', () => {
+      expect(rpc.handlers.has(receiveEventEndpoint.name)).toBe(false);
+    });
+
+    test('registers on the receive endpoint, not the send endpoint', () => {
+      context.__start();
+      expect(rpc.handlers.has(receiveEventEndpoint.name)).toBe(true);
+      expect(rpc.handlers.has(sendEventEndpoint.name)).toBe(false);
+    });
+
+    test('a delivered payload reaches an addEventListener listener', () => {
+      const listener = rstest.fn();
+      context.addEventListener('my-event', listener);
+      context.__start();
+
+      rpc.deliver(receiveEventEndpoint, {
+        type: 'my-event',
+        data: { hello: 'world' },
+      });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event = listener.mock.calls[0]![0] as MessageEvent;
+      expect(event.type).toBe('my-event');
+      expect(event.data).toStrictEqual({ hello: 'world' });
+    });
+
+    test('delivery does not echo back out over rpc', () => {
+      context.__start();
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+      // Receiving must not re-send, which would loop between the threads.
+      expect(rpc.invocations).toHaveLength(0);
+    });
+
+    test('only listeners for the delivered type run', () => {
+      const wanted = rstest.fn();
+      const other = rstest.fn();
+      context.addEventListener('my-event', wanted);
+      context.addEventListener('other-event', other);
+      context.__start();
+
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+
+      expect(wanted).toHaveBeenCalledTimes(1);
+      expect(other).not.toHaveBeenCalled();
+    });
+
+    test('supports several listeners on one type', () => {
+      const a = rstest.fn();
+      const b = rstest.fn();
+      context.addEventListener('my-event', a);
+      context.addEventListener('my-event', b);
+      context.__start();
+
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+
+    test('removeEventListener stops delivery', () => {
+      const listener = rstest.fn();
+      context.addEventListener('my-event', listener);
+      context.__start();
+
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      context.removeEventListener('my-event', listener);
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('a listener added after __start() still receives', () => {
+      context.__start();
+      const listener = rstest.fn();
+      context.addEventListener('my-event', listener);
+
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('successive deliveries each fire', () => {
+      const seen: unknown[] = [];
+      context.addEventListener('my-event', (e) => {
+        seen.push((e as MessageEvent).data);
+      });
+      context.__start();
+
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: 1 });
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: 2 });
+
+      expect(seen).toStrictEqual([1, 2]);
+    });
+
+    test('two contexts sharing one rpc stay on their own endpoints', () => {
+      // `createBackgroundLynx` builds a core context and a devtool context over
+      // the same `Rpc`; a delivery to one must not surface on the other.
+      const other = new LynxCrossThreadContext({
+        rpc: rpc.asRpc(),
+        receiveEventEndpoint: sendEventEndpoint,
+        sendEventEndpoint: receiveEventEndpoint,
+      });
+      const mine = rstest.fn();
+      const theirs = rstest.fn();
+      context.addEventListener('my-event', mine);
+      other.addEventListener('my-event', theirs);
+      context.__start();
+      other.__start();
+
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+
+      expect(mine).toHaveBeenCalledTimes(1);
+      expect(theirs).not.toHaveBeenCalled();
+    });
+  });
+
+  // `data: data ?? {}` — an absent payload becomes an empty object. This is a
+  // different contract from `LynxEngineContextImpl`, which intentionally keeps
+  // `data: undefined`; the two must not be "unified".
+  describe('missing data defaults to an empty object', () => {
+    const readData = (payload: { type: string; data?: unknown }) => {
+      let seen: unknown = 'unset';
+      context.addEventListener('my-event', (e) => {
+        seen = (e as MessageEvent).data;
+      });
+      context.__start();
+      rpc.deliver(receiveEventEndpoint, payload);
+      return seen;
+    };
+
+    test('undefined data arrives as {}', () => {
+      const seen = readData({ type: 'my-event', data: undefined });
+      expect(seen).toStrictEqual({});
+      // Without the `?? {}`, `MessageEvent` coerces `undefined` to `null`.
+      expect(seen).not.toBeNull();
+      expect(seen).not.toBe(undefined);
+    });
+
+    test('an absent data property arrives as {}', () => {
+      expect(readData({ type: 'my-event' })).toStrictEqual({});
+    });
+
+    test('null data also arrives as {}', () => {
+      // `??` treats null like undefined.
+      const seen = readData({ type: 'my-event', data: null });
+      expect(seen).toStrictEqual({});
+      expect(seen).not.toBeNull();
+    });
+
+    test('falsy-but-present data is preserved verbatim', () => {
+      // `??` must not swallow these the way `||` would.
+      expect(readData({ type: 'my-event', data: 0 })).toBe(0);
+    });
+
+    test('an empty string is preserved', () => {
+      expect(readData({ type: 'my-event', data: '' })).toBe('');
+    });
+
+    test('array data is preserved', () => {
+      expect(readData({ type: 'my-event', data: [1, 2] })).toStrictEqual([
+        1,
+        2,
+      ]);
+    });
+  });
+
+  describe('postMessage', () => {
+    test('is not implemented and reports on console.error', () => {
+      const consoleError = rstest.spyOn(console, 'error').mockImplementation(
+        () => {},
+      );
+
+      context.postMessage({ a: 1 }, 'second');
+
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError.mock.calls[0]![0]).toContain(
+        'postMessage not implemented',
+      );
+      // The arguments are echoed for debuggability.
+      expect(consoleError.mock.calls[0]!.slice(1)).toStrictEqual([
+        { a: 1 },
+        'second',
+      ]);
+      consoleError.mockRestore();
+    });
+
+    test('does not send anything over rpc', () => {
+      const consoleError = rstest.spyOn(console, 'error').mockImplementation(
+        () => {},
+      );
+      context.postMessage({ a: 1 });
+      expect(rpc.invocations).toHaveLength(0);
+      consoleError.mockRestore();
+    });
+  });
+
+  // Regression guard for the harness itself. `__start()` builds a
+  // `MessageEvent` and passes it to `EventTarget.prototype.dispatchEvent`,
+  // which brand-checks its argument. If `tests/jsdom.ts` ever supplies `Event`
+  // from jsdom without also supplying the matching `EventTarget`, the two
+  // realms disagree and every delivery throws
+  // `TypeError: The "event" argument must be an instance of Event` — which is
+  // exactly why this class went untested for so long.
+  describe('Event/EventTarget realm agreement', () => {
+    test('delivery does not throw a realm brand-check TypeError', () => {
+      context.__start();
+      expect(() => {
+        rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+      }).not.toThrow();
+    });
+
+    test('the delivered object is a real Event instance', () => {
+      const listener = rstest.fn();
+      context.addEventListener('my-event', listener);
+      context.__start();
+
+      rpc.deliver(receiveEventEndpoint, { type: 'my-event', data: {} });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0]![0]).toBeInstanceOf(Event);
+    });
+  });
+});

--- a/packages/web-platform/web-core/tests/engine-context.spec.ts
+++ b/packages/web-platform/web-core/tests/engine-context.spec.ts
@@ -1,0 +1,303 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import './jsdom.js';
+import { beforeEach, describe, expect, rstest, test } from '@rstest/core';
+import {
+  dispatchEngineEventWithFallback,
+  LynxEngineContextImpl,
+} from '../ts/client/mainthread/LynxEngineContext.js';
+import { DispatchEventResult } from '../ts/client/LynxCrossThreadContext.js';
+import { EngineMessageEventType } from '../ts/constants.js';
+import { createMainThreadGlobalAPIs } from '../ts/client/mainthread/createMainThreadGlobalAPIs.js';
+import type { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.js';
+
+// `tests/jsdom.ts` provides `requestAnimationFrame` but not its canceller, and
+// `createMainThreadLynx` captures both at module scope.
+if (typeof globalThis.cancelAnimationFrame !== 'function') {
+  globalThis.cancelAnimationFrame = (handle: number) => clearTimeout(handle);
+}
+
+describe('Engine context proxy (lynx.getEngine)', () => {
+  let engine: LynxEngineContextImpl;
+  beforeEach(() => {
+    rstest.resetAllMocks();
+    engine = new LynxEngineContextImpl();
+  });
+
+  test('event type constants match the engine', () => {
+    // core/runtime/js/runtime_constant.h
+    expect(EngineMessageEventType.RenderPage).toBe('__RenderPage');
+    expect(EngineMessageEventType.UpdatePage).toBe('__UpdatePage');
+    expect(EngineMessageEventType.DestroyLifetime).toBe('__DestroyLifetime');
+    expect(EngineMessageEventType.UpdateGlobalProps).toBe(
+      '__UpdateGlobalProps',
+    );
+  });
+
+  test('lynx.getEngine() returns the instance engine context', () => {
+    const engineContext = new LynxEngineContextImpl();
+    const { lynx } = createMainThreadGlobalAPIs({
+      engineContext,
+      globalprops: {},
+      systemInfo: {},
+      templateUrl: 'http://localhost/a.bundle',
+      backgroundThread: {
+        markTiming: rstest.fn(),
+        jsContext: { dispatchEvent: rstest.fn() },
+      },
+      i18nManager: { _I18nResourceTranslation: rstest.fn() },
+    } as unknown as LynxViewInstance);
+    expect(lynx.getEngine()).toBe(engineContext);
+    // getEngine and getJSContext must be distinct channels
+    expect(lynx.getEngine()).not.toBe(lynx.getJSContext());
+  });
+
+  describe('addEventListener / removeEventListener / dispatchEvent', () => {
+    test('dispatches a MessageEvent carrying type and data', () => {
+      const received: Event[] = [];
+      engine.addEventListener('__RenderPage', (e) => received.push(e));
+
+      const result = engine.dispatchEvent({
+        type: '__RenderPage',
+        data: [{ hello: 'world' }],
+      });
+
+      expect(received).toHaveLength(1);
+      const event = received[0]!;
+      expect(event.type).toBe('__RenderPage');
+      expect(event.data).toStrictEqual([{ hello: 'world' }]);
+      expect(result).toBe(DispatchEventResult.NotCanceled);
+    });
+
+    test('dispatching an unlistened type invokes nothing', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener);
+      engine.dispatchEvent({ type: '__UpdatePage', data: undefined });
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('removeEventListener stops delivery', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__DestroyLifetime', listener);
+      engine.dispatchEvent({
+        type: '__DestroyLifetime',
+        data: undefined,
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      engine.removeEventListener('__DestroyLifetime', listener);
+      engine.dispatchEvent({
+        type: '__DestroyLifetime',
+        data: undefined,
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('all four engine event types round-trip', () => {
+      const seen: string[] = [];
+      for (const type of Object.values(EngineMessageEventType)) {
+        engine.addEventListener(type, (e) => seen.push(e.type));
+      }
+      for (const type of Object.values(EngineMessageEventType)) {
+        engine.dispatchEvent({ type, data: undefined });
+      }
+      expect(seen).toStrictEqual([
+        '__RenderPage',
+        '__UpdatePage',
+        '__DestroyLifetime',
+        '__UpdateGlobalProps',
+      ]);
+    });
+
+    test('supports multiple listeners on the same type', () => {
+      const a = rstest.fn();
+      const b = rstest.fn();
+      engine.addEventListener('__RenderPage', a);
+      engine.addEventListener('__RenderPage', b);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+
+    test('once listeners fire a single time', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener, { once: true });
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('dispatch is synchronous', () => {
+      let ran = false;
+      engine.addEventListener('__RenderPage', () => {
+        ran = true;
+      });
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      // no await / microtask needed: the engine and MTS share a thread
+      expect(ran).toBe(true);
+    });
+  });
+
+  describe('hasEventListener', () => {
+    test('reflects registration state', () => {
+      const listener = rstest.fn();
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      engine.addEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      // unrelated types are unaffected
+      expect(engine.hasEventListener('__UpdatePage')).toBe(false);
+      engine.removeEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+    });
+
+    test('stays true until the last listener is removed', () => {
+      const a = rstest.fn();
+      const b = rstest.fn();
+      engine.addEventListener('__RenderPage', a);
+      engine.addEventListener('__RenderPage', b);
+      engine.removeEventListener('__RenderPage', a);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      engine.removeEventListener('__RenderPage', b);
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+    });
+
+    test('deduplicates re-registration of the same listener', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener);
+      engine.addEventListener('__RenderPage', listener);
+      // EventTarget ignores the second add, so a single remove must clear it
+      engine.removeEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+    });
+
+    test('tracks capture and bubble registrations separately', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener, { capture: true });
+      engine.addEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      // removing only the bubble registration leaves the capture one
+      engine.removeEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      engine.removeEventListener('__RenderPage', listener, { capture: true });
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+    });
+
+    test('removing a never-registered listener does not go negative', () => {
+      const listener = rstest.fn();
+      engine.removeEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      engine.addEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+    });
+
+    test('a once listener stops being reported after it fires', () => {
+      engine.addEventListener('__RenderPage', rstest.fn(), { once: true });
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+    });
+  });
+
+  describe('dispose', () => {
+    test('drops every listener', () => {
+      const render = rstest.fn();
+      const destroy = rstest.fn();
+      engine.addEventListener('__RenderPage', render);
+      engine.addEventListener('__DestroyLifetime', destroy, { capture: true });
+
+      engine.dispose();
+
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      expect(engine.hasEventListener('__DestroyLifetime')).toBe(false);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      engine.dispatchEvent({ type: '__DestroyLifetime', data: undefined });
+      expect(render).not.toHaveBeenCalled();
+      expect(destroy).not.toHaveBeenCalled();
+    });
+  });
+
+  // The highest-priority behaviour: existing ReactLynx bundles export
+  // `globalThis.renderPage` and never touch `lynx.getEngine()`, so the engine
+  // must keep calling them directly. Mirrors
+  // `TemplateAssembler::DispatchEventFromEngineToCoreContext`.
+  describe('fallback semantics', () => {
+    test('with a listener: dispatches the event and skips the direct call', () => {
+      const directCall = rstest.fn();
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener);
+
+      const usedEventChannel = dispatchEngineEventWithFallback(
+        engine,
+        '__RenderPage',
+        directCall,
+        [{ a: 1 }],
+      );
+
+      expect(usedEventChannel).toBe(true);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0]![0].data).toStrictEqual([
+        { a: 1 },
+      ]);
+      expect(directCall).not.toHaveBeenCalled();
+    });
+
+    test('without a listener: calls globalThis.renderPage directly', () => {
+      const directCall = rstest.fn();
+
+      const usedEventChannel = dispatchEngineEventWithFallback(
+        engine,
+        '__RenderPage',
+        directCall,
+        [{ a: 1 }],
+      );
+
+      expect(usedEventChannel).toBe(false);
+      expect(directCall).toHaveBeenCalledTimes(1);
+    });
+
+    test('a listener on a different type does not divert the direct call', () => {
+      const directCall = rstest.fn();
+      engine.addEventListener('__UpdatePage', rstest.fn());
+
+      expect(
+        dispatchEngineEventWithFallback(
+          engine,
+          '__RenderPage',
+          directCall,
+          [],
+        ),
+      ).toBe(false);
+      expect(directCall).toHaveBeenCalledTimes(1);
+    });
+
+    test('removing the last listener restores the direct-call path', () => {
+      const directCall = rstest.fn();
+      const listener = rstest.fn();
+      engine.addEventListener('__UpdatePage', listener);
+
+      dispatchEngineEventWithFallback(engine, '__UpdatePage', directCall, []);
+      expect(directCall).not.toHaveBeenCalled();
+
+      engine.removeEventListener('__UpdatePage', listener);
+      dispatchEngineEventWithFallback(engine, '__UpdatePage', directCall, []);
+      expect(directCall).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('positional args are packed into the event data array', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__UpdatePage', listener);
+
+      dispatchEngineEventWithFallback(engine, '__UpdatePage', rstest.fn(), [
+        { data: 1 },
+        { processorName: 'p' },
+      ]);
+
+      expect(listener.mock.calls[0]![0].data).toStrictEqual([
+        { data: 1 },
+        { processorName: 'p' },
+      ]);
+    });
+  });
+});

--- a/packages/web-platform/web-core/tests/engine-context.spec.ts
+++ b/packages/web-platform/web-core/tests/engine-context.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '../ts/client/mainthread/LynxEngineContext.js';
 import { DispatchEventResult } from '../ts/client/LynxCrossThreadContext.js';
 import { EngineMessageEventType } from '../ts/constants.js';
+import type { EngineMessageEvent } from '../ts/types/index.js';
 import { createMainThreadGlobalAPIs } from '../ts/client/mainthread/createMainThreadGlobalAPIs.js';
 import type { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.js';
 
@@ -55,7 +56,7 @@ describe('Engine context proxy (lynx.getEngine)', () => {
 
   describe('addEventListener / removeEventListener / dispatchEvent', () => {
     test('dispatches a MessageEvent carrying type and data', () => {
-      const received: Event[] = [];
+      const received: EngineMessageEvent[] = [];
       engine.addEventListener('__RenderPage', (e) => received.push(e));
 
       const result = engine.dispatchEvent({

--- a/packages/web-platform/web-core/tests/engine-context.spec.ts
+++ b/packages/web-platform/web-core/tests/engine-context.spec.ts
@@ -200,6 +200,224 @@ describe('Engine context proxy (lynx.getEngine)', () => {
     });
   });
 
+  // `hasEventListener` is backed by a ledger kept alongside `EventTarget`'s own
+  // registrations, so every case where `EventTarget` does *not* store what a
+  // naive counter would assume has to stay in sync. Drift here is worse than a
+  // merely wrong boolean: it silently flips the engine between the event
+  // channel and the direct `globalThis.renderPage` call.
+  describe('ledger parity with EventTarget', () => {
+    test('a duplicate add is one registration, cleared by one remove', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener);
+      engine.addEventListener('__RenderPage', listener);
+
+      // The duplicate add must not register a second time...
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // ...so a single remove has to clear the type entirely.
+      engine.removeEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('capture and bubble are independent registrations of one callback', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener, { capture: true });
+      engine.addEventListener('__RenderPage', listener);
+
+      // Both registrations are live, so the callback runs twice per dispatch.
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      // Removing the bubble one leaves the capture one behind.
+      engine.removeEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).toHaveBeenCalledTimes(3);
+
+      engine.removeEventListener('__RenderPage', listener, { capture: true });
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).toHaveBeenCalledTimes(3);
+    });
+
+    test('a capture flag passed as a boolean is the same registration', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener, { capture: true });
+      // `true` and `{ capture: true }` denote one registration for EventTarget.
+      engine.removeEventListener('__RenderPage', listener, true);
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('removing with a mismatched capture flag removes nothing', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener, { capture: true });
+      engine.removeEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('removing one of two distinct callbacks keeps the type reported', () => {
+      const a = rstest.fn();
+      const b = rstest.fn();
+      engine.addEventListener('__RenderPage', a);
+      engine.addEventListener('__RenderPage', b);
+      engine.removeEventListener('__RenderPage', a);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(a).not.toHaveBeenCalled();
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+
+    test('a redundant remove does not corrupt a later add', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener);
+      engine.removeEventListener('__RenderPage', listener);
+      engine.removeEventListener('__RenderPage', listener);
+      engine.addEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('a listener added during dispatch survives the dispatch', () => {
+      const late = rstest.fn();
+      engine.addEventListener('__RenderPage', () => {
+        engine.addEventListener('__UpdatePage', late);
+      }, { once: true });
+
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+
+      // The spent `once` listener is gone but the newly added one is not.
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      expect(engine.hasEventListener('__UpdatePage')).toBe(true);
+      engine.dispatchEvent({ type: '__UpdatePage', data: undefined });
+      expect(late).toHaveBeenCalledTimes(1);
+    });
+
+    test('a once listener may re-arm itself from inside its handler', () => {
+      let calls = 0;
+      const handler = () => {
+        calls++;
+        engine.addEventListener('__UpdatePage', handler, { once: true });
+      };
+      engine.addEventListener('__UpdatePage', handler, { once: true });
+
+      engine.dispatchEvent({ type: '__UpdatePage', data: undefined });
+      // Re-armed, so it must still be reported and must fire again.
+      expect(engine.hasEventListener('__UpdatePage')).toBe(true);
+      engine.dispatchEvent({ type: '__UpdatePage', data: undefined });
+      expect(calls).toBe(2);
+      expect(engine.hasEventListener('__UpdatePage')).toBe(true);
+    });
+
+    test('a once listener removed before firing is not reported', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener, { once: true });
+      engine.removeEventListener('__RenderPage', listener);
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('one once listener firing does not unregister its siblings', () => {
+      const onceFn = rstest.fn();
+      const persistent = rstest.fn();
+      engine.addEventListener('__RenderPage', onceFn, { once: true });
+      engine.addEventListener('__RenderPage', persistent);
+
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(engine.hasEventListener('__RenderPage')).toBe(true);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+
+      expect(onceFn).toHaveBeenCalledTimes(1);
+      expect(persistent).toHaveBeenCalledTimes(2);
+    });
+
+    test('a throwing listener still settles the once bookkeeping', () => {
+      const consoleError = rstest.spyOn(console, 'error').mockImplementation(
+        () => {},
+      );
+      engine.addEventListener('__RenderPage', () => {
+        throw new Error('boom');
+      }, { once: true });
+
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
+    test('a throwing listener does not stop the remaining listeners', () => {
+      const consoleError = rstest.spyOn(console, 'error').mockImplementation(
+        () => {},
+      );
+      const after = rstest.fn();
+      engine.addEventListener('__RenderPage', () => {
+        throw new Error('boom');
+      });
+      engine.addEventListener('__RenderPage', after);
+
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+
+      expect(after).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
+    test('capture listeners run before bubble listeners', () => {
+      const order: string[] = [];
+      engine.addEventListener('__RenderPage', () => order.push('bubble'));
+      engine.addEventListener('__RenderPage', () => order.push('capture'), {
+        capture: true,
+      });
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(order).toStrictEqual(['capture', 'bubble']);
+    });
+
+    test('a non-function listener is ignored rather than reported', () => {
+      engine.addEventListener(
+        '__RenderPage',
+        undefined as unknown as () => void,
+      );
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+    });
+  });
+
+  // The card-visible event object must keep the `{ type, data }` shape the
+  // engine hands lepus, even though it now travels as a real `MessageEvent`.
+  describe('event payload shape', () => {
+    test('an argument-less event carries undefined, not null', () => {
+      // `new MessageEvent(type, { data: undefined })` coerces `data` to `null`;
+      // `__DestroyLifetime` is a bare signal and must stay `undefined`.
+      let seen: unknown = 'unset';
+      engine.addEventListener('__DestroyLifetime', (e) => {
+        seen = e.data;
+      });
+      engine.dispatchEvent({ type: '__DestroyLifetime', data: undefined });
+      expect(seen).toBe(undefined);
+      expect(seen).not.toBe(null);
+    });
+
+    test('packed arguments survive as the same array contents', () => {
+      let seen: unknown;
+      engine.addEventListener('__UpdatePage', (e) => {
+        seen = e.data;
+      });
+      engine.dispatchEvent({
+        type: '__UpdatePage',
+        data: [{ a: 1 }, { b: 2 }],
+      });
+      expect(seen).toStrictEqual([{ a: 1 }, { b: 2 }]);
+    });
+  });
+
   describe('dispose', () => {
     test('drops every listener', () => {
       const render = rstest.fn();
@@ -215,6 +433,34 @@ describe('Engine context proxy (lynx.getEngine)', () => {
       engine.dispatchEvent({ type: '__DestroyLifetime', data: undefined });
       expect(render).not.toHaveBeenCalled();
       expect(destroy).not.toHaveBeenCalled();
+    });
+
+    test('a listener registered after disposal is inert', () => {
+      const late = rstest.fn();
+      engine.dispose();
+
+      // A card that subscribes during its own teardown must not resurrect the
+      // channel, and the engine must stay on the direct-call path.
+      engine.addEventListener('__RenderPage', late);
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(late).not.toHaveBeenCalled();
+
+      const directCall = rstest.fn();
+      expect(
+        dispatchEngineEventWithFallback(engine, '__RenderPage', directCall, []),
+      ).toBe(false);
+      expect(directCall).toHaveBeenCalledTimes(1);
+    });
+
+    test('disposal is idempotent', () => {
+      const listener = rstest.fn();
+      engine.addEventListener('__RenderPage', listener);
+      engine.dispose();
+      engine.dispose();
+      expect(engine.hasEventListener('__RenderPage')).toBe(false);
+      engine.dispatchEvent({ type: '__RenderPage', data: undefined });
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/web-platform/web-core/tests/engine-destroy-lifetime.spec.ts
+++ b/packages/web-platform/web-core/tests/engine-destroy-lifetime.spec.ts
@@ -1,0 +1,130 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import './jsdom.js';
+import { beforeEach, describe, expect, rstest, test } from '@rstest/core';
+import { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.js';
+import { LynxEngineContextImpl } from '../ts/client/mainthread/LynxEngineContext.js';
+import { EngineMessageEventType } from '../ts/constants.js';
+
+/**
+ * Drive `LynxViewInstance`'s teardown path without standing up a real worker,
+ * wasm context or template bundle. Only the collaborators that
+ * `[Symbol.asyncDispose]` reaches are stubbed; the engine dispatch logic under
+ * test is the real implementation.
+ */
+describe('__DestroyLifetime on teardown', () => {
+  let instance: LynxViewInstance;
+  let disposeCalls: string[];
+
+  beforeEach(() => {
+    rstest.resetAllMocks();
+    disposeCalls = [];
+
+    instance = Object.create(LynxViewInstance.prototype) as LynxViewInstance;
+    // `engineContext` is a readonly class field, so install it the way the
+    // real constructor would.
+    Object.defineProperty(instance, 'engineContext', {
+      value: new LynxEngineContextImpl(),
+      writable: false,
+      configurable: true,
+    });
+    Object.assign(instance, {
+      boundingClientRectService: {
+        dispose: () => disposeCalls.push('boundingClientRect'),
+      },
+      backgroundThread: {
+        [Symbol.asyncDispose]: async () => {
+          disposeCalls.push('backgroundThread');
+        },
+      },
+      exposureServices: { dispose: () => disposeCalls.push('exposure') },
+      mtsWasmBinding: {
+        disposeEventListeners: () => disposeCalls.push('mtsEventListeners'),
+        dispose: () => disposeCalls.push('mtsBinding'),
+      },
+    });
+  });
+
+  test('dispatches __DestroyLifetime when the instance is disposed', async () => {
+    const cleanup = rstest.fn();
+    instance.engineContext.addEventListener(
+      EngineMessageEventType.DestroyLifetime,
+      cleanup,
+    );
+
+    await instance[Symbol.asyncDispose]();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(
+      (cleanup.mock.calls[0]![0] as unknown as { type: string }).type,
+    ).toBe('__DestroyLifetime');
+  });
+
+  test('the card can still clean up element listeners during the event', async () => {
+    // The card's cleanup must run while the element tree is still intact, so
+    // __DestroyLifetime has to fire *before* the binding is torn down.
+    instance.engineContext.addEventListener(
+      EngineMessageEventType.DestroyLifetime,
+      () => disposeCalls.push('cardCleanup'),
+    );
+
+    await instance[Symbol.asyncDispose]();
+
+    expect(disposeCalls[0]).toBe('cardCleanup');
+    expect(disposeCalls).toContain('mtsEventListeners');
+    expect(disposeCalls.indexOf('cardCleanup')).toBeLessThan(
+      disposeCalls.indexOf('mtsEventListeners'),
+    );
+  });
+
+  test('listeners are dropped after disposal', async () => {
+    const cleanup = rstest.fn();
+    instance.engineContext.addEventListener(
+      EngineMessageEventType.DestroyLifetime,
+      cleanup,
+    );
+
+    await instance[Symbol.asyncDispose]();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    // the proxy must not retain card closures past teardown
+    expect(
+      instance.engineContext.hasEventListener(
+        EngineMessageEventType.DestroyLifetime,
+      ),
+    ).toBe(false);
+    instance.engineContext.dispatchEvent({
+      type: EngineMessageEventType.DestroyLifetime,
+      data: undefined,
+    });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test('disposal completes even with no __DestroyLifetime listener', async () => {
+    await expect(instance[Symbol.asyncDispose]()).resolves.toBeUndefined();
+    expect(disposeCalls).toContain('backgroundThread');
+    expect(disposeCalls).toContain('mtsEventListeners');
+  });
+
+  test('a throwing card cleanup does not abort teardown', async () => {
+    // Otherwise a buggy card would leak the worker and DOM listeners.
+    const consoleError = rstest.spyOn(console, 'error').mockImplementation(
+      () => {},
+    );
+    instance.engineContext.addEventListener(
+      EngineMessageEventType.DestroyLifetime,
+      () => {
+        throw new Error('card cleanup blew up');
+      },
+    );
+
+    await expect(instance[Symbol.asyncDispose]()).resolves.toBeUndefined();
+
+    expect(disposeCalls).toContain('backgroundThread');
+    expect(disposeCalls).toContain('exposure');
+    expect(disposeCalls).toContain('mtsEventListeners');
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/web-platform/web-core/tests/jsdom.ts
+++ b/packages/web-platform/web-core/tests/jsdom.ts
@@ -117,4 +117,12 @@ Object.assign(globalThis, {
   DOMRect: window.DOMRect,
   Event: window.Event,
   MouseEvent: window.MouseEvent,
+  // `Event` above comes from jsdom, so `EventTarget` must too: Node's own
+  // `EventTarget.prototype.dispatchEvent` brand-checks its argument against
+  // Node's internal `Event`, which a jsdom `Event` is not. Mixing the two
+  // makes any `dispatchEvent` throw
+  // `TypeError: The "event" argument must be an instance of Event`, which is
+  // what production code built on `EventTarget` — `LynxCrossThreadContext`
+  // and `LynxEngineContextImpl` — relies on.
+  EventTarget: window.EventTarget,
 });

--- a/packages/web-platform/web-core/tests/register-dispose-handler.spec.ts
+++ b/packages/web-platform/web-core/tests/register-dispose-handler.spec.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import './jsdom.js';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  rstest,
+  test,
+} from '@rstest/core';
+import { registerDisposeHandler } from '../ts/client/background/background-apis/crossThreadHandlers/registerDisposeHandler.js';
+import { disposeEndpoint } from '../ts/client/endpoints.js';
+import type { NativeApp } from '../ts/types/index.js';
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+
+/**
+ * `registerDisposeHandler` is the background-thread side of `lynx-view`
+ * teardown. It bridges to two lynx-core entry points:
+ *
+ * - `callDestroyLifetimeFun(id)` forwards to `tt.callDestroyLifetimeFun`, an
+ *   *optional* hook that only the ReactLynx background runtime installs;
+ * - `destroyCard(id)` is mandatory — it destroys the app and removes it from
+ *   `nativeGlobal.multiApps`.
+ *
+ * Buildless (vanilla / Lynx XML markup) cards ship their own background script
+ * and never install the ReactLynx hook, so lynx-core throws a `TypeError` for
+ * them. These tests pin down that the optional hook cannot take the mandatory
+ * teardown down with it.
+ */
+describe('registerDisposeHandler', () => {
+  let handler: () => void;
+  let rpc: Rpc;
+  let nativeApp: NativeApp;
+  let consoleError: ReturnType<typeof rstest.spyOn>;
+
+  beforeEach(() => {
+    handler = () => {
+      throw new Error('dispose handler was never registered');
+    };
+    rpc = {
+      registerHandler: (endpoint: { name: string }, fn: () => void) => {
+        expect(endpoint.name).toBe(disposeEndpoint.name);
+        handler = fn;
+      },
+    } as unknown as Rpc;
+    nativeApp = { id: '0' } as unknown as NativeApp;
+    // Spy rather than assign, so real error output is restored for other specs
+    // that may share this worker.
+    consoleError = rstest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  test('calls the lifetime hook before destroying the card', () => {
+    const calls: string[] = [];
+    registerDisposeHandler(
+      rpc,
+      nativeApp,
+      (id) => calls.push(`destroyCard:${id}`),
+      (id) => calls.push(`callDestroyLifetimeFun:${id}`),
+    );
+
+    handler();
+
+    expect(calls).toStrictEqual([
+      'callDestroyLifetimeFun:0',
+      'destroyCard:0',
+    ]);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('still destroys the card when the card has no lifetime hook', () => {
+    const calls: string[] = [];
+    registerDisposeHandler(
+      rpc,
+      nativeApp,
+      (id) => calls.push(`destroyCard:${id}`),
+      () => {
+        // The shape lynx-core throws for a card that never ran ReactLynx's
+        // `injectTt`, i.e. every Lynx XML markup card.
+        throw new TypeError(
+          'nativeGlobal.multiApps[id].callDestroyLifetimeFun is not a function',
+        );
+      },
+    );
+
+    expect(() => handler()).not.toThrow();
+
+    expect(calls).toStrictEqual(['destroyCard:0']);
+    // A card simply not having the optional hook is not an error worth logging.
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('reports a failing lifetime callback but still destroys the card', () => {
+    const calls: string[] = [];
+    const failure = new Error('framework cleanup blew up');
+    registerDisposeHandler(
+      rpc,
+      nativeApp,
+      (id) => calls.push(`destroyCard:${id}`),
+      () => {
+        throw failure;
+      },
+    );
+
+    expect(() => handler()).not.toThrow();
+
+    expect(calls).toStrictEqual(['destroyCard:0']);
+    // Unlike a missing hook, a hook that exists and throws is a real defect and
+    // must stay visible.
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0]?.[1]).toBe(failure);
+  });
+});

--- a/packages/web-platform/web-core/ts/client/background/background-apis/crossThreadHandlers/registerDisposeHandler.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/crossThreadHandlers/registerDisposeHandler.ts
@@ -14,7 +14,36 @@ export function registerDisposeHandler(
 ): void {
   rpc.registerHandler(disposeEndpoint, () => {
     const id = nativeApp.id;
-    callDestroyLifetimeFun(id);
+    // `callDestroyLifetimeFun` forwards to `tt.callDestroyLifetimeFun`, which is
+    // injected by the ReactLynx background runtime (`injectTt`). Buildless
+    // (vanilla / Lynx XML markup) cards run their own background script and
+    // never install that hook, so lynx-core throws
+    // "callDestroyLifetimeFun is not a function" for them. The framework
+    // lifetime callback is optional, but `destroyCard` — which tears the app
+    // down and drops it from `nativeGlobal.multiApps` — is not, so the throw
+    // must not be allowed to skip it.
+    try {
+      callDestroyLifetimeFun(id);
+    } catch (e) {
+      // Nothing to report when the card simply has no framework lifetime hook;
+      // a genuine failure inside a framework's callback is still surfaced.
+      if (!isMissingLifetimeHookError(e)) {
+        console.error(
+          '[lynx-web] error while calling the card destroy lifetime hook',
+          e,
+        );
+      }
+    }
     destroyCard(id);
   });
+}
+
+/**
+ * Whether `error` is lynx-core complaining that the card never installed
+ * `tt.callDestroyLifetimeFun`, as opposed to a framework lifetime callback
+ * failing on its own.
+ */
+function isMissingLifetimeHookError(error: unknown): boolean {
+  return error instanceof TypeError
+    && error.message.includes('callDestroyLifetimeFun');
 }

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxEngineContext.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxEngineContext.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2025 The Lynx Authors. All rights reserved.
+ * Licensed under the Apache License Version 2.0 that can be found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import type {
+  Cloneable,
+  ContextCrossThreadEvent,
+  EngineMessageEvent,
+  LynxEngineContext,
+} from '../../types/index.js';
+import { DispatchEventResult } from '../LynxCrossThreadContext.js';
+
+interface Registration {
+  listener: (event: EngineMessageEvent) => void;
+  once: boolean;
+}
+
+/**
+ * Main-thread-local implementation of the Engine context proxy
+ * (`ContextProxy::Type::kEngine`).
+ *
+ * Buildless (vanilla) Lynx cards subscribe to engine lifecycle events instead
+ * of exporting `globalThis.renderPage` / `globalThis.updatePage`:
+ *
+ * ```js
+ * const engine = lynx.getEngine();
+ * engine.addEventListener('__RenderPage', onRenderPage);
+ * engine.addEventListener('__DestroyLifetime', cleanup);
+ * ```
+ *
+ * The engine side (`LynxViewInstance`) must consult {@link hasEventListener}
+ * before dispatching and fall back to the direct global call when no listener
+ * is registered — this is what keeps existing ReactLynx bundles working. See
+ * `TemplateAssembler::DispatchEventFromEngineToCoreContext` and
+ * {@link dispatchEngineEventWithFallback}.
+ *
+ * Unlike `LynxCrossThreadContext`, this is not backed by a DOM `EventTarget`.
+ * The engine and the main-thread script share a thread, so there is no event
+ * tree to propagate through and no RPC hop; listeners are invoked
+ * synchronously and receive a plain `{ type, data }` object. That mirrors the
+ * engine, where `LepusClosureEventListener::ConvertEventToLepusValue` hands
+ * a `MessageEvent` to lepus as a plain object carrying `type` and `data`
+ * rather than as a DOM event.
+ */
+export class LynxEngineContextImpl implements LynxEngineContext {
+  /**
+   * `type` -> capture flag -> registrations, in insertion order.
+   *
+   * `capture` is part of listener identity for `EventTarget` parity (adding
+   * the same callback once capturing and once bubbling yields two
+   * registrations), even though there is no tree to capture through.
+   */
+  #listeners: Map<
+    string,
+    Map<boolean, Map<(event: EngineMessageEvent) => void, Registration>>
+  > = new Map();
+
+  static #captureOf(
+    options?: boolean | AddEventListenerOptions | EventListenerOptions,
+  ): boolean {
+    return typeof options === 'boolean' ? options : options?.capture === true;
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: EngineMessageEvent) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    if (typeof listener !== 'function') return;
+    const capture = LynxEngineContextImpl.#captureOf(options);
+    let byCapture = this.#listeners.get(type);
+    if (!byCapture) {
+      byCapture = new Map();
+      this.#listeners.set(type, byCapture);
+    }
+    let registrations = byCapture.get(capture);
+    if (!registrations) {
+      registrations = new Map();
+      byCapture.set(capture, registrations);
+    }
+    // Re-adding the same (type, listener, capture) triple is a no-op, matching
+    // `EventTarget`.
+    if (registrations.has(listener)) return;
+    registrations.set(listener, {
+      listener,
+      once: typeof options === 'object' && options?.once === true,
+    });
+  }
+
+  removeEventListener(
+    type: string,
+    listener: (event: EngineMessageEvent) => void,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    const capture = LynxEngineContextImpl.#captureOf(options);
+    const byCapture = this.#listeners.get(type);
+    const registrations = byCapture?.get(capture);
+    if (!registrations?.delete(listener)) return;
+    if (registrations.size === 0) byCapture!.delete(capture);
+    if (byCapture!.size === 0) this.#listeners.delete(type);
+  }
+
+  /**
+   * Whether at least one listener is registered for `type`, regardless of its
+   * capture flag. This is the web counterpart of
+   * `ContextProxy::HasEventListener`, which the engine consults to choose
+   * between the event channel and the legacy direct call.
+   */
+  hasEventListener(type: string): boolean {
+    return this.#listeners.has(type);
+  }
+
+  /**
+   * Dispatch an engine message event to the main-thread script.
+   *
+   * Accepts the `{ type, data }` shape used by `LynxCrossThreadContext` so
+   * card code can dispatch onto the engine proxy with the same call shape it
+   * uses for `lynx.getJSContext()`.
+   *
+   * Listeners run synchronously. A throwing listener is reported and does not
+   * prevent the remaining listeners from running, matching `EventTarget`.
+   */
+  dispatchEvent(event: ContextCrossThreadEvent): number {
+    const byCapture = this.#listeners.get(event.type);
+    if (!byCapture) return DispatchEventResult.NotCanceled;
+
+    const messageEvent: EngineMessageEvent = {
+      type: event.type,
+      data: event.data,
+    };
+    // Capture listeners first, then bubble ones, mirroring DOM ordering.
+    for (const capture of [true, false]) {
+      const registrations = byCapture.get(capture);
+      if (!registrations) continue;
+      // Snapshot: a listener may add or remove listeners while running.
+      for (const registration of [...registrations.values()]) {
+        if (registration.once) {
+          this.removeEventListener(event.type, registration.listener, capture);
+        }
+        try {
+          registration.listener(messageEvent);
+        } catch (e) {
+          console.error(
+            `[lynx-web] error in engine "${event.type}" listener`,
+            e,
+          );
+        }
+      }
+    }
+    return DispatchEventResult.NotCanceled;
+  }
+
+  /**
+   * Drop every listener. Called on teardown *after* `__DestroyLifetime` has
+   * been delivered, so a card that forgets to unsubscribe cannot keep the
+   * main-thread realm alive through this proxy.
+   */
+  dispose(): void {
+    this.#listeners.clear();
+  }
+}
+
+/**
+ * Deliver an engine lifecycle event to the main-thread script, mirroring
+ * `TemplateAssembler::DispatchEventFromEngineToCoreContext`:
+ *
+ * - if the Engine context proxy has a listener for `eventName`, dispatch a
+ *   message event whose `data` carries the call arguments;
+ * - otherwise fall back to calling the corresponding global function
+ *   (`globalThis.renderPage` / `globalThis.updatePage`) directly.
+ *
+ * The fallback is what keeps existing ReactLynx bundles — which export
+ * `globalThis.renderPage` and never touch `lynx.getEngine()` — working
+ * unchanged.
+ *
+ * `args` is passed as an array, matching the engine, which packs `args...`
+ * into a `lepus::CArray`. Events dispatched outside this helper - such as
+ * `__DestroyLifetime`, a bare teardown signal - carry no arguments and so do
+ * not use the array shape.
+ *
+ * @returns `true` when the event channel was used, `false` when `directCall`
+ * ran. Returned for observability (tests, tracing); callers may ignore it.
+ */
+export function dispatchEngineEventWithFallback(
+  engineContext: LynxEngineContext,
+  eventName: string,
+  directCall: () => void,
+  args: unknown[],
+): boolean {
+  if (engineContext.hasEventListener(eventName)) {
+    engineContext.dispatchEvent({
+      type: eventName,
+      data: args as Cloneable,
+    });
+    return true;
+  }
+  directCall();
+  return false;
+}

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxEngineContext.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxEngineContext.ts
@@ -10,9 +10,53 @@ import type {
 } from '../../types/index.js';
 import { DispatchEventResult } from '../LynxCrossThreadContext.js';
 
-interface Registration {
-  listener: (event: EngineMessageEvent) => void;
-  once: boolean;
+type EngineEventListener = (event: EngineMessageEvent) => void;
+
+function captureOf(
+  options?: boolean | AddEventListenerOptions | EventListenerOptions,
+): boolean {
+  return typeof options === 'boolean' ? options : options?.capture === true;
+}
+
+/**
+ * Ledger key. `capture` is part of listener identity for `EventTarget` — the
+ * same callback added once capturing and once bubbling is two registrations —
+ * so it is part of the key too.
+ */
+function ledgerKey(type: string, capture: boolean): string {
+  return `${capture ? 'C' : 'B'}\u0000${type}`;
+}
+
+/** An `Event` carrying the engine's `data` payload. See {@link engineEvent}. */
+interface EngineEventCtor {
+  new(type: string, data: Cloneable[] | undefined): Event;
+}
+let EngineEvent: EngineEventCtor | undefined;
+
+/**
+ * Build the object handed to `super.dispatchEvent`.
+ *
+ * `EventTarget` only accepts a real `Event`, so the engine's `{ type, data }`
+ * has to travel as one. It is deliberately an `Event` subclass rather than a
+ * `MessageEvent`: `new MessageEvent(type, { data: undefined })` coerces `data`
+ * to `null`, whereas the engine uses `undefined` to mark an event that carries
+ * no packed arguments (`__DestroyLifetime`), and the public
+ * `EngineMessageEvent.data` type admits no `null`. Subclassing also keeps the
+ * event in the same realm as the `Event` this class was defined against, which
+ * `dispatchEvent` brand-checks.
+ *
+ * The class is built on first use because `Event` is not guaranteed to exist
+ * when this module is evaluated.
+ */
+function engineEvent(type: string, data: Cloneable[] | undefined): Event {
+  EngineEvent ??= class extends Event {
+    readonly data: Cloneable[] | undefined;
+    constructor(eventType: string, eventData: Cloneable[] | undefined) {
+      super(eventType);
+      this.data = eventData;
+    }
+  };
+  return new EngineEvent(type, data);
 }
 
 /**
@@ -34,70 +78,105 @@ interface Registration {
  * `TemplateAssembler::DispatchEventFromEngineToCoreContext` and
  * {@link dispatchEngineEventWithFallback}.
  *
- * Unlike `LynxCrossThreadContext`, this is not backed by a DOM `EventTarget`.
- * The engine and the main-thread script share a thread, so there is no event
- * tree to propagate through and no RPC hop; listeners are invoked
- * synchronously and receive a plain `{ type, data }` object. That mirrors the
- * engine, where `LepusClosureEventListener::ConvertEventToLepusValue` hands
- * a `MessageEvent` to lepus as a plain object carrying `type` and `data`
- * rather than as a DOM event.
+ * Registration identity, invocation order, `once` and duplicate-add semantics
+ * are delegated to `EventTarget`, exactly as `LynxCrossThreadContext` does for
+ * `lynx.getJSContext()`, so the two contexts a card can reach behave alike.
+ * Listeners receive an event whose `type` and `data` mirror the engine, where
+ * `LepusClosureEventListener::ConvertEventToLepusValue` reads those same two
+ * fields off the event before handing them to lepus.
+ *
+ * Unlike the JS context there is no RPC hop: the engine and the main-thread
+ * script share a thread, so `dispatchEvent` delivers synchronously.
  */
-export class LynxEngineContextImpl implements LynxEngineContext {
+export class LynxEngineContextImpl extends EventTarget
+  implements LynxEngineContext
+{
   /**
-   * `type` -> capture flag -> registrations, in insertion order.
+   * Mirror of what has been handed to `EventTarget`, keyed by
+   * {@link ledgerKey} and mapping each card callback to the wrapper actually
+   * registered for it.
    *
-   * `capture` is part of listener identity for `EventTarget` parity (adding
-   * the same callback once capturing and once bubbling yields two
-   * registrations), even though there is no tree to capture through.
+   * `EventTarget` exposes no way to ask whether a type has listeners, and the
+   * engine needs exactly that to choose between the event channel and the
+   * legacy direct call. The ledger answers {@link hasEventListener} and holds
+   * the wrappers needed to unregister; it never decides ordering or delivery.
+   * Empty buckets are dropped, so a bucket's presence is itself the answer.
    */
-  #listeners: Map<
-    string,
-    Map<boolean, Map<(event: EngineMessageEvent) => void, Registration>>
-  > = new Map();
+  #ledger: Map<string, Map<EngineEventListener, EventListener>> = new Map();
 
-  static #captureOf(
-    options?: boolean | AddEventListenerOptions | EventListenerOptions,
-  ): boolean {
-    return typeof options === 'boolean' ? options : options?.capture === true;
-  }
+  #disposed = false;
 
-  addEventListener(
+  // @ts-expect-error the listener receives the `{ type, data }` view of the
+  // dispatched `MessageEvent`, which is narrower than DOM `EventListener`.
+  override addEventListener(
     type: string,
-    listener: (event: EngineMessageEvent) => void,
+    listener: EngineEventListener,
     options?: boolean | AddEventListenerOptions,
   ): void {
-    if (typeof listener !== 'function') return;
-    const capture = LynxEngineContextImpl.#captureOf(options);
-    let byCapture = this.#listeners.get(type);
-    if (!byCapture) {
-      byCapture = new Map();
-      this.#listeners.set(type, byCapture);
+    if (typeof listener !== 'function' || this.#disposed) return;
+    const capture = captureOf(options);
+    const key = ledgerKey(type, capture);
+    let bucket = this.#ledger.get(key);
+    if (!bucket) {
+      bucket = new Map();
+      this.#ledger.set(key, bucket);
     }
-    let registrations = byCapture.get(capture);
-    if (!registrations) {
-      registrations = new Map();
-      byCapture.set(capture, registrations);
+    if (bucket.has(listener)) {
+      // `EventTarget` ignores a repeated (type, listener, capture) triple and
+      // keeps the first registration's options. Returning here keeps that
+      // no-op exact: re-registering the same wrapper would be ignored anyway,
+      // but building a *new* wrapper would read as a distinct listener and be
+      // invoked a second time.
+      return;
     }
-    // Re-adding the same (type, listener, capture) triple is a no-op, matching
-    // `EventTarget`.
-    if (registrations.has(listener)) return;
-    registrations.set(listener, {
-      listener,
-      once: typeof options === 'object' && options?.once === true,
-    });
+    const once = typeof options === 'object' && options.once === true;
+    const wrapper = ((event: Event) => {
+      // `EventTarget` unregisters a `once` listener *before* invoking it, so
+      // the ledger can settle up here rather than trying to predict from the
+      // outside which registrations a dispatch consumed. Doing it first also
+      // means a handler that re-arms itself (`addEventListener(type, self,
+      // { once: true })` from inside its own call) re-enters the ledger after
+      // this removal and is correctly kept.
+      if (once) this.#forget(key, listener);
+      try {
+        listener(event as unknown as EngineMessageEvent);
+      } catch (e) {
+        // Report and carry on, so one broken card callback cannot stop the
+        // remaining listeners — or, on the `__DestroyLifetime` path, abort
+        // teardown and leak the worker. `EventTarget` would otherwise hand the
+        // throw to the host's "report an exception" step, which a bare jsdom
+        // realm discards silently.
+        console.error(`[lynx-web] error in engine "${type}" listener`, e);
+      }
+    }) as EventListener;
+    bucket.set(listener, wrapper);
+    super.addEventListener(type, wrapper, options);
   }
 
-  removeEventListener(
+  // @ts-expect-error see `addEventListener`.
+  override removeEventListener(
     type: string,
-    listener: (event: EngineMessageEvent) => void,
+    listener: EngineEventListener,
     options?: boolean | EventListenerOptions,
   ): void {
-    const capture = LynxEngineContextImpl.#captureOf(options);
-    const byCapture = this.#listeners.get(type);
-    const registrations = byCapture?.get(capture);
-    if (!registrations?.delete(listener)) return;
-    if (registrations.size === 0) byCapture!.delete(capture);
-    if (byCapture!.size === 0) this.#listeners.delete(type);
+    if (typeof listener !== 'function') return;
+    const capture = captureOf(options);
+    const wrapper = this.#forget(ledgerKey(type, capture), listener);
+    if (wrapper) super.removeEventListener(type, wrapper, capture);
+  }
+
+  /** Drop `listener` from the ledger, returning the wrapper to unregister. */
+  #forget(
+    key: string,
+    listener: EngineEventListener,
+  ): EventListener | undefined {
+    const bucket = this.#ledger.get(key);
+    if (!bucket) return undefined;
+    const wrapper = bucket.get(listener);
+    if (bucket.delete(listener) && bucket.size === 0) {
+      this.#ledger.delete(key);
+    }
+    return wrapper;
   }
 
   /**
@@ -107,56 +186,40 @@ export class LynxEngineContextImpl implements LynxEngineContext {
    * between the event channel and the legacy direct call.
    */
   hasEventListener(type: string): boolean {
-    return this.#listeners.has(type);
+    return this.#ledger.has(ledgerKey(type, true))
+      || this.#ledger.has(ledgerKey(type, false));
   }
 
   /**
    * Dispatch an engine message event to the main-thread script.
    *
-   * Accepts the `{ type, data }` shape used by `LynxCrossThreadContext` so
-   * card code can dispatch onto the engine proxy with the same call shape it
-   * uses for `lynx.getJSContext()`.
-   *
-   * Listeners run synchronously. A throwing listener is reported and does not
-   * prevent the remaining listeners from running, matching `EventTarget`.
+   * Accepts the `{ type, data }` shape used by `LynxCrossThreadContext` so card
+   * code can dispatch onto the engine proxy with the same call shape it uses
+   * for `lynx.getJSContext()`. Listeners run synchronously.
    */
-  dispatchEvent(event: EngineMessageEvent): number {
-    const byCapture = this.#listeners.get(event.type);
-    if (!byCapture) return DispatchEventResult.NotCanceled;
-
-    const messageEvent: EngineMessageEvent = {
-      type: event.type,
-      data: event.data,
-    };
-    // Capture listeners first, then bubble ones, mirroring DOM ordering.
-    for (const capture of [true, false]) {
-      const registrations = byCapture.get(capture);
-      if (!registrations) continue;
-      // Snapshot: a listener may add or remove listeners while running.
-      for (const registration of [...registrations.values()]) {
-        if (registration.once) {
-          this.removeEventListener(event.type, registration.listener, capture);
-        }
-        try {
-          registration.listener(messageEvent);
-        } catch (e) {
-          console.error(
-            `[lynx-web] error in engine "${event.type}" listener`,
-            e,
-          );
-        }
-      }
-    }
+  // @ts-expect-error the engine dispatches the `{ type, data }` shape and reads
+  // back a `DispatchEventResult`, not the DOM `boolean`.
+  override dispatchEvent(event: EngineMessageEvent): number {
+    if (this.#disposed) return DispatchEventResult.NotCanceled;
+    // `once` bookkeeping is settled by the wrapper itself, as `EventTarget`
+    // invokes it, so nothing has to be reconciled around this call.
+    super.dispatchEvent(engineEvent(event.type, event.data));
     return DispatchEventResult.NotCanceled;
   }
 
   /**
-   * Drop every listener. Called on teardown *after* `__DestroyLifetime` has
-   * been delivered, so a card that forgets to unsubscribe cannot keep the
-   * main-thread realm alive through this proxy.
+   * Stop delivering events. Called on teardown *after* `__DestroyLifetime` has
+   * been delivered.
+   *
+   * Listeners are not individually unregistered. This proxy is owned by the
+   * `LynxViewInstance` being destroyed — its only construction site — so once
+   * that instance is unreachable the proxy and every listener it holds are
+   * collected together. Clearing the ledger and refusing further dispatch is
+   * the part callers can observe.
    */
   dispose(): void {
-    this.#listeners.clear();
+    this.#disposed = true;
+    this.#ledger.clear();
   }
 }
 

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxEngineContext.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxEngineContext.ts
@@ -5,7 +5,6 @@
  */
 import type {
   Cloneable,
-  ContextCrossThreadEvent,
   EngineMessageEvent,
   LynxEngineContext,
 } from '../../types/index.js';
@@ -121,7 +120,7 @@ export class LynxEngineContextImpl implements LynxEngineContext {
    * Listeners run synchronously. A throwing listener is reported and does not
    * prevent the remaining listeners from running, matching `EventTarget`.
    */
-  dispatchEvent(event: ContextCrossThreadEvent): number {
+  dispatchEvent(event: EngineMessageEvent): number {
     const byCapture = this.#listeners.get(event.type);
     if (!byCapture) return DispatchEventResult.NotCanceled;
 
@@ -191,7 +190,7 @@ export function dispatchEngineEventWithFallback(
   if (engineContext.hasEventListener(eventName)) {
     engineContext.dispatchEvent({
       type: eventName,
-      data: args as Cloneable,
+      data: args as Cloneable[],
     });
     return true;
   }

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxViewInstance.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxViewInstance.ts
@@ -15,6 +15,7 @@ import type {
   PageConfig,
 } from '../../types/index.js';
 import {
+  EngineMessageEventType,
   loadUnknownElementEventName,
   systemInfoBase,
 } from '../../constants.js';
@@ -26,6 +27,10 @@ import { createInvokeUIMethod } from './elementAPIs/createInvokeUIMethod.js';
 import { ExposureServices } from './ExposureServices.js';
 import { createElementAPI } from './elementAPIs/createElementAPI.js';
 import { createMainThreadGlobalAPIs } from './createMainThreadGlobalAPIs.js';
+import {
+  dispatchEngineEventWithFallback,
+  LynxEngineContextImpl,
+} from './LynxEngineContext.js';
 import { templateManager } from './TemplateManager.js';
 import { loadAllWebElements } from '../webElementsDynamicLoader.js';
 // @ts-expect-error
@@ -68,6 +73,13 @@ export class LynxViewInstance implements AsyncDisposable {
   readonly i18nManager: I18nManager;
   readonly exposureServices: ExposureServices;
   readonly webElementsLoadingPromises: Promise<void>[] = [];
+  /**
+   * The Engine context proxy handed to main-thread scripts via
+   * `lynx.getEngine()`. Buildless cards subscribe here for engine lifecycle
+   * events; see {@link dispatchEngineEvent} for the fallback semantics that
+   * keep `globalThis.renderPage`-style bundles working.
+   */
+  readonly engineContext: LynxEngineContextImpl = new LynxEngineContextImpl();
 
   // A `.web.bundle` url is only ever loaded one way — as a lazy component
   // (`queryComponent`) or as an external bundle (`loadExternalBundle`), never
@@ -195,6 +207,24 @@ export class LynxViewInstance implements AsyncDisposable {
     }
   }
 
+  /**
+   * Deliver an engine lifecycle event to the main-thread script with the
+   * "listener wins, else direct call" fallback semantics. See
+   * {@link dispatchEngineEventWithFallback}.
+   */
+  #dispatchEngineEvent(
+    eventName: string,
+    directCall: () => void,
+    args: unknown[],
+  ): void {
+    dispatchEngineEventWithFallback(
+      this.engineContext,
+      eventName,
+      directCall,
+      args,
+    );
+  }
+
   onMTSScriptsExecuted() {
     this.backgroundThread.markTiming('lepus_execute_end');
     this.webElementsLoadingPromises.length = 0;
@@ -218,7 +248,11 @@ export class LynxViewInstance implements AsyncDisposable {
     if (this.isSSR) {
       this.rootDom.querySelector('[part="page"]')?.remove();
     }
-    this.mainThreadGlobalThis.renderPage?.(processedData);
+    this.#dispatchEngineEvent(
+      EngineMessageEventType.RenderPage,
+      () => this.mainThreadGlobalThis.renderPage?.(processedData),
+      [processedData],
+    );
     this.mainThreadGlobalThis.__FlushElementTree();
   }
 
@@ -331,11 +365,28 @@ export class LynxViewInstance implements AsyncDisposable {
         && this.mainThreadGlobalThis.processData
       ? this.mainThreadGlobalThis.processData(data, processorName)
       : data;
-    this.mainThreadGlobalThis.updatePage?.(processedData, { processorName });
+    this.#dispatchEngineEvent(
+      EngineMessageEventType.UpdatePage,
+      () =>
+        this.mainThreadGlobalThis.updatePage?.(processedData, {
+          processorName,
+        }),
+      [processedData, { processorName }],
+    );
     await this.backgroundThread.updateData(processedData, { processorName });
   }
 
   async updateGlobalProps(data: Cloneable) {
+    // `__UpdateGlobalProps` has no legacy global-function counterpart on web
+    // (the engine calls `kUpdateGlobalProps`, which web-platform never
+    // exposed), so the fallback branch is a no-op: cards that subscribe get
+    // the event, and everything else keeps relying solely on the
+    // background-thread notification below.
+    this.#dispatchEngineEvent(
+      EngineMessageEventType.UpdateGlobalProps,
+      () => {},
+      [data],
+    );
     await this.backgroundThread.updateGlobalProps(data);
   }
 
@@ -361,6 +412,27 @@ export class LynxViewInstance implements AsyncDisposable {
   }
 
   async [Symbol.asyncDispose]() {
+    // Give the card a chance to clean up (remove element listeners, notify the
+    // background thread) while the element tree and wasmContext are still
+    // alive. Mirrors the `__DestroyLifetime` dispatch in
+    // `LynxShell::Destroy` / `BTSRuntime`, which likewise fires before the
+    // engine is torn down. `dispatchEvent` runs listeners synchronously, so
+    // the card's cleanup has completed by the time this returns.
+    try {
+      // `data` is `undefined` rather than an empty array on purpose: unlike
+      // `__RenderPage` / `__UpdatePage`, this event does not travel through the
+      // engine's argument-packing path, so it carries no positional arguments.
+      // Cards subscribe to it purely as a teardown signal.
+      this.engineContext.dispatchEvent({
+        type: EngineMessageEventType.DestroyLifetime,
+        data: undefined,
+      });
+    } catch (e) {
+      // A throwing card cleanup must not abort teardown of the rest of the
+      // instance, otherwise we leak workers and DOM listeners.
+      console.error('[lynx-web] error while dispatching __DestroyLifetime', e);
+    }
+    this.engineContext.dispose();
     this.boundingClientRectService.dispose();
     await this.backgroundThread[Symbol.asyncDispose]();
     this.exposureServices.dispose();

--- a/packages/web-platform/web-core/ts/client/mainthread/createMainThreadGlobalAPIs.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/createMainThreadGlobalAPIs.ts
@@ -30,6 +30,9 @@ function createMainThreadLynx(
     getJSContext() {
       return lynxViewInstance.backgroundThread.jsContext;
     },
+    getEngine() {
+      return lynxViewInstance.engineContext;
+    },
     requestAnimationFrame(cb: FrameRequestCallback) {
       return requestAnimationFrameBrowserImpl(cb);
     },

--- a/packages/web-platform/web-core/ts/constants.ts
+++ b/packages/web-platform/web-core/ts/constants.ts
@@ -26,6 +26,20 @@ export const LYNX_TIMING_FLAG_ATTRIBUTE =
 
 export const i18nResourceMissedEventName = 'i18nResourceMissed' as const;
 
+/**
+ * Message event types the engine dispatches onto the Engine context proxy
+ * returned by `lynx.getEngine()`.
+ *
+ * Mirrors the `kMessageEventType*` constants in
+ * `core/runtime/js/runtime_constant.h` of the Lynx engine.
+ */
+export const EngineMessageEventType = /*#__PURE__*/ {
+  RenderPage: '__RenderPage',
+  UpdatePage: '__UpdatePage',
+  DestroyLifetime: '__DestroyLifetime',
+  UpdateGlobalProps: '__UpdateGlobalProps',
+} as const;
+
 export const uniqueIdSymbol = /*#__PURE__*/ Symbol('uniqueId');
 
 export const systemInfoBase = /*#__PURE__*/ {

--- a/packages/web-platform/web-core/ts/server/createServerLynx.ts
+++ b/packages/web-platform/web-core/ts/server/createServerLynx.ts
@@ -31,6 +31,18 @@ export function createServerLynx(
       // Return a basic mock for SSR
       return {} as any;
     },
+    getEngine() {
+      // SSR renders the first frame only; there is no engine lifetime to
+      // observe, so hand back an inert proxy. `hasEventListener` reporting
+      // `false` keeps the engine on the direct `globalThis.renderPage` path,
+      // matching how SSR drives rendering today.
+      return {
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent: () => 0,
+        hasEventListener: () => false,
+      };
+    },
     requestAnimationFrame(cb: () => void) {
       // Invoke immediately or ignore in SSR
       // Since it's often used for animations, we might just ignore or run once.

--- a/packages/web-platform/web-core/ts/types/LynxEngineContext.ts
+++ b/packages/web-platform/web-core/ts/types/LynxEngineContext.ts
@@ -3,7 +3,6 @@
  * Licensed under the Apache License Version 2.0 that can be found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type { ContextCrossThreadEvent } from './LynxContextEventTarget.js';
 import type { Cloneable } from './Cloneable.js';
 
 /**
@@ -18,7 +17,12 @@ import type { Cloneable } from './Cloneable.js';
  */
 export interface EngineMessageEvent {
   type: string;
-  data: Cloneable;
+  /**
+   * The engine call's positional arguments, or `undefined` for an event that
+   * carries none - `__DestroyLifetime` is a bare teardown signal, so it does
+   * not go through the argument-packing path at all.
+   */
+  data: Cloneable[] | undefined;
 }
 
 /**
@@ -42,7 +46,7 @@ export interface LynxEngineContext {
     listener: (event: EngineMessageEvent) => void,
     options?: boolean | EventListenerOptions,
   ): void;
-  dispatchEvent(event: ContextCrossThreadEvent): number;
+  dispatchEvent(event: EngineMessageEvent): number;
   /**
    * Whether at least one listener is currently registered for `type`.
    *

--- a/packages/web-platform/web-core/ts/types/LynxEngineContext.ts
+++ b/packages/web-platform/web-core/ts/types/LynxEngineContext.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Lynx Authors. All rights reserved.
+ * Licensed under the Apache License Version 2.0 that can be found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import type { ContextCrossThreadEvent } from './LynxContextEventTarget.js';
+import type { Cloneable } from './Cloneable.js';
+
+/**
+ * The event object an Engine context listener receives.
+ *
+ * A plain `{ type, data }` object rather than a DOM event: the engine hands
+ * lepus the same shape via
+ * `LepusClosureEventListener::ConvertEventToLepusValue`, which copies `type`
+ * and `data` off the `MessageEvent`. `data` holds the engine call's positional
+ * arguments as an array, matching the `lepus::CArray` packing in
+ * `DispatchEventFromEngineToCoreContext`.
+ */
+export interface EngineMessageEvent {
+  type: string;
+  data: Cloneable;
+}
+
+/**
+ * The object returned by `lynx.getEngine()` on the main thread.
+ *
+ * This is the web counterpart of `ContextProxy::Type::kEngine`
+ * (`core/runtime/common/bindings/event/context_proxy.h`). Unlike
+ * {@link LynxContextEventTarget}, which bridges two workers over RPC, the
+ * Engine proxy is main-thread-internal: the engine (the `lynx-view` host) is
+ * the event *origin* and the main-thread script is the *target*, so events are
+ * delivered synchronously without crossing a thread boundary.
+ */
+export interface LynxEngineContext {
+  addEventListener(
+    type: string,
+    listener: (event: EngineMessageEvent) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: (event: EngineMessageEvent) => void,
+    options?: boolean | EventListenerOptions,
+  ): void;
+  dispatchEvent(event: ContextCrossThreadEvent): number;
+  /**
+   * Whether at least one listener is currently registered for `type`.
+   *
+   * The engine uses this to decide between the event channel and the legacy
+   * direct-call path, mirroring `ContextProxy::HasEventListener` as used by
+   * `TemplateAssembler::DispatchEventFromEngineToCoreContext`.
+   */
+  hasEventListener(type: string): boolean;
+}

--- a/packages/web-platform/web-core/ts/types/MainThreadLynx.ts
+++ b/packages/web-platform/web-core/ts/types/MainThreadLynx.ts
@@ -6,10 +6,17 @@
 import type { Cloneable } from './Cloneable.js';
 import type { ExternalBundleLynxAPIs } from './ExternalBundle.js';
 import type { LynxContextEventTarget } from './LynxContextEventTarget.js';
+import type { LynxEngineContext } from './LynxEngineContext.js';
 import type { LynxPerformance } from './NativeApp.js';
 export interface MainThreadLynx extends ExternalBundleLynxAPIs {
   performance: LynxPerformance;
   getJSContext: () => LynxContextEventTarget;
+  /**
+   * The Engine context proxy. Buildless cards use it to subscribe to engine
+   * lifecycle events (`__RenderPage`, `__UpdatePage`, `__DestroyLifetime`,
+   * `__UpdateGlobalProps`) instead of exporting `globalThis.renderPage`.
+   */
+  getEngine: () => LynxEngineContext;
   requestAnimationFrame: (cb: () => void) => number;
   cancelAnimationFrame: (handler: number) => void;
   __globalProps: unknown;

--- a/packages/web-platform/web-core/ts/types/index.ts
+++ b/packages/web-platform/web-core/ts/types/index.ts
@@ -14,6 +14,7 @@ export type * from './NapiModules.js';
 export type * from './I18nTypes.js';
 export type * from './NativeApp.js';
 export type * from './LynxContextEventTarget.js';
+export type * from './LynxEngineContext.js';
 export type * from './MainThreadLynx.js';
 export type * from './ExternalBundle.js';
 export type * from './IMtsBinding.js';

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -16,6 +16,36 @@ const reporters: RstestConfig['reporters'] = process.env.GITHUB_ACTIONS
 export default defineConfig({
   coverage: {
     reporters: ['json', 'text'],
+    // `web-elements`' built output cannot be instrumented: doing so aborts
+    // coverage reporting for the entire run.
+    //
+    // TypeScript lowers its `@Component`-decorated custom elements into a
+    // class `static {}` block whose statements have no original source
+    // position, so the emitted `.js.map` maps them to line 0.
+    // `istanbul-lib-source-maps` lets a `line: 0` entry through
+    // (`isInvalidPosition` only rejects `line < 0`) and hands it to
+    // `@jridgewell/trace-mapping`, which throws "`line` must be greater than
+    // 0". A single such mapping kills report generation for the whole run and
+    // exits non-zero *after* every test has already passed — a green test list
+    // with a red `test-rstest` job and no Codecov upload.
+    //
+    // This output is never imported by a test directly; it is pulled in
+    // transitively, because a module under test imports
+    // `@lynx-js/web-elements/all` at module scope.
+    //
+    // Deliberately scoped to `web-elements/dist` — do NOT broaden this to
+    // `**/dist/**`. Other workspace packages are also consumed as built
+    // output, but theirs carries valid source maps that remap back to tracked
+    // `src/**`, so those rows land in the report under their real source
+    // paths. Excluding them happens *before* that remapping and silently
+    // drops ~12 files of genuine source coverage (`css-serializer/src/**`,
+    // `debug-metadata/src/**`, `web-worker-rpc/src/**`), which would show up
+    // as an unexplained Codecov drop rather than an error.
+    //
+    // Must live in the root config: `coverage.exclude` set inside an
+    // individual project config is ignored when projects run under this root
+    // config, which is how CI invokes rstest.
+    exclude: ['**/web-elements/dist/**'],
   },
   reporters,
   projects: [


### PR DESCRIPTION
> [!IMPORTANT]
> **2 of 3.** Stacked on #3388 — please review that first. This branch contains
> its commit, so the diff shown here includes it until #3388 lands.
>
> 1. [element event listener PAPIs](https://github.com/lynx-family/lynx-stack/pull/3388)
> 2. **engine context proxy** ← you are here
> 3. Lynx XML markup template support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added element event listener APIs with callback registration, removal, capture, once, passive, and propagation options.
  * Added `lynx.getEngine()` for synchronous lifecycle event subscription and dispatch.
  * Added lifecycle events for rendering, updates, global properties, and teardown.
  * Added server-rendering compatibility with inert event and engine APIs.

* **Bug Fixes**
  * Improved teardown reliability when lifecycle hooks are unavailable or fail.
  * Ensured listeners and resources are cleaned up during disposal.

* **Tests**
  * Added comprehensive coverage for event listeners, engine events, and teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## What this adds

`lynx.getEngine()`, the main-thread Engine context proxy — the web counterpart of
the engine's `kEngine` context proxy.

A card subscribes to it to receive the engine lifecycle events `__RenderPage`,
`__UpdatePage`, `__DestroyLifetime` and `__UpdateGlobalProps`. This is how a card
built directly from the Element PAPIs drives its own first paint, updates and
cleanup, instead of exporting `globalThis.renderPage` the way a compiled bundle
does.

## Compatibility — the important part

Existing bundles are untouched. Each lifecycle event keeps the engine's own
fallback rule:

- the card registered a listener → dispatch the event
- otherwise → make the existing `globalThis.renderPage` / `updatePage` call,
  exactly as before

`hasEventListener(type)` decides, mirroring how the engine picks between the
event channel and the direct call. Both directions are tested: with a listener,
the event fires and `renderPage` is **not** called; without one, `renderPage` is.
SSR always reports no listener, so it stays on the direct path with zero
behaviour change.

## Event shape

Listeners receive a plain `{ type, data }` object rather than a DOM event,
matching what the engine hands scripts. For `__RenderPage` / `__UpdatePage`,
`data` carries the call's positional arguments as an array.

Two reasons for not using a DOM `EventTarget`: the engine and the main-thread
script share a thread, so there is no tree to propagate through; and
`tests/jsdom.ts` replaces the global `Event`, after which Node's `EventTarget`
rejects any `MessageEvent`, making such a proxy untestable in this harness.

`__DestroyLifetime` carries `data: undefined` rather than an empty array, because
it does not travel through the argument-packing path and has no positional
arguments — the engine passes a scalar there too.

## Bug fixed along the way

Teardown called `tt.callDestroyLifetimeFun` unconditionally, but only the
ReactLynx background runtime installs that hook. A card running its own
background script therefore threw, and the throw **skipped `destroyCard`**,
leaving the card registered in `nativeGlobal.multiApps` after its view was gone.
It is now an optional hook, while a hook that exists and genuinely fails is still
reported.

This only reproduced in a real browser — the unit tests were green while the leak
was happening.

## Testing

29 unit tests across `engine-context`, `engine-destroy-lifetime` and
`register-dispose-handler`, including both fallback directions, listener dedup,
`once` deregistration and teardown ordering. `web-core` is at 226 passing with no
existing test changed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required). — `minor`, additive; the fallback keeps existing bundles unchanged.
