### PR TITLE
feat(web-core): compile a Lynx XML markup card into a bundle in the browser

### DIFF
--- a/.changeset/css-serializer-source-field.md
+++ b/.changeset/css-serializer-source-field.md
@@ -1,0 +1,22 @@
+---
+"@lynx-js/css-serializer": patch
+---
+
+Point `@lynx-js/source-field` at `src/index.ts`, so a bundler in this repo can
+resolve the package without waiting for its `dist/`.
+
+`@lynx-js/css-serializer` has no `build` script - its `dist/` is emitted by the
+repository's root `tsc --build`, which is a separate turbo task with no ordering
+relationship to any package's `build`. That was invisible while every consumer
+was itself type-checked rather than bundled, but `@lynx-js/web-core` bundles its
+client with rspack, and rspack resolving `main: dist/index.js` before the root
+build has emitted it fails outright.
+
+`@rsbuild/plugin-source-build` is already how this repository answers that -
+`@lynx-js/web-elements` and `@lynx-js/web-worker-rpc` declare the same field and
+are consumed straight from source. Declaring it here removes the ordering
+question rather than scheduling around it.
+
+The field is inert outside such a build: it is a plain, unknown top-level
+`package.json` key, so no `exports` map is introduced and no existing entry point
+or deep import changes.

--- a/.changeset/web-core-markup-card.md
+++ b/.changeset/web-core-markup-card.md
@@ -1,0 +1,111 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Load a hand-written Lynx XML markup card in the browser, by compiling it into a
+`.web.bundle` there and then loading that.
+
+A markup card is not a kind of artifact. The decode worker already dispatches on
+the eight header bytes it reads - `{` for a `.json` template, the magic header for
+a bundle - and a markup card is what neither of those claims, so it costs the two
+shapes that stream nothing to reach. From there it is handed to `encodeLynxXML`,
+the same function `@lynx-js/web-core/encode` gives a build, which returns real
+bundle bytes: magic header, version, and the five sections in the encoder's order.
+Those bytes go straight back to `handleStream`, so every section is read by the
+reader that already existed. There is no markup decoding anywhere - not in the
+worker, not on the main thread - and a markup card is not merely equivalent to a
+built card, it _is_ one by the time anything decodes it.
+
+Compiling in the browser is what #3589 made possible: `binary/encode`'s glue used
+to load its wasm through `node:fs`, and is now generated with
+`wasm-bindgen --target bundler`, which a bundler resolves on either platform.
+
+**What this costs, measured**
+
+Both sides rebuilt from source - `npm run build:wasm` then `rsbuild build`, with
+`--force` so neither figure is a cache replay - because `binary/` is gitignored
+and survives `git switch`, which has produced wrong numbers here before. Raw /
+`gzip -9`.
+
+| artifact                            | `origin/main`    | this change      | delta         |
+| ----------------------------------- | ---------------- | ---------------- | ------------- |
+| `binary/client/client_bg.wasm`      | 227,536 / 82,883 | _byte-identical_ | 0             |
+| `binary/client_legacy/…_bg.wasm`    | 183,444 / 74,949 | _byte-identical_ | 0             |
+| eager `client.js`                   | 45,287 / 14,388  | _byte-identical_ | 0             |
+| `web-core-main-chunk.js`            | 159,621 / 33,074 | _byte-identical_ | 0             |
+| `web-core-worker-chunk.js`          | 15,135 / 6,001   | _byte-identical_ | 0             |
+| worker chunk (`…-loader-thread.js`) | 33,257 / 9,912   | 34,755 / 10,357  | +1,498 / +445 |
+| `web-core-markup-encoder.js` (new)  | –                | 227,811 / 64,809 | new, lazy     |
+| encode wasm asset (new)             | –                | 167,689 / 55,689 | new, lazy     |
+
+So a card that was built ahead of time pays **+1,498 B raw / +445 B gzip**, all of
+it in the worker chunk, and nothing at all in the eager entry or the main chunk.
+The four byte-identical rows are sha256 comparisons, not size comparisons.
+
+The laziness is load bearing rather than tidy: `TemplateManager` requests the
+worker with `webpackPrefetch`, `webpackPreload` and `fetchPriority: "high"`, so a
+static import would eagerly fetch all 395 kB for _every_ card. Verified positively
+and with a negative control on `origin/main`, counting occurrences (a minified
+chunk is one line, so a line count cannot tell 1 from 60):
+
+| marker                       | eager `client.js` | worker chunk | main chunk | markup chunk |
+| ---------------------------- | ----------------- | ------------ | ---------- | ------------ |
+| encode wasm asset name       | 0                 | 0            | 0          | 1            |
+| `css-tree` token names       | 0 / 0             | 0 / 0        | 0 / 0      | 2 / 2        |
+| the XML parser's own message | 0                 | 0            | 0          | 2            |
+
+All of these are 0 everywhere on `origin/main`, including in the chunk that does
+not exist there. `encode_legacy_json_generated_raw_style_info` reads 2 in the
+eager entry and 3 in the worker chunk on **both** sides - it is the _client_ wasm's
+own export, used by `cssLoader` for `.json` artifacts, and is not this change.
+
+Compiling itself is work that moved from a build into the browser, medians of 41
+interleaved rounds: a 72 B stylesheet takes 0.42 ms, 872 B takes 0.89 ms, 9.1 kB
+takes 7.4 ms and 26 kB takes 23.5 ms. Only markup cards pay it.
+
+**Reviewer decisions this change deliberately leaves open**
+
+- **`encodeLynxXML` warns on the console unconditionally, and now does so at
+  runtime.** It reports each at-rule the Lynx style format cannot carry. That was
+  written when the only caller was a build, which has no production runtime to
+  stay quiet for; the same code now runs in a browser. It is left exactly as it is
+  on `origin/main` so that `ts/encode/` keeps a zero diff, but gating it on a dev
+  build, or deduplicating it per at-rule name, are both reasonable and neither is
+  done here.
+- **The published tarball grows by 397 kB**, being the new markup chunk plus the
+  encode wasm, which rspack now also emits under `dist/client_prod/static/wasm/`.
+  That wasm is consequently present three times in the package - there, under
+  `dist/encode_prod/static/wasm/` since #3589, and under `binary/encode/`. Nothing
+  here makes that worse than the pattern already in place for the client wasm, and
+  reclaiming it is a `files` change that would alter what deep importers can
+  reach, so it is left out of this change.
+- **If #3390 lands first, the two chunk figures above need re-measuring.** It
+  reaches `css-tree` directly where this change reaches it through
+  `@lynx-js/css-serializer`; the spec resolves to a single `css-tree@3.2.1`, so
+  rspack would either duplicate it into both lazy chunks or hoist it into a shared
+  one. Nobody has built the union yet, so no combined figure is quoted here.
+
+**Other limits worth knowing**
+
+- `@lynx-js/css-serializer` becomes a real `dependency` rather than the optional
+  peer it was. `dist/client` ships as unbundled ESM, so the `import` the compiler
+  chunk performs is resolved by the consumer, and an optional peer nobody installs
+  would make a markup card fail to load in exactly the packaging that looks fine
+  on disk.
+- **A corrupted bundle now reaches the markup path**, because markup is what is
+  left when a response is neither a bundle nor JSON. Handing those bytes to the XML
+  parser would answer `expected '<lynx version="...">' root element`, which points
+  the reader at a markup bug in a file that is not markup, so the two are told
+  apart first - before the compiler chunk is even fetched - on whether the content
+  begins a tag at all. Bytes that do not keep the diagnosis they always had,
+  `Invalid Magic Header`, now carrying the eight header bytes that failed to match;
+  a document that does gets the XML parser's own message and offset. A response
+  shorter than 8 bytes is still rejected by the header read, exactly as before.
+- `@media`, `@supports` and `@layer` are dropped, as they already were when
+  building a markup card into a bundle: Lynx's style format has no rule kind for a
+  conditional group, so they are not Lynx features on any platform. Same for
+  `@import` with a URL.
+- The `handleMarkup` recursion is one level deep and cannot loop: `encode` writes
+  the magic header at offset 0 unconditionally, so the second `handleStream` takes
+  the binary branch. Were that untrue, the bytes would fail the "begins a tag"
+  check and the recursion would end in a thrown error rather than a cycle.

--- a/packages/tools/css-serializer/package.json
+++ b/packages/tools/css-serializer/package.json
@@ -29,5 +29,6 @@
   "devDependencies": {
     "@types/css-tree": "^3.2.0",
     "@types/node": "^24.13.3"
-  }
+  },
+  "@lynx-js/source-field": "./src/index.ts"
 }

