### PR TITLE
chore(deps): replace create-rstack with create-toolkit

### DIFF
--- a/.changeset/replace-create-toolkit.md
+++ b/.changeset/replace-create-toolkit.md
@@ -1,0 +1,5 @@
+---
+"create-rspeedy": patch
+---
+
+Replace the renamed `create-rstack` dependency with `@rstackjs/create-toolkit`.

--- a/.github/create-rspeedy-pack.instructions.md
+++ b/.github/create-rspeedy-pack.instructions.md
@@ -4,4 +4,4 @@ applyTo: "packages/rspeedy/create-rspeedy/**"
 
 When maintaining the `create-rspeedy` package `files` list under pnpm 11, include template directories with `template-*/**`; a bare `template-*` only packs the matched directory entries and can omit nested template files from the published tarball.
 
-When defining `create-rstack` extra tools in `packages/rspeedy/create-rspeedy/src/index.ts`, use the `create-rstack` 2.x callback shape for `when`: destructure `({ templateName })` instead of accepting a bare template-name string.
+When defining `@rstackjs/create-toolkit` extra tools in `packages/rspeedy/create-rspeedy/src/index.ts`, use the 2.x callback shape for `when`: destructure `({ templateName })` instead of accepting a bare template-name string.

--- a/packages/rspeedy/create-rspeedy/package.json
+++ b/packages/rspeedy/create-rspeedy/package.json
@@ -35,7 +35,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "create-rstack": "2.1.3"
+    "@rstackjs/create-toolkit": "2.1.4"
   },
   "devDependencies": {
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:^",

--- a/packages/rspeedy/create-rspeedy/src/index.ts
+++ b/packages/rspeedy/create-rspeedy/src/index.ts
@@ -7,8 +7,13 @@ import { createRequire } from 'node:module'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import type { Argv } from 'create-rstack'
-import { checkCancel, copyFolder, create, select } from 'create-rstack'
+import type { Argv } from '@rstackjs/create-toolkit'
+import {
+  checkCancel,
+  copyFolder,
+  create,
+  select,
+} from '@rstackjs/create-toolkit'
 
 type LANG = 'js' | 'ts'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1514,9 +1514,9 @@ importers:
 
   packages/rspeedy/create-rspeedy:
     dependencies:
-      create-rstack:
-        specifier: 2.1.3
-        version: 2.1.3
+      '@rstackjs/create-toolkit':
+        specifier: 2.1.4
+        version: 2.1.4
     devDependencies:
       '@lynx-js/qrcode-rsbuild-plugin':
         specifier: workspace:^
@@ -5697,6 +5697,10 @@ packages:
       '@rspress/core':
         optional: true
 
+  '@rstackjs/create-toolkit@2.1.4':
+    resolution: {integrity: sha512-kwPhfMdgWN7z/Op5UKMszhmZy7+hzqXeiQPli4uycYYTLxCVUGLlEW3etoGoZlrM2t5zLqXZQAgL60PTUR/ocw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@rstest/adapter-rsbuild@0.11.3':
     resolution: {integrity: sha512-kVopE2qcDcKTZs+lNWk0pybj4t6p9jSi45sMJ3+iZhR+Utckt0dsKJktZ+pQsVDVJ7QoKEBG5UuSIQKKAOPMIw==}
     peerDependencies:
@@ -7395,10 +7399,6 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
-
-  create-rstack@2.1.3:
-    resolution: {integrity: sha512-3n8JzuzbMYger7fnhIb8DDYs7b4lnNgLJm6kKve+qCKeqpCsTZaiZBQ3cYy7/FjWNtccbJ4XhfA/WNvzETD3vw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -16056,6 +16056,8 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.18(@rspack/core@2.1.7(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(supports-color@10.2.2)
 
+  '@rstackjs/create-toolkit@2.1.4': {}
+
   '@rstest/adapter-rsbuild@0.11.3(@rsbuild/core@2.1.7(core-js@3.49.0))(@rstest/core@0.11.3(core-js@3.49.0)(jsdom@27.4.0(supports-color@10.2.2)))':
     dependencies:
       '@rsbuild/core': 2.1.7(core-js@3.49.0)
@@ -17745,8 +17747,6 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-
-  create-rstack@2.1.3: {}
 
   crelt@1.0.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,10 +47,11 @@ minimumReleaseAgeExclude:
   - "@lynx-js/*"
   # typia-rspack-plugin uses trusted publish + staged publish
   - "typia-rspack-plugin"
-  # First-party Rspack/Rsbuild toolchain — trusted, upgraded deliberately.
+  # First-party Rstack toolchain — trusted, upgraded deliberately.
   - "@rspack/*"
   - "@rsbuild/*"
   - "@rstest/*"
+  - "@rstackjs/create-toolkit"
   # Renovate security update: turbo@2.9.14
   - turbo@2.9.14
   # Renovate security update: dompurify@3.4.0


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the project creation workflow to use the renamed `@rstackjs/create-toolkit`.
  * Updated extra-tool callback guidance to support the toolkit’s 2.x callback format.
  * Added the toolkit to the approved release workflow alongside other Rstack tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replace `create-rstack` with its renamed package, `@rstackjs/create-toolkit` v2.1.4.
- Update `create-rspeedy` imports and dependency policy, and add a patch changeset.

## Related Links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.1.4

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, or not required.