### PR TITLE
feat: add pluginVanillaLynx for Vanilla Lynx

### DIFF
--- a/.changeset/add-vanilla-rsbuild-plugin.md
+++ b/.changeset/add-vanilla-rsbuild-plugin.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/vanilla-rsbuild-plugin": patch
+---
+
+Add `pluginVanillaLynx` for building native and web Vanilla Lynx Element PAPI applications with Rsbuild and Rspeedy.

--- a/.github/plugin-vanilla.instructions.md
+++ b/.github/plugin-vanilla.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "packages/rspeedy/plugin-vanilla/**"
+---
+
+Keep `pluginVanillaLynx` as the Vanilla Lynx DSL integration layer; do not move Vanilla entry conventions into the DSL-neutral `pluginLynx` base.
+
+Mark emitted main-thread assets with `asset.info['lynx:main-thread']` before `LynxTemplatePlugin` groups assets. Do not manually replace `encodeData.manifest` or `encodeData.lepusCode`.
+
+Keep Element PAPI code on the main-thread entry and wrap only optional background-thread assets with `RuntimeWrapperWebpackPlugin`.
+
+Treat both `lynx` / `lynx-*` and `web` / `web-*` as Vanilla template environments. Use `LynxEncodePlugin` and background runtime wrapping only for Lynx; use `WebEncodePlugin` with unwrapped background JavaScript for Web so `[platform]` emits a loadable `.web.bundle`.
+
+Vanilla Lynx HMR and live reload must remain disabled until the plugin installs and tests a compatible hot-update runtime.

--- a/.github/vanilla-example.instructions.md
+++ b/.github/vanilla-example.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "examples/vanilla/**"
+---
+
+Create the page with `__CreatePage`, then append an `__CreateView` content container and put flex or linear layout styles on that container. On Web, the page root is a plain `div`, while Lynx-transformed flex custom properties are consumed by Lynx container elements; applying `flex-direction` directly to the page root can therefore fall back to a horizontal row.

--- a/examples/vanilla/README.md
+++ b/examples/vanilla/README.md
@@ -1,0 +1,21 @@
+# Vanilla Element PAPI
+
+This example renders a counter directly with Element PAPI and TypeScript, without ReactLynx, JSX, or a virtual DOM. A `tap` event starts on the main thread, increments the counter on the background thread, and sends the new value back for the main thread to render.
+
+## Run
+
+From the repository root:
+
+```bash
+pnpm --filter @lynx-js/example-vanilla dev
+```
+
+To build the bundle:
+
+```bash
+pnpm --filter @lynx-js/example-vanilla build
+```
+
+The build targets the `web` and `lynx` environments.
+
+The config uses `pluginVanillaLynx()` from `@lynx-js/vanilla-rsbuild-plugin`. Its `source.entry` points directly to `main-thread.ts`; the plugin discovers the sibling `background.ts` and `style.css` files automatically.

--- a/examples/vanilla/lynx.config.ts
+++ b/examples/vanilla/lynx.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVanillaLynx } from '@lynx-js/vanilla-rsbuild-plugin';
+
+export default defineConfig({
+  source: {
+    entry: './src/main-thread.ts',
+  },
+  plugins: [pluginVanillaLynx()],
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lynx-js/example-vanilla",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "test:type": "tsc6 --noEmit"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/type-element-api": "0.0.9",
+    "@lynx-js/types": "4.1.0",
+    "@lynx-js/vanilla-rsbuild-plugin": "workspace:*"
+  }
+}

--- a/examples/vanilla/src/background.ts
+++ b/examples/vanilla/src/background.ts
@@ -1,0 +1,31 @@
+import type { CounterPatch } from './events.js';
+import {
+  counterUpdatedEventName,
+  destroyLifetimeEventName,
+  incrementCounterEventName,
+} from './events.js';
+
+const mainThread = lynx.getCoreContext();
+
+let count = 0;
+
+function onIncrementCounter(): void {
+  count += 1;
+
+  const patch: CounterPatch = { count };
+  mainThread.dispatchEvent({
+    type: counterUpdatedEventName,
+    data: patch,
+  });
+}
+
+function cleanup(): void {
+  mainThread.removeEventListener(
+    incrementCounterEventName,
+    onIncrementCounter,
+  );
+  mainThread.removeEventListener(destroyLifetimeEventName, cleanup);
+}
+
+mainThread.addEventListener(incrementCounterEventName, onIncrementCounter);
+mainThread.addEventListener(destroyLifetimeEventName, cleanup);

--- a/examples/vanilla/src/events.ts
+++ b/examples/vanilla/src/events.ts
@@ -1,0 +1,7 @@
+export const counterUpdatedEventName = 'CounterUpdated';
+export const destroyLifetimeEventName = '__DestroyLifetime';
+export const incrementCounterEventName = 'IncrementCounter';
+
+export interface CounterPatch {
+  count: number;
+}

--- a/examples/vanilla/src/main-thread.ts
+++ b/examples/vanilla/src/main-thread.ts
@@ -1,0 +1,102 @@
+import type { ElementRef } from '@lynx-js/type-element-api';
+
+import type { CounterPatch } from './events.js';
+import {
+  counterUpdatedEventName,
+  destroyLifetimeEventName,
+  incrementCounterEventName,
+} from './events.js';
+
+const page = __CreatePage('0', 0);
+const pageId = __GetElementUniqueID(page);
+__SetClasses(page, 'page');
+
+Object.assign(globalThis, {
+  processData: (data: unknown): unknown => data,
+});
+
+const engine = lynx.getEngine();
+const backgroundThread = lynx.getJSContext();
+
+let button: ElementRef | undefined;
+let counterText: ElementRef | undefined;
+
+function replaceText(text: ElementRef, value: string): void {
+  __ReplaceElements(
+    text,
+    [__CreateRawText(value)],
+    __GetChildren(text),
+  );
+}
+
+function onTap(): void {
+  backgroundThread.dispatchEvent({
+    type: incrementCounterEventName,
+    data: undefined,
+  });
+}
+
+function onCounterUpdated(event: { data: unknown }): void {
+  const patch = event.data as Partial<CounterPatch> | undefined;
+  if (typeof patch?.count !== 'number' || !counterText) {
+    return;
+  }
+
+  replaceText(counterText, `Clicked ${patch.count} times`);
+  __FlushElementTree();
+}
+
+function renderPage(): void {
+  if (button || counterText) {
+    return;
+  }
+
+  const content = __CreateView(pageId);
+  __SetClasses(content, 'content');
+  __AppendElement(page, content);
+
+  const text = __CreateText(pageId);
+  __SetClasses(text, 'title');
+  __AppendElement(text, __CreateRawText('Hello Vanilla Lynx'));
+  __AppendElement(content, text);
+
+  counterText = __CreateText(pageId);
+  __SetClasses(counterText, 'counter');
+  __AppendElement(counterText, __CreateRawText('Clicked 0 times'));
+  __AppendElement(content, counterText);
+
+  button = __CreateView(pageId);
+  __SetClasses(button, 'button');
+
+  const buttonLabel = __CreateText(pageId);
+  __SetClasses(buttonLabel, 'button-label');
+  __AppendElement(buttonLabel, __CreateRawText('Click me'));
+  __AppendElement(button, buttonLabel);
+  __AppendElement(content, button);
+
+  __AddEventListener(button, 'tap', onTap, {});
+}
+
+function cleanup(): void {
+  backgroundThread.dispatchEvent({
+    type: destroyLifetimeEventName,
+    data: undefined,
+  });
+  backgroundThread.removeEventListener(
+    counterUpdatedEventName,
+    onCounterUpdated,
+  );
+  engine.removeEventListener('__RenderPage', renderPage);
+  engine.removeEventListener(destroyLifetimeEventName, cleanup);
+
+  if (button) {
+    __RemoveEventListener(button, 'tap', onTap);
+  }
+
+  button = undefined;
+  counterText = undefined;
+}
+
+backgroundThread.addEventListener(counterUpdatedEventName, onCounterUpdated);
+engine.addEventListener('__RenderPage', renderPage);
+engine.addEventListener(destroyLifetimeEventName, cleanup);

