### PR TITLE
fix(react): avoid orphan DEV_ONLY_SetSnapshotEntryName for lazy bundles loaded during first-screen direct render

### DIFF
--- a/.changeset/lazy-lions-repeat.md
+++ b/.changeset/lazy-lions-repeat.md
@@ -2,10 +2,4 @@
 '@lynx-js/react': patch
 ---
 
-Fix an orphan `DEV_ONLY_SetSnapshotEntryName` when a lazy bundle is loaded during first-screen direct render.
-
-`DEV_ONLY_AddSnapshot` is emitted from the `snapshotCreatorMap` `Proxy` set trap (at chunk evaluation time), while `DEV_ONLY_SetSnapshotEntryName` is emitted from inside `createSnapshot()` (at render time). Since snapshots became lazily created, those two moments sit on opposite sides of hydration: a lazy bundle loaded during first-screen direct render evaluates its chunk while `__globalSnapshotPatch` does not exist yet — so `DEV_ONLY_AddSnapshot` is skipped — but its `createSnapshot()` call happens after hydration and still emitted `DEV_ONLY_SetSnapshotEntryName`.
-
-The main thread then rewrote the creator compiled into its *own* chunk (rather than the one serialized over from the background thread), which does not round-trip through `Function.prototype.toString`. `evaluate()` threw `SyntaxError`, aborting the whole patch loop and cascading into `snapshotPatchApply failed: ctx not found`.
-
-The background thread now tracks which creators it actually sent and only emits `DEV_ONLY_SetSnapshotEntryName` for those, and the main thread guards on the `globDynamicComponentEntry` placeholder still being present and no longer lets this DEV-only HMR step abort patch application.
+Fix `snapshotPatchApply failed: ctx not found` when a lazy bundle is loaded during first-screen direct render.

--- a/.changeset/lazy-lions-repeat.md
+++ b/.changeset/lazy-lions-repeat.md
@@ -1,0 +1,11 @@
+---
+'@lynx-js/react': patch
+---
+
+Fix an orphan `DEV_ONLY_SetSnapshotEntryName` when a lazy bundle is loaded during first-screen direct render.
+
+`DEV_ONLY_AddSnapshot` is emitted from the `snapshotCreatorMap` `Proxy` set trap (at chunk evaluation time), while `DEV_ONLY_SetSnapshotEntryName` is emitted from inside `createSnapshot()` (at render time). Since snapshots became lazily created, those two moments sit on opposite sides of hydration: a lazy bundle loaded during first-screen direct render evaluates its chunk while `__globalSnapshotPatch` does not exist yet — so `DEV_ONLY_AddSnapshot` is skipped — but its `createSnapshot()` call happens after hydration and still emitted `DEV_ONLY_SetSnapshotEntryName`.
+
+The main thread then rewrote the creator compiled into its *own* chunk (rather than the one serialized over from the background thread), which does not round-trip through `Function.prototype.toString`. `evaluate()` threw `SyntaxError`, aborting the whole patch loop and cascading into `snapshotPatchApply failed: ctx not found`.
+
+The background thread now tracks which creators it actually sent and only emits `DEV_ONLY_SetSnapshotEntryName` for those, and the main thread guards on the `globDynamicComponentEntry` placeholder still being present and no longer lets this DEV-only HMR step abort patch application.

