### PR TITLE
feat(web-core): implement lynx.accessibilityAnnounce()

### DIFF
--- a/.changeset/web-core-accessibility-announce.md
+++ b/.changeset/web-core-accessibility-announce.md
@@ -1,0 +1,10 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Implement `lynx.accessibilityAnnounce()` on web. Content passed to it is now
+announced to screen readers via a visually-hidden `aria-live="assertive"`
+region owned by the main thread (where the LynxView's DOM actually lives).
+
+Closes the web platform gap tracked by
+`lynx-api/lynx/accessibilityAnnounce` in `lynx-compat-data`.

--- a/packages/web-platform/web-core/tests/register-accessibility-announce-handler.spec.ts
+++ b/packages/web-platform/web-core/tests/register-accessibility-announce-handler.spec.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import './jsdom.js';
+import { describe, expect, test } from '@rstest/core';
+import { registerAccessibilityAnnounceHandler } from '../ts/client/mainthread/crossThreadHandlers/registerAccessibilityAnnounceHandler.js';
+import { accessibilityAnnounceEndpoint } from '../ts/client/endpoints.js';
+import { ErrorCode } from '../ts/constants.js';
+import type { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.js';
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+
+/**
+ * `registerAccessibilityAnnounceHandler` is the main-thread side of
+ * `lynx.accessibilityAnnounce()`: the background thread has no DOM, so the
+ * actual ARIA live-region announcement has to happen here, where the
+ * LynxView's shadow root lives.
+ */
+describe('registerAccessibilityAnnounceHandler', () => {
+  function setup() {
+    const host = document.createElement('div');
+    const rootDom = host.attachShadow({ mode: 'open' });
+    let handler: (
+      content: string,
+    ) => { code: ErrorCode } = () => {
+      throw new Error('accessibilityAnnounce handler was never registered');
+    };
+    const rpc = {
+      registerHandler: (
+        endpoint: { name: string },
+        fn: typeof handler,
+      ) => {
+        expect(endpoint.name).toBe(accessibilityAnnounceEndpoint.name);
+        handler = fn;
+      },
+    } as unknown as Rpc;
+    const lynxViewInstance = { rootDom } as unknown as LynxViewInstance;
+    registerAccessibilityAnnounceHandler(rpc, lynxViewInstance);
+    return { rootDom, invoke: (content: string) => handler(content) };
+  }
+
+  test('creates a visually-hidden aria-live region and announces the content', async () => {
+    const { rootDom, invoke } = setup();
+
+    const res = invoke('hello lynx');
+    expect(res).toEqual({ code: ErrorCode.SUCCESS });
+
+    const announcer = rootDom.querySelector(
+      '[data-lynx-accessibility-announcer]',
+    );
+    expect(announcer).not.toBeNull();
+    expect(announcer!.getAttribute('aria-live')).toBe('assertive');
+    expect(announcer!.getAttribute('aria-atomic')).toBe('true');
+    // Cleared synchronously; the real text lands after a microtask so a
+    // change is always observable, even for repeated announcements.
+    expect(announcer!.textContent).toBe('');
+
+    await Promise.resolve();
+    expect(announcer!.textContent).toBe('hello lynx');
+  });
+
+  test('reuses the same announcer element across calls', async () => {
+    const { rootDom, invoke } = setup();
+
+    invoke('first');
+    await Promise.resolve();
+    invoke('second');
+    await Promise.resolve();
+
+    const announcers = rootDom.querySelectorAll(
+      '[data-lynx-accessibility-announcer]',
+    );
+    expect(announcers.length).toBe(1);
+    expect(announcers[0]!.textContent).toBe('second');
+  });
+
+  test('re-announces identical content back-to-back', async () => {
+    const { rootDom, invoke } = setup();
+
+    invoke('same message');
+    await Promise.resolve();
+    const announcer = rootDom.querySelector(
+      '[data-lynx-accessibility-announcer]',
+    )!;
+    expect(announcer.textContent).toBe('same message');
+
+    invoke('same message');
+    // Cleared immediately, so a screen reader observes a genuine change even
+    // though the final text is identical to what was already there.
+    expect(announcer.textContent).toBe('');
+    await Promise.resolve();
+    expect(announcer.textContent).toBe('same message');
+  });
+
+  test('only the latest of two rapid announcements wins', async () => {
+    const { rootDom, invoke } = setup();
+
+    invoke('stale');
+    invoke('fresh');
+    await Promise.resolve();
+
+    const announcer = rootDom.querySelector(
+      '[data-lynx-accessibility-announcer]',
+    );
+    expect(announcer!.textContent).toBe('fresh');
+  });
+});

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import {
+  accessibilityAnnounceEndpoint,
   dispatchCoreContextOnBackgroundEndpoint,
   dispatchDevtoolEventOnBackgroundEndpoint,
   dispatchDevtoolEventOnMainThreadEndpoint,
@@ -13,7 +14,7 @@ import {
 import type { Rpc } from '@lynx-js/web-worker-rpc';
 import { createGetCustomSection } from './crossThreadHandlers/createGetCustomSection.js';
 import { createElement } from './createElement.js';
-import type { Cloneable, NativeApp } from '../../../types/index.js';
+import type { Cloneable, InvokeCallbackRes, NativeApp } from '../../../types/index.js';
 import { LynxCrossThreadContext } from '../../LynxCrossThreadContext.js';
 
 export function createBackgroundLynx(
@@ -34,6 +35,10 @@ export function createBackgroundLynx(
   });
   const fetchExternalBundle = mainThreadRpc.createCall(
     fetchExternalBundleEndpoint,
+  );
+  const accessibilityAnnounceCallbackify = mainThreadRpc.createCallbackify(
+    accessibilityAnnounceEndpoint,
+    1,
   );
   return {
     __globalProps: globalProps,
@@ -73,6 +78,15 @@ export function createBackgroundLynx(
     ) => nativeApp.queryComponent(source, callback),
     reload: () => {
       mainThreadRpc.invoke(reloadEndpoint, []);
+    },
+    accessibilityAnnounce(
+      params: { content: string },
+      callback?: (res: InvokeCallbackRes) => void,
+    ) {
+      accessibilityAnnounceCallbackify(
+        params.content,
+        callback ?? (() => {}),
+      );
     },
     fetchBundle(url: string) {
       return fetchExternalBundle(url);

--- a/packages/web-platform/web-core/ts/client/endpoints.ts
+++ b/packages/web-platform/web-core/ts/client/endpoints.ts
@@ -240,3 +240,13 @@ export const reloadEndpoint = createRpcEndpoint<
   [],
   void
 >('reload', false, false);
+
+/**
+ * Backs the background-thread `lynx.accessibilityAnnounce()` call: announces
+ * `content` to screen readers via an ARIA live region owned by the main
+ * thread (where the actual DOM lives).
+ */
+export const accessibilityAnnounceEndpoint = createRpcEndpoint<
+  [content: string],
+  InvokeCallbackRes
+>('accessibilityAnnounce', false, true);

--- a/packages/web-platform/web-core/ts/client/mainthread/Background.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/Background.ts
@@ -46,6 +46,7 @@ import { registerTriggerElementMethodEndpointHandler } from './crossThreadHandle
 import { registerNapiModulesCallHandler } from './crossThreadHandlers/registerNapiModulesCallHandler.js';
 import { registerNativeModulesCallHandler } from './crossThreadHandlers/registerNativeModulesCallHandler.js';
 import { registerReloadHandler } from './crossThreadHandlers/registerReloadHandler.js';
+import { registerAccessibilityAnnounceHandler } from './crossThreadHandlers/registerAccessibilityAnnounceHandler.js';
 
 function createWebWorker(): Worker {
   return new Worker(
@@ -275,6 +276,7 @@ export class BackgroundThread implements AsyncDisposable {
       },
     );
     registerReloadHandler(this.#rpc, this.#lynxViewInstance);
+    registerAccessibilityAnnounceHandler(this.#rpc, this.#lynxViewInstance);
     registerGetPathInfoHandler(this.#rpc, this.#lynxViewInstance);
     registerInvokeUIMethodHandler(this.#rpc, this.#lynxViewInstance);
     registerNapiModulesCallHandler(this.#rpc, this.#lynxViewInstance);

--- a/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerAccessibilityAnnounceHandler.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerAccessibilityAnnounceHandler.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+import { ErrorCode } from '../../../constants.js';
+import { accessibilityAnnounceEndpoint } from '../../endpoints.js';
+import type { LynxViewInstance } from '../LynxViewInstance.js';
+
+// Tracks the most recent pending announcement per announcer element, so two
+// LynxView instances announcing concurrently never race each other's
+// microtask (see the guard in the handler below).
+const pendingAnnouncementId = new WeakMap<HTMLElement, number>();
+
+/**
+ * Lazily creates (and caches) a visually-hidden `aria-live` region inside the
+ * LynxView's shadow root, so screen readers announce `lynx.accessibilityAnnounce()`
+ * content the same way native platforms surface an accessibility announcement.
+ */
+function getAnnouncer(rootDom: ShadowRoot): HTMLElement {
+  let announcer = rootDom.querySelector<HTMLElement>(
+    '[data-lynx-accessibility-announcer]',
+  );
+  if (!announcer) {
+    announcer = document.createElement('div');
+    announcer.setAttribute('data-lynx-accessibility-announcer', '');
+    announcer.setAttribute('aria-live', 'assertive');
+    announcer.setAttribute('aria-atomic', 'true');
+    // Visually hidden but still exposed to accessibility tree ("sr-only").
+    announcer.style.cssText =
+      'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;';
+    rootDom.append(announcer);
+  }
+  return announcer;
+}
+
+export function registerAccessibilityAnnounceHandler(
+  rpc: Rpc,
+  lynxViewInstance: LynxViewInstance,
+) {
+  rpc.registerHandler(
+    accessibilityAnnounceEndpoint,
+    (content) => {
+      const announcer = getAnnouncer(lynxViewInstance.rootDom);
+      // Screen readers only fire a new announcement on a content *change*, so
+      // repeating the same text back-to-back would otherwise be silently
+      // dropped. Toggling through an empty state (a microtask apart) forces
+      // the live region to re-announce every call, including repeats.
+      announcer.textContent = '';
+      const id = (pendingAnnouncementId.get(announcer) ?? 0) + 1;
+      pendingAnnouncementId.set(announcer, id);
+      queueMicrotask(() => {
+        // Guard against a newer announce() call already overtaking this one.
+        if (pendingAnnouncementId.get(announcer) === id) {
+          announcer.textContent = content;
+        }
+      });
+      return { code: ErrorCode.SUCCESS };
+    },
+  );
+}


### PR DESCRIPTION
<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

@coderabbitai summary

## What

Closes a real web platform gap: [`lynx-api/lynx/accessibilityAnnounce`](https://lynxjs.org/api/lynx-api/lynx/lynx-accessibility-announce) is supported on android/ios/harmony/clay (compat-data: `packages/lynx-compat-data/lynx-api/lynx/accessibilityAnnounce.json`) but was entirely unimplemented on web (`web_lynx: false`).

`lynx.accessibilityAnnounce({ content }, callback?)` makes screen readers announce the given text — used for surfacing state changes / operation results to visually-impaired users.

## How

The background thread has no DOM, so the actual announcement has to happen on the main thread, where the LynxView's shadow root lives:

- **`endpoints.ts`**: new `accessibilityAnnounceEndpoint` RPC endpoint, `(content: string) -> InvokeCallbackRes`, following the same shape as the existing `invokeUIMethod`/`selectComponent` endpoints.
- **`registerAccessibilityAnnounceHandler.ts`** (new, main thread): lazily creates a cached, visually-hidden `aria-live="assertive"` region inside the LynxView's shadow root and writes the announced content into it. It clears the region synchronously and re-sets the text a microtask later, so repeated identical announcements still produce an observable DOM change (screen readers only announce on content *change*). A per-announcer `WeakMap` counter guards against races between concurrent `announce()` calls (last write wins) without one LynxView's announcement being able to suppress another's.
- **`Background.ts`**: registers the new handler alongside the other cross-thread handlers.
- **`createBackgroundLynx.ts`**: wires `lynx.accessibilityAnnounce(params, callback)` using `Rpc#createCallbackify`, the same helper already used for `callLepusMethod`/`selectComponent`.

SSR doesn't need a stub — `accessibilityAnnounce` is background-thread only (like `reload`/`reportError`/`getSharedData`), and SSR's `createServerLynx.ts` only implements `MainThreadLynx`.

## Test plan

- 4 new cases in `web-core/tests/register-accessibility-announce-handler.spec.ts`: region creation + ARIA attributes, element reuse across calls, re-announcing identical content, and last-write-wins under back-to-back calls.
- Full `web-core` suite: 280/280 passing (`pnpm build:wasm && pnpm test`).
- `eslint` clean on all touched source files.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). — no doc changes needed; the existing `lynx-accessibility-announce.mdx` doc already describes this API, this PR only makes web match it.
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

Found via the weekly Lynx Web Platform gap audit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9C8LRjDxtcCYLyADgkfAL)_