### PR TITLE
feat(webpack-dev-transport): recover HMR after a failed apply

### DIFF
--- a/.changeset/hmr-recover-after-failed-apply.md
+++ b/.changeset/hmr-recover-after-failed-apply.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/webpack-dev-transport": minor
+"@lynx-js/rspeedy": patch
+---
+
+Recover the HMR session after an update fails to apply.

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -261,6 +261,12 @@ export function pluginDev(
         const rspeedyDir = path.dirname(
           require.resolve('@lynx-js/rspeedy/package.json'),
         )
+        // The upstream `@rspack/core/hot/dev-server` recovers from a failed
+        // `apply` with `window.location.reload()`, which Lynx does not have.
+        // This replacement reloads through the DevTool instead.
+        const hotDevServerPath = require.resolve(
+          '@lynx-js/webpack-dev-transport/hotDevServer',
+        )
         const hostname = environment.config.dev?.client?.host ?? ''
 
         const searchParams = new URLSearchParams({
@@ -299,13 +305,7 @@ export function pluginDev(
                   paths: [rsbuildPath],
                 })
               )
-              // The upstream `@rspack/core/hot/dev-server` recovers from a failed
-              // `apply` with `window.location.reload()`, which Lynx does not
-              // have. This replacement reloads through the DevTool instead.
-              .set(
-                '@rspack/core/hot/dev-server',
-                require.resolve('@lynx-js/webpack-dev-transport/hotDevServer')
-              )
+              .set('@rspack/core/hot/dev-server', hotDevServerPath)
             .end()
           .end()
           .plugin('lynx.hmr.provide.dev_server_client')

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -299,11 +299,12 @@ export function pluginDev(
                   paths: [rsbuildPath],
                 })
               )
