### PR TITLE
feat(web-core): build a Lynx XML markup document into a web bundle

### DIFF
--- a/.changeset/xml-to-web-bundle.md
+++ b/.changeset/xml-to-web-bundle.md
@@ -39,8 +39,8 @@ markup card's `<style>`:
   `@namespace` are not recognised by the Lynx CSS parser and are dropped the same
   way, along with anything inside them.
 - `@import url("...")` does not resolve. A markup card owns a single stylesheet and
-  has nothing to link to, so it is dropped rather than aborting the build. The
-  numeric form a build step emits is unaffected.
+  has nothing to link to, so it is dropped rather than aborting the build. `@import`
+  itself is supported - the numeric form a build step emits is unaffected.
 - `@font-face` and `@keyframes` **nested inside** one of the above are dropped with
   their enclosing block, even though both are supported at the top level.
 

--- a/.changeset/xml-to-web-bundle.md
+++ b/.changeset/xml-to-web-bundle.md
@@ -1,0 +1,52 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Build a single file Lynx XML markup document into a `.web.bundle`.
+
+`@lynx-js/web-core/encode` gains `encodeLynxXML(source)` and `xmlToTasmJSON(source)`,
+which turn a hand-written Lynx XML document - a versioned `<lynx>` root wrapping an
+optional `<style>`, a required `<script main-thread>` and an optional
+`<script background>` - into the same bundle bytes a ReactLynx build produces: same
+magic header, same section sequence, same rkyv-encoded `StyleInfo`. Nothing
+downstream has to know the card was hand-written, and no new decode path is
+introduced.
+
+Because the stylesheet is tokenized into the bundle rather than passed through as
+text, a markup card gets the engine's full style pipeline:
+
+- the `transform-vw` / `transform-vh` / `transform-rem` attributes apply, so those
+  units resolve against the `lynx-view` box. They remain off by default, in which
+  case the units keep their native browser meaning.
+- Lynx-specific property rewriting runs, so `display: linear` and the `linear-*`
+  properties are translated instead of being discarded by the browser as invalid.
+- `:root` is rewritten to the card's own root element. A card renders inside a
+  shadow root, where a literal `:root` matches nothing.
+
+A parse failure is returned rather than thrown, formatted like the engine's
+reference parser and located by offset.
+
+**At-rules that Lynx does not support are dropped from the bundle.** This is
+intended, not a limitation of the web implementation: Lynx's binary style format
+has exactly three rule kinds - style, `@font-face` and `@keyframes` - so a
+conditional group has no representation on any Lynx platform. Concretely, in a
+markup card's `<style>`:
+
+- `@media`, `@supports` and `@layer` do not apply. The rules inside them are
+  dropped with them; they are not promoted to the top level, so a card renders as
+  though those blocks had not been written.
+- `@container`, `@property`, `@scope`, `@starting-style`, `@page`, `@charset` and
+  `@namespace` are not recognised by the Lynx CSS parser and are dropped the same
+  way, along with anything inside them.
+- `@import url("...")` does not resolve. A markup card owns a single stylesheet and
+  has nothing to link to, so it is dropped rather than aborting the build. The
+  numeric form a build step emits is unaffected.
+- `@font-face` and `@keyframes` **nested inside** one of the above are dropped with
+  their enclosing block, even though both are supported at the top level.
+
+Every one of these is reported on the console during the build, once per at-rule,
+naming the at-rule and why it could not be carried - so the cause is visible rather
+than showing up later as a rendering difference with nothing to go on.
+
+The existing encode path is untouched: `encodeCSS` and `encode` are byte for byte
+unchanged, and a ReactLynx build produces exactly the bundle it produced before.

