### PR TITLE
fix(ci): skip scaffolding templates in the dependency changeset check

### DIFF
--- a/.github/scripts/check-dep-changes-have-changeset.cjs
+++ b/.github/scripts/check-dep-changes-have-changeset.cjs
@@ -68,6 +68,12 @@ function findMissingChangesets({
     }
     if (curPkg.private) continue;
     if (!curPkg.name) continue;
+    // Scaffolding templates carry a placeholder name that is substituted at
+    // generation time (`packages/genui/cli/templates/default` is named
+    // `{{projectName}}`). That name can never appear in `changeset status`
+    // releases, so a dependency bump inside such a template is reported as
+    // missing a changeset forever and no PR touching it can go green.
+    if (curPkg.name.includes('{{')) continue;
     const depsChanged = !isShallowEqual(
       curPkg.dependencies,
       basePkg.dependencies,

--- a/.github/scripts/check-dep-changes-have-changeset.test.cjs
+++ b/.github/scripts/check-dep-changes-have-changeset.test.cjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { findMissingChangesets } = require(
+  './check-dep-changes-have-changeset.cjs',
+);
+
+const TEMPLATE = 'packages/genui/cli/templates/default/package.json';
+const PACKAGE = 'packages/genui/package.json';
+
+function bumped(name, version) {
+  return JSON.stringify({
+    name,
+    dependencies: { '@lynx-js/lynx-ui': version },
+  });
+}
+
+function run(releases) {
+  const current = {
+    [TEMPLATE]: bumped('{{projectName}}', '^3.135.4'),
+    [PACKAGE]: bumped('@lynx-js/genui', '^3.135.4'),
+  };
+  const base = {
+    [TEMPLATE]: bumped('{{projectName}}', '^3.135.0'),
+    [PACKAGE]: bumped('@lynx-js/genui', '^3.135.0'),
+  };
+  return findMissingChangesets({
+    releases,
+    changedFiles: Object.keys(current),
+    readCurrent: (f) => current[f],
+    readBase: (f) => base[f],
+  }).map((m) => m.name);
+}
+
+test('scaffolding templates with a placeholder name are skipped', () => {
+  // `{{projectName}}` is substituted at generation time and can never appear in
+  // `changeset status` releases, so it must not be reported as missing one.
+  assert.deepEqual(run([{ name: '@lynx-js/genui', type: 'patch' }]), []);
+});
+
+test('a real package with dep changes and no changeset is still reported', () => {
+  assert.deepEqual(run([]), ['@lynx-js/genui']);
+});


### PR DESCRIPTION
`packages/genui/cli/templates/default/package.json` is a scaffolding template named `{{projectName}}`, substituted at generation time. It is neither `private` nor nameless, so it passes both existing guards in `findMissingChangesets`, but that name can never appear in `changeset status` releases — `willBump.has(curPkg.name)` is false for it no matter which changesets a PR carries.

Any PR that bumps a dependency inside the template therefore fails, permanently:

```
The following packages changed dependencies or peerDependencies but no changeset bumps them:

  - {{projectName}}  [dependencies]
    packages/genui/cli/templates/default/package.json

Error: 1 package(s) with dep changes lack a changeset.
```

The template depends on `@lynx-js/genui`, `@lynx-js/lynx-ui` and `@lynx-js/react`, so Renovate runs into this regularly. #3373 is stuck on it right now.

## Tests

Added alongside the sibling `check-no-heading-changeset.test.cjs`, covering both directions so the guard cannot silently swallow real misses:

- a template with a placeholder name is skipped
- a real package with dependency changes and no changeset is still reported

```
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scaffolding template packages from being incorrectly reported as missing release notes.
  * Continued reporting real packages that require release notes.

* **Tests**
  * Added coverage to verify template packages are excluded while affected packages remain detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->