--- a/examples/vanilla/src/rspeedy-env.d.ts
+++ b/examples/vanilla/src/rspeedy-env.d.ts
@@ -1,0 +1,22 @@
+/// <reference types="@rspeedy/core/client" />
+
+import type { ElementRef } from '@lynx-js/type-element-api';
+import type { LynxSetTimeout } from '@lynx-js/types';
+
+declare global {
+  const setTimeout: LynxSetTimeout;
+
+  function __AddEventListener(
+    node: ElementRef,
+    name: string,
+    handler: (...args: unknown[]) => unknown,
+    eventOptions?: Record<string, unknown>,
+  ): void;
+
+  function __RemoveEventListener(
+    node: ElementRef,
+    name: string,
+    handler: (...args: unknown[]) => unknown,
+    eventOptions?: Record<string, unknown>,
+  ): void;
+}

--- a/examples/vanilla/src/style.css
+++ b/examples/vanilla/src/style.css
@@ -1,0 +1,49 @@
+:root {
+  background-color: #101114;
+}
+
+.page {
+  min-height: 100vh;
+}
+
+.content {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.title {
+  color: #ffffff;
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.counter {
+  margin-top: 16px;
+  color: #b7bbc8;
+  font-size: 18px;
+}
+
+.button {
+  width: 180px;
+  height: 52px;
+  margin-top: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #4f6ef7;
+  border-radius: 12px;
+}
+
+.button:active {
+  opacity: 0.8;
+}
+
+.button-label {
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 700;
+}

--- a/examples/vanilla/tsconfig.json
+++ b/examples/vanilla/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "isolatedDeclarations": false,
+  },
+  "include": ["src", "lynx.config.ts"],
+  "references": [
+    { "path": "../../packages/rspeedy/core/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-vanilla/tsconfig.build.json" },
+  ],
+}

--- a/packages/rspeedy/plugin-vanilla/CHANGELOG.md
+++ b/packages/rspeedy/plugin-vanilla/CHANGELOG.md
@@ -1,0 +1,1 @@
+# `@lynx-js/vanilla-rsbuild-plugin`

--- a/packages/rspeedy/plugin-vanilla/README.md
+++ b/packages/rspeedy/plugin-vanilla/README.md
@@ -1,0 +1,77 @@
+# `@lynx-js/vanilla-rsbuild-plugin`
+
+An Rsbuild plugin for building Vanilla Lynx applications directly with Element PAPI.
+
+## Usage with Rspeedy
+
+```ts
+import { defineConfig } from '@lynx-js/rspeedy'
+import { pluginVanillaLynx } from '@lynx-js/vanilla-rsbuild-plugin'
+
+export default defineConfig({
+  plugins: [
+    pluginVanillaLynx({
+      entries: {
+        card: {
+          mainThread: './src/card/main-thread.ts',
+          background: './src/card/background.ts',
+          css: './src/card/style.css',
+        },
+      },
+    }),
+  ],
+})
+```
+
+For a convention-based entry, `source.entry` points to the main-thread source:
+
+```ts
+export default defineConfig({
+  source: {
+    entry: {
+      card: './src/card/main-thread.ts',
+    },
+  },
+  plugins: [pluginVanillaLynx()],
+})
+```
+
+The plugin discovers these optional sibling files:
+
+```text
+src/card/
+  main-thread.ts
+  background.ts
+  style.css
+```
+
+`background.ts` runs in the background JavaScript thread. Element PAPI tree creation and mutation must stay in `main-thread.ts`.
+
+Use an explicit `entries` item when the two thread sources are in different directories. Set `background: false` for a main-thread-only card. Explicit entries take precedence over `source.entry`.
+
+Entry sources are module requests and use Rspeedy or Rsbuild resolution,
+including aliases and configured extensions. Automatic sibling discovery is a
+filesystem convention: it runs only when `mainThread` names an existing local
+file. When `mainThread` is an alias or package request, configure `background`
+and `css` explicitly when they are needed.
+
+The plugin emits one `.bundle` per logical entry, marks the main-thread asset for Lepus encoding, wraps only the native background asset, and enables the event-handler config required by Element PAPI listeners. HMR and live reload are disabled because Vanilla Lynx does not currently install a compatible hot-update runtime.
+
+When Rspeedy configures both `web` and `lynx` environments, the plugin emits a web-encoded `[name].web.bundle` and a native `[name].lynx.bundle`. Background JavaScript is runtime-wrapped only for native Lynx; the web encoder embeds the unwrapped background chunk for the web runtime.
+
+## Options
+
+```ts
+pluginVanillaLynx({
+  entries: {
+    card: {
+      mainThread: './src/card/main-thread.ts',
+      background: './src/card/background.ts',
+    },
+  },
+  engineVersion: '3.5',
+  bundleFilename: '[name].bundle',
+})
+```
+
+When `bundleFilename` is omitted, the plugin uses Rspeedy's `output.filename.bundle`. Outside Rspeedy it defaults to `[name].[platform].bundle`.

--- a/packages/rspeedy/plugin-vanilla/package.json
+++ b/packages/rspeedy/plugin-vanilla/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@lynx-js/vanilla-rsbuild-plugin",
+  "version": "0.0.0",
+  "description": "An Rsbuild plugin for building Vanilla Lynx applications with Element PAPI.",
+  "keywords": [
+    "rsbuild",
+    "Lynx",
+    "Vanilla Lynx",
+    "Element PAPI"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lynx-family/lynx-stack.git",
+    "directory": "packages/rspeedy/plugin-vanilla"
+  },
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Lynx Authors"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "types": "./lib/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "rslib build",
+    "test": "rstest",
+    "test:type": "tsc6 --noEmit"
+  },
+  "dependencies": {
+    "@lynx-js/runtime-wrapper-webpack-plugin": "workspace:*",
+    "@lynx-js/template-webpack-plugin": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/test-tools": "workspace:*",
+    "@rsbuild/core": "catalog:rsbuild",
+    "@rstest/core": "catalog:rstest"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "./package.json": "./package.json"
+    },
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/rspeedy/plugin-vanilla/rslib.config.ts
+++ b/packages/rspeedy/plugin-vanilla/rslib.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@rslib/core'
+
+export default defineConfig({
+  lib: [
+    { format: 'esm', syntax: 'es2022', dts: { bundle: true, tsgo: false } },
+  ],
+  source: {
+    tsconfigPath: './tsconfig.build.json',
+  },
+  output: {
+    externals: [
+      '@lynx-js/runtime-wrapper-webpack-plugin',
+      '@lynx-js/template-webpack-plugin',
+      '@rsbuild/core',
+    ],
+  },
+})