--- a/packages/web-platform/web-core/tests/fixtures/markup-card.xml
+++ b/packages/web-platform/web-core/tests/fixtures/markup-card.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE lynx>
+<lynx version="5.4.2">
+<style><![CDATA[
+  /*
+    Card-wide custom properties are declared on the page's own class. `:root`
+    would work too - a markup card's CSS is tokenized, so `:root` is rewritten
+    to the card's root element - but `.page` is set on that same element by the
+    main-thread script below, so this keeps the stylesheet explicit about what
+    it targets. `markup-root-selector.xml` covers the `:root` form.
+  */
+  /*
+    No `height` here on purpose: the card lets the host size itself, so
+    `lynx-view` can stay on its default `height="auto"` and grow with the
+    content. Pinning the page to `100vh` would force every embedder to give the
+    host a viewport-sized box just to avoid clipping.
+  */
+  .page {
+    --accent: #2f6d54;
+    width: 100%;
+    font-size: calc(100vw / 24);
+    background-color: #edf4ef;
+  }
+
+  .shell {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+  }
+
+  .card {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: 1.75rem;
+    background: linear-gradient(145deg, #123f35 0%, #4c8665 100%);
+  }
+
+  .title {
+    color: #f7f4e7;
+    font-size: 1.5rem;
+    font-weight: 700;
+  }
+
+  .tabs {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .tab {
+    display: flex;
+    padding: 0.5rem 0.75rem;
+    border-radius: 62.5rem;
+    background-color: rgba(255, 255, 255, 0.09);
+  }
+
+  .tab-active {
+    background-color: var(--accent);
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    padding: 0.75rem;
+  }
+]]></style>
+
+<script main-thread="true"><![CDATA[
+  const days = [
+    // Day 1's detail carries an embedded newline on purpose: raw text has to
+    // reach the DOM with the break intact, neither collapsed into a space nor
+    // escaped into a literal backslash-n.
+    { tab: 'Day 1', title: 'Lakeside', detail: 'Walk the causeway\nat sunrise.' },
+    { tab: 'Day 2', title: 'Tea hills', detail: 'Climb between the tea rows.' },
+    { tab: 'Day 3', title: 'Old town', detail: 'Follow the canal after dusk.' },
+  ];
+
+  const page = __CreatePage('0', 0);
+  const pageId = __GetElementUniqueID(page);
+  const engine = lynx.getEngine();
+  const backgroundThread = lynx.getJSContext();
+  const listeners = [];
+  const tabNodes = [];
+  let activeIndex = 0;
+  let panelSlot;
+  let rendered = false;
+
+  __SetClasses(page, 'page');
+
+  Object.assign(globalThis, {
+    processData(data) {
+      return data;
+    },
+  });
+
+  function createView(className) {
+    const node = __CreateView(pageId);
+    __SetClasses(node, className);
+    return node;
+  }
+
+  function createText(className, value) {
+    const node = __CreateText(pageId);
+    __SetClasses(node, className);
+    __AppendElement(node, __CreateRawText(value));
+    return node;
+  }
+
+  function append(parent, child) {
+    __AppendElement(parent, child);
+    return child;
+  }
+
+  function bindTap(node, handler) {
+    const options = {};
+    __AddEventListener(node, 'tap', handler, options);
+    listeners.push({ node, name: 'tap', handler, options });
+  }
+
+  function createTabs() {
+    const tabs = createView('tabs');
+    days.forEach((day, index) => {
+      const tab = append(tabs, createView(index === activeIndex ? 'tab tab-active' : 'tab'));
+      append(tab, createText('title', day.tab));
+      bindTap(tab, () => selectDay(index));
+      tabNodes.push(tab);
+    });
+    return tabs;
+  }
+
+  function createPanel(day) {
+    const panel = createView('panel');
+    append(panel, createText('title', day.title));
+    append(panel, createText('detail', day.detail));
+    return panel;
+  }
+
+  function selectDay(index) {
+    if (index === activeIndex) {
+      return;
+    }
+    activeIndex = index;
+    tabNodes.forEach((tab, tabIndex) => {
+      __SetClasses(tab, tabIndex === activeIndex ? 'tab tab-active' : 'tab');
+    });
+    __ReplaceElements(panelSlot, [createPanel(days[activeIndex])], __GetChildren(panelSlot));
+    __FlushElementTree(page);
+  }
+
+  function renderPage() {
+    if (rendered) {
+      return;
+    }
+    rendered = true;
+    const scroll = __CreateScrollView(pageId);
+    __SetAttribute(scroll, 'scroll-orientation', 'vertical');
+    append(page, scroll);
+
+    const shell = append(scroll, createView('shell'));
+    const card = append(shell, createView('card'));
+    append(card, createText('title', 'City escape'));
+    append(card, createTabs());
+    panelSlot = append(card, createView('panel-slot'));
+    append(panelSlot, createPanel(days[activeIndex]));
+  }
+
+  function onRenderPage() {
+    renderPage();
+  }
+
+  function cleanup() {
+    listeners.splice(0).forEach((listener) => {
+      __RemoveEventListener(listener.node, listener.name, listener.handler, listener.options);
+    });
+    engine.removeEventListener('__RenderPage', onRenderPage);
+    engine.removeEventListener('__DestroyLifetime', cleanup);
+    backgroundThread.dispatchEvent({ type: '__DestroyLifetime', data: undefined });
+    tabNodes.splice(0);
+    panelSlot = undefined;
+  }
+
+  engine.addEventListener('__RenderPage', onRenderPage);
+  engine.addEventListener('__DestroyLifetime', cleanup);
+]]></script>
+
+<script background="true"><![CDATA[
+  const mainThread = lynx.getCoreContext();
+
+  function cleanupBackground() {
+    mainThread.removeEventListener('__DestroyLifetime', cleanupBackground);
+  }
+
+  mainThread.addEventListener('__DestroyLifetime', cleanupBackground);
+]]></script>
+</lynx>

--- a/packages/web-platform/web-core/tests/parseLynxXML.spec.ts
+++ b/packages/web-platform/web-core/tests/parseLynxXML.spec.ts
@@ -1,0 +1,547 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from '@rstest/core';
+
+import { parseLynxXML } from '../ts/common/xml/parseLynxXML.js';
+import type {
+  LynxXMLParseResult,
+  LynxXMLParseSuccess,
+} from '../ts/common/xml/parseLynxXML.js';
+
+function expectSuccess(result: LynxXMLParseResult): LynxXMLParseSuccess {
+  if (!result.success) {
+    throw new Error(`expected a successful parse: ${result.error.message}`);
+  }
+  return result;
+}
+
+function expectFailure(source: string): string {
+  const result = parseLynxXML(source);
+  if (result.success) {
+    throw new Error(`expected a failed parse for: ${source}`);
+  }
+  expect(result.error.formattedMessage).toBe(
+    `invalid TemplateBundle XML at offset ${result.error.offset}: ${result.error.message}`,
+  );
+  expect(result.error.formattedMessage.startsWith(
+    'invalid TemplateBundle XML at offset',
+  )).toBe(true);
+  expect(result.error.offset).toBeGreaterThanOrEqual(0);
+  return result.error.message;
+}
+
+describe('parseLynxXML', () => {
+  describe('happy paths', () => {
+    it('parses a full document with declaration, doctype and CDATA', () => {
+      const style = '\n.card { width: 100px; color: red; }\n';
+      const mainThreadScript = '\nfunction renderPage() { return null; }\n';
+      const backgroundThreadScript =
+        '\nglobalThis.__background_started = true;\n';
+      const result = expectSuccess(parseLynxXML(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+          + '<!DOCTYPE lynx>\n'
+          + '<lynx version="5.4.2">\n'
+          + `<style><![CDATA[${style}]]></style>\n`
+          + `<script main-thread="true"><![CDATA[${mainThreadScript}]]></script>\n`
+          + `<script background="true"><![CDATA[${backgroundThreadScript}]]></script>\n`
+          + '</lynx>',
+      ));
+
+      expect(result.style).toBe(style);
+      expect(result.mainThreadScript).toBe(mainThreadScript);
+      expect(result.backgroundThreadScript).toBe(backgroundThreadScript);
+    });
+
+    it('parses the minimal legal document', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2"><script main-thread>main</script></lynx>',
+      ));
+
+      expect(result.style).toBeUndefined();
+      expect(result.mainThreadScript).toBe('main');
+      expect(result.backgroundThreadScript).toBeUndefined();
+    });
+
+    it('keeps bare (non CDATA) content verbatim, whitespace included', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2">\n'
+          + '<style>\n.card { width: 1px; }\n</style>\n'
+          + '<script main-thread>\nmain\n</script>\n'
+          + '</lynx>',
+      ));
+
+      expect(result.style).toBe('\n.card { width: 1px; }\n');
+      expect(result.mainThreadScript).toBe('\nmain\n');
+    });
+
+    it('allows CDATA content that itself contains a closing tag', () => {
+      const mainThreadScript = '\nconst closingTag = "</script>";\n';
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2">'
+          + `<script main-thread="true"><![CDATA[${mainThreadScript}]]></script>`
+          + '</lynx>',
+      ));
+
+      expect(result.mainThreadScript).toBe(mainThreadScript);
+    });
+
+    it('accepts the three boolean attribute spellings', () => {
+      for (
+        const attribute of [
+          'main-thread',
+          'main-thread="true"',
+          'main-thread=\'true\'',
+        ]
+      ) {
+        const result = expectSuccess(parseLynxXML(
+          `<lynx version="5.4.2"><script ${attribute}>main</script></lynx>`,
+        ));
+        expect(result.mainThreadScript).toBe('main');
+      }
+      for (
+        const attribute of [
+          'background',
+          'background="true"',
+          'background=\'true\'',
+        ]
+      ) {
+        const result = expectSuccess(parseLynxXML(
+          `<lynx version="5.4.2"><script main-thread>main</script>`
+            + `<script ${attribute}>bg</script></lynx>`,
+        ));
+        expect(result.backgroundThreadScript).toBe('bg');
+      }
+    });
+
+    it('accepts doctype casing variants', () => {
+      for (
+        const doctype of [
+          '<!DOCTYPE lynx>',
+          '<!doctype lynx>',
+          '<!DoCtYpE LyNx>',
+          '<!DOCTYPE   lynx  >',
+        ]
+      ) {
+        const result = expectSuccess(parseLynxXML(
+          `${doctype}<lynx version="5.4.2">`
+            + '<script main-thread>main</script></lynx>',
+        ));
+        expect(result.mainThreadScript).toBe('main');
+      }
+    });
+
+    it('accepts a single quoted version attribute', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version=\'5.4.2\'><script main-thread>main</script></lynx>',
+      ));
+      expect(result.mainThreadScript).toBe('main');
+    });
+
+    it('skips comments in every ignorable position', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<!-- before declaration -->\n'
+          + '<?xml version="1.0"?>\n'
+          + '<!-- between declaration and doctype -->\n'
+          + '<!DOCTYPE lynx>\n'
+          + '<!-- before root -->\n'
+          + '<lynx version="5.4.2">\n'
+          + '<!-- inside root -->\n'
+          + '<script main-thread>main</script>\n'
+          + '<!-- between sections -->\n'
+          + '<script background>bg</script>\n'
+          + '</lynx>\n'
+          + '<!-- after root -->\n',
+      ));
+
+      expect(result.mainThreadScript).toBe('main');
+      expect(result.backgroundThreadScript).toBe('bg');
+    });
+
+    it('accepts optional sections in any order and a leading BOM', () => {
+      const result = expectSuccess(parseLynxXML(
+        '\uFEFF<lynx version="5.4.2">\n'
+          + '<script background>background-code</script>\n'
+          + '<script main-thread>main-code</script>\n'
+          + '</lynx>',
+      ));
+
+      expect(result.style).toBeUndefined();
+      expect(result.mainThreadScript).toBe('main-code');
+      expect(result.backgroundThreadScript).toBe('background-code');
+    });
+
+    it('parses a document without a style section', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2">'
+          + '<script main-thread>main</script>'
+          + '<script background>bg</script>'
+          + '</lynx>',
+      ));
+
+      expect(result.style).toBeUndefined();
+      expect(result.backgroundThreadScript).toBe('bg');
+    });
+
+    it('parses a document without a background script section', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2">'
+          + '<style>.a { width: 1px; }</style>'
+          + '<script main-thread>main</script>'
+          + '</lynx>',
+      ));
+
+      expect(result.style).toBe('.a { width: 1px; }');
+      expect(result.backgroundThreadScript).toBeUndefined();
+    });
+
+    it('keeps an empty style section as an empty string', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2"><style></style>'
+          + '<script main-thread>main</script></lynx>',
+      ));
+
+      expect(result.style).toBe('');
+    });
+
+    it('accepts extra whitespace around attributes', () => {
+      for (
+        const source of [
+          '<lynx  version = "5.4.2" ><script main-thread>m</script></lynx>',
+          '<lynx version="5.4.2" ><script main-thread>m</script></lynx>',
+          '<lynx version="5.4.2"><script  main-thread  =  "true" >m</script></lynx>',
+        ]
+      ) {
+        expect(expectSuccess(parseLynxXML(source)).mainThreadScript).toBe('m');
+      }
+    });
+
+    it('keeps an empty CDATA section as an empty string', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2">'
+          + '<script main-thread><![CDATA[]]></script></lynx>',
+      ));
+
+      expect(result.mainThreadScript).toBe('');
+    });
+
+    it('tolerates trailing whitespace after the root closing tag', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2"><script main-thread>main</script></lynx>\n\n',
+      ));
+
+      expect(result.mainThreadScript).toBe('main');
+    });
+  });
+
+  describe('error branches', () => {
+    it('rejects a missing root element', () => {
+      expect(expectFailure('<script main-thread>main</script>')).toContain(
+        'root element',
+      );
+    });
+
+    it('rejects a non lynx doctype', () => {
+      expect(expectFailure(
+        '<!doctype html><lynx version="5.4.2">'
+          + '<script main-thread>main</script></lynx>',
+      )).toBe('expected \'<!doctype lynx>\'');
+    });
+
+    it('rejects an unterminated doctype declaration', () => {
+      expect(expectFailure('<!doctype lynx')).toBe(
+        'unterminated doctype declaration',
+      );
+    });
+
+    it('rejects a missing version attribute', () => {
+      expect(expectFailure(
+        '<lynx><script main-thread>main</script></lynx>',
+      )).toContain('\'version\' attribute');
+    });
+
+    it('rejects an empty version attribute', () => {
+      expect(expectFailure(
+        '<lynx version=""><script main-thread>main</script></lynx>',
+      )).toContain('\'version\' attribute');
+    });
+
+    it('rejects an unrelated root attribute', () => {
+      expect(expectFailure(
+        '<lynx lang="en"><script main-thread>main</script></lynx>',
+      )).toContain('\'version\' attribute');
+    });
+
+    it('rejects an unterminated root opening tag', () => {
+      expect(expectFailure('<lynx version="5.4.2"')).toBe(
+        'unterminated \'<lynx>\' opening tag',
+      );
+    });
+
+    it('rejects a missing main-thread script', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"><script background>background</script></lynx>',
+      )).toBe('missing \'<script main-thread>\' section');
+    });
+
+    it('rejects a document with only a style section', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"><style>.a { width: 1px; }</style></lynx>',
+      )).toBe('missing \'<script main-thread>\' section');
+    });
+
+    it('rejects duplicate script sections', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"><script main-thread>main</script>'
+          + '<script main-thread>duplicate</script></lynx>',
+      )).toContain('duplicate');
+      expect(expectFailure(
+        '<lynx version="5.4.2"><script main-thread>main</script>'
+          + '<script background>a</script><script background>b</script></lynx>',
+      )).toContain('duplicate');
+    });
+
+    it('rejects duplicate style sections', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"><style>a</style><style>b</style>'
+          + '<script main-thread>main</script></lynx>',
+      )).toBe('duplicate \'<style>\' section');
+    });
+
+    it('rejects attributes on the style section', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"><style scoped>.a { width: 1px; }</style>'
+          + '<script main-thread>main</script></lynx>',
+      )).toBe('\'<style>\' does not accept attributes');
+    });
+
+    it('rejects a script without main-thread or background', () => {
+      for (
+        const openingTag of [
+          '<script>',
+          '<script worker>',
+          '<script main-thread="false">',
+          '<script background="false">',
+          '<script main-thread background>',
+        ]
+      ) {
+        expect(expectFailure(
+          `<lynx version="5.4.2">${openingTag}main</script></lynx>`,
+        )).toBe(
+          '\'<script>\' requires exactly one of \'main-thread\' or \'background\'',
+        );
+      }
+    });
+
+    it('rejects unknown top-level tags, naming the tag', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"><view></view>'
+          + '<script main-thread>main</script></lynx>',
+      )).toBe('unsupported top-level tag \'<view>\'');
+    });
+
+    it('rejects an unexpected closing tag at the top level', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"></style>'
+          + '<script main-thread>main</script></lynx>',
+      )).toBe('unexpected closing tag');
+    });
+
+    it('rejects an unterminated section opening tag', () => {
+      expect(expectFailure('<lynx version="5.4.2"><script main-thread')).toBe(
+        'unterminated opening tag',
+      );
+    });
+
+    it('rejects an unterminated CDATA section', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2">'
+          + '<script main-thread="true"><![CDATA[main</script></lynx>',
+      )).toBe('unterminated CDATA section');
+    });
+
+    it('rejects content after the CDATA section', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2">'
+          + '<script main-thread><![CDATA[a]]>trailing]]></script></lynx>',
+      )).toBe('unexpected content after the CDATA section');
+    });
+
+    it('rejects an unterminated comment', () => {
+      expect(expectFailure('<lynx version="5.4.2"><!-- unterminated')).toBe(
+        'unterminated comment',
+      );
+    });
+
+    it('rejects a missing section closing tag', () => {
+      expect(expectFailure('<lynx version="5.4.2"><script main-thread>main'))
+        .toBe('missing closing tag \'</script>\'');
+    });
+
+    it('rejects a missing root closing tag', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"><script main-thread="true">main</script>',
+      )).toBe('missing closing tag \'</lynx>\'');
+    });
+
+    it('rejects content after the root closing tag', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2"><script main-thread>main</script></lynx>trailing',
+      )).toBe('unexpected content after \'</lynx>\'');
+    });
+
+    it('rejects an unterminated XML declaration', () => {
+      expect(expectFailure(
+        '<?xml version="1.0"<lynx version="5.4.2">'
+          + '<script main-thread>main</script></lynx>',
+      )).toBe('unterminated XML declaration');
+    });
+
+    it('rejects an empty document', () => {
+      expect(expectFailure('')).toContain('root element');
+    });
+
+    it('rejects bare text between sections', () => {
+      expect(expectFailure(
+        '<lynx version="5.4.2">garbage'
+          + '<script main-thread>main</script></lynx>',
+      )).toBe('unexpected content outside a section');
+    });
+
+    it('never throws, whatever the input is', () => {
+      for (
+        const source of [
+          '',
+          '<',
+          '<!',
+          '<!-',
+          '<?xml',
+          '<lynx',
+          '<lynx version',
+          '<lynx version=',
+          '<lynx version="',
+          '</lynx>',
+          '<![CDATA[',
+          '\uFEFF',
+          '\uFEFF<lynx version="1">',
+        ]
+      ) {
+        expect(() => parseLynxXML(source)).not.toThrow();
+        expect(parseLynxXML(source).success).toBe(false);
+      }
+    });
+
+    it('reports the offset of the failing section, not of the document', () => {
+      const prefix = '<lynx version="5.4.2">\n';
+      const result = parseLynxXML(
+        `${prefix}<view></view><script main-thread>main</script></lynx>`,
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.offset).toBe(prefix.length);
+      }
+    });
+  });
+
+  describe('real world fixture', () => {
+    it('parses markup-card.xml into three non-empty sections', () => {
+      const source = readFileSync(
+        join(
+          dirname(fileURLToPath(import.meta.url)),
+          'fixtures',
+          'markup-card.xml',
+        ),
+        'utf8',
+      );
+      const result = expectSuccess(parseLynxXML(source));
+
+      expect(result.style).toBeTruthy();
+      expect(result.style).toContain('.page');
+      expect(result.mainThreadScript).toBeTruthy();
+      expect(result.mainThreadScript).toContain('__CreatePage');
+      expect(result.backgroundThreadScript).toBeTruthy();
+      expect(result.backgroundThreadScript).toContain('lynx.getCoreContext');
+      // No CDATA markers may leak into the extracted sections.
+      for (
+        const section of [
+          result.style!,
+          result.mainThreadScript,
+          result.backgroundThreadScript!,
+        ]
+      ) {
+        expect(section).not.toContain('<![CDATA[');
+        expect(section).not.toContain(']]>');
+      }
+    });
+  });
+
+  /**
+   * The corpus below mirrors the rejection and acceptance cases of the
+   * engine-side reference parser, so that any behavioral drift from it is
+   * caught here.
+   */
+  describe('parity with the reference parser', () => {
+    it('rejects every document the reference parser rejects', () => {
+      const sources = [
+        '<script main-thread>main</script>',
+        '<!doctype html><lynx version="5.4.2">'
+        + '<script main-thread>main</script></lynx>',
+        '<lynx version="5.4.2"><style scoped>.a { width: 1px; }</style>'
+        + '<script main-thread>main</script></lynx>',
+        '<lynx version="5.4.2"><script>main</script></lynx>',
+        '<lynx version="5.4.2"><script worker>main</script></lynx>',
+        '<lynx version="5.4.2"><script main-thread>main</script>'
+        + '<script main-thread>duplicate</script></lynx>',
+        '<lynx version="5.4.2"><script background>background</script></lynx>',
+        '<lynx version="5.4.2"><view></view>'
+        + '<script main-thread>main</script></lynx>',
+        '<lynx version="5.4.2"><script main-thread>main',
+        '<lynx version="5.4.2"><!-- unterminated',
+        '<lynx><script main-thread>main</script></lynx>',
+        '<lynx version=""><script main-thread>main</script></lynx>',
+        '<lynx lang="en"><script main-thread>main</script></lynx>',
+        '<lynx version="5.4.2">'
+        + '<script main-thread="false">main</script></lynx>',
+        '<lynx version="5.4.2">'
+        + '<script main-thread="true"><![CDATA[main</script></lynx>',
+        '<lynx version="5.4.2">'
+        + '<script main-thread="true">main</script>',
+      ];
+
+      expect(sources.filter((source) => parseLynxXML(source).success))
+        .toEqual([]);
+      for (const source of sources) {
+        expectFailure(source);
+      }
+    });
+
+    it('extracts the same sections as the reference parser', () => {
+      const full = expectSuccess(parseLynxXML(
+        '<?xml version="1.0"?>\n'
+          + '<!-- A Lynx single-file bundle. -->\n'
+          + '<lynx version="5.4.2">\n'
+          + '<style>\n.card { width: 100px; }\n</style>\n'
+          + '<script main-thread>\nmain\n</script>\n'
+          + '<script background>\nbackground\n</script>\n'
+          + '</lynx>',
+      ));
+      expect(full.style).toBe('\n.card { width: 100px; }\n');
+      expect(full.mainThreadScript).toBe('\nmain\n');
+      expect(full.backgroundThreadScript).toBe('\nbackground\n');
+
+      const anyOrder = expectSuccess(parseLynxXML(
+        '\uFEFF<lynx version="5.4.2">\n'
+          + '<script background>background-code</script>\n'
+          + '<script main-thread>main-code</script>\n'
+          + '</lynx>',
+      ));
+      expect(anyOrder.style).toBeUndefined();
+      expect(anyOrder.mainThreadScript).toBe('main-code');
+      expect(anyOrder.backgroundThreadScript).toBe('background-code');
+    });
+  });
+});

