### PR TITLE
fix(genui): prevent data model prototype pollution

### DIFF
--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -50,6 +50,8 @@ When rendering the unified `ChatPage`, key it by protocol so switching between A
 
 When adding or updating playground conversation history, keep records isolated by protocol. Store new records with `ConversationMeta.protocol`, use protocol-scoped active-id metadata such as `activeConversationId:a2ui` and `activeConversationId:openui`, and treat legacy records without a `protocol` field as A2UI conversations so existing browser history remains visible.
 
+Treat external `updateDataModel` paths and values as untrusted when materializing conversation snapshots. Traverse only own properties and define own data properties without invoking the legacy `__proto__` setter, while preserving prototype-like names as valid JSON keys.
+
 Rebuild A2UI `Generated Output` cards from each ordinary assistant history entry, preserving transcript order and rendering the entry's A2UI message array as separate chunks. Keep successful action responses in their action-specific Applied cards, and do not replace history-scoped output cards with a single controller-level artifact derived from the latest preview output.
 
 When an action response is merged with the current preview messages, clear any previous or action-only snapshot payload URL and persist the merged inline preview. Treat an explicitly present `snapshotPreviewPayloadUrls: null` as a clear operation rather than falling back to `previewPayloadUrls`; otherwise reopened and shared conversations can render a stale pre-action snapshot.

--- a/packages/genui/playground/src/hooks/useConversation.ts
+++ b/packages/genui/playground/src/hooks/useConversation.ts
@@ -16,6 +16,7 @@ import {
   saveConversationMessages,
   setActiveConversationId,
 } from '../storage/conversationRepo.js';
+import { applyA2UIMessagesToSnapshot } from '../storage/conversationSnapshot.js';
 import type { SharedConversationDoc } from '../storage/sharedConversation.js';
 import type {
   ConversationMeta,
@@ -92,15 +93,6 @@ function cloneDataModel(
   }
 }
 