--- a/packages/rspeedy/plugin-vanilla/rstest.config.ts
+++ b/packages/rspeedy/plugin-vanilla/rstest.config.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { defineConfig } from '@rstest/core'
+import type { RstestConfig } from '@rstest/core'
+
+import { lynxRstestConfig } from '@lynx-js/test-tools/rstest-config'
+
+const config: RstestConfig = defineConfig({
+  ...lynxRstestConfig({
+    name: 'rspeedy/vanilla',
+    url: import.meta.url,
+    setupFiles: ['@lynx-js/test-tools/setup-rspeedy'],
+    env: { NODE_ENV: 'test' },
+  }),
+})
+
+export default config

--- a/packages/rspeedy/plugin-vanilla/src/index.ts
+++ b/packages/rspeedy/plugin-vanilla/src/index.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * @packageDocumentation
+ *
+ * An Rsbuild plugin that integrates Vanilla Lynx applications with Rspeedy.
+ */
+
+import type {
+  LynxTemplatePlugin as InnerLynxTemplatePlugin,
+  TemplateHooks,
+} from '@lynx-js/template-webpack-plugin'
+
+export { LAYERS, pluginVanillaLynx } from './pluginVanillaLynx.js'
+export type {
+  PluginVanillaLynxOptions,
+  VanillaBundleFilename,
+  VanillaBundleFilenameContext,
+  VanillaLynxEntry,
+} from './pluginVanillaLynx.js'
+
+interface LynxTemplatePlugin {
+  getLynxTemplatePluginHooks:
+    typeof InnerLynxTemplatePlugin.getLynxTemplatePluginHooks
+}
+
+// Only export the exposed plugin API types. Consumers should retrieve the
+// implementation with `api.useExposed(Symbol.for('LynxTemplatePlugin'))`.
+export type { LynxTemplatePlugin, TemplateHooks }