--- a/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
+++ b/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
@@ -458,7 +458,7 @@ describe('XML markup document to web bundle', () => {
       const { buffer, discarded } = build(source);
       // Reported, so the author is not left wondering where the import went.
       expect(discarded).toStrictEqual([
-        { name: '@import', reason: 'unrepresentable' },
+        { name: '@import', reason: 'unresolvable' },
       ]);
       const { sections } = readBundle(buffer);
       const config = readJSONSection(

--- a/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
+++ b/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
@@ -213,6 +213,12 @@ describe('XML markup document to web bundle', () => {
       config,
     );
     expect(css).toContain('color:red');
+    // The stylesheet has to land under css id 0, the card's own sheet. Any other
+    // id makes the decoder scope every selector with `:where([l-css-id="N"])`,
+    // which never matches the card's elements - the rules would decode fine and
+    // still apply to nothing.
+    expect(css).not.toContain('l-css-id');
+    expect(css).toContain('.a:not([l-e-name])');
   });
 
   test('omits the sections an XML document cannot fill', () => {
@@ -226,6 +232,48 @@ describe('XML markup document to web bundle', () => {
       readJSONSection(sections.get(TemplateSectionLabel.CustomSections)!),
     ).toStrictEqual({});
     expect(sections.has(TemplateSectionLabel.ElementTemplates)).toBe(false);
+  });
+
+  /**
+   * Proves the framing assertions above are load-bearing.
+   *
+   * `readBundle` is the whole basis for claiming the bytes are a valid bundle, so
+   * if it accepted a corrupted one the round-trip tests would be vacuous. These
+   * corrupt a known-good bundle in the three ways the decoder itself rejects.
+   */
+  describe('the bundle reader rejects what the decoder rejects', () => {
+    function goodBundle() {
+      return build(xml({ style: '.a{color:red}' })).buffer;
+    }
+
+    test('rejects a wrong magic header', () => {
+      const buffer = goodBundle();
+      // The decoder throws `Invalid Magic Header` on exactly this.
+      buffer[0] = buffer[0]! ^ 0xff;
+      expect(() => readBundle(buffer)).toThrow();
+    });
+
+    test('rejects a version the decoder would refuse', () => {
+      const buffer = goodBundle();
+      new DataView(buffer.buffer, buffer.byteOffset).setUint32(8, 2, true);
+      expect(() => readBundle(buffer)).toThrow();
+    });
+
+    test('rejects a truncated bundle', () => {
+      const buffer = goodBundle();
+      // Losing the tail makes the last section's declared length overrun, which
+      // is the `Unexpected EOF reading section content` case.
+      expect(() => readBundle(buffer.subarray(0, buffer.byteLength - 4)))
+        .toThrow();
+    });
+
+    test('rejects a bundle with a lying section length', () => {
+      const buffer = goodBundle();
+      const view = new DataView(buffer.buffer, buffer.byteOffset);
+      // The first section's length, at magic(8) + version(4) + label(4).
+      view.setUint32(16, view.getUint32(16, true) + 1, true);
+      expect(() => readBundle(buffer)).toThrow();
+    });
   });
 
   test('reports a malformed document instead of throwing', () => {

--- a/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
+++ b/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
@@ -1,0 +1,588 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * XML markup document -> `.web.bundle` bytes -> back through the decoder.
+ *
+ * The claim under test is that a hand-written card can be *built*, rather than
+ * needing a load-time bypass: the bytes must be an ordinary modern bundle, with
+ * the same header, the same sections and the same rkyv-encoded `StyleInfo` a
+ * ReactLynx build produces. So the assertions do not inspect intermediate
+ * structures - they walk the produced bytes exactly as
+ * `decodeWorker/decode.worker.ts` does, and hand the `StyleInfo` section to the
+ * same `decode_style_info` the browser calls. If the encoder produced something
+ * the decoder could not read, `from_bytes_unchecked` on the other side would not
+ * return this CSS.
+ */
+
+import './jsdom.js';
+import { describe, expect, test } from '@rstest/core';
+import * as CSS from '@lynx-js/css-serializer';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  decode_style_info,
+  get_font_face_content,
+  get_style_content,
+} from '../binary/encode/encode.js';
+import { TemplateSectionLabel } from '../ts/constants.js';
+import {
+  diagnoseDiscardedAtRules,
+  encodeLynxXML,
+  xmlToTasmJSON,
+} from '../ts/encode/xmlToTasmJSON.js';
+
+const MagicHeader0 = 0x41524453;
+const MagicHeader1 = 0x464F5257;
+
+/**
+ * Walks a bundle the way the decode worker does: magic, version, then
+ * label/length framed sections until EOF.
+ *
+ * Deliberately not sharing code with the encoder - a shared helper could agree
+ * with a wrong encoder.
+ */
+function readBundle(buffer: Uint8Array) {
+  const view = new DataView(
+    buffer.buffer,
+    buffer.byteOffset,
+    buffer.byteLength,
+  );
+  expect(view.getUint32(0, true)).toBe(MagicHeader0);
+  expect(view.getUint32(4, true)).toBe(MagicHeader1);
+  const version = view.getUint32(8, true);
+  // The decoder rejects anything above 1.
+  expect(version).toBeLessThanOrEqual(1);
+
+  const sections = new Map<number, Uint8Array>();
+  let offset = 12;
+  while (offset < buffer.byteLength) {
+    const label = view.getUint32(offset, true);
+    offset += 4;
+    const length = view.getUint32(offset, true);
+    offset += 4;
+    expect(offset + length).toBeLessThanOrEqual(buffer.byteLength);
+    // Copied, not a view. `StreamReader.read` copies too (via `slice`), and the
+    // decoder relies on it: `decodeJSONMap` builds a `Uint16Array` over
+    // `byteOffset`, which throws for an odd offset - and a section can start at
+    // one, since `LepusCode` is UTF-8 and may have odd length. Taking a view
+    // here would fail on a bundle the browser reads fine.
+    sections.set(label, buffer.slice(offset, offset + length));
+    offset += length;
+  }
+  // Framing consumed the buffer exactly, with no trailing slack.
+  expect(offset).toBe(buffer.byteLength);
+  return { version, sections };
+}
+
+/**
+ * `Configurations` and `CustomSections` are UTF-16 code units of a JSON string,
+ * see `encodeAsJSON`.
+ */
+function readJSONSection(bytes: Uint8Array): Record<string, unknown> {
+  const units = new Uint16Array(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength / 2,
+  );
+  return JSON.parse(String.fromCharCode(...units));
+}
+
+/**
+ * `Manifest` and `LepusCode` are a count followed by length-prefixed UTF-8
+ * key/value pairs, see `encodeStringMap`.
+ */
+function readStringMap(bytes: Uint8Array): Record<string, string> {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const decoder = new TextDecoder();
+  const count = view.getUint32(0, true);
+  let offset = 4;
+  const out: Record<string, string> = {};
+  for (let i = 0; i < count; i++) {
+    const keyLength = view.getUint32(offset, true);
+    offset += 4;
+    const key = decoder.decode(bytes.subarray(offset, offset + keyLength));
+    offset += keyLength;
+    const valueLength = view.getUint32(offset, true);
+    offset += 4;
+    const value = decoder.decode(bytes.subarray(offset, offset + valueLength));
+    offset += valueLength;
+    out[key] = value;
+  }
+  expect(offset).toBe(bytes.byteLength);
+  return out;
+}
+
+/**
+ * Runs the `StyleInfo` section through the decoder the browser uses, and returns
+ * the stylesheet it yields.
+ */
+function decodeStyle(
+  section: Uint8Array,
+  config: Record<string, unknown>,
+  {
+    transformVW = false,
+    transformVH = false,
+    transformREM = false,
+  } = {},
+) {
+  const decoded = decode_style_info(
+    section,
+    config['isLazy'] === 'true' ? 'http://example.com/card' : undefined,
+    config['enableCSSSelector'] === 'true',
+    transformVW,
+    transformVH,
+    transformREM,
+  );
+  return {
+    css: get_style_content(decoded),
+    fontFace: get_font_face_content(decoded),
+  };
+}
+
+function xml(
+  { style, background }: { style?: string; background?: string } = {},
+) {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE lynx>',
+    '<lynx version="5.4.2">',
+    style === undefined ? '' : `<style><![CDATA[${style}]]></style>`,
+    '<script main-thread="true"><![CDATA[globalThis.__mts = 1;]]></script>',
+    background === undefined
+      ? ''
+      : `<script background="true"><![CDATA[${background}]]></script>`,
+    '</lynx>',
+  ].filter(Boolean).join('\n');
+}
+
+function build(source: string) {
+  const result = encodeLynxXML(source);
+  if (!result.success) {
+    throw new Error(`expected a bundle, got: ${result.message}`);
+  }
+  return result;
+}
+
+describe('XML markup document to web bundle', () => {
+  test('produces a bundle the decoder frames and reads', () => {
+    const { buffer } = build(
+      xml({
+        style: '.a{color:red}',
+        background: 'globalThis.__bts = 1;',
+      }),
+    );
+    const { version, sections } = readBundle(buffer);
+    expect(version).toBe(1);
+
+    // Every section a markup card can fill, and only those: the format carries
+    // no custom sections and no element templates.
+    expect([...sections.keys()].sort((a, b) => a - b)).toStrictEqual([
+      TemplateSectionLabel.Manifest,
+      TemplateSectionLabel.StyleInfo,
+      TemplateSectionLabel.LepusCode,
+      TemplateSectionLabel.CustomSections,
+      TemplateSectionLabel.Configurations,
+    ].sort((a, b) => a - b));
+
+    const config = readJSONSection(
+      sections.get(TemplateSectionLabel.Configurations)!,
+    );
+    expect(config).toMatchObject({
+      cardType: 'react',
+      isLazy: 'false',
+      enableCSSSelector: 'true',
+      enableRemoveCSSScope: 'true',
+      defaultDisplayLinear: 'false',
+      defaultOverflowVisible: 'false',
+      enableJSDataProcessor: 'false',
+    });
+
+    // The main-thread script rides the `root` lepus chunk.
+    expect(readStringMap(sections.get(TemplateSectionLabel.LepusCode)!))
+      .toStrictEqual({ root: 'globalThis.__mts = 1;' });
+    // The background script rides the manifest, verbatim.
+    expect(readStringMap(sections.get(TemplateSectionLabel.Manifest)!))
+      .toStrictEqual({ '/app-service.js': 'globalThis.__bts = 1;' });
+
+    const { css } = decodeStyle(
+      sections.get(TemplateSectionLabel.StyleInfo)!,
+      config,
+    );
+    expect(css).toContain('color:red');
+  });
+
+  test('omits the sections an XML document cannot fill', () => {
+    // No `<style>` and no background script: the encoder must still frame a
+    // readable bundle rather than emit an empty or malformed section.
+    const { buffer } = build(xml());
+    const { sections } = readBundle(buffer);
+    expect(readStringMap(sections.get(TemplateSectionLabel.Manifest)!))
+      .toStrictEqual({});
+    expect(
+      readJSONSection(sections.get(TemplateSectionLabel.CustomSections)!),
+    ).toStrictEqual({});
+    expect(sections.has(TemplateSectionLabel.ElementTemplates)).toBe(false);
+  });
+
+  test('reports a malformed document instead of throwing', () => {
+    const result = encodeLynxXML('<lynx>no closing tag');
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error('unreachable');
+    }
+    expect(result.message).toMatch(/invalid TemplateBundle XML at offset \d+:/);
+  });
+
+  describe('the style pipeline the bundle path unlocks', () => {
+    test('translates Lynx layout properties through the real decoder', () => {
+      // `display: linear` is not web CSS - a browser discards the value and
+      // falls back to `block`. Because the bundle carries tokenized rules, the
+      // Rust style transformer runs and turns it into custom properties plus a
+      // real `display`.
+      const { buffer } = build(
+        xml({ style: '.row{display:linear;linear-direction:row}' }),
+      );
+      const { sections } = readBundle(buffer);
+      const config = readJSONSection(
+        sections.get(TemplateSectionLabel.Configurations)!,
+      );
+      const { css } = decodeStyle(
+        sections.get(TemplateSectionLabel.StyleInfo)!,
+        config,
+      );
+      expect(css).toContain('--lynx-display:linear');
+      expect(css).toContain('display:flex');
+      expect(css).toContain('--lynx-linear-orientation:horizontal');
+    });
+
+    test('rewrites rem, vw and vh when the host asks for it', () => {
+      const { buffer } = build(
+        xml({ style: '.a{padding:1rem;width:50vw;height:2vh}' }),
+      );
+      const { sections } = readBundle(buffer);
+      const config = readJSONSection(
+        sections.get(TemplateSectionLabel.Configurations)!,
+      );
+      const section = sections.get(TemplateSectionLabel.StyleInfo)!;
+
+      const on = decodeStyle(section, config, {
+        transformREM: true,
+        transformVW: true,
+        transformVH: true,
+      });
+      expect(on.css).toContain('padding:calc(1 * var(--rem-unit))');
+      expect(on.css).toContain('width:calc(50 * var(--vw-unit))');
+      expect(on.css).toContain('height:calc(2 * var(--vh-unit))');
+
+      // Same bytes, transforms off: the units survive. Proves the rewrite is the
+      // decoder's doing and is driven by the host, not baked into the bundle.
+      const off = decodeStyle(section, config);
+      expect(off.css).toContain('padding:1rem');
+      expect(off.css).toContain('width:50vw');
+    });
+
+    test('rewrites :root, which never matches inside a shadow root', () => {
+      const { buffer } = build(
+        xml({ style: ':root{--accent:#f00;font-size:14px}' }),
+      );
+      const { sections } = readBundle(buffer);
+      const config = readJSONSection(
+        sections.get(TemplateSectionLabel.Configurations)!,
+      );
+      const { css } = decodeStyle(
+        sections.get(TemplateSectionLabel.StyleInfo)!,
+        config,
+      );
+      expect(css).toContain('[part="page"]');
+      expect(css).not.toContain(':root');
+    });
+
+    test('restores var() rather than shipping the interchange placeholder', () => {
+      // `css-serializer` rewrites `var()` into `{{--name}}` as its own wire
+      // format; unrestored it would reach the engine as literal text.
+      const { buffer } = build(
+        xml({
+          style:
+            '.a{background-color:var(--accent);border:var(--w, 2px) solid red}',
+        }),
+      );
+      const { sections } = readBundle(buffer);
+      const config = readJSONSection(
+        sections.get(TemplateSectionLabel.Configurations)!,
+      );
+      const { css } = decodeStyle(
+        sections.get(TemplateSectionLabel.StyleInfo)!,
+        config,
+      );
+      expect(css).toContain('var(--accent)');
+      expect(css).toContain('var(--w, 2px)');
+      expect(css).not.toContain('{{');
+    });
+
+    test('carries @keyframes and @font-face, the two group kinds Lynx has', () => {
+      const { buffer, discarded } = build(
+        xml({
+          style: '@keyframes spin{from{opacity:0}to{opacity:1}}'
+            + '@font-face{font-family:CardFont;src:url(a.woff2)}',
+        }),
+      );
+      expect(discarded).toStrictEqual([]);
+      const { sections } = readBundle(buffer);
+      const config = readJSONSection(
+        sections.get(TemplateSectionLabel.Configurations)!,
+      );
+      const { css, fontFace } = decodeStyle(
+        sections.get(TemplateSectionLabel.StyleInfo)!,
+        config,
+      );
+      expect(css).toContain('@keyframes spin');
+      expect(css).toContain('opacity:1');
+      expect(fontFace).toContain('CardFont');
+    });
+  });
+
+  /**
+   * Specified behaviour, not a defect.
+   *
+   * Lynx's style format has three rule kinds and no conditional group, so
+   * `@media` / `@supports` / `@layer` are not Lynx features on any platform, and
+   * the CSS parser has no case for the rest. Carrying them on web would give a
+   * markup card a capability a ReactLynx card does not have, so they are dropped
+   * - and reported, so the author is not left guessing.
+   */
+  describe('at-rules Lynx does not support are dropped and reported', () => {
+    const cases: Record<
+      string,
+      { css: string; reason: 'unrepresentable' | 'unsupported'; gone: string }
+    > = {
+      '@media': {
+        css: '@media (max-width:600px){.i{color:navy}}',
+        reason: 'unrepresentable',
+        gone: 'navy',
+      },
+      '@supports': {
+        css: '@supports (display:grid){.i{color:teal}}',
+        reason: 'unrepresentable',
+        gone: 'teal',
+      },
+      '@layer': {
+        css: '@layer base{.i{color:olive}}',
+        reason: 'unrepresentable',
+        gone: 'olive',
+      },
+      '@container': {
+        css: '@container (min-width:1px){.i{color:maroon}}',
+        reason: 'unsupported',
+        gone: 'maroon',
+      },
+      '@property': {
+        css: '@property --x{syntax:"<length>";inherits:false}',
+        reason: 'unsupported',
+        gone: 'syntax',
+      },
+      '@scope': {
+        css: '@scope (.a){.i{color:peru}}',
+        reason: 'unsupported',
+        gone: 'peru',
+      },
+      '@page': {
+        css: '@page{margin:1cm}',
+        reason: 'unsupported',
+        gone: '1cm',
+      },
+      '@charset': {
+        css: '@charset "utf-8";',
+        reason: 'unsupported',
+        gone: 'utf-8',
+      },
+      '@namespace': {
+        css: '@namespace svg url(http://www.w3.org/2000/svg);',
+        reason: 'unsupported',
+        gone: 'w3.org',
+      },
+      '@starting-style': {
+        css: '@starting-style{.i{opacity:0}}',
+        reason: 'unsupported',
+        gone: 'opacity',
+      },
+      'an at-rule newer than the parser': {
+        css: '@future-thing x{.i{color:plum}}',
+        reason: 'unsupported',
+        gone: 'plum',
+      },
+    };
+
+    for (const [name, { css: atRule, reason, gone }] of Object.entries(cases)) {
+      test(`drops ${name} and says so`, () => {
+        const source = xml({
+          style: `.before{color:red}${atRule}.after{color:black}`,
+        });
+        const { buffer, discarded } = build(source);
+
+        // Reported once, with the right reason.
+        expect(discarded).toStrictEqual([{
+          name: name.startsWith('@') ? name : '@future-thing',
+          reason,
+        }]);
+
+        const { sections } = readBundle(buffer);
+        const config = readJSONSection(
+          sections.get(TemplateSectionLabel.Configurations)!,
+        );
+        const { css } = decodeStyle(
+          sections.get(TemplateSectionLabel.StyleInfo)!,
+          config,
+        );
+        // The rules around it are untouched...
+        expect(css).toContain('color:red');
+        expect(css).toContain('color:black');
+        // ... and nothing from inside it was promoted to top level.
+        expect(css).not.toContain(gone);
+        expect(css).not.toContain('.i');
+      });
+    }
+
+    test('drops a URL @import instead of failing the build', () => {
+      // `encodeCSS` throws on a non-numeric css id, so an unfiltered
+      // `@import url(...)` would abort bundle production. It is not a Lynx
+      // feature for this format - a markup card owns one stylesheet and has
+      // nothing to link to - so it is dropped like the rest.
+      const source = xml({
+        style: '@import url("theme.css");\n.a{color:red}',
+      });
+      expect(() => build(source)).not.toThrow();
+      const { buffer, discarded } = build(source);
+      // Reported, so the author is not left wondering where the import went.
+      expect(discarded).toStrictEqual([
+        { name: '@import', reason: 'unrepresentable' },
+      ]);
+      const { sections } = readBundle(buffer);
+      const config = readJSONSection(
+        sections.get(TemplateSectionLabel.Configurations)!,
+      );
+      const { css } = decodeStyle(
+        sections.get(TemplateSectionLabel.StyleInfo)!,
+        config,
+      );
+      expect(css).toContain('color:red');
+      expect(css).not.toContain('theme.css');
+    });
+
+    test('keeps a numeric @import, which a build step does emit', () => {
+      // `@import` itself is representable - the tokenized channel links one
+      // numeric css id to another. Only the URL form is not, so the numeric form
+      // must survive untouched.
+      const { discarded } = build(
+        xml({ style: '@import url("1");\n.a{color:red}' }),
+      );
+      expect(discarded).toStrictEqual([]);
+    });
+
+    test('reports a hollow group, which looks preserved but is not', () => {
+      // The nastiest shape: `css-serializer` produces a `MediaRule` with zero
+      // children and an empty `errors` array, so the group appears to have been
+      // understood while its contents are already gone.
+      const style = '@media screen{@font-face{font-family:CardFont}}';
+      const parsed = CSS.parse(style);
+      expect(parsed.errors).toStrictEqual([]);
+      expect(parsed.root).toStrictEqual([{
+        type: 'MediaRule',
+        prelude: { value: 'screen', loc: { line: 1, column: 14 } },
+        rules: [],
+      }]);
+
+      const { discarded } = build(xml({ style }));
+      // Both losses are named, so the report matches what actually happened.
+      expect(discarded).toStrictEqual([
+        { name: '@media', reason: 'unrepresentable' },
+      ]);
+    });
+
+    test('names every distinct at-rule once, at any depth', () => {
+      const found = diagnoseDiscardedAtRules(
+        '@media screen{.a{color:red}}'
+          + '@media print{.b{color:red}}'
+          + '@supports (display:grid){@container (min-width:1px){.c{color:red}}}'
+          + '@keyframes k{from{opacity:0}}',
+      );
+      expect(found).toStrictEqual([
+        { name: '@media', reason: 'unrepresentable' },
+        { name: '@supports', reason: 'unrepresentable' },
+        // Nested inside the group, and still reported.
+        { name: '@container', reason: 'unsupported' },
+      ]);
+    });
+  });
+
+  describe('the real world fixture', () => {
+    const source = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        'fixtures',
+        'markup-card.xml',
+      ),
+      'utf-8',
+    );
+
+    test('builds into a bundle with every section populated', () => {
+      const { buffer, discarded } = build(source);
+      // A hand-authored card written for Lynx uses nothing unsupported.
+      expect(discarded).toStrictEqual([]);
+
+      const { sections } = readBundle(buffer);
+      const config = readJSONSection(
+        sections.get(TemplateSectionLabel.Configurations)!,
+      );
+      expect(readStringMap(sections.get(TemplateSectionLabel.LepusCode)!).root)
+        .toContain('__RenderPage');
+      expect(
+        readStringMap(sections.get(TemplateSectionLabel.Manifest)!)[
+          '/app-service.js'
+        ],
+      ).toBeTypeOf('string');
+
+      const { css } = decodeStyle(
+        sections.get(TemplateSectionLabel.StyleInfo)!,
+        config,
+        { transformREM: true, transformVW: true, transformVH: true },
+      );
+      // The card's own custom property survives, and its rem paddings are
+      // rewritten against the lynx-view box.
+      expect(css).toContain('--accent');
+      expect(css).toContain('var(--rem-unit)');
+      // This fixture scopes to `.page` rather than `:root` (see its own comment),
+      // so the selector rewrite to check for is the css-scope suffix.
+      expect(css).toContain('.page:not([l-e-name])');
+    });
+
+    test('is deterministic', () => {
+      // A build artifact has to be reproducible, or caching downstream breaks.
+      const a = build(source).buffer;
+      const b = build(source).buffer;
+      expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+    });
+  });
+
+  test('keeps the JSON encode path reachable and unchanged in shape', () => {
+    // `xmlToTasmJSON` must produce the very shape `encode` already accepts, with
+    // no markup-specific field, or the two paths have silently diverged.
+    const result = xmlToTasmJSON(xml({ style: '.a{color:red}' }));
+    if (!result.success) {
+      throw new Error('unreachable');
+    }
+    expect(Object.keys(result.tasmJSON).sort()).toStrictEqual([
+      'appType',
+      'cardType',
+      'customSections',
+      'elementTemplates',
+      'lepusCode',
+      'manifest',
+      'pageConfig',
+      'styleInfo',
+    ]);
+  });
+});

