### PR TITLE
fix(renovate): hold @modelcontextprotocol/sdk below 1.29

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,20 @@
       "allowedVersions": "<4",
     },
     {
+      // >=1.29 adds a `types` condition to the `./*` subpath export that does
+      // not strip the `.js` extension:
+      //
+      //   "./*": { "types": "./dist/esm/*.d.ts", "import": "./dist/esm/*", ... }
+      //
+      // so `@modelcontextprotocol/sdk/server/mcp.js` resolves its types to
+      // `dist/esm/server/mcp.js.d.ts`, which the package does not ship. The
+      // TypeScript resolver prefers the `types` condition, so `eslint` fails
+      // `import/no-unresolved` on `packages/mcp-servers/docs-mcp-server`
+      // (#3210, and again in #3213). Lift this once upstream ships a fix.
+      "matchPackageNames": ["@modelcontextprotocol/sdk"],
+      "allowedVersions": "<1.29",
+    },
+    {
       // Batch low-risk updates: all devDependencies minor/patch bumps share one
       // rolling PR instead of one PR each. Kept near the top on purpose -- the
       // specific groups below (Rspack, types, linting, ...) match later and win,


### PR DESCRIPTION
From `1.29` the `./*` subpath export gained a `types` condition that does not strip the `.js` extension:

```jsonc
// 1.25.2 (pinned today)
"./*": { "import": "./dist/esm/*", "require": "./dist/cjs/*" }

// 1.30.0 (proposed by #3213)
"./*": { "types": "./dist/esm/*.d.ts", "import": "./dist/esm/*", "require": "./dist/cjs/*" }
```

`@modelcontextprotocol/sdk/server/mcp.js` therefore resolves its types to `dist/esm/server/mcp.js.d.ts`, which the package does not ship — the real file is `mcp.d.ts`. The TypeScript resolver prefers the `types` condition, so `eslint` fails on `packages/mcp-servers/docs-mcp-server/main.ts`:

```
10:27  error  Unable to resolve path to module "@modelcontextprotocol/sdk/server/mcp.js"    import/no-unresolved
11:38  error  Unable to resolve path to module "@modelcontextprotocol/sdk/server/stdio.js"  import/no-unresolved
```

This first surfaced in #3210 and was worked around by pinning exactly in #3220. #3213 then proposed 1.30.0 and hit the same wall, so the constraint is worth encoding rather than rediscovering: `allowedVersions` stops Renovate from opening PRs that cannot pass CI, the same way `tailwindcss` is held below 4.

Lift this once upstream ships a fix. #3213 should be closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted automatic updates for the Model Context Protocol SDK to versions below 1.29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->