### PR TITLE
fix(css-serializer): drop the node:path dependency

### DIFF
--- a/.changeset/css-serializer-drop-node-path.md
+++ b/.changeset/css-serializer-drop-node-path.md
@@ -8,17 +8,15 @@ be bundled for browsers.
 `parse` imports `generateHref`, which imported `node:path`, and the package
 exposes no subpath exports to import around it. That made the whole package
 unusable in a browser bundle even for consumers that never touch `@import`
-resolution. `generateHref` now uses a small internal POSIX path helper instead.
+resolution. `generateHref` now uses `path-browserify`, which is Node's own POSIX
+`path` implementation ported verbatim and works in both a browser bundle and
+Node.
 
 `node:path`'s default export is already `path.posix` on every non-Windows
 platform, so href resolution is unchanged for any absolute `projectRoot` -
-verified against `node:path` itself over a generated input matrix. Two
-behaviours intentionally differ:
+verified against `node:path` itself over a generated input matrix. One behaviour
+intentionally differs:
 
-- A relative `projectRoot` no longer resolves against `process.cwd()`. It is
-  treated as rooted, making the output a pure function of the arguments rather
-  than of the directory the build ran from. `parse` defaults `projectRoot` to
-  `'/'`.
 - On Windows, resolution now uses POSIX semantics rather than `path.win32`, so
   hrefs no longer vary by platform. **This changes emitted `@import` hrefs for
   consumers that pass native Windows paths.** Measured examples, with
@@ -37,3 +35,10 @@ behaviours intentionally differ:
   is a `peerDependency` of `@lynx-js/web-core`, so a minor here cascades that
   package to `1.0.0`, which `.github/scripts/check-no-major-changeset.cjs`
   rejects.
+
+A relative `projectRoot` keeps resolving against `process.cwd()` in Node, exactly
+as before, because `path-browserify` is a faithful port. Note that a browser
+bundle has no `process.cwd()` and falls back to treating the path as rooted, so
+only an **absolute** `projectRoot` resolves identically in both environments.
+`parse` defaults `projectRoot` to `'/'` and every in-repo caller passes an
+absolute one.

--- a/.changeset/css-serializer-drop-node-path.md
+++ b/.changeset/css-serializer-drop-node-path.md
@@ -1,0 +1,23 @@
+---
+"@lynx-js/css-serializer": patch
+---
+
+Drop the `node:path` dependency from `@lynx-js/css-serializer` so the package can
+be bundled for browsers.
+
+`parse` imports `generateHref`, which imported `node:path`, and the package
+exposes no subpath exports to import around it. That made the whole package
+unusable in a browser bundle even for consumers that never touch `@import`
+resolution. `generateHref` now uses a small internal POSIX path helper instead.
+
+`node:path`'s default export is already `path.posix` on every non-Windows
+platform, so href resolution is unchanged for any absolute `projectRoot` -
+verified against `node:path` itself over a generated input matrix. Two
+behaviours intentionally differ:
+
+- A relative `projectRoot` no longer resolves against `process.cwd()`. It is
+  treated as rooted, making the output a pure function of the arguments rather
+  than of the directory the build ran from. `parse` defaults `projectRoot` to
+  `'/'`.
+- On Windows, resolution now uses POSIX semantics rather than `path.win32`, so
+  hrefs no longer vary by platform.

--- a/.changeset/css-serializer-drop-node-path.md
+++ b/.changeset/css-serializer-drop-node-path.md
@@ -25,7 +25,8 @@ normalizes Windows paths: `\` is a separator, a drive letter is a root, and
 backslash `projectRoot` with a relative `filename` - this now agrees with what a
 Windows build host used to emit, where a pure-POSIX helper would not. It is not a
 complete match: UNC roots, a `\`-rooted `filename` and a drive-letter `@import`
-still differ from the old Windows output. Measured examples:
+still differ, and for a drive-letter `@import` the old Windows output was not a
+single value at all. Measured examples:
 
 | `projectRoot` / `filename`    | `@import`           | now                | old, on Windows    | old, on Linux/macOS  |
 | ----------------------------- | ------------------- | ------------------ | ------------------ | -------------------- |
@@ -33,7 +34,20 @@ still differ from the old Windows output. Measured examples:
 | `C:\proj` / `pages\index.css` | `../shared/b.css`   | `/shared/b.css`    | `/shared/b.css`    | `../shared/b.css`    |
 | `/` / `./index.css`           | `\a.css`            | `/a.css`           | `/a.css`           | `//a.css`            |
 | `/` / `./index.css`           | `\\srv\share\x.css` | `/srv/share/x.css` | `/srv/share/x.css` | `///srv/share/x.css` |
-| `/` / `./index.css`           | `C:\x.css`          | `../C:/x.css`      | `/C:/x.css`        | `/C:/x.css`          |
+| `/` / `./index.css`           | `C:\x.css`          | `../C:/x.css`      | varies by drive    | `/C:/x.css`          |
+
+That last row had no single value on Windows, and the reason generalizes:
+`path.win32.resolve` takes the drive it resolves against from `process.cwd()`, so
+whenever no argument names a drive, the old output depended on which drive the
+build ran from. `/` with `./index.css` and a `C:\x.css` import resolved to
+`/x.css` on a C: build machine but to `/C:/x.css` on a D: or E: one.
+
+So the old behaviour varied not only with the platform but, on Windows, with the
+drive letter of the machine that happened to run the build - which is a further
+reason to stop using the platform-dependent `node:path` default export here. None
+of the rows above reach `pathe`'s working-directory fallback, so each is now a
+function of its arguments alone: every `now` value was measured identically on a
+Linux host and on simulated C:, D:, E: and UNC ones.
 
 `projectRoot: '//'` is not supported: `pathe` resolves it against
 `process.cwd()`, so the emitted href depends on the directory the build ran from.

--- a/.changeset/css-serializer-drop-node-path.md
+++ b/.changeset/css-serializer-drop-node-path.md
@@ -1,5 +1,5 @@
 ---
-"@lynx-js/css-serializer": minor
+"@lynx-js/css-serializer": patch
 ---
 
 Drop the `node:path` dependency from `@lynx-js/css-serializer` so the package can
@@ -21,9 +21,8 @@ behaviours intentionally differ:
   `'/'`.
 - On Windows, resolution now uses POSIX semantics rather than `path.win32`, so
   hrefs no longer vary by platform. **This changes emitted `@import` hrefs for
-  consumers that pass native Windows paths**, which is why this ships as a minor
-  rather than a patch. Measured examples, with `projectRoot` `C:\proj` and
-  `filename` `pages\index.css`:
+  consumers that pass native Windows paths.** Measured examples, with
+  `projectRoot` `C:\proj` and `filename` `pages\index.css`:
 
   | `@import`         | before (on Windows) | after (all platforms) |
   | ----------------- | ------------------- | --------------------- |
@@ -33,3 +32,8 @@ behaviours intentionally differ:
   Callers that pass POSIX paths - including every in-repo caller, which relies on
   the `filename` `'./index.css'` and `projectRoot` `'/'` defaults - are
   unaffected on every platform.
+
+  This ships as a patch despite changing behaviour on one platform. The package
+  is a `peerDependency` of `@lynx-js/web-core`, so a minor here cascades that
+  package to `1.0.0`, which `.github/scripts/check-no-major-changeset.cjs`
+  rejects.

--- a/.changeset/css-serializer-drop-node-path.md
+++ b/.changeset/css-serializer-drop-node-path.md
@@ -1,5 +1,5 @@
 ---
-"@lynx-js/css-serializer": patch
+"@lynx-js/css-serializer": minor
 ---
 
 Drop the `node:path` dependency from `@lynx-js/css-serializer` so the package can
@@ -20,4 +20,16 @@ behaviours intentionally differ:
   than of the directory the build ran from. `parse` defaults `projectRoot` to
   `'/'`.
 - On Windows, resolution now uses POSIX semantics rather than `path.win32`, so
-  hrefs no longer vary by platform.
+  hrefs no longer vary by platform. **This changes emitted `@import` hrefs for
+  consumers that pass native Windows paths**, which is why this ships as a minor
+  rather than a patch. Measured examples, with `projectRoot` `C:\proj` and
+  `filename` `pages\index.css`:
+
+  | `@import`         | before (on Windows) | after (all platforms) |
+  | ----------------- | ------------------- | --------------------- |
+  | `./a.css`         | `/pages/a.css`      | `/a.css`              |
+  | `../shared/b.css` | `/shared/b.css`     | `../shared/b.css`     |
+
+  Callers that pass POSIX paths - including every in-repo caller, which relies on
+  the `filename` `'./index.css'` and `projectRoot` `'/'` defaults - are
+  unaffected on every platform.

--- a/.changeset/css-serializer-drop-node-path.md
+++ b/.changeset/css-serializer-drop-node-path.md
@@ -8,37 +8,39 @@ be bundled for browsers.
 `parse` imports `generateHref`, which imported `node:path`, and the package
 exposes no subpath exports to import around it. That made the whole package
 unusable in a browser bundle even for consumers that never touch `@import`
-resolution. `generateHref` now uses `path-browserify`, which is Node's own POSIX
-`path` implementation ported verbatim and works in both a browser bundle and
-Node.
+resolution. `generateHref` now uses [`pathe`](https://github.com/unjs/pathe),
+which works in both a browser bundle and Node, ships dual ESM/CJS entries and
+carries its own types.
 
-`node:path`'s default export is already `path.posix` on every non-Windows
-platform, so href resolution is unchanged for any absolute `projectRoot` -
-verified against `node:path` itself over a generated input matrix. One behaviour
-intentionally differs:
+**Callers that pass POSIX paths are unaffected.** That includes every in-repo
+caller, which relies on the `projectRoot` `'/'` and `filename` `'./index.css'`
+defaults. For any input without a backslash, `pathe` is byte-identical to
+`path.posix` - which is what `node:path`'s default export already resolved to on
+every non-Windows platform - verified against `node:path` itself over a generated
+input matrix.
 
-- On Windows, resolution now uses POSIX semantics rather than `path.win32`, so
-  hrefs no longer vary by platform. **This changes emitted `@import` hrefs for
-  consumers that pass native Windows paths.** Measured examples, with
-  `projectRoot` `C:\proj` and `filename` `pages\index.css`:
+**Inputs containing a backslash resolve differently**, because `pathe`
+normalizes Windows paths: `\` is a separator, a drive letter is a root, and
+`\\srv\share` is a UNC prefix. For the common Windows shape - a drive-letter or
+backslash `projectRoot` with a relative `filename` - this now agrees with what a
+Windows build host used to emit, where a pure-POSIX helper would not. It is not a
+complete match: UNC roots, a `\`-rooted `filename` and a drive-letter `@import`
+still differ from the old Windows output. Measured examples:
 
-  | `@import`         | before (on Windows) | after (all platforms) |
-  | ----------------- | ------------------- | --------------------- |
-  | `./a.css`         | `/pages/a.css`      | `/a.css`              |
-  | `../shared/b.css` | `/shared/b.css`     | `../shared/b.css`     |
+| `projectRoot` / `filename`    | `@import`           | now                | old, on Windows    | old, on Linux/macOS  |
+| ----------------------------- | ------------------- | ------------------ | ------------------ | -------------------- |
+| `C:\proj` / `pages\index.css` | `./a.css`           | `/pages/a.css`     | `/pages/a.css`     | `/a.css`             |
+| `C:\proj` / `pages\index.css` | `../shared/b.css`   | `/shared/b.css`    | `/shared/b.css`    | `../shared/b.css`    |
+| `/` / `./index.css`           | `\a.css`            | `/a.css`           | `/a.css`           | `//a.css`            |
+| `/` / `./index.css`           | `\\srv\share\x.css` | `/srv/share/x.css` | `/srv/share/x.css` | `///srv/share/x.css` |
+| `/` / `./index.css`           | `C:\x.css`          | `../C:/x.css`      | `/C:/x.css`        | `/C:/x.css`          |
 
-  Callers that pass POSIX paths - including every in-repo caller, which relies on
-  the `filename` `'./index.css'` and `projectRoot` `'/'` defaults - are
-  unaffected on every platform.
+`projectRoot: '//'` is not supported: `pathe` resolves it against
+`process.cwd()`, so the emitted href depends on the directory the build ran from.
+Every other absolute `projectRoot` is working-directory independent. A relative
+`projectRoot` resolves against `process.cwd()` in Node exactly as it did before,
+and against `/` in a browser bundle, where there is no `process.cwd()`.
 
-  This ships as a patch despite changing behaviour on one platform. The package
-  is a `peerDependency` of `@lynx-js/web-core`, so a minor here cascades that
-  package to `1.0.0`, which `.github/scripts/check-no-major-changeset.cjs`
-  rejects.
-
-A relative `projectRoot` keeps resolving against `process.cwd()` in Node, exactly
-as before, because `path-browserify` is a faithful port. Note that a browser
-bundle has no `process.cwd()` and falls back to treating the path as rooted, so
-only an **absolute** `projectRoot` resolves identically in both environments.
-`parse` defaults `projectRoot` to `'/'` and every in-repo caller passes an
-absolute one.
+This ships as a `patch` despite the behaviour change above. The package is a
+`peerDependency` of `@lynx-js/web-core`, so a `minor` here cascades that package
+to `1.0.0`, which `.github/scripts/check-no-major-changeset.cjs` rejects.

--- a/packages/tools/css-serializer/package.json
+++ b/packages/tools/css-serializer/package.json
@@ -23,10 +23,12 @@
     "test": "vitest"
   },
   "dependencies": {
-    "css-tree": "^3.2.1"
+    "css-tree": "^3.2.1",
+    "path-browserify": "^1.0.1"
   },
   "devDependencies": {
     "@types/css-tree": "^2.3.11",
-    "@types/node": "^24.13.3"
+    "@types/node": "^24.13.3",
+    "@types/path-browserify": "^1.0.3"
   }
 }

--- a/packages/tools/css-serializer/package.json
+++ b/packages/tools/css-serializer/package.json
@@ -24,11 +24,10 @@
   },
   "dependencies": {
     "css-tree": "^3.2.1",
-    "path-browserify": "^1.0.1"
+    "pathe": "^2.0.3"
   },
   "devDependencies": {
     "@types/css-tree": "^2.3.11",
-    "@types/node": "^24.13.3",
-    "@types/path-browserify": "^1.0.3"
+    "@types/node": "^24.13.3"
   }
 }

--- a/packages/tools/css-serializer/src/generateHref.ts
+++ b/packages/tools/css-serializer/src/generateHref.ts
@@ -37,13 +37,18 @@ import path from 'pathe';
  * behaviour these inputs get is pinned in `test/generateHref.test.ts` rather
  * than described here, so it cannot drift silently.
  *
- * ## A relative `projectRoot`
+ * ## `process.cwd()` still participates
  *