--- a/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
@@ -990,6 +990,53 @@ describe('DEV_ONLY_addSnapshot', () => {
     `);
   });
 
+  it('with lazy bundle loaded before hydration', () => {
+    const uniqID1 = 'first-screen-lazy-0';
+    deinitGlobalSnapshotPatch();
+    snapshotCreatorMap[uniqID1] = (uniqID1) => {
+      globalThis.createSnapshot(
+        uniqID1,
+        /* v8 ignore start */
+        () => {
+          const pageId = 0;
+          const el = __CreateView(pageId);
+          return [el];
+        },
+        /* v8 ignore stop */
+        null,
+        null,
+        undefined,
+        globDynamicComponentEntry,
+        null,
+        true,
+      );
+    };
+    initGlobalSnapshotPatch();
+
+    const oldDynamicComponentEntry = global.globDynamicComponentEntry;
+    global.globDynamicComponentEntry = 'https://example.com/lazy-bundle.js';
+    new SnapshotInstance(uniqID1);
+    global.globDynamicComponentEntry = oldDynamicComponentEntry;
+
+    expect(takeGlobalSnapshotPatch()).toMatchInlineSnapshot(`[]`);
+  });
+
+  it('with a creator that cannot be re-evaluated', () => {
+    const uniqID1 = 'first-screen-lazy-1';
+    snapshotCreatorMap[uniqID1] = ((uniqID1) => {
+      globalThis.createSnapshot(uniqID1, () => [__CreateView(0)], null, null, undefined, undefined, null, true);
+    }).bind(null);
+
+    expect(snapshotCreatorMap[uniqID1].toString()).toContain('[native code]');
+    expect(() =>
+      snapshotPatchApply([
+        SnapshotOperation.DEV_ONLY_SetSnapshotEntryName,
+        uniqID1,
+        'https://example.com/lazy-bundle.js',
+      ])
+    ).not.toThrow();
+  });
+
   it('with update', () => {
     const uniqID1 = 'with-update-0';
     // We have to use `snapshotCreatorMap[uniqID1] =` so that it can be created after `initGlobalSnapshotPatch`

--- a/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
@@ -1037,6 +1037,27 @@ describe('DEV_ONLY_addSnapshot', () => {
     ).not.toThrow();
   });
 
+  it('with a creator whose rewrite is not evaluatable', () => {
+    const uniqID1 = 'first-screen-lazy-2';
+    const holder = {
+      globDynamicComponentEntry() {
+        return 1;
+      },
+    };
+    snapshotCreatorMap[uniqID1] = holder.globDynamicComponentEntry;
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() =>
+      snapshotPatchApply([
+        SnapshotOperation.DEV_ONLY_SetSnapshotEntryName,
+        uniqID1,
+        'https://example.com/lazy-bundle.js',
+      ])
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
   it('with update', () => {
     const uniqID1 = 'with-update-0';
     // We have to use `snapshotCreatorMap[uniqID1] =` so that it can be created after `initGlobalSnapshotPatch`

--- a/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/snapshotPatch.test.jsx
@@ -1058,6 +1058,16 @@ describe('DEV_ONLY_addSnapshot', () => {
     warn.mockRestore();
   });
 
+  it('with a creator that is missing', () => {
+    expect(() =>
+      snapshotPatchApply([
+        SnapshotOperation.DEV_ONLY_SetSnapshotEntryName,
+        'first-screen-lazy-missing',
+        'https://example.com/lazy-bundle.js',
+      ])
+    ).not.toThrow();
+  });
+
   it('with update', () => {
     const uniqID1 = 'with-update-0';
     // We have to use `snapshotCreatorMap[uniqID1] =` so that it can be created after `initGlobalSnapshotPatch`

--- a/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
@@ -126,9 +126,23 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
 
           // HMR-related
           // Update the evaluated snapshot entryName from JS.
-          snapshotCreatorMap[uniqID] = evaluate<(uniqId: string) => string>(
-            snapshotCreatorMap[uniqID]!.toString().replace(/globDynamicComponentEntry/g, JSON.stringify(entryName)),
-          );
+          //
+          // Only a creator that was serialized over from the background thread via
+          // `DEV_ONLY_AddSnapshot` still carries the `globDynamicComponentEntry`
+          // placeholder and round-trips through its own `toString()`. Guard on that
+          // invariant directly, and never let a DEV-only HMR nicety abort the patch
+          // loop — doing so leaves the rest of the patch unapplied and cascades into
+          // `snapshotPatchApply failed: ctx not found`.
+          const source = snapshotCreatorMap[uniqID]?.toString();
+          if (source?.includes('globDynamicComponentEntry')) {
+            try {
+              snapshotCreatorMap[uniqID] = evaluate<(uniqId: string) => string>(
+                source.replace(/globDynamicComponentEntry/g, JSON.stringify(entryName)),
+              );
+            } catch (e) {
+              console.warn(`[ReactLynx] failed to rewrite snapshot entryName for ${uniqID}`, e);
+            }
+          }
         }
         break;
       }

--- a/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
+++ b/packages/react/runtime/src/snapshot/lifecycle/patch/snapshotPatchApply.ts
@@ -126,13 +126,6 @@ export function snapshotPatchApply(snapshotPatch: SnapshotPatch): void {
 
           // HMR-related
           // Update the evaluated snapshot entryName from JS.
-          //
-          // Only a creator that was serialized over from the background thread via
-          // `DEV_ONLY_AddSnapshot` still carries the `globDynamicComponentEntry`
-          // placeholder and round-trips through its own `toString()`. Guard on that
-          // invariant directly, and never let a DEV-only HMR nicety abort the patch
-          // loop — doing so leaves the rest of the patch unapplied and cascades into
-          // `snapshotPatchApply failed: ctx not found`.
           const source = snapshotCreatorMap[uniqID]?.toString();
           if (source?.includes('globDynamicComponentEntry')) {
             try {

--- a/packages/react/runtime/src/snapshot/snapshot/definition.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/definition.ts
@@ -14,7 +14,7 @@ import {
 } from './dynamicPartType.js';
 import { snapshotCreateList } from './list.js';
 import type { SnapshotInstance } from './snapshot.js';
-import { snapshotCreatorMap, snapshotCreatorRuntime } from './snapshotCreatorMap.js';
+import { devOnlySentSnapshots, snapshotCreatorMap, snapshotCreatorRuntime } from './snapshotCreatorMap.js';
 import { updateSpread } from './spread.js';
 import { entryUniqID, getCloneSnapshotInfo } from './utils.js';
 import { SnapshotOperation, __globalSnapshotPatch } from '../lifecycle/patch/snapshotPatch.js';
@@ -143,12 +143,22 @@ export function createSnapshot(
     __DEV__ && __JS__ && __globalSnapshotPatch && entryName && entryName !== DEFAULT_ENTRY_NAME
     // `uniqID` will be `https://example.com/main.lynx.bundle:__snapshot_835da_eff1e_1` when loading a standalone lazy bundle after hydration.
     && !uniqID.includes(':')
+    // Rewriting the entryName only makes sense when the main thread's creator is
+    // the one we serialized over. A lazy bundle loaded during first-screen direct
+    // render never sends `DEV_ONLY_AddSnapshot`; there the main thread uses the
+    // creator compiled into its own chunk, where `globDynamicComponentEntry` is
+    // already bound by that chunk's scope and must not be rewritten.
+    && devOnlySentSnapshots!.has(uniqID)
   ) {
     __globalSnapshotPatch.push(
       SnapshotOperation.DEV_ONLY_SetSnapshotEntryName,
       uniqID,
       entryName,
     );
+    // One-shot: once the main thread applies this op the placeholder is gone, so
+    // the creator must not be rewritten again. A later re-registration (HMR)
+    // re-arms it through the Proxy in `snapshot.ts`.
+    devOnlySentSnapshots!.delete(uniqID);
   }
 
   const s: Snapshot = { create, update, slot, cssId, entryName, refAndSpreadIndexes };

--- a/packages/react/runtime/src/snapshot/snapshot/definition.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/definition.ts
@@ -143,14 +143,14 @@ export function createSnapshot(
     __DEV__ && __JS__ && __globalSnapshotPatch && entryName && entryName !== DEFAULT_ENTRY_NAME
     // `uniqID` will be `https://example.com/main.lynx.bundle:__snapshot_835da_eff1e_1` when loading a standalone lazy bundle after hydration.
     && !uniqID.includes(':')
-    && devOnlySentSnapshots!.has(uniqID)
+    && devOnlySentSnapshots.has(uniqID)
   ) {
     __globalSnapshotPatch.push(
       SnapshotOperation.DEV_ONLY_SetSnapshotEntryName,
       uniqID,
       entryName,
     );
-    devOnlySentSnapshots!.delete(uniqID);
+    devOnlySentSnapshots.delete(uniqID);
   }
 
   const s: Snapshot = { create, update, slot, cssId, entryName, refAndSpreadIndexes };

--- a/packages/react/runtime/src/snapshot/snapshot/definition.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/definition.ts
@@ -143,11 +143,6 @@ export function createSnapshot(
     __DEV__ && __JS__ && __globalSnapshotPatch && entryName && entryName !== DEFAULT_ENTRY_NAME
     // `uniqID` will be `https://example.com/main.lynx.bundle:__snapshot_835da_eff1e_1` when loading a standalone lazy bundle after hydration.
     && !uniqID.includes(':')
-    // Rewriting the entryName only makes sense when the main thread's creator is
-    // the one we serialized over. A lazy bundle loaded during first-screen direct
-    // render never sends `DEV_ONLY_AddSnapshot`; there the main thread uses the
-    // creator compiled into its own chunk, where `globDynamicComponentEntry` is
-    // already bound by that chunk's scope and must not be rewritten.
     && devOnlySentSnapshots!.has(uniqID)
   ) {
     __globalSnapshotPatch.push(
@@ -155,9 +150,6 @@ export function createSnapshot(
       uniqID,
       entryName,
     );
-    // One-shot: once the main thread applies this op the placeholder is gone, so
-    // the creator must not be rewritten again. A later re-registration (HMR)
-    // re-arms it through the Proxy in `snapshot.ts`.
     devOnlySentSnapshots!.delete(uniqID);
   }
 

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -18,7 +18,12 @@ import { snapshotDestroyList } from './list.js';
 import { getListItemPlatformInfoFromIndexedValue } from './platformInfo.js';
 import type { PlatformInfo } from './platformInfo.js';
 import { unref } from './ref.js';
-import { setSnapshotCreatorMap, snapshotCreatorMap, snapshotCreatorRuntime } from './snapshotCreatorMap.js';
+import {
+  devOnlySentSnapshots,
+  setSnapshotCreatorMap,
+  snapshotCreatorMap,
+  snapshotCreatorRuntime,
+} from './snapshotCreatorMap.js';
 import type { SnapshotCreator } from './snapshotCreatorMap.js';
 import { snapshotInstanceManager } from './snapshotInstanceManager.js';
 import type { SerializedSnapshotInstance } from './types.js';
@@ -108,6 +113,15 @@ if (__DEV__ && __JS__) {
             // This allows the updates to be applied to main thread.
             value.toString(),
           );
+          // The main thread now holds *our* creator, so a later
+          // `DEV_ONLY_SetSnapshotEntryName` may rewrite its placeholder.
+          devOnlySentSnapshots!.add(prop);
+        } else {
+          // No `DEV_ONLY_AddSnapshot` was sent this time, so the main thread keeps
+          // the creator compiled into its own chunk. Clear any stale token,
+          // otherwise a re-registration (HMR) would leave one armed from a previous
+          // round and emit an orphan `DEV_ONLY_SetSnapshotEntryName`.
+          devOnlySentSnapshots!.delete(prop);
         }
         target[prop] = value;
         return true;

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -113,14 +113,8 @@ if (__DEV__ && __JS__) {
             // This allows the updates to be applied to main thread.
             value.toString(),
           );
-          // The main thread now holds *our* creator, so a later
-          // `DEV_ONLY_SetSnapshotEntryName` may rewrite its placeholder.
           devOnlySentSnapshots!.add(prop);
         } else {
-          // No `DEV_ONLY_AddSnapshot` was sent this time, so the main thread keeps
-          // the creator compiled into its own chunk. Clear any stale token,
-          // otherwise a re-registration (HMR) would leave one armed from a previous
-          // round and emit an orphan `DEV_ONLY_SetSnapshotEntryName`.
           devOnlySentSnapshots!.delete(prop);
         }
         target[prop] = value;

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -113,9 +113,9 @@ if (__DEV__ && __JS__) {
             // This allows the updates to be applied to main thread.
             value.toString(),
           );
