### PR TITLE
fix(ci): publish the workspace dependency closure to pkg.pr.new

### DIFF
--- a/.changeset/genui-pkg-pr-new-probe.md
+++ b/.changeset/genui-pkg-pr-new-probe.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/genui": patch
+---
+
+Probe changeset used to exercise the pkg.pr.new preview flow. Remove before merging.

--- a/.changeset/genui-pkg-pr-new-probe.md
+++ b/.changeset/genui-pkg-pr-new-probe.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/genui": patch
----
-
-Probe changeset used to exercise the pkg.pr.new preview flow. Remove before merging.

--- a/.github/scripts/list-changeset-packages.cjs
+++ b/.github/scripts/list-changeset-packages.cjs
@@ -5,11 +5,80 @@
 // LICENSE file in the root directory of this source tree.
 
 // Print the directories of publishable workspace packages that appear in the
-// `releases` array of a `changeset status --output` JSON file. One path per
-// line, relative to the repository root. Used by the pkg.pr.new workflow to
-// publish only packages touched by a PR's changesets.
+// `releases` array of a `changeset status --output` JSON file, plus every
+// workspace package they depend on. One path per line, relative to the
+// repository root. Used by the pkg.pr.new workflow.
+//
+// A `workspace:` dependency that is not published alongside its dependent
+// resolves to the dependent's local version, which may never have been
+// released — `@lynx-js/genui` depending on `@lynx-js/react-signals@0.0.1`
+// made every preview 404 on install. Publishing the closure keeps the
+// preview self-consistent: those deps become pkg.pr.new URLs pinned to the
+// same commit.
 const { execSync } = require('node:child_process');
 const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const RUNTIME_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+function readWorkspace() {
+  const packages = JSON.parse(
+    execSync('pnpm m ls --json --depth=-1', { encoding: 'utf8' }),
+  );
+
+  const byName = new Map();
+  for (const pkg of packages) {
+    if (!pkg.name) continue;
+    const manifest = JSON.parse(
+      readFileSync(path.join(pkg.path, 'package.json'), 'utf8'),
+    );
+    byName.set(pkg.name, {
+      path: pkg.path,
+      private: pkg.private === true || manifest.private === true,
+      manifest,
+    });
+  }
+  return byName;
+}
+
+function workspaceDependenciesOf(pkg, workspace) {
+  const names = [];
+  for (const field of RUNTIME_DEPENDENCY_FIELDS) {
+    const deps = pkg.manifest[field];
+    if (!deps) continue;
+    for (const [name, spec] of Object.entries(deps)) {
+      if (
+        typeof spec === 'string' && spec.startsWith('workspace:')
+        && workspace.has(name)
+      ) names.push(name);
+    }
+  }
+  return names;
+}
+
+function expandToDependencyClosure(seed, workspace) {
+  const closure = new Set();
+  const queue = [...seed];
+
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (closure.has(name)) continue;
+    closure.add(name);
+
+    const pkg = workspace.get(name);
+    if (!pkg) continue;
+
+    for (const dependency of workspaceDependenciesOf(pkg, workspace)) {
+      if (!closure.has(dependency)) queue.push(dependency);
+    }
+  }
+
+  return closure;
+}
 
 function main() {
   const statusFile = process.argv[2] || '.changeset-status.json';
@@ -29,13 +98,22 @@ function main() {
     return;
   }
 
-  const workspace = JSON.parse(
-    execSync('pnpm m ls --json --depth=-1', { encoding: 'utf8' }),
-  );
+  const workspace = readWorkspace();
+  const closure = expandToDependencyClosure(affected, workspace);
 
-  for (const pkg of workspace) {
-    if (!pkg.name || pkg.private) continue;
-    if (!affected.has(pkg.name)) continue;
+  for (const name of closure) {
+    const pkg = workspace.get(name);
+    if (pkg?.private && !affected.has(name)) {
+      process.stderr.write(
+        `warning: ${name} is a workspace dependency of a published package but is private; `
+          + `previews will resolve it from the registry.\n`,
+      );
+    }
+  }
+
+  for (const [name, pkg] of workspace) {
+    if (pkg.private) continue;
+    if (!closure.has(name)) continue;
     process.stdout.write(`${pkg.path}\n`);
   }
 }

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -190,7 +190,7 @@ jobs:
         if: steps.changeset.outputs.skip == 'false'
         env:
           PACKAGE_DIRS: ${{ steps.changeset.outputs.package-dirs }}
-        # zizmor: ignore[trusted-publishing] pkg.pr.new authenticates via its own GitHub App, not the npm trusted-publishing flow this heuristic suggests.
+        # zizmor: ignore[use-trusted-publishing] pkg.pr.new authenticates via its own GitHub App, not the npm trusted-publishing flow this heuristic suggests.
         run: |
           read -ra package_dirs <<< "$PACKAGE_DIRS"
           pnpm exec pkg-pr-new publish \

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -191,4 +191,12 @@ jobs:
         env:
           PACKAGE_DIRS: ${{ steps.changeset.outputs.package-dirs }}
         # zizmor: ignore[trusted-publishing] pkg.pr.new authenticates via its own GitHub App, not the npm trusted-publishing flow this heuristic suggests.
-        run: pnpm dlx pkg-pr-new publish --compact --pnpm $PACKAGE_DIRS
+        run: |
+          read -ra package_dirs <<< "$PACKAGE_DIRS"
+          pnpm exec pkg-pr-new publish \
+            --compact \
+            --pnpm \
+            --commentWithSha \
+            --packageManager=pnpm \
+            --no-template \
+            "${package_dirs[@]}"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "globals": "^16.5.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "pkg-pr-new": "0.0.87",
     "sort-package-json": "^3.7.1",
     "ts-patch": "^4.0.1",
     "turbo": "^2.10.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      pkg-pr-new:
+        specifier: 0.0.87
+        version: 0.0.87
       sort-package-json:
         specifier: ^3.7.1
         version: 3.7.1
@@ -10257,6 +10260,10 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  pkg-pr-new@0.0.87:
+    resolution: {integrity: sha512-nm+30Py1csXWfyMH1ueQyTR11IZGHS5oW8Qok/MxMwjPx9g1jX3wMRrJf8TgEvNo0a0M4i14T0zQsEPWdZfAhg==}
+    hasBin: true
 
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
@@ -21123,6 +21130,8 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-pr-new@0.0.87: {}
 
   playwright-core@1.61.1: {}
 


### PR DESCRIPTION
Two related changes to the pkg.pr.new preview publish.

## 1. Publish the workspace dependency closure

A `workspace:` dependency that is **not** published alongside its dependent resolves to the dependent's *local* version, which may never have been released.

`@lynx-js/genui` depends on `@lynx-js/react-signals` via `workspace:*`:

| | |
|---|---|
| `react-signals` local workspace version | `0.0.1` |
| published on npm | **only `0.0.0-rc.0`** |

So the preview carried `"@lynx-js/react-signals": "0.0.1"` and 404'd on install. The workaround has been to hand-write an extra changeset so the dependency lands in the same batch; this automates it by expanding the publish set to the transitive workspace dependency closure (`dependencies`, `peerDependencies`, `optionalDependencies`).

Verified on this PR before the probe changeset was removed — both packages published, and the preview resolved correctly:

```diff
- "@lynx-js/react-signals": "0.0.1"
+ "@lynx-js/react-signals": "https://pkg.pr.new/lynx-family/lynx-stack/@lynx-js/react-signals@a09da2a5..."
```

`npm install` of the preview then succeeded (38 packages), while `registry.npmjs.org/@lynx-js/react-signals/0.0.1` still returns 404.

A private workspace dependency cannot be published; the script warns on stderr rather than silently emitting a broken preview.

## 2. Pin pkg-pr-new and harden the invocation

- **`pnpm dlx` → `pnpm exec`** with `pkg-pr-new` pinned in root `devDependencies`. It was previously fetched unpinned at run time, so an upstream release could change the output with no change in this repo.
- **`--commentWithSha`** — the PR-number URL is an alias that follows the PR head. Observed on #3440: `@3440` and an earlier commit of the same PR return different bytes under a fixed URL while `version` stays `0.16.3`. Commit URLs are immutable.
- **`--no-template`** — skips the default StackBlitz project upload.
- **`--packageManager=pnpm`** — comment shows the pnpm install command.
- Argument passing uses a quoted bash array.

### Why not `--previewVersion`

It rewrites `version` unconditionally, but only rewrites `peerDependencies` when `--peerDeps` is also set:

```js
const realDeps = isPeerDepsEnabled ? new Map() : null;
if (realDeps) hijackDeps(realDeps, pJson.peerDependencies);
if (newVersion) pJson.version = newVersion;
```

This repo has 12 peerDeps pointing at workspace packages by version range (6 of them on `@lynx-js/react`). `0.0.0-preview-<sha>` satisfies none of them — not even `*`, since prereleases do not match plain ranges. Enabling it would need `--peerDeps` alongside; left off for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved preview publishing to include all affected publishable packages and required runtime dependencies.
  * Excluded private packages from preview publishing and added warnings when they are encountered.
  * Standardized preview package publishing options for more consistent results.
  * Added tooling support to improve the reliability of preview package publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->