-function cloneDataValue(value: unknown): unknown {
-  if (value === null || typeof value !== 'object') return value;
-  try {
-    return JSON.parse(JSON.stringify(value)) as unknown;
-  } catch {
-    return value;
-  }
-}
-
 function clonePreviewPerformanceMetrics(
   value: PreviewPerformanceMetrics | null | undefined,
 ): PreviewPerformanceMetrics | undefined {
@@ -132,79 +124,6 @@ function truncateConversationHistory(
   }
 
   return kept;
-}
-
-function applyDataModel(
-  model: Record<string, unknown>,
-  path: string,
-  value: unknown,
-): void {
-  if (!path || path === '/' || path === '') {
-    for (const key of Object.keys(model)) {
-      delete model[key];
-    }
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      Object.assign(model, cloneDataValue(value) as Record<string, unknown>);
-    }
-    return;
-  }
-
-  const parts = path.replace(/^\//u, '').split('/').filter(Boolean);
-  let cursor = model;
-  for (let i = 0; i < parts.length - 1; i++) {
-    const key = parts[i];
-    if (!key) continue;
-    if (typeof cursor[key] !== 'object' || cursor[key] === null) {
-      cursor[key] = {};
-    }
-    cursor = cursor[key] as Record<string, unknown>;
-  }
-
-  const last = parts[parts.length - 1];
-  if (!last) return;
-  if (value === undefined) {
-    delete cursor[last];
-  } else {
-    cursor[last] = cloneDataValue(value);
-  }
-}
-
-function applyA2UIMessagesToSnapshot(
-  dataModel: Record<string, unknown>,
-  surfaceIds: Set<string>,
-  messages: unknown[],
-): void {
-  for (const message of messages) {
-    if (!message || typeof message !== 'object') continue;
-    const record = message as {
-      createSurface?: { surfaceId?: unknown };
-      deleteSurface?: { surfaceId?: unknown };
-      updateDataModel?: { path?: unknown; value?: unknown };
-    };
-    if (
-      record.createSurface
-      && typeof record.createSurface.surfaceId === 'string'
-    ) {
-      surfaceIds.add(record.createSurface.surfaceId);
-      continue;
-    }
-    if (
-      record.deleteSurface
-      && typeof record.deleteSurface.surfaceId === 'string'
-    ) {
-      surfaceIds.delete(record.deleteSurface.surfaceId);
-      continue;
-    }
-    if (record.updateDataModel) {
-      applyDataModel(
-        dataModel,
-        typeof record.updateDataModel.path === 'string'
-          ? record.updateDataModel.path
-          : '/',
-        record.updateDataModel.value,
-      );
-    }
-  }
 }
 
 function titleFromMessage(content: string): string {

--- a/packages/genui/playground/src/storage/conversationSnapshot.test.ts
+++ b/packages/genui/playground/src/storage/conversationSnapshot.test.ts
@@ -1,0 +1,115 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { afterEach, describe, expect, test } from '@rstest/core';
+
+import { applyA2UIMessagesToSnapshot } from './conversationSnapshot.js';
+
+const POLLUTED_KEY = '__genui_polluted__';
+const objectPrototype = Object.prototype as Record<string, unknown>;
+
+afterEach(() => {
+  delete objectPrototype[POLLUTED_KEY];
+});
+
+describe('conversation data model snapshot', () => {
+  test('stores __proto__ path segments without polluting Object.prototype', () => {
+    const dataModel: Record<string, unknown> = {};
+    const surfaceIds = new Set<string>();
+
+    applyA2UIMessagesToSnapshot(dataModel, surfaceIds, [
+      { createSurface: { surfaceId: 'main' } },
+      {
+        updateDataModel: {
+          surfaceId: 'main',
+          path: `/__proto__/${POLLUTED_KEY}`,
+          value: 'nested',
+        },
+      },
+    ]);
+
+    expect(surfaceIds).toEqual(new Set(['main']));
+    expect(Object.getPrototypeOf(dataModel)).toBe(Object.prototype);
+    expect(objectPrototype[POLLUTED_KEY]).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(dataModel, '__proto__')).toBe(
+      true,
+    );
+    expect(
+      (Reflect.get(dataModel, '__proto__') as Record<string, unknown>)[
+        POLLUTED_KEY
+      ],
+    ).toBe('nested');
+  });
+
+  test('replaces the root without invoking the __proto__ setter', () => {
+    const dataModel: Record<string, unknown> = { stale: true };
+    const rootValue = JSON.parse(
+      `{"__proto__":{"${POLLUTED_KEY}":"root"},"safe":true}`,
+    ) as Record<string, unknown>;
+
+    applyA2UIMessagesToSnapshot(dataModel, new Set(), [
+      { updateDataModel: { path: '/', value: rootValue } },
+    ]);
+
+    expect(dataModel.stale).toBeUndefined();
+    expect(dataModel.safe).toBe(true);
+    expect(Object.getPrototypeOf(dataModel)).toBe(Object.prototype);
+    expect(objectPrototype[POLLUTED_KEY]).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(dataModel, '__proto__')).toBe(
+      true,
+    );
+    expect(
+      (Reflect.get(dataModel, '__proto__') as Record<string, unknown>)[
+        POLLUTED_KEY
+      ],
+    ).toBe('root');
+  });
+
+  test('does not retain prototype references from non-JSON values', () => {
+    const dataModel: Record<string, unknown> = {};
+    const cyclicValue: Record<string, unknown> = {
+      target: Object.prototype,
+    };
+    cyclicValue.self = cyclicValue;
+
+    applyA2UIMessagesToSnapshot(dataModel, new Set(), [
+      { updateDataModel: { path: '/holder', value: cyclicValue } },
+      {
+        updateDataModel: {
+          path: `/holder/target/${POLLUTED_KEY}`,
+          value: 'local',
+        },
+      },
+    ]);
+
+    expect(objectPrototype[POLLUTED_KEY]).toBeUndefined();
+    const holder = dataModel.holder as Record<string, unknown>;
+    const target = holder.target as Record<string, unknown>;
+    expect(target[POLLUTED_KEY]).toBe('local');
+  });
+
+  test('updates an array length without redefining its attributes', () => {
+    const dataModel: Record<string, unknown> = {};
+
+    applyA2UIMessagesToSnapshot(dataModel, new Set(), [
+      { updateDataModel: { path: '/items', value: ['a', 'b'] } },
+      { updateDataModel: { path: '/items/length', value: 1 } },
+    ]);
+
+    expect(dataModel.items).toEqual(['a']);
+  });
+
+  test('updates and deletes ordinary nested values', () => {
+    const dataModel: Record<string, unknown> = {};
+
+    applyA2UIMessagesToSnapshot(dataModel, new Set(), [
+      { updateDataModel: { path: '/profile/name', value: 'Ada' } },
+    ]);
+    expect(dataModel).toEqual({ profile: { name: 'Ada' } });
+
+    applyA2UIMessagesToSnapshot(dataModel, new Set(), [
+      { updateDataModel: { path: '/profile/name', value: undefined } },
+    ]);
+    expect(dataModel).toEqual({ profile: {} });
+  });
+});

