### PR TITLE
fix(deps): update dependency markdown-it to v15

### DIFF
--- a/.changeset/renovate-ebe470d4.md
+++ b/.changeset/renovate-ebe470d4.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Update `markdown-it` from `^14.3.0` to `^15.0.0`

--- a/packages/web-platform/web-elements/package.json
+++ b/packages/web-platform/web-elements/package.json
@@ -143,7 +143,7 @@
   },
   "dependencies": {
     "dompurify": "^3.4.13",
-    "markdown-it": "^14.3.0"
+    "markdown-it": "^15.0.0"
   },
   "devDependencies": {
     "@lynx-js/playwright-fixtures": "workspace:*",

--- a/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
+++ b/packages/web-platform/web-elements/src/elements/XMarkdown/XMarkdownAttributes.ts
@@ -3,7 +3,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 */
-import type MarkdownIt from 'markdown-it';
+// markdown-it 15 ships its own types: the default export is the callable
+// factory and the instance type is a named `MarkdownIt` export, so the two
+// cannot come from one `import type` (TS1363).
+import type MarkdownItCallable from 'markdown-it';
+import type { MarkdownIt } from 'markdown-it';
 import type createDOMPurify from 'dompurify';
 import {
   boostedQueueMicrotask,
@@ -12,7 +16,7 @@ import {
 } from '../../element-reactive/index.js';
 import type { XMarkdown } from './XMarkdown.js';
 
-type MarkdownItCtor = typeof MarkdownIt;
+type MarkdownItCtor = typeof MarkdownItCallable;
 type DOMPurifyCtor = typeof createDOMPurify;
 
 let MarkdownItLoaded: MarkdownItCtor | undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2199,8 +2199,8 @@ importers:
         specifier: ^3.4.13
         version: 3.4.13
       markdown-it:
-        specifier: ^14.3.0
-        version: 14.3.0
+        specifier: ^15.0.0
+        version: 15.0.0
     devDependencies:
       '@lynx-js/playwright-fixtures':
         specifier: workspace:*
@@ -6947,6 +6947,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  argparse@3.0.0:
+    resolution: {integrity: sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -7788,6 +7791,10 @@ packages:
   entities@6.0.0:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   envinfo@7.21.0:
     resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
@@ -9330,6 +9337,9 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
+  linkify-it@6.1.0:
+    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
+
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
     engines: {node: '>=20.17'}
@@ -9454,6 +9464,10 @@ packages:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
+  markdown-it@15.0.0:
+    resolution: {integrity: sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==}
+    hasBin: true
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -9539,8 +9553,8 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
-  mdurl@2.0.0:
-    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -11821,6 +11835,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uc.micro@3.0.0:
+    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -17311,6 +17328,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  argparse@3.0.0: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -18142,6 +18161,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.0: {}
+
+  entities@8.0.0: {}
 
   envinfo@7.21.0: {}
 
@@ -19924,6 +19945,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  linkify-it@6.1.0:
+    dependencies:
+      uc.micro: 3.0.0
+
   lint-staged@16.4.0:
     dependencies:
       commander: 14.0.3
@@ -20050,9 +20075,18 @@ snapshots:
       argparse: 2.0.1
       entities: 4.5.0
       linkify-it: 5.0.2
-      mdurl: 2.0.0
+      mdurl: 2.1.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  markdown-it@15.0.0:
+    dependencies:
+      argparse: 3.0.0
+      entities: 8.0.0
+      linkify-it: 6.1.0
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 3.0.0
 
   markdown-table@3.0.4: {}
 
@@ -20260,7 +20294,7 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mdurl@2.0.0: {}
+  mdurl@2.1.0: {}
 
   media-typer@1.1.0: {}
 
@@ -22801,6 +22835,8 @@ snapshots:
       typescript: 6.0.3
 
   uc.micro@2.1.0: {}
+
+  uc.micro@3.0.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
Same content as #3392 — the Renovate bump plus the type adaptation it needs — reopened on a fresh branch because GitHub stopped delivering push events for `renovate/markdown-it-15.x`: nine check-suites sit `queued` with no `github-actions` suite at all, and neither a force-push to a new SHA nor a close/reopen brought CI back.

## The type change

markdown-it 14 shipped no types, so `MarkdownIt` resolved through `@types/markdown-it`, where a single `export =` served as both the constructor and the instance type.

15 ships its own declarations and splits the two: the default export is `MarkdownItCallable`, the instance type is a named `MarkdownIt` export. `import type MarkdownIt from "markdown-it"` therefore binds a value:

```
XMarkdownAttributes.ts(125,33): error TS2749: MarkdownIt refers to a value, but is being used as a type.
```

The constructor now comes from the default import and the instance type from the named one. They need two statements — a type-only import cannot carry a default and named bindings at once (TS1363).

Verified against markdown-it 15.0.0 with `tsc --module nodenext`, exercising the same call shapes the file uses (`new Ctor({ html, linkify })`, `enable([...])`, `parse`, `renderer.render`).

Closes #3392.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated Markdown rendering to the latest version.
  * Improved compatibility with the updated Markdown engine while preserving existing rendering behavior.

* **Release**
  * Included a patch release update for the web elements package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->