--- a/packages/web-platform/web-core/package.json
+++ b/packages/web-platform/web-core/package.json
@@ -62,12 +62,12 @@
     ]
   },
   "dependencies": {
+    "@lynx-js/css-serializer": "workspace:*",
     "@lynx-js/web-elements": "workspace:*",
     "@lynx-js/web-worker-rpc": "workspace:*",
     "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {
-    "@lynx-js/css-serializer": "workspace:*",
     "@lynx-js/lynx-core": "0.1.4",
     "@rsbuild/core": "catalog:rsbuild",
     "@rsbuild/plugin-eslint": "1.3.0",
@@ -82,14 +82,10 @@
     "tslib": "^2.8.1"
   },
   "peerDependencies": {
-    "@lynx-js/css-serializer": "workspace:*",
     "@lynx-js/lynx-core": "0.1.4",
     "tslib": "^2.5.0"
   },
   "peerDependenciesMeta": {
-    "@lynx-js/css-serializer": {
-      "optional": true
-    },
     "@lynx-js/lynx-core": {
       "optional": true
     },

--- a/packages/web-platform/web-core/tests/encode-style-path.spec.ts
+++ b/packages/web-platform/web-core/tests/encode-style-path.spec.ts
@@ -1,0 +1,115 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Byte-level guard on the encode (ReactLynx build) style path.
+ *
+ * `encodeCSS` runs at build time for every ReactLynx card, so a refactor that
+ * makes its conversion reusable by the browser must not move a single byte of
+ * its output. The hashes below were captured from `origin/main` before the
+ * conversion was extracted, which is what makes them evidence rather than a
+ * snapshot of current behaviour.
+ *
+ * A mismatch is not automatically a bug - an intentional change to the encoder
+ * legitimately moves them - but it must never move as a side effect, so updating
+ * one is a deliberate act that needs justification.
+ */
+
+import { describe, expect, test } from '@rstest/core';
+import { createHash } from 'node:crypto';
+import * as CSS from '@lynx-js/css-serializer';
+
+import { encodeCSS } from '../ts/encode/encodeCSS.js';
+
+/**
+ * One stylesheet per feature the encode path can represent, plus the constructs
+ * it deliberately cannot.
+ */
+const sources: Record<string, string> = {
+  plain: '.a{color:red;padding:1rem}',
+  selectors:
+    '.a .b>.c+.d~.e{color:red}#id[data-x="1"]:hover::before{color:blue}*{margin:0}div{padding:0}',
+  variables: ':root{--accent:#f00;font-size:14px}.t{color:var(--accent)}',
+  varFallback: '.t{border:var(--w, 2px) solid var(--c)}',
+  important: '.a{width:100vw !important;height:50vh;font-size:10rpx}',
+  keyframes:
+    '@keyframes spin{from{transform:rotate(0);--v:1}to{transform:rotate(360deg)}}',
+  fontFace: '@font-face{font-family:X;src:url(a.woff2)}',
+  // A css var inside `@font-face` and inside `@keyframes`. Without these two,
+  // the `restoreCSSVarValue` call in those branches is indistinguishable from a
+  // bare `decl.value`: no other fixture carries a var there, so a mutation that
+  // drops the restoration survives the entire set. Measured, not assumed -
+  // replacing `restoreCSSVarValue(decl)` with `decl.value` in the `FontFaceRule`
+  // branch passed all 9 original fixtures and is caught only once `fontFaceVar`
+  // is present.
+  fontFaceVar:
+    '@font-face{font-family:X;src:url(a.woff2);font-weight:{{--fw}}}',
+  keyframesVar: '@keyframes k{from{color:{{--c}}}to{color:blue}}',
+  lynxProps: '.a{display:linear;linear-direction:column;flex:1}',
+  // Group at-rules: `RuleType` has no variant for them, so the encode path has
+  // always dropped them. Pinned so that the drop stays intentional.
+  groupAtRules:
+    '.a{color:red}@media (max-width:600px){.b{color:blue}}@supports (display:grid){.c{display:grid}}@layer base{.d{color:pink}}.e{color:black}',
+};
+
+function fingerprint(css: string): string {
+  const buffer = encodeCSS({ '0': CSS.parse(css).root });
+  return createHash('sha256').update(Buffer.from(buffer)).digest('hex');
+}
+
+describe('encode style path', () => {
+  test('encodes byte for byte as it did before the conversion was shared', () => {
+    // Captured on origin/main at fe63f6cef, i.e. with the conversion still
+    // inline in `ts/encode/encodeCSS.ts`.
+    const expected: Record<string, string> = {
+      plain: '15c134ae85563a76958229342d9631db41681ba615946743267bfb418cd616d1',
+      selectors:
+        '390f7ce839aa720c280a65011662331b3fef6cfd38dd777cff8f1c402e096c5a',
+      variables:
+        '4427cce9029ab56bcd309f0b720dca1aed103ec66d7c8d60b908e24b71fe120d',
+      varFallback:
+        'f5ba7a8c4f2ca62caf6912a0a97e84a9f751b213e42615c2aa42caffa70d0f42',
+      important:
+        'f4afd7bd210fee4eb8c8825314c55ff9caa4155a4cf845f987a9df1d98ede561',
+      keyframes:
+        'b9e454bb3bd6536d942bba30535e66d9aa31937bec7c3c737e95d4213228b434',
+      fontFace:
+        'fea9aa27bae5623785ea94421aefb66bd702100a8776afe613244c5236dda896',
+      fontFaceVar:
+        'b9affb67c4444921a59aabc8f6ce3ff93311f38b899bc28b0d2ed3c1d2377bd3',
+      keyframesVar:
+        '5fb65a1a9a913d2d9b78df8c297207b3c7385e7eeb4d3266171c4272fa72c00c',
+      lynxProps:
+        'a4a5369454a5272dd176930dafbdd559822b274f984bca1e99db59b6afe86a57',
+      groupAtRules:
+        '1b606238bbbc95cc4b0658e06aa90ff51a48cbd0f57b518894a636d22cddc089',
+    };
+    const actual = Object.fromEntries(
+      Object.entries(sources).map(([name, css]) => [name, fingerprint(css)]),
+    );
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test('keeps rejecting what it always rejected', () => {
+    expect(() => encodeCSS({ nope: [] })).toThrowError(/Invalid cssId/);
+    expect(() =>
+      encodeCSS({ '0': CSS.parse('@import url("theme.css");').root })
+    ).toThrowError(/Invalid importCssId/);
+  });
+
+  test('still drops a group at-rule rather than mangling it', () => {
+    // The hashes above would also hold if the encoder emitted nothing at all,
+    // so assert that the surrounding rules survive and the group does not.
+    const buffer = encodeCSS({ '0': CSS.parse(sources.groupAtRules!).root });
+    const text = new TextDecoder('utf-8', { fatal: false }).decode(buffer);
+    // The two top-level rules, by their (unique) declaration values.
+    expect(text).toContain('red');
+    expect(text).toContain('black');
+    // Everything the three groups carried, prelude and body alike.
+    expect(text).not.toContain('max-width');
+    expect(text).not.toContain('blue');
+    expect(text).not.toContain('grid');
+    expect(text).not.toContain('pink');
+  });
+});

--- a/packages/web-platform/web-core/tests/markup-compile.spec.ts
+++ b/packages/web-platform/web-core/tests/markup-compile.spec.ts
@@ -1,0 +1,197 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * A markup (buildless Lynx XML) card is compiled into a bundle in the browser.
+ *
+ * ## What is worth asserting, and what is not
+ *
+ * A markup card used to be converted into an artifact object and decoded down a
+ * path of its own, so the property that made it sound was that its output agreed
+ * with the bundle path's. That is no longer a property: the card is now compiled
+ * by `encodeLynxXML` - the same function a build runs - into bundle bytes, which
+ * are handed back to `handleStream`. There is one path, so "the two paths agree"
+ * is not something a test can fail and has been deleted rather than kept as a
+ * tautology.
+ *
+ * What is left to establish is that the bytes really are a bundle, and that is
+ * asserted here against an *independent* reader: `decodeTemplate` in
+ * `ts/server/decode.ts`, the SSR decoder, which walks the header, the version and
+ * every section length with its own code. If it accepts what the browser
+ * compiled, the bytes are a `.web.bundle` by a second opinion rather than by
+ * construction.
+ *
+ * The end-to-end half - that loading the XML through the worker is
+ * indistinguishable from loading those compiled bytes - is in
+ * `template-manager.spec.ts`, which has the worker harness.
+ */
+
+import { describe, expect, rstest, test } from '@rstest/core';
+
+import { encodeLynxXML } from '../ts/encode/index.js';
+import {
+  MagicHeader0,
+  MagicHeader1,
+  TemplateSectionLabel,
+} from '../ts/constants.js';
+
+// The SSR decoder's own style step needs the server wasm, which is beside the
+// point here: what is being checked is that it can walk the container. Identity
+// keeps the section's bytes visible for assertion, exactly as `decode.spec.ts`
+// does it.
+rstest.mock('../ts/server/wasm.js', () => ({
+  decode_style_info: rstest.fn((buffer: Uint8Array) => buffer),
+}));
+
+const { decodeTemplate } = await import('../ts/server/decode.js');
+
+const MAIN_THREAD_SCRIPT = 'globalThis.__mts = 1;';
+const BACKGROUND_SCRIPT = 'globalThis.__bts = 2;';
+
+function cardOf(style: string): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<lynx version="5.4.2">',
+    `<style><![CDATA[${style}]]></style>`,
+    `<script main-thread="true"><![CDATA[${MAIN_THREAD_SCRIPT}]]></script>`,
+    `<script background="true"><![CDATA[${BACKGROUND_SCRIPT}]]></script>`,
+    '</lynx>',
+  ].join('\n');
+}
+
+function compile(source: string): Uint8Array {
+  const result = encodeLynxXML(source);
+  if (!result.success) {
+    throw new Error(result.message);
+  }
+  return result.buffer;
+}
+
+/** The section labels the bytes carry, in the order they appear. */
+function sectionOrder(buffer: Uint8Array): string[] {
+  const view = new DataView(
+    buffer.buffer,
+    buffer.byteOffset,
+    buffer.byteLength,
+  );
+  const names = Object.fromEntries(
+    Object.entries(TemplateSectionLabel).map(([name, value]) => [value, name]),
+  ) as Record<number, string>;
+  const found: string[] = [];
+  let offset = 12; // magic header (8) + version (4)
+  while (offset + 8 <= buffer.length) {
+    const label = view.getUint32(offset, true);
+    const length = view.getUint32(offset + 4, true);
+    found.push(names[label] ?? `unknown(${label})`);
+    offset += 8 + length;
+  }
+  // A trailing partial section would mean the lengths do not tile the buffer.
+  expect(offset).toBe(buffer.length);
+  return found;
+}
+
+describe('a markup card compiles to bundle bytes', () => {
+  const buffer = compile(cardOf('.a{color:red;display:linear}'));
+
+  test('begins with the bundle magic header', () => {
+    const view = new DataView(
+      buffer.buffer,
+      buffer.byteOffset,
+      buffer.byteLength,
+    );
+    expect(view.getUint32(0, true)).toBe(MagicHeader0);
+    expect(view.getUint32(4, true)).toBe(MagicHeader1);
+    // Spelled out, because the header is what every other reader dispatches on.
+    expect(new TextDecoder().decode(buffer.subarray(0, 8))).toBe('SDRAWROF');
+    expect(view.getUint32(8, true)).toBe(1);
+  });
+
+  /**
+   * The magic header is also what makes `handleMarkup`'s recursion terminate: it
+   * hands these bytes back to `handleStream`, which takes the binary branch on
+   * them and so cannot reach `handleMarkup` a second time. Pinned because the
+   * argument is in a comment there and this is the fact it rests on.
+   */
+  test('does not look like either of the other two artifact shapes', () => {
+    expect(buffer[0]).not.toBe(0x7b); // '{', the JSON branch
+    expect(buffer[0]).not.toBe(0x3c); // '<', what the markup fallback needs
+  });
+
+  test('carries the sections the encoder emits, in its order', () => {
+    expect(sectionOrder(buffer)).toStrictEqual([
+      'Configurations',
+      'LepusCode',
+      'CustomSections',
+      'StyleInfo',
+      'Manifest',
+    ]);
+  });
+
+  /**
+   * The second opinion. `decodeTemplate` shares no container-parsing code with
+   * the worker's `handleStream`, so its accepting these bytes is a statement
+   * about the bytes rather than about one reader's tolerance.
+   */
+  describe('and the SSR decoder reads them as an ordinary bundle', () => {
+    const decoded = decodeTemplate(buffer, false, false, false);
+
+    test('recovers the config the engine hard-codes for a markup card', () => {
+      expect(decoded.config).toMatchObject({
+        cardType: 'react',
+        isLazy: 'false',
+        enableCSSSelector: 'true',
+        enableRemoveCSSScope: 'true',
+        defaultDisplayLinear: 'false',
+      });
+    });
+
+    test('recovers the main thread script', () => {
+      expect(Object.keys(decoded.lepusCode)).toStrictEqual(['root']);
+      expect(new TextDecoder().decode(decoded.lepusCode['root']!)).toBe(
+        MAIN_THREAD_SCRIPT,
+      );
+    });
+
+    test('recovers a non-empty StyleInfo section', () => {
+      expect(decoded.styleInfo).toBeDefined();
+      expect(decoded.styleInfo!.length).toBeGreaterThan(0);
+    });
+  });
+
+  /**
+   * Not covered by the container assertions: they would hold just as well if the
+   * stylesheet had been dropped on the way through.
+   *
+   * The `StyleInfo` section is rkyv-encoded and tokenised, so a declaration is
+   * not present as the text `display:linear` and a value like `rgb(1,2,3)` is
+   * stored as seven separate tokens. Single-token strings are therefore what can
+   * be asserted on: the selector's own name and two ident values. `linear` in
+   * particular is a Lynx-only `display` value, so finding it shows the author's
+   * CSS reached the bytes rather than some browser-legal default.
+   */
+  test('carries the card\'s own declarations, not an empty stylesheet', () => {
+    const withStyle = compile(
+      cardOf('.lynxMarkupProbe{display:linear;color:cornflowerblue}'),
+    );
+    const withoutStyle = compile(cardOf(''));
+    expect(withStyle.length).toBeGreaterThan(withoutStyle.length);
+
+    const decode = (bytes: Uint8Array) =>
+      new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+    for (const token of ['lynxMarkupProbe', 'cornflowerblue', 'linear']) {
+      expect(decode(withStyle)).toContain(token);
+      // Absent without the stylesheet, so the assertion above is not matching
+      // something the container carries regardless.
+      expect(decode(withoutStyle)).not.toContain(token);
+    }
+  });
+
+  test('reports a document it cannot parse instead of throwing', () => {
+    const result = encodeLynxXML('<lynx version="1">never closed');
+    expect(result.success).toBe(false);
+    expect((result as { message: string }).message).toMatch(
+      /invalid TemplateBundle XML at offset \d+:/,
+    );
+  });
+});

--- a/packages/web-platform/web-core/tests/markup-encoder-chunk.spec.ts
+++ b/packages/web-platform/web-core/tests/markup-encoder-chunk.spec.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * The bundle compiler must stay out of the eager worker chunk.
+ *
+ * `TemplateManager` requests the decode worker with `webpackPrefetch`,
+ * `webpackPreload` and `fetchPriority: "high"`. Anything `decode.worker.ts`
+ * imports statically is therefore eagerly fetched for *every* card - and what is
+ * behind this particular import is a CSS parser plus the `binary/encode` wasm,
+ * measured at 227.8 kB of JS and 167.7 kB of wasm. A card built ahead of time
+ * never needs any of it.
+ *
+ * None of that is observable behaviourally: turn the dynamic `import()` into a
+ * static one and every test still passes, the card still loads, it is just slower
+ * for everyone who never writes markup. So it is guarded at the source level.
+ *
+ * The built artifacts corroborate this from the other side - the encode wasm asset
+ * appears once in `web-core-markup-encoder.js` and zero times in `client.js`, the
+ * worker chunk and the main chunk - but that measurement needs a bundle and does
+ * not belong in a unit test. It is recorded in the changeset instead.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, test } from '@rstest/core';
+
+const WORKER = '../ts/client/decodeWorker/decode.worker.ts';
+const ENCODER_SPECIFIER = '../../encode/xmlToTasmJSON.js';
+
+const workerSource = readFileSync(
+  new URL(WORKER, import.meta.url),
+  'utf8',
+);
+
+/**
+ * The prose above the import names the module and the reason, so the assertions
+ * about *code* have to run with the comments removed - otherwise rewording a
+ * comment could turn a guard into a pass, or a mention in prose could satisfy
+ * one.
+ */
+const workerCode = workerSource
+  .replace(/\/\*[^]*?\*\//g, '')
+  .replace(/\/\/[^\n]*/g, '');
+
+describe('the bundle compiler stays behind a lazy import', () => {
+  /**
+   * Known-positive control. Without it, every `not.toMatch` below would pass
+   * just as well against an empty string - which is what a greedy comment strip
+   * would leave behind.
+   */
+  test('the comment stripping left the worker code behind', () => {
+    expect(workerCode).toContain('async function handleMarkup');
+    expect(workerCode).toContain('async function handleStream');
+    expect(workerCode.length).toBeGreaterThan(4000);
+  });
+
+  test('the worker names the encoder module exactly once', () => {
+    // Guards the assertions below against silently stopping to look at
+    // anything, should the module be renamed or moved.
+    const references = workerCode.split(ENCODER_SPECIFIER).length - 1;
+    expect(references).toBe(1);
+  });
+
+  test('and reaches it only through a dynamic import()', () => {
+    expect(workerSource).toMatch(
+      /import\(\s*(?:\/\*[^]*?\*\/\s*)*'\.\.\/\.\.\/encode\/xmlToTasmJSON\.js'\s*\)/,
+    );
+    // No static import of it, and no static import of anything else under
+    // `ts/encode/` either: `webEncoder`, `encodeCSS` and `index` all reach the
+    // same wasm.
+    expect(workerCode).not.toMatch(/^\s*import\s[^\n]*'\.\.\/\.\.\/encode\//m);
+    expect(workerCode).not.toMatch(
+      /^\s*export\s[^\n]*from\s[^\n]*'\.\.\/\.\.\/encode\//m,
+    );
+  });
+
+  test('and marks the chunk lazy rather than eager', () => {
+    expect(workerSource).toContain(
+      'webpackChunkName: "web-core-markup-encoder"',
+    );
+    expect(workerSource).toContain('webpackMode: "lazy"');
+    // The worker chunk is requested with prefetch, preload and high priority;
+    // these three are what stop this chunk from inheriting them.
+    expect(workerSource).toContain('webpackPrefetch: false');
+    expect(workerSource).toContain('webpackPreload: false');
+    expect(workerSource).toContain('webpackFetchPriority: "low"');
+  });
+
+  /**
+   * The corrupt-bundle diagnosis has to be decided before the chunk is
+   * requested, or every misconfigured server response downloads a few hundred
+   * kilobytes only to be rejected. Ordering, unlike the presence of the check,
+   * has no behavioural signature under jsdom, so it is read off the source.
+   */
+  test('and decides a corrupt bundle before requesting the chunk', () => {
+    const guard = workerCode.indexOf('startsXMLDocument(source)');
+    const request = workerCode.indexOf('loadMarkupEncoder()');
+    expect(guard).toBeGreaterThan(-1);
+    expect(request).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(request);
+  });
+});

--- a/packages/web-platform/web-core/tests/parseLynxXML.spec.ts
+++ b/packages/web-platform/web-core/tests/parseLynxXML.spec.ts
@@ -447,6 +447,129 @@ describe('parseLynxXML', () => {
     });
   });
 