--- a/packages/genui/playground/src/storage/conversationSnapshot.ts
+++ b/packages/genui/playground/src/storage/conversationSnapshot.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+function cloneDataValue(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  try {
+    return JSON.parse(JSON.stringify(value)) as unknown;
+  } catch {
+    // Snapshot values are JSON data. Never retain an external object reference.
+    return null;
+  }
+}
+
+function defineOwnDataProperty(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  const descriptor = Object.getOwnPropertyDescriptor(target, key);
+  if (descriptor && !descriptor.configurable) {
+    // Preserve attributes such as an array's non-configurable `length`.
+    Object.defineProperty(target, key, { value });
+    return;
+  }
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+function applyDataModel(
+  model: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  if (!path || path === '/' || path === '') {
+    for (const key of Object.keys(model)) {
+      delete model[key];
+    }
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const cloned = cloneDataValue(value);
+      if (cloned && typeof cloned === 'object' && !Array.isArray(cloned)) {
+        for (const [key, childValue] of Object.entries(cloned)) {
+          defineOwnDataProperty(model, key, childValue);
+        }
+      }
+    }
+    return;
+  }
+
+  const parts = path.replace(/^\//u, '').split('/').filter(Boolean);
+  let cursor = model;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i];
+    if (!key) continue;
+    const child = Object.prototype.hasOwnProperty.call(cursor, key)
+      ? cursor[key]
+      : undefined;
+    if (typeof child !== 'object' || child === null) {
+      const next: Record<string, unknown> = {};
+      defineOwnDataProperty(cursor, key, next);
+      cursor = next;
+    } else {
+      cursor = child as Record<string, unknown>;
+    }
+  }
+
+  const last = parts[parts.length - 1];
+  if (!last) return;
+  if (value === undefined) {
+    delete cursor[last];
+  } else {
+    defineOwnDataProperty(cursor, last, cloneDataValue(value));
+  }
+}
+
+export function applyA2UIMessagesToSnapshot(
+  dataModel: Record<string, unknown>,
+  surfaceIds: Set<string>,
+  messages: unknown[],
+): void {
+  for (const message of messages) {
+    if (!message || typeof message !== 'object') continue;
+    const record = message as {
+      createSurface?: { surfaceId?: unknown };
+      deleteSurface?: { surfaceId?: unknown };
+      updateDataModel?: { path?: unknown; value?: unknown };
+    };
+    if (
+      record.createSurface
+      && typeof record.createSurface.surfaceId === 'string'
+    ) {
+      surfaceIds.add(record.createSurface.surfaceId);
+      continue;
+    }
+    if (
+      record.deleteSurface
+      && typeof record.deleteSurface.surfaceId === 'string'
+    ) {
+      surfaceIds.delete(record.deleteSurface.surfaceId);
+      continue;
+    }
+    if (record.updateDataModel) {
+      applyDataModel(
+        dataModel,
+        typeof record.updateDataModel.path === 'string'
+          ? record.updateDataModel.path
+          : '/',
+        record.updateDataModel.value,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Harden A2UI conversation snapshot updates so untrusted paths traverse only own properties and writes always create own data properties.
- Preserve prototype-like JSON keys without invoking the legacy `__proto__` setter, and discard non-JSON object references when cloning fails.
- Add regression coverage for nested and root `__proto__` updates, cyclic values, array `length`, and ordinary nested updates.

## Root cause

The snapshot materializer read path segments through normal property lookup and wrote them through assignment or `Object.assign`. A model-provided path such as `/__proto__/...` could therefore follow the inherited prototype and mutate `Object.prototype`; a root replacement containing `__proto__` could also invoke the legacy setter.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo build` — 66/66 tasks passed
- `pnpm --filter genui-playground test` — 18 files, 122/122 tests passed
- `pnpm dprint check`
- `pnpm biome check packages/genui/playground/src/hooks/useConversation.ts packages/genui/playground/src/storage/conversationSnapshot.ts packages/genui/playground/src/storage/conversationSnapshot.test.ts`
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint .` — 0 errors
- `pnpm changeset status --since=origin/main`

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Changeset not required because `genui-playground` is private.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation snapshot handling for nested data updates, value replacement, deletion, and array changes.
  * Prevented unsafe property names from altering application behavior or prototype data.
  * Ensured malformed messages are ignored without disrupting saved conversation state.
  * Preserved valid JSON keys that resemble prototype properties.
* **Reliability**
  * Improved cloning of stored values, including graceful handling of unsupported values.
  * Kept surface additions and removals synchronized with conversation snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->