-          devOnlySentSnapshots!.add(prop);
+          devOnlySentSnapshots.add(prop);
         } else {
-          devOnlySentSnapshots!.delete(prop);
+          devOnlySentSnapshots.delete(prop);
         }
         target[prop] = value;
         return true;

--- a/packages/react/runtime/src/snapshot/snapshot/snapshotCreatorMap.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshotCreatorMap.ts
@@ -29,3 +29,21 @@ export let snapshotCreatorRuntime: SnapshotCreatorRuntime | undefined;
 export function setSnapshotCreatorRuntime(runtime: SnapshotCreatorRuntime): void {
   snapshotCreatorRuntime = runtime;
 }
+
+/**
+ * One-shot tokens recording that the main thread's creator for a `uniqID` is the
+ * one we serialized over via `DEV_ONLY_AddSnapshot` — and therefore still carries
+ * the `globDynamicComponentEntry` placeholder and round-trips through
+ * `Function.prototype.toString`.
+ *
+ * `DEV_ONLY_SetSnapshotEntryName` rewrites that placeholder, so it is only
+ * meaningful while this invariant holds. A lazy bundle loaded *during first-screen
+ * direct render* never sends `DEV_ONLY_AddSnapshot` (`__globalSnapshotPatch` does
+ * not exist before hydration), yet its `createSnapshot()` call happens after
+ * hydration — without this token the background thread would emit an orphan
+ * `DEV_ONLY_SetSnapshotEntryName` against the creator compiled into the main
+ * thread's own chunk.
+ *
+ * Only populated in `__DEV__ && __JS__`.
+ */
+export const devOnlySentSnapshots: Set<string> | undefined = (__DEV__ && __JS__) ? new Set() : undefined;

