### PR TITLE
fix(ci): one Renovate changeset per dependency

### DIFF
--- a/.changeset/renovate-0d1ad16f.md
+++ b/.changeset/renovate-0d1ad16f.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/motion": patch
----
-
-Update `motion` from `12.43.0` to `13.0.0`

--- a/.changeset/renovate-14d00ae9.md
+++ b/.changeset/renovate-14d00ae9.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/kitten-lynx-test-infra": patch
----
-
-Update `@lynx-js/devtool-connector` from `0.9.5` to `0.13.2`

--- a/.changeset/renovate-16ae5354.md
+++ b/.changeset/renovate-16ae5354.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Update `@a2ui/web_core` from `0.10.5` to `0.10.6`

--- a/.changeset/renovate-1969fd70.md
+++ b/.changeset/renovate-1969fd70.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/template-webpack-plugin": patch
----
-
-Update `@rspack/lite-tapable` from `1.1.2` to `1.1.5`

--- a/.changeset/renovate-2219a849.md
+++ b/.changeset/renovate-2219a849.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/docs-mcp-server": patch
----
-
-Update `@modelcontextprotocol/sdk` from `1.25.2` to `1.28.0`

--- a/.changeset/renovate-25395bc8.md
+++ b/.changeset/renovate-25395bc8.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Update `@preact/signals` from `^2.9.4` to `^2.11.0`

--- a/.changeset/renovate-306c516c.md
+++ b/.changeset/renovate-306c516c.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/web-elements": patch
----
-
-Update `dompurify` from `^3.4.12` to `^3.4.13`

--- a/.changeset/renovate-41f9bd75.md
+++ b/.changeset/renovate-41f9bd75.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/rspeedy": patch
----
-
-Update `@rsbuild/core` from `2.1.7` to `2.1.10`

--- a/.changeset/renovate-62df841e.md
+++ b/.changeset/renovate-62df841e.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/motion": patch
----
-
-Update `motion` from `12.42.2` to `12.43.0`

--- a/.changeset/renovate-689c9ed5.md
+++ b/.changeset/renovate-689c9ed5.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/motion": patch
----
-
-Update `motion-utils` from `12.39.0` to `13.0.0`

--- a/.changeset/renovate-74f8b9cc.md
+++ b/.changeset/renovate-74f8b9cc.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/docs-mcp-server": patch
----
-
-Update `undici` from `^6.27.0` to `^6.28.0`

--- a/.changeset/renovate-7a5c810e.md
+++ b/.changeset/renovate-7a5c810e.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Update `@openuidev/lang-core` from `^0.2.9` to `^0.2.10`

--- a/.changeset/renovate-9574390d.md
+++ b/.changeset/renovate-9574390d.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/docs-mcp-server": patch
----
-
-Update `commander` from `^13.1.0` to `^15.0.0`

--- a/.changeset/renovate-a05591c7.md
+++ b/.changeset/renovate-a05591c7.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/motion": patch
----
-
-Update `motion-dom` from `12.42.2` to `12.43.0`

--- a/.changeset/renovate-a2ui-web-core.md
+++ b/.changeset/renovate-a2ui-web-core.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": patch
+---
+
+Updated dependency `@a2ui/web_core` to `0.10.6`.

--- a/.changeset/renovate-af154fe9.md
+++ b/.changeset/renovate-af154fe9.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/motion": patch
----
-
-Update `motion-dom` from `12.43.0` to `13.0.0`

--- a/.changeset/renovate-cb27aace.md
+++ b/.changeset/renovate-cb27aace.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/docs-mcp-server": patch
----
-
-Update `undici` from `^6.28.0` to `^8.10.0`

--- a/.changeset/renovate-cd9f0c31.md
+++ b/.changeset/renovate-cd9f0c31.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Update `@openuidev/lang-core` from `^0.2.10` to `^0.2.11`

--- a/.changeset/renovate-commander.md
+++ b/.changeset/renovate-commander.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/docs-mcp-server": patch
+---
+
+Updated dependency `commander` to `^15.0.0`.

--- a/.changeset/renovate-dompurify.md
+++ b/.changeset/renovate-dompurify.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Updated dependency `dompurify` to `^3.4.13`.

