### PR TITLE
fix(lynx-bundle-rslib-config): require @rslib/core >= 1.0.0-beta.1

### DIFF
--- a/.changeset/lynx-bundle-rslib-config-rslib-peer.md
+++ b/.changeset/lynx-bundle-rslib-config-rslib-peer.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": minor
+---
+
+Require `@rslib/core ^1.0.0-beta.1` in `peerDependencies`, matching the `output.autoExternal` usage introduced by the Rslib v1 upgrade.

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -50,7 +50,7 @@
     "@rstest/core": "catalog:rstest"
   },
   "peerDependencies": {
-    "@rslib/core": ">=0.22.0"
+    "@rslib/core": "^1.0.0-beta.1"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"


### PR DESCRIPTION
## Summary

Since #3355 the exported external-bundle config sets `output.autoExternal`, which only exists in Rslib v1 — Rslib 0.23.x does not read it, so `autoExternal` silently falls back to the CJS default `true`, workspace dependencies get auto-externalized, and the emitted bundle contains invalid code such as:

```js
module.exports = @scope/some-workspace-package;
```

The `peerDependencies` still declare `@rslib/core >= 0.22.0`, so 0.23.x consumers hit this at build time with no install-time warning (reproduced on `0.6.4-canary-20260810-948eece0`).

Bump the peer range to `^1.0.0-beta.1` so package managers surface the real requirement.

## Checklist

- [x] Changeset added