--- a/packages/react/runtime/src/snapshot/snapshot/snapshotCreatorMap.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshotCreatorMap.ts
@@ -30,4 +30,4 @@ export function setSnapshotCreatorRuntime(runtime: SnapshotCreatorRuntime): void
   snapshotCreatorRuntime = runtime;
 }
 
-export const devOnlySentSnapshots: Set<string> | undefined = (__DEV__ && __JS__) ? new Set() : undefined;
+export const devOnlySentSnapshots: Set<string> = new Set();

--- a/packages/react/runtime/src/snapshot/snapshot/snapshotCreatorMap.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshotCreatorMap.ts
@@ -30,20 +30,4 @@ export function setSnapshotCreatorRuntime(runtime: SnapshotCreatorRuntime): void
   snapshotCreatorRuntime = runtime;
 }
 
-/**
- * One-shot tokens recording that the main thread's creator for a `uniqID` is the
- * one we serialized over via `DEV_ONLY_AddSnapshot` — and therefore still carries
- * the `globDynamicComponentEntry` placeholder and round-trips through
- * `Function.prototype.toString`.
- *
- * `DEV_ONLY_SetSnapshotEntryName` rewrites that placeholder, so it is only
- * meaningful while this invariant holds. A lazy bundle loaded *during first-screen
- * direct render* never sends `DEV_ONLY_AddSnapshot` (`__globalSnapshotPatch` does
- * not exist before hydration), yet its `createSnapshot()` call happens after
- * hydration — without this token the background thread would emit an orphan
- * `DEV_ONLY_SetSnapshotEntryName` against the creator compiled into the main
- * thread's own chunk.
- *
- * Only populated in `__DEV__ && __JS__`.
- */
 export const devOnlySentSnapshots: Set<string> | undefined = (__DEV__ && __JS__) ? new Set() : undefined;