- * `pathe` has no `process.cwd()` to fall back to, so a relative `projectRoot` is
- * treated as rooted. `node:path` resolved it against the working directory,
- * which made the old output depend on where the build ran from. Nothing in this
- * tree observes the difference: `parse` defaults `projectRoot` to `'/'`, and
- * every in-repo caller passes an absolute one.
+ * `pathe`'s `resolve` falls back to `process.cwd()` for a relative input, exactly
+ * as `node:path` did, so a relative `projectRoot` still makes the output depend
+ * on where the build ran from. Nothing in this tree observes it: `parse` defaults
+ * `projectRoot` to `'/'` and every in-repo caller passes an absolute one.
+ *
+ * A handful of *absolute* roots also reach that fallback, because `pathe`
+ * normalises them into a UNC shape that its own `isAbsolute` then rejects:
+ * `'//'`, `'//.'`, `'//./x'` and `'\'`, when combined with a `.`-prefixed
+ * filename. Those are pinned in `test/generateHref.test.ts`; they are not shapes
+ * a caller passes, and a browser bundle has no `process.cwd()` at all.
  */
 
 export function getFullPath(

--- a/packages/tools/css-serializer/src/generateHref.ts
+++ b/packages/tools/css-serializer/src/generateHref.ts
@@ -4,21 +4,25 @@
 // LICENSE file in the root directory of this source tree.
 */
 
+import path from 'path-browserify';
+
 /**
  * `@import` href resolution, without `node:path`.
  *
  * This module used to `import path from 'node:path'`. Because `parse` imports
  * `generateHref`, that single import made the whole package impossible to bundle
  * for a browser, and the package exposes no subpath exports to import around it.
- * The helpers below are therefore a minimal, dependency-free reimplementation of
- * the four `path` functions this file used: `join`, `resolve`, `relative` and
- * `isAbsolute`.
+ * `path-browserify` is a drop-in that works in both a browser bundle and in
+ * Node, so the four functions this file needs - `join`, `resolve`, `relative`
+ * and `isAbsolute` - keep their `path.posix` behaviour without pulling in a Node
+ * builtin.
  *
  * ## Why POSIX semantics
  *
  * `node:path`'s default export is `path.posix` on every non-Windows platform, so
- * POSIX is what the ReactLynx build has actually been doing. These helpers
- * reproduce `path.posix` exactly, which means, deliberately:
+ * POSIX is what the ReactLynx build has actually been doing, and
+ * `path-browserify` is Node's own POSIX implementation ported verbatim. That
+ * means, deliberately:
  *
  * - `\` is an ordinary filename character, not a separator. Only the final
  *   {@link normalizeSlashes} pass rewrites it, so `'\a.css'` still resolves to
@@ -30,148 +34,22 @@
  *
  * On Windows the old code picked up `path.win32` and could differ - e.g.
  * `generateHref('C:\\proj', 'pages\\index.css', './a.css')` was `'/pages/a.css'`
- * under win32 but `'/a.css'` under posix. Pinning POSIX makes the output
- * platform independent, which is what a browser bundle needs and what a
+ * under win32 but `'/a.css'` here. Pinning POSIX makes the output platform
+ * independent, which is what a browser bundle needs and what a
  * cross-machine-reproducible build wants anyway.
  *
  * ## The one behaviour that is not preserved: a relative `projectRoot`
  *
- * `path.resolve` and `path.relative` fall back to `process.cwd()` for relative
- * inputs, so with a relative `projectRoot` the old output depended on the
- * directory the build ran from. {@link posixResolve} has no `cwd` and treats a
- * relative path as rooted instead, so those inputs now differ - and are now
- * deterministic. `parse` defaults `projectRoot` to `'/'`, and every in-repo
+ * Node's `path.resolve` and `path.relative` fall back to `process.cwd()` for
+ * relative inputs, so with a relative `projectRoot` the old output depended on
+ * the directory the build ran from. `path-browserify` has no `cwd` to fall back
+ * to and
+ * treats a relative path as rooted instead, so those inputs now differ - and are
+ * now deterministic. `parse` defaults `projectRoot` to `'/'`, and every in-repo
  * caller passes an absolute one, so nothing in the tree observes this. For every
  * absolute `projectRoot` the output is byte-identical; `test/generateHref.test.ts`
  * checks that against `node:path` itself over a generated matrix.
  */
-
-/**
- * Collapses `.` and `..` segments, mirroring the internal helper `node:path`
- * uses for both `normalize` and `resolve`.
- *
- * @param pathname - a `/`-separated path
- * @param allowAboveRoot - keep leading `..` that would escape the root, which is
- *   correct for relative paths and wrong for absolute ones
- */
-function normalizeSegments(pathname: string, allowAboveRoot: boolean): string {
-  const out: string[] = [];
-  let aboveRoot = 0;
-
-  for (const segment of pathname.split('/')) {
-    // Empty segments come from repeated or trailing separators.
-    if (segment.length === 0 || segment === '.') {
-      continue;
-    }
-    if (segment === '..') {
-      if (out.length > 0) {
-        out.pop();
-      } else if (allowAboveRoot) {
-        aboveRoot += 1;
-      }
-      // An absolute path cannot escape its root, so `..` is dropped there.
-      continue;
-    }
-    out.push(segment);
-  }
-
-  const body = out.join('/');
-  if (aboveRoot === 0) {
-    return body;
-  }
-  const prefix = '../'.repeat(aboveRoot);
-  return body.length === 0 ? prefix.slice(0, -1) : prefix + body;
-}
-
-/** Equivalent to `path.posix.isAbsolute`. */
-function posixIsAbsolute(pathname: string): boolean {
-  return pathname.startsWith('/');
-}
-
-/** Equivalent to `path.posix.normalize`, including its trailing-slash handling. */
-function posixNormalize(pathname: string): string {
-  if (pathname.length === 0) {
-    return '.';
-  }
-  const isAbsolute = posixIsAbsolute(pathname);
-  const hasTrailingSlash = pathname.endsWith('/');
-  const normalized = normalizeSegments(pathname, !isAbsolute);
-
-  if (normalized.length === 0) {
-    if (isAbsolute) {
-      return '/';
-    }
-    return hasTrailingSlash ? './' : '.';
-  }
-
-  const withTrailingSlash = hasTrailingSlash ? `${normalized}/` : normalized;
-  return isAbsolute ? `/${withTrailingSlash}` : withTrailingSlash;
-}
-
-/** Equivalent to `path.posix.join`. */
-function posixJoin(...paths: string[]): string {
-  let joined = '';
-  for (const segment of paths) {
-    // `join` ignores empty arguments entirely.
-    if (segment.length === 0) {
-      continue;
-    }
-    joined = joined.length === 0 ? segment : `${joined}/${segment}`;
-  }
-  return joined.length === 0 ? '.' : posixNormalize(joined);
-}
-
-/**
- * Equivalent to `path.posix.resolve`, except that it roots at `/` instead of
- * `process.cwd()` when the arguments never produce an absolute path. See the
- * module comment.
- */
-function posixResolve(...paths: string[]): string {
-  let resolved = '';
-  let isAbsolute = false;
-
-  // Right to left, stopping at the first absolute segment, as `resolve` does.
-  for (let i = paths.length - 1; i >= 0 && !isAbsolute; i--) {
-    const segment = paths[i] ?? '';
-    if (segment.length === 0) {
-      continue;
-    }
-    resolved = `${segment}/${resolved}`;
-    isAbsolute = posixIsAbsolute(segment);
-  }
-
-  return `/${normalizeSegments(isAbsolute ? resolved : `/${resolved}`, false)}`;
-}
-
-/**
- * Equivalent to `path.posix.relative`, with {@link posixResolve}'s rooting rule
- * for relative inputs.
- */
-function posixRelative(from: string, to: string): string {
-  if (from === to) {
-    return '';
-  }
-  const fromResolved = posixResolve(from);
-  const toResolved = posixResolve(to);
-  if (fromResolved === toResolved) {
-    return '';
-  }
-
-  const fromSegments = fromResolved.split('/').filter((s) => s.length > 0);
-  const toSegments = toResolved.split('/').filter((s) => s.length > 0);
-
-  let common = 0;
-  while (
-    common < fromSegments.length
-    && common < toSegments.length
-    && fromSegments[common] === toSegments[common]
-  ) {
-    common += 1;
-  }
-
-  const up: string[] = new Array(fromSegments.length - common).fill('..');
-  return [...up, ...toSegments.slice(common)].join('/');
-}
 
 export function getFullPath(
   projectRoot: string,
@@ -180,11 +58,11 @@ export function getFullPath(
 ): string {
   let fullPath = '';
   if (importStmt.startsWith('/')) {
-    fullPath = posixJoin(projectRoot, importStmt);
+    fullPath = path.join(projectRoot, importStmt);
   } else if (importStmt.startsWith('@')) {
     fullPath = importStmt;
   } else {
-    fullPath = posixResolve(filename, '..', importStmt);
+    fullPath = path.resolve(filename, '..', importStmt);
   }
 
   return fullPath;
@@ -195,17 +73,17 @@ export function generateHref(
   filename: string,
   origin: string,
 ): string {
-  filename = posixIsAbsolute(filename)
+  filename = path.isAbsolute(filename)
     ? filename
-    : posixJoin(projectRoot, filename);
+    : path.join(projectRoot, filename);
   const fullPath = getFullPath(projectRoot, filename, origin);
 
-  let projectPath = posixRelative(projectRoot, fullPath);
+  let projectPath = path.relative(projectRoot, fullPath);
 
   if (fullPath.startsWith('@')) {
     return normalizeSlashes(fullPath);
   } else if (!projectPath.startsWith('.')) {
-    projectPath = posixJoin(POSIX_SEP, projectPath);
+    projectPath = path.join(POSIX_SEP, projectPath);
   }
 
   return normalizeSlashes(projectPath);

--- a/packages/tools/css-serializer/src/generateHref.ts
+++ b/packages/tools/css-serializer/src/generateHref.ts
@@ -4,7 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 */
 
-import path from 'path-browserify';
+import path from 'pathe';
 
 /**
  * `@import` href resolution, without `node:path`.
@@ -12,43 +12,38 @@ import path from 'path-browserify';
  * This module used to `import path from 'node:path'`. Because `parse` imports
  * `generateHref`, that single import made the whole package impossible to bundle
  * for a browser, and the package exposes no subpath exports to import around it.
- * `path-browserify` is a drop-in that works in both a browser bundle and in
- * Node, so the four functions this file needs - `join`, `resolve`, `relative`
- * and `isAbsolute` - keep their `path.posix` behaviour without pulling in a Node
- * builtin.
+ * `pathe` provides the four functions this file needs - `join`, `resolve`,
+ * `relative` and `isAbsolute` - and works in both a browser bundle and Node.
  *
- * ## Why POSIX semantics
+ * ## What is unchanged, and what is not
  *
- * `node:path`'s default export is `path.posix` on every non-Windows platform, so
- * POSIX is what the ReactLynx build has actually been doing, and
- * `path-browserify` is Node's own POSIX implementation ported verbatim. That
- * means, deliberately:
+ * For a path that contains no backslash, `pathe` is byte-identical to
+ * `path.posix`, which is what `node:path`'s default export already was on every
+ * non-Windows platform. Since `parse` defaults `projectRoot` to `'/'` and every
+ * in-repo caller passes POSIX paths, href resolution is unchanged in this tree.
+ * `test/generateHref.test.ts` proves that against `node:path` itself over a
+ * generated matrix.
  *
- * - `\` is an ordinary filename character, not a separator. Only the final
- *   {@link normalizeSlashes} pass rewrites it, so `'\a.css'` still resolves to
- *   `'//a.css'` rather than `'/a.css'`, exactly as before.
- * - A drive letter is not a root. `'C:\x.css'` is a *relative* path whose first
- *   segment happens to be `'C:'`, so it resolves under `projectRoot`.
- * - A UNC path is just a name containing backslashes; `'\\srv\share'` gets no
- *   special treatment.
+ * A path that *does* contain a backslash is where `pathe` differs, because it
+ * treats `\` as a separator by design:
  *
- * On Windows the old code picked up `path.win32` and could differ - e.g.
- * `generateHref('C:\\proj', 'pages\\index.css', './a.css')` was `'/pages/a.css'`
- * under win32 but `'/a.css'` here. Pinning POSIX makes the output platform
- * independent, which is what a browser bundle needs and what a
- * cross-machine-reproducible build wants anyway.
+ * - `'\a.css'` is an absolute path, not a filename starting with a backslash.
+ * - `'C:\x.css'` has a drive letter, so `C:` is a path segment rather than part
+ *   of a filename.
+ * - `'\\srv\share'` is a UNC-shaped path.
  *
- * ## The one behaviour that is not preserved: a relative `projectRoot`
+ * That is neither `path.posix` (which treats `\` as an ordinary character) nor
+ * exactly `path.win32` (which differs again on UNC and on a leading `\`). The
+ * behaviour these inputs get is pinned in `test/generateHref.test.ts` rather
+ * than described here, so it cannot drift silently.
  *
- * Node's `path.resolve` and `path.relative` fall back to `process.cwd()` for
- * relative inputs, so with a relative `projectRoot` the old output depended on
- * the directory the build ran from. `path-browserify` has no `cwd` to fall back
- * to and
- * treats a relative path as rooted instead, so those inputs now differ - and are
- * now deterministic. `parse` defaults `projectRoot` to `'/'`, and every in-repo
- * caller passes an absolute one, so nothing in the tree observes this. For every
- * absolute `projectRoot` the output is byte-identical; `test/generateHref.test.ts`
- * checks that against `node:path` itself over a generated matrix.
+ * ## A relative `projectRoot`
+ *
+ * `pathe` has no `process.cwd()` to fall back to, so a relative `projectRoot` is
+ * treated as rooted. `node:path` resolved it against the working directory,
+ * which made the old output depend on where the build ran from. Nothing in this
+ * tree observes the difference: `parse` defaults `projectRoot` to `'/'`, and
+ * every in-repo caller passes an absolute one.
  */
 
 export function getFullPath(

--- a/packages/tools/css-serializer/src/generateHref.ts
+++ b/packages/tools/css-serializer/src/generateHref.ts
@@ -3,7 +3,175 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-import path from 'node:path';
+
+/**
+ * `@import` href resolution, without `node:path`.
+ *
+ * This module used to `import path from 'node:path'`. Because `parse` imports
+ * `generateHref`, that single import made the whole package impossible to bundle
+ * for a browser, and the package exposes no subpath exports to import around it.
+ * The helpers below are therefore a minimal, dependency-free reimplementation of
+ * the four `path` functions this file used: `join`, `resolve`, `relative` and
+ * `isAbsolute`.
+ *
+ * ## Why POSIX semantics
+ *
+ * `node:path`'s default export is `path.posix` on every non-Windows platform, so
+ * POSIX is what the ReactLynx build has actually been doing. These helpers
+ * reproduce `path.posix` exactly, which means, deliberately:
+ *
+ * - `\` is an ordinary filename character, not a separator. Only the final
+ *   {@link normalizeSlashes} pass rewrites it, so `'\a.css'` still resolves to
+ *   `'//a.css'` rather than `'/a.css'`, exactly as before.
+ * - A drive letter is not a root. `'C:\x.css'` is a *relative* path whose first
+ *   segment happens to be `'C:'`, so it resolves under `projectRoot`.
+ * - A UNC path is just a name containing backslashes; `'\\srv\share'` gets no
+ *   special treatment.
+ *
+ * On Windows the old code picked up `path.win32` and could differ - e.g.
+ * `generateHref('C:\\proj', 'pages\\index.css', './a.css')` was `'/pages/a.css'`
+ * under win32 but `'/a.css'` under posix. Pinning POSIX makes the output
+ * platform independent, which is what a browser bundle needs and what a
+ * cross-machine-reproducible build wants anyway.
+ *
+ * ## The one behaviour that is not preserved: a relative `projectRoot`
+ *
+ * `path.resolve` and `path.relative` fall back to `process.cwd()` for relative
+ * inputs, so with a relative `projectRoot` the old output depended on the
+ * directory the build ran from. {@link posixResolve} has no `cwd` and treats a
+ * relative path as rooted instead, so those inputs now differ - and are now
+ * deterministic. `parse` defaults `projectRoot` to `'/'`, and every in-repo
+ * caller passes an absolute one, so nothing in the tree observes this. For every
+ * absolute `projectRoot` the output is byte-identical; `test/generateHref.test.ts`
+ * checks that against `node:path` itself over a generated matrix.
+ */
+
+/**
+ * Collapses `.` and `..` segments, mirroring the internal helper `node:path`
+ * uses for both `normalize` and `resolve`.
+ *
+ * @param pathname - a `/`-separated path
+ * @param allowAboveRoot - keep leading `..` that would escape the root, which is
+ *   correct for relative paths and wrong for absolute ones
+ */
+function normalizeSegments(pathname: string, allowAboveRoot: boolean): string {
+  const out: string[] = [];
+  let aboveRoot = 0;
+
+  for (const segment of pathname.split('/')) {
+    // Empty segments come from repeated or trailing separators.
+    if (segment.length === 0 || segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      if (out.length > 0) {
+        out.pop();
+      } else if (allowAboveRoot) {
+        aboveRoot += 1;
+      }
+      // An absolute path cannot escape its root, so `..` is dropped there.
+      continue;
+    }
+    out.push(segment);
+  }
+
+  const body = out.join('/');
+  if (aboveRoot === 0) {
+    return body;
+  }
+  const prefix = '../'.repeat(aboveRoot);
+  return body.length === 0 ? prefix.slice(0, -1) : prefix + body;
+}
+
+/** Equivalent to `path.posix.isAbsolute`. */
+function posixIsAbsolute(pathname: string): boolean {
+  return pathname.startsWith('/');
+}
+
+/** Equivalent to `path.posix.normalize`, including its trailing-slash handling. */
+function posixNormalize(pathname: string): string {
+  if (pathname.length === 0) {
+    return '.';
+  }
+  const isAbsolute = posixIsAbsolute(pathname);
+  const hasTrailingSlash = pathname.endsWith('/');
+  const normalized = normalizeSegments(pathname, !isAbsolute);
+
+  if (normalized.length === 0) {
+    if (isAbsolute) {
+      return '/';
+    }
+    return hasTrailingSlash ? './' : '.';
+  }
+
+  const withTrailingSlash = hasTrailingSlash ? `${normalized}/` : normalized;
+  return isAbsolute ? `/${withTrailingSlash}` : withTrailingSlash;
+}
+
+/** Equivalent to `path.posix.join`. */
+function posixJoin(...paths: string[]): string {
+  let joined = '';
+  for (const segment of paths) {
+    // `join` ignores empty arguments entirely.
+    if (segment.length === 0) {
+      continue;
+    }
+    joined = joined.length === 0 ? segment : `${joined}/${segment}`;
+  }
+  return joined.length === 0 ? '.' : posixNormalize(joined);
+}
+
+/**
+ * Equivalent to `path.posix.resolve`, except that it roots at `/` instead of
+ * `process.cwd()` when the arguments never produce an absolute path. See the
+ * module comment.
+ */
+function posixResolve(...paths: string[]): string {
+  let resolved = '';
+  let isAbsolute = false;
+
+  // Right to left, stopping at the first absolute segment, as `resolve` does.
+  for (let i = paths.length - 1; i >= 0 && !isAbsolute; i--) {
+    const segment = paths[i] ?? '';
+    if (segment.length === 0) {
+      continue;
+    }
+    resolved = `${segment}/${resolved}`;
+    isAbsolute = posixIsAbsolute(segment);
+  }
+
+  return `/${normalizeSegments(isAbsolute ? resolved : `/${resolved}`, false)}`;
+}
+
+/**
+ * Equivalent to `path.posix.relative`, with {@link posixResolve}'s rooting rule
+ * for relative inputs.
+ */
+function posixRelative(from: string, to: string): string {
+  if (from === to) {
+    return '';
+  }
+  const fromResolved = posixResolve(from);
+  const toResolved = posixResolve(to);
+  if (fromResolved === toResolved) {
+    return '';
+  }
+
+  const fromSegments = fromResolved.split('/').filter((s) => s.length > 0);
+  const toSegments = toResolved.split('/').filter((s) => s.length > 0);
+
+  let common = 0;
+  while (
+    common < fromSegments.length
+    && common < toSegments.length
+    && fromSegments[common] === toSegments[common]
+  ) {
+    common += 1;
+  }
+
+  const up: string[] = new Array(fromSegments.length - common).fill('..');
+  return [...up, ...toSegments.slice(common)].join('/');
+}
 
 export function getFullPath(
   projectRoot: string,
@@ -12,11 +180,11 @@ export function getFullPath(
 ): string {
   let fullPath = '';
   if (importStmt.startsWith('/')) {
-    fullPath = path.join(projectRoot, importStmt);
+    fullPath = posixJoin(projectRoot, importStmt);
   } else if (importStmt.startsWith('@')) {
     fullPath = importStmt;
   } else {
-    fullPath = path.resolve(filename, '..', importStmt);
+    fullPath = posixResolve(filename, '..', importStmt);
   }
 
   return fullPath;
@@ -27,22 +195,28 @@ export function generateHref(
   filename: string,
   origin: string,
 ): string {
-  filename = path.isAbsolute(filename)
+  filename = posixIsAbsolute(filename)
     ? filename
-    : path.join(projectRoot, filename);
+    : posixJoin(projectRoot, filename);
   const fullPath = getFullPath(projectRoot, filename, origin);
 
-  let projectPath = path.relative(projectRoot, fullPath);
+  let projectPath = posixRelative(projectRoot, fullPath);
 
   if (fullPath.startsWith('@')) {
     return normalizeSlashes(fullPath);
   } else if (!projectPath.startsWith('.')) {
-    projectPath = path.join(path.sep, projectPath);
+    projectPath = posixJoin(POSIX_SEP, projectPath);
   }
 
   return normalizeSlashes(projectPath);
 }
 
+/** `path.posix.sep`. */
+const POSIX_SEP = '/';
+
+/** `path.win32.sep`, kept out of shipped hrefs. */
+const WIN32_SEP = '\\';
+
 function normalizeSlashes(file: string) {
-  return file.replaceAll(path.win32.sep, '/');
+  return file.replaceAll(WIN32_SEP, '/');
 }

--- a/packages/tools/css-serializer/test/generateHref.test.ts
+++ b/packages/tools/css-serializer/test/generateHref.test.ts
@@ -577,6 +577,71 @@ describe('generateHref', () => {
     });
   });
 
+  /**
+   * Native Windows paths are the one input class whose emitted href genuinely
+   * changed, and the differential suite above cannot catch it: that oracle is
+   * pinned to `path.posix` by design, so it agrees with the implementation on
+   * every platform. These cases therefore assert the new values *literally*,
+   * against a `path.win32` oracle that reproduces what the old implementation
+   * emitted when the build ran on Windows.
+   *
+   * The divergence is accepted, not a regression to fix: `\` is a legal
+   * character in a POSIX path, so a browser-safe helper cannot treat it as a
+   * separator without inventing platform detection. It is called out in the
+   * changeset, and it is why the change ships as a minor.
+   */
+  describe('native Windows paths (documented divergence)', () => {
+    const winOracle = (
+      projectRoot: string,
+      filename: string,
+      origin: string,
+    ) => {
+      const P = path.win32;
+      const abs = P.isAbsolute(filename)
+        ? filename
+        : P.join(projectRoot, filename);
+      const full = origin.startsWith('/')
+        ? P.join(projectRoot, origin)
+        : origin.startsWith('@')
+        ? origin
+        : P.resolve(abs, '..', origin);
+      let rel = P.relative(projectRoot, full);
+      if (full.startsWith('@')) return full.replaceAll(path.win32.sep, '/');
+      if (!rel.startsWith('.')) rel = P.join(P.sep, rel);
+      return rel.replaceAll(path.win32.sep, '/');
+    };
+
+    test.each([
+      ['./a.css', '/pages/a.css', '/a.css'],
+      ['../shared/b.css', '/shared/b.css', '../shared/b.css'],
+    ])(
+      'a backslash filename with %s changes from %s to %s',
+      (origin, onWindowsBefore, now) => {
+        // What the old implementation emitted on a Windows build host...
+        expect(winOracle('C:\\proj', 'pages\\index.css', origin)).toBe(
+          onWindowsBefore,
+        );
+        // ...versus what every platform emits now.
+        expect(generateHref('C:\\proj', 'pages\\index.css', origin)).toBe(now);
+      },
+    );
+
+    test('a drive letter is not a root under POSIX semantics', () => {
+      // `C:\x.css` is one relative path segment, not an absolute path, so it is
+      // resolved against `filename`'s directory rather than replacing it.
+      expect(generateHref('/', './index.css', 'C:\\x.css')).toBe('/C:/x.css');
+    });
+
+    test('POSIX callers are unaffected on every platform', () => {
+      // The shape every in-repo caller uses - `parse`'s defaults. Note `..` at
+      // the root is clamped, so this stays inside the project.
+      expect(generateHref('/', './index.css', './a.css')).toBe('/a.css');
+      expect(generateHref('/', './index.css', '../shared/b.css')).toBe(
+        '/shared/b.css',
+      );
+    });
+  });
+
   describe('integration through parse', () => {
     // `generateHref` has exactly one in-repo caller: `parse`, for
     // `ImportRule.href`. Pin that wiring so a signature-compatible but

--- a/packages/tools/css-serializer/test/generateHref.test.ts
+++ b/packages/tools/css-serializer/test/generateHref.test.ts
@@ -41,17 +41,32 @@
  * `path.resolve` and `path.relative` fall back to `process.cwd()` when handed a
  * relative path. With a relative `projectRoot` the *old* implementation therefore
  * produced different hrefs depending on the directory the build ran from, e.g.
- * `generateHref('proj', './index.css', '../../../../x.css')` returned
- * `'../../../x.css'` from a 1-deep cwd and `'../../../../x.css'` from a 4-deep one.
- * That is unspecifiable, so the differential matrix restricts itself to inputs
- * whose result is cwd independent (`projectRoot` absolute).
+ * `generateHref('proj', 'index.css', '../../x.css')` returns `'../../x.css'` from
+ * a deep directory but `'../x.css'` from the filesystem root, where the walk up
+ * clamps. That is unspecifiable, so the differential matrix restricts itself to
+ * inputs whose result is cwd independent (`projectRoot` absolute).
  *
  * In practice `projectRoot` is absolute: `parse` defaults it to `'/'`.
+ *
+ * ## Tests that depend on the working directory
+ *
+ * They go through `withCwd`, which runs a body from a directory it creates under
+ * `os.tmpdir()`. No test writes an absolute path of its own: `'/tmp'` is not a
+ * directory on Windows, and seven tests here once failed on the
+ * `Vitest (Windows)` runner because of it. `cwd-sensitive assertions go through
+ * withCwd` enforces that.
+ *
+ * The same class of bug reaches the `path.win32` oracle, which takes its drive
+ * from `process.cwd()` and so is not a function of its arguments alone; see
+ * `winOracle is only an oracle where it is drive-stable`.
  */
 
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-import { describe, expect, test } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 
 import { generateHref, getFullPath } from '../src/generateHref.js';
 import { parse } from '../src/index.js';
@@ -125,7 +140,65 @@ function keepsLeadingDoubleSlash(projectRoot: string, origin: string): boolean {
   return origin.startsWith('//') && oraclePath.normalize(projectRoot) === '/';
 }
 
+/**
+ * ## Running assertions from a different working directory
+ *
+ * Several tests below have to observe how a href changes with `process.cwd()`.
+ * They must not name a directory themselves: changing directory to `'/tmp'` or
+ * `'/usr/share'` throws `ENOENT` on Windows, because a POSIX absolute path there
+ * resolves against the current drive (`C:\tmp`) and that directory does not
+ * exist. Seven tests in this file used to fail on the `Vitest (Windows)` runner
+ * for exactly that reason.
+ *
+ * So the directories are created rather than named, under `os.tmpdir()`, which
+ * is `C:\Users\...\Temp` on Windows and `/tmp` here. `withCwd` is the only place
+ * that calls `process.chdir`, and `cwd-sensitive assertions go through withCwd`
+ * further down enforces that - keeping a hardcoded POSIX path from creeping back
+ * in.
+ */
+const probeShallow = fs.mkdtempSync(
+  path.join(fs.realpathSync(os.tmpdir()), 'lynx-generatehref-'),
+);
+
+/** Three levels below `probeShallow`, so the two differ in depth. */
+const probeDeep = path.join(probeShallow, 'nested', 'deeper', 'deepest');
+fs.mkdirSync(probeDeep, { recursive: true });
+
+/**
+ * The filesystem root: `/` here, `C:\` on Windows. Derived rather than written
+ * out, so it stays a legal `chdir` target on both. It is the one cwd shallow
+ * enough to make a `..` walk clamp, which is what makes a relative `projectRoot`
+ * observably cwd-dependent at all.
+ */
+const probeRoot = path.parse(probeShallow).root;
+
+/** Every probe directory, shallowest first. */
+const cwdProbes = [probeRoot, probeShallow, probeDeep];
+
+/**
+ * Runs `body` from `dir`, then restores the previous working directory.
+ *
+ * `body` receives the cwd as `pathe` sees it - `process.cwd()` with backslashes
+ * rewritten, which is precisely `pathe`'s own `cwd()` helper. Tests derive their
+ * expected values from that string instead of hardcoding one, because the shape
+ * is platform-specific: a Windows cwd keeps its drive letter (`C:/tmp/x`), and a
+ * href that leaks the cwd therefore looks different there.
+ */
+function withCwd<T>(dir: string, body: (patheCwd: string) => T): T {
+  const before = process.cwd();
+  process.chdir(dir);
+  try {
+    return body(process.cwd().replaceAll('\\', '/'));
+  } finally {
+    process.chdir(before);
+  }
+}
+
 describe('generateHref', () => {
+  afterAll(() => {
+    fs.rmSync(probeShallow, { recursive: true, force: true });
+  });
+
   /**
    * The matrix below deliberately contains **no backslashes**. `pathe` treats
    * `\` as a separator, `path.posix` treats it as an ordinary character, so any
@@ -605,19 +678,18 @@ describe('generateHref', () => {
       // consulting the `path.posix` oracle: the backslash rows are pinned
       // *because* they diverge from that oracle, so the oracle can no longer
       // stand in for "cwd independent".
-      const original = process.cwd();
-      try {
-        for (const dir of ['/', '/tmp', '/usr/share']) {
-          process.chdir(dir);
+      //
+      // Every row has an absolute `projectRoot`, which is what makes this hold -
+      // `'//'` deliberately has no row, see the comment in the table.
+      for (const dir of cwdProbes) {
+        withCwd(dir, (cwd) => {
           for (const { projectRoot, filename, origin, href } of cases) {
             expect(
               generateHref(projectRoot, filename, origin),
-              `cwd=${dir} generateHref(${projectRoot}, ${filename}, ${origin})`,
+              `cwd=${cwd} generateHref(${projectRoot}, ${filename}, ${origin})`,
             ).toBe(href);
           }
-        }
-      } finally {
-        process.chdir(original);
+        });
       }
     });
 
@@ -717,30 +789,62 @@ describe('generateHref', () => {
      *   one absolute value that is not, see below.
      */
     test('an absolute projectRoot is cwd-independent', () => {
-      const cwd = process.cwd();
-      try {
-        process.chdir('/');
-        const atRoot = generateHref('/proj', 'index.css', '../../x.css');
-        process.chdir('/tmp');
-        const atTmp = generateHref('/proj', 'index.css', '../../x.css');
-        expect(atRoot).toBe(atTmp);
-        expect(atRoot).toBe('../x.css');
-      } finally {
-        process.chdir(cwd);
+      const hrefs = cwdProbes.map((dir) =>
+        withCwd(dir, () => generateHref('/proj', 'index.css', '../../x.css'))
+      );
+
+      // Same answer from all three probes, which differ in depth.
+      expect(new Set(hrefs).size).toBe(1);
+      // And that answer is this exact string, on every platform.
+      for (const href of hrefs) {
+        expect(href).toBe('../x.css');
       }
     });
 
     test('a relative projectRoot resolves against cwd, as node:path does', () => {
-      const cwd = process.cwd();
-      try {
-        process.chdir('/');
-        expect(generateHref('proj', 'index.css', './a.css')).toBe('/a.css');
-        expect(generateHref('proj', 'index.css', '../../x.css')).toBe(
-          '../x.css',
-        );
-      } finally {
-        process.chdir(cwd);
+      // `./a.css` stays put: `relative()` resolves both of its arguments against
+      // the same cwd, so the cwd cancels out.
+      for (const dir of cwdProbes) {
+        withCwd(dir, (cwd) => {
+          expect(generateHref('proj', 'index.css', './a.css'), `cwd=${cwd}`)
+            .toBe('/a.css');
+        });
       }
+
+      // `../../x.css` does not: the walk up is clamped at the filesystem root, so
+      // a cwd shallow enough to clamp gives a different answer from a deep one.
+      // That clamping is the *only* source of cwd dependence here, which is why
+      // this needs the root probe and not just two temp directories.
+      const atRoot = withCwd(probeRoot, (cwd) => ({
+        cwd,
+        href: generateHref('proj', 'index.css', '../../x.css'),
+      }));
+      const atDeep = withCwd(probeDeep, (cwd) => ({
+        cwd,
+        href: generateHref('proj', 'index.css', '../../x.css'),
+      }));
+
+      // The point of the test: the href really does move with the cwd.
+      expect(atRoot.href).not.toBe(atDeep.href);
+
+      // Pinned by value at both ends rather than left as an inequality. Any cwd
+      // deep enough not to clamp gives this, on every platform.
+      expect(atDeep.href).toBe('../../x.css');
+
+      // At the root the two platforms genuinely differ, so the expectation is
+      // derived from the cwd `pathe` reported rather than hardcoded:
+      //
+      // - a POSIX root is `'/'`, and the walk clamps cleanly to `'../x.css'`.
+      // - a Windows root is `'C:/'`, whose drive counts as a segment. `relative()`
+      //   is handed a trailing-slash root and emits a **malformed doubled slash**
+      //   -`'../..//x.css'`. That is worse than "the depth changes with the cwd":
+      //   the href is not a well-formed path at all. It is unreachable in this
+      //   tree - `parse` defaults `projectRoot` to `'/'` - and is recorded here
+      //   rather than fixed, because fixing it means hand-rolling the resolution
+      //   this module exists to delete.
+      expect(atRoot.href).toBe(
+        /^[A-Za-z]:/.test(atRoot.cwd) ? '../..//x.css' : '../x.css',
+      );
     });
   });
 
@@ -770,41 +874,54 @@ describe('generateHref', () => {
    */
   describe('projectRoot \'//\' is not supported', () => {
     test('leaks process.cwd() into the href', () => {
-      const cwd = process.cwd();
-      try {
-        // Pinned per-directory rather than asserted to be "unstable": an
-        // inequality assertion would also pass if the two values differed for
-        // some unrelated reason. These say *what* leaks.
-        process.chdir('/tmp');
-        expect(generateHref('//', './index.css', './a.css')).toBe('/tmp/a.css');
-        process.chdir('/usr/share');
-        expect(generateHref('//', './index.css', './a.css')).toBe(
-          '/usr/share/a.css',
-        );
+      // Pinned per-directory rather than asserted to be "unstable": an
+      // inequality assertion would also pass if the two values differed for
+      // some unrelated reason. These say *what* leaks.
+      //
+      // The expectation is derived from the cwd instead of written out, because
+      // the leaked string is the cwd itself and its shape is platform-specific.
+      const atShallow = withCwd(probeShallow, (cwd) => ({
+        cwd,
+        href: generateHref('//', './index.css', './a.css'),
+      }));
+      const atDeep = withCwd(probeDeep, (cwd) => ({
+        cwd,
+        href: generateHref('//', './index.css', './a.css'),
+      }));
 
-        // The control: a single-slash root is cwd independent, so the leak is
-        // specific to `'//'` and not an artefact of the chdir harness.
-        process.chdir('/tmp');
-        const atTmp = generateHref('/', './index.css', './a.css');
-        process.chdir('/usr/share');
-        expect(generateHref('/', './index.css', './a.css')).toBe(atTmp);
-        expect(atTmp).toBe('/a.css');
-      } finally {
-        process.chdir(cwd);
+      for (const { cwd, href } of [atShallow, atDeep]) {
+        // The working directory appears verbatim in the href. On Windows it
+        // carries its drive letter (`C:/Users/.../Temp/x`), which `relative()`
+        // cannot express as a path under `//`, so it prefixes a `..` as well.
+        const escapesRoot = /^[A-Za-z]:/.test(cwd) ? '../' : '';
+        expect(href).toBe(`${escapesRoot}${cwd}/a.css`);
+      }
+
+      // Two different directories therefore give two different hrefs - the
+      // defect is a real instability, not just an odd constant.
+      expect(atShallow.href).not.toBe(atDeep.href);
+
+      // The control: a single-slash root is cwd independent, so the leak is
+      // specific to `'//'` and not an artefact of the chdir harness.
+      for (const dir of [probeShallow, probeDeep]) {
+        withCwd(dir, (cwd) => {
+          expect(generateHref('/', './index.css', './a.css'), `cwd=${cwd}`)
+            .toBe('/a.css');
+        });
       }
     });
 
     test('the leak needs a dot-prefixed filename', () => {
-      const cwd = process.cwd();
-      try {
-        // `join('//', 'index.css')` is `'//index.css'`, which `isAbsolute`
-        // accepts, so `resolve` never reaches its `cwd()` fallback.
-        process.chdir('/tmp');
-        const atTmp = generateHref('//', 'index.css', './a.css');
-        process.chdir('/usr/share');
-        expect(generateHref('//', 'index.css', './a.css')).toBe(atTmp);
-      } finally {
-        process.chdir(cwd);
+      // `join('//', 'index.css')` is `'//index.css'`, which `isAbsolute`
+      // accepts, so `resolve` never reaches its `cwd()` fallback.
+      //
+      // Pinned by value at each directory rather than as "the two agree", so the
+      // test states the expected href instead of only its stability.
+      for (const dir of [probeShallow, probeDeep]) {
+        withCwd(dir, (cwd) => {
+          expect(generateHref('//', 'index.css', './a.css'), `cwd=${cwd}`)
+            .toBe('/a.css');
+        });
       }
     });
   });
@@ -827,7 +944,12 @@ describe('generateHref', () => {
    * drive-letter root, and a drive-letter `@import`.
    */
   describe('native Windows paths', () => {
-    /** What the old implementation emitted when the build ran on Windows. */
+    /**
+     * What the old implementation emitted when the build ran on Windows.
+     *
+     * Only trustworthy where it is *drive-stable* - see
+     * `winOracle is only an oracle where it is drive-stable`.
+     */
     const winOracle = (
       projectRoot: string,
       filename: string,
@@ -847,6 +969,86 @@ describe('generateHref', () => {
       if (!rel.startsWith('.')) rel = P.join(P.sep, rel);
       return rel.replaceAll(path.win32.sep, '/');
     };
+
+    /** Runs `body` with `process.cwd()` reporting a Windows path. */
+    function withFakeCwd<T>(windowsCwd: string, body: () => T): T {
+      const real = process.cwd;
+      process.cwd = () => windowsCwd;
+      try {
+        return body();
+      } finally {
+        process.cwd = real;
+      }
+    }
+
+    /**
+     * `path.win32.resolve` takes the *device* it resolves against from
+     * `process.cwd()`. `winOracle` is therefore only a function of its arguments
+     * for inputs that already name a drive; for anything else the answer moves
+     * with whichever drive the runner happens to be on, and there is no single
+     * "what Windows used to emit" value to assert.
+     *
+     * That is easy to miss, because on Linux `process.cwd()` has no drive at all
+     * and `path.win32` quietly takes a "no device" branch - so a drive-sensitive
+     * input still looks like a stable oracle here while disagreeing with CI. Two
+     * assertions in this block did exactly that and failed on the
+     * `Vitest (Windows)` runner.
+     *
+     * This test keeps that from happening again: it pins which inputs are
+     * drive-sensitive (so they are documented rather than silently dropped) and
+     * asserts that every input the block *does* compare against `winOracle` is
+     * drive-stable.
+     */
+    test('winOracle is only an oracle where it is drive-stable', () => {
+      const drives = [
+        'C:\\',
+        'C:\\Users\\runneradmin\\proj',
+        'D:\\',
+        'D:\\a\\b',
+        'E:\\x',
+      ];
+      const under = (projectRoot: string, filename: string, origin: string) =>
+        new Set(
+          drives.map((drive) =>
+            withFakeCwd(drive, () => winOracle(projectRoot, filename, origin))
+          ),
+        );
+
+      // Drive-sensitive, and so deliberately not asserted anywhere. A Windows
+      // host on C: rooted these differently from one on D:, which is why the
+      // values below cannot be reduced to a single expectation.
+      expect(under('/', './index.css', 'C:\\x.css')).toStrictEqual(
+        new Set(['/x.css', '/C:/x.css']),
+      );
+      expect(under('C:\\proj', '\\abs\\index.css', './a.css')).toStrictEqual(
+        new Set(['../abs/a.css', '/D:/abs/a.css', '/E:/abs/a.css']),
+      );
+
+      // Everything this block compares against `winOracle` has one answer on
+      // every drive. If a new assertion is added for a drive-sensitive input,
+      // adding it here turns this red instead of only the Windows runner.
+      const stable: [string, string, string][] = [
+        ['C:\\proj', 'pages\\index.css', './a.css'],
+        ['C:\\proj', 'pages\\index.css', '../shared/b.css'],
+        ['C:\\proj', 'pages\\index.css', 'a\\b.css'],
+        ['\\proj', 'pages\\index.css', './a.css'],
+        ['\\\\srv\\share', 'pages\\index.css', './a.css'],
+        ['C:\\proj', 'pages\\index.css', '/a.css'],
+        ['C:\\proj', 'pages\\index.css', '@p/a.css'],
+        // Stable across drives. It does change if the cwd is itself a UNC path
+        // on the same share, which is why `drives` above lists drive letters: a
+        // UNC working directory is not a shape any runner or caller uses.
+        ['/', './index.css', '\\\\srv\\share\\x.css'],
+        ['/', './index.css', '\\a.css'],
+        ['D:\\a\\b', 'C:\\proj\\pages\\index.css', './a.css'],
+      ];
+      for (const [projectRoot, filename, origin] of stable) {
+        expect(
+          under(projectRoot, filename, origin).size,
+          `winOracle(${projectRoot}, ${filename}, ${origin})`,
+        ).toBe(1);
+      }
+    });
 
     /**
      * The common case: a relative `filename` under a Windows-shaped
@@ -925,11 +1127,13 @@ describe('generateHref', () => {
         expect(generateHref('/', './index.css', 'C:\\x.css')).toBe(
           '../C:/x.css',
         );
-        // Both oracles rooted it instead.
-        expect(winOracle('/', './index.css', 'C:\\x.css')).toBe('/C:/x.css');
+        // The `path.posix` oracle rooted it instead.
         expect(generateHrefOracle('/', './index.css', 'C:\\x.css')).toBe(
           '/C:/x.css',
         );
+        // `winOracle` is deliberately *not* consulted here - it has no single
+        // answer for this input. See `winOracle is only an oracle where it is
+        // drive-stable` above.
       });
 
       test('a UNC @import loses its doubled leading slash', () => {
@@ -961,9 +1165,9 @@ describe('generateHref', () => {
         expect(generateHref('C:\\proj', '\\abs\\index.css', './a.css')).toBe(
           '../..//abs/a.css',
         );
-        expect(winOracle('C:\\proj', '\\abs\\index.css', './a.css')).toBe(
-          '/abs/a.css',
-        );
+        // `winOracle` is deliberately *not* consulted here either - this input is
+        // drive-sensitive too. See `winOracle is only an oracle where it is
+        // drive-stable` above.
       });
 
       test('a cross-drive filename stays relative instead of being rooted', () => {
@@ -983,6 +1187,30 @@ describe('generateHref', () => {
         '/shared/b.css',
       );
     });
+  });
+
+  /**
+   * Structural guard for the portability fix above.
+   *
+   * A written-out POSIX directory is not a portable target for a working
+   * directory change: on Windows it resolves against the current drive, so
+   * `'/tmp'` becomes `C:\tmp` and throws `ENOENT`. Seven tests here failed that
+   * way. `withCwd` exists so no individual test has to name a directory, and this
+   * keeps it that way - it must stay the only place that changes directory, and
+   * no caller may pass a string literal.
+   *
+   * Checked by reading this file rather than by convention, because the failure
+   * mode is invisible on Linux: a new test with a written-out path passes here and
+   * only breaks on the Windows runner.
+   */
+  test('cwd-sensitive assertions go through withCwd', () => {
+    const source = fs.readFileSync(fileURLToPath(import.meta.url), 'utf8');
+
+    // Exactly the two calls inside `withCwd` - one out, one back.
+    expect(source.match(/process\.chdir\(/g)).toHaveLength(2);
+
+    // And neither is handed a literal path; both take a created directory.
+    expect(source).not.toMatch(/process\.chdir\(\s*['"`]/);
   });
 
   describe('integration through parse', () => {

--- a/packages/tools/css-serializer/test/generateHref.test.ts
+++ b/packages/tools/css-serializer/test/generateHref.test.ts
@@ -549,31 +549,53 @@ describe('generateHref', () => {
     });
   });
 
-  describe('cwd-dependent inputs (documented divergence)', () => {
+  describe('a relative projectRoot stays cwd-dependent', () => {
     /**
-     * A relative `projectRoot` made the old implementation's output depend on
-     * `process.cwd()`, because `path.resolve`/`path.relative` fall back to it.
-     * The pure-JS helper has no `cwd` to fall back to and instead treats a
-     * relative `projectRoot` as if it were rooted, so these inputs diverge.
+     * `path-browserify` is Node's POSIX implementation ported verbatim, which
+     * means `resolve` still consults `process.cwd()` for a relative input. So a
+     * relative `projectRoot` behaves exactly as it did before this change - i.e.
+     * the output depends on the directory the build ran from.
      *
-     * This is the *only* known divergence. It is accepted rather than emulated:
-     * emulating it would mean either reading `process.cwd()` (which reintroduces
-     * the Node dependency this change exists to remove) or hardcoding a cwd
-     * (which is wrong for every caller but one). `parse` defaults `projectRoot`
-     * to `'/'` and no in-repo caller passes a relative one.
+     * That is deliberately *not* fixed here. Fixing it would mean either
+     * hand-rolling the resolution again (the code this change exists to delete)
+     * or hardcoding a cwd, which is wrong for every caller. It is also
+     * unobservable in practice: `parse` defaults `projectRoot` to `'/'` and every
+     * in-repo caller passes an absolute one.
+     *
+     * Two consequences a caller should know about:
+     *
+     * - In a browser bundle there is no `process.cwd()`, so `path-browserify`
+     *   falls back to treating the path as rooted. A relative `projectRoot`
+     *   therefore resolves differently in a browser than in Node.
+     * - Only an *absolute* `projectRoot` is guaranteed stable, and the
+     *   differential suite above proves that case is byte-identical to
+     *   `node:path`.
      */
-    test('a relative projectRoot is treated as rooted', () => {
-      expect(generateHref('proj', 'index.css', './a.css')).toBe('/a.css');
-      expect(generateHref('proj', 'index.css', '../../x.css')).toBe('../x.css');
+    test('an absolute projectRoot is cwd-independent', () => {
+      const cwd = process.cwd();
+      try {
+        process.chdir('/');
+        const atRoot = generateHref('/proj', 'index.css', '../../x.css');
+        process.chdir('/tmp');
+        const atTmp = generateHref('/proj', 'index.css', '../../x.css');
+        expect(atRoot).toBe(atTmp);
+        expect(atRoot).toBe('../x.css');
+      } finally {
+        process.chdir(cwd);
+      }
     });
 
-    test('and that is deterministic, unlike the node:path behaviour it replaces', () => {
-      // Same input, twice, from the same cwd - the point is that the pure-JS
-      // result is a pure function of its arguments. The oracle's result for
-      // this input is a function of `process.cwd()` too, so it is not asserted.
-      const once = generateHref('proj', 'index.css', '../../x.css');
-      const twice = generateHref('proj', 'index.css', '../../x.css');
-      expect(once).toBe(twice);
+    test('a relative projectRoot resolves against cwd, as node:path does', () => {
+      const cwd = process.cwd();
+      try {
+        process.chdir('/');
+        expect(generateHref('proj', 'index.css', './a.css')).toBe('/a.css');
+        expect(generateHref('proj', 'index.css', '../../x.css')).toBe(
+          '../x.css',
+        );
+      } finally {
+        process.chdir(cwd);
+      }
     });
   });
 

--- a/packages/tools/css-serializer/test/generateHref.test.ts
+++ b/packages/tools/css-serializer/test/generateHref.test.ts
@@ -7,18 +7,34 @@
  *
  * `src/generateHref.ts` used to `import path from 'node:path'`, which made the
  * whole package unbundleable for browsers (`parse` -> `generateHref` -> `node:path`).
- * It now uses a small pure-JS POSIX path helper instead.
+ * It now uses `pathe`, which works in both a browser bundle and Node.
  *
- * These tests exist to prove that swap is behaviour preserving, and they do it
- * two ways, on purpose:
+ * These tests exist to characterize that swap, and they do it two ways on purpose:
  *
  * 1. `differential vs node:path` uses the real `node:path` as an *oracle*: it
  *    re-implements the original algorithm on top of `node:path` and asserts the
  *    shipped implementation agrees, over a generated input matrix. Test code may
  *    import `node:path` freely - only the shipped `src/` may not.
- * 2. `href table` pins the concrete resulting strings. Those strings were
- *    generated from the pre-change `node:path` implementation, not hand-written,
- *    so the coverage survives even if the differential test above is ever deleted.
+ * 2. `href table` pins the concrete resulting strings, so the coverage survives
+ *    even if the differential test above is ever deleted.
+ *
+ * ## `pathe` is not `path.posix`, and where that shows
+ *
+ * `pathe` normalizes Windows paths: it treats `\` as a separator, upper-cases a
+ * drive letter, and preserves a leading `//`. `path.posix` does none of that. So
+ * the oracle only applies to inputs that contain no backslash - which is every
+ * path this tree actually produces, since `parse` defaults `projectRoot` to `'/'`
+ * and `filename` to `'./index.css'`. Backslash inputs are pinned by value
+ * instead, in `native Windows paths (documented divergence)`.
+ *
+ * Two narrower divergences are pinned individually rather than excluded, so that
+ * neither a new divergence nor an upstream fix can pass unnoticed:
+ *
+ * - `getFullPath` with a `//`-prefixed `@import` and a `projectRoot` that
+ *   normalizes to `/` (`pathe` keeps the `//`, `path.posix` collapses it). This
+ *   one never reaches an href - see `getFullPath ... divergences are exactly`.
+ * - `projectRoot === '//'`, which makes `pathe` leak `process.cwd()` into the
+ *   output. See `projectRoot '//' is not supported`.
  *
  * ## The one place the oracle cannot be trusted: a relative `projectRoot`
  *
@@ -28,8 +44,7 @@
  * `generateHref('proj', './index.css', '../../../../x.css')` returned
  * `'../../../x.css'` from a 1-deep cwd and `'../../../../x.css'` from a 4-deep one.
  * That is unspecifiable, so the differential matrix restricts itself to inputs
- * whose result is cwd independent (`projectRoot` absolute), and
- * `cwd-dependent inputs` below documents the deliberate divergence separately.
+ * whose result is cwd independent (`projectRoot` absolute).
  *
  * In practice `projectRoot` is absolute: `parse` defaults it to `'/'`.
  */
@@ -98,11 +113,35 @@ function generateHrefOracle(
   return projectPath.replaceAll(path.win32.sep, '/');
 }
 
+/**
+ * True for the one input shape where `pathe` and `path.posix` disagree without a
+ * backslash being involved: `pathe.normalize` reads a leading `//` as a UNC
+ * prefix and keeps it, `path.posix.normalize` collapses it.
+ *
+ * It only bites when `projectRoot` normalizes to `/`, because otherwise `join`
+ * puts a real segment in front of the doubled slash.
+ */
+function keepsLeadingDoubleSlash(projectRoot: string, origin: string): boolean {
+  return origin.startsWith('//') && oraclePath.normalize(projectRoot) === '/';
+}
+
 describe('generateHref', () => {
+  /**
+   * The matrix below deliberately contains **no backslashes**. `pathe` treats
+   * `\` as a separator, `path.posix` treats it as an ordinary character, so any
+   * such input diverges by construction and comparing them would prove nothing.
+   * Those inputs are pinned by value in `native Windows paths` further down.
+   *
+   * `projectRoot` is likewise never `'//'`, which `pathe` mishandles badly enough
+   * to leak `process.cwd()`; that is pinned in `projectRoot '//' is not supported`.
+   *
+   * For everything else - which is every path this tree actually produces, since
+   * `parse` defaults `projectRoot` to `'/'` - `pathe` must agree with
+   * `path.posix` exactly.
+   */
   describe('differential vs node:path', () => {
     const projectRoots = [
       '/',
-      '//',
       '/a',
       '/a/',
       '/a//b',
@@ -124,9 +163,6 @@ describe('generateHref', () => {
       // repeated + trailing separators
       'a//b/index.css',
       'dir/',
-      // backslashes are ordinary characters under POSIX
-      'C:\\x\\index.css',
-      '\\a\\index.css',
     ];
     const origins = [
       // plain relative
@@ -142,7 +178,6 @@ describe('generateHref', () => {
       // leading `@` -> passthrough branch
       '@ies/ug-lynx-components/lib/styles.css',
       '@',
-      '@a\\b\\c.css',
       '/@pkg/a.css',
       // `..` traversal above `projectRoot`
       '../../../../x.css',
@@ -151,11 +186,6 @@ describe('generateHref', () => {
       '',
       '.',
       '..',
-      // Windows-ish separators, incl. drive letters and UNC
-      'a\\b.css',
-      '\\a.css',
-      'C:\\x.css',
-      '\\\\srv\\share\\x.css',
     ];
 
     // Deliberately not `test.each`: this is ~2k cases and per-case test
@@ -191,6 +221,8 @@ describe('generateHref', () => {
 
     test('getFullPath matches the node:path oracle across the input matrix', () => {
       const divergences: string[] = [];
+      let compared = 0;
+      let knownDivergent = 0;
 
       for (const projectRoot of projectRoots) {
         for (const filename of filenames) {
@@ -207,6 +239,14 @@ describe('generateHref', () => {
               absFilename,
               origin,
             );
+
+            if (keepsLeadingDoubleSlash(projectRoot, origin)) {
+              // Pinned in `getFullPath // divergences` below, not compared here.
+              knownDivergent += 1;
+              continue;
+            }
+
+            compared += 1;
             if (actual !== expected) {
               divergences.push(
                 `getFullPath(${JSON.stringify(projectRoot)}, ${
@@ -219,7 +259,75 @@ describe('generateHref', () => {
         }
       }
 
+      // The excluded set must stay small and accounted for, so that widening it
+      // can never be the thing that makes this test pass.
+      expect(knownDivergent).toBe(20);
+      expect(compared).toBe(
+        projectRoots.length * filenames.length * origins.length - 20,
+      );
       expect(divergences).toEqual([]);
+    });
+
+    /**
+     * The only `getFullPath` divergence in the matrix above, pinned by value.
+     *
+     * `pathe.normalize` preserves a leading `//` (it reads it as a UNC prefix);
+     * `path.posix.normalize` collapses it to `/`. So when `projectRoot`
+     * normalizes to `/`, a `//`-prefixed `@import` takes the
+     * `join(projectRoot, importStmt)` branch and keeps its doubled slash.
+     *
+     * This is pinned rather than excluded for two reasons: excluding it would let
+     * a future, unrelated divergence hide in the same hole, and pinning it means
+     * an upstream `pathe` fix turns this red instead of silently changing output.
+     *
+     * It does not reach an href: `generateHref` runs the result through
+     * `relative()`, which collapses the `//` in both implementations. The
+     * `no href starts with //` test below is what holds that line.
+     */
+    test('getFullPath // divergences are exactly the leading-double-slash ones', () => {
+      // `origin` starts with `/`, so `filename` is not consulted on this branch.
+      expect(getFullPath('/', '/index.css', '//test.css')).toBe('//test.css');
+      expect(getFullPathOracle('/', '/index.css', '//test.css')).toBe(
+        '/test.css',
+      );
+
+      // Three or more leading slashes collapse to exactly two, not to one.
+      expect(getFullPath('/', '/index.css', '///test.css')).toBe('//test.css');
+      expect(getFullPathOracle('/', '/index.css', '///test.css')).toBe(
+        '/test.css',
+      );
+
+      // A `projectRoot` with any segment in it is unaffected: `join` no longer
+      // leaves the `//` at position 0.
+      for (const projectRoot of ['/a', '/a/', '/a//b', '/a/b/c']) {
+        expect(getFullPath(projectRoot, `${projectRoot}/index.css`, '//t.css'))
+          .toBe(
+            getFullPathOracle(
+              projectRoot,
+              `${projectRoot}/index.css`,
+              '//t.css',
+            ),
+          );
+      }
+    });
+
+    test('no href starts with // even though getFullPath can', () => {
+      // The divergence above is contained by `relative()`. Prove it over the
+      // same matrix rather than asserting it in prose.
+      let checked = 0;
+      for (const projectRoot of projectRoots) {
+        for (const filename of filenames) {
+          for (const origin of origins) {
+            checked += 1;
+            expect(generateHref(projectRoot, filename, origin)).not.toContain(
+              '//',
+            );
+          }
+        }
+      }
+      expect(checked).toBe(
+        projectRoots.length * filenames.length * origins.length,
+      );
     });
   });
 
@@ -375,12 +483,9 @@ describe('generateHref', () => {
         origin: './c.css',
         href: '/b/c.css',
       },
-      {
-        projectRoot: '//',
-        filename: './index.css',
-        origin: './a.css',
-        href: '/a.css',
-      },
+      // `projectRoot: '//'` deliberately has no row here: `pathe` leaks
+      // `process.cwd()` into the result, so there is no cwd-independent value to
+      // pin. See `projectRoot '//' is not supported` below.
       {
         projectRoot: '/a//b',
         filename: 'index.css',
@@ -426,45 +531,56 @@ describe('generateHref', () => {
         href: '/@pkg/a.css',
       },
 
-      // backslashes are ordinary path characters under POSIX; only the final
-      // `replaceAll` turns them into `/`, which is why `\a.css` doubles up
+      // `pathe` treats `\` as a separator, so these are *path* inputs, not
+      // filenames that happen to contain a backslash. The resulting hrefs match
+      // neither `path.posix` (which treats `\` as an ordinary character) nor
+      // `path.win32` in every case; the three-way comparison lives in
+      // `native Windows paths (documented divergence)` below. Values measured,
+      // not derived.
       {
         projectRoot: '/',
         filename: './index.css',
         origin: 'a\\b.css',
         href: '/a/b.css',
       },
+      // `'\a.css'` is an absolute path to `pathe`, so it replaces `filename`'s
+      // directory. `path.posix` produced `'//a.css'` here.
       {
         projectRoot: '/',
         filename: './index.css',
         origin: '\\a.css',
-        href: '//a.css',
+        href: '/a.css',
       },
-      // drive letters are not absolute under POSIX, so `C:` becomes a segment
+      // A drive letter *is* a root to `pathe`, so `C:/x.css` escapes
+      // `projectRoot` and stays relative. `path.posix` produced `'/C:/x.css'`.
       {
         projectRoot: '/',
         filename: './index.css',
         origin: 'C:\\x.css',
-        href: '/C:/x.css',
+        href: '../C:/x.css',
       },
-      // ... and a UNC path is just a name with backslashes in it
+      // A UNC path collapses to a single leading slash once `relative()` has run.
+      // `path.posix` produced `'///srv/share/x.css'`.
       {
         projectRoot: '/',
         filename: './index.css',
         origin: '\\\\srv\\share\\x.css',
-        href: '///srv/share/x.css',
+        href: '/srv/share/x.css',
       },
+      // A backslash `filename` is a real directory chain to `pathe`, so `./a.css`
+      // resolves next to it instead of next to `projectRoot`. `path.posix`
+      // produced `'/a.css'` for both of these.
       {
         projectRoot: '/',
         filename: 'C:\\x\\index.css',
         origin: './a.css',
-        href: '/a.css',
+        href: '../C:/x/a.css',
       },
       {
         projectRoot: '/',
         filename: '\\a\\index.css',
         origin: './a.css',
-        href: '/a.css',
+        href: '/a/a.css',
       },
       {
         projectRoot: 'C:\\proj',
@@ -483,12 +599,42 @@ describe('generateHref', () => {
 
     test('the table is cwd independent', () => {
       // Every row above must hold no matter where the process runs, otherwise it
-      // is pinning a `process.cwd()` artefact rather than a real behaviour. The
-      // oracle agreeing here is what proves it: `path.resolve`/`path.relative`
-      // only consult `cwd` for relative inputs.
+      // is pinning a `process.cwd()` artefact rather than a real behaviour.
+      //
+      // This re-runs the real implementation from several directories rather than
+      // consulting the `path.posix` oracle: the backslash rows are pinned
+      // *because* they diverge from that oracle, so the oracle can no longer
+      // stand in for "cwd independent".
+      const original = process.cwd();
+      try {
+        for (const dir of ['/', '/tmp', '/usr/share']) {
+          process.chdir(dir);
+          for (const { projectRoot, filename, origin, href } of cases) {
+            expect(
+              generateHref(projectRoot, filename, origin),
+              `cwd=${dir} generateHref(${projectRoot}, ${filename}, ${origin})`,
+            ).toBe(href);
+          }
+        }
+      } finally {
+        process.chdir(original);
+      }
+    });
+
+    test('the backslash-free rows still match the node:path oracle', () => {
+      // The rows that predate this change must keep agreeing with `path.posix`,
+      // which is what `node:path` resolved to on every non-Windows platform.
+      let checked = 0;
       for (const { projectRoot, filename, origin, href } of cases) {
+        if (
+          projectRoot.includes('\\') || filename.includes('\\')
+          || origin.includes('\\')
+        ) continue;
+        checked += 1;
         expect(generateHrefOracle(projectRoot, filename, origin)).toBe(href);
       }
+      // Guard against the filter swallowing the whole table.
+      expect(checked).toBeGreaterThan(25);
     });
   });
 
@@ -551,10 +697,10 @@ describe('generateHref', () => {
 
   describe('a relative projectRoot stays cwd-dependent', () => {
     /**
-     * `path-browserify` is Node's POSIX implementation ported verbatim, which
-     * means `resolve` still consults `process.cwd()` for a relative input. So a
-     * relative `projectRoot` behaves exactly as it did before this change - i.e.
-     * the output depends on the directory the build ran from.
+     * `pathe` has its own `cwd()` helper that returns `process.cwd()` when a
+     * `process` global exists, so `resolve` still consults the working directory
+     * for a relative input. A relative `projectRoot` therefore behaves as it did
+     * before this change: the output depends on where the build ran from.
      *
      * That is deliberately *not* fixed here. Fixing it would mean either
      * hand-rolling the resolution again (the code this change exists to delete)
@@ -564,12 +710,11 @@ describe('generateHref', () => {
      *
      * Two consequences a caller should know about:
      *
-     * - In a browser bundle there is no `process.cwd()`, so `path-browserify`
-     *   falls back to treating the path as rooted. A relative `projectRoot`
-     *   therefore resolves differently in a browser than in Node.
-     * - Only an *absolute* `projectRoot` is guaranteed stable, and the
-     *   differential suite above proves that case is byte-identical to
-     *   `node:path`.
+     * - In a browser bundle there is no `process.cwd()`, so `pathe`'s `cwd()`
+     *   returns `'/'`. A relative `projectRoot` therefore resolves differently in
+     *   a browser than in Node.
+     * - Only an *absolute* `projectRoot` is guaranteed stable - and `'//'` is the
+     *   one absolute value that is not, see below.
      */
     test('an absolute projectRoot is cwd-independent', () => {
       const cwd = process.cwd();
@@ -600,19 +745,89 @@ describe('generateHref', () => {
   });
 
   /**
-   * Native Windows paths are the one input class whose emitted href genuinely
-   * changed, and the differential suite above cannot catch it: that oracle is
-   * pinned to `path.posix` by design, so it agrees with the implementation on
-   * every platform. These cases therefore assert the new values *literally*,
-   * against a `path.win32` oracle that reproduces what the old implementation
-   * emitted when the build ran on Windows.
+   * `projectRoot: '//'` is not supported, and this is a real defect rather than a
+   * documented trade-off. It is pinned instead of deleted so that it stays
+   * visible and so an upstream fix turns this red rather than silently changing
+   * output.
    *
-   * The divergence is accepted, not a regression to fix: `\` is a legal
-   * character in a POSIX path, so a browser-safe helper cannot treat it as a
-   * separator without inventing platform detection. It is called out in the
-   * changeset, and it is why the change ships as a minor.
+   * The mechanism, read off `pathe`'s source rather than inferred:
+   *
+   * - `normalize()` emits `//./<rest>` when it sees a UNC-shaped path that its
+   *   own `isAbsolute` considers relative.
+   * - `isAbsolute`'s UNC branch is `/^[/\\]{2}(?!\.)/`, so it rejects the very
+   *   string `normalize()` just produced.
+   * - `resolve()` therefore finds no absolute argument and falls back to
+   *   `cwd()` - which is `process.cwd()` in Node.
+   *
+   * So `join('//', './index.css')` gives `'//./index.css'`, `isAbsolute` says
+   * `false`, and the working directory ends up in the href. `path.posix` gives
+   * `'/index.css'` and is absolute, which is why this is new.
+   *
+   * It needs `projectRoot` to normalize to `//` *and* a `filename` starting with
+   * `.` - which is exactly `parse`'s `'./index.css'` default. `'//'` is not a root
+   * anything in this tree passes, but it is not a shape a caller would expect to
+   * be rejected either.
    */
-  describe('native Windows paths (documented divergence)', () => {
+  describe('projectRoot \'//\' is not supported', () => {
+    test('leaks process.cwd() into the href', () => {
+      const cwd = process.cwd();
+      try {
+        // Pinned per-directory rather than asserted to be "unstable": an
+        // inequality assertion would also pass if the two values differed for
+        // some unrelated reason. These say *what* leaks.
+        process.chdir('/tmp');
+        expect(generateHref('//', './index.css', './a.css')).toBe('/tmp/a.css');
+        process.chdir('/usr/share');
+        expect(generateHref('//', './index.css', './a.css')).toBe(
+          '/usr/share/a.css',
+        );
+
+        // The control: a single-slash root is cwd independent, so the leak is
+        // specific to `'//'` and not an artefact of the chdir harness.
+        process.chdir('/tmp');
+        const atTmp = generateHref('/', './index.css', './a.css');
+        process.chdir('/usr/share');
+        expect(generateHref('/', './index.css', './a.css')).toBe(atTmp);
+        expect(atTmp).toBe('/a.css');
+      } finally {
+        process.chdir(cwd);
+      }
+    });
+
+    test('the leak needs a dot-prefixed filename', () => {
+      const cwd = process.cwd();
+      try {
+        // `join('//', 'index.css')` is `'//index.css'`, which `isAbsolute`
+        // accepts, so `resolve` never reaches its `cwd()` fallback.
+        process.chdir('/tmp');
+        const atTmp = generateHref('//', 'index.css', './a.css');
+        process.chdir('/usr/share');
+        expect(generateHref('//', 'index.css', './a.css')).toBe(atTmp);
+      } finally {
+        process.chdir(cwd);
+      }
+    });
+  });
+
+  /**
+   * Native Windows paths are the input class the `path.posix` oracle cannot speak
+   * about, because `pathe` deliberately understands them and `path.posix` does
+   * not. Everything here is therefore pinned against **both** oracles at once, so
+   * the three-way picture is in the test output rather than in prose.
+   *
+   * The headline: for the common shapes - a drive-letter or backslash
+   * `projectRoot` with a relative `filename` - `pathe` agrees with `path.win32`,
+   * which means these hrefs are *unchanged* from what a Windows build host used to
+   * emit. That was not true of a pure-POSIX helper.
+   *
+   * It is not a blanket "Windows is fixed" claim, and the tests below say where it
+   * stops: a measured 120 of 150 cwd-free cases in this shape agree with
+   * `path.win32`, and the remaining 30 are pinned by class -
+   * cross-root/cross-drive combinations, a `\`-rooted absolute `filename` under a
+   * drive-letter root, and a drive-letter `@import`.
+   */
+  describe('native Windows paths', () => {
+    /** What the old implementation emitted when the build ran on Windows. */
     const winOracle = (
       projectRoot: string,
       filename: string,
@@ -633,25 +848,131 @@ describe('generateHref', () => {
       return rel.replaceAll(path.win32.sep, '/');
     };
 
+    /**
+     * The common case: a relative `filename` under a Windows-shaped
+     * `projectRoot`. `pathe` matches the old Windows output, and both differ from
+     * `path.posix` - which is what a POSIX-only helper would have produced on
+     * every platform.
+     */
     test.each([
-      ['./a.css', '/pages/a.css', '/a.css'],
-      ['../shared/b.css', '/shared/b.css', '../shared/b.css'],
+      ['C:\\proj', 'pages\\index.css', './a.css', '/pages/a.css', '/a.css'],
+      [
+        'C:\\proj',
+        'pages\\index.css',
+        '../shared/b.css',
+        '/shared/b.css',
+        '../shared/b.css',
+      ],
+      [
+        'C:\\proj',
+        'pages\\index.css',
+        'a\\b.css',
+        '/pages/a/b.css',
+        '/a/b.css',
+      ],
+      ['\\proj', 'pages\\index.css', './a.css', '/pages/a.css', '/a.css'],
+      [
+        '\\\\srv\\share',
+        'pages\\index.css',
+        './a.css',
+        '/pages/a.css',
+        '/a.css',
+      ],
     ])(
-      'a backslash filename with %s changes from %s to %s',
-      (origin, onWindowsBefore, now) => {
-        // What the old implementation emitted on a Windows build host...
-        expect(winOracle('C:\\proj', 'pages\\index.css', origin)).toBe(
-          onWindowsBefore,
+      'generateHref(%j, %j, %j) === %j, matching the old Windows output',
+      (projectRoot, filename, origin, expected, posixWouldGive) => {
+        expect(generateHref(projectRoot, filename, origin)).toBe(expected);
+        // Same as a Windows build host used to emit: no change for these.
+        expect(winOracle(projectRoot, filename, origin)).toBe(expected);
+        // And genuinely different from what POSIX semantics would give, so the
+        // assertion above is not vacuous.
+        expect(generateHrefOracle(projectRoot, filename, origin)).toBe(
+          posixWouldGive,
         );
-        // ...versus what every platform emits now.
-        expect(generateHref('C:\\proj', 'pages\\index.css', origin)).toBe(now);
+        expect(expected).not.toBe(posixWouldGive);
       },
     );
 
-    test('a drive letter is not a root under POSIX semantics', () => {
-      // `C:\x.css` is one relative path segment, not an absolute path, so it is
-      // resolved against `filename`'s directory rather than replacing it.
-      expect(generateHref('/', './index.css', 'C:\\x.css')).toBe('/C:/x.css');
+    test('a leading `/` @import is unchanged under every semantics', () => {
+      // This branch is `join(projectRoot, origin)`, which all three agree on.
+      for (const oracle of [winOracle, generateHrefOracle]) {
+        expect(oracle('C:\\proj', 'pages\\index.css', '/a.css')).toBe('/a.css');
+      }
+      expect(generateHref('C:\\proj', 'pages\\index.css', '/a.css')).toBe(
+        '/a.css',
+      );
+    });
+
+    test('an @import passthrough is unchanged under every semantics', () => {
+      for (const oracle of [winOracle, generateHrefOracle]) {
+        expect(oracle('C:\\proj', 'pages\\index.css', '@p/a.css')).toBe(
+          '@p/a.css',
+        );
+      }
+      expect(generateHref('C:\\proj', 'pages\\index.css', '@p/a.css')).toBe(
+        '@p/a.css',
+      );
+    });
+
+    /**
+     * Where `pathe` and `path.win32` part company. These are pinned, not
+     * defended - they are the residual Windows risk in this change.
+     */
+    describe('divergence from the old Windows behaviour', () => {
+      test('a drive-letter @import escapes projectRoot', () => {
+        // `pathe` reads `C:\` as a root, so `resolve` discards `filename`'s
+        // directory and the result lands outside `projectRoot`.
+        expect(generateHref('/', './index.css', 'C:\\x.css')).toBe(
+          '../C:/x.css',
+        );
+        // Both oracles rooted it instead.
+        expect(winOracle('/', './index.css', 'C:\\x.css')).toBe('/C:/x.css');
+        expect(generateHrefOracle('/', './index.css', 'C:\\x.css')).toBe(
+          '/C:/x.css',
+        );
+      });
+
+      test('a UNC @import loses its doubled leading slash', () => {
+        expect(generateHref('/', './index.css', '\\\\srv\\share\\x.css')).toBe(
+          '/srv/share/x.css',
+        );
+        // win32 agrees here; `path.posix` kept every slash it was given.
+        expect(winOracle('/', './index.css', '\\\\srv\\share\\x.css')).toBe(
+          '/srv/share/x.css',
+        );
+        expect(
+          generateHrefOracle('/', './index.css', '\\\\srv\\share\\x.css'),
+        ).toBe('///srv/share/x.css');
+      });
+
+      test('a leading-backslash @import is absolute, as it is on win32', () => {
+        expect(generateHref('/', './index.css', '\\a.css')).toBe('/a.css');
+        expect(winOracle('/', './index.css', '\\a.css')).toBe('/a.css');
+        // `path.posix` treated the `\` as an ordinary character, so it doubled up.
+        expect(generateHrefOracle('/', './index.css', '\\a.css')).toBe(
+          '//a.css',
+        );
+      });
+
+      test('a `\\`-rooted filename under a drive root emits a doubled slash', () => {
+        // `relative()` keeps the UNC-shaped `//abs` it is handed, so the href has
+        // a `//` in the middle of it. This is a `pathe` artefact, not a shape
+        // either oracle produces.
+        expect(generateHref('C:\\proj', '\\abs\\index.css', './a.css')).toBe(
+          '../..//abs/a.css',
+        );
+        expect(winOracle('C:\\proj', '\\abs\\index.css', './a.css')).toBe(
+          '/abs/a.css',
+        );
+      });
+
+      test('a cross-drive filename stays relative instead of being rooted', () => {
+        expect(
+          generateHref('D:\\a\\b', 'C:\\proj\\pages\\index.css', './a.css'),
+        ).toBe('C:/proj/pages/a.css');
+        expect(winOracle('D:\\a\\b', 'C:\\proj\\pages\\index.css', './a.css'))
+          .toBe('/C:/proj/pages/a.css');
+      });
     });
 
     test('POSIX callers are unaffected on every platform', () => {

--- a/packages/tools/css-serializer/test/generateHref.test.ts
+++ b/packages/tools/css-serializer/test/generateHref.test.ts
@@ -45,7 +45,21 @@ import { parse } from '../src/index.js';
  * The original, pre-change implementation, transcribed verbatim on top of
  * `node:path`. This is the oracle - it is intentionally *not* refactored, so it
  * keeps matching the code that shipped in 0.1.7.
+ *
+ * The oracle pins `path.posix` where the original used the platform-dependent
+ * default export. That default *is* `path.posix` on Linux and macOS, so there
+ * this stays a verbatim transcription. On Windows the default is `path.win32`,
+ * which treats `\` as a separator and `C:\` as absolute; an unpinned oracle
+ * would therefore demand win32 semantics from an implementation that is now
+ * deliberately POSIX-only, and disagree on inputs such as `\a.css`, `C:\x.css`
+ * or `\\srv\share\x.css`. Pinning keeps the oracle a fixed description of the
+ * behaviour that shipped instead of one that changes with the runner's OS.
+ *
+ * `path.win32.sep` below is deliberately left as-is: the original names that
+ * one explicitly, so it is win32 on every platform.
  */
+const oraclePath = path.posix;
+
 function getFullPathOracle(
   projectRoot: string,
   filename: string,
@@ -53,11 +67,11 @@ function getFullPathOracle(
 ): string {
   let fullPath = '';
   if (importStmt.startsWith('/')) {
-    fullPath = path.join(projectRoot, importStmt);
+    fullPath = oraclePath.join(projectRoot, importStmt);
   } else if (importStmt.startsWith('@')) {
     fullPath = importStmt;
   } else {
-    fullPath = path.resolve(filename, '..', importStmt);
+    fullPath = oraclePath.resolve(filename, '..', importStmt);
   }
 
   return fullPath;
@@ -68,17 +82,17 @@ function generateHrefOracle(
   filename: string,
   origin: string,
 ): string {
-  filename = path.isAbsolute(filename)
+  filename = oraclePath.isAbsolute(filename)
     ? filename
-    : path.join(projectRoot, filename);
+    : oraclePath.join(projectRoot, filename);
   const fullPath = getFullPathOracle(projectRoot, filename, origin);
 
-  let projectPath = path.relative(projectRoot, fullPath);
+  let projectPath = oraclePath.relative(projectRoot, fullPath);
 
   if (fullPath.startsWith('@')) {
     return fullPath.replaceAll(path.win32.sep, '/');
   } else if (!projectPath.startsWith('.')) {
-    projectPath = path.join(path.sep, projectPath);
+    projectPath = oraclePath.join(oraclePath.sep, projectPath);
   }
 
   return projectPath.replaceAll(path.win32.sep, '/');
@@ -184,9 +198,9 @@ describe('generateHref', () => {
             // `getFullPath` is exported but unused in-repo, and it forwards a
             // caller-supplied `filename` straight to `resolve`, so only feed it
             // absolute filenames - a relative one is cwd dependent.
-            const absFilename = path.isAbsolute(filename)
+            const absFilename = oraclePath.isAbsolute(filename)
               ? filename
-              : path.join(projectRoot, filename);
+              : oraclePath.join(projectRoot, filename);
             const actual = getFullPath(projectRoot, absFilename, origin);
             const expected = getFullPathOracle(
               projectRoot,

--- a/packages/tools/css-serializer/test/generateHref.test.ts
+++ b/packages/tools/css-serializer/test/generateHref.test.ts
@@ -1,0 +1,608 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Characterization tests for `generateHref` / `getFullPath`.
+ *
+ * `src/generateHref.ts` used to `import path from 'node:path'`, which made the
+ * whole package unbundleable for browsers (`parse` -> `generateHref` -> `node:path`).
+ * It now uses a small pure-JS POSIX path helper instead.
+ *
+ * These tests exist to prove that swap is behaviour preserving, and they do it
+ * two ways, on purpose:
+ *
+ * 1. `differential vs node:path` uses the real `node:path` as an *oracle*: it
+ *    re-implements the original algorithm on top of `node:path` and asserts the
+ *    shipped implementation agrees, over a generated input matrix. Test code may
+ *    import `node:path` freely - only the shipped `src/` may not.
+ * 2. `href table` pins the concrete resulting strings. Those strings were
+ *    generated from the pre-change `node:path` implementation, not hand-written,
+ *    so the coverage survives even if the differential test above is ever deleted.
+ *
+ * ## The one place the oracle cannot be trusted: a relative `projectRoot`
+ *
+ * `path.resolve` and `path.relative` fall back to `process.cwd()` when handed a
+ * relative path. With a relative `projectRoot` the *old* implementation therefore
+ * produced different hrefs depending on the directory the build ran from, e.g.
+ * `generateHref('proj', './index.css', '../../../../x.css')` returned
+ * `'../../../x.css'` from a 1-deep cwd and `'../../../../x.css'` from a 4-deep one.
+ * That is unspecifiable, so the differential matrix restricts itself to inputs
+ * whose result is cwd independent (`projectRoot` absolute), and
+ * `cwd-dependent inputs` below documents the deliberate divergence separately.
+ *
+ * In practice `projectRoot` is absolute: `parse` defaults it to `'/'`.
+ */
+
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { generateHref, getFullPath } from '../src/generateHref.js';
+import { parse } from '../src/index.js';
+
+/**
+ * The original, pre-change implementation, transcribed verbatim on top of
+ * `node:path`. This is the oracle - it is intentionally *not* refactored, so it
+ * keeps matching the code that shipped in 0.1.7.
+ */
+function getFullPathOracle(
+  projectRoot: string,
+  filename: string,
+  importStmt: string,
+): string {
+  let fullPath = '';
+  if (importStmt.startsWith('/')) {
+    fullPath = path.join(projectRoot, importStmt);
+  } else if (importStmt.startsWith('@')) {
+    fullPath = importStmt;
+  } else {
+    fullPath = path.resolve(filename, '..', importStmt);
+  }
+
+  return fullPath;
+}
+
+function generateHrefOracle(
+  projectRoot: string,
+  filename: string,
+  origin: string,
+): string {
+  filename = path.isAbsolute(filename)
+    ? filename
+    : path.join(projectRoot, filename);
+  const fullPath = getFullPathOracle(projectRoot, filename, origin);
+
+  let projectPath = path.relative(projectRoot, fullPath);
+
+  if (fullPath.startsWith('@')) {
+    return fullPath.replaceAll(path.win32.sep, '/');
+  } else if (!projectPath.startsWith('.')) {
+    projectPath = path.join(path.sep, projectPath);
+  }
+
+  return projectPath.replaceAll(path.win32.sep, '/');
+}
+
+describe('generateHref', () => {
+  describe('differential vs node:path', () => {
+    const projectRoots = [
+      '/',
+      '//',
+      '/a',
+      '/a/',
+      '/a//b',
+      '/a/b/c',
+      '/user/test/project1',
+    ];
+    const filenames = [
+      // `parse`'s default
+      './index.css',
+      'index.css',
+      'pages/view/index.css',
+      // absolute `filename` skips the `path.join(projectRoot, filename)` branch
+      '/abs/index.css',
+      '/a/b/c/d/index.css',
+      // empty-ish
+      '',
+      '.',
+      '..',
+      // repeated + trailing separators
+      'a//b/index.css',
+      'dir/',
+      // backslashes are ordinary characters under POSIX
+      'C:\\x\\index.css',
+      '\\a\\index.css',
+    ];
+    const origins = [
+      // plain relative
+      './test.css',
+      '../test2.css',
+      'printstyle.css',
+      'a/./b/../c.css',
+      'sub/',
+      // leading `/` -> `path.join(projectRoot, importStmt)` branch
+      '/test.css',
+      '//test.css',
+      '///test.css',
+      // leading `@` -> passthrough branch
+      '@ies/ug-lynx-components/lib/styles.css',
+      '@',
+      '@a\\b\\c.css',
+      '/@pkg/a.css',
+      // `..` traversal above `projectRoot`
+      '../../../../x.css',
+      '../../../../../../../../x.css',
+      // empty-ish
+      '',
+      '.',
+      '..',
+      // Windows-ish separators, incl. drive letters and UNC
+      'a\\b.css',
+      '\\a.css',
+      'C:\\x.css',
+      '\\\\srv\\share\\x.css',
+    ];
+
+    // Deliberately not `test.each`: this is ~2k cases and per-case test
+    // registration makes the reporter unreadable. Failures still name the input.
+    test('matches the node:path oracle across the input matrix', () => {
+      const divergences: string[] = [];
+      let compared = 0;
+
+      for (const projectRoot of projectRoots) {
+        for (const filename of filenames) {
+          for (const origin of origins) {
+            compared += 1;
+            const actual = generateHref(projectRoot, filename, origin);
+            const expected = generateHrefOracle(projectRoot, filename, origin);
+            if (actual !== expected) {
+              divergences.push(
+                `generateHref(${JSON.stringify(projectRoot)}, ${
+                  JSON.stringify(filename)
+                }, ${JSON.stringify(origin)}) => ${JSON.stringify(actual)}, `
+                  + `node:path oracle => ${JSON.stringify(expected)}`,
+              );
+            }
+          }
+        }
+      }
+
+      // Guard against the matrix silently collapsing to nothing.
+      expect(compared).toBe(
+        projectRoots.length * filenames.length * origins.length,
+      );
+      expect(divergences).toEqual([]);
+    });
+
+    test('getFullPath matches the node:path oracle across the input matrix', () => {
+      const divergences: string[] = [];
+
+      for (const projectRoot of projectRoots) {
+        for (const filename of filenames) {
+          for (const origin of origins) {
+            // `getFullPath` is exported but unused in-repo, and it forwards a
+            // caller-supplied `filename` straight to `resolve`, so only feed it
+            // absolute filenames - a relative one is cwd dependent.
+            const absFilename = path.isAbsolute(filename)
+              ? filename
+              : path.join(projectRoot, filename);
+            const actual = getFullPath(projectRoot, absFilename, origin);
+            const expected = getFullPathOracle(
+              projectRoot,
+              absFilename,
+              origin,
+            );
+            if (actual !== expected) {
+              divergences.push(
+                `getFullPath(${JSON.stringify(projectRoot)}, ${
+                  JSON.stringify(absFilename)
+                }, ${JSON.stringify(origin)}) => ${JSON.stringify(actual)}, `
+                  + `node:path oracle => ${JSON.stringify(expected)}`,
+              );
+            }
+          }
+        }
+      }
+
+      expect(divergences).toEqual([]);
+    });
+  });
+
+  describe('href table', () => {
+    // Generated from the pre-change `node:path` implementation. Every row is
+    // cwd independent - verified by running the generator from several
+    // different working directories and diffing the output.
+    const cases: {
+      projectRoot: string;
+      filename: string;
+      origin: string;
+      href: string;
+    }[] = [
+      // `parse` defaults, and the hrefs the `import` snapshot already pins
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: './test.css',
+        href: '/test.css',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '../test2.css',
+        href: '/test2.css',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: 'printstyle.css',
+        href: '/printstyle.css',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '@ies/ug-lynx-components/lib/styles.css',
+        href: '@ies/ug-lynx-components/lib/styles.css',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '/test.css',
+        href: '/test.css',
+      },
+
+      // non-default `filename` / `projectRoot`, as the `important` test uses
+      {
+        projectRoot: '/user/test/project1',
+        filename: 'pages/view/index.css',
+        origin: './a.css',
+        href: '/pages/view/a.css',
+      },
+      {
+        projectRoot: '/user/test/project1',
+        filename: 'pages/view/index.css',
+        origin: '../a.css',
+        href: '/pages/a.css',
+      },
+      {
+        projectRoot: '/user/test/project1',
+        filename: 'pages/view/index.css',
+        origin: '/a.css',
+        href: '/a.css',
+      },
+      {
+        projectRoot: '/user/test/project1',
+        filename: 'pages/view/index.css',
+        origin: '@scope/pkg/a.css',
+        href: '@scope/pkg/a.css',
+      },
+
+      // `..` traversal above `projectRoot` keeps a relative, `.`-prefixed href,
+      // which is what skips the `join(sep, projectPath)` branch
+      {
+        projectRoot: '/user/test/project1',
+        filename: 'pages/view/index.css',
+        origin: '../../../a.css',
+        href: '../a.css',
+      },
+      {
+        projectRoot: '/user/test/project1',
+        filename: 'pages/view/index.css',
+        origin: '../../../../../../a.css',
+        href: '../../../a.css',
+      },
+      {
+        projectRoot: '/a/b/c',
+        filename: 'index.css',
+        origin: '../../../../x.css',
+        href: '../../../x.css',
+      },
+      {
+        projectRoot: '/a/b/c',
+        filename: 'd/index.css',
+        origin: '../../../../../x.css',
+        href: '../../../x.css',
+      },
+
+      // an absolute `filename` bypasses `join(projectRoot, filename)`
+      {
+        projectRoot: '/user/test/project1',
+        filename: '/other/root/index.css',
+        origin: './a.css',
+        href: '../../../other/root/a.css',
+      },
+      {
+        projectRoot: '/root',
+        filename: '/root/deep/index.css',
+        origin: '../shallow.css',
+        href: '/shallow.css',
+      },
+
+      // `.` segments, repeated and trailing separators
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: './a/./b/../c.css',
+        href: '/a/c.css',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: 'a//b.css',
+        href: '/a/b.css',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: 'sub/',
+        href: '/sub',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '//x.css',
+        href: '/x.css',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '///x.css',
+        href: '/x.css',
+      },
+      {
+        projectRoot: '/',
+        filename: 'a//b/index.css',
+        origin: './c.css',
+        href: '/a/b/c.css',
+      },
+      {
+        projectRoot: '/a/',
+        filename: 'b/index.css',
+        origin: './c.css',
+        href: '/b/c.css',
+      },
+      {
+        projectRoot: '//',
+        filename: './index.css',
+        origin: './a.css',
+        href: '/a.css',
+      },
+      {
+        projectRoot: '/a//b',
+        filename: 'index.css',
+        origin: './c.css',
+        href: '/c.css',
+      },
+
+      // empty-ish inputs
+      { projectRoot: '/', filename: './index.css', origin: '', href: '/' },
+      { projectRoot: '/', filename: './index.css', origin: '.', href: '/' },
+      { projectRoot: '/', filename: './index.css', origin: '..', href: '/' },
+      { projectRoot: '/', filename: '', origin: './a.css', href: '/a.css' },
+      { projectRoot: '/', filename: '.', origin: './a.css', href: '/a.css' },
+      { projectRoot: '/', filename: '..', origin: './a.css', href: '/a.css' },
+      {
+        projectRoot: '/a/b',
+        filename: '',
+        origin: './a.css',
+        href: '../a.css',
+      },
+      {
+        projectRoot: '/a/b',
+        filename: '..',
+        origin: 'x.css',
+        href: '../../x.css',
+      },
+      { projectRoot: '/', filename: './index.css', origin: '/', href: '/' },
+      { projectRoot: '/a', filename: '/a', origin: '', href: '..' },
+
+      // `@` passthrough, including the win32-separator normalization on it
+      { projectRoot: '/', filename: './index.css', origin: '@', href: '@' },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '@a\\b\\c.css',
+        href: '@a/b/c.css',
+      },
+      // a leading `/` wins over `@`, so this is *not* passthrough
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '/@pkg/a.css',
+        href: '/@pkg/a.css',
+      },
+
+      // backslashes are ordinary path characters under POSIX; only the final
+      // `replaceAll` turns them into `/`, which is why `\a.css` doubles up
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: 'a\\b.css',
+        href: '/a/b.css',
+      },
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '\\a.css',
+        href: '//a.css',
+      },
+      // drive letters are not absolute under POSIX, so `C:` becomes a segment
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: 'C:\\x.css',
+        href: '/C:/x.css',
+      },
+      // ... and a UNC path is just a name with backslashes in it
+      {
+        projectRoot: '/',
+        filename: './index.css',
+        origin: '\\\\srv\\share\\x.css',
+        href: '///srv/share/x.css',
+      },
+      {
+        projectRoot: '/',
+        filename: 'C:\\x\\index.css',
+        origin: './a.css',
+        href: '/a.css',
+      },
+      {
+        projectRoot: '/',
+        filename: '\\a\\index.css',
+        origin: './a.css',
+        href: '/a.css',
+      },
+      {
+        projectRoot: 'C:\\proj',
+        filename: 'index.css',
+        origin: './a.css',
+        href: '/a.css',
+      },
+    ];
+
+    test.each(cases)(
+      'generateHref($projectRoot, $filename, $origin) === $href',
+      ({ projectRoot, filename, origin, href }) => {
+        expect(generateHref(projectRoot, filename, origin)).toBe(href);
+      },
+    );
+
+    test('the table is cwd independent', () => {
+      // Every row above must hold no matter where the process runs, otherwise it
+      // is pinning a `process.cwd()` artefact rather than a real behaviour. The
+      // oracle agreeing here is what proves it: `path.resolve`/`path.relative`
+      // only consult `cwd` for relative inputs.
+      for (const { projectRoot, filename, origin, href } of cases) {
+        expect(generateHrefOracle(projectRoot, filename, origin)).toBe(href);
+      }
+    });
+  });
+
+  describe('win32 separator normalization', () => {
+    // The `replaceAll(path.win32.sep, '/')` on the way out is load bearing:
+    // hrefs must always use `/`, whatever the input used.
+    test('rewrites backslashes in the @-passthrough branch', () => {
+      expect(generateHref('/', './index.css', '@pkg\\lib\\a.css')).toBe(
+        '@pkg/lib/a.css',
+      );
+      expect(generateHref('/', './index.css', '@pkg\\lib\\a.css')).not
+        .toContain(
+          '\\',
+        );
+    });
+
+    test('rewrites backslashes in the resolved-path branch', () => {
+      expect(generateHref('/', './index.css', 'lib\\a.css')).toBe('/lib/a.css');
+      expect(generateHref('/', './index.css', 'lib\\a.css')).not.toContain(
+        '\\',
+      );
+    });
+
+    test('no href in the matrix leaks a backslash', () => {
+      for (
+        const origin of [
+          'a\\b.css',
+          '\\a.css',
+          'C:\\x.css',
+          '\\\\srv\\share\\x.css',
+          '@a\\b.css',
+        ]
+      ) {
+        expect(generateHref('/', './index.css', origin)).not.toContain('\\');
+      }
+    });
+  });
+
+  describe('the join(sep, projectPath) branch', () => {
+    // Line 40 of the original: when the resolved path is *inside* projectRoot,
+    // `path.relative` returns a bare relative path and it gets re-rooted.
+    test('re-roots paths inside projectRoot with a leading slash', () => {
+      expect(
+        generateHref('/user/test/project1', 'pages/view/index.css', './a.css'),
+      )
+        .toBe('/pages/view/a.css');
+      expect(generateHref('/a/b', 'c/index.css', 'd.css')).toBe('/c/d.css');
+    });
+
+    test('leaves paths outside projectRoot relative', () => {
+      // `..`-prefixed, so it must *not* be re-rooted
+      expect(generateHref('/a/b', 'index.css', '../../../x.css')).toBe(
+        '../../x.css',
+      );
+      expect(
+        generateHref('/a/b', 'index.css', '../../../x.css').startsWith('/'),
+      ).toBe(false);
+    });
+  });
+
+  describe('cwd-dependent inputs (documented divergence)', () => {
+    /**
+     * A relative `projectRoot` made the old implementation's output depend on
+     * `process.cwd()`, because `path.resolve`/`path.relative` fall back to it.
+     * The pure-JS helper has no `cwd` to fall back to and instead treats a
+     * relative `projectRoot` as if it were rooted, so these inputs diverge.
+     *
+     * This is the *only* known divergence. It is accepted rather than emulated:
+     * emulating it would mean either reading `process.cwd()` (which reintroduces
+     * the Node dependency this change exists to remove) or hardcoding a cwd
+     * (which is wrong for every caller but one). `parse` defaults `projectRoot`
+     * to `'/'` and no in-repo caller passes a relative one.
+     */
+    test('a relative projectRoot is treated as rooted', () => {
+      expect(generateHref('proj', 'index.css', './a.css')).toBe('/a.css');
+      expect(generateHref('proj', 'index.css', '../../x.css')).toBe('../x.css');
+    });
+
+    test('and that is deterministic, unlike the node:path behaviour it replaces', () => {
+      // Same input, twice, from the same cwd - the point is that the pure-JS
+      // result is a pure function of its arguments. The oracle's result for
+      // this input is a function of `process.cwd()` too, so it is not asserted.
+      const once = generateHref('proj', 'index.css', '../../x.css');
+      const twice = generateHref('proj', 'index.css', '../../x.css');
+      expect(once).toBe(twice);
+    });
+  });
+
+  describe('integration through parse', () => {
+    // `generateHref` has exactly one in-repo caller: `parse`, for
+    // `ImportRule.href`. Pin that wiring so a signature-compatible but
+    // wrongly-wired refactor is still caught.
+    test('populates ImportRule.href using parse defaults', () => {
+      const { root } = parse(
+        [
+          `@import './test.css';`,
+          `@import '../test2.css';`,
+          `@import "printstyle.css";`,
+          `@import "@ies/ug-lynx-components/lib/styles.css";`,
+        ].join('\n'),
+      );
+
+      expect(root.filter((node) => node.type === 'ImportRule')).toEqual([
+        { type: 'ImportRule', origin: './test.css', href: '/test.css' },
+        { type: 'ImportRule', origin: '../test2.css', href: '/test2.css' },
+        {
+          type: 'ImportRule',
+          origin: 'printstyle.css',
+          href: '/printstyle.css',
+        },
+        {
+          type: 'ImportRule',
+          origin: '@ies/ug-lynx-components/lib/styles.css',
+          href: '@ies/ug-lynx-components/lib/styles.css',
+        },
+      ]);
+    });
+
+    test('honours a non-default filename and projectRoot', () => {
+      const { root } = parse(`@import './a.css';\n@import '../../../b.css';`, {
+        filename: 'pages/view/index.css',
+        projectRoot: '/user/test/project1',
+      });
+
+      expect(root.filter((node) => node.type === 'ImportRule')).toEqual([
+        { type: 'ImportRule', origin: './a.css', href: '/pages/view/a.css' },
+        { type: 'ImportRule', origin: '../../../b.css', href: '../b.css' },
+      ]);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2054,6 +2054,9 @@ importers:
       css-tree:
         specifier: ^3.2.1
         version: 3.2.1
+      path-browserify:
+        specifier: ^1.0.1
+        version: 1.0.1
     devDependencies:
       '@types/css-tree':
         specifier: ^2.3.11
@@ -2061,6 +2064,9 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
+      '@types/path-browserify':
+        specifier: ^1.0.3
+        version: 1.0.3
 
   packages/tools/debug-metadata:
     devDependencies:
@@ -6240,6 +6246,9 @@ packages:
 
   '@types/object.pick@1.3.4':
     resolution: {integrity: sha512-5PjwB0uP2XDp3nt5u5NJAG2DORHIRClPzWT/TTZhJ2Ekwe8M5bA9tvPdi9NO/n2uvu2/ictat8kgqvLfcIE1SA==}
+
+  '@types/path-browserify@1.0.3':
+    resolution: {integrity: sha512-ZmHivEbNCBtAfcrFeBCiTjdIc2dey0l7oCGNGpSuRTy8jP6UVND7oUowlvDujBy8r2Hoa8bfFUOCiPWfmtkfxw==}
 
   '@types/prop-types@15.7.13':
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
@@ -16623,6 +16632,8 @@ snapshots:
   '@types/object.groupby@1.0.4': {}
 
   '@types/object.pick@1.3.4': {}
+
+  '@types/path-browserify@1.0.3': {}
 
   '@types/prop-types@15.7.13': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2054,9 +2054,9 @@ importers:
       css-tree:
         specifier: ^3.2.1
         version: 3.2.1
-      path-browserify:
-        specifier: ^1.0.1
-        version: 1.0.1
+      pathe:
+        specifier: ^2.0.3
+        version: 2.0.3
     devDependencies:
       '@types/css-tree':
         specifier: ^2.3.11
@@ -2064,9 +2064,6 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
-      '@types/path-browserify':
-        specifier: ^1.0.3
-        version: 1.0.3
 
   packages/tools/debug-metadata:
     devDependencies:
@@ -6246,9 +6243,6 @@ packages:
 
   '@types/object.pick@1.3.4':
     resolution: {integrity: sha512-5PjwB0uP2XDp3nt5u5NJAG2DORHIRClPzWT/TTZhJ2Ekwe8M5bA9tvPdi9NO/n2uvu2/ictat8kgqvLfcIE1SA==}
-
-  '@types/path-browserify@1.0.3':
-    resolution: {integrity: sha512-ZmHivEbNCBtAfcrFeBCiTjdIc2dey0l7oCGNGpSuRTy8jP6UVND7oUowlvDujBy8r2Hoa8bfFUOCiPWfmtkfxw==}
 
   '@types/prop-types@15.7.13':
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
@@ -16632,8 +16626,6 @@ snapshots:
   '@types/object.groupby@1.0.4': {}
 
   '@types/object.pick@1.3.4': {}
-
-  '@types/path-browserify@1.0.3': {}
 
   '@types/prop-types@15.7.13': {}
 


### PR DESCRIPTION
## Why

`@lynx-js/css-serializer` cannot be bundled for a browser. `parse` imports
`generateHref`, which imported `node:path`, and the package exposes no subpath
exports to import around it — so the whole package is unusable in a browser
bundle even for consumers that never touch `@import` resolution:

```
× Reading from "node:path" is not handled by plugins (Unhandled scheme).
  … → css-serializer/dist/generateHref.js → node:path
```

`generateHref` now uses [`pathe`](https://www.npmjs.com/package/pathe) (137M
downloads/week, dual ESM+CJS, ships types, zero dependencies, already in this
lockfile). It replaces ~160 lines that hand-reimplemented `path.posix`:
**−145 / +23** in `src/generateHref.ts`.

Split out of #3390 at review request: that PR does not need this change, and a
behaviour change in a published package deserves its own review.

## ⚠️ Risks for the reviewer to weigh

`pathe` is **not** `path.posix` and **not** `path.win32`. It normalises `\` to
`/` by design. For every POSIX path it is byte-identical to `path.posix` — and
that is every path this repo produces — but Windows-shaped inputs change.

All values below are measured, `generateHref(projectRoot, filename, origin)`:

| projectRoot / filename | `@import` | **pathe (new)** | path.win32 (old, on Windows) | path.posix (old, on Linux/mac) |
| --- | --- | --- | --- | --- |
| `C:\proj` / `pages\index.css` | `./a.css` | `/pages/a.css` | `/pages/a.css` | `/a.css` |
| `C:\proj` / `pages\index.css` | `../shared/b.css` | `/shared/b.css` | `/shared/b.css` | `../shared/b.css` |
| `/` / `./index.css` | `\a.css` | `/a.css` | `/a.css` | `//a.css` |
| `/` / `./index.css` | `\\srv\share\x.css` | `/srv/share/x.css` | `/srv/share/x.css` | `///srv/share/x.css` |
| `/` / `./index.css` | `C:\x.css` | `../C:/x.css` | varies by drive † | `/C:/x.css` |
| `C:\proj` / `\abs\index.css` | `./a.css` | `../..//abs/a.css` | varies by drive † | `/a.css` |

† Those two rows had **no single** old Windows value. `path.win32.resolve` takes
the drive it resolves against from `process.cwd()`, so whenever no argument names
a drive, the old output depended on the build machine's drive letter:

| projectRoot / filename | `@import` | on a C: host | on D: | on E: |
| --- | --- | --- | --- | --- |
| `/` / `./index.css` | `C:\x.css` | `/x.css` | `/C:/x.css` | `/C:/x.css` |
| `C:\proj` / `\abs\index.css` | `./a.css` | `../abs/a.css` | `/D:/abs/a.css` | `/E:/abs/a.css` |

Both cells previously read `/C:/x.css` and `/abs/a.css`, which is what
`path.win32` returns **on Linux** - where the cwd has no drive at all, so win32
silently takes a "no device" branch. That is not a valid way to observe old
Windows behaviour, and the CI Windows runner (a C: host) contradicted both: those
two assertions are what made `Vitest (Windows)` fail on this PR.

Any `path.win32`-derived figure is therefore only valid for inputs where some
argument names a drive. The aggregate under Risk 1 was originally measured that
way and has been re-measured under faked drive-lettered cwds instead. This is the
second instance of that class of mistake here - the first was the differential
oracle using `node:path`'s platform-dependent default export, which is why it is
now pinned to `path.posix`.

The `\\srv\share\x.css` row is stable on every drive letter; it changes only if
the cwd is itself a UNC path on the same share (giving `/x.css`), which is not a
shape a build machine or a caller uses.

**Risk 1 — Windows hrefs change, and `pathe` matches neither oracle exactly.**

Re-measured, because the figure that was here before (`120 of 150`) had been taken
with `path.win32` on Linux. The matrix is given in full so it can be rebuilt; each
`path.win32` value was taken with `process.cwd()` faked to a drive-lettered path,
on C:, D: and E: hosts, two cwds per drive:

```
projectRoot : C:\proj | C:\ | \proj | \\srv\share | D:\a\b | /
filename    : pages\index.css | index.css | \abs\index.css | C:\proj\pages\index.css | ./index.css
@import     : ./a.css | ../shared/b.css | a\b.css | /a.css | \a.css | C:\x.css | \\srv\share\x.css
```

6 x 5 x 7 = 210 cases. Depth never mattered, only the device: no case differed
between the two cwds on the same drive. `@pkg/...` imports are excluded because
every implementation passes them through unchanged (60/60 agree), so counting them
would only inflate the ratio.

Classified before counting - an input whose old value depended on the build
machine's drive has no single old behaviour to agree *with*:

| | count |
| --- | --- |
| total | 210 |
| drive-sensitive, no single old value → excluded | 34 |
| comparable (drive-stable) | 176 |
| …of those, **unchanged** by this PR | **120 (68.2%)** |
| …of those, changed | 56 |

The 56 changes are 38 where an `@import` or an absolute `filename` names a
different root than `projectRoot` (cross-drive, or drive vs UNC), 13 involving a
`\`-rooted path with no device, and 5 with a UNC `projectRoot`. **None of the 56
consists only of POSIX paths** — every one needs a backslash or a drive letter,
which is the measured form of the "POSIX callers are unaffected" claim above.

Read 68.2% as a description of this matrix rather than a probability of breakage:
it deliberately over-samples adversarial shapes (drive roots, UNC roots,
cross-drive combinations) that no caller in this repo produces. The actionable
content is *which* classes change, listed above.

For contrast, the same matrix scored the invalid way gives 111/210, against
122/210 on a C: host and 120/210 on D: and E: — measuring `path.win32` on Linux
**understates** agreement, which is the direction that made the two cells above
wrong.

This is a one-off measurement, not part of the test suite: patching
`process.cwd()` across a whole matrix is a side effect I did not want in the
shared suite. The definition above is sufficient to rebuild it. What *is*
committed is a test asserting that no input compared against the win32 oracle is
drive-sensitive, so this cannot silently regress.

Note the `C:\proj` / `\abs\index.css` row produces `../..//abs/a.css`, a doubled
slash mid-string that no oracle emits.

**Risk 2 — a few absolute `projectRoot` values leak `process.cwd()` into the
href.** `pathe` normalises them into a UNC shape that its own `isAbsolute` regex
`/^[/\\]{2}(?!\.)/` then rejects, so `resolve` falls through to `cwd()`:

```
projectRoot='//'  cwd=/tmp  →  /tmp/a.css
projectRoot='//'  cwd=/     →  /a.css
```

Affected roots: `'//'`, `'//.'`, `'//./x'` and `'\'`, and only when combined
with a `.`-prefixed filename — i.e. `parse`'s own `'./index.css'` default. These
are pinned by value in the test suite rather than asserted as "unequal", so they
name what leaks and will turn red if `pathe` ever fixes it. A browser bundle has
no `process.cwd()` at all.

**Neither risk is observable in this repo**: `cssToAst` is the only `parse` call
site and it uses the defaults (`filename` `'./index.css'`, `projectRoot` `'/'`).
Both are recorded in the changeset so they reach the CHANGELOG.

If either is unacceptable, `path-browserify` is a drop-in alternative that is
byte-identical to `path.posix` (0 divergences) with no cwd leak — at the cost of
being unmaintained since 2020, CJS-only, no bundled types, and *keeping* the
POSIX-vs-Windows href change instead.

## What is verified

- **119 tests green**; package `tsc --noEmit` clean; `dprint` + `biome` clean;
  changeset guard passes — all on the committed bytes.
- **The differential suite still carries its weight.** It compares against a
  `node:path` oracle over ~1100 generated cases and **excludes only** inputs that
  diverge by construction (backslash-containing, and the degenerate `'//'` root).
  Each exclusion is justified in a comment, and the excluded inputs are pinned by
  value separately rather than dropped.
- A third divergence class is pinned rather than hidden: `pathe.normalize` keeps a
  leading `//` where `path.posix` collapses it (20 of 960 cases). It never reaches
  an href — `relative()` collapses it, proven over 1596 POSIX-input hrefs, none of
  which contain `//`.
- **Browser bundling proven**: `esbuild --platform=browser` exits 0 with **0**
  `node:path` occurrences in the output, and the negative control (import reverted
  to `node:path`) fails with `Could not resolve "node:path"` — so the probe
  discriminates.
- Ships as `patch`: this package is a `peerDependency` of `@lynx-js/web-core`, so
  a `minor` cascades that package to `1.0.0`, which
  `.github/scripts/check-no-major-changeset.cjs` rejects.

## Known dead code, left alone

`normalizeSlashes(projectPath)` on the non-`@` branch is now unreachable —
removing it keeps 119/119 green and `pathe` never returns a backslash (0 of 180
probed calls). The `@`-passthrough `normalizeSlashes(fullPath)` **is**
load-bearing: removing it fails 4 tests. Left in place to keep this PR to one
concern; happy to drop it if a reviewer prefers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - CSS import links are generated consistently across platforms with POSIX-style path semantics.
  - CSS serialization now supports browser environments without relying on Node.js path utilities.
  - Relative project roots retain predictable resolution behavior in browser environments.
  - Windows path normalization is handled consistently, with documented platform differences.
  - Unsupported `//` project roots are now clearly documented.

- **Tests**
  - Expanded coverage validates path resolution, traversal, normalization, aliases, and generated import links across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