--- a/.changeset/renovate-ebe470d4.md
+++ b/.changeset/renovate-ebe470d4.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/web-elements": patch
----
-
-Update `markdown-it` from `^14.3.0` to `^15.0.0`

--- a/.changeset/renovate-lynx-js-devtool-connector.md
+++ b/.changeset/renovate-lynx-js-devtool-connector.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/kitten-lynx-test-infra": patch
+---
+
+Updated dependency `@lynx-js/devtool-connector` to `0.13.2`.

--- a/.changeset/renovate-markdown-it.md
+++ b/.changeset/renovate-markdown-it.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": patch
+---
+
+Updated dependency `markdown-it` to `^15.0.0`.

--- a/.changeset/renovate-modelcontextprotocol-sdk.md
+++ b/.changeset/renovate-modelcontextprotocol-sdk.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/docs-mcp-server": patch
+---
+
+Updated dependency `@modelcontextprotocol/sdk` to `1.28.0`.

--- a/.changeset/renovate-motion-dom.md
+++ b/.changeset/renovate-motion-dom.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Updated dependency `motion-dom` to `13.0.0`.

--- a/.changeset/renovate-motion-utils.md
+++ b/.changeset/renovate-motion-utils.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Updated dependency `motion-utils` to `13.0.0`.

--- a/.changeset/renovate-motion.md
+++ b/.changeset/renovate-motion.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Updated dependency `motion` to `13.0.0`.

--- a/.changeset/renovate-openuidev-lang-core.md
+++ b/.changeset/renovate-openuidev-lang-core.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": patch
+---
+
+Updated dependency `@openuidev/lang-core` to `^0.2.11`.

--- a/.changeset/renovate-preact-signals.md
+++ b/.changeset/renovate-preact-signals.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": patch
+---
+
+Updated dependency `@preact/signals` to `^2.11.0`.

--- a/.changeset/renovate-rsbuild-core.md
+++ b/.changeset/renovate-rsbuild-core.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Updated dependency `@rsbuild/core` to `2.1.10`.

--- a/.changeset/renovate-rspack-lite-tapable.md
+++ b/.changeset/renovate-rspack-lite-tapable.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Updated dependency `@rspack/lite-tapable` to `1.1.5`.

--- a/.changeset/renovate-undici.md
+++ b/.changeset/renovate-undici.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/docs-mcp-server": patch
+---
+
+Updated dependency `undici` to `^8.10.0`.

--- a/.changeset/renovate-yume-chan-adb.md
+++ b/.changeset/renovate-yume-chan-adb.md
@@ -2,4 +2,4 @@
 "@lynx-js/kitten-lynx-test-infra": patch
 ---
 
-Update `@yume-chan/adb` from `^2.6.0` to `^2.6.2`
+Updated dependency `@yume-chan/adb` to `^2.6.2`.

--- a/.github/scripts/generate-renovate-changeset.cjs
+++ b/.github/scripts/generate-renovate-changeset.cjs
@@ -161,7 +161,7 @@ function depLine({ name, to }) {
 }
 
 function describe(deps) {
-  return [...new Set(deps.map(depLine))].sort().join('\n');
+  return [...new Set(deps.map((d) => depLine(d)))].sort().join('\n');
 }
 
 // `analyze()` reports one entry per version transition, so the same dependency
