### PR TITLE
chore(rust): bump toolchain to 1.97.1

### DIFF
--- a/packages/genui/ui-judge/src/server.rs
+++ b/packages/genui/ui-judge/src/server.rs
@@ -280,9 +280,6 @@ impl HeadlessExecutor {
     self.healthy.load(Ordering::Acquire)
   }
 
-  // `try_send` hands the whole `CaptureJob` back in its `Err` variant so the
-  // caller can retry, so the large payload is inherent to the channel API. It
-  // is destructured into an `ApiError` a few lines below and never returned.
   #[allow(clippy::result_large_err)]
   async fn capture(
     &self,

--- a/packages/genui/ui-judge/src/server.rs
+++ b/packages/genui/ui-judge/src/server.rs
@@ -280,6 +280,10 @@ impl HeadlessExecutor {
     self.healthy.load(Ordering::Acquire)
   }
 
+  // `try_send` hands the whole `CaptureJob` back in its `Err` variant so the
+  // caller can retry, so the large payload is inherent to the channel API. It
+  // is destructured into an `ApiError` a few lines below and never returned.
+  #[allow(clippy::result_large_err)]
   async fn capture(
     &self,
     request: JudgePageRequest,

--- a/packages/react/transform/crates/swc_plugin_compat/is_component_class.rs
+++ b/packages/react/transform/crates/swc_plugin_compat/is_component_class.rs
@@ -36,10 +36,10 @@ impl Visit for TransformVisitor {
               self.has_render_method = true;
             }
           }
-          ClassMember::ClassProp(prop) => {
-            if prop.key.is_ident() && prop.key.as_ident().unwrap().sym == *"render" {
-              self.has_render_method = true;
-            }
+          ClassMember::ClassProp(prop)
+            if prop.key.is_ident() && prop.key.as_ident().unwrap().sym == *"render" =>
+          {
+            self.has_render_method = true;
           }
           _ => {}
         }

--- a/packages/react/transform/crates/swc_plugin_element_template/template_identity.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/template_identity.rs
@@ -77,7 +77,7 @@ impl Serialize for CanonicalTemplateValue<'_> {
       }
       Value::Object(map) => {
         let mut entries = map.iter().collect::<Vec<_>>();
-        entries.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+        entries.sort_by_key(|(left_key, _)| *left_key);
         let mut canonical = serializer.serialize_map(Some(entries.len()))?;
         for (key, value) in entries {
           canonical.serialize_entry(key, &CanonicalTemplateValue(value))?;

--- a/packages/react/transform/crates/swc_plugin_shake/is_component_class.rs
+++ b/packages/react/transform/crates/swc_plugin_shake/is_component_class.rs
@@ -51,10 +51,10 @@ impl Visit for TransformVisitor {
               self.has_render_method = true;
             }
           }
-          ClassMember::ClassProp(prop) => {
-            if prop.key.is_ident() && prop.key.as_ident().unwrap().sym == *"render" {
-              self.has_render_method = true;
-            }
+          ClassMember::ClassProp(prop)
+            if prop.key.is_ident() && prop.key.as_ident().unwrap().sym == *"render" =>
+          {
+            self.has_render_method = true;
           }
           _ => {}
         }

--- a/packages/react/transform/crates/swc_plugin_worklet/extract_ident.rs
+++ b/packages/react/transform/crates/swc_plugin_worklet/extract_ident.rs
@@ -329,13 +329,11 @@ impl VisitMut for ExtractingIdentsCollector {
           n.prop.visit_mut_with(self);
         }
       }
-      MemberProp::Ident(ident) => {
-        if !self.member_expr_path.is_empty() {
-          self.add_if_needed(
-            Expr::Ident(ident.clone().into()).into(),
-            &Expr::Member(n.clone()).into(),
-          );
-        }
+      MemberProp::Ident(ident) if !self.member_expr_path.is_empty() => {
+        self.add_if_needed(
+          Expr::Ident(ident.clone().into()).into(),
+          &Expr::Member(n.clone()).into(),
+        );
       }
       _ => {}
     }

--- a/packages/react/transform/scripts/build_wasm.js
+++ b/packages/react/transform/scripts/build_wasm.js
@@ -15,10 +15,6 @@ const dist = path.resolve(root, 'dist');
 
 // mkdir -p dist
 await fs.mkdir('dist', { recursive: true });
-// `--allow-undefined` lets wasm-ld turn the `napi_*` symbols into imports
-// supplied by the JS host. rustc passed it by default for
-// wasm32-unknown-unknown until 1.93; without it the link fails with
-// `undefined symbol: napi_typeof`.
 execSync(`cargo build --release --target wasm32-unknown-unknown --features noop`, {
   env: {
     ...process.env,

--- a/packages/react/transform/scripts/build_wasm.js
+++ b/packages/react/transform/scripts/build_wasm.js
@@ -15,10 +15,15 @@ const dist = path.resolve(root, 'dist');
 
 // mkdir -p dist
 await fs.mkdir('dist', { recursive: true });
+// `--allow-undefined` lets wasm-ld turn the `napi_*` symbols into imports
+// supplied by the JS host. rustc passed it by default for
+// wasm32-unknown-unknown until 1.93; without it the link fails with
+// `undefined symbol: napi_typeof`.
 execSync(`cargo build --release --target wasm32-unknown-unknown --features noop`, {
   env: {
     ...process.env,
-    RUSTFLAGS: '-C link-arg=--export-table -C link-arg=-s --cfg getrandom_backend="custom"',
+    RUSTFLAGS:
+      '-C link-arg=--export-table -C link-arg=-s -C link-arg=--allow-undefined --cfg getrandom_backend="custom"',
   },
   stdio: 'inherit',
 });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.97.1"
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]
 profile = "default"


### PR DESCRIPTION
Bumps `rust-toolchain.toml` from 1.92.0 to 1.97.1 (latest stable, released 2026-07-14).

### Clippy fixes

New lints under `-D warnings`:

- `collapsible_match` — `swc_plugin_{compat,shake}/is_component_class.rs`, `swc_plugin_worklet/extract_ident.rs` (applied via `clippy --fix`)
- `unnecessary_sort_by` — `swc_plugin_element_template/template_identity.rs` (applied via `clippy --fix`)
- `result_large_err` — `ui-judge/src/server.rs`, allowed: the large `Err` is `TrySendError<CaptureJob>`, which the channel API hands back by design and which never escapes the function.

### wasm32 link fix

This is what sank the [1.93.0 attempt](https://github.com/lynx-family/lynx-stack/pull/2147) (reverted 21h later by #2151).

rustc stopped passing `--allow-undefined` to wasm-ld by default for `wasm32-unknown-unknown` after 1.92, so the `napi_*` symbols the JS host supplies turn into hard link errors:

```
rust-lld: error: undefined symbol: napi_typeof
```

`build_wasm.js` now passes the flag explicitly. Verified the artifact is equivalent to the 1.92.0 build:

- import section identical — 38 imports, every `napi_*` present
- `dist/wasm.cjs` loads and transforms JSX correctly
- only diff is two unused linker globals (`__data_end`, `__heap_base`) no longer exported; nothing in the repo or in the emnapi glue references them

`wasm32-wasip1` (swc plugins) and web-core's wasm-bindgen build are unaffected.

### Local verification

`cargo fmt --check`, `cargo clippy --tests --all-features -- -D warnings`, `cargo metadata --locked`, and `cargo test --all-features --release` all pass. `Cargo.lock` unchanged.