### PR TITLE
fix(test-tools): align the jest.Matchers type parameters with @rstest/core

### DIFF
--- a/packages/webpack/test-tools/src/setup-rspeedy.ts
+++ b/packages/webpack/test-tools/src/setup-rspeedy.ts
@@ -22,13 +22,18 @@ declare module '@rstest/core' {
 }
 
 declare global {
-  // @rstest/core's internal `JestAssertion` extends `jest.Matchers` without
-  // declaring the namespace (masked by `skipLibCheck`); declaring it here
-  // types the `.not` chain, which resolves through that internal interface.
+  // Up to @rstest/core 0.11.3 the internal `JestAssertion` extended
+  // `jest.Matchers` without declaring the namespace (masked by
+  // `skipLibCheck`); declaring it here types the `.not` chain, which resolves
+  // through that internal interface. From 0.11.5 @rstest/core declares the
+  // namespace itself as `Matchers<R, T = {}>`, and TS2428 requires every
+  // declaration to carry an identical type parameter list — so the default for
+  // `T` has to match theirs. `T` is unused here, so this stays correct on both.
   // biome-ignore lint/style/noNamespace: must match the `jest.Matchers` reference
   namespace jest {
     // biome-ignore lint/correctness/noUnusedVariables: referenced as `jest.Matchers<void, T>`
-    interface Matchers<R, T = unknown> {
+    // biome-ignore lint/complexity/noBannedTypes: the default must match @rstest/core's `Matchers<R, T = {}>` verbatim
+    interface Matchers<R, T = {}> {
       toHaveLoader: (loader: string | RegExp) => R;
     }
   }


### PR DESCRIPTION
Up to `@rstest/core` 0.11.3 the internal `JestAssertion` extended `jest.Matchers` without declaring the namespace, so `setup-rspeedy.ts` declared it locally as `Matchers<R, T = unknown>`.

From 0.11.5 `@rstest/core` ships that declaration itself — in `index.d.ts`, `adapter.d.ts`, `browser.d.ts`, `worker.d.ts` and `globalSetupWorker.d.ts` — as:

```ts
declare global {
  namespace jest {
    interface Matchers<R, T = {}> {}
  }
}
```

TS2428 requires every declaration of an interface to carry an identical type parameter list, defaults included, so the local one stops merging and the catalog bump fails to build:

```
packages/webpack/test-tools/src/setup-rspeedy.ts(31,15): error TS2428:
  All declarations of Matchers must have identical type parameters.
```

`T` is unused in the local declaration, so matching their default is enough, and it stays correct on 0.11.3 where this is still the only declaration.

## Verification

Reduced to two files and checked with `tsc --noEmit --skipLibCheck`, mirroring the real shape — the project declaration in a `.ts` file, the package one in a `.d.ts`:

| local `.ts` | vs `@rstest/core` `<R, T = {}>` |
|---|---|
| `<R, T = unknown>` | `TS2428` — reproduces the failure |
| `<R, T = {}>` | clean |

(`--skipLibCheck` suppresses this error between two `.d.ts` files, which is why it only surfaces from `setup-rspeedy.ts`.)

This unblocks the `@rstest/*` catalog bump currently carried by #3278.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across supported versions of the testing framework.
  * Preserved support for the existing custom loader matcher.
  * Resolved type declaration conflicts that could cause test setup or type-checking issues.
  * Updated testing utilities to provide more consistent behavior across different development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->