+  /**
+   * A comment may appear in every ignorable position, so an *unterminated* one
+   * has to be rejected from every one of them. Each slot is a separate call
+   * site in `parse()`, and a missed one degrades quietly: the parser would stop
+   * scanning and report whatever the state happened to be - typically "missing
+   * closing tag" or a bogus success - instead of naming the real defect.
+   */
+  describe('an unterminated comment is rejected from every position', () => {
+    const root = '<lynx version="5.4.2"><script main-thread>m</script></lynx>';
+    /**
+     * `truncated` and `closed` differ only in the comment's `-->`, so the pair
+     * shows the rejection is about the missing terminator and not about a
+     * comment being disallowed in that position.
+     */
+    const positions: Record<string, { truncated: string; closed: string }> = {
+      'before the XML declaration': {
+        truncated: `<!-- oops\n<?xml version="1.0"?>\n${root}`,
+        closed: `<!-- fine -->\n<?xml version="1.0"?>\n${root}`,
+      },
+      'between the declaration and the doctype': {
+        truncated: `<?xml version="1.0"?>\n<!-- oops\n<!DOCTYPE lynx>\n${root}`,
+        closed:
+          `<?xml version="1.0"?>\n<!-- fine -->\n<!DOCTYPE lynx>\n${root}`,
+      },
+      'between the doctype and the root element': {
+        truncated: `<!DOCTYPE lynx>\n<!-- oops\n${root}`,
+        closed: `<!DOCTYPE lynx>\n<!-- fine -->\n${root}`,
+      },
+      'between two sections': {
+        truncated: '<lynx version="5.4.2"><script main-thread>m</script>\n'
+          + '<!-- oops\n<script background>b</script></lynx>',
+        closed: '<lynx version="5.4.2"><script main-thread>m</script>\n'
+          + '<!-- fine -->\n<script background>b</script></lynx>',
+      },
+      'after the root closing tag': {
+        truncated: `${root}\n<!-- oops`,
+        closed: `${root}\n<!-- fine -->`,
+      },
+    };
+
+    for (const [where, { truncated, closed }] of Object.entries(positions)) {
+      it(`rejects one ${where}`, () => {
+        expect(expectFailure(truncated)).toBe('unterminated comment');
+
+        const result = parseLynxXML(truncated);
+        if (result.success) {
+          throw new Error('unreachable');
+        }
+        // Pointing at the comment's own start is what makes the message
+        // actionable; the end of the document would be useless.
+        expect(result.error.offset).toBe(truncated.indexOf('<!--'));
+
+        expectSuccess(parseLynxXML(closed));
+      });
+    }
+  });
+
+  /**
+   * Both attribute matchers start with a `startsWith` test, so a missing
+   * follow-up check would accept any attribute that merely *begins* with the
+   * expected name. That is the silent-acceptance direction: the document looks
+   * legal, and the value is then read from the wrong attribute.
+   */
+  describe('attribute names are matched whole, not by prefix', () => {
+    const versionRejected =
+      '\'<lynx>\' requires exactly one non-empty \'version\' attribute';
+
+    it('rejects a bare \'version\' with no value', () => {
+      expect(expectFailure(
+        '<lynx version><script main-thread>m</script></lynx>',
+      )).toBe(versionRejected);
+    });
+
+    it('rejects an attribute that only starts with \'version\'', () => {
+      for (const attribute of ['versionless="1"', 'version-name="5.4.2"']) {
+        expect(expectFailure(
+          `<lynx ${attribute}><script main-thread>m</script></lynx>`,
+        )).toBe(versionRejected);
+      }
+    });
+
+    it('rejects a script attribute that only starts with a known name', () => {
+      for (const attribute of ['main-threaded', 'backgrounded="true"']) {
+        expect(expectFailure(
+          `<lynx version="5.4.2"><script ${attribute}>m</script></lynx>`,
+        )).toBe(
+          '\'<script>\' requires exactly one of \'main-thread\' or \'background\'',
+        );
+      }
+    });
+  });
+
+  describe('CDATA boundaries', () => {
+    it('rejects text after the CDATA section with no second \']]>\'', () => {
+      // Distinct from both existing CDATA failures: the `]]>` *is* found, so
+      // the section is not unterminated from `#consumeSection`'s point of
+      // view, and the trailing text is not a second CDATA end either. Without
+      // the `endsWith` check the trailing text would be silently swallowed
+      // into - or dropped from - the section's content.
+      const source = '<lynx version="5.4.2">'
+        + '<script main-thread><![CDATA[main]]>tail</script></lynx>';
+      expect(expectFailure(source)).toBe('unterminated CDATA section');
+
+      const result = parseLynxXML(source);
+      if (result.success) {
+        throw new Error('unreachable');
+      }
+      // Reported at the section's content start, i.e. where the CDATA began.
+      expect(result.error.offset).toBe(source.indexOf('<![CDATA['));
+    });
+
+    it('strips whitespace around a CDATA wrapper but not inside it', () => {
+      const result = expectSuccess(parseLynxXML(
+        '<lynx version="5.4.2">'
+          + '<style>\n  <![CDATA[ .a { width: 1px; } ]]>\n  </style>'
+          + '<script main-thread>m</script></lynx>',
+      ));
+      // The wrapper's surrounding whitespace is layout, the inner whitespace is
+      // content.
+      expect(result.style).toBe(' .a { width: 1px; } ');
+    });
+  });
+
   describe('real world fixture', () => {
     it('parses markup-card.xml into three non-empty sections', () => {
       const source = readFileSync(

--- a/packages/web-platform/web-core/tests/template-manager.spec.ts
+++ b/packages/web-platform/web-core/tests/template-manager.spec.ts
@@ -1,6 +1,10 @@
 import './jsdom.js';
 import { describe, test, expect, rstest, beforeEach } from '@rstest/core';
-import { encode, type TasmJSONInfo } from '../ts/encode/index.js';
+import {
+  encode,
+  encodeLynxXML,
+  type TasmJSONInfo,
+} from '../ts/encode/index.js';
 import { MagicHeader0, MagicHeader1 } from '../ts/constants.js';
 import type { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.js';
 import type { HeartbreakMessage } from '../ts/client/decodeWorker/types.js';
@@ -662,5 +666,306 @@ describe('Template Manager', () => {
     expect(decodedCustomSections).toEqual(sampleTasm.customSections);
     expect(instance1.onPageConfigReady).toHaveBeenCalled();
     expect(instance2.onPageConfigReady).toHaveBeenCalled();
+  });
+  /**
+   * The markup path, end to end through the worker.
+   *
+   * A markup card is decoded in the worker like any other artifact, and it is
+   * reached the way the worker reaches everything else: `handleStream` reads the
+   * 8 byte header, dispatches JSON on `{` and a bundle on the magic header, and
+   * what is left over is a markup card. It is the only artifact that cannot be
+   * streamed - the XML parser has no incremental mode - so it is the one that
+   * waits for the whole response, and putting it last is what keeps the two that
+   * do stream from paying for it.
+   *
+   * The conversion happens in a lazily loaded chunk and emits the ordinary
+   * `Configurations` / `StyleInfo` / `LepusCode` / `Manifest` sections. The main
+   * thread has no markup branch at all, so what these assert is precisely that -
+   * a markup card arrives through the same section handler, and completes through
+   * the same `done`, as a built card.
+   */
+  describe('markup cards', () => {
+    const markupSource = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<!DOCTYPE lynx>',
+      '<lynx version="5.4.2">',
+      // The viewport and root-relative units are load bearing, not decoration:
+      // they are what makes `transformVW` / `transformVH` / `transformREM`
+      // observable in the decoded bytes. Without them those flags are no-ops and
+      // any test comparing two loads would agree however they were propagated.
+      '<style><![CDATA[.a{color:red;display:linear;width:10vw;height:20vh;font-size:2rem}]]></style>',
+      '<script main-thread="true"><![CDATA[globalThis.__mts = 1;]]></script>',
+      '<script background="true"><![CDATA[globalThis.__bts = 1;]]></script>',
+      '</lynx>',
+    ].join('\n');
+
+    function serveBytes(bytes: Uint8Array, chunkSize = bytes.length) {
+      const stream = new ReadableStream({
+        start(controller) {
+          for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+            controller.enqueue(bytes.slice(offset, offset + chunkSize));
+          }
+          controller.close();
+        },
+      });
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: stream,
+      });
+    }
+
+    function serveText(text: string, chunkSize?: number) {
+      const bytes = new TextEncoder().encode(text);
+      serveBytes(bytes, chunkSize ?? bytes.length);
+    }
+
+    function load(url: string, transforms = false) {
+      return templateManager.fetchBundle(
+        url,
+        Promise.resolve(mockLynxViewInstance),
+        transforms,
+        transforms,
+        transforms,
+      );
+    }
+
+    test('loads a markup card and resolves the load', async () => {
+      const url = 'http://example.com/card.xml';
+      serveText(markupSource);
+
+      await load(url);
+
+      const bundle = templateManager.getBundle(url);
+      expect(bundle).toBeDefined();
+      // The engine hard-codes a markup bundle's config, so these are the values
+      // a native XML bundle would carry too.
+      expect(bundle!.config).toMatchObject({
+        cardType: 'react',
+        isLazy: 'false',
+        enableCSSSelector: 'true',
+      });
+      expect(bundle!.styleSheet).toBeDefined();
+      expect(Object.keys(bundle!.lepusCode ?? {})).toStrictEqual(['root']);
+      expect(Object.keys(bundle!.backgroundCode ?? {})).toStrictEqual([
+        '/app-service.js',
+      ]);
+
+      // Same callbacks, same order, as a bundle card.
+      expect(mockLynxViewInstance.onPageConfigReady).toHaveBeenCalled();
+      expect(mockLynxViewInstance.onStyleInfoReady).toHaveBeenCalledWith(url);
+      expect(mockLynxViewInstance.onMTSScriptsLoaded).toHaveBeenCalledWith(
+        url,
+        false,
+      );
+      expect(mockLynxViewInstance.onBTSScriptsLoaded).toHaveBeenCalledWith(url);
+    });
+
+    /**
+     * The whole claim of the markup path, end to end: a hand-written card is
+     * compiled in the browser into the bundle a build would have produced, and
+     * loading it is therefore the same act as loading that bundle.
+     *
+     * Asserted on what the worker actually posts, because that is the entire
+     * interface between the two threads. The section *order* matters as much as
+     * the payloads: a markup card is not adapted into the section sequence, it
+     * produces the encoder's own sequence, because after compiling
+     * `handleMarkup` hands the bytes back to `handleStream` and the ordinary
+     * binary reader takes over. If it were reordered, adapted, or given the wrong
+     * transform flags on the way through, these would diverge.
+     *
+     * The `StyleInfo` payload is copied out of the message before it is posted:
+     * the worker transfers that `ArrayBuffer`, so reading it afterwards would
+     * find it detached.
+     */
+    test('is indistinguishable from loading the bundle compiled from it', async () => {
+      const compiled = encodeLynxXML(markupSource);
+      expect(compiled.success).toBe(true);
+      const bundleBytes = (compiled as { buffer: Uint8Array }).buffer;
+
+      function recordSections() {
+        const seen: { label: number; bytes?: number[] }[] = [];
+        const original = globalThis.postMessage;
+        const spy = rstest.spyOn(globalThis, 'postMessage')
+          .mockImplementation(
+            ((message: any, ...rest: any[]) => {
+              if (message?.type === 'section') {
+                seen.push({
+                  label: message.label,
+                  ...(message.data instanceof ArrayBuffer
+                    ? { bytes: Array.from(new Uint8Array(message.data)) }
+                    : {}),
+                });
+              }
+              return (original as any).call(globalThis, message, ...rest);
+            }) as any,
+          );
+        return { seen, restore: () => spy.mockRestore() };
+      }
+
+      async function sectionsOf(
+        url: string,
+        serve: () => void,
+        transforms: boolean,
+      ) {
+        const recorder = recordSections();
+        serve();
+        await load(url, transforms);
+        recorder.restore();
+        return recorder.seen;
+      }
+
+      // Run under both flag settings. The card carries `vw`, `vh` and `rem`, so
+      // the transforms genuinely move the decoded style bytes - which is what
+      // makes this sensitive to the flags being carried into the recursive
+      // `handleStream` call rather than defaulted or dropped along the way.
+      for (const transforms of [false, true]) {
+        const suffix = transforms ? 'transformed' : 'plain';
+        const asMarkup = await sectionsOf(
+          `http://example.com/twin-${suffix}.xml`,
+          () => serveText(markupSource),
+          transforms,
+        );
+        const asBundle = await sectionsOf(
+          `http://example.com/twin-${suffix}.web.bundle`,
+          () => serveBytes(bundleBytes),
+          transforms,
+        );
+
+        // Control: the recording saw a whole load, so an equality between two
+        // empty arrays cannot be what passes here.
+        expect(asMarkup).toHaveLength(5);
+        expect(asMarkup).toStrictEqual(asBundle);
+      }
+
+      // And the two flag settings really do produce different bytes, so the
+      // equality above cannot be holding because the transforms did nothing.
+      const plain = await sectionsOf(
+        'http://example.com/twin-a.xml',
+        () => serveText(markupSource),
+        false,
+      );
+      const transformed = await sectionsOf(
+        'http://example.com/twin-b.xml',
+        () => serveText(markupSource),
+        true,
+      );
+      expect(plain).not.toStrictEqual(transformed);
+    });
+
+    /**
+     * The document is reassembled from the 8 header bytes `handleStream` already
+     * consumed plus the remainder, so how the response was split has to make no
+     * difference. One byte at a time is the worst case for that seam.
+     */
+    test('loads a card delivered one byte at a time', async () => {
+      const url = 'http://example.com/card-drip.xml';
+      serveText(markupSource, 1);
+
+      await load(url);
+      expect(templateManager.getBundle(url)?.styleSheet).toBeDefined();
+    });
+
+    /**
+     * A BOM and leading whitespace are the author's, not the tool's, so however
+     * much of it there is the card still loads.
+     *
+     * This used to have a limit. When the markup check ran ahead of
+     * `handleStream` it only ever saw 8 bytes, so a `<` pushed past byte 8 by a
+     * BOM plus a few blank lines was not recognised and the card was reported as
+     * a corrupt binary. Reaching markup by elimination removes the window
+     * entirely: the padding here is deliberately far longer than 8 bytes.
+     */
+    test('tolerates a BOM and any amount of leading whitespace', async () => {
+      const url = 'http://example.com/card-bom.xml';
+      serveText('\ufeff\n \t\n \t\n \t\n \t\n \t\n \t\n' + markupSource);
+
+      await load(url);
+      expect(templateManager.getBundle(url)?.styleSheet).toBeDefined();
+    });
+
+    /**
+     * A document that is markup but wrong is reported by the XML parser, in the
+     * parser's own words and with an offset.
+     */
+    test('rejects an unparsable card with the parser\'s own message', async () => {
+      const url = 'http://example.com/card-broken.xml';
+      serveText('<lynx version="1">never closed');
+
+      await expect(load(url)).rejects.toThrow(
+        /invalid TemplateBundle XML at offset \d+:/,
+      );
+    });
+
+    /**
+     * The cost of making markup the fallback, paid off deliberately.
+     *
+     * A corrupted bundle no longer stops at `Invalid Magic Header`; it reaches
+     * the markup path like anything else that is not a bundle and not JSON. Left
+     * alone it would come back as `expected '<lynx version="...">' root element`,
+     * which points whoever is reading it at a markup bug in a file that is not
+     * markup. So the two are told apart before the parser is even loaded, on
+     * whether the content begins a tag at all, and a corrupt bundle keeps the
+     * diagnosis it always had.
+     */
+    describe('bytes that are no kind of Lynx artifact', () => {
+      test('a corrupted bundle is reported as a bad header, not as bad XML', async () => {
+        const url = 'http://example.com/corrupt.bundle';
+        const encoded = encode(sampleTasm);
+        // One flipped bit in the magic header, the cheapest real corruption.
+        // 'S' of 'SDRAWROF' becomes 0xac.
+        expect(encoded[0]).toBe(0x53);
+        encoded[0] = encoded[0]! ^ 0xff;
+        serveBytes(encoded);
+
+        const error = await load(url).then(
+          () => undefined,
+          (thrown: Error) => thrown,
+        );
+        expect(error).toBeDefined();
+        expect(error!.message).toContain('Invalid Magic Header');
+        // Not the XML parser's answer: that is the confusing outcome this
+        // guards against.
+        expect(error!.message).not.toContain('TemplateBundle XML');
+        // The bytes that failed to match, so the reader can see how close it
+        // was - 'DRAWROF' is still legible after the corrupted first byte.
+        expect(error!.message).toContain('ac 44 52 41 57 52 4f 46');
+      });
+
+      test('a non-text payload is reported the same way', async () => {
+        const url = 'http://example.com/not-lynx.gz';
+        // A gzip member: real enough that a misconfigured server could serve it.
+        serveBytes(
+          new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0, 0, 0, 0, 0x00, 0x03]),
+        );
+
+        await expect(load(url)).rejects.toThrow(
+          /Invalid Magic Header.*1f 8b 08 00 00 00 00 00/s,
+        );
+      });
+
+      /**
+       * The one input markup does *not* rescue, pinned because it is the
+       * boundary of the fallback rather than an oversight.
+       *
+       * Markup is reached from the magic header check, which is downstream of
+       * the eight byte header read, so a response too short to fill that header
+       * never gets there and keeps the stream errors it always had. Making
+       * markup work for a document shorter than eight bytes would mean moving
+       * the read, and no useful card is that short.
+       */
+      test('a response too short for the header keeps the stream errors', async () => {
+        serveText('<a>');
+        await expect(load('http://example.com/tiny.xml')).rejects.toThrow(
+          'Unexpected end of stream. Expected 8 bytes, got 3',
+        );
+
+        serveBytes(new Uint8Array(0));
+        await expect(load('http://example.com/empty.xml')).rejects.toThrow(
+          'Empty stream',
+        );
+      });
+    });
   });
 });

