### PR TITLE
test(react): show that a portal container swap rebuilds the fiber elements

### DIFF
--- a/.changeset/portal-element-papi-alog-rewrap.md
+++ b/.changeset/portal-element-papi-alog-rewrap.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Make `initElementPAPICallAlog` idempotent so the element PAPI alog is not installed twice over the same globals, which logged every call once per layer.

--- a/packages/react/runtime/src/snapshot/alog/elementPAPICall.ts
+++ b/packages/react/runtime/src/snapshot/alog/elementPAPICall.ts
@@ -45,6 +45,8 @@ const fiberElementPAPINameList = [
   '__RemoveGestureDetector',
 ];
 
+const ALOG_WRAPPED = Symbol.for('__ELEMENT_PAPI_CALL_ALOG_WRAPPED__');
+
 export function initElementPAPICallAlog(globalWithIndex: Record<string, unknown> = globalThis): void {
   let count = 0;
   const fiberElementMap = new Map<any, {
@@ -65,8 +67,14 @@ export function initElementPAPICallAlog(globalWithIndex: Record<string, unknown>
 
   filteredFiberElementPAPINameList.forEach(fiberElementPAPIName => {
     const oldFiberElementPAPI = globalWithIndex[fiberElementPAPIName];
+    // Both this module's own bootstrap and the testing-library setup hook can
+    // reach the same globals. Wrapping an existing wrapper stacks two
+    // independent counters and logs every call twice, so skip it.
+    if ((oldFiberElementPAPI as { [ALOG_WRAPPED]?: boolean })?.[ALOG_WRAPPED]) {
+      return;
+    }
     if (typeof oldFiberElementPAPI === 'function') {
-      globalWithIndex[fiberElementPAPIName] = (...args: unknown[]): unknown => {
+      const wrapped = (...args: unknown[]): unknown => {
         if (typeof __PROFILE__ !== 'undefined' && __PROFILE__) {
           profileStart(`FiberElementPAPI: ${fiberElementPAPIName}`, {
             args: {
@@ -127,6 +135,8 @@ export function initElementPAPICallAlog(globalWithIndex: Record<string, unknown>
         );
         return result;
       };
+      (wrapped as { [ALOG_WRAPPED]?: boolean })[ALOG_WRAPPED] = true;
+      globalWithIndex[fiberElementPAPIName] = wrapped;
     }
   });
 }

--- a/packages/react/testing-library/src/__tests__/portals.test.jsx
+++ b/packages/react/testing-library/src/__tests__/portals.test.jsx
@@ -456,6 +456,166 @@ describe('createPortal (idiomatic ref={setState})', () => {
   });
 });
 
+/**
+ * `Portal` keeps its target in `props._container` and compares it by object
+ * identity. When that changes it calls its own `componentWillUnmount`, which
+ * `render(null, _temp)`s the whole portaled subtree before a fresh one is
+ * mounted (`packages/react/runtime/src/snapshot/lynx/portals.ts`). Changing the
+ * container is therefore a remount, not a reparent.
+ *
+ * These tests read the fiber element PAPI calls off `console.alog` (the testing
+ * environment enables `__ALOG_ELEMENT_API__`, so `initElementPAPICallAlog`
+ * reports every call there) to show exactly which elements are torn down and
+ * rebuilt.
+ */
+const ELEMENT_PAPI_LOG = /^\[ReactLynxDebug\] FiberElement API call #\d+: /;
+
+// `console.alog` also carries background render logs and the BTS -> MTS patch
+// dumps; keep only the element PAPI calls.
+function elementPAPICalls() {
+  return lynxTestingEnv.mainThread.console.alog.mock.calls
+    .map(([line]) => String(line))
+    .filter((line) => ELEMENT_PAPI_LOG.test(line))
+    .map((line) => line.replace(ELEMENT_PAPI_LOG, ''));
+}
+
+describe('createPortal container swap', () => {
+  it('rebuilds the portaled elements when the container changes', () => {
+    vi.spyOn(lynxTestingEnv.mainThread.console, 'alog');
+
+    let swap;
+    let bump;
+    function Counter() {
+      const [n, setN] = useState(0);
+      bump = () => setN(v => v + 1);
+      return <text data-testid='p'>{`count:${n}`}</text>;
+    }
+    function App() {
+      const [aHost, setAHost] = useState(null);
+      const [bHost, setBHost] = useState(null);
+      const [useB, setUseB] = useState(false);
+      swap = () => setUseB(true);
+      const target = useB ? bHost : aHost;
+      return (
+        <view>
+          <view data-testid='a' ref={setAHost} />
+          <view data-testid='b' ref={setBHost} />
+          {target && createPortal(<Counter />, target)}
+        </view>
+      );
+    }
+
+    const { getByTestId, queryByText } = render(<App />);
+
+    act(() => bump());
+    expect(queryByText('count:1')).toBeInTheDocument();
+    const beforeSwap = getByTestId('p');
+
+    lynxTestingEnv.mainThread.console.alog.mockClear();
+    act(() => swap());
+
+    // The element in host A is removed and a brand new one is built for host
+    // B. Nothing reparents the existing element.
+    expect(elementPAPICalls()).toMatchInlineSnapshot(`
+      [
+        "__GetPageElement() => PAGE#0",
+        "__RemoveElement(VIEW#2, TEXT#5)",
+        "__FlushElementTree(PAGE#0, {"pipelineOptions":{"pipelineID":"pipelineID","needTimestamps":true,"pipelineOrigin":"reactLynxHydrate","dsl":"reactLynx","stage":"hydrate"}})",
+        "__GetPageElement() => PAGE#0",
+        "__CreateText(0) => TEXT#7",
+        "__AddDataset(TEXT#7, "testid", "p")",
+        "__CreateRawText("") => #text#8",
+        "__SetAttribute(#text#8, "text", "count:0")",
+        "__AppendElement(TEXT#7, #text#8)",
+        "__AppendElement(VIEW#3, TEXT#7)",
+        "__FlushElementTree(PAGE#0, {"pipelineOptions":{"pipelineID":"pipelineID","needTimestamps":true,"pipelineOrigin":"reactLynxHydrate","dsl":"reactLynx","stage":"hydrate"}})",
+        "__FlushElementTree(PAGE#0, {"emptyPatch":true,"pipelineOptions":{"pipelineID":"pipelineID","needTimestamps":true,"pipelineOrigin":"reactLynxHydrate","dsl":"reactLynx","stage":"hydrate"}})",
+      ]
+    `);
+
+    const afterSwap = getByTestId('p');
+    expect(afterSwap).not.toBe(beforeSwap);
+    expect(getByTestId('b')).toContainElement(afterSwap);
+    expect(getByTestId('a')).not.toContainElement(afterSwap);
+
+    // The remount resets state inside the portal, matching react-dom.
+    expect(queryByText('count:1')).not.toBeInTheDocument();
+    expect(queryByText('count:0')).toBeInTheDocument();
+  });
+
+  /**
+   * The comparison looks at the `NodesRef` wrapper rather than the element it
+   * points at, and `lynx.createSelectorQuery().select()` returns a new wrapper
+   * on every call. So re-selecting the same host rebuilds the portaled elements
+   * into that same host, even though the target never changed. react-dom does
+   * not do this: passing the same node twice leaves the portal alone.
+   *
+   * `serializeNodesRef` already produces a stable identifier for both
+   * `RefProxy` and selector-backed refs, so the comparison could be made
+   * value-based if this remount turns out to be unwanted.
+   */
+  it('also rebuilds them when a new NodesRef points at the same container', () => {
+    vi.spyOn(lynxTestingEnv.mainThread.console, 'alog');
+
+    let setHostFromOutside;
+    let bump;
+    function Counter() {
+      const [n, setN] = useState(0);
+      bump = () => setN(v => v + 1);
+      return <text data-testid='p'>{`count:${n}`}</text>;
+    }
+    function App() {
+      const [host, setHost] = useState(null);
+      setHostFromOutside = setHost;
+      return (
+        <view>
+          <view id='same-host' data-testid='host' />
+          {host && createPortal(<Counter />, host)}
+        </view>
+      );
+    }
+
+    const { getByTestId, queryByText } = render(<App />);
+
+    act(() => {
+      setHostFromOutside(lynx.createSelectorQuery().select('#same-host'));
+    });
+    act(() => bump());
+    expect(queryByText('count:1')).toBeInTheDocument();
+    const beforeReselect = getByTestId('p');
+
+    lynxTestingEnv.mainThread.console.alog.mockClear();
+    act(() => {
+      setHostFromOutside(lynx.createSelectorQuery().select('#same-host'));
+    });
+
+    // Same parent on both sides: the element is destroyed and rebuilt in place.
+    expect(elementPAPICalls()).toMatchInlineSnapshot(`
+      [
+        "__GetPageElement() => PAGE#0",
+        "__RemoveElement(VIEW#2, TEXT#4)",
+        "__FlushElementTree(PAGE#0, {"pipelineOptions":{"pipelineID":"pipelineID","needTimestamps":true,"pipelineOrigin":"reactLynxHydrate","dsl":"reactLynx","stage":"hydrate"}})",
+        "__GetPageElement() => PAGE#0",
+        "__CreateText(0) => TEXT#6",
+        "__AddDataset(TEXT#6, "testid", "p")",
+        "__CreateRawText("") => #text#7",
+        "__SetAttribute(#text#7, "text", "count:0")",
+        "__AppendElement(TEXT#6, #text#7)",
+        "__AppendElement(VIEW#2, TEXT#6)",
+        "__FlushElementTree(PAGE#0, {"pipelineOptions":{"pipelineID":"pipelineID","needTimestamps":true,"pipelineOrigin":"reactLynxHydrate","dsl":"reactLynx","stage":"hydrate"}})",
+        "__FlushElementTree(PAGE#0, {"emptyPatch":true,"pipelineOptions":{"pipelineID":"pipelineID","needTimestamps":true,"pipelineOrigin":"reactLynxHydrate","dsl":"reactLynx","stage":"hydrate"}})",
+      ]
+    `);
+
+    const afterReselect = getByTestId('p');
+    expect(afterReselect).not.toBe(beforeReselect);
+    // The host keeps exactly one child, so this is a clean remount rather than
+    // a duplicate or a leak.
+    expect(getByTestId('host').children).toHaveLength(1);
+    expect(queryByText('count:0')).toBeInTheDocument();
+  });
+});
+
 describe('createPortal cleanup ordering', () => {
   it('does not throw when portal container is removed before portaled children', () => {
     vi.spyOn(lynx.getNativeApp(), 'callLepusMethod');
@@ -508,7 +668,7 @@ describe('createPortal cleanup ordering', () => {
           {
             "id": 2,
             "op": "CreateElement",
-            "type": "__snapshot_73047_test_31",
+            "type": "__snapshot_73047_test_35",
           },
           {
             "id": 2,
@@ -527,7 +687,7 @@ describe('createPortal cleanup ordering', () => {
           {
             "id": 3,
             "op": "CreateElement",
-            "type": "__snapshot_73047_test_32",
+            "type": "__snapshot_73047_test_36",
           },
           {
             "id": 4,
@@ -861,7 +1021,7 @@ describe('createPortal with list-item reuse', () => {
           <list
             data-testid="list"
             style="width:100%;height:100%"
-            update-list-info="[{"insertAction":[{"position":0,"type":"__snapshot_73047_test_41","item-key":"0","full-span":true},{"position":1,"type":"__snapshot_73047_test_41","item-key":"1","full-span":true},{"position":2,"type":"__snapshot_73047_test_41","item-key":"2","full-span":true},{"position":3,"type":"__snapshot_73047_test_41","item-key":"3","full-span":true},{"position":4,"type":"__snapshot_73047_test_41","item-key":"4","full-span":true},{"position":5,"type":"__snapshot_73047_test_41","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]}]"
+            update-list-info="[{"insertAction":[{"position":0,"type":"__snapshot_73047_test_45","item-key":"0","full-span":true},{"position":1,"type":"__snapshot_73047_test_45","item-key":"1","full-span":true},{"position":2,"type":"__snapshot_73047_test_45","item-key":"2","full-span":true},{"position":3,"type":"__snapshot_73047_test_45","item-key":"3","full-span":true},{"position":4,"type":"__snapshot_73047_test_45","item-key":"4","full-span":true},{"position":5,"type":"__snapshot_73047_test_45","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]}]"
           />
         </view>
       </page>
@@ -987,7 +1147,7 @@ describe('createPortal with list-item reuse', () => {
           <list
             data-testid="list"
             style="width:100%;height:100%"
-            update-list-info="[{"insertAction":[{"position":0,"type":"__snapshot_73047_test_41","item-key":"0","full-span":true},{"position":1,"type":"__snapshot_73047_test_41","item-key":"1","full-span":true},{"position":2,"type":"__snapshot_73047_test_41","item-key":"2","full-span":true},{"position":3,"type":"__snapshot_73047_test_41","item-key":"3","full-span":true},{"position":4,"type":"__snapshot_73047_test_41","item-key":"4","full-span":true},{"position":5,"type":"__snapshot_73047_test_41","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]},{"insertAction":[],"removeAction":[3],"updateAction":[]}]"
+            update-list-info="[{"insertAction":[{"position":0,"type":"__snapshot_73047_test_45","item-key":"0","full-span":true},{"position":1,"type":"__snapshot_73047_test_45","item-key":"1","full-span":true},{"position":2,"type":"__snapshot_73047_test_45","item-key":"2","full-span":true},{"position":3,"type":"__snapshot_73047_test_45","item-key":"3","full-span":true},{"position":4,"type":"__snapshot_73047_test_45","item-key":"4","full-span":true},{"position":5,"type":"__snapshot_73047_test_45","item-key":"5","full-span":true}],"removeAction":[],"updateAction":[]},{"insertAction":[],"removeAction":[3],"updateAction":[]}]"
           >
             <list-item
               full-span="true"

--- a/packages/react/testing-library/src/setupFiles/common/runtime-setup.js
+++ b/packages/react/testing-library/src/setupFiles/common/runtime-setup.js
@@ -66,12 +66,14 @@ globalThis.onInjectMainThreadGlobals = (target) => {
 
   target.globalPipelineOptions = undefined;
 
-  if (
-    typeof target.__ALOG_ELEMENT_API__ !== 'undefined' && target.__ALOG_ELEMENT_API__
-    && !target.__initElementPAPICallAlogInjected
-  ) {
+  // Re-wrap on every injection. `injectMainThreadGlobals` reinstalls the
+  // element PAPIs (`__injectElementApi`) before calling this hook, so the
+  // wrappers installed for the previous test are already gone. Guarding this
+  // with a flag on `target` left the flag behind while the wrappers were
+  // replaced, which silently limited the element PAPI alog to the first test
+  // in a file.
+  if (typeof target.__ALOG_ELEMENT_API__ !== 'undefined' && target.__ALOG_ELEMENT_API__) {
     initElementPAPICallAlog(target);
-    target.__initElementPAPICallAlogInjected = true;
   }
 };
 globalThis.onInjectBackgroundThreadGlobals = (target) => {


### PR DESCRIPTION
## Question

Does the fiber element survive when a `createPortal` moves from container A to container B?

## Answer: no, it is destroyed and rebuilt

`Portal` keeps the target in `props._container` and compares it by object identity. A change calls its own `componentWillUnmount`, which `render(null, _temp)`s the whole portaled subtree before a fresh one is mounted (`packages/react/runtime/src/snapshot/lynx/portals.ts`).

The new tests capture the fiber element PAPI calls around the swap:

```
__RemoveElement(VIEW#2, TEXT#5)      <- old element leaves host A
__CreateText(0) => TEXT#7            <- brand new element
__AddDataset(TEXT#7, "testid", "p")
__CreateRawText("") => #text#8
__SetAttribute(#text#8, "text", "count:0")
__AppendElement(TEXT#7, #text#8)
__AppendElement(VIEW#3, TEXT#7)      <- appended to host B
```

No PAPI reparents the existing element. Element identity changes, and state inside the portal resets (`count:1` -> `count:0`). This matches react-dom and preact, which also remount a portal whose container changes, so it is documented rather than treated as a defect.

## The part that may be unintended

The comparison is on the `NodesRef` wrapper, not on the element it resolves to. `lynx.createSelectorQuery().select('#same-host')` returns a fresh wrapper on every call, so re-selecting the *same* host rebuilds the portaled elements into that same host:

```
__RemoveElement(VIEW#2, TEXT#4)
__CreateText(0) => TEXT#6
...
__AppendElement(VIEW#2, TEXT#6)      <- same parent as the element just removed
```

react-dom does not do this: passing the same node twice leaves the portal alone. `serializeNodesRef` already yields a stable identifier for both `RefProxy` and selector-backed refs, so the comparison could be made value-based. This PR only documents the behavior; no fix is included pending a decision on whether the remount is wanted.

## Incidental fix: the element PAPI alog only worked once per file

Capturing the traces surfaced a bug in the alog itself.

`injectMainThreadGlobals` reinstalls the element PAPIs via `__injectElementApi` before calling `onInjectMainThreadGlobals`, but the testing-library hook guarded installation with a flag stored on the same globals. The flag outlived the wrappers it guarded, so from the second test in a file onwards no element PAPI call was reported. `alog.test.jsx` never caught this because it holds a single test.

Removing the guard alone stacked two wrapper layers (the runtime's own bootstrap in `lynx.ts` plus the testing-library hook), which logged every call twice with two independent counters. So `initElementPAPICallAlog` is now idempotent: an already-wrapped PAPI is skipped.

## Verification

- `packages/react/testing-library`: 165 tests pass
- `packages/react/runtime`: 815 pass, 2 skipped, 4 todo

Four lines of existing inline snapshots in `portals.test.jsx` change because the new JSX shifts the generated `__snapshot_73047_test_NN` ids. Mechanical rename, no behavior change.