### PR TITLE
fix(rsbuild-plugin): publish the moved pluginMinify

### DIFF
--- a/.changeset/release-rsbuild-plugin-minify.md
+++ b/.changeset/release-rsbuild-plugin-minify.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Move `pluginOutput` and `pluginMinify` into `pluginLynx()`.


### PR DESCRIPTION
`pluginMinify` moved into this package in #3313, but the version stayed at `0.0.1`, which is already on the registry without it. `pnpm publish` skips versions that already exist, so consumers installing the published package resolve the old build and lose the Lynx `compress` / `mangle` defaults.

Not visible in-repo: the workspace always resolves the source. It shows up once the package is installed from a registry — a downstream regression build measured main-thread.js at 42.5 KB → 104.6 KB, with 142 of 143 modules unchanged in `sourceSize`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented that the `pluginOutput` and `pluginMinify` options are now configured through `pluginLynx()`.
  * Clarified the updated plugin configuration location.
  * Added a patch release note for `@lynx-js/rsbuild-plugin`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->