--- a/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
+++ b/packages/web-platform/web-core/tests/xml-to-web-bundle.spec.ts
@@ -33,7 +33,7 @@ import {
   diagnoseDiscardedAtRules,
   encodeLynxXML,
   xmlToTasmJSON,
-} from '../ts/encode/xmlToTasmJSON.js';
+} from '../ts/encode/index.js';
 
 const MagicHeader0 = 0x41524453;
 const MagicHeader1 = 0x464F5257;
@@ -563,6 +563,123 @@ describe('XML markup document to web bundle', () => {
         // Nested inside the group, and still reported.
         { name: '@container', reason: 'unsupported' },
       ]);
+    });
+
+    test('says so on the console, which is the only place a build looks', () => {
+      // The design's whole justification for dropping rather than failing is
+      // that the loss is *reported*. `discarded` alone does not achieve that:
+      // the common caller is a build script that never reads the return value,
+      // so the console message is the actual delivery mechanism and has to be
+      // asserted rather than assumed.
+      const source = xml({
+        style: '@media screen{.a{color:red}}'
+          + '@property --x{syntax:"<length>";inherits:false}'
+          + '@import url("theme.css");',
+      });
+
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.map(String).join(' '));
+      };
+      let discarded;
+      try {
+        discarded = build(source).discarded;
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      // One line per distinct at-rule, and each names its own reason - a single
+      // generic "some CSS was dropped" would not tell an author what to change.
+      expect(discarded).toStrictEqual([
+        { name: '@media', reason: 'unrepresentable' },
+        { name: '@property', reason: 'unsupported' },
+        { name: '@import', reason: 'unresolvable' },
+      ]);
+      expect(warnings).toHaveLength(3);
+      expect(warnings.every((line) => line.startsWith('[lynx-web] '))).toBe(
+        true,
+      );
+      expect(warnings.find((line) => line.includes('@media'))).toContain(
+        'no representation in the Lynx style format',
+      );
+      expect(warnings.find((line) => line.includes('@property'))).toContain(
+        'not recognised by the Lynx CSS parser',
+      );
+      expect(warnings.find((line) => line.includes('@import'))).toContain(
+        'owns a single stylesheet',
+      );
+    });
+
+    test('stays silent when the card uses nothing unsupported', () => {
+      // The counterpart to the test above: a warning that fires for a clean
+      // card would train authors to ignore it.
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.map(String).join(' '));
+      };
+      try {
+        build(xml({ style: '.a{color:red}@keyframes k{from{opacity:0}}' }));
+      } finally {
+        console.warn = originalWarn;
+      }
+      expect(warnings).toStrictEqual([]);
+    });
+  });
+
+  describe('the conversion\'s own output contract', () => {
+    test('tells an empty stylesheet apart from an absent one', () => {
+      // `<style></style>` is not the same document as no `<style>` at all, and
+      // the difference has to survive into `styleInfo`: the card's css id must
+      // exist with no rules rather than not exist. Testing for truthiness
+      // instead of `undefined` anywhere on this path would collapse the two.
+      const empty = xmlToTasmJSON(xml({ style: '' }));
+      const absent = xmlToTasmJSON(xml());
+      if (!empty.success || !absent.success) {
+        throw new Error('unreachable');
+      }
+      expect(empty.tasmJSON.styleInfo).toStrictEqual({ '0': [] });
+      expect(absent.tasmJSON.styleInfo).toStrictEqual({});
+
+      // Both still frame into a bundle the reader accepts.
+      for (const source of [xml({ style: '' }), xml()]) {
+        expect(() => readBundle(build(source).buffer)).not.toThrow();
+      }
+    });
+
+    test('hands out a fresh pageConfig for every document', () => {
+      // `markupPageConfig` is module state. Handing out the object itself would
+      // let one card's caller mutate the config every later card is built with,
+      // which is a corruption no test of a single build would notice.
+      const first = xmlToTasmJSON(xml());
+      if (!first.success) {
+        throw new Error('unreachable');
+      }
+      expect(first.tasmJSON.pageConfig['defaultDisplayLinear']).toBe('false');
+      first.tasmJSON.pageConfig['defaultDisplayLinear'] = 'true';
+
+      const second = xmlToTasmJSON(xml());
+      if (!second.success) {
+        throw new Error('unreachable');
+      }
+      expect(second.tasmJSON.pageConfig['defaultDisplayLinear']).toBe('false');
+    });
+
+    test('passes the parser\'s own message through unchanged', () => {
+      // The conversion must not restate the failure in its own words, or the
+      // offset and wording stop matching the reference implementation.
+      const source = '<lynx version="5.4.2"><view></view></lynx>';
+      const result = xmlToTasmJSON(source);
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error('unreachable');
+      }
+      expect(result.message).toBe(
+        `invalid TemplateBundle XML at offset ${
+          source.indexOf('<view>')
+        }: unsupported top-level tag '<view>'`,
+      );
     });
   });
 