--- a/packages/web-platform/web-core/ts/common/xml/parseLynxXML.ts
+++ b/packages/web-platform/web-core/ts/common/xml/parseLynxXML.ts
@@ -1,0 +1,545 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * A zero-dependency parser for the single file Lynx XML markup format.
+ *
+ * The behavior of this module mirrors the reference parser in the Lynx engine,
+ * so that a document accepted here is accepted there and vice versa. It is
+ * written without `DOMParser` or any third party XML library so that it can run
+ * inside a Web Worker.
+ *
+ * The grammar accepted here is intentionally tiny:
+ *
+ * ```xml
+ * <?xml version="1.0" encoding="UTF-8"?>
+ * <!DOCTYPE lynx>
+ * <lynx version="5.4.2">
+ * <style><![CDATA[ ... ]]></style>
+ * <script main-thread="true"><![CDATA[ ... ]]></script>
+ * <script background="true"><![CDATA[ ... ]]></script>
+ * </lynx>
+ * ```
+ */
+
+/**
+ * The structured error describing why a document could not be parsed.
+ */
+export interface LynxXMLParseError {
+  /**
+   * The offset inside the source where the failure was detected, counted in
+   * JavaScript string indices, i.e. UTF-16 code units. Note that the reference
+   * implementation counts UTF-8 bytes instead, so for documents containing
+   * non-ASCII text before the failure the two numbers differ.
+   */
+  offset: number;
+  /**
+   * The human readable reason, without the offset prefix.
+   */
+  message: string;
+  /**
+   * The full message, formatted exactly like the reference implementation:
+   * `invalid TemplateBundle XML at offset <offset>: <message>`.
+   */
+  formattedMessage: string;
+}
+
+/**
+ * The result of a successful parse.
+ */
+export interface LynxXMLParseSuccess {
+  success: true;
+  /**
+   * The content of the `<style>` section. `undefined` when the document has no
+   * `<style>` section, which is legal.
+   */
+  style: string | undefined;
+  /**
+   * The content of the `<script main-thread>` section. Always present, a
+   * document without it is rejected.
+   */
+  mainThreadScript: string;
+  /**
+   * The content of the `<script background>` section. `undefined` when the
+   * document has no background script section, which is legal.
+   */
+  backgroundThreadScript: string | undefined;
+}
+
+/**
+ * The result of a failed parse.
+ */
+export interface LynxXMLParseFailure {
+  success: false;
+  error: LynxXMLParseError;
+}
+
+/**
+ * The discriminated union returned by {@link parseLynxXML}. Errors are returned
+ * instead of thrown so that callers can forward them as `error` events.
+ */
+export type LynxXMLParseResult = LynxXMLParseSuccess | LynxXMLParseFailure;
+
+const xmlDeclarationStart = '<?xml';
+const xmlDeclarationEnd = '?>';
+const commentStart = '<!--';
+const commentEnd = '-->';
+const cdataStart = '<![CDATA[';
+const cdataEnd = ']]>';
+const lynxRootClosingTag = '</lynx>';
+const utf8ByteOrderMark = '\uFEFF';
+
+/**
+ * The whitespace set of the reference implementation. Note that this is narrower than
+ * what `String.prototype.trim` considers whitespace, therefore all trimming in
+ * this module goes through {@link trimASCIIWhitespace}.
+ */
+function isASCIIWhitespace(value: string): boolean {
+  return value === ' ' || value === '\t' || value === '\n' || value === '\r'
+    || value === '\f';
+}
+
+function trimASCIIWhitespace(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && isASCIIWhitespace(value[start]!)) {
+    start++;
+  }
+  while (end > start && isASCIIWhitespace(value[end - 1]!)) {
+    end--;
+  }
+  return value.slice(start, end);
+}
+
+/**
+ * Returns the index of the first ASCII whitespace, or `-1`.
+ */
+function findFirstASCIIWhitespace(value: string): number {
+  for (let index = 0; index < value.length; index++) {
+    if (isASCIIWhitespace(value[index]!)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function equalsASCIICaseInsensitive(lhs: string, rhs: string): boolean {
+  return lhs.length === rhs.length
+    && lhs.toLowerCase() === rhs.toLowerCase();
+}
+
+function isOpeningTag(
+  source: string,
+  position: number,
+  tagName: string,
+): boolean {
+  if (
+    position >= source.length || source[position] !== '<'
+    || !source.startsWith(tagName, position + 1)
+  ) {
+    return false;
+  }
+  const boundary = position + tagName.length + 1;
+  return boundary < source.length
+    && (source[boundary] === '>' || isASCIIWhitespace(source[boundary]!));
+}
+
+/**
+ * Matches a boolean attribute written as `name`, `name="true"` or `name='true'`
+ * and nothing else. The attribute has to be the only attribute of the tag.
+ */
+function isBooleanAttribute(
+  attributes: string,
+  attributeName: string,
+): boolean {
+  if (attributes === attributeName) {
+    return true;
+  }
+  if (!attributes.startsWith(attributeName)) {
+    return false;
+  }
+  let rest = trimASCIIWhitespace(attributes.slice(attributeName.length));
+  if (rest.length === 0 || rest[0] !== '=') {
+    return false;
+  }
+  rest = trimASCIIWhitespace(rest.slice(1));
+  return rest === '"true"' || rest === '\'true\'';
+}
+
+/**
+ * Matches exactly one `version="..."` attribute with a non-empty value.
+ */
+function isVersionAttribute(attributes: string): boolean {
+  if (attributes.length === 0) {
+    return false;
+  }
+  const version = 'version';
+  if (!attributes.startsWith(version)) {
+    return false;
+  }
+  let rest = trimASCIIWhitespace(attributes.slice(version.length));
+  if (rest.length === 0 || rest[0] !== '=') {
+    return false;
+  }
+  rest = trimASCIIWhitespace(rest.slice(1));
+  const quote = rest[0];
+  if (rest.length < 3 || (quote !== '"' && quote !== '\'')) {
+    return false;
+  }
+  const closingQuote = rest.indexOf(quote, 1);
+  return closingQuote === rest.length - 1 && closingQuote > 1;
+}
+
+interface SectionSlot {
+  assign: (content: string) => void;
+  isSeen: () => boolean;
+}
+
+class LynxXMLParser {
+  #source: string;
+  #position = 0;
+  #style: string | undefined;
+  #mainThreadScript: string | undefined;
+  #backgroundThreadScript: string | undefined;
+  #rootClosed = false;
+  #error: LynxXMLParseError | undefined;
+
+  constructor(source: string) {
+    this.#source = source;
+  }
+
+  parse(): LynxXMLParseResult {
+    const source = this.#source;
+    if (source.startsWith(utf8ByteOrderMark)) {
+      this.#position += utf8ByteOrderMark.length;
+    }
+    if (!this.#consumeIgnorable()) {
+      return this.#result();
+    }
+    if (source.startsWith(xmlDeclarationStart, this.#position)) {
+      const declarationEnd = source.indexOf(
+        xmlDeclarationEnd,
+        this.#position + xmlDeclarationStart.length,
+      );
+      if (declarationEnd === -1) {
+        this.#fail(this.#position, 'unterminated XML declaration');
+        return this.#result();
+      }
+      this.#position = declarationEnd + xmlDeclarationEnd.length;
+      if (!this.#consumeIgnorable()) {
+        return this.#result();
+      }
+    }
+    if (source.startsWith('<!', this.#position)) {
+      if (!this.#consumeDoctype()) {
+        return this.#result();
+      }
+      if (!this.#consumeIgnorable()) {
+        return this.#result();
+      }
+    }
+    if (!isOpeningTag(source, this.#position, 'lynx')) {
+      this.#fail(
+        this.#position,
+        'expected \'<lynx version="...">\' root element',
+      );
+      return this.#result();
+    }
+    if (!this.#consumeRootStart()) {
+      return this.#result();
+    }
+
+    for (;;) {
+      if (!this.#consumeIgnorable()) {
+        return this.#result();
+      }
+      if (source.startsWith(lynxRootClosingTag, this.#position)) {
+        this.#position += lynxRootClosingTag.length;
+        this.#rootClosed = true;
+        break;
+      }
+      if (this.#position === source.length) {
+        break;
+      }
+      if (!this.#consumeSection()) {
+        return this.#result();
+      }
+    }
+
+    if (!this.#rootClosed) {
+      this.#fail(this.#position, 'missing closing tag \'</lynx>\'');
+      return this.#result();
+    }
+    if (!this.#consumeIgnorable()) {
+      return this.#result();
+    }
+    if (this.#position !== source.length) {
+      this.#fail(this.#position, 'unexpected content after \'</lynx>\'');
+      return this.#result();
+    }
+    if (this.#mainThreadScript === undefined) {
+      this.#fail(this.#position, 'missing \'<script main-thread>\' section');
+      return this.#result();
+    }
+    return {
+      success: true,
+      style: this.#style,
+      mainThreadScript: this.#mainThreadScript,
+      backgroundThreadScript: this.#backgroundThreadScript,
+    };
+  }
+
+  /**
+   * Skips ASCII whitespace and comments. Comments may appear anywhere an
+   * ignorable token is allowed.
+   */
+  #consumeIgnorable(): boolean {
+    const source = this.#source;
+    for (;;) {
+      while (
+        this.#position < source.length
+        && isASCIIWhitespace(source[this.#position]!)
+      ) {
+        this.#position++;
+      }
+      if (!source.startsWith(commentStart, this.#position)) {
+        return true;
+      }
+      const foundCommentEnd = source.indexOf(
+        commentEnd,
+        this.#position + commentStart.length,
+      );
+      if (foundCommentEnd === -1) {
+        return this.#fail(this.#position, 'unterminated comment');
+      }
+      this.#position = foundCommentEnd + commentEnd.length;
+    }
+  }
+
+  #consumeDoctype(): boolean {
+    const source = this.#source;
+    const doctypeEnd = source.indexOf('>', this.#position + 2);
+    if (doctypeEnd === -1) {
+      return this.#fail(this.#position, 'unterminated doctype declaration');
+    }
+    const declaration = trimASCIIWhitespace(
+      source.slice(this.#position + 2, doctypeEnd),
+    );
+    const keywordEnd = findFirstASCIIWhitespace(declaration);
+    if (
+      keywordEnd === -1
+      || !equalsASCIICaseInsensitive(
+        declaration.slice(0, keywordEnd),
+        'doctype',
+      )
+      || !equalsASCIICaseInsensitive(
+        trimASCIIWhitespace(declaration.slice(keywordEnd)),
+        'lynx',
+      )
+    ) {
+      return this.#fail(this.#position, 'expected \'<!doctype lynx>\'');
+    }
+    this.#position = doctypeEnd + 1;
+    return true;
+  }
+
+  #consumeRootStart(): boolean {
+    const source = this.#source;
+    const openingTagEnd = source.indexOf('>', this.#position + 1);
+    if (openingTagEnd === -1) {
+      return this.#fail(this.#position, 'unterminated \'<lynx>\' opening tag');
+    }
+    const openingTag = trimASCIIWhitespace(
+      source.slice(this.#position + 1, openingTagEnd),
+    );
+    const tagNameEnd = findFirstASCIIWhitespace(openingTag);
+    const attributes = tagNameEnd === -1
+      ? ''
+      : trimASCIIWhitespace(openingTag.slice(tagNameEnd));
+    if (!isVersionAttribute(attributes)) {
+      return this.#fail(
+        this.#position,
+        '\'<lynx>\' requires exactly one non-empty \'version\' attribute',
+      );
+    }
+    this.#position = openingTagEnd + 1;
+    return true;
+  }
+
+  /**
+   * Unwraps an optional CDATA wrapper. Bare (non-CDATA) text is kept verbatim,
+   * including the surrounding whitespace.
+   */
+  #assignSectionContent(
+    slot: SectionSlot,
+    content: string,
+    contentStart: number,
+  ): boolean {
+    const trimmed = trimASCIIWhitespace(content);
+    if (!trimmed.startsWith(cdataStart)) {
+      slot.assign(content);
+      return true;
+    }
+    if (
+      trimmed.length < cdataStart.length + cdataEnd.length
+      || !trimmed.endsWith(cdataEnd)
+    ) {
+      return this.#fail(contentStart, 'unterminated CDATA section');
+    }
+    const cdata = trimmed.slice(
+      cdataStart.length,
+      trimmed.length - cdataEnd.length,
+    );
+    if (cdata.includes(cdataEnd)) {
+      return this.#fail(
+        contentStart,
+        'unexpected content after the CDATA section',
+      );
+    }
+    slot.assign(cdata);
+    return true;
+  }
+
+  #consumeSection(): boolean {
+    const source = this.#source;
+    const sectionStart = this.#position;
+    if (source[this.#position] !== '<') {
+      return this.#fail(this.#position, 'unexpected content outside a section');
+    }
+    const openingTagEnd = source.indexOf('>', this.#position + 1);
+    if (openingTagEnd === -1) {
+      return this.#fail(this.#position, 'unterminated opening tag');
+    }
+    const openingTag = trimASCIIWhitespace(
+      source.slice(this.#position + 1, openingTagEnd),
+    );
+    if (openingTag.length === 0 || openingTag[0] === '/') {
+      return this.#fail(this.#position, 'unexpected closing tag');
+    }
+    const tagNameEnd = findFirstASCIIWhitespace(openingTag);
+    const tagName = tagNameEnd === -1
+      ? openingTag
+      : openingTag.slice(0, tagNameEnd);
+    const attributes = tagNameEnd === -1
+      ? ''
+      : trimASCIIWhitespace(openingTag.slice(tagNameEnd));
+
+    let closingTag: string;
+    let slot: SectionSlot;
+    if (tagName === 'style') {
+      if (attributes.length !== 0) {
+        return this.#fail(
+          sectionStart,
+          '\'<style>\' does not accept attributes',
+        );
+      }
+      closingTag = '</style>';
+      slot = {
+        assign: (content) => {
+          this.#style = content;
+        },
+        isSeen: () => this.#style !== undefined,
+      };
+    } else if (tagName === 'script') {
+      closingTag = '</script>';
+      if (isBooleanAttribute(attributes, 'main-thread')) {
+        slot = {
+          assign: (content) => {
+            this.#mainThreadScript = content;
+          },
+          isSeen: () => this.#mainThreadScript !== undefined,
+        };
+      } else if (isBooleanAttribute(attributes, 'background')) {
+        slot = {
+          assign: (content) => {
+            this.#backgroundThreadScript = content;
+          },
+          isSeen: () => this.#backgroundThreadScript !== undefined,
+        };
+      } else {
+        return this.#fail(
+          sectionStart,
+          '\'<script>\' requires exactly one of \'main-thread\' or \'background\'',
+        );
+      }
+    } else {
+      return this.#fail(
+        sectionStart,
+        `unsupported top-level tag '<${tagName}>'`,
+      );
+    }
+
+    if (slot.isSeen()) {
+      return this.#fail(sectionStart, `duplicate '<${openingTag}>' section`);
+    }
+
+    const contentStart = openingTagEnd + 1;
+    let closingTagSearchStart = contentStart;
+    while (
+      closingTagSearchStart < source.length
+      && isASCIIWhitespace(source[closingTagSearchStart]!)
+    ) {
+      closingTagSearchStart++;
+    }
+    if (source.startsWith(cdataStart, closingTagSearchStart)) {
+      const foundCdataEnd = source.indexOf(
+        cdataEnd,
+        closingTagSearchStart + cdataStart.length,
+      );
+      if (foundCdataEnd === -1) {
+        return this.#fail(closingTagSearchStart, 'unterminated CDATA section');
+      }
+      closingTagSearchStart = foundCdataEnd + cdataEnd.length;
+    }
+    const closingTagStart = source.indexOf(closingTag, closingTagSearchStart);
+    if (closingTagStart === -1) {
+      return this.#fail(contentStart, `missing closing tag '${closingTag}'`);
+    }
+    if (
+      !this.#assignSectionContent(
+        slot,
+        source.slice(contentStart, closingTagStart),
+        contentStart,
+      )
+    ) {
+      return false;
+    }
+    this.#position = closingTagStart + closingTag.length;
+    return true;
+  }
+
+  #fail(offset: number, message: string): false {
+    this.#error = {
+      offset,
+      message,
+      formattedMessage:
+        `invalid TemplateBundle XML at offset ${offset}: ${message}`,
+    };
+    return false;
+  }
+
+  #result(): LynxXMLParseFailure {
+    return {
+      success: false,
+      error: this.#error ?? {
+        offset: this.#position,
+        message: 'unknown error',
+        formattedMessage:
+          `invalid TemplateBundle XML at offset ${this.#position}: unknown error`,
+      },
+    };
+  }
+}
+
+/**
+ * Parses a single file Lynx XML markup document into its three source sections.
+ *
+ * This never throws for malformed input: inspect the `success` discriminant of
+ * the returned {@link LynxXMLParseResult} instead.
+ *
+ * @param source - The whole XML document. A leading UTF-8 BOM is tolerated.
+ */
+export function parseLynxXML(source: string): LynxXMLParseResult {
+  return new LynxXMLParser(source).parse();
+}

--- a/packages/web-platform/web-core/ts/encode/index.ts
+++ b/packages/web-platform/web-core/ts/encode/index.ts
@@ -4,3 +4,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 export { encode, type TasmJSONInfo } from './webEncoder.js';
+export {
+  diagnoseDiscardedAtRules,
+  type DiscardedAtRule,
+  encodeLynxXML,
+  xmlToTasmJSON,
+  type XMLToTasmJSONResult,
+} from './xmlToTasmJSON.js';

--- a/packages/web-platform/web-core/ts/encode/xmlToTasmJSON.ts
+++ b/packages/web-platform/web-core/ts/encode/xmlToTasmJSON.ts
@@ -105,8 +105,10 @@ export interface DiscardedAtRule {
    * `unrepresentable` - Lynx's style format has no rule kind for it.
    * `unsupported` - the CSS parser has no case for it, so it never even reached
    * this module. Its contents are gone with it.
+   * `unresolvable` - the construct exists in the format but this document cannot
+   * express it, which currently means only `@import` with a URL.
    */
-  reason: 'unrepresentable' | 'unsupported';
+  reason: 'unrepresentable' | 'unsupported' | 'unresolvable';
 }
 
 /**
@@ -259,7 +261,7 @@ export function xmlToTasmJSON(source: string): XMLToTasmJSONResult {
       // Only detectable from the parsed node: whether an `@import` is
       // representable depends on its resolved href, which the source scan in
       // `diagnoseDiscardedAtRules` deliberately does not try to reproduce.
-      discarded.push({ name: '@import', reason: 'unrepresentable' });
+      discarded.push({ name: '@import', reason: 'unresolvable' });
     }
   }
 
@@ -312,8 +314,10 @@ export function encodeLynxXML(
   for (const { name, reason } of result.discarded) {
     console.warn(
       reason === 'unrepresentable'
-        ? `[lynx-web] ${name} has no representation in the Lynx style format and was dropped from the bundle. It is not supported on any Lynx platform.`
-        : `[lynx-web] ${name} is not supported by the Lynx CSS parser and was dropped from the bundle, along with any rules inside it.`,
+        ? `[lynx-web] ${name} has no representation in the Lynx style format and was dropped from the bundle, along with the rules inside it. It is not supported on any Lynx platform.`
+        : reason === 'unsupported'
+        ? `[lynx-web] ${name} is not recognised by the Lynx CSS parser and was dropped from the bundle, along with the rules inside it.`
+        : `[lynx-web] ${name} with a URL cannot be resolved for a markup card, which owns a single stylesheet, and was dropped from the bundle.`,
     );
   }
 

--- a/packages/web-platform/web-core/ts/encode/xmlToTasmJSON.ts
+++ b/packages/web-platform/web-core/ts/encode/xmlToTasmJSON.ts
@@ -1,0 +1,325 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Turns a single file Lynx XML markup document into the input
+ * {@link encode} takes, so that a hand-written card can be built into an
+ * ordinary `.web.bundle` instead of needing a load-time bypass.
+ *
+ * The whole point of going through {@link encode} is that the bundle a markup
+ * card produces is indistinguishable from the bundle a ReactLynx build produces:
+ * same magic header, same sections, same rkyv-encoded `StyleInfo`, and therefore
+ * the same decoder on the other side. Nothing downstream has to know the card
+ * was hand-written.
+ *
+ * ## Unsupported at-rules are discarded, deliberately
+ *
+ * Lynx's binary style format has three rule kinds - `Declaration`, `FontFace`
+ * and `KeyFrames` (`raw_style_info.rs`). There is no representation for a
+ * conditional group, so `@media`, `@supports` and `@layer` are not Lynx
+ * features: a ReactLynx card cannot use them either, on any platform. Discarding
+ * them here is what keeps a markup card's capabilities equal to a built card's,
+ * rather than giving web-only cards a feature native does not have.
+ *
+ * `@lynx-js/css-serializer` already discards most of the rest before this module
+ * sees anything - `@container`, `@scope`, `@starting-style`, `@property`,
+ * `@page`, `@charset`, `@namespace` and anything newer than its dispatch, all
+ * with an empty `errors` array. That is the same intent, so this module does not
+ * try to recover them; it only makes the outcome visible.
+ *
+ * Because none of it is an error, the only failure mode would be silence: an
+ * author writes `@property --x` and gets a card that renders wrong with nothing
+ * to go on. So every discarded at-rule is reported through
+ * {@link diagnoseDiscardedAtRules}, once per kind. This module runs inside the
+ * build (`@lynx-js/web-core/encode` is Node-only - it loads the `binary/encode`
+ * wasm through `node:fs` glue), so the report is a build-time diagnostic and
+ * never reaches a production browser runtime; that is why it is unconditional
+ * rather than gated on a dev flag, of which this package has none.
+ */
+
+import * as CSS from '@lynx-js/css-serializer';
+
+import { parseLynxXML } from '../common/xml/parseLynxXML.js';
+import { encode, type TasmJSONInfo } from './webEncoder.js';
+
+/**
+ * The `manifest` key a card's background chunk is expected to live under. The
+ * bts realm resolves the chunk through `templateCache['/app-service.js']`, see
+ * `createChunkLoading`.
+ */
+const backgroundChunkPath = '/app-service.js';
+
+/**
+ * The `styleInfo` css id a card's own (non component scoped) rules live under.
+ *
+ * A markup card owns exactly one stylesheet, so this is the only id it ever
+ * uses - which is also why `@import` cannot mean anything here, see
+ * {@link stripUnrepresentable}.
+ */
+const cardCSSId = '0';
+
+/**
+ * The page config a markup card is built with.
+ *
+ * The values mirror `LynxTemplateBundle::Build()` in the engine, which
+ * hard-codes the config for XML bundles rather than reading it from the document
+ * - the markup format has no config section: `app_type = CARD`,
+ * `front_end_dsl = REACT`, `enable_css_selector = true`,
+ * `enable_css_parser = false`, `enable_css_variable = true`,
+ * `enable_fiber_arch = true`.
+ *
+ * The web-only keys have no engine counterpart and follow `buildLynxTemplate()`
+ * in `packages/repl`, the established precedent for rendering a hand-written
+ * card on web:
+ *
+ * - `enableRemoveCSSScope: true` - a markup card has a single global stylesheet
+ *   and no per-component css scoping, so scoping must not be applied.
+ * - `defaultDisplayLinear: false` - **differs from `packages/repl`, which passes
+ *   `true`.** The engine is followed instead: `Build()` never sets this field and
+ *   the generated `PageConfig` declares `bool default_display_linear_{false}`,
+ *   so a native XML bundle renders with `false`. It is also what hand-written
+ *   CSS expects, since a document's `flex-direction` / `display: flex` rules
+ *   assume web box semantics rather than an implicit linear container.
+ * - `defaultOverflowVisible: false` - likewise, `overflow: hidden` is the Lynx
+ *   default and hand-written CSS opts in explicitly.
+ * - `enableJSDataProcessor: false` - the markup format has no data processor.
+ */
+const markupPageConfig: Record<string, string> = {
+  enableCSSSelector: 'true',
+  enableRemoveCSSScope: 'true',
+  defaultDisplayLinear: 'false',
+  defaultOverflowVisible: 'false',
+  enableJSDataProcessor: 'false',
+};
+
+/**
+ * A construct the bundle format cannot carry, reported rather than hidden.
+ */
+export interface DiscardedAtRule {
+  /** The at-rule's name, with its `@`, e.g. `@media`. */
+  name: string;
+  /**
+   * Why it cannot be carried.
+   *
+   * `unrepresentable` - Lynx's style format has no rule kind for it.
+   * `unsupported` - the CSS parser has no case for it, so it never even reached
+   * this module. Its contents are gone with it.
+   */
+  reason: 'unrepresentable' | 'unsupported';
+}
+
+/**
+ * The at-rules `css-serializer` turns into nodes. Anything else it drops, so
+ * anything else found in the source is reported as `unsupported`.
+ */
+const parsedAtRules = new Set([
+  'media',
+  'supports',
+  'layer',
+  'import',
+  'keyframes',
+  'font-face',
+]);
+
+/**
+ * The at-rules that parse but have no rule kind in the binary style format.
+ */
+const unrepresentableAtRules = new Set(['media', 'supports', 'layer']);
+
+/**
+ * Finds every at-rule in `source` that will not survive into the bundle.
+ *
+ * Needed because the two kinds of loss are invisible from different places: an
+ * `@media` node reaches {@link stripUnrepresentable} and can be counted there,
+ * but a `@property` never becomes a node at all, so the only way to know it was
+ * written is to look at the source. `css-serializer` re-exports the `css-tree`
+ * it already depends on, so this costs a parse but no new dependency.
+ *
+ * Reported at any nesting depth, since a group's contents are dropped with it.
+ */
+export function diagnoseDiscardedAtRules(source: string): DiscardedAtRule[] {
+  let ast: CSS.csstree.CssNode;
+  try {
+    ast = CSS.csstree.parse(source, {
+      parseValue: false,
+      parseAtrulePrelude: false,
+      parseCustomProperty: false,
+      parseRulePrelude: false,
+      positions: false,
+    });
+  } catch {
+    // A stylesheet that will not parse at all is a separate problem, reported by
+    // the caller when the conversion itself fails.
+    return [];
+  }
+
+  const seen = new Map<string, DiscardedAtRule>();
+  CSS.csstree.walk(ast, (node) => {
+    if (node.type !== 'Atrule') {
+      return;
+    }
+    const reason = !parsedAtRules.has(node.name)
+      ? 'unsupported'
+      : unrepresentableAtRules.has(node.name)
+      ? 'unrepresentable'
+      : undefined;
+    if (reason === undefined) {
+      return;
+    }
+    const name = `@${node.name}`;
+    if (!seen.has(name)) {
+      seen.set(name, { name, reason });
+    }
+  });
+  return [...seen.values()];
+}
+
+/**
+ * Removes the nodes {@link encode} cannot accept.
+ *
+ * Two of them, and both would otherwise be worse than a drop:
+ *
+ * - a group at-rule (`@media` / `@supports` / `@layer`) falls through
+ *   `encodeCSS`'s dispatch and is dropped there anyway, silently;
+ * - an `@import` whose href is not a numeric css id makes `encodeCSS` **throw**,
+ *   which would fail the whole build. A hand-written `@import url("theme.css")`
+ *   is exactly that: the tokenized channel can only link one numeric css id to
+ *   another, which is a build step's notion, and a markup card owns a single
+ *   stylesheet with nothing to link to. So `@import` with a URL is not a Lynx
+ *   feature for this format, and is dropped like the rest instead of aborting.
+ *
+ * Filtering here rather than teaching `encodeCSS` about it keeps the encode path
+ * that every ReactLynx build depends on byte for byte unchanged.
+ */
+function stripUnrepresentable(
+  nodes: CSS.LynxStyleNode[],
+): { nodes: CSS.LynxStyleNode[]; droppedURLImport: boolean } {
+  let droppedURLImport = false;
+  const kept = nodes.filter((node) => {
+    if (
+      node.type === 'MediaRule' || node.type === 'SupportsRule'
+      || node.type === 'LayerRule'
+    ) {
+      return false;
+    }
+    if (node.type === 'ImportRule') {
+      const href = node.href.startsWith('/') ? node.href.slice(1) : node.href;
+      if (isNaN(Number(href))) {
+        droppedURLImport = true;
+        return false;
+      }
+    }
+    return true;
+  });
+  return { nodes: kept, droppedURLImport };
+}
+
+/**
+ * What {@link xmlToTasmJSON} produces.
+ */
+export type XMLToTasmJSONResult =
+  | {
+    success: true;
+    tasmJSON: TasmJSONInfo;
+    /** At-rules that will not appear in the bundle, empty when there are none. */
+    discarded: DiscardedAtRule[];
+  }
+  | {
+    success: false;
+    /** The parser's message, formatted like the reference implementation. */
+    message: string;
+  };
+
+/**
+ * Translates a Lynx XML document into {@link encode}'s input.
+ *
+ * Returns the parser's structured error instead of throwing, so a caller can
+ * report it however it likes.
+ */
+export function xmlToTasmJSON(source: string): XMLToTasmJSONResult {
+  const parsed = parseLynxXML(source);
+  if (!parsed.success) {
+    return { success: false, message: parsed.error.formattedMessage };
+  }
+
+  // A `<style></style>` section that is present but empty yields `''`, which is
+  // meaningfully different from an absent section, so test against `undefined`
+  // rather than for truthiness.
+  const hasStyle = parsed.style !== undefined;
+  const discarded = hasStyle
+    ? diagnoseDiscardedAtRules(parsed.style!)
+    : [];
+
+  let styleInfo: Record<string, CSS.LynxStyleNode[]> = {};
+  if (hasStyle) {
+    const stripped = stripUnrepresentable(CSS.parse(parsed.style!).root);
+    styleInfo = { [cardCSSId]: stripped.nodes };
+    if (stripped.droppedURLImport) {
+      // Only detectable from the parsed node: whether an `@import` is
+      // representable depends on its resolved href, which the source scan in
+      // `diagnoseDiscardedAtRules` deliberately does not try to reproduce.
+      discarded.push({ name: '@import', reason: 'unrepresentable' });
+    }
+  }
+
+  return {
+    success: true,
+    tasmJSON: {
+      styleInfo,
+      // The background source is kept verbatim: `createChunkLoading` runs each
+      // bts chunk through `new Function(...paramNames, jsContent)`, which is the
+      // web equivalent of the engine's module wrapper, so wrapping here would
+      // nest two module functions and hide the source's top-level bindings.
+      manifest: parsed.backgroundThreadScript !== undefined
+        ? { [backgroundChunkPath]: parsed.backgroundThreadScript }
+        : {},
+      cardType: 'react',
+      appType: 'card',
+      pageConfig: { ...markupPageConfig },
+      // The main-thread script rides the card's `root` lepus chunk, which the
+      // runtime auto-executes once the section arrives.
+      lepusCode: { root: parsed.mainThreadScript },
+      // The markup format has no way to carry either.
+      customSections: {},
+      elementTemplates: {},
+    },
+    discarded,
+  };
+}
+
+/**
+ * Builds a `.web.bundle` from a Lynx XML markup document.
+ *
+ * The bytes are an ordinary modern bundle - see the note at the top of the file
+ * - so the existing decoder consumes them with no markup-specific handling.
+ *
+ * Discarded at-rules are reported on the console as well as returned, because
+ * the common caller is a build script that would otherwise drop the information
+ * on the floor.
+ */
+export function encodeLynxXML(
+  source: string,
+): { success: true; buffer: Uint8Array; discarded: DiscardedAtRule[] } | {
+  success: false;
+  message: string;
+} {
+  const result = xmlToTasmJSON(source);
+  if (!result.success) {
+    return result;
+  }
+
+  for (const { name, reason } of result.discarded) {
+    console.warn(
+      reason === 'unrepresentable'
+        ? `[lynx-web] ${name} has no representation in the Lynx style format and was dropped from the bundle. It is not supported on any Lynx platform.`
+        : `[lynx-web] ${name} is not supported by the Lynx CSS parser and was dropped from the bundle, along with any rules inside it.`,
+    );
+  }
+
+  return {
+    success: true,
+    buffer: encode(result.tasmJSON),
+    discarded: result.discarded,
+  };
+}


### PR DESCRIPTION
## What

Adds `xmlToWebBundle()`: takes a single-file Lynx XML markup document and produces a real
`.web.bundle` — the **modern rkyv format**, the same bytes a build step emits — by reusing the
existing `webEncoder.encode()` / `encodeCSS` path rather than translating XML into the legacy
JSON-artifact shape.

Node-only in this PR, by request: get the conversion working and proven first, wire it into the
browser decode worker separately.

## Why this shape

The style section goes through the engine's own decoder, so an XML card gets Lynx CSS semantics
for free instead of re-implementing them:

- `display: linear` → `--lynx-display: linear` + `display: flex`, `linear-direction` → `--lynx-linear-orientation`
- `1rem` / `50vw` / `2vh` → `calc(1 * var(--rem-unit))` etc. — asserted **with a transforms-off
  control on identical input**, proving the rewrite is host-driven and not baked into the bytes
- `:root` → `[part="page"]`
- `var()` restored (no `{{--x}}` placeholder leakage)

## How "the decoder accepts it" is proven

Not by inspecting intermediates. The spec walks the produced bytes the way `decode.worker.ts`
does (magic → version → label/length framing, asserting the framing consumes the buffer
*exactly*), then hands the `StyleInfo` section to the **same `decode_style_info`** the browser
calls and reads the CSS back with `get_style_content` / `get_font_face_content`. Invalid rkyv
bytes could not return that CSS.

There is also a **negative control**: a corrupted bundle must be *rejected*, so the acceptance
test cannot pass vacuously.

Sections emitted: `Configurations`, `LepusCode`, `Manifest`, `CustomSections`, `StyleInfo`
(`ElementTemplates` correctly absent). Determinism is asserted — two builds are byte-identical.

## Unsupported at-rules are discarded, by design

Lynx's style format has three rule kinds — `Declaration`, `FontFace`, `KeyFrames`. There is no
representation for `@media` / `@supports` / `@layer` anywhere in the engine, so those are **not
Lynx features**; carrying them on web would manufacture web/native divergence. They are dropped,
and so are at-rules the parser has no case for (`@container`, `@property`, `@scope`, `@page`, …).

11 at-rules are pinned as specification tests, each also asserting inner rules are **not
hoisted** and surrounding rules are untouched. Every discard is **reported** — both as a
`console.warn` and as structured `discarded` data, so a caller can fail the build on it.

Reasons are distinguished rather than lumped together: `unrepresentable` (no rule kind exists),
`unsupported` (parser has no case), `unresolvable` (URL `@import` only).

### `@import`

`@import` *is* a Lynx feature, but only as a link between numeric css ids — a build step's
notion. A markup card owns one stylesheet and has nothing to link to, so the URL form is
meaningless here: it is filtered out **before** reaching `encodeCSS`, which otherwise throws on a
non-numeric href and would abort bundle production. A numeric `@import` still survives.

### One nasty shape worth knowing

`@media screen { @font-face { … } }` parses to a `MediaRule` with **zero children** and
`errors: []` — it looks preserved while being hollow. Pinned as its own test.

## The existing encode path is untouched

`git diff origin/main...HEAD -- ts/encode/encodeCSS.ts ts/encode/webEncoder.ts` is **empty**, and
the branch has **zero deletions** (2265 insertions, 0). The ReactLynx build path cannot be
affected by this PR.

## Verification

- web-core **351 tests / 19 files** pass; package `tsc --noEmit` clean — both measured on the
  committed bytes after pre-commit hooks ran
- Mutation-checked: dropping the `@import` filter → 1 red; not scanning source for unsupported
  at-rules → 9 red; not reporting unrepresentable groups → 5 red
- Independent of #3401: css-serializer still imports `node:path` on this branch and the tests
  pass regardless. **This proves Node sufficiency only** — it says nothing about browser safety,
  since the suite runs in Node where `node:path` resolves. The browser follow-up must stack on
  #3401.

## Latent trap recorded

The section reader copies rather than views. A section can start at an **odd** byte offset
(`LepusCode` is UTF-8 and may have odd length), and `decodeJSONMap` builds a `Uint16Array` over
`byteOffset`. Production is safe today only because `StreamReader.read` uses `.slice()` — not
because the format guarantees alignment. A comment records this, so optimising `read()` into a
view later cannot silently break.

## Provenance

`ts/common/xml/parseLynxXML.ts`, `tests/parseLynxXML.spec.ts` and `tests/fixtures/markup-card.xml`
are taken verbatim from #3390 and the commit says so. If both land, that overlap needs resolving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting hand-written Lynx XML documents into `.web.bundle` files.
  * Added XML parsing with validation for styles, scripts, metadata, comments, and supported document structure.
  * Added CSS transformations for Lynx-specific units and properties.
  * Added diagnostics for unsupported CSS at-rules that are removed during bundling.

* **Tests**
  * Added comprehensive parser and bundle-generation coverage, including malformed input and compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->