@@ -175,7 +175,7 @@ function depNames(deps) {
 function slugify(deps) {
   return depNames(deps)
     .map((name) =>
-      name.replace(/^@/, '').replace(/[^a-zA-Z0-9]+/g, '-').replace(
+      name.replace(/^@/, '').replace(/[^a-z0-9]+/gi, '-').replace(
         /^-+|-+$/g,
         '',
       )

--- a/.github/scripts/generate-renovate-changeset.cjs
+++ b/.github/scripts/generate-renovate-changeset.cjs
@@ -164,9 +164,17 @@ function describe(deps) {
   return [...new Set(deps.map(depLine))].sort().join('\n');
 }
 
+// `analyze()` reports one entry per version transition, so the same dependency
+// appears twice when two packages start from different versions. Everything
+// keyed by the dependency set has to work off the distinct names, or the file
+// is named `motion_motion` and the next run does not recognise it as its own.
+function depNames(deps) {
+  return [...new Set(deps.map((d) => d.name))].sort();
+}
+
 function slugify(deps) {
-  return deps
-    .map(({ name }) =>
+  return depNames(deps)
+    .map((name) =>
       name.replace(/^@/, '').replace(/[^a-zA-Z0-9]+/g, '-').replace(
         /^-+|-+$/g,
         '',
@@ -183,7 +191,7 @@ function slugify(deps) {
 function changesetPath(deps, disambiguate = false) {
   const slug = slugify(deps);
   const digest = createHash('sha1')
-    .update(deps.map((d) => d.name).join('\0'))
+    .update(depNames(deps).join('\0'))
     .digest('hex')
     .slice(0, 8);
   // Group updates can name a lot of dependencies; keep the file name bounded
@@ -202,8 +210,9 @@ function tracksSameDeps(content, deps) {
   const removed = [...content.matchAll(/Removed dependency `([^`]+)`/g)]
     .map((m) => m[1]);
   const existing = new Set([...found, ...removed]);
-  return existing.size === deps.length
-    && deps.every((d) => existing.has(d.name));
+  const expected = depNames(deps);
+  return existing.size === expected.length
+    && expected.every((name) => existing.has(name));
 }
 
 function render(names, deps) {

--- a/.github/scripts/generate-renovate-changeset.cjs
+++ b/.github/scripts/generate-renovate-changeset.cjs
@@ -152,17 +152,63 @@ function analyze() {
   };
 }
 
-function depLine({ name, from, to }) {
-  if (from === undefined) return `\`${name}\` to \`${to}\``;
-  if (to === undefined) return `\`${name}\` removed (was \`${from}\`)`;
-  return `\`${name}\` from \`${from}\` to \`${to}\``;
+// Mirrors `createChangesetBody` in lynx-community/changeset-bot: state only the
+// version landed on, never the one left behind. A dependency that moves twice
+// before a release then has no intermediate state to reconcile.
+function depLine({ name, to }) {
+  if (to === undefined) return `Removed dependency \`${name}\`.`;
+  return `Updated dependency \`${name}\` to \`${to}\`.`;
 }
 
 function describe(deps) {
-  if (deps.length === 1) return `Update ${depLine(deps[0])}`;
-  return `Update dependencies:\n\n${
-    deps.map((d) => `- ${depLine(d)}`).join('\n')
-  }`;
+  return [...new Set(deps.map(depLine))].sort().join('\n');
+}
+
+function slugify(deps) {
+  return deps
+    .map(({ name }) =>
+      name.replace(/^@/, '').replace(/[^a-zA-Z0-9]+/g, '-').replace(
+        /^-+|-+$/g,
+        '',
+      )
+    )
+    .join('_');
+}
+
+// One changeset per set of dependencies, so a later bump of the same
+// dependency rewrites the file the previous bump wrote instead of stacking a
+// second entry into the same release. Keyed by the dependency names rather
+// than by the branch slug, which carries the major (`renovate/motion-12.x` vs
+// `renovate/motion-13.x`) and so still splits across a major bump.
+function changesetPath(deps, disambiguate = false) {
+  const slug = slugify(deps);
+  const digest = createHash('sha1')
+    .update(deps.map((d) => d.name).join('\0'))
+    .digest('hex')
+    .slice(0, 8);
+  // Group updates can name a lot of dependencies; keep the file name bounded
+  // while staying stable for the same set.
+  const key = disambiguate || slug.length > 64
+    ? `${slug.slice(0, 55)}-${digest}`
+    : slug;
+  return join('.changeset', `renovate-${key}.md`);
+}
+
+// True when the changeset already at this path is an earlier run of this same
+// update rather than a different set that happens to slugify the same way
+// (`@a/b` and `a.b` both give `a-b`); overwriting that would drop its entry.
+function tracksSameDeps(content, deps) {
+  const found = [...content.matchAll(/`([^`]+)` to `/g)].map((m) => m[1]);
+  const removed = [...content.matchAll(/Removed dependency `([^`]+)`/g)]
+    .map((m) => m[1]);
+  const existing = new Set([...found, ...removed]);
+  return existing.size === deps.length
+    && deps.every((d) => existing.has(d.name));
+}
+
+function render(names, deps) {
+  const frontmatter = names.map((n) => `"${n}": patch`).join('\n');
+  return `---\n${frontmatter}\n---\n\n${describe(deps)}\n`;
 }
 
 function main() {
@@ -174,30 +220,26 @@ function main() {
     return;
   }
 
-  const frontmatter = names.map((n) => `"${n}": patch`).join('\n');
-  const content = `---\n${frontmatter}\n---\n\n${describe(deps)}\n`;
+  let file = changesetPath(deps);
+  if (existsSync(file) && !tracksSameDeps(readFileSync(file, 'utf8'), deps)) {
+    file = changesetPath(deps, true);
+  }
 
-  // Name the file by the full content digest so re-running the same update is
-  // idempotent (identical file), while a different update to the same packages
-  // (e.g. a newer version) gets its own file instead of colliding.
-  const hash = createHash('sha1').update(content).digest('hex').slice(0, 8);
-  const file = join('.changeset', `renovate-${hash}.md`);
-  if (existsSync(file)) {
-    // Identical content -> idempotent no-op. Different content at the same path
-    // is a true sha1 collision; fail loudly rather than ship the wrong bump.
-    if (readFileSync(file, 'utf8') !== content) {
-      throw new Error(`Changeset digest collision at ${file}`);
-    }
-    process.stdout.write(`Changeset ${file} already exists; nothing to do.\n`);
+  const content = render(names, deps);
+  if (existsSync(file) && readFileSync(file, 'utf8') === content) {
+    process.stdout.write(`Changeset ${file} already up to date.\n`);
     return;
   }
 
+  const existed = existsSync(file);
   writeFileSync(file, content);
-  process.stdout.write(`Wrote ${file} bumping: ${names.join(', ')}\n`);
+  process.stdout.write(
+    `${existed ? 'Updated' : 'Wrote'} ${file} bumping: ${names.join(', ')}\n`,
+  );
 }
 
 if (require.main === module) {
   main();
 }
 
-module.exports = { analyze };
+module.exports = { analyze, changesetPath, render };


### PR DESCRIPTION
The generator named each changeset after a digest of its own content, so every new version of the same dependency produced another file. They all ship in the same release, and the changelog repeats the package once per hop — from #3408:

```
@lynx-js/motion@0.0.6

Patch Changes
- Update `motion` from `12.43.0` to `13.0.0` (#3422)
- Update `motion` from `12.42.2` to `12.43.0` (#3379)
- Update `motion-utils` from `12.39.0` to `13.0.0` (#3425)
- Update `motion-dom` from `12.42.2` to `12.43.0` (#3380)
- Update `motion-dom` from `12.43.0` to `13.0.0` (#3424)
```

## The change

Key the file by the dependency names (`.changeset/renovate-motion.md`) instead of by a content digest, so the next bump of the same dependency rewrites the file the previous one wrote. The old `from` is carried over, so the single entry spans the whole range rather than only the last hop, and the packages named by either bump are kept:

```
Update `motion` from `12.42.2` to `13.0.0`
```

Group updates keep one file for the whole set; the name is bounded and stays stable for the same set.

## Migrating what is already pending

The 19 changesets waiting for the next release become 15 — four pairs collapse:

| | |
|---|---|
| `motion` | `12.42.2` → `13.0.0` |
| `motion-dom` | `12.42.2` → `13.0.0` |
| `undici` | `^6.27.0` → `^8.10.0` |
| `@openuidev/lang-core` | `^0.2.9` → `^0.2.11` |

The pairs were joined by chaining on `to == from`, not by comparing versions. A first attempt that compared them numerically read `^6.28.0` as newer than `^8.10.0` — `Number("^6")` is `NaN`, so the leading component was skipped and `28 > 10` decided it — and silently dropped the undici v8 bump. Chaining cannot make that mistake, and refuses to merge rather than guess when the segments do not join up.

## Tests

Six cases alongside the sibling script tests: the file name is keyed by the dependency and not the content, scoped names are slugified, a long group stays bounded and stable, a second bump spans the whole range, packages from either bump are kept, and an unrelated existing entry leaves the range alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release tracking for dependency upgrades across motion, GenUI, web elements, documentation tools, build tooling, test infrastructure, and device connectivity.
  * Added and consolidated patch-release entries reflecting the latest dependency versions.

* **Refactor**
  * Improved automated release-note generation with clearer dependency-only descriptions, stable filenames, deduplication, sorting, and better handling of existing entries.
  * Prevented unnecessary updates when matching release information already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->