+              // The upstream `@rspack/core/hot/dev-server` recovers from a failed
+              // `apply` with `window.location.reload()`, which Lynx does not
+              // have. This replacement reloads through the DevTool instead.
               .set(
                 '@rspack/core/hot/dev-server',
-                require.resolve('@rspack/core/hot/dev-server', {
-                  paths: [rsbuildPath],
-                })
+                require.resolve('@lynx-js/webpack-dev-transport/hotDevServer')
               )
             .end()
           .end()

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -223,7 +223,7 @@ describe('Plugins - Dev', () => {
     )
     expect(config.resolve?.alias).toHaveProperty(
       '@rspack/core/hot/dev-server',
-      expect.stringContaining('hot/dev-server.js'.replaceAll('/', path.sep)),
+      expect.stringContaining('hotDevServer.js'),
     )
     expect(config.resolve?.alias).toHaveProperty(
       '@lynx-js/webpack-dev-transport/client',

--- a/packages/webpack/webpack-dev-transport/client/hotDevServer.ts
+++ b/packages/webpack/webpack-dev-transport/client/hotDevServer.ts
@@ -1,0 +1,22 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Replaces `@rspack/core/hot/dev-server` in Lynx, where the upstream fallback
+ * to `window.location.reload()` does not exist. Aliased in `@lynx-js/rspeedy`.
+ */
+
+import { emitter as hotEmitter } from '@rspack/core/hot/emitter.js';
+
+import { startHotDevServer } from './startHotDevServer.js';
+
+if (import.meta.webpackHot) {
+  startHotDevServer(
+    import.meta.webpackHot,
+    hotEmitter,
+    () => __webpack_hash__,
+  );
+} else {
+  throw new Error('[HMR] Hot Module Replacement is disabled.');
+}

--- a/packages/webpack/webpack-dev-transport/client/reloadApp.ts
+++ b/packages/webpack/webpack-dev-transport/client/reloadApp.ts
@@ -44,19 +44,18 @@ function reloadApp({ hot, liveReload }: Options, status: Status): void {
   else if (liveReload) {
     const intervalId = +setInterval(() => {
       // reload immediately
-      applyReload(intervalId);
+      clearInterval(intervalId);
+      reloadPage();
     }, 10);
   }
 }
 
-function applyReload(intervalId: number) {
-  clearInterval(intervalId);
-
+function reloadPage(): void {
   if (
     typeof NativeModules.LynxDevToolSetModule?.invokeCdp !== 'function'
     && typeof NativeModules.LynxDevtoolSetModule?.invokeCdp !== 'function'
   ) {
-    console.error('[HMR] live-reload failed: cannot invoke cdp from DevTool.');
+    console.error('[HMR] reload failed: cannot invoke cdp from DevTool.');
     console.error('[HMR] Please reload the page manually.');
     return;
   }
@@ -85,7 +84,7 @@ function applyReload(intervalId: number) {
           error?: { message: string; code: number };
         };
         if (error) {
-          console.error('[HMR] live-reload failed:', error.message);
+          console.error('[HMR] reload failed:', error.message);
         }
       } catch {
         // explicitly ignore error
@@ -95,3 +94,4 @@ function applyReload(intervalId: number) {
 }
 
 export default reloadApp;
+export { reloadPage };

--- a/packages/webpack/webpack-dev-transport/client/rspack.d.ts
+++ b/packages/webpack/webpack-dev-transport/client/rspack.d.ts
@@ -10,3 +10,18 @@ declare module '@rspack/core/hot/emitter.js' {
     on(eventName: string, callback: (...args: unknown[]) => void): void;
   };
 }
+
+declare module '@rspack/core/hot/log.js' {
+  export function log(
+    level: 'info' | 'warning' | 'error',
+    message: string,
+  ): void;
+  export function formatError(error: unknown): string;
+}
+
+declare module '@rspack/core/hot/log-apply-result.js' {
+  export function logApplyResult(
+    updatedModules: (string | number)[],
+    renewedModules: (string | number)[],
+  ): void;
+}

--- a/packages/webpack/webpack-dev-transport/client/startHotDevServer.ts
+++ b/packages/webpack/webpack-dev-transport/client/startHotDevServer.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/*
+  Derived from `@rspack/core/hot/dev-server.js`
+
+  MIT License http://www.opensource.org/licenses/mit-license.php
+  Author Tobias Koppers @sokra
+
+  The upstream module recovers from a failed `apply` with
+  `window.location.reload()`, which Lynx does not have. Without it the HMR
+  session stays in `abort` or `fail` forever and every later edit is silently
+  ignored, so this reloads through the DevTool instead.
+*/
+
+import { logApplyResult } from '@rspack/core/hot/log-apply-result.js';
+import { formatError, log } from '@rspack/core/hot/log.js';
+
+import { reloadPage } from './reloadApp.js';
+
+type WebpackHot = NonNullable<ImportMeta['webpackHot']>;
+
+interface HotEmitter {
+  on(eventName: string, callback: (...args: unknown[]) => void): void;
+}
+
+function startHotDevServer(
+  webpackHot: WebpackHot,
+  hotEmitter: HotEmitter,
+  getCurrentHash: () => string,
+): void {
+  let lastHash: string | undefined;
+
+  const upToDate = () => (lastHash ?? '').includes(getCurrentHash());
+
+  const check = () => {
+    webpackHot
+      .check(true)
+      .then((updatedModules) => {
+        if (!updatedModules) {
+          log('warning', '[HMR] Cannot find update. Need to do a full reload!');
+          log(
+            'warning',
+            '[HMR] (Probably because of restarting the rspack-dev-server)',
+          );
+          reloadPage();
+          return;
+        }
+
+        if (!upToDate()) {
+          check();
+        }
+
+        logApplyResult(updatedModules, updatedModules);
+
+        if (upToDate()) {
+          log('info', '[HMR] App is up to date.');
+        }
+      })
+      .catch((err: unknown) => {
+        const status = webpackHot.status();
+        // `abort` and `fail` are terminal: the session can never apply another
+        // update, so reloading is the only way back.
+        if (status === 'abort' || status === 'fail') {
+          log(
+            'warning',
+            '[HMR] Cannot apply update. Need to do a full reload!',
+          );
+          log('warning', `[HMR] ${formatError(err)}`);
+          reloadPage();
+        } else {
+          log('warning', `[HMR] Update failed: ${formatError(err)}`);
+        }
+      });
+  };
+
+  hotEmitter.on('webpackHotUpdate', (currentHash) => {
+    lastHash = currentHash as string;
+    if (!upToDate() && webpackHot.status() === 'idle') {
+      log('info', '[HMR] Checking for updates on the server...');
+      check();
+    }
+  });
+
+  log('info', '[HMR] Waiting for update signal from WDS...');
+}
+
+export { startHotDevServer };

--- a/packages/webpack/webpack-dev-transport/package.json
+++ b/packages/webpack/webpack-dev-transport/package.json
@@ -23,6 +23,11 @@
       "node": "./lib/client/index.js",
       "import": "./lib/client/index.js"
     },
+    "./hotDevServer": {
+      "types": "./lib/client/hotDevServer.d.ts",
+      "node": "./lib/client/hotDevServer.js",
+      "import": "./lib/client/hotDevServer.js"
+    },
     "./reloadApp": {
       "types": "./lib/client/reloadApp.d.ts",
       "node": "./lib/client/reloadApp.js",
@@ -39,6 +44,9 @@
     "*": {
       "client": [
         "lib/client/index.d.ts"
+      ],
+      "hotDevServer": [
+        "lib/client/hotDevServer.d.ts"
       ],
       "reloadApp": [
         "lib/client/reloadApp.d.ts"

--- a/packages/webpack/webpack-dev-transport/test/client/startHotDevServer.test.ts
+++ b/packages/webpack/webpack-dev-transport/test/client/startHotDevServer.test.ts
@@ -45,17 +45,20 @@ describe('startHotDevServer', () => {
     status.mockReturnValue('idle');
   });
 
-  it('should reload when an update cannot be applied', async () => {
-    check.mockRejectedValue(new Error('Module build failed'));
-    // `apply` moves the session to a terminal state
-    status.mockReturnValueOnce('idle').mockReturnValue('abort');
+  // `apply` moves the session to a terminal state
+  it.each(['abort', 'fail'])(
+    'should reload when an update cannot be applied (%s)',
+    async (terminalStatus) => {
+      check.mockRejectedValue(new Error('Module build failed'));
+      status.mockReturnValueOnce('idle').mockReturnValue(terminalStatus);
 
-    start();
-    onHotUpdate('next-hash');
-    await vi.waitFor(() => {
-      expect(reloadPage).toBeCalledTimes(1);
-    });
-  });
+      start();
+      onHotUpdate('next-hash');
+      await vi.waitFor(() => {
+        expect(reloadPage).toBeCalledTimes(1);
+      });
+    },
+  );
 
   it('should reload when the update is gone from the server', async () => {
     check.mockResolvedValue(null);

--- a/packages/webpack/webpack-dev-transport/test/client/startHotDevServer.test.ts
+++ b/packages/webpack/webpack-dev-transport/test/client/startHotDevServer.test.ts
@@ -1,0 +1,88 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { reloadPage } from '../../client/reloadApp.js';
+import { startHotDevServer } from '../../client/startHotDevServer.js';
+
+vi.mock('../../client/reloadApp.js', () => ({
+  default: vi.fn(),
+  reloadPage: vi.fn(),
+}));
+
+vi.mock('@rspack/core/hot/log.js', () => ({
+  log: vi.fn(),
+  formatError: (error: unknown) => String(error),
+}));
+
+vi.mock('@rspack/core/hot/log-apply-result.js', () => ({
+  logApplyResult: vi.fn(),
+}));
+
+describe('startHotDevServer', () => {
+  const check = vi.fn();
+  const status = vi.fn<() => string>();
+  let onHotUpdate: (hash: string) => void;
+
+  const start = () => {
+    const hotEmitter = {
+      on: vi.fn((_event: string, callback: (...args: unknown[]) => void) => {
+        onHotUpdate = callback as (hash: string) => void;
+      }),
+    };
+    startHotDevServer(
+      { check, status } as unknown as NonNullable<ImportMeta['webpackHot']>,
+      hotEmitter,
+      () => 'current-hash',
+    );
+  };
+
+  beforeEach(() => {
+    vi.mocked(reloadPage).mockClear();
+    check.mockReset();
+    status.mockReset();
+    status.mockReturnValue('idle');
+  });
+
+  it('should reload when an update cannot be applied', async () => {
+    check.mockRejectedValue(new Error('Module build failed'));
+    // `apply` moves the session to a terminal state
+    status.mockReturnValueOnce('idle').mockReturnValue('abort');
+
+    start();
+    onHotUpdate('next-hash');
+    await vi.waitFor(() => {
+      expect(reloadPage).toBeCalledTimes(1);
+    });
+  });
+
+  it('should reload when the update is gone from the server', async () => {
+    check.mockResolvedValue(null);
+
+    start();
+    onHotUpdate('next-hash');
+    await vi.waitFor(() => {
+      expect(reloadPage).toBeCalledTimes(1);
+    });
+  });
+
+  it('should not reload while the session can still be updated', async () => {
+    check.mockRejectedValue(new Error('transient'));
+    status.mockReturnValueOnce('idle').mockReturnValue('idle');
+
+    start();
+    onHotUpdate('next-hash');
+    await vi.waitFor(() => {
+      expect(check).toBeCalled();
+    });
+    expect(reloadPage).not.toBeCalled();
+  });
+
+  it('should not check when already up to date', () => {
+    start();
+    onHotUpdate('contains current-hash inside');
+
+    expect(check).not.toBeCalled();
+  });
+});


### PR DESCRIPTION
## Summary

After an update fails to apply, the HMR session never recovers: every later edit is silently ignored until the page is reloaded by hand.

```
[HMR] Cannot apply update. Please reload manually!
```

The cause is in `@rspack/core/hot/dev-server`, which is aliased into the background layer. Both of its recovery paths are gated on `window`:

```js
log('warning', '[HMR] Cannot apply update. ' +
  (typeof window !== 'undefined' ? 'Need to do a full reload!' : 'Please reload manually!'));
if (typeof window !== 'undefined') {
  window.location.reload();   // ← never runs in Lynx
}
```

Lynx has no `window`, so the session is left in `abort`/`fail` with nothing to bring it back. The `Please reload manually!` wording is upstream telling us exactly that.

Note that reaching a failed `apply` at all is normal and not Lynx-specific: `optimization.emitOnErrors` defaults to `true` in development (`!production`), so a failed compilation still emits a hot-update containing a module that throws. Rsbuild on the web hits the same thing and recovers with its own full reload. This PR only restores the missing recovery.

## Details

`@rspack/core/hot/dev-server` is replaced with an implementation that reloads through the DevTool, reusing the `Page.reload` path `reloadApp` already used for live-reload — the capability was there, it just was not wired to the failed-apply path. `applyReload` is extracted as `reloadPage` for that, and its two failure messages lose the `live-` prefix since they now cover hot updates too.

The logic lives in `startHotDevServer.ts` with `hotDevServer.ts` doing only the `import.meta.webpackHot` wiring, so the recovery can be tested — `import.meta.webpackHot` cannot be stubbed, and the top-level guard throws on import.

Adds a `./hotDevServer` export, hence the minor bump.

## Test Plan

- `test/client/startHotDevServer.test.ts` asserts a reload happens on a terminal (`abort`/`fail`) status and on a missing update, and that a still-recoverable status does not reload. Verified the first case fails without the fix.
- Verified on device (Android, LynxExplorer): breaking a `.scss` file, fixing it, then editing again now reloads and picks up the change, instead of ignoring every further edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hot module replacement recovery after failed or unavailable updates.
  * Added DevTool-based page recovery instead of relying solely on browser reloads.
  * Added retry handling for stale update hashes and automatic fallback reloads when recovery is not possible.
  * Added a dedicated hot development server entry point for improved HMR integration.

* **Bug Fixes**
  * Prevented unnecessary reloads during recoverable HMR states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->