--- a/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
+++ b/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
@@ -1,0 +1,623 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { statSync } from 'node:fs'
+import path from 'node:path'
+
+import type {
+  RsbuildPlugin,
+  RsbuildPluginAPI,
+  Rspack,
+  RspackChain,
+} from '@rsbuild/core'
+
+import { RuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+  WebEncodePlugin,
+} from '@lynx-js/template-webpack-plugin'
+
+const PLUGIN_NAME = 'lynx:vanilla'
+const VANILLA_WEBPACK_PLUGIN_NAME = 'VanillaLynxWebpackPlugin'
+const DEFAULT_ENGINE_VERSION = '3.5'
+const DEFAULT_BUNDLE_FILENAME = '[name].[platform].bundle'
+const INTERMEDIATE_DIR = '.rspeedy'
+
+/**
+ * Rspack layers used by Vanilla Lynx entries.
+ *
+ * @public
+ */
+export const LAYERS: Readonly<{
+  BACKGROUND: 'vanilla:background'
+  MAIN_THREAD: 'vanilla:main-thread'
+}> = Object.freeze({
+  BACKGROUND: 'vanilla:background',
+  MAIN_THREAD: 'vanilla:main-thread',
+})
+
+/**
+ * Context passed to a Vanilla Lynx bundle filename function.
+ *
+ * @public
+ */
+export interface VanillaBundleFilenameContext {
+  /** The logical Rsbuild entry name. */
+  entryName: string
+  /** Vanilla Lynx currently emits only the main card bundle. */
+  lazyBundle: false
+  /** The Rsbuild environment name. */
+  platform: string
+}
+
+/**
+ * The final Vanilla Lynx bundle filename.
+ *
+ * @public
+ */
+export type VanillaBundleFilename =
+  | string
+  | ((
+    context: VanillaBundleFilenameContext,
+  ) => string)
+
+/**
+ * The two thread source files of a logical Vanilla Lynx entry.
+ *
+ * @public
+ */
+export interface VanillaLynxEntry {
+  /**
+   * Module request executed on the Lynx main thread with Element PAPI globals.
+   *
+   * @remarks
+   * The request is resolved by Rspeedy or Rsbuild. When it names an existing
+   * local file, optional sibling `background.ts` and `style.css` files are
+   * discovered by convention.
+   */
+  mainThread: string
+
+  /**
+   * Source executed in the background JavaScript thread.
+   *
+   * @remarks
+   * When omitted, a sibling `background.ts` is used when it exists. Set this
+   * to `false` to explicitly create a main-thread-only bundle.
+   */
+  background?: string | false | undefined
+
+  /**
+   * CSS source encoded into the Lynx template.
+   *
+   * @remarks
+   * When omitted, a sibling `style.css` is used when it exists. Set this to
+   * `false` to disable the convention.
+   */
+  css?: string | false | undefined
+}
+
+/**
+ * Options for {@link pluginVanillaLynx}.
+ *
+ * @public
+ */
+export interface PluginVanillaLynxOptions {
+  /**
+   * Explicit two-thread entries.
+   *
+   * @remarks
+   * When omitted, every Rsbuild `source.entry` is treated as a main-thread
+   * entry and optional sibling `background.ts` and `style.css` files are
+   * discovered by convention.
+   */
+  entries?: Record<string, VanillaLynxEntry> | undefined
+
+  /**
+   * Override the final `.bundle` filename.
+   *
+   * @remarks
+   * When omitted under Rspeedy, `output.filename.bundle` is used.
+   * The default outside Rspeedy is `[name].[platform].bundle`.
+   */
+  bundleFilename?: VanillaBundleFilename | undefined
+
+  /**
+   * The minimum Lynx Engine version required by the emitted bundle.
+   *
+   * @defaultValue `'3.5'`
+   */
+  engineVersion?: string | undefined
+
+  /**
+   * Alias of {@link PluginVanillaLynxOptions.engineVersion}.
+   *
+   * @deprecated Use `engineVersion` instead.
+   */
+  targetSdkVersion?: string | undefined
+}
+
+interface RspeedyExposure {
+  config?: {
+    output?: {
+      filename?: RspeedyFilename | undefined
+    } | undefined
+  } | undefined
+}
+
+interface LynxConfigExposure {
+  config?: {
+    targetSdkVersion?: string | undefined
+  } | undefined
+}
+
+interface ResolvedVanillaEntry {
+  backgroundSource?: string | undefined
+  mainThreadImports: string[]
+  styleSource?: string | undefined
+}
+
+type RspeedyFilename =
+  | string
+  | {
+    bundle?: VanillaBundleFilename | undefined
+    template?: string | undefined
+  }
+
+interface ResolvedPluginVanillaLynxOptions {
+  bundleFilename?: VanillaBundleFilename | undefined
+  engineVersion: string
+  entries?: Record<string, VanillaLynxEntry> | undefined
+}
+
+interface VanillaEntryContext {
+  bundleFilename?: VanillaBundleFilename | undefined
+  engineVersion: string
+  platform: string
+  rspeedyFilename?: RspeedyFilename | undefined
+}
+
+interface VanillaEntryArtifacts {
+  hasBackground: boolean
+  mainThreadAsset: string
+}
+
+type VanillaPlatform = 'lynx' | 'web'
+
+/**
+ * Create the Vanilla Lynx DSL integration for Rsbuild or Rspeedy.
+ *
+ * A logical entry can explicitly declare its main-thread and background-thread
+ * sources. As a shorthand, an Rsbuild entry is treated as the main-thread
+ * source and optional sibling `background.ts` and `style.css` files are
+ * discovered by convention.
+ *
+ * @public
+ */
+export function pluginVanillaLynx(
+  options: PluginVanillaLynxOptions = {},
+): RsbuildPlugin {
+  return {
+    name: PLUGIN_NAME,
+    pre: ['lynx:rsbuild:plugin-api', 'lynx:config'],
+    setup(api) {
+      const resolvedOptions = resolvePluginOptions(api, options)
+
+      exposeVanillaCapabilities(api)
+      disableVanillaHotUpdates(api)
+      setupVanillaBundler(api, resolvedOptions)
+    },
+  }
+}
+
+function resolvePluginOptions(
+  api: RsbuildPluginAPI,
+  options: PluginVanillaLynxOptions,
+): ResolvedPluginVanillaLynxOptions {
+  const lynxConfig = api.useExposed<LynxConfigExposure>(
+    Symbol.for('lynx.config'),
+  )?.config
+
+  return {
+    bundleFilename: options.bundleFilename,
+    engineVersion: options.engineVersion
+      ?? options.targetSdkVersion
+      ?? lynxConfig?.targetSdkVersion
+      ?? DEFAULT_ENGINE_VERSION,
+    entries: options.entries,
+  }
+}
+
+function exposeVanillaCapabilities(api: RsbuildPluginAPI): void {
+  api.expose(Symbol.for('LAYERS'), LAYERS)
+  api.expose(Symbol.for('LynxTemplatePlugin'), {
+    LynxTemplatePlugin: {
+      getLynxTemplatePluginHooks: LynxTemplatePlugin
+        .getLynxTemplatePluginHooks.bind(LynxTemplatePlugin),
+    },
+  })
+}
+
+function disableVanillaHotUpdates(api: RsbuildPluginAPI): void {
+  // Vanilla Lynx does not yet install a compatible hot-update runtime.
+  api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) =>
+    mergeRsbuildConfig(config, {
+      dev: {
+        hmr: false,
+        liveReload: false,
+      },
+    })
+  )
+}
+
+function setupVanillaBundler(
+  api: RsbuildPluginAPI,
+  options: ResolvedPluginVanillaLynxOptions,
+): void {
+  api.modifyBundlerChain((chain, { environment }) => {
+    const rspeedyFilename = api.useExposed<RspeedyExposure>(
+      Symbol.for('rspeedy.api'),
+    )?.config?.output?.filename
+    const platform = getVanillaPlatform(environment.name)
+
+    if (!platform) {
+      return
+    }
+
+    const entries = resolveVanillaEntries(
+      api,
+      chain.entryPoints.entries() ?? {},
+      options.entries,
+    )
+    const entryContext: VanillaEntryContext = {
+      bundleFilename: options.bundleFilename,
+      engineVersion: options.engineVersion,
+      platform: environment.name,
+      rspeedyFilename,
+    }
+
+    chain.entryPoints.clear()
+
+    const artifacts = entries.map(([entryName, entry]) =>
+      addVanillaEntry(chain, entryName, entry, entryContext)
+    )
+
+    addVanillaBundlerPlugins(
+      chain,
+      artifacts,
+      options.engineVersion,
+      platform,
+    )
+  })
+}
+
+function addVanillaEntry(
+  chain: RspackChain,
+  entryName: string,
+  entry: ResolvedVanillaEntry,
+  context: VanillaEntryContext,
+): VanillaEntryArtifacts {
+  const { backgroundSource, styleSource } = entry
+  const hasBackground = backgroundSource !== undefined
+
+  const backgroundEntry = `${entryName}__background`
+  const mainThreadEntry = `${entryName}__main-thread`
+  const backgroundAsset = path.posix.join(
+    INTERMEDIATE_DIR,
+    entryName,
+    'background.js',
+  )
+  const mainThreadAsset = path.posix.join(
+    INTERMEDIATE_DIR,
+    entryName,
+    'main-thread.js',
+  )
+
+  if (hasBackground) {
+    chain.entry(backgroundEntry).add({
+      layer: LAYERS.BACKGROUND,
+      import: backgroundSource,
+      filename: backgroundAsset,
+    })
+  }
+
+  chain.entry(mainThreadEntry).add({
+    layer: LAYERS.MAIN_THREAD,
+    import: styleSource
+      ? [...entry.mainThreadImports, styleSource]
+      : entry.mainThreadImports,
+    filename: mainThreadAsset,
+  })
+
+  chain.plugin(`${PLUGIN_NAME}:template:${entryName}`).use(
+    LynxTemplatePlugin,
+    [{
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: hasBackground
+        ? [backgroundEntry, mainThreadEntry]
+        : [mainThreadEntry],
+      dsl: 'react_nodiff',
+      filename: resolveBundleFilename(
+        context.rspeedyFilename,
+        context.bundleFilename,
+        entryName,
+        context.platform,
+      ),
+      intermediate: path.posix.join(INTERMEDIATE_DIR, entryName),
+      targetSdkVersion: context.engineVersion,
+    }],
+  )
+
+  return { hasBackground, mainThreadAsset }
+}
+
+function addVanillaBundlerPlugins(
+  chain: RspackChain,
+  artifacts: VanillaEntryArtifacts[],
+  engineVersion: string,
+  platform: VanillaPlatform,
+): void {
+  chain.plugin(VANILLA_WEBPACK_PLUGIN_NAME).use(
+    createVanillaWebpackPlugin(
+      artifacts.map(artifact => artifact.mainThreadAsset),
+    ),
+  )
+
+  if (
+    platform === 'lynx'
+    && artifacts.some(artifact => artifact.hasBackground)
+  ) {
+    chain.plugin(`${PLUGIN_NAME}:runtime-wrapper`).use(
+      RuntimeWrapperWebpackPlugin,
+      [{
+        targetSdkVersion: engineVersion,
+        test: /^\.rspeedy\/.+\/background\.js$/,
+      }],
+    )
+  }
+
+  if (platform === 'lynx') {
+    chain.plugin(LynxEncodePlugin.name).use(LynxEncodePlugin, [])
+  } else {
+    chain.plugin(WebEncodePlugin.name).use(WebEncodePlugin, [])
+  }
+}
+
+function resolveVanillaEntries(
+  api: RsbuildPluginAPI,
+  rawEntries: Record<string, { values(): unknown[] }>,
+  configuredEntries: Record<string, VanillaLynxEntry> | undefined,
+): [string, ResolvedVanillaEntry][] {
+  if (configuredEntries) {
+    return Object.entries(configuredEntries).map(([entryName, entry]) => {
+      const mainThreadSource = locateLocalSource(
+        api.context.rootPath,
+        entry.mainThread,
+      )
+      const entryDir = mainThreadSource
+        ? path.dirname(mainThreadSource)
+        : undefined
+
+      return [entryName, {
+        backgroundSource: resolveOptionalSource(
+          entry.background,
+          entryDir ? path.join(entryDir, 'background.ts') : undefined,
+        ),
+        mainThreadImports: [entry.mainThread],
+        styleSource: resolveOptionalSource(
+          entry.css,
+          entryDir ? path.join(entryDir, 'style.css') : undefined,
+        ),
+      }]
+    })
+  }
+
+  return Object.entries(rawEntries).map(([entryName, entryPoint]) => {
+    const imports = getEntryImports(entryPoint.values())
+    const mainThreadRequest = getMainThreadRequest(entryName, imports)
+    const mainThreadSource = locateLocalSource(
+      api.context.rootPath,
+      mainThreadRequest,
+    )
+    const entryDir = mainThreadSource
+      ? path.dirname(mainThreadSource)
+      : undefined
+
+    return [entryName, {
+      backgroundSource: resolveOptionalSource(
+        undefined,
+        entryDir ? path.join(entryDir, 'background.ts') : undefined,
+      ),
+      mainThreadImports: imports,
+      styleSource: resolveOptionalSource(
+        undefined,
+        entryDir ? path.join(entryDir, 'style.css') : undefined,
+      ),
+    }]
+  })
+}
+
+function getVanillaPlatform(name: string): VanillaPlatform | undefined {
+  if (name === 'lynx' || name.startsWith('lynx-')) {
+    return 'lynx'
+  }
+  if (name === 'web' || name.startsWith('web-')) {
+    return 'web'
+  }
+  return undefined
+}
+
+function getEntryImports(values: unknown[]): string[] {
+  const imports: string[] = []
+
+  for (const value of values) {
+    if (typeof value === 'string') {
+      imports.push(value)
+      continue
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === 'string') {
+          imports.push(item)
+        }
+      }
+      continue
+    }
+
+    if (typeof value !== 'object' || value === null || !('import' in value)) {
+      continue
+    }
+
+    const entryImport = value.import
+    if (typeof entryImport === 'string') {
+      imports.push(entryImport)
+    } else if (Array.isArray(entryImport)) {
+      for (const item of entryImport) {
+        if (typeof item === 'string') {
+          imports.push(item)
+        }
+      }
+    }
+  }
+
+  return imports
+}
+
+function getMainThreadRequest(
+  entryName: string,
+  imports: string[],
+): string {
+  const source =
+    imports.find(value =>
+      /(?:^|\/)main-thread\.[cm]?[jt]sx?(?:\?.*)?$/.test(
+        value.replaceAll('\\', '/'),
+      )
+    ) ?? (imports.length === 1 ? imports[0] : undefined)
+
+  if (!source) {
+    throw new Error(
+      `[pluginVanillaLynx] Entry \`${entryName}\` must contain exactly one `
+        + '`main-thread.ts` source.',
+    )
+  }
+
+  return source
+}
+
+function locateLocalSource(
+  rootPath: string,
+  request: string,
+): string | undefined {
+  const source = request.split(/[?#]/, 1)[0]
+  if (!source) {
+    return undefined
+  }
+
+  const candidate = path.isAbsolute(source)
+    ? source
+    : path.resolve(rootPath, source)
+
+  return isFile(candidate) ? candidate : undefined
+}
+
+function isFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile()
+  } catch {
+    return false
+  }
+}
+
+function resolveOptionalSource(
+  source: string | false | undefined,
+  conventionSource: string | undefined,
+): string | undefined {
+  if (source === false) {
+    return undefined
+  }
+
+  if (source) {
+    return source
+  }
+
+  return conventionSource && isFile(conventionSource)
+    ? conventionSource
+    : undefined
+}
+
+function resolveBundleFilename(
+  rspeedyFilename:
+    | string
+    | {
+      bundle?: VanillaBundleFilename | undefined
+      template?: string | undefined
+    }
+    | undefined,
+  option: VanillaBundleFilename | undefined,
+  entryName: string,
+  platform: string,
+): string {
+  const configured = option
+    ?? (typeof rspeedyFilename === 'object'
+      ? rspeedyFilename.bundle ?? rspeedyFilename.template
+      : rspeedyFilename)
+    ?? DEFAULT_BUNDLE_FILENAME
+  const context: VanillaBundleFilenameContext = {
+    entryName,
+    lazyBundle: false,
+    platform,
+  }
+  const filename = typeof configured === 'function'
+    ? configured(context)
+    : configured
+
+  return filename
+    .replaceAll('[name]', entryName)
+    .replaceAll('[platform]', platform)
+}
+
+function createVanillaWebpackPlugin(
+  mainThreadAssets: string[],
+): Rspack.RspackPluginInstance {
+  return {
+    apply(compiler) {
+      compiler.hooks.thisCompilation.tap(
+        VANILLA_WEBPACK_PLUGIN_NAME,
+        compilation => {
+          compilation.hooks.processAssets.tap(
+            {
+              name: VANILLA_WEBPACK_PLUGIN_NAME,
+              stage: compiler.webpack.Compilation
+                .PROCESS_ASSETS_STAGE_ADDITIONAL,
+            },
+            () => {
+              for (const name of mainThreadAssets) {
+                const asset = compilation.getAsset(name)
+                if (!asset) {
+                  throw new Error(
+                    `[pluginVanillaLynx] Main-thread asset was not emitted: ${name}`,
+                  )
+                }
+                compilation.updateAsset(asset.name, asset.source, {
+                  ...asset.info,
+                  'lynx:main-thread': true,
+                })
+              }
+            },
+          )
+
+          const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+            compilation,
+          )
+          hooks.beforeEncode.tap(VANILLA_WEBPACK_PLUGIN_NAME, args => {
+            args.encodeData.sourceContent.config['enableEventHandleRefactor'] =
+              true
+            return args
+          })
+        },
+      )
+    },
+  }
+}

--- a/packages/rspeedy/plugin-vanilla/test/fixtures/basic/background.ts
+++ b/packages/rspeedy/plugin-vanilla/test/fixtures/basic/background.ts
@@ -1,0 +1,3 @@
+Object.assign(globalThis, {
+  __vanillaBackgroundLoaded: true,
+})

--- a/packages/rspeedy/plugin-vanilla/test/fixtures/basic/main-thread.ts
+++ b/packages/rspeedy/plugin-vanilla/test/fixtures/basic/main-thread.ts
@@ -1,0 +1,3 @@
+Object.assign(globalThis, {
+  __vanillaMainThreadLoaded: true,
+})

--- a/packages/rspeedy/plugin-vanilla/test/fixtures/basic/style.css
+++ b/packages/rspeedy/plugin-vanilla/test/fixtures/basic/style.css
@@ -1,0 +1,3 @@
+:root {
+  background-color: #fff;
+}

--- a/packages/rspeedy/plugin-vanilla/test/pluginVanillaLynx.test.ts
+++ b/packages/rspeedy/plugin-vanilla/test/pluginVanillaLynx.test.ts
@@ -1,0 +1,584 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type {
+  RsbuildPlugin,
+  RsbuildPluginAPI,
+  Rspack,
+  RspackChain,
+} from '@rsbuild/core'
+import { afterAll, describe, expect, test } from '@rstest/core'
+
+import { createRspeedy } from '@lynx-js/rspeedy'
+
+import * as vanilla from '../src/index.js'
+
+const tempDirs: string[] = []
+
+interface EntryPointStub {
+  values(): unknown[]
+}
+
+interface PluginUse {
+  args?: unknown[] | undefined
+  plugin: unknown
+}
+
+interface HarnessOptions {
+  environment?: string | undefined
+  lynxConfigTarget?: string | undefined
+  pluginOptions?: vanilla.PluginVanillaLynxOptions | undefined
+  rawEntries?: Record<string, EntryPointStub> | undefined
+  rspeedyFilename?: string | {
+    bundle?: vanilla.VanillaBundleFilename | undefined
+    template?: string | undefined
+  } | undefined
+}
+
+interface HarnessResult {
+  clearedEntries: boolean
+  entries: Map<string, unknown>
+  exposed: Map<string | symbol, unknown>
+  plugins: Map<string, PluginUse>
+}
+
+type BundlerChainModifier = (
+  chain: RspackChain,
+  context: { environment: { name: string } },
+) => void | Promise<void>
+
+function fixturePath(name: string): string {
+  return fileURLToPath(new URL(`./fixtures/basic/${name}`, import.meta.url))
+}
+
+async function runPluginHarness(
+  options: HarnessOptions = {},
+): Promise<HarnessResult> {
+  const exposed = new Map<string | symbol, unknown>()
+  if (options.lynxConfigTarget) {
+    exposed.set(Symbol.for('lynx.config'), {
+      config: { targetSdkVersion: options.lynxConfigTarget },
+    })
+  }
+  if (options.rspeedyFilename) {
+    exposed.set(Symbol.for('rspeedy.api'), {
+      config: { output: { filename: options.rspeedyFilename } },
+    })
+  }
+
+  let bundlerChainModifier: BundlerChainModifier | undefined
+  const api = {
+    context: { rootPath: process.cwd() },
+    expose(id: string | symbol, value: unknown) {
+      exposed.set(id, value)
+    },
+    modifyBundlerChain(handler: unknown) {
+      bundlerChainModifier = handler as BundlerChainModifier
+    },
+    modifyRsbuildConfig() {
+      // The unit harness only exercises the bundler-chain hook.
+    },
+    useExposed(id: string | symbol) {
+      return exposed.get(id)
+    },
+  } as unknown as RsbuildPluginAPI
+
+  const plugin = vanilla.pluginVanillaLynx(options.pluginOptions)
+  await plugin.setup(api)
+
+  if (!bundlerChainModifier) {
+    throw new Error('pluginVanillaLynx did not register modifyBundlerChain')
+  }
+
+  const entries = new Map<string, unknown>()
+  const plugins = new Map<string, PluginUse>()
+  let clearedEntries = false
+  const chain = {
+    entry(name: string) {
+      return {
+        add(value: unknown) {
+          entries.set(name, value)
+        },
+      }
+    },
+    entryPoints: {
+      clear() {
+        clearedEntries = true
+      },
+      entries() {
+        return options.rawEntries
+      },
+    },
+    plugin(name: string) {
+      return {
+        use(pluginConstructorOrInstance: unknown, args?: unknown[]) {
+          plugins.set(name, {
+            args,
+            plugin: pluginConstructorOrInstance,
+          })
+        },
+      }
+    },
+  } as unknown as RspackChain
+
+  await bundlerChainModifier(chain, {
+    environment: { name: options.environment ?? 'lynx' },
+  })
+
+  return { clearedEntries, entries, exposed, plugins }
+}
+
+function getTemplateOptions(
+  result: HarnessResult,
+  entryName: string,
+): Record<string, unknown> {
+  const options = result.plugins.get(
+    `lynx:vanilla:template:${entryName}`,
+  )?.args?.[0]
+  if (typeof options !== 'object' || options === null) {
+    throw new Error(`Missing template options for entry ${entryName}`)
+  }
+  return options as Record<string, unknown>
+}
+
+function getVanillaWebpackPlugin(
+  result: HarnessResult,
+): Rspack.RspackPluginInstance {
+  const plugin = result.plugins.get('VanillaLynxWebpackPlugin')?.plugin
+  if (typeof plugin !== 'object' || plugin === null || !('apply' in plugin)) {
+    throw new Error('Missing VanillaLynxWebpackPlugin')
+  }
+  return plugin as Rspack.RspackPluginInstance
+}
+
+afterAll(async () => {
+  await Promise.all(tempDirs.map(async dir => {
+    await rm(dir, { force: true, recursive: true })
+  }))
+})
+
+describe('pluginVanillaLynx', () => {
+  test('builds main-thread, background, CSS, and template assets', async () => {
+    const outputRoot = await mkdtemp(
+      path.join(tmpdir(), 'rspeedy-vanilla-test-'),
+    )
+    tempDirs.push(outputRoot)
+
+    let beforeEncodeArgs:
+      | Parameters<
+        Parameters<vanilla.TemplateHooks['beforeEncode']['tap']>[1]
+      >[0]
+      | undefined
+
+    const observeTemplate: RsbuildPlugin = {
+      name: 'test:observe-vanilla-template',
+      setup(api) {
+        api.modifyBundlerChain(chain => {
+          const exposed = api.useExposed<{
+            LynxTemplatePlugin: vanilla.LynxTemplatePlugin
+          }>(Symbol.for('LynxTemplatePlugin'))
+          const plugin: Rspack.RspackPluginInstance = {
+            apply(compiler) {
+              compiler.hooks.thisCompilation.tap(
+                'test:observe-vanilla-template',
+                compilation => {
+                  const hooks = exposed!.LynxTemplatePlugin
+                    .getLynxTemplatePluginHooks(compilation)
+                  hooks.beforeEncode.tap(
+                    'test:observe-vanilla-template',
+                    args => {
+                      beforeEncodeArgs = args
+                      return args
+                    },
+                  )
+                },
+              )
+            },
+          }
+          chain.plugin('test:observe-vanilla-template').use(plugin)
+        })
+      },
+    }
+
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        output: {
+          distPath: { root: outputRoot },
+          filename: '[name].bundle',
+        },
+        plugins: [
+          vanilla.pluginVanillaLynx({
+            entries: {
+              card: {
+                mainThread: fileURLToPath(
+                  new URL(
+                    './fixtures/basic/main-thread.ts',
+                    import.meta.url,
+                  ),
+                ),
+              },
+            },
+          }),
+          observeTemplate,
+        ],
+      },
+    })
+
+    await rspeedy.build()
+
+    expect(existsSync(path.join(outputRoot, 'card.bundle'))).toBe(true)
+    expect(beforeEncodeArgs?.encodeData.lepusCode.root?.name).toBe(
+      '.rspeedy/card/main-thread.js',
+    )
+    expect(
+      beforeEncodeArgs?.encodeData.lepusCode.root?.source.source().toString(),
+    ).toContain('__vanillaMainThreadLoaded')
+    expect(Object.keys(beforeEncodeArgs?.encodeData.manifest ?? {})).toEqual([
+      '/app-service.js',
+      '/.rspeedy/card/background.js',
+    ])
+    expect(beforeEncodeArgs?.encodeData.compilerOptions).toMatchObject({
+      targetSdkVersion: '3.5',
+    })
+    expect(beforeEncodeArgs?.encodeData.sourceContent.config).toMatchObject({
+      enableEventHandleRefactor: true,
+    })
+  })
+
+  test('builds web and lynx bundles with platform-specific encoders', async () => {
+    const outputRoot = await mkdtemp(
+      path.join(tmpdir(), 'rspeedy-vanilla-platforms-test-'),
+    )
+    tempDirs.push(outputRoot)
+
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        environments: {
+          web: {},
+          lynx: {},
+        },
+        output: {
+          distPath: { root: outputRoot },
+        },
+        plugins: [vanilla.pluginVanillaLynx()],
+        source: {
+          entry: fixturePath('main-thread.ts'),
+        },
+      },
+    })
+
+    const [webConfig, lynxConfig] = await rspeedy.initConfigs()
+
+    expect(
+      webConfig?.plugins?.some(plugin =>
+        plugin?.constructor.name === 'WebEncodePlugin'
+      ),
+    ).toBe(true)
+    expect(
+      webConfig?.plugins?.some(plugin =>
+        plugin?.constructor.name === 'RuntimeWrapperWebpackPlugin'
+      ),
+    ).toBe(false)
+    expect(
+      lynxConfig?.plugins?.some(plugin =>
+        plugin?.constructor.name === 'LynxEncodePlugin'
+      ),
+    ).toBe(true)
+    expect(
+      lynxConfig?.plugins?.some(plugin =>
+        plugin?.constructor.name === 'RuntimeWrapperWebpackPlugin'
+      ),
+    ).toBe(true)
+
+    await rspeedy.build()
+
+    expect(existsSync(path.join(outputRoot, 'main.web.bundle'))).toBe(true)
+    expect(existsSync(path.join(outputRoot, 'main.lynx.bundle'))).toBe(true)
+  })
+
+  test('exposes Vanilla Lynx layers', async () => {
+    let exposedLayers: typeof vanilla.LAYERS | undefined
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        plugins: [
+          vanilla.pluginVanillaLynx(),
+          {
+            name: 'test:read-vanilla-layers',
+            setup(api) {
+              api.modifyRsbuildConfig(config => {
+                exposedLayers = api.useExposed<typeof vanilla.LAYERS>(
+                  Symbol.for('LAYERS'),
+                )
+                return config
+              })
+            },
+          } satisfies RsbuildPlugin,
+        ],
+        source: {
+          entry: fileURLToPath(
+            new URL('./fixtures/basic/main-thread.ts', import.meta.url),
+          ),
+        },
+      },
+    })
+
+    await rspeedy.initConfigs()
+
+    expect(exposedLayers).toEqual({
+      BACKGROUND: 'vanilla:background',
+      MAIN_THREAD: 'vanilla:main-thread',
+    })
+  })
+
+  test('delegates explicit entry requests to Rspeedy resolution', async () => {
+    const outputRoot = await mkdtemp(
+      path.join(tmpdir(), 'rspeedy-vanilla-resolve-test-'),
+    )
+    tempDirs.push(outputRoot)
+
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        output: {
+          distPath: { root: outputRoot },
+          filename: '[name].bundle',
+        },
+        plugins: [
+          vanilla.pluginVanillaLynx({
+            entries: {
+              card: {
+                background: 'vanilla-background',
+                css: 'vanilla-style',
+                mainThread: 'vanilla-main-thread',
+              },
+            },
+          }),
+        ],
+        resolve: {
+          alias: {
+            'vanilla-background$': fixturePath('background.ts'),
+            'vanilla-main-thread$': fixturePath('main-thread.ts'),
+            'vanilla-style$': fixturePath('style.css'),
+          },
+        },
+      },
+    })
+
+    await rspeedy.build()
+
+    expect(existsSync(path.join(outputRoot, 'card.bundle'))).toBe(true)
+  })
+})
+
+describe('pluginVanillaLynx configuration', () => {
+  test('normalizes heterogeneous Rsbuild entry values', async () => {
+    const mainThreadRequest = `${
+      path.relative(
+        process.cwd(),
+        fixturePath('main-thread.ts'),
+      )
+    }?raw`
+    const result = await runPluginHarness({
+      environment: 'web-preview',
+      rawEntries: {
+        card: {
+          values: () => [
+            42,
+            null,
+            { ignored: true },
+            ['setup.ts', false, mainThreadRequest],
+            { import: 'object-entry.ts' },
+            { import: ['array-entry.ts', false] },
+          ],
+        },
+      },
+    })
+
+    expect(result.entries.get('card__background')).toEqual({
+      filename: '.rspeedy/card/background.js',
+      import: fixturePath('background.ts'),
+      layer: vanilla.LAYERS.BACKGROUND,
+    })
+    expect(result.entries.get('card__main-thread')).toEqual({
+      filename: '.rspeedy/card/main-thread.js',
+      import: [
+        'setup.ts',
+        mainThreadRequest,
+        'object-entry.ts',
+        'array-entry.ts',
+        fixturePath('style.css'),
+      ],
+      layer: vanilla.LAYERS.MAIN_THREAD,
+    })
+    expect(getTemplateOptions(result, 'card')).toMatchObject({
+      chunks: ['card__background', 'card__main-thread'],
+      filename: 'card.web-preview.bundle',
+    })
+    expect(result.plugins.has('WebEncodePlugin')).toBe(true)
+    expect(result.plugins.has('lynx:vanilla:runtime-wrapper')).toBe(false)
+  })
+
+  test('supports main-thread-only entries and option functions', async () => {
+    let filenameContext: unknown
+    const result = await runPluginHarness({
+      environment: 'lynx-preview',
+      lynxConfigTarget: '3.8',
+      pluginOptions: {
+        bundleFilename(context) {
+          filenameContext = context
+          return '[name].[platform].custom.bundle'
+        },
+        engineVersion: '4.0',
+        entries: {
+          card: {
+            background: false,
+            css: false,
+            mainThread: '?raw',
+          },
+        },
+        targetSdkVersion: '3.9',
+      },
+      rspeedyFilename: '[name].ignored.bundle',
+    })
+
+    expect(filenameContext).toEqual({
+      entryName: 'card',
+      lazyBundle: false,
+      platform: 'lynx-preview',
+    })
+    expect(result.entries.has('card__background')).toBe(false)
+    expect(result.entries.get('card__main-thread')).toEqual({
+      filename: '.rspeedy/card/main-thread.js',
+      import: ['?raw'],
+      layer: vanilla.LAYERS.MAIN_THREAD,
+    })
+    expect(getTemplateOptions(result, 'card')).toMatchObject({
+      chunks: ['card__main-thread'],
+      filename: 'card.lynx-preview.custom.bundle',
+      targetSdkVersion: '4.0',
+    })
+    expect(result.plugins.has('lynx:vanilla:runtime-wrapper')).toBe(false)
+    expect(result.plugins.has('LynxEncodePlugin')).toBe(true)
+  })
+
+  test('resolves target SDK and Rspeedy filename fallbacks', async () => {
+    const scenarios: Array<{
+      expectedFilename: string
+      expectedTarget: string
+      lynxConfigTarget?: string | undefined
+      pluginOptions?: vanilla.PluginVanillaLynxOptions | undefined
+      rspeedyFilename?: HarnessOptions['rspeedyFilename']
+    }> = [
+      {
+        expectedFilename: 'main.template.bundle',
+        expectedTarget: '3.9',
+        lynxConfigTarget: '3.8',
+        pluginOptions: { targetSdkVersion: '3.9' },
+        rspeedyFilename: { template: '[name].template.bundle' },
+      },
+      {
+        expectedFilename: 'main.bundle-only',
+        expectedTarget: '3.8',
+        lynxConfigTarget: '3.8',
+        rspeedyFilename: {
+          bundle: '[name].bundle-only',
+          template: '[name].ignored',
+        },
+      },
+      {
+        expectedFilename: 'main.lynx.bundle',
+        expectedTarget: '3.5',
+      },
+    ]
+
+    for (const scenario of scenarios) {
+      const result = await runPluginHarness({
+        lynxConfigTarget: scenario.lynxConfigTarget,
+        pluginOptions: scenario.pluginOptions,
+        rawEntries: {
+          main: { values: () => ['virtual-main-thread'] },
+        },
+        rspeedyFilename: scenario.rspeedyFilename,
+      })
+
+      expect(getTemplateOptions(result, 'main')).toMatchObject({
+        filename: scenario.expectedFilename,
+        targetSdkVersion: scenario.expectedTarget,
+      })
+    }
+  })
+
+  test('ignores unsupported environments and accepts an empty entry map', async () => {
+    const unsupported = await runPluginHarness({
+      environment: 'node',
+    })
+    expect(unsupported.clearedEntries).toBe(false)
+    expect(unsupported.plugins.size).toBe(0)
+
+    const empty = await runPluginHarness({
+      environment: 'lynx-custom',
+    })
+    expect(empty.clearedEntries).toBe(true)
+    expect(empty.entries.size).toBe(0)
+    expect(empty.plugins.has('VanillaLynxWebpackPlugin')).toBe(true)
+    expect(empty.plugins.has('LynxEncodePlugin')).toBe(true)
+  })
+
+  test('rejects an ambiguous Rsbuild entry', async () => {
+    await expect(runPluginHarness({
+      rawEntries: {
+        ambiguous: {
+          values: () => [
+            'first.ts',
+            'second.ts',
+            { import: 42 },
+          ],
+        },
+      },
+    })).rejects.toThrow(
+      '[pluginVanillaLynx] Entry `ambiguous` must contain exactly one `main-thread.ts` source.',
+    )
+  })
+
+  test('reports a missing main-thread asset', async () => {
+    const result = await runPluginHarness({
+      rawEntries: {
+        main: { values: () => ['virtual-main-thread'] },
+      },
+    })
+    const plugin = getVanillaWebpackPlugin(result)
+    const compilation = {
+      getAsset() {
+        return undefined
+      },
+      hooks: {
+        processAssets: {
+          tap(_options: unknown, handler: () => void) {
+            handler()
+          },
+        },
+      },
+    }
+    const compiler = {
+      hooks: {
+        thisCompilation: {
+          tap(_name: string, handler: (compilation: unknown) => void) {
+            handler(compilation)
+          },
+        },
+      },
+      webpack: {
+        Compilation: { PROCESS_ASSETS_STAGE_ADDITIONAL: 0 },
+      },
+    } as unknown as Rspack.Compiler
+
+    expect(() => plugin.apply(compiler)).toThrow(
+      '[pluginVanillaLynx] Main-thread asset was not emitted: .rspeedy/main/main-thread.js',
+    )
+  })
+})

--- a/packages/rspeedy/plugin-vanilla/tsconfig.build.json
+++ b/packages/rspeedy/plugin-vanilla/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./lib",
+    "rootDir": "./src",
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../webpack/runtime-wrapper-webpack-plugin/tsconfig.build.json" },
+    { "path": "../../webpack/template-webpack-plugin/tsconfig.build.json" },
+  ],
+}

--- a/packages/rspeedy/plugin-vanilla/tsconfig.json
+++ b/packages/rspeedy/plugin-vanilla/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["./tsconfig.build.json"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+  },
+  "include": ["src", "test", "rstest.config.ts"],
+  "references": [
+    { "path": "../../webpack/runtime-wrapper-webpack-plugin/tsconfig.build.json" },
+    { "path": "../../webpack/template-webpack-plugin/tsconfig.build.json" },
+  ],
+}

--- a/packages/rspeedy/plugin-vanilla/turbo.json
+++ b/packages/rspeedy/plugin-vanilla/turbo.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": [
+    "//"
+  ],
+  "tasks": {
+    "build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "src/**",
+        "rslib.config.ts",
+        "tsconfig.build.json"
+      ],
+      "outputs": [
+        "dist"
+      ]
+    }
+  }
+}

--- a/packages/rspeedy/tsconfig.json
+++ b/packages/rspeedy/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "./plugin-qrcode/tsconfig.build.json" },
     { "path": "./plugin-react/tsconfig.build.json" },
     { "path": "./plugin-react-alias/tsconfig.build.json" },
+    { "path": "./plugin-vanilla/tsconfig.build.json" },
     { "path": "./lynx-bundle-rslib-config/tsconfig.build.json" },
     { "path": "./plugin-external-bundle/tsconfig.build.json" },
     { "path": "./plugin-config/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,6 +774,21 @@ importers:
         specifier: ^3.4.19
         version: 3.4.19
 
+  examples/vanilla:
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      '@lynx-js/type-element-api':
+        specifier: 0.0.9
+        version: 0.0.9
+      '@lynx-js/types':
+        specifier: 4.1.0
+        version: 4.1.0
+      '@lynx-js/vanilla-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-vanilla
+
   packages/background-only: {}
 
   packages/genui:
@@ -1840,6 +1855,28 @@ importers:
       semver:
         specifier: ^7.8.5
         version: 7.8.5
+
+  packages/rspeedy/plugin-vanilla:
+    dependencies:
+      '@lynx-js/runtime-wrapper-webpack-plugin':
+        specifier: workspace:*
+        version: link:../../webpack/runtime-wrapper-webpack-plugin
+      '@lynx-js/template-webpack-plugin':
+        specifier: workspace:*
+        version: link:../../webpack/template-webpack-plugin
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../core
+      '@lynx-js/test-tools':
+        specifier: workspace:*
+        version: link:../../webpack/test-tools
+      '@rsbuild/core':
+        specifier: catalog:rsbuild
+        version: 2.1.10(core-js@3.50.0)
+      '@rstest/core':
+        specifier: catalog:rstest
+        version: 0.11.6(core-js@3.50.0)(jsdom@27.4.0(supports-color@10.2.2))
 
   packages/rspeedy/upgrade-rspeedy:
     devDependencies:

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -15,7 +15,7 @@ const reporters: RstestConfig['reporters'] = process.env.GITHUB_ACTIONS
 
 export default defineConfig({
   coverage: {
-    reporters: ['json', 'text'],
+    reporters: ['lcov', 'text'],
     // `web-elements`' built output cannot be instrumented: doing so aborts
     // coverage reporting for the entire run.
     //


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Vanilla Lynx Rsbuild plugin for building native and web Element PAPI applications.
  * Supports automatic or explicit entry configuration, platform-specific output, styling, and dual-thread event handling.
  * Added a complete Vanilla Lynx counter example with development, build, and type-check workflows.

* **Documentation**
  * Added setup guidance, configuration options, platform behavior, output details, and usage examples.
  * Documented current HMR and live-reload limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