### PR DESCRIPTION
## Summary

`DEV_ONLY_SetSnapshotEntryName` can reach the main thread without a preceding `DEV_ONLY_AddSnapshot`, which makes the main thread rewrite a creator that was never meant to be rewritten. In dev this throws a `SyntaxError` out of `evaluate()`, aborts the whole `snapshotPatchApply` loop, and cascades into `snapshotPatchApply failed: ctx not found`.

Reported downstream as: *"`snapshotPatchApply failed: ctx not found`, async chunk + first-screen direct render, only in dev"*.

```
main-thread.js exception: SyntaxError: expecting ']'
    at evaluate (file:///main-thread.js)
    at snapshotPatchApply (file:///main-thread.js)
    at updateMainThread (file:///main-thread.js)

snapshotPatchApply failed: ctx not found, snapshot type: '__snapshot_efd3e_4cd06_3'
```

## Root cause

The two DEV-only ops are emitted from **different places, at different times, but guarded on the same flag**:

| op | emitted from | when |
|---|---|---|
| `DEV_ONLY_AddSnapshot` | `snapshotCreatorMap` `Proxy` set trap (`snapshot.ts`) | chunk evaluation — `snapshotCreatorMap[id] = ...` |
| `DEV_ONLY_SetSnapshotEntryName` | inside `createSnapshot()` (`definition.ts`) | render — when the snapshot is first instantiated |

