### PR TITLE
fix(renovate): match pnpm catalog deps in the Rspack/Rsbuild/Rstest groups

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,6 +90,9 @@
         "nyc",
         "tiny-invariant",
         "wasm-feature-detect",
+        "@lynx-js/lynx-core",
+        "@preact/signals",
+        "@rspack/lite-tapable",
       ],
       "groupName": null,
     },
@@ -100,6 +103,7 @@
       "matchDepTypes": [
         "devDependencies",
         "dependencies",
+        "pnpm.catalog.rspack",
       ],
       "matchPackageNames": [
         "/@rspack/*/",
@@ -113,6 +117,7 @@
       "matchDepTypes": [
         "devDependencies",
         "dependencies",
+        "pnpm.catalog.rsbuild",
       ],
       "matchPackageNames": [
         "/@rsbuild/*/",
@@ -131,6 +136,7 @@
       "matchDepTypes": [
         "devDependencies",
         "dependencies",
+        "pnpm.catalog.rstest",
       ],
       "matchPackageNames": [
         "/@rstest/*/",


### PR DESCRIPTION
The `Rspack`, `Rsbuild` and `Rstest` rules filter on `matchDepTypes: ["devDependencies", "dependencies"]`, but Renovate extracts `pnpm-workspace.yaml` catalog entries as `pnpm.catalog.<name>`. The groups therefore never matched the catalog — which is where those packages actually live — so each catalog bump got its own PR.

That is exactly the failure the Rstest rule was added to prevent. Bumping one `@rstest/*` package without the others cannot resolve `strictPeerDependencies`, so Renovate writes the catalog change without a matching `pnpm-lock.yaml` and CI fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — see #3317 and #3318, both currently red for this reason.

Evidence that the groups were not matching: #3368 (the `@rstest/core` pin in the `create-rspeedy` template, a real `devDependencies` entry) carries the `upstream:rspack` label that these rules add, while #3267 (the `@rsbuild/core` catalog bump) carries only `bot:renovate`.

This also ungroups three more dependencies that are a `dependencies` of one workspace package and a `devDependencies` of another. The "dev minor & patch" group takes the devDependencies half and leaves the rest in a separate PR; `sherif` requires a single version across the workspace, so neither half can merge on its own — #3230 and #3179 both carry half of `@preact/signals` today, the same shape as `@rsdoctor/rspack-plugin` in #3117 vs #3179. A scan of the workspace found 11 dependencies split this way; these were the three missing from the list.

## Verification

Run with `renovate --platform=local --dry-run=lookup`, which reads the working tree and writes nothing:

| | branches |
|---|---|
| before | `renovate/rstest-core-0.x`, `renovate/rstest-adapter-rsbuild-0.x`, `renovate/rstest-coverage-istanbul-0.x`, `renovate/rstest`, `renovate/rsbuild-core-2.x`, `renovate/rspack-dev-server-2.x`, `renovate/rspack-monorepo` |
| after | `renovate/rstest`, `renovate/rsbuild`, `renovate/rspack` |

`@preact/signals` also no longer appears in `renovate/dev-non-major`.

Once this lands, #3278, #3317, #3318 and #3230 should be closed so Renovate can recreate them as grouped PRs that carry a consistent lock file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update coverage for Lynx, Preact Signals, and Rspack Lite Tapable.
  * Dependency updates managed through pnpm catalogs are now included for Rspack, Rsbuild, and Rstest packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->