### PR TITLE
feat(webpack-dev-transport): log the content of build errors

### DIFF
--- a/.changeset/log-build-errors.md
+++ b/.changeset/log-build-errors.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/webpack-dev-transport": patch
+---
+
+Log the content of build errors instead of dropping it.

--- a/packages/webpack/webpack-dev-transport/client/index.ts
+++ b/packages/webpack/webpack-dev-transport/client/index.ts
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 import { createSocketURL } from './createSocketURL.js';
 import { log, logEnabledFeatures } from './log.js';
+import { logBuildErrors } from './logBuildErrors.js';
+import type { BuildErrors } from './logBuildErrors.js';
 import { parseURL } from './parseURL.js';
 import reloadApp from './reloadApp.js';
 import socket from './socket.js';
@@ -132,9 +134,8 @@ const onSocketMessage = {
     reloadApp({ liveReload: true, hot: false, progress: false }, status);
   },
 
-  errors(_errors: Error[]) {
-    log.error('Errors while compiling. Reload prevented.');
-    // TODO: format errors
+  errors(errors: BuildErrors) {
+    logBuildErrors(errors);
   },
   error(error: Error) {
     log.error(error.toString());

--- a/packages/webpack/webpack-dev-transport/client/logBuildErrors.ts
+++ b/packages/webpack/webpack-dev-transport/client/logBuildErrors.ts
@@ -16,7 +16,7 @@ const MAX_LOGGED_ERRORS = 5;
 // The `text` sent by the dev-server keeps the colors it uses in the terminal.
 // Lynx consoles do not resolve them, so they would show up as escape sequences.
 // eslint-disable-next-line no-control-regex
-const SGR_PATTERN = /\u001B\[[0-9;]+m/g;
+const SGR_PATTERN = /\u001B\[[0-9;]*m/g;
 
 function toMessages(errors: BuildErrors): string[] {
   const messages = Array.isArray(errors)

--- a/packages/webpack/webpack-dev-transport/client/logBuildErrors.ts
+++ b/packages/webpack/webpack-dev-transport/client/logBuildErrors.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { log } from './log.js';
+
+/**
+ * Rsbuild sends `{ text, html }`, whereas `webpack-dev-server` sends an array.
+ */
+export type BuildErrors =
+  | { text?: string[]; html?: string }
+  | (Error | string)[]
+  | undefined;
+
+const MAX_LOGGED_ERRORS = 5;
+
+// The `text` sent by the dev-server keeps the colors it uses in the terminal.
+// Lynx consoles do not resolve them, so they would show up as escape sequences.
+// eslint-disable-next-line no-control-regex
+const SGR_PATTERN = /\u001B\[[0-9;]+m/g;
+
+function toMessages(errors: BuildErrors): string[] {
+  const messages = Array.isArray(errors)
+    ? errors.map((error) => String(error))
+    : errors?.text ?? [];
+  return messages.map((message) => message.replace(SGR_PATTERN, ''));
+}
+
+function logBuildErrors(errors: BuildErrors): void {
+  log.error('Errors while compiling. Reload prevented.');
+
+  const messages = toMessages(errors);
+
+  for (let i = 0; i < messages.length; i++) {
+    if (i === MAX_LOGGED_ERRORS) {
+      log.error(
+        'Additional errors detected. View complete log in terminal for details.',
+      );
+      break;
+    }
+    log.error(messages[i]!);
+  }
+}
+
+export { logBuildErrors };

--- a/packages/webpack/webpack-dev-transport/test/client/logBuildErrors.test.ts
+++ b/packages/webpack/webpack-dev-transport/test/client/logBuildErrors.test.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { log } from '../../client/log.js';
+import { logBuildErrors } from '../../client/logBuildErrors.js';
+
+describe('logBuildErrors', () => {
+  // `log` binds `console.error` at module load, so spying on `console` itself
+  // would not be observed.
+  const logError = vi.spyOn(log, 'error').mockReturnValue(undefined);
+
+  beforeEach(() => {
+    logError.mockClear();
+  });
+
+  it('should log errors sent by Rsbuild', () => {
+    logBuildErrors({ text: ['SassError: expected ")".'], html: '<div />' });
+
+    expect(logError).toBeCalledWith(
+      'Errors while compiling. Reload prevented.',
+    );
+    expect(logError).toBeCalledWith('SassError: expected ")".');
+  });
+
+  it('should log errors sent by webpack-dev-server', () => {
+    logBuildErrors([new Error('Module not found')]);
+
+    expect(logError).toBeCalledWith('Error: Module not found');
+  });
+
+  it('should strip the terminal colors', () => {
+    logBuildErrors({
+      text: [
+        '\u001B[31m\u00D7 \u001B[0m\u001B[1mModule build failed\u001B[22m',
+      ],
+    });
+
+    expect(logError).toBeCalledWith('× Module build failed');
+  });
+
+  it('should truncate when there are too many errors', () => {
+    logBuildErrors({ text: ['1', '2', '3', '4', '5', '6', '7'] });
+
+    expect(logError).toBeCalledWith('5');
+    expect(logError).not.toBeCalledWith('6');
+    expect(logError).toBeCalledWith(
+      'Additional errors detected. View complete log in terminal for details.',
+    );
+  });
+
+  it('should still log when there is no error text', () => {
+    logBuildErrors(undefined);
+
+    expect(logError).toBeCalledTimes(1);
+    expect(logError).toBeCalledWith(
+      'Errors while compiling. Reload prevented.',
+    );
+  });
+});

--- a/packages/webpack/webpack-dev-transport/test/client/logBuildErrors.test.ts
+++ b/packages/webpack/webpack-dev-transport/test/client/logBuildErrors.test.ts
@@ -40,6 +40,12 @@ describe('logBuildErrors', () => {
     expect(logError).toBeCalledWith('× Module build failed');
   });
 
+  it('should strip a reset sequence with no parameters', () => {
+    logBuildErrors({ text: ['\u001B[mplain'] });
+
+    expect(logError).toBeCalledWith('plain');
+  });
+
   it('should truncate when there are too many errors', () => {
     logBuildErrors({ text: ['1', '2', '3', '4', '5', '6', '7'] });
 


### PR DESCRIPTION
## Summary

When a compilation fails, the dev-server client only logged a generic line and threw the payload away:

```ts
errors(_errors: Error[]) {
  log.error('Errors while compiling. Reload prevented.');
  // TODO: format errors
},
```

So on device there was no indication of *what* broke. The details only showed up later, as a side effect of the next update failing to apply — and if you did not touch another file, they never showed up at all.

This logs every error message, matching what Rsbuild's own client does.

## Details

**The parameter type was wrong**, which is why the `TODO` was awkward to pick up. The handler declares `Error[]`, but the Rsbuild dev-server sends:

```ts
type ServerMessageErrors = {
  type: 'errors';
  data: { text: string[]; html: string };
};
```

`webpack-dev-server` is the one that sends an array, so `BuildErrors` accepts both shapes. The `html` field is only useful for a DOM overlay and is ignored.

**Terminal colors are stripped.** The `text` can carry the SGR escapes used for terminal output. Lynx consoles do not resolve them, so the messages would arrive as `[2m`/`[31m` noise. The pattern matches the one `ansiHTML()` handles on the Rsbuild side.

**Output is capped at 5 messages** with a pointer to the terminal, same as Rsbuild's client.

## Test Plan

- `test/client/logBuildErrors.test.ts` covers both payload shapes, the color stripping, the cap, and the empty payload.
- Verified on device (Android, LynxExplorer): breaking a `linear-gradient(` in a `.scss` file now prints the sass error with the offending line, instead of just `Errors while compiling. Reload prevented.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build errors now display detailed, readable messages in the terminal instead of only a generic compilation failure.
  * Terminal color codes are removed for cleaner error output.
  * Error output is limited to five messages, with an indication when additional errors are available.
  * Error details are shown consistently across supported development server configurations.
  * Outputs with missing error text are handled gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->