--- a/packages/web-platform/web-core/ts/client/decodeWorker/decode.worker.ts
+++ b/packages/web-platform/web-core/ts/client/decodeWorker/decode.worker.ts
@@ -24,6 +24,37 @@ import { decodeBinaryMap } from '../../common/decodeUtils.js';
 const MTS_CODE_WRAPPER_PREFIX =
   '//# allFunctionsCalledOnLoad\n(function(){ "use strict"; const navigator=void 0,postMessage=void 0; let window=void 0; ';
 
+/**
+ * The bundle compiler, loaded only when a markup (buildless Lynx XML) card
+ * actually arrives.
+ *
+ * This is `@lynx-js/web-core/encode`'s own `encodeLynxXML` - the function the
+ * build uses - reached through its source module rather than reimplemented. It is
+ * heavy: a CSS parser (`@lynx-js/css-serializer`, which re-exports `css-tree`)
+ * plus the `binary/encode` wasm, a few hundred kilobytes a card built ahead of
+ * time never needs.
+ *
+ * It must stay behind this lazy `import()`. `TemplateManager` requests this worker
+ * with `webpackPrefetch`, `webpackPreload` and `fetchPriority: "high"`, so
+ * anything imported statically here is eagerly fetched for *every* card; the magic
+ * comments below undo those inherited hints for this one chunk. Nothing in
+ * `decodeWorker/` may import `ts/encode/` statically.
+ *
+ * Reaching the encoder from a browser bundle at all is what #3589 made possible:
+ * `binary/encode`'s glue used to load its wasm through `node:fs` and is now
+ * generated with `wasm-bindgen --target bundler`, which a bundler resolves on
+ * either platform.
+ */
+const loadMarkupEncoder = () =>
+  import(
+    /* webpackChunkName: "web-core-markup-encoder" */
+    /* webpackMode: "lazy" */
+    /* webpackFetchPriority: "low" */
+    /* webpackPrefetch: false */
+    /* webpackPreload: false */
+    '../../encode/xmlToTasmJSON.js'
+  );
+
 const HEARTBREAK_INTERVAL_MS = 1000;
 let heartbreakTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -219,7 +250,22 @@ async function handleStream(
   const magic0 = view.getUint32(0, true);
   const magic1 = view.getUint32(4, true);
   if (magic0 !== MagicHeader0 || magic1 !== MagicHeader1) {
-    throw new Error('Invalid Magic Header');
+    // Neither a bundle nor JSON, so the one artifact shape left is a Lynx XML
+    // markup card. It arrives here rather than being sniffed for up front
+    // because it is the only shape that cannot be streamed - the XML parser has
+    // no incremental mode - and making every artifact pay for a look-ahead in
+    // order to route the one that does not stream had it backwards. By this
+    // point the header is already in hand and nothing has to be replayed.
+    await handleMarkup(
+      headerBytes,
+      await streamReader.readRest(),
+      url,
+      transformVW,
+      transformVH,
+      transformREM,
+      overrideConfig,
+    );
+    return;
   }
 
   // 2. Check Version
@@ -375,6 +421,116 @@ async function handleStream(
         throw new Error(`Unknown section label: ${label}`);
     }
   }
+}
+
+/**
+ * Whether the text begins an XML document, i.e. its first non-whitespace
+ * character opens a tag.
+ *
+ * This is not a sniff and nothing is routed by it: by the time it runs the
+ * artifact has already been classified as markup, by elimination. It exists only
+ * so that {@link handleMarkup} can tell the two failures apart - a document the
+ * author wrote wrong, and bytes that were never a Lynx artifact of any kind.
+ *
+ * The rule is deliberately the parser's own precondition rather than a new one:
+ * `parseLynxXML` skips a BOM (already stripped by `TextDecoder` here) and the
+ * same ASCII whitespace set, then requires `<?xml`, `<!` or `<lynx`. Anything
+ * this rejects would have been rejected there too, one step later and with a
+ * message about a missing root element.
+ */
+function startsXMLDocument(source: string): boolean {
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]!;
+    if (
+      character === ' ' || character === '\t' || character === '\n'
+      || character === '\r' || character === '\f'
+    ) {
+      continue;
+    }
+    return character === '<';
+  }
+  return false;
+}
+
+/**
+ * Compiles a Lynx XML markup card into a bundle and loads that, the artifact
+ * shape reached by elimination.
+ *
+ * A markup card is not a third kind of artifact. It is compiled here, in the
+ * browser, by the same `encodeLynxXML` a build would run, into the same
+ * `.web.bundle` bytes a build would emit - magic header, version, and the five
+ * sections in the encoder's order - and those bytes are then handed back to
+ * {@link handleStream}. Every section is read by the reader that already exists,
+ * so there is no markup-specific decoding anywhere: not in this worker, and not
+ * on the main thread.
+ *
+ * The recursion terminates after exactly one extra level. `encode` writes
+ * `MagicHeader0`/`MagicHeader1` at offset 0 unconditionally, so the second
+ * `handleStream` takes the binary branch. Were that ever untrue the bytes would
+ * reach {@link startsXMLDocument}, whose answer for a bundle's first byte (`S`)
+ * is `false`, and the recursion would end in a thrown error rather than a loop.
+ *
+ * ## Why it reports two different failures
+ *
+ * Because it is the fallback, a corrupted binary bundle lands here too: a single
+ * flipped bit in the magic header is enough. Handing those bytes to the XML
+ * parser would answer with `expected '<lynx version="...">' root element`, which
+ * sends whoever is reading it looking for a markup bug in a file that is not
+ * markup. So the bytes are checked for the shape of a text document first, and if
+ * they do not have it the diagnosis `handleStream` used to give -
+ * `Invalid Magic Header` - is reported instead, with the offending header bytes.
+ * That check also keeps the several hundred kilobyte compiler chunk from being
+ * fetched only to reject a corrupt bundle.
+ */
+async function handleMarkup(
+  head: Uint8Array,
+  rest: Uint8Array,
+  url: string,
+  transformVW: boolean,
+  transformVH: boolean,
+  transformREM: boolean,
+  overrideConfig?: Partial<PageConfig>,
+) {
+  const bytes = new Uint8Array(head.length + rest.length);
+  bytes.set(head);
+  bytes.set(rest, head.length);
+  // Joined before a single `TextDecoder` pass rather than decoded in two,
+  // because a multi-byte sequence can straddle the eight byte header. Nothing
+  // observable rests on it today: bytes 0..7 of a Lynx XML document are ASCII
+  // by grammar - `<?xml`, `<!`, `<lynx` or whitespace - so a character can only
+  // straddle inside a leading comment or declaration, both of which are
+  // discarded. It costs three lines and stops being a question.
+  // `TextDecoder` strips a leading UTF-8 BOM for us.
+  const source = new TextDecoder().decode(bytes);
+
+  if (!startsXMLDocument(source)) {
+    const headHex = Array.from(head, byte => byte.toString(16).padStart(2, '0'))
+      .join(' ');
+    throw new Error(
+      `Invalid Magic Header: not a Lynx bundle, and not a Lynx XML markup card`
+        + ` either - the content does not begin a tag. First bytes: ${headHex}`,
+    );
+  }
+
+  const { encodeLynxXML } = await loadMarkupEncoder();
+  const compiled = encodeLynxXML(source);
+  if (!compiled.success) {
+    throw new Error(compiled.message);
+  }
+
+  await handleStream(
+    url,
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(compiled.buffer);
+        controller.close();
+      },
+    }).getReader(),
+    transformVW,
+    transformVH,
+    transformREM,
+    overrideConfig,
+  );
 }
 
 async function handleJSON(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2210,6 +2210,9 @@ importers:
 
   packages/web-platform/web-core:
     dependencies:
+      '@lynx-js/css-serializer':
+        specifier: workspace:*
+        version: link:../../tools/css-serializer
       '@lynx-js/web-elements':
         specifier: workspace:*
         version: link:../web-elements
@@ -2220,9 +2223,6 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
     devDependencies:
-      '@lynx-js/css-serializer':
-        specifier: workspace:*
-        version: link:../../tools/css-serializer
       '@lynx-js/lynx-core':
         specifier: 0.1.4
         version: 0.1.4


### PR DESCRIPTION
## Why

A hand-written Lynx XML card cannot be loaded by `@lynx-js/web-core` today. This
PR makes it loadable — by **compiling it into a real `.web.bundle` in the browser**
and then loading that, rather than by giving markup a decode path of its own.

This replaces the shape this PR carried before (a main-thread assembler, then a
worker-side style loader). Both of those made a markup card a *third kind of
artifact*. This one does not: after ~0.4 ms of compiling, a markup card **is** a
bundle, and every byte after that is read by code that already existed.

## What it does

`handleStream` already dispatches on the eight header bytes it reads — `{` for a
`.json` template, the magic header for a bundle. A markup card is what neither of
those claims, so it costs the two shapes that *do* stream nothing to reach. From
there:

```
XML text
  → lazily import ts/encode/xmlToTasmJSON.js       (the build's own module)
  → encodeLynxXML(source)                          → real .web.bundle bytes
  → hand those bytes back to handleStream          → the existing binary reader
```

The recursion is one level deep and cannot loop: `encode` writes the magic header
at offset 0 unconditionally, so the second `handleStream` takes the binary branch.

Compiling in the browser at all is what **#3589** made possible — `binary/encode`'s
glue used to load its wasm through `node:fs`, and is now generated with
`wasm-bindgen --target bundler`.

## Diff, before and after this reshape

| | files | insertions | **deletions / edits to existing code** |
|---|---|---|---|
| previous shape | 22 | +1,851 | **−219** |
| **this shape** | **12** | **+1,259** | **−12** |

The `−12` is the whole intrusion into pre-existing code, and 11 of it is one
`import` line reflow. Everything below returned to `origin/main` **byte-identical**:

| reverted | evidence |
|---|---|
| `scripts/build.js` (the `client,encode` feature) | absent from `git diff --name-only origin/main` |
| `binary/client{,_legacy}/*.d.ts` | same |
| `handleJSON` (the injected `loadStyle` / `LoadStyle`) | brace-matched extraction, `cmp` equal, 2,375 B both sides |
| `ts/encode/index.ts`, `encodeCSS.ts` (back to 172 lines) | zero diff |
| `ts/encode/xmlToTasmJSON.ts` | moved back; zero diff |
| **deleted outright** | `markupLoader.ts`, `ts/common/css/buildRawStyleInfo.ts`, `ts/common/xml/xmlToTasmJSON.ts`, `ts/encode/encodeLynxXML.ts` |

`encodeLynxXML` did not need to be written — it is already on `main` inside
`ts/encode/xmlToTasmJSON.ts`. `buildRawStyleInfo`/`pushStyleNodes` could be deleted
because, with `markupLoader` gone, `encodeCSS` was its only remaining consumer.

The 33-commit stack was rebuilt as 5 commits. Most of it had become
self-cancelling (`feat: build a StyleSheetResource without rkyv` → `revert: drop
the rkyv-free fast path` → the file deleted here), including the
add-then-revert detour that was left pending a decision. The final tree is
unchanged by the rebuild: `git diff origin/main...HEAD | sha256sum` is
`01da1c2b…` both before and after.

## Cost, measured

Both sides fully rebuilt — `npm run build:wasm` then `rsbuild build --force` —
because `binary/` is gitignored and **survives `git switch`**, which has produced
wrong numbers on this PR twice. Raw / `gzip -9`.

| artifact | `origin/main` | this PR | delta |
|---|---|---|---|
| `binary/client/client_bg.wasm` | 227,536 / 82,883 | **byte-identical** (`c2f630ba…`) | 0 |
| `binary/client_legacy/…_bg.wasm` | 183,444 / 74,949 | **byte-identical** (`aa06d815…`) | 0 |
| eager `client.js` | 45,287 / 14,388 | **byte-identical** (`b547bdff…`) | 0 |
| `web-core-main-chunk.js` | 159,621 / 33,074 | **byte-identical** | 0 |
| `web-core-worker-chunk.js` | 15,135 / 6,001 | **byte-identical** | 0 |
| worker chunk (`…-loader-thread.js`) | 33,257 / 9,912 | 34,755 / 10,357 | +1,498 / +445 |
| `web-core-markup-encoder.js` *(new, lazy)* | – | 227,811 / 64,809 | new |
| encode wasm asset *(new, lazy)* | – | 167,689 / 55,689 | new |

A card built ahead of time pays **+1,498 B raw / +445 B gzip**, all of it in the
worker chunk. The previous shape charged every card **+6,226 B gzip** on the client
wasm and moved the eager entry's sha; both are now zero.

Compiling is work moved from a build into the browser, medians of 41 interleaved
rounds: 72 B stylesheet 0.42 ms, 872 B 0.89 ms, 9.1 kB 7.4 ms, 26 kB 23.5 ms.

## The compiler is lazy — positive evidence, with a control

Occurrence counts (a minified chunk is one line, so a *line* count cannot tell 1
from 60):

| marker | eager `client.js` | worker chunk | main chunk | markup chunk |
|---|---|---|---|---|
| encode wasm asset name | 0 | 0 | 0 | **1** |
| `css-tree` token names | 0 / 0 | 0 / 0 | 0 / 0 | **2 / 2** |
| the XML parser's own message | 0 | 0 | 0 | **2** |

All are **0 everywhere on `origin/main`** (negative control).
`encode_legacy_json_generated_raw_style_info` reads 2 / 3 in the eager entry and
worker chunk on **both** sides — that is the *client* wasm's own export, used by
`cssLoader` for `.json` artifacts, and is not this PR.

## Tests

`markup-loader.spec.ts` (36 tests) is **deleted, not ported.** Its oracle was "the
markup path agrees with the bundle path"; there is now one path, so that assertion
cannot fail and keeping it would have been a tautology dressed as coverage.

What replaces it asserts things that *can* fail:

- **`markup-compile.spec.ts`** — the bytes are a bundle according to an
  *independent* reader: `decodeTemplate` in `ts/server/decode.ts` shares no
  container-parsing code with `handleStream`, and it recovers the config, the main
  thread script and a non-empty `StyleInfo` from what the browser compiled.
- **`template-manager.spec.ts`** — end to end through the real worker: loading the
  XML and loading the pre-compiled bundle produce the **identical sequence of
  posted sections, byte for byte**, under both transform-flag settings, plus a
  control that the two flag settings do differ.
- **`markup-encoder-chunk.spec.ts`** — source-level guards on the lazy import,
  with a known-positive control so a greedy comment strip cannot make them vacuous.

Suite total `424 → 402`, attributed per file (23 specs unchanged):
`−36` deleted spec, `+8` `markup-compile`, `+5` `markup-encoder-chunk`, `+1`
`template-manager` = `−22`. `424 − 22 = 402`, which is what rstest reports.

**Mutation probes** (all red when mutated, green and byte-identical after restore):

| mutation | result |
|---|---|
| recursive `handleStream` given a hardcoded `transformVW=true` | `template-manager` **red** |
| drop `webpackPrefetch: false` | `markup-encoder-chunk` **red** |
| dynamic `import()` → static import | `markup-encoder-chunk` **red** |
| truncate the compiled bundle by one byte | `template-manager` **4 red** |
| drop the `startsXMLDocument` guard | 2 **red** across 2 files |

The first probe originally **passed**, which found a real hole in my own test: the
card had no `vw`/`vh`/`rem`, so the transform flags were no-ops and unobservable.
The fixture now carries them.

## Gates run locally

`pnpm turbo build` **71/71** (17 cached / 71 → 54 executed, not a replay) ·
`npx tsc6 --build --force` **0** · package `tsc --noEmit` **0** ·
web-core rstest **402/402** · `cargo clippy -p web-core --tests --all-features -D warnings` **0**
(this PR has zero `.rs` changes) · `dprint check` **0** · `biome check packages/` **0** ·
`sherif -i tailwindcss` **0 errors** · all four changeset scripts **pass** ·
`node --test .github/scripts/*.test.cjs` **15/15** · `meta-updater --test` **0** ·
`check-single-preact-instance` **pass** · `typos` and `typos --hidden .changeset/` **0**.

Two gate-validity notes: `typos` skips `.changeset/` by default, so it was run
explicitly; and repo-level `eslint` **ignores `packages/web-platform/**`**
(`eslint.config.js:123`), so the standalone eslint job says nothing about this
change — the eslint that *does* see it is `pluginEslint` inside web-core's
`rsbuild build`, confirmed to have teeth by injecting
`Promise.withResolvers()` and watching the build fail on `no-restricted-syntax`.

## For reviewers to decide

- **`encodeLynxXML` warns on the console unconditionally, and now does so at
  runtime.** That was written when the only caller was a build. Left as-is so
  `ts/encode/` keeps a zero diff; gating it on a dev build or deduplicating per
  at-rule name are both reasonable and neither is done here.
- **The tarball grows by 397 kB** — the markup chunk plus the encode wasm, which
  rspack now also emits under `dist/client_prod/static/wasm/`. That wasm is now
  present three times in the package (there, `dist/encode_prod/` since #3589, and
  `binary/encode/`). Reclaiming it is a `files` change that alters what deep
  importers can reach, so it is out of scope here.
- **A corrupted bundle reaches the markup fallback**, since markup is what is left
  when a response is neither a bundle nor JSON. The two are told apart *before* the
  compiler chunk is fetched, on whether the content begins a tag; a corrupt bundle
  keeps `Invalid Magic Header`, now carrying the eight bytes that failed to match.
- **#3390 overlaps on `css-tree@3.2.1`.** It reaches css-tree directly where this
  PR reaches it through `@lynx-js/css-serializer`; one instance resolves, so
  rspack would either duplicate it into both lazy chunks or hoist it. **Whoever
  lands second must re-measure, and the first may shift too.** Nobody has built
  the union, so no combined figure is quoted.

## Baseline note

Rebased onto `e4c7741e9` (`main` moved from `cf98e1461` mid-review). The artifact
A/B above was measured against `cf98e1461`; the one intervening commit (#3588) is
CI-only — `.github/**` plus `packages/tools/canary-release/pnpr-config.js`, with
no overlap with `packages/web-platform/**`, Rust, or the lockfile — so the
comparison is unaffected. The full gate battery above was re-run after the rebase.
