### PR TITLE
fix(web-core): allow flushing during event dispatch

### DIFF
--- a/.changeset/flush-element-tree-reentrancy.md
+++ b/.changeset/flush-element-tree-reentrancy.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Allow `__FlushElementTree()` to run inside a main-thread event handler without
+triggering wasm-bindgen's recursive-borrow error or aborting the remaining
+event dispatch.

--- a/packages/web-platform/web-core/src/main_thread/client/main_thread_context.rs
+++ b/packages/web-platform/web-core/src/main_thread/client/main_thread_context.rs
@@ -18,7 +18,7 @@ use wasm_bindgen::prelude::*;
 pub struct MainThreadWasmContext {
   pub(super) unique_id_to_element_map: Vec<Option<Rc<RefCell<Box<LynxElementData>>>>>,
   pub(super) unique_id_to_dom_map: FnvHashMap<usize, js_sys::WeakRef>,
-  pub(super) timing_flags: Vec<String>,
+  pub(super) timing_flags: RefCell<Vec<String>>,
 
   pub(super) enabled_events: FnvHashSet<String>,
   pub(super) page_element_unique_id: Option<usize>,
@@ -54,7 +54,7 @@ impl MainThreadWasmContext {
       unique_id_to_element_map: vec![None],
       unique_id_to_dom_map: FnvHashMap::default(),
       enabled_events: FnvHashSet::default(),
-      timing_flags: vec![],
+      timing_flags: RefCell::new(vec![]),
       page_element_unique_id: None,
       config_enable_css_selector,
       style_manager,
@@ -123,8 +123,8 @@ impl MainThreadWasmContext {
     self.unique_id_to_dom_map.get(&unique_id).cloned()
   }
 
-  pub fn take_timing_flags(&mut self) -> Vec<String> {
-    std::mem::take(&mut self.timing_flags)
+  pub fn take_timing_flags(&self) -> Vec<String> {
+    std::mem::take(&mut *self.timing_flags.borrow_mut())
   }
 
   pub fn get_unique_id_by_component_id(&self, component_id: &str) -> Option<usize> {

--- a/packages/web-platform/web-core/tests/event-dispatch-reentrancy.spec.ts
+++ b/packages/web-platform/web-core/tests/event-dispatch-reentrancy.spec.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import './jsdom.js';
+import { beforeEach, describe, expect, rstest, test } from '@rstest/core';
+import { createElementAPI } from '../ts/client/mainthread/elementAPIs/createElementAPI.js';
+import { WASMJSBinding } from '../ts/client/mainthread/elementAPIs/WASMJSBinding.js';
+import { createTestLynxViewInstance } from './createTestLynxViewInstance.js';
+
+/**
+ * A main-thread event handler runs while the Rust dispatcher is on the stack,
+ * so every Element PAPI it calls re-enters the same `MainThreadWasmContext`.
+ * `wasm-bindgen` holds a borrow of that context for the whole exported call, so
+ * a nested call that needs an exclusive borrow throws "recursive use of an
+ * object detected which would lead to unsafe aliasing in rust" - and the throw
+ * unwinds out through the dispatcher rather than the handler, aborting the rest
+ * of the dispatch.
+ *
+ * The documented mutate-then-flush pattern hits this through
+ * `__FlushElementTree`, which drains the timing flags off the context.
+ *
+ * @see https://github.com/lynx-family/lynx-stack/issues/3395
+ */
+function clickOn(node: HTMLElement): void {
+  node.dispatchEvent(
+    new (globalThis as any).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+describe('__FlushElementTree called from inside a main-thread event handler', () => {
+  let rootDom: ShadowRoot;
+  let mts: ReturnType<typeof createElementAPI>;
+  let mtsBinding: WASMJSBinding;
+
+  beforeEach(() => {
+    rstest.resetAllMocks();
+    const lynxViewDom = document.createElement('div') as unknown as HTMLElement;
+    rootDom = lynxViewDom.attachShadow({ mode: 'open' });
+    mtsBinding = new WASMJSBinding(createTestLynxViewInstance(rootDom));
+    mts = createElementAPI(
+      rootDom,
+      mtsBinding,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+    );
+  });
+
+  test('a flush does not abort the rest of the dispatch', () => {
+    // The real damage of the throw: it unwinds the dispatcher, so every handler
+    // ordered after the flushing one is skipped.
+    const parent = mts.__CreateView(0);
+    const child = mts.__CreateView(0);
+    mts.__AppendElement(parent, child);
+    rootDom.appendChild(parent);
+
+    const order: string[] = [];
+    mtsBinding.lynxViewInstance.mainThreadGlobalThis.runWorklet = (handler) => {
+      const id = (handler as { _wkltId: string })._wkltId;
+      order.push(id);
+      if (id === 'child') {
+        mts.__FlushElementTree(child, undefined);
+      }
+    };
+    mts.__AddEvent(child, 'bindEvent', 'tap', {
+      type: 'worklet',
+      value: { _wkltId: 'child' },
+    });
+    mts.__AddEvent(parent, 'bindEvent', 'tap', {
+      type: 'worklet',
+      value: { _wkltId: 'parent' },
+    });
+
+    clickOn(child);
+
+    expect(order).toStrictEqual(['child', 'parent']);
+  });
+
+  test('a worklet handler can flush', () => {
+    // `main-thread:bind*` goes through `runWorklet` while the Rust dispatcher
+    // still holds a shared borrow of the wasm context.
+    const node = mts.__CreateView(0);
+    rootDom.appendChild(node);
+    let error: unknown = undefined;
+    let called = false;
+
+    mtsBinding.lynxViewInstance.mainThreadGlobalThis.runWorklet = () => {
+      called = true;
+      try {
+        mts.__FlushElementTree(node, undefined);
+      } catch (e) {
+        error = e;
+      }
+    };
+    mts.__AddEvent(node, 'bindEvent', 'tap', {
+      type: 'worklet',
+      value: { _wkltId: 'x' },
+    });
+
+    clickOn(node);
+
+    expect(called).toBe(true);
+    expect(error).toBe(undefined);
+  });
+});


### PR DESCRIPTION
Fixes #3395.

## Summary

- Store `timing_flags` in a `RefCell<Vec<String>>`.
- Change `take_timing_flags` from `&mut self` to `&self` and drain the flags through the inner `RefCell`.
- Add real-WASM regression coverage for `__FlushElementTree()` inside a main-thread worklet handler, including continued bubbling after the flush.

## Why this scope

`common_event_handler` retains a shared wasm-bindgen borrow while it calls into the main-thread worklet. `__FlushElementTree()` re-enters the same context through `take_timing_flags`; when that method requires `&mut self`, wasm-bindgen rejects the nested exclusive borrow with `recursive use of an object detected which would lead to unsafe aliasing in rust`.

Making only the timing-flags field internally mutable removes that exclusive borrow and directly fixes the reported `__FlushElementTree()` failure without changing any other `MainThreadWasmContext` method signature. PR #3396 explores the broader architectural alternative for all Element PAPIs reachable during event dispatch.

## Verification

The regression tests were A/B checked against both implementations:

- old `&mut self` implementation: 2/2 regression tests fail with the reported recursive-use error; the parent bubble handler is skipped
- this fix: 2/2 regression tests pass and bubbling continues
- `pnpm turbo build`: 66/66 tasks passed
- `pnpm --filter @lynx-js/web-core test`: 175/175 tests passed
- Rust and TypeScript formatting checks passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling when the element tree is flushed during event dispatch.
  * Parent handlers now continue processing correctly after a child handler triggers a flush.
  * Worklet handlers can flush the element tree without causing an error.

* **Tests**
  * Added regression coverage for reentrant event-dispatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->