Both check `__globalSnapshotPatch`, whose comment states it *"does not exist before hydration, so the snapshot of the first screen will not be sent to the main thread"*. Since snapshots became **lazily created**, those two moments now sit on opposite sides of hydration.

For a lazy bundle loaded **during first-screen direct render**:

```
lazy bundle chunk evaluated   ->  __globalSnapshotPatch not initialized  ->  AddSnapshot skipped
      | hydration completes
component renders, createSnapshot()  ->  __globalSnapshotPatch exists    ->  SetSnapshotEntryName sent
```

The main thread then takes `snapshotCreatorMap[uniqID]` — which is the creator **compiled into its own chunk**, not the one serialized over from the background thread — calls `.toString()` on it, rewrites `globDynamicComponentEntry` and `evaluate()`s the result. That creator does not round-trip through `Function.prototype.toString`, so it throws, and because the throw escapes the `switch`, every remaining operation in the patch is dropped.

Skipping is both correct and cheaper than back-filling `AddSnapshot`: the main thread already has a perfectly good compiled creator (both layers of a lazy bundle ship in the same template), and in that copy `globDynamicComponentEntry` is already bound by the chunk's own scope.

## Changes

**Background thread** — `devOnlySentSnapshots`, a one-shot token set recording that the main thread's creator for a `uniqID` really is the one we serialized over:

- armed in the `Proxy` set trap when `DEV_ONLY_AddSnapshot` is actually pushed
- **cleared in the `else` branch too** — otherwise a re-registration (HMR) that happens to skip `AddSnapshot` would leave a token armed from a previous round
- consumed (`delete`) right after `DEV_ONLY_SetSnapshotEntryName` is pushed, since the main thread's copy no longer contains the placeholder once it applies the op; a later re-registration re-arms it

**Main thread** — `snapshotPatchApply` now guards on the invariant directly (the creator source still containing `globDynamicComponentEntry`) and wraps the rewrite in `try/catch`. A DEV-only HMR convenience should never be able to abort patch application.

The two layers are complementary: the background side is bookkeeping (it cannot inspect the main thread's copy), the main side verifies the invariant itself and contains the blast radius if the bookkeeping is ever wrong again.

## Testing

- `tsc --noEmit` on `@lynx-js/react` runtime is clean.
- I could not get the local suite to run in my checkout (unrelated `@tsconfig/node24` resolution failure that fails all 109 files at collection time), so **I'm relying on CI here** — happy to add a regression test once maintainers confirm the preferred shape. The scenario worth pinning is: *lazy bundle loaded before hydration completes + `entryName !== DEFAULT_ENTRY_NAME` + a patch produced afterwards*, asserting no `DEV_ONLY_SetSnapshotEntryName` is emitted and that patch application is never aborted.
- Verified downstream on a real app (TikTok eco-activity-templates) as a `pnpm patch` against `@lynx-js/react@0.121.1`: builds cleanly and the fix is present in the bundle.

## Honest caveat

The final link in the chain — *what exactly* `Function.prototype.toString()` returns for the compiled creator in the Lepus VM — is **inferred, not captured**. The reported error coordinate `<input>:2:13` lines up exactly with the `code` token in `function () {\n    [native code]\n}`, but I have not yet captured that string from a device. That uncertainty does not affect the fix: whichever shape it has, rewriting a creator we did not serialize is wrong, and the guard removes the operation entirely. Marking this a draft until device verification lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lazy-bundle loading during first-screen direct rendering.
  * Prevented snapshot hydration and patching from throwing when snapshot creators are missing, unavailable, or cannot be evaluated.
  * Added warnings for snapshot creators that cannot be evaluated.
  * Improved development-only snapshot tracking to avoid unnecessary patches when bundles are already loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->