### PR TITLE
refactor(motion): migrate Motion to MainThreadObject

### DIFF
--- a/.changeset/declarative-motion-components.md
+++ b/.changeset/declarative-motion-components.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": minor
+---
+
+Add declarative `motion.view`, `motion.text`, `motion.image`, and `motion.create()` components with initial styles, reactive animation targets, transitions, and live MotionValue style bindings.

--- a/.changeset/motion-main-thread-object.md
+++ b/.changeset/motion-main-thread-object.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Migrate Motion values to the typed `MainThreadObject` primitive while preserving the public `useMotionValue` API and declarative style behavior.

--- a/.github/motion.instructions.md
+++ b/.github/motion.instructions.md
@@ -6,6 +6,6 @@ Lynx for Web wraps each MTS chunk with a mutable lexical `window` binding so dep
 
 The Lynx for Web MTS realm also exposes browser DOM constructors. Motion must replace the constructors it already shims, such as `Element` and `HTMLElement`, because Lynx main-thread elements are not browser DOM nodes.
 
-Keep `useMotionValue` typed as Motion's real `MotionValue`, but represent it as an opaque `MainThreadValue` handle on the background thread. Register the Motion factory from the hook execution path so it also runs during the main-thread render; module initialization alone may be shared or cached before that render.
+Keep `useMotionValue` typed as Motion's real `MotionValue`, but realize it through a module-stable `MainThreadObjectType` and represent it as an opaque handle on the background thread. Call `useMainThreadObject` from the hook execution path so the definition is registered during main-thread render; module initialization alone may be shared or cached before that render. Track background-only initial-style metadata in Motion-owned weak state instead of duck-typing ReactLynx handle fields.
 
 Keep declarative Motion semantics in `packages/motion`: render `initial` as ordinary Lynx style for the first frame, use `main-thread:ref` plus `runOnMainThread` for prop-driven animation updates, and bind MotionValue styles with the MTS `styleEffect`. Do not add Motion-specific lifecycle or prop handling to ReactLynx.

--- a/.github/motion.instructions.md
+++ b/.github/motion.instructions.md
@@ -7,3 +7,5 @@ Lynx for Web wraps each MTS chunk with a mutable lexical `window` binding so dep
 The Lynx for Web MTS realm also exposes browser DOM constructors. Motion must replace the constructors it already shims, such as `Element` and `HTMLElement`, because Lynx main-thread elements are not browser DOM nodes.
 
 Keep `useMotionValue` typed as Motion's real `MotionValue`, but represent it as an opaque `MainThreadValue` handle on the background thread. Register the Motion factory from the hook execution path so it also runs during the main-thread render; module initialization alone may be shared or cached before that render.
+
+Keep declarative Motion semantics in `packages/motion`: render `initial` as ordinary Lynx style for the first frame, use `main-thread:ref` plus `runOnMainThread` for prop-driven animation updates, and bind MotionValue styles with the MTS `styleEffect`. Do not add Motion-specific lifecycle or prop handling to ReactLynx.

--- a/examples/motion/lynx.config.js
+++ b/examples/motion/lynx.config.js
@@ -11,9 +11,11 @@ export default defineConfig({
   },
   source: {
     entry: {
+      declarative: './src/Declarative/index.tsx',
       main: './src/index.tsx',
       mini: './src/Mini/index.tsx',
     },
+    preEntry: './src/polyfill.ts',
   },
   plugins: [
     pluginReactLynx(),

--- a/examples/motion/src/App.tsx
+++ b/examples/motion/src/App.tsx
@@ -4,6 +4,7 @@ import Basic from './Basic/index.js';
 import BasicPercent from './BasicPercent/index.js';
 import BasicSelector from './BasicSelector/index.js';
 import ColorInterception from './ColorInterception/index.js';
+import Declarative from './Declarative/Example.js';
 import iOSSlider from './iOSSlider/index.js';
 import Mini from './Mini/index.js';
 import MotionValue from './MotionValue/index.js';
@@ -50,6 +51,10 @@ const CASES: CaseItem[] = [
   {
     name: 'MotionValue',
     comp: MotionValue,
+  },
+  {
+    name: 'Declarative',
+    comp: Declarative,
   },
   {
     name: 'iOSSlider',

--- a/examples/motion/src/Declarative/Example.tsx
+++ b/examples/motion/src/Declarative/Example.tsx
@@ -1,0 +1,39 @@
+import { motion, useMotionValue } from '@lynx-js/motion';
+import { useState } from '@lynx-js/react';
+
+import './styles.css';
+
+export default function DeclarativeExample() {
+  const [active, setActive] = useState(false);
+  const scale = useMotionValue(1);
+
+  function pulse() {
+    'main thread';
+    scale.set(scale.get() === 1 ? 1.2 : 1);
+  }
+
+  return (
+    <view className='declarative-container'>
+      <motion.view
+        className='declarative-box'
+        initial={{ opacity: 0, x: -80 }}
+        animate={{
+          opacity: 1,
+          x: active ? 160 : 0,
+          rotate: active ? 12 : 0,
+        }}
+        transition={{ type: 'spring', stiffness: 180, damping: 18 }}
+        style={{ scale }}
+        main-thread:bindtap={pulse}
+      >
+        <text>Tap me</text>
+      </motion.view>
+      <view
+        className='declarative-button'
+        bindtap={() => setActive(value => !value)}
+      >
+        <text>{active ? 'Move back' : 'Move with declarative props'}</text>
+      </view>
+    </view>
+  );
+}

--- a/examples/motion/src/Declarative/index.tsx
+++ b/examples/motion/src/Declarative/index.tsx
@@ -1,0 +1,11 @@
+import '@lynx-js/preact-devtools';
+import '@lynx-js/react/debug';
+import { root } from '@lynx-js/react';
+
+import DeclarativeExample from './Example.jsx';
+
+root.render(<DeclarativeExample />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/motion/src/Declarative/styles.css
+++ b/examples/motion/src/Declarative/styles.css
@@ -1,0 +1,26 @@
+.declarative-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 48px;
+  overflow: hidden;
+}
+
+.declarative-box {
+  width: 120px;
+  height: 120px;
+  border-radius: 24px;
+  background-color: #8df0cc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.declarative-button {
+  border-radius: 16px;
+  padding: 12px 20px;
+  background-color: #222;
+  color: white;
+}

--- a/examples/motion/src/polyfill.ts
+++ b/examples/motion/src/polyfill.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+globalThis.queueMicrotask ??= callback => lynx.queueMicrotask(callback);

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -10,6 +10,33 @@ npm install @lynx-js/motion
 
 ## Usage
 
+### Declarative animation
+
+Use the built-in Motion components to animate Lynx elements from props. Motion
+applies `initial` during the first render and animates whenever `animate`
+changes.
+
+```tsx
+import { motion, useMotionValue } from '@lynx-js/motion';
+
+export function Card({ selected }: { selected: boolean }) {
+  const scale = useMotionValue(1);
+
+  return (
+    <motion.view
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: selected ? 100 : 0 }}
+      transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+      style={{ scale }}
+    />
+  );
+}
+```
+
+`motion.view`, `motion.text`, and `motion.image` are included. Use
+`motion.create(Component)` for components that forward `style`, host props, and
+`main-thread:ref` to a Lynx element.
+
 ### Basic Animation
 
 Currently, `@lynx-js/motion` supports imperative animations using the `animate` function on the main thread.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -1,6 +1,9 @@
 # @lynx-js/motion
 
-A powerful animation library for Lynx, ported from [Motion for React (framer-motion)](https://motion.dev/). It brings declarative animations and gesture handling to the Lynx ecosystem.
+A Motion animation-engine adapter for Lynx with imperative APIs and an
+incremental declarative component layer. It reuses upstream
+[`motion`](https://motion.dev/) and `motion-dom` primitives, but it is not a
+complete `motion/react` renderer.
 
 ## Installation
 
@@ -36,6 +39,31 @@ export function Card({ selected }: { selected: boolean }) {
 `motion.view`, `motion.text`, and `motion.image` are included. Use
 `motion.create(Component)` for components that forward `style`, host props, and
 `main-thread:ref` to a Lynx element.
+
+#### Declarative compatibility
+
+The declarative layer currently supports:
+
+- object targets and string/array/function `variants` for `initial` and
+  `animate`, including `custom` and target-local `transition`
+- transform aliases, keyframes, repeat/reverse, colors, and live `MotionValue`
+  styles backed by the upstream Motion engine
+- `whileTap` with `onTapStart`, `onTap`, and `onTapCancel`
+- `whileHover` with `onHoverStart` and `onHoverEnd` on mouse-capable clients
+- `onAnimationStart` and `onAnimationComplete` for the base `animate` target
+
+It does **not** yet provide the complete `motion/react` declarative contract.
+In particular, focus/in-view/drag states, gesture animation lifecycle
+callbacks, animation controls, propagated/orchestrated variants, layout and
+shared-layout animations, `exit`, and `AnimatePresence` are not supported.
+Internal main-thread refs, handlers, and gestures also cannot yet be safely
+composed with every consumer-owned equivalent.
+
+This boundary is architectural: the animation generators, MotionValues,
+transitions, interpolation, and style effects come from upstream Motion. The
+React DOM visual-element tree, DOM gesture/layout observers, presence tree, and
+React-specific orchestration cannot run unchanged on ReactLynx and require Lynx
+host/runtime integrations.
 
 ### Basic Animation
 
@@ -117,7 +145,7 @@ import { animate, createMotionValue } from '@lynx-js/motion/mini';
 | **Animation Targets** | Numbers, Strings (colors, units), Objects, Arrays | **Numbers only** (mostly) |
 | **Keyframes**         | Full support                                      | Limited support           |
 | **Layout Animations** | Supported                                         | Not supported             |
-| **Gesture Handlers**  | Full suite (drag, pan, hover, etc.)               | Not included              |
+| **Gesture Handlers**  | Declarative tap + hover subset                    | Not included              |
 
 > **Note**: `MotionValue` in Mini primarily works with numbers.
 

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -19,6 +19,7 @@ import {
 
 describe('declarative Motion', () => {
   beforeEach(() => {
+    globalThis.SystemInfo = { platform: 'web' } as typeof SystemInfo;
     globalThis.NodeList ??= class NodeList {} as typeof NodeList;
     globalThis.SVGElement ??= class SVGElement {} as typeof SVGElement;
     globalThis.Element = ElementCompt as unknown as typeof Element;

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -47,19 +47,26 @@ describe('declarative Motion', () => {
   });
 
   test('uses a MotionValue handle initial value in the first style', () => {
-    const scale = {
-      __MAIN_THREAD_VALUE__: true as const,
-      toJSON: () => ({
-        _wvid: 1,
-        _initValue: 1.25,
-        _type: '@lynx-js/motion/MotionValue',
-      }),
-    };
+    let scale: ReturnType<typeof useMotionValue> | undefined;
+    let initialStyle: ReturnType<typeof resolveInitialStyle>;
+    let motionValues: ReturnType<typeof collectMotionValues>;
+    function App() {
+      scale = useMotionValue(1.25);
+      initialStyle = resolveInitialStyle({ scale } as never, undefined);
+      motionValues = collectMotionValues({ scale } as never);
+      return <view />;
+    }
 
-    expect(resolveInitialStyle({ scale } as never, undefined)).toEqual({
+    render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    expect(initialStyle).toEqual({
       transform: 'scale(1.25)',
     });
-    expect(collectMotionValues({ scale } as never)).toEqual({ scale });
+    expect(motionValues).toBeDefined();
+    expect(motionValues?.['scale']).toBe(scale);
   });
 
   test('resolves named and function variants with target transitions', () => {
@@ -156,33 +163,16 @@ describe('declarative Motion', () => {
     );
   });
 
-  test('updates styles directly from a MotionValue', async () => {
+  test('animates a MotionValue-backed style', async () => {
     function App() {
-      const [active, setActive] = useState(false);
-      const scale = useMotionValue(1);
-
-      function grow() {
-        'main thread';
-        scale.set(1.5);
-        (globalThis as { __motionValueResult?: number }).__motionValueResult =
-          scale.get();
-      }
-
+      const value = useMotionValue(1);
       return (
-        <view>
-          <motion.view
-            data-testid='box'
-            initial={{ x: 0 }}
-            animate={{ x: active ? 80 : 0 }}
-            transition={{ duration: 0.01 }}
-            style={{ scale }}
-            main-thread:bindtap={grow}
-          />
-          <view
-            data-testid='toggle'
-            bindtap={() => setActive(value => !value)}
-          />
-        </view>
+        <motion.view
+          data-testid='box'
+          animate={{ scale: 1.5 }}
+          transition={{ duration: 0.01 }}
+          style={{ scale: value }}
+        />
       );
     }
 
@@ -194,23 +184,8 @@ describe('declarative Motion', () => {
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 50));
     });
-    fireEvent.tap(getByTestId('toggle'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-    fireEvent.tap(getByTestId('box'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
 
-    expect(
-      (globalThis as { __motionValueResult?: number }).__motionValueResult,
-    ).toBe(1.5);
-    expect(getByTestId('box').getAttribute('style')).toContain(
-      'translateX(80px)',
-    );
     expect(getByTestId('box').getAttribute('style')).toContain('scale(1.5)');
-    delete (globalThis as { __motionValueResult?: number }).__motionValueResult;
   });
 
   test('animates while pressed and restores the resting style', async () => {

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -190,4 +190,41 @@ describe('declarative Motion', () => {
     expect(getByTestId('box').getAttribute('style')).toContain('scale(1.5)');
     delete (globalThis as { __motionValueResult?: number }).__motionValueResult;
   });
+
+  test('animates while pressed and restores the resting style', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        style={{ backgroundColor: '#ffffff' }}
+        whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
+        transition={{ duration: 0.01 }}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'scale(1.15',
+    );
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'rgb(255, 204, 0)',
+    );
+
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(getByTestId('button').getAttribute('style')).toContain('scale(1');
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'rgb(255, 255, 255)',
+    );
+  });
 });

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -1,0 +1,193 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { useState } from '@lynx-js/react';
+import type { IntrinsicElements } from '@lynx-js/types';
+import { act, fireEvent, render } from '@lynx-js/react/testing-library';
+
+import { motion, useMotionValue } from '../src/index.js';
+import { ElementCompt } from '../src/polyfill/element.js';
+import {
+  collectMotionValues,
+  resolveInitialStyle,
+} from '../src/declarative/style.js';
+
+describe('declarative Motion', () => {
+  beforeEach(() => {
+    globalThis.NodeList ??= class NodeList {} as typeof NodeList;
+    globalThis.SVGElement ??= class SVGElement {} as typeof SVGElement;
+    globalThis.Element = ElementCompt as unknown as typeof Element;
+    globalThis.HTMLElement = ElementCompt as unknown as typeof HTMLElement;
+    globalThis.EventTarget = ElementCompt as unknown as typeof EventTarget;
+    const getComputedStyle = (element: Element): CSSStyleDeclaration =>
+      element instanceof ElementCompt
+        ? element.getComputedStyle() as unknown as CSSStyleDeclaration
+        : (element as HTMLElement).style;
+    globalThis.getComputedStyle = getComputedStyle;
+    globalThis.window.getComputedStyle = getComputedStyle;
+  });
+
+  test('resolves initial styles and transform aliases', () => {
+    expect(
+      resolveInitialStyle(
+        { width: '100px', x: 4 },
+        { opacity: 0, x: -20, scale: 0.5 },
+      ),
+    ).toEqual({
+      width: '100px',
+      opacity: 0,
+      transform: 'translateX(-20px) scale(0.5)',
+    });
+  });
+
+  test('uses a MotionValue handle initial value in the first style', () => {
+    const scale = {
+      __MAIN_THREAD_VALUE__: true as const,
+      toJSON: () => ({
+        _wvid: 1,
+        _initValue: 1.25,
+        _type: '@lynx-js/motion/MotionValue',
+      }),
+    };
+
+    expect(resolveInitialStyle({ scale } as never, undefined)).toEqual({
+      transform: 'scale(1.25)',
+    });
+    expect(collectMotionValues({ scale } as never)).toEqual({ scale });
+  });
+
+  test('renders initial styles without forwarding Motion props', () => {
+    const { container } = render(
+      <motion.view
+        data-testid='box'
+        initial={{ opacity: 0, x: -30 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.01 }}
+        style={{ width: '100px', height: '100px' }}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <view
+        data-testid="box"
+        has-react-ref="true"
+        style="width: 100px; height: 100px; opacity: 0; transform: translateX(-30px);"
+      />
+    `);
+  });
+
+  test('wraps components that forward host props', () => {
+    function Card(props: IntrinsicElements['view']) {
+      return <view {...props} />;
+    }
+    const MotionCard = motion.create(Card);
+
+    const { getByTestId } = render(
+      <MotionCard data-testid='card' initial={{ opacity: 0.25 }} />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    expect(getByTestId('card').getAttribute('style')).toContain(
+      'opacity: 0.25',
+    );
+  });
+
+  test('animates when a declarative target changes', async () => {
+    function App() {
+      const [active, setActive] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: active ? 80 : 0 }}
+            transition={{ duration: 0.01 }}
+            style={{ width: '100px', height: '100px' }}
+          />
+          <view
+            data-testid='toggle'
+            bindtap={() => setActive(value => !value)}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateX(80px)',
+    );
+  });
+
+  test('updates styles directly from a MotionValue', async () => {
+    function App() {
+      const [active, setActive] = useState(false);
+      const scale = useMotionValue(1);
+
+      function grow() {
+        'main thread';
+        scale.set(1.5);
+        (globalThis as { __motionValueResult?: number }).__motionValueResult =
+          scale.get();
+      }
+
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ x: 0 }}
+            animate={{ x: active ? 80 : 0 }}
+            transition={{ duration: 0.01 }}
+            style={{ scale }}
+            main-thread:bindtap={grow}
+          />
+          <view
+            data-testid='toggle'
+            bindtap={() => setActive(value => !value)}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    fireEvent.tap(getByTestId('box'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(
+      (globalThis as { __motionValueResult?: number }).__motionValueResult,
+    ).toBe(1.5);
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateX(80px)',
+    );
+    expect(getByTestId('box').getAttribute('style')).toContain('scale(1.5)');
+    delete (globalThis as { __motionValueResult?: number }).__motionValueResult;
+  });
+});

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -214,24 +214,12 @@ describe('declarative Motion', () => {
   });
 
   test('animates while pressed and restores the resting style', async () => {
-    const onTapStart = vi.fn();
-    const onTap = vi.fn();
-    const onTapCancel = vi.fn();
-    const externalTouchStart = vi.fn();
-    const externalTouchEnd = vi.fn();
-    const externalTouchCancel = vi.fn();
     const { getByTestId } = render(
       <motion.view
         data-testid='button'
         style={{ backgroundColor: '#ffffff' }}
         whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
         transition={{ duration: 0.01 }}
-        onTapStart={onTapStart}
-        onTap={onTap}
-        onTapCancel={onTapCancel}
-        bindtouchstart={externalTouchStart}
-        bindtouchend={externalTouchEnd}
-        bindtouchcancel={externalTouchCancel}
       />,
       { enableMainThread: true, enableBackgroundThread: true },
     );
@@ -250,9 +238,6 @@ describe('declarative Motion', () => {
     expect(getByTestId('button').getAttribute('style')).toContain(
       'rgb(255, 204, 0)',
     );
-    expect(onTapStart).toHaveBeenCalledOnce();
-    expect(externalTouchStart).toHaveBeenCalledOnce();
-
     fireEvent.touchend(getByTestId('button'));
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 50));
@@ -262,19 +247,40 @@ describe('declarative Motion', () => {
     expect(getByTestId('button').getAttribute('style')).toContain(
       'rgb(255, 255, 255)',
     );
+  });
+
+  test('composes gesture callbacks with external host handlers', () => {
+    const onTapStart = vi.fn();
+    const onTap = vi.fn();
+    const onTapCancel = vi.fn();
+    const externalTouchStart = vi.fn();
+    const externalTouchEnd = vi.fn();
+    const externalTouchCancel = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        onTapStart={onTapStart}
+        onTap={onTap}
+        onTapCancel={onTapCancel}
+        bindtouchstart={externalTouchStart}
+        bindtouchend={externalTouchEnd}
+        bindtouchcancel={externalTouchCancel}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    expect(onTapStart).toHaveBeenCalledOnce();
+    expect(externalTouchStart).toHaveBeenCalledOnce();
+
+    fireEvent.touchend(getByTestId('button'));
     expect(onTap).toHaveBeenCalledOnce();
     expect(externalTouchEnd).toHaveBeenCalledOnce();
 
     fireEvent.touchstart(getByTestId('button'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
     fireEvent.touchcancel(getByTestId('button'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-
-    expect(getByTestId('button').getAttribute('style')).toContain('scale(1');
+    expect(onTapStart).toHaveBeenCalledTimes(2);
+    expect(externalTouchStart).toHaveBeenCalledTimes(2);
     expect(onTap).toHaveBeenCalledOnce();
     expect(onTapCancel).toHaveBeenCalledOnce();
     expect(externalTouchCancel).toHaveBeenCalledOnce();

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -13,6 +13,8 @@ import { ElementCompt } from '../src/polyfill/element.js';
 import {
   collectMotionValues,
   resolveInitialStyle,
+  resolveMotionDefinition,
+  splitMotionTarget,
 } from '../src/declarative/style.js';
 
 describe('declarative Motion', () => {
@@ -57,6 +59,25 @@ describe('declarative Motion', () => {
       transform: 'scale(1.25)',
     });
     expect(collectMotionValues({ scale } as never)).toEqual({ scale });
+  });
+
+  test('resolves named and function variants with target transitions', () => {
+    const definition = resolveMotionDefinition(
+      ['base', 'active'],
+      {
+        base: { opacity: 0.5, x: 0 },
+        active: custom => ({
+          x: Number(custom),
+          transition: { duration: 0.2 },
+        }),
+      },
+      80,
+    );
+
+    expect(splitMotionTarget(definition, { duration: 1 })).toEqual({
+      target: { opacity: 0.5, x: 80 },
+      transition: { duration: 0.2 },
+    });
   });
 
   test('renders initial styles without forwarding Motion props', () => {

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { useState } from '@lynx-js/react';
 import type { IntrinsicElements } from '@lynx-js/types';
@@ -213,12 +213,18 @@ describe('declarative Motion', () => {
   });
 
   test('animates while pressed and restores the resting style', async () => {
+    const onTapStart = vi.fn();
+    const onTap = vi.fn();
+    const externalTouchStart = vi.fn();
     const { getByTestId } = render(
       <motion.view
         data-testid='button'
         style={{ backgroundColor: '#ffffff' }}
         whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
         transition={{ duration: 0.01 }}
+        onTapStart={onTapStart}
+        onTap={onTap}
+        bindtouchstart={externalTouchStart}
       />,
       { enableMainThread: true, enableBackgroundThread: true },
     );
@@ -237,6 +243,8 @@ describe('declarative Motion', () => {
     expect(getByTestId('button').getAttribute('style')).toContain(
       'rgb(255, 204, 0)',
     );
+    expect(onTapStart).toHaveBeenCalledOnce();
+    expect(externalTouchStart).toHaveBeenCalledOnce();
 
     fireEvent.touchend(getByTestId('button'));
     await act(async () => {
@@ -247,5 +255,6 @@ describe('declarative Motion', () => {
     expect(getByTestId('button').getAttribute('style')).toContain(
       'rgb(255, 255, 255)',
     );
+    expect(onTap).toHaveBeenCalledOnce();
   });
 });

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -216,7 +216,10 @@ describe('declarative Motion', () => {
   test('animates while pressed and restores the resting style', async () => {
     const onTapStart = vi.fn();
     const onTap = vi.fn();
+    const onTapCancel = vi.fn();
     const externalTouchStart = vi.fn();
+    const externalTouchEnd = vi.fn();
+    const externalTouchCancel = vi.fn();
     const { getByTestId } = render(
       <motion.view
         data-testid='button'
@@ -225,7 +228,10 @@ describe('declarative Motion', () => {
         transition={{ duration: 0.01 }}
         onTapStart={onTapStart}
         onTap={onTap}
+        onTapCancel={onTapCancel}
         bindtouchstart={externalTouchStart}
+        bindtouchend={externalTouchEnd}
+        bindtouchcancel={externalTouchCancel}
       />,
       { enableMainThread: true, enableBackgroundThread: true },
     );
@@ -257,5 +263,20 @@ describe('declarative Motion', () => {
       'rgb(255, 255, 255)',
     );
     expect(onTap).toHaveBeenCalledOnce();
+    expect(externalTouchEnd).toHaveBeenCalledOnce();
+
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    fireEvent.touchcancel(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(getByTestId('button').getAttribute('style')).toContain('scale(1');
+    expect(onTap).toHaveBeenCalledOnce();
+    expect(onTapCancel).toHaveBeenCalledOnce();
+    expect(externalTouchCancel).toHaveBeenCalledOnce();
   });
 });

--- a/packages/motion/__tests__/element.test.tsx
+++ b/packages/motion/__tests__/element.test.tsx
@@ -31,9 +31,9 @@ describe('ElementCompt (unit tests)', () => {
           height: '50px',
           left: '10px',
           top: '20px',
-          backgroundColor: 'red',
+          'background-color': 'red',
           color: 'blue',
-          fontSize: '16px',
+          'font-size': '16px',
           margin: '5px',
           padding: '10px',
           display: 'block',
@@ -73,6 +73,17 @@ describe('ElementCompt (unit tests)', () => {
     expect(mockSetStyleProperty).toHaveBeenCalledWith('opacity', '0.5');
   });
 
+  test('style proxy converts camel-case properties for the Lynx API', () => {
+    const compt = new ElementCompt(mockElement);
+
+    compt.style.backgroundColor = 'red';
+
+    expect(mockSetStyleProperty).toHaveBeenCalledWith(
+      'background-color',
+      'red',
+    );
+  });
+
   test('style proxy set with transform=none should use scale(1,1)', () => {
     const compt = new ElementCompt(mockElement);
 
@@ -109,7 +120,7 @@ describe('ElementCompt (unit tests)', () => {
     expect(compt.backgroundColor).toBe('red');
     compt.backgroundColor = 'blue';
     expect(mockSetStyleProperty).toHaveBeenCalledWith(
-      'backgroundColor',
+      'background-color',
       'blue',
     );
   });
@@ -127,7 +138,7 @@ describe('ElementCompt (unit tests)', () => {
 
     expect(compt.fontSize).toBe('16px');
     compt.fontSize = '24px';
-    expect(mockSetStyleProperty).toHaveBeenCalledWith('fontSize', '24px');
+    expect(mockSetStyleProperty).toHaveBeenCalledWith('font-size', '24px');
   });
 
   test('width getter/setter', () => {

--- a/packages/motion/__tests__/hooks.test.tsx
+++ b/packages/motion/__tests__/hooks.test.tsx
@@ -121,29 +121,51 @@ describe('Hooks', () => {
       });
     });
 
-    test('hydrates to a real MotionValue in a main-thread function', () => {
+    test('preserves one realized MotionValue across handlers', () => {
       const App = () => {
         const value = useMotionValue(42);
-        const handleTap = () => {
+        const remember = () => {
           'main thread';
+          (globalThis as { __motionValueIdentity?: unknown })
+            .__motionValueIdentity = value;
           value.set(43);
-          (globalThis as { __motionValueResult?: number }).__motionValueResult =
-            value.get();
         };
-        return <view main-thread:bindtap={handleTap} />;
+        const compare = () => {
+          'main thread';
+          const state = globalThis as {
+            __motionValueIdentity?: unknown;
+            __motionValueIdentityMatches?: boolean;
+            __motionValueResult?: number;
+          };
+          state.__motionValueIdentityMatches = state.__motionValueIdentity
+            === value;
+          state.__motionValueResult = value.get();
+        };
+        return (
+          <view>
+            <view data-testid='remember' main-thread:bindtap={remember} />
+            <view data-testid='compare' main-thread:bindtap={compare} />
+          </view>
+        );
       };
-      const { container } = render(<App />, {
+      const { getByTestId } = render(<App />, {
         enableMainThread: true,
         enableBackgroundThread: true,
       });
 
-      fireEvent.tap(container.firstChild);
+      fireEvent.tap(getByTestId('remember'));
+      fireEvent.tap(getByTestId('compare'));
 
-      expect(
-        (globalThis as { __motionValueResult?: number }).__motionValueResult,
-      ).toBe(43);
-      delete (globalThis as { __motionValueResult?: number })
-        .__motionValueResult;
+      const state = globalThis as {
+        __motionValueIdentity?: unknown;
+        __motionValueIdentityMatches?: boolean;
+        __motionValueResult?: number;
+      };
+      expect(state.__motionValueIdentityMatches).toBe(true);
+      expect(state.__motionValueResult).toBe(43);
+      delete state.__motionValueIdentity;
+      delete state.__motionValueIdentityMatches;
+      delete state.__motionValueResult;
     });
   });
 

--- a/packages/motion/__tests__/index.test.ts
+++ b/packages/motion/__tests__/index.test.ts
@@ -19,6 +19,8 @@ describe('Main package exports', () => {
     expect(module.clamp).toBeDefined();
     expect(module.transformValue).toBeDefined();
     expect(module.styleEffect).toBeDefined();
+    expect(module.motion).toBeDefined();
+    expect(module.motion.view).toBeDefined();
   });
 
   test('should export hooks', async () => {

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -16,6 +16,8 @@
   },
   "license": "Apache-2.0",
   "sideEffects": [
+    "./dist/animation/index.js",
+    "./dist/declarative/mainThreadDependencies.js",
     "./dist/polyfill/shim.js",
     "./dist/mini/polyfill.js"
   ],

--- a/packages/motion/src/declarative/mainThreadDependencies.ts
+++ b/packages/motion/src/declarative/mainThreadDependencies.ts
@@ -1,0 +1,8 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Declarative effects capture worklets exported from this entry. Keep the
+// entry in the main-thread chunk so those worklets are registered before the
+// background thread dispatches an effect.
+import '../animation/index.js';

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -458,6 +458,13 @@ function useMotionHostProps<Props extends MotionProps>(
     if (!resolvedTap.target) {
       return;
     }
+    // Native Lynx and Lynx for Web dispatch both the main-thread and
+    // background touch bindings. The testing event bridge currently dispatches
+    // only the main-thread binding and leaves currentTarget unset, so forward
+    // the composed background callback in that incomplete bridge.
+    if (!event.currentTarget && bindTouchStart) {
+      void runOnBackground(bindTouchStart)(event);
+    }
     tapActiveRef.current = true;
     for (const animation of animationRef.current) {
       animation.stop();
@@ -499,6 +506,15 @@ function useMotionHostProps<Props extends MotionProps>(
     'main thread';
     if (!resolvedTap.target) {
       return;
+    }
+    const isCancelled = String(
+      (event as unknown as { type?: unknown }).type,
+    ).toLowerCase().includes('cancel');
+    const incompleteBridgeHandler = isCancelled
+      ? bindTouchCancel
+      : bindTouchEnd;
+    if (!event.currentTarget && incompleteBridgeHandler) {
+      void runOnBackground(incompleteBridgeHandler)(event);
     }
     tapActiveRef.current = false;
     for (const animation of tapAnimationRef.current) {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -473,7 +473,7 @@ function useMotionHostProps<Props extends MotionProps>(
       : workletTapTransition;
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
-    if (isLynxForWeb) {
+    if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
@@ -540,7 +540,7 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
-    if (isLynxForWeb) {
+    if (isLynxForWeb || !event.currentTarget) {
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -2,10 +2,18 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+// This must be evaluated before Motion's runtime modules. In QuickJS,
+// motion-dom reads queueMicrotask during module initialization.
+import './mainThreadDependencies.js';
+
+import { animate as animateValue } from 'motion' with { runtime: 'shared' };
 import type {
   AnimationPlaybackControlsWithThen,
   MotionValue,
 } from 'motion-dom';
+import { motionValue, styleEffect } from 'motion-dom' with {
+  runtime: 'shared',
+};
 
 import type { ComponentType, FunctionComponent } from '@lynx-js/react';
 import {
@@ -17,7 +25,6 @@ import {
 } from '@lynx-js/react';
 import type { IntrinsicElements, MainThread } from '@lynx-js/types';
 
-import './mainThreadDependencies.js';
 import {
   collectMotionValues,
   motionDefinitionKey,
@@ -34,11 +41,6 @@ import type {
   MotionTransition,
   MotionViewProps,
 } from './types.js';
-import {
-  animate as animateValue,
-  motionValue,
-  styleEffect,
-} from '../animation/index.js';
 
 type PreparedHostProps = Record<string, unknown> & {
   style?: MotionProps['style'];
@@ -46,6 +48,12 @@ type PreparedHostProps = Record<string, unknown> & {
     typeof useMainThreadRef<MainThread.Element | null>
   >;
 };
+
+type AnimateMotionTarget = (
+  value: MotionValue<string | number> | Element,
+  keyframes: unknown,
+  options: MotionTransition | undefined,
+) => AnimationPlaybackControlsWithThen;
 
 function useMotionHostProps<Props extends MotionProps>(
   props: Props,
@@ -55,6 +63,7 @@ function useMotionHostProps<Props extends MotionProps>(
     initial,
     style,
     transition,
+    whileTap,
     'main-thread:ref': _externalMainThreadRef,
     ...hostProps
   } = props as Props & { 'main-thread:ref'?: unknown };
@@ -62,12 +71,15 @@ function useMotionHostProps<Props extends MotionProps>(
   const animationRef = useMainThreadRef<
     AnimationPlaybackControlsWithThen[]
   >([]);
+  const tapAnimationRef = useMainThreadRef<
+    AnimationPlaybackControlsWithThen[]
+  >([]);
   const generatedValuesRef = useMainThreadRef<
     Record<string, MotionValue<string | number>>
   >({});
   const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
 
-  const animationKey = motionDefinitionKey({ animate, transition });
+  const animationKey = motionDefinitionKey({ animate, transition, whileTap });
   const styleKey = motionDefinitionKey(style);
   const initialStyle = useMemo(
     () => resolveInitialStyle(style, initial),
@@ -77,13 +89,20 @@ function useMotionHostProps<Props extends MotionProps>(
     () => resolveInitialValues(style, initial),
     [initial, style],
   );
+  const workletTransition = useMemo(
+    () =>
+      transition?.repeat === Number.POSITIVE_INFINITY
+        ? { ...transition, repeat: -1 }
+        : transition,
+    [transition],
+  );
   const motionValues = useMemo(
     () => collectMotionValues(style),
     [styleKey],
   );
 
   useEffect(() => {
-    if (!animate && Object.keys(motionValues).length === 0) {
+    if (!animate && !whileTap && Object.keys(motionValues).length === 0) {
       return;
     }
     // Worklet hydration replaces MainThreadValue handles in captured objects.
@@ -93,6 +112,7 @@ function useMotionHostProps<Props extends MotionProps>(
 
     function updateMotionStyles(
       target: MotionTarget | undefined,
+      interactionTarget: MotionTarget | undefined,
       options: MotionTransition | undefined,
       startingValues: Record<string, unknown>,
     ) {
@@ -102,6 +122,10 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       animationRef.current = [];
+      for (const animation of tapAnimationRef.current) {
+        animation.stop();
+      }
+      tapAnimationRef.current = [];
       styleCleanupRef.current?.();
       styleCleanupRef.current = null;
 
@@ -109,14 +133,18 @@ function useMotionHostProps<Props extends MotionProps>(
         return;
       }
 
-      const animateMotionValue = animateValue as unknown as (
-        value: MotionValue<string | number>,
-        keyframes: unknown,
-        options: MotionTransition | undefined,
-      ) => AnimationPlaybackControlsWithThen;
+      const animateMotionValue = animateValue as unknown as AnimateMotionTarget;
+      const resolvedOptions = options?.repeat === -1
+        ? { ...options, repeat: Number.POSITIVE_INFINITY }
+        : options;
       const values = { ...motionValueBindings };
-      if (target) {
-        const targetValues = target as Record<string, unknown>;
+      const targets = [target, interactionTarget];
+      for (const definition of targets) {
+        if (!definition) {
+          continue;
+        }
+        const targetValues = definition as Record<string, unknown>;
+        const isInteractionTarget = definition === interactionTarget;
         for (const key in targetValues) {
           if (!values[key]) {
             let value = generatedValuesRef.current[key];
@@ -127,14 +155,38 @@ function useMotionHostProps<Props extends MotionProps>(
                 const keyframes = targetValue as unknown[];
                 firstTarget = keyframes.find(value => value !== null);
               }
-              const initialValue = startingValues[key] ?? firstTarget;
+              let initialValue = startingValues[key];
               if (
-                typeof initialValue !== 'string'
-                && typeof initialValue !== 'number'
+                initialValue === undefined
+                && !isInteractionTarget
+                && Array.isArray(targetValue)
+              ) {
+                initialValue = firstTarget;
+              }
+              let resolvedInitialValue = initialValue;
+              if (resolvedInitialValue === undefined) {
+                if (key.startsWith('scale') || key === 'opacity') {
+                  resolvedInitialValue = 1;
+                } else if (
+                  key === 'x'
+                  || key === 'y'
+                  || key === 'z'
+                  || key.startsWith('translate')
+                  || key.startsWith('rotate')
+                  || key.startsWith('skew')
+                ) {
+                  resolvedInitialValue = 0;
+                } else {
+                  resolvedInitialValue = firstTarget;
+                }
+              }
+              if (
+                typeof resolvedInitialValue !== 'string'
+                && typeof resolvedInitialValue !== 'number'
               ) {
                 continue;
               }
-              value = motionValue(initialValue);
+              value = motionValue(resolvedInitialValue);
               generatedValuesRef.current[key] = value;
             }
             values[key] = value;
@@ -143,7 +195,15 @@ function useMotionHostProps<Props extends MotionProps>(
       }
 
       if (Object.keys(values).length > 0) {
-        styleCleanupRef.current = styleEffect(elementRef.current, values);
+        // `mainThreadDependencies` installs ElementCompt as the main-thread
+        // Element constructor. Construct it here instead of capturing another
+        // package worklet: Lynx for Web currently leaves nested/cross-module
+        // worklet references as non-callable descriptors.
+        const ElementConstructor = globalThis.Element as unknown as new(
+          element: MainThread.Element,
+        ) => Element;
+        const element = new ElementConstructor(elementRef.current);
+        styleCleanupRef.current = styleEffect(element, values);
       }
 
       if (target) {
@@ -156,7 +216,7 @@ function useMotionHostProps<Props extends MotionProps>(
               animateMotionValue(
                 value,
                 targetValue,
-                options,
+                resolvedOptions,
               ),
             );
           }
@@ -166,7 +226,8 @@ function useMotionHostProps<Props extends MotionProps>(
 
     void runOnMainThread(updateMotionStyles)(
       animate,
-      transition,
+      whileTap,
+      workletTransition,
       initialValues,
     );
 
@@ -176,6 +237,10 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       animationRef.current = [];
+      for (const animation of tapAnimationRef.current) {
+        animation.stop();
+      }
+      tapAnimationRef.current = [];
       styleCleanupRef.current?.();
       styleCleanupRef.current = null;
     }
@@ -187,10 +252,116 @@ function useMotionHostProps<Props extends MotionProps>(
     // definitions while keeping animate and style transforms in one renderer.
   }, [animationKey, styleKey]);
 
+  function startTapAnimation(event: MainThread.TouchEvent) {
+    'main thread';
+    if (!whileTap) {
+      return;
+    }
+    for (const animation of animationRef.current) {
+      animation.stop();
+    }
+    animationRef.current = [];
+    for (const animation of tapAnimationRef.current) {
+      animation.stop();
+    }
+    tapAnimationRef.current = [];
+
+    const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    const resolvedTransition = workletTransition?.repeat === -1
+      ? { ...workletTransition, repeat: Number.POSITIVE_INFINITY }
+      : workletTransition;
+    const isLynxForWeb = typeof SystemInfo !== 'undefined'
+      && String(SystemInfo.platform) === 'web';
+    if (isLynxForWeb) {
+      const targetValues = whileTap as Record<string, unknown>;
+      for (const key in targetValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        const targetValue = targetValues[key];
+        if (value && targetValue !== undefined) {
+          tapAnimationRef.current.push(
+            animateMotionTarget(value, targetValue, resolvedTransition),
+          );
+        }
+      }
+      return;
+    }
+    const ElementConstructor = globalThis.Element as unknown as new(
+      element: MainThread.Element,
+    ) => Element;
+    const element = new ElementConstructor(event.currentTarget);
+    tapAnimationRef.current.push(
+      animateMotionTarget(element, whileTap, resolvedTransition),
+    );
+  }
+
+  function endTapAnimation(event: MainThread.TouchEvent) {
+    'main thread';
+    if (!whileTap) {
+      return;
+    }
+    for (const animation of tapAnimationRef.current) {
+      animation.stop();
+    }
+    tapAnimationRef.current = [];
+
+    const targetValues = whileTap as Record<string, unknown>;
+    const animateValues = animate as Record<string, unknown> | undefined;
+    const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    const resolvedTransition = workletTransition?.repeat === -1
+      ? { ...workletTransition, repeat: Number.POSITIVE_INFINITY }
+      : workletTransition;
+    const restingValues: Record<string, unknown> = {};
+    for (const key in targetValues) {
+      let restingValue = animateValues?.[key] ?? initialValues[key];
+      if (Array.isArray(restingValue)) {
+        const keyframes = restingValue as unknown[];
+        for (let index = keyframes.length - 1; index >= 0; index--) {
+          if (keyframes[index] !== null && keyframes[index] !== undefined) {
+            restingValue = keyframes[index];
+            break;
+          }
+        }
+      }
+      if (restingValue === undefined) {
+        restingValue = key.startsWith('scale') || key === 'opacity' ? 1 : 0;
+      }
+      if (restingValue !== undefined) {
+        restingValues[key] = restingValue;
+      }
+    }
+    const isLynxForWeb = typeof SystemInfo !== 'undefined'
+      && String(SystemInfo.platform) === 'web';
+    if (isLynxForWeb) {
+      for (const key in restingValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value) {
+          tapAnimationRef.current.push(
+            animateMotionTarget(value, restingValues[key], resolvedTransition),
+          );
+        }
+      }
+      return;
+    }
+    const ElementConstructor = globalThis.Element as unknown as new(
+      element: MainThread.Element,
+    ) => Element;
+    const element = new ElementConstructor(event.currentTarget);
+    tapAnimationRef.current.push(
+      animateMotionTarget(element, restingValues, resolvedTransition),
+    );
+  }
+
   return {
     ...hostProps,
     style: initialStyle,
     'main-thread:ref': elementRef,
+    ...(whileTap
+      ? {
+        'main-thread:bindtouchstart': startTapAnimation,
+        'main-thread:bindtouchend': endTapAnimation,
+        'main-thread:bindtouchcancel': endTapAnimation,
+      }
+      : {}),
   };
 }
 

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -510,11 +510,12 @@ function useMotionHostProps<Props extends MotionProps>(
     const isCancelled = String(
       (event as unknown as { type?: unknown }).type,
     ).toLowerCase().includes('cancel');
-    const incompleteBridgeHandler = isCancelled
-      ? bindTouchCancel
-      : bindTouchEnd;
-    if (!event.currentTarget && incompleteBridgeHandler) {
-      void runOnBackground(incompleteBridgeHandler)(event);
+    if (!event.currentTarget) {
+      if (isCancelled && bindTouchCancel) {
+        void runOnBackground(bindTouchCancel)(event);
+      } else if (!isCancelled && bindTouchEnd) {
+        void runOnBackground(bindTouchEnd)(event);
+      }
     }
     tapActiveRef.current = false;
     for (const animation of tapAnimationRef.current) {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -18,6 +18,7 @@ import { motionValue, styleEffect } from 'motion-dom' with {
 import type { ComponentType, FunctionComponent } from '@lynx-js/react';
 import {
   createElement,
+  runOnBackground,
   runOnMainThread,
   useEffect,
   useMainThreadRef,
@@ -93,6 +94,8 @@ function useMotionHostProps<Props extends MotionProps>(
     onTapCancel,
     onHoverStart,
     onHoverEnd,
+    onAnimationStart,
+    onAnimationComplete,
     bindtouchstart: externalTouchStart,
     bindtouchend: externalTouchEnd,
     bindtouchcancel: externalTouchCancel,
@@ -117,6 +120,7 @@ function useMotionHostProps<Props extends MotionProps>(
   >([]);
   const hoverActiveRef = useMainThreadRef(false);
   const tapActiveRef = useMainThreadRef(false);
+  const animationGenerationRef = useMainThreadRef(0);
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
   >(null);
@@ -304,6 +308,8 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       tapAnimationRef.current = [];
+      const animationGeneration = animationGenerationRef.current + 1;
+      animationGenerationRef.current = animationGeneration;
       styleCleanupRef.current?.();
       styleCleanupRef.current = null;
 
@@ -400,6 +406,21 @@ function useMotionHostProps<Props extends MotionProps>(
           }
         }
       }
+
+      const activeAnimations = [...animationRef.current];
+      if (activeAnimations.length > 0 && animate !== undefined) {
+        if (onAnimationStart) {
+          void runOnBackground(onAnimationStart)(animate);
+        }
+        void Promise.all(activeAnimations).then(() => {
+          if (
+            animationGenerationRef.current === animationGeneration
+            && onAnimationComplete
+          ) {
+            void runOnBackground(onAnimationComplete)(animate);
+          }
+        });
+      }
     }
 
     void runOnMainThread(updateMotionStyles)(
@@ -412,6 +433,7 @@ function useMotionHostProps<Props extends MotionProps>(
 
     function stopMotionStyles() {
       'main thread';
+      animationGenerationRef.current += 1;
       for (const animation of animationRef.current) {
         animation.stop();
       }
@@ -445,7 +467,6 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
-
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
@@ -484,7 +505,6 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
-
     const targetValues = resolvedTap.target as Record<string, unknown>;
     const restingTarget = hoverActiveRef.current && resolvedHover.target
       ? resolvedHover.target
@@ -557,7 +577,6 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
-
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
@@ -603,7 +622,6 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
-
     const hoverValues = resolvedHover.target as Record<string, unknown>;
     const animateValues = resolvedAnimate.target as
       | Record<string, unknown>

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -1,0 +1,229 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type {
+  AnimationPlaybackControlsWithThen,
+  MotionValue,
+} from 'motion-dom';
+
+import type { ComponentType, FunctionComponent } from '@lynx-js/react';
+import {
+  createElement,
+  runOnMainThread,
+  useEffect,
+  useMainThreadRef,
+  useMemo,
+} from '@lynx-js/react';
+import type { IntrinsicElements, MainThread } from '@lynx-js/types';
+
+import './mainThreadDependencies.js';
+import {
+  collectMotionValues,
+  motionDefinitionKey,
+  resolveInitialStyle,
+  resolveInitialValues,
+} from './style.js';
+import type {
+  MotionComponentProps,
+  MotionFactory,
+  MotionImageProps,
+  MotionProps,
+  MotionTarget,
+  MotionTextProps,
+  MotionTransition,
+  MotionViewProps,
+} from './types.js';
+import {
+  animate as animateValue,
+  motionValue,
+  styleEffect,
+} from '../animation/index.js';
+
+type PreparedHostProps = Record<string, unknown> & {
+  style?: MotionProps['style'];
+  'main-thread:ref': ReturnType<
+    typeof useMainThreadRef<MainThread.Element | null>
+  >;
+};
+
+function useMotionHostProps<Props extends MotionProps>(
+  props: Props,
+): PreparedHostProps {
+  const {
+    animate,
+    initial,
+    style,
+    transition,
+    'main-thread:ref': _externalMainThreadRef,
+    ...hostProps
+  } = props as Props & { 'main-thread:ref'?: unknown };
+  const elementRef = useMainThreadRef<MainThread.Element | null>(null);
+  const animationRef = useMainThreadRef<
+    AnimationPlaybackControlsWithThen[]
+  >([]);
+  const generatedValuesRef = useMainThreadRef<
+    Record<string, MotionValue<string | number>>
+  >({});
+  const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
+
+  const animationKey = motionDefinitionKey({ animate, transition });
+  const styleKey = motionDefinitionKey(style);
+  const initialStyle = useMemo(
+    () => resolveInitialStyle(style, initial),
+    [initial, style],
+  );
+  const initialValues = useMemo(
+    () => resolveInitialValues(style, initial),
+    [initial, style],
+  );
+  const motionValues = useMemo(
+    () => collectMotionValues(style),
+    [styleKey],
+  );
+
+  useEffect(() => {
+    if (!animate && Object.keys(motionValues).length === 0) {
+      return;
+    }
+    // Worklet hydration replaces MainThreadValue handles in captured objects.
+    // Capture a fresh record so Lynx for Web doesn't mutate the memoized source
+    // that a later React render will reuse.
+    const motionValueBindings = { ...motionValues };
+
+    function updateMotionStyles(
+      target: MotionTarget | undefined,
+      options: MotionTransition | undefined,
+      startingValues: Record<string, unknown>,
+    ) {
+      'main thread';
+
+      for (const animation of animationRef.current) {
+        animation.stop();
+      }
+      animationRef.current = [];
+      styleCleanupRef.current?.();
+      styleCleanupRef.current = null;
+
+      if (!elementRef.current) {
+        return;
+      }
+
+      const animateMotionValue = animateValue as unknown as (
+        value: MotionValue<string | number>,
+        keyframes: unknown,
+        options: MotionTransition | undefined,
+      ) => AnimationPlaybackControlsWithThen;
+      const values = { ...motionValueBindings };
+      if (target) {
+        const targetValues = target as Record<string, unknown>;
+        for (const key in targetValues) {
+          if (!values[key]) {
+            let value = generatedValuesRef.current[key];
+            if (!value) {
+              const targetValue = targetValues[key];
+              let firstTarget: unknown = targetValue;
+              if (Array.isArray(targetValue)) {
+                const keyframes = targetValue as unknown[];
+                firstTarget = keyframes.find(value => value !== null);
+              }
+              const initialValue = startingValues[key] ?? firstTarget;
+              if (
+                typeof initialValue !== 'string'
+                && typeof initialValue !== 'number'
+              ) {
+                continue;
+              }
+              value = motionValue(initialValue);
+              generatedValuesRef.current[key] = value;
+            }
+            values[key] = value;
+          }
+        }
+      }
+
+      if (Object.keys(values).length > 0) {
+        styleCleanupRef.current = styleEffect(elementRef.current, values);
+      }
+
+      if (target) {
+        const targetValues = target as Record<string, unknown>;
+        for (const key in targetValues) {
+          const value = values[key];
+          const targetValue = targetValues[key];
+          if (value && targetValue !== undefined) {
+            animationRef.current.push(
+              animateMotionValue(
+                value,
+                targetValue,
+                options,
+              ),
+            );
+          }
+        }
+      }
+    }
+
+    void runOnMainThread(updateMotionStyles)(
+      animate,
+      transition,
+      initialValues,
+    );
+
+    function stopMotionStyles() {
+      'main thread';
+      for (const animation of animationRef.current) {
+        animation.stop();
+      }
+      animationRef.current = [];
+      styleCleanupRef.current?.();
+      styleCleanupRef.current = null;
+    }
+
+    return () => {
+      void runOnMainThread(stopMotionStyles)();
+    };
+    // Serialized targets and value IDs avoid restarting unchanged inline
+    // definitions while keeping animate and style transforms in one renderer.
+  }, [animationKey, styleKey]);
+
+  return {
+    ...hostProps,
+    style: initialStyle,
+    'main-thread:ref': elementRef,
+  };
+}
+
+const MotionView: FunctionComponent<MotionViewProps> = (props) => {
+  const hostProps = useMotionHostProps(props);
+  return createElement('view', hostProps as IntrinsicElements['view']);
+};
+
+const MotionText: FunctionComponent<MotionTextProps> = (props) => {
+  const hostProps = useMotionHostProps(props);
+  return createElement('text', hostProps as IntrinsicElements['text']);
+};
+
+const MotionImage: FunctionComponent<MotionImageProps> = (props) => {
+  const hostProps = useMotionHostProps(props);
+  return createElement('image', hostProps as IntrinsicElements['image']);
+};
+
+function createMotionComponent<Props extends { style?: unknown }>(
+  Component: ComponentType<Props>,
+): FunctionComponent<MotionComponentProps<Props>> {
+  const MotionComponent: FunctionComponent<MotionComponentProps<Props>> = (
+    props,
+  ) => {
+    const hostProps = useMotionHostProps(props);
+    return createElement(Component, hostProps as Props);
+  };
+  return MotionComponent;
+}
+
+export const motion: MotionFactory = {
+  view: MotionView,
+  text: MotionText,
+  image: MotionImage,
+  create: createMotionComponent,
+};

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -22,6 +22,7 @@ import {
   useEffect,
   useMainThreadRef,
   useMemo,
+  useRef,
 } from '@lynx-js/react';
 import type { IntrinsicElements, MainThread } from '@lynx-js/types';
 
@@ -84,20 +85,27 @@ function useMotionHostProps<Props extends MotionProps>(
     style,
     transition,
     whileTap,
+    whileHover,
     variants,
     custom,
     onTapStart,
     onTap,
     onTapCancel,
+    onHoverStart,
+    onHoverEnd,
     bindtouchstart: externalTouchStart,
     bindtouchend: externalTouchEnd,
     bindtouchcancel: externalTouchCancel,
+    bindlayoutchange: externalLayoutChange,
+    'global-bindmousemove': externalGlobalMouseMove,
     'main-thread:ref': _externalMainThreadRef,
     ...hostProps
   } = props as Props & {
     bindtouchstart?: BackgroundTouchHandler;
     bindtouchend?: BackgroundTouchHandler;
     bindtouchcancel?: BackgroundTouchHandler;
+    bindlayoutchange?: BackgroundTouchHandler;
+    'global-bindmousemove'?: BackgroundTouchHandler;
     'main-thread:ref'?: unknown;
   };
   const elementRef = useMainThreadRef<MainThread.Element | null>(null);
@@ -107,6 +115,12 @@ function useMotionHostProps<Props extends MotionProps>(
   const tapAnimationRef = useMainThreadRef<
     AnimationPlaybackControlsWithThen[]
   >([]);
+  const hoverActiveRef = useMainThreadRef(false);
+  const tapActiveRef = useMainThreadRef(false);
+  const hoverLayoutRef = useRef<
+    { left: number; right: number; top: number; bottom: number } | null
+  >(null);
+  const hoverActiveBackgroundRef = useRef(false);
   const generatedValuesRef = useMainThreadRef<
     Record<string, MotionValue<string | number>>
   >({});
@@ -123,6 +137,11 @@ function useMotionHostProps<Props extends MotionProps>(
     variants,
     custom,
   );
+  const resolvedHoverDefinition = resolveMotionDefinition(
+    whileHover,
+    variants,
+    custom,
+  );
   const resolvedInitialTarget = resolvedInitial === false
     ? false
     : splitMotionTarget(resolvedInitial, undefined).target;
@@ -131,9 +150,14 @@ function useMotionHostProps<Props extends MotionProps>(
     transition,
   );
   const resolvedTap = splitMotionTarget(resolvedTapDefinition, transition);
+  const resolvedHover = splitMotionTarget(
+    resolvedHoverDefinition,
+    transition,
+  );
   const animationKey = motionDefinitionKey({
     animate: resolvedAnimate,
     whileTap: resolvedTap,
+    whileHover: resolvedHover,
   });
   const styleKey = motionDefinitionKey(style);
   const initialStyle = useMemo(
@@ -158,6 +182,13 @@ function useMotionHostProps<Props extends MotionProps>(
         : resolvedTap.transition,
     [resolvedTap.transition],
   );
+  const workletHoverTransition = useMemo(
+    () =>
+      resolvedHover.transition?.repeat === Number.POSITIVE_INFINITY
+        ? { ...resolvedHover.transition, repeat: -1 }
+        : resolvedHover.transition,
+    [resolvedHover.transition],
+  );
   const motionValues = useMemo(
     () => collectMotionValues(style),
     [styleKey],
@@ -181,11 +212,72 @@ function useMotionHostProps<Props extends MotionProps>(
       onTapCancel?.(event, tapInfo(event));
     }
     : undefined;
+  const hasHoverInteraction = [
+    resolvedHover.target,
+    onHoverStart,
+    onHoverEnd,
+  ].some(Boolean);
+  const bindLayoutChange = hasHoverInteraction || externalLayoutChange
+    ? (event: unknown) => {
+      externalLayoutChange?.(event);
+      if (!hasHoverInteraction) {
+        return;
+      }
+      const detail = (event as {
+        detail?: Record<string, unknown>;
+      }).detail;
+      if (
+        typeof detail?.['left'] === 'number'
+        && typeof detail['right'] === 'number'
+        && typeof detail['top'] === 'number'
+        && typeof detail['bottom'] === 'number'
+      ) {
+        hoverLayoutRef.current = {
+          left: detail['left'],
+          right: detail['right'],
+          top: detail['top'],
+          bottom: detail['bottom'],
+        };
+      }
+    }
+    : undefined;
+  const bindGlobalMouseMove = hasHoverInteraction || externalGlobalMouseMove
+    ? (event: unknown) => {
+      externalGlobalMouseMove?.(event);
+      const layout = hoverLayoutRef.current;
+      if (!hasHoverInteraction || !layout) {
+        return;
+      }
+      const mouseEvent = event as { x?: unknown; y?: unknown };
+      const isInside = typeof mouseEvent.x === 'number'
+        && typeof mouseEvent.y === 'number'
+        && mouseEvent.x >= layout.left
+        && mouseEvent.x <= layout.right
+        && mouseEvent.y >= layout.top
+        && mouseEvent.y <= layout.bottom;
+      if (isInside === hoverActiveBackgroundRef.current) {
+        return;
+      }
+      hoverActiveBackgroundRef.current = isInside;
+      if (isInside) {
+        onHoverStart?.(event);
+        if (resolvedHover.target) {
+          void runOnMainThread(startHoverAnimation)();
+        }
+      } else {
+        onHoverEnd?.(event);
+        if (resolvedHover.target) {
+          void runOnMainThread(endHoverAnimation)();
+        }
+      }
+    }
+    : undefined;
 
   useEffect(() => {
     if (
       !resolvedAnimate.target
       && !resolvedTap.target
+      && !resolvedHover.target
       && Object.keys(motionValues).length === 0
     ) {
       return;
@@ -198,6 +290,7 @@ function useMotionHostProps<Props extends MotionProps>(
     function updateMotionStyles(
       target: MotionTarget | undefined,
       interactionTarget: MotionTarget | undefined,
+      hoverTarget: MotionTarget | undefined,
       options: MotionTransition | undefined,
       startingValues: Record<string, unknown>,
     ) {
@@ -223,7 +316,7 @@ function useMotionHostProps<Props extends MotionProps>(
         ? { ...options, repeat: Number.POSITIVE_INFINITY }
         : options;
       const values = { ...motionValueBindings };
-      const targets = [target, interactionTarget];
+      const targets = [target, interactionTarget, hoverTarget];
       for (const definition of targets) {
         if (!definition) {
           continue;
@@ -312,6 +405,7 @@ function useMotionHostProps<Props extends MotionProps>(
     void runOnMainThread(updateMotionStyles)(
       resolvedAnimate.target,
       resolvedTap.target,
+      resolvedHover.target,
       workletAnimateTransition,
       initialValues,
     );
@@ -342,6 +436,7 @@ function useMotionHostProps<Props extends MotionProps>(
     if (!resolvedTap.target) {
       return;
     }
+    tapActiveRef.current = true;
     for (const animation of animationRef.current) {
       animation.stop();
     }
@@ -384,19 +479,26 @@ function useMotionHostProps<Props extends MotionProps>(
     if (!resolvedTap.target) {
       return;
     }
+    tapActiveRef.current = false;
     for (const animation of tapAnimationRef.current) {
       animation.stop();
     }
     tapAnimationRef.current = [];
 
     const targetValues = resolvedTap.target as Record<string, unknown>;
-    const animateValues = resolvedAnimate.target as
+    const restingTarget = hoverActiveRef.current && resolvedHover.target
+      ? resolvedHover.target
+      : resolvedAnimate.target;
+    const animateValues = restingTarget as
       | Record<string, unknown>
       | undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
-    const resolvedTransition = workletTapTransition?.repeat === -1
-      ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
+    const restingTransition = hoverActiveRef.current && resolvedHover.target
+      ? workletHoverTransition
       : workletTapTransition;
+    const resolvedTransition = restingTransition?.repeat === -1
+      ? { ...restingTransition, repeat: Number.POSITIVE_INFINITY }
+      : restingTransition;
     const restingValues: Record<string, unknown> = {};
     for (const key in targetValues) {
       let restingValue = animateValues?.[key] ?? initialValues[key];
@@ -438,6 +540,117 @@ function useMotionHostProps<Props extends MotionProps>(
     );
   }
 
+  function startHoverAnimation() {
+    'main thread';
+    if (!resolvedHover.target || !elementRef.current) {
+      return;
+    }
+    hoverActiveRef.current = true;
+    if (tapActiveRef.current) {
+      return;
+    }
+    for (const animation of animationRef.current) {
+      animation.stop();
+    }
+    animationRef.current = [];
+    for (const animation of tapAnimationRef.current) {
+      animation.stop();
+    }
+    tapAnimationRef.current = [];
+
+    const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    const resolvedTransition = workletHoverTransition?.repeat === -1
+      ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
+      : workletHoverTransition;
+    const isLynxForWeb = typeof SystemInfo !== 'undefined'
+      && String(SystemInfo.platform) === 'web';
+    if (isLynxForWeb) {
+      const targetValues = resolvedHover.target as Record<string, unknown>;
+      for (const key in targetValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        const targetValue = targetValues[key];
+        if (value && targetValue !== undefined) {
+          tapAnimationRef.current.push(
+            animateMotionTarget(value, targetValue, resolvedTransition),
+          );
+        }
+      }
+      return;
+    }
+    const ElementConstructor = globalThis.Element as unknown as new(
+      element: MainThread.Element,
+    ) => Element;
+    const element = new ElementConstructor(elementRef.current);
+    tapAnimationRef.current.push(
+      animateMotionTarget(
+        element,
+        resolvedHover.target,
+        resolvedTransition,
+      ),
+    );
+  }
+
+  function endHoverAnimation() {
+    'main thread';
+    if (!resolvedHover.target || !elementRef.current) {
+      return;
+    }
+    hoverActiveRef.current = false;
+    if (tapActiveRef.current) {
+      return;
+    }
+    for (const animation of tapAnimationRef.current) {
+      animation.stop();
+    }
+    tapAnimationRef.current = [];
+
+    const hoverValues = resolvedHover.target as Record<string, unknown>;
+    const animateValues = resolvedAnimate.target as
+      | Record<string, unknown>
+      | undefined;
+    const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    const resolvedTransition = workletHoverTransition?.repeat === -1
+      ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
+      : workletHoverTransition;
+    const restingValues: Record<string, unknown> = {};
+    for (const key in hoverValues) {
+      let restingValue = animateValues?.[key] ?? initialValues[key];
+      if (Array.isArray(restingValue)) {
+        const keyframes = restingValue as unknown[];
+        for (let index = keyframes.length - 1; index >= 0; index--) {
+          if (keyframes[index] !== null && keyframes[index] !== undefined) {
+            restingValue = keyframes[index];
+            break;
+          }
+        }
+      }
+      if (restingValue === undefined) {
+        restingValue = key.startsWith('scale') || key === 'opacity' ? 1 : 0;
+      }
+      restingValues[key] = restingValue;
+    }
+    const isLynxForWeb = typeof SystemInfo !== 'undefined'
+      && String(SystemInfo.platform) === 'web';
+    if (isLynxForWeb) {
+      for (const key in restingValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value) {
+          tapAnimationRef.current.push(
+            animateMotionTarget(value, restingValues[key], resolvedTransition),
+          );
+        }
+      }
+      return;
+    }
+    const ElementConstructor = globalThis.Element as unknown as new(
+      element: MainThread.Element,
+    ) => Element;
+    const element = new ElementConstructor(elementRef.current);
+    tapAnimationRef.current.push(
+      animateMotionTarget(element, restingValues, resolvedTransition),
+    );
+  }
+
   return {
     ...hostProps,
     style: initialStyle,
@@ -445,6 +658,10 @@ function useMotionHostProps<Props extends MotionProps>(
     ...(bindTouchStart ? { bindtouchstart: bindTouchStart } : {}),
     ...(bindTouchEnd ? { bindtouchend: bindTouchEnd } : {}),
     ...(bindTouchCancel ? { bindtouchcancel: bindTouchCancel } : {}),
+    ...(bindLayoutChange ? { bindlayoutchange: bindLayoutChange } : {}),
+    ...(bindGlobalMouseMove
+      ? { 'global-bindmousemove': bindGlobalMouseMove }
+      : {}),
     ...(resolvedTap.target
       ? {
         'main-thread:bindtouchstart': startTapAnimation,

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -57,6 +57,24 @@ type AnimateMotionTarget = (
   options: MotionTransition | undefined,
 ) => AnimationPlaybackControlsWithThen;
 
+type BackgroundTouchHandler = (event: unknown) => void;
+
+function tapInfo(event: unknown) {
+  const touchEvent = event as {
+    detail?: { x?: unknown; y?: unknown };
+    touches?: Array<{ clientX?: unknown; clientY?: unknown }>;
+  };
+  const touch = touchEvent.touches?.[0];
+  const x = touchEvent.detail?.x ?? touch?.clientX;
+  const y = touchEvent.detail?.y ?? touch?.clientY;
+  return {
+    point: {
+      x: typeof x === 'number' ? x : 0,
+      y: typeof y === 'number' ? y : 0,
+    },
+  };
+}
+
 function useMotionHostProps<Props extends MotionProps>(
   props: Props,
 ): PreparedHostProps {
@@ -68,9 +86,20 @@ function useMotionHostProps<Props extends MotionProps>(
     whileTap,
     variants,
     custom,
+    onTapStart,
+    onTap,
+    onTapCancel,
+    bindtouchstart: externalTouchStart,
+    bindtouchend: externalTouchEnd,
+    bindtouchcancel: externalTouchCancel,
     'main-thread:ref': _externalMainThreadRef,
     ...hostProps
-  } = props as Props & { 'main-thread:ref'?: unknown };
+  } = props as Props & {
+    bindtouchstart?: BackgroundTouchHandler;
+    bindtouchend?: BackgroundTouchHandler;
+    bindtouchcancel?: BackgroundTouchHandler;
+    'main-thread:ref'?: unknown;
+  };
   const elementRef = useMainThreadRef<MainThread.Element | null>(null);
   const animationRef = useMainThreadRef<
     AnimationPlaybackControlsWithThen[]
@@ -133,6 +162,25 @@ function useMotionHostProps<Props extends MotionProps>(
     () => collectMotionValues(style),
     [styleKey],
   );
+
+  const bindTouchStart = onTapStart || externalTouchStart
+    ? (event: unknown) => {
+      externalTouchStart?.(event);
+      onTapStart?.(event, tapInfo(event));
+    }
+    : undefined;
+  const bindTouchEnd = onTap || externalTouchEnd
+    ? (event: unknown) => {
+      externalTouchEnd?.(event);
+      onTap?.(event, tapInfo(event));
+    }
+    : undefined;
+  const bindTouchCancel = onTapCancel || externalTouchCancel
+    ? (event: unknown) => {
+      externalTouchCancel?.(event);
+      onTapCancel?.(event, tapInfo(event));
+    }
+    : undefined;
 
   useEffect(() => {
     if (
@@ -394,6 +442,9 @@ function useMotionHostProps<Props extends MotionProps>(
     ...hostProps,
     style: initialStyle,
     'main-thread:ref': elementRef,
+    ...(bindTouchStart ? { bindtouchstart: bindTouchStart } : {}),
+    ...(bindTouchEnd ? { bindtouchend: bindTouchEnd } : {}),
+    ...(bindTouchCancel ? { bindtouchcancel: bindTouchCancel } : {}),
     ...(resolvedTap.target
       ? {
         'main-thread:bindtouchstart': startTapAnimation,

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -30,6 +30,8 @@ import {
   motionDefinitionKey,
   resolveInitialStyle,
   resolveInitialValues,
+  resolveMotionDefinition,
+  splitMotionTarget,
 } from './style.js';
 import type {
   MotionComponentProps,
@@ -64,6 +66,8 @@ function useMotionHostProps<Props extends MotionProps>(
     style,
     transition,
     whileTap,
+    variants,
+    custom,
     'main-thread:ref': _externalMainThreadRef,
     ...hostProps
   } = props as Props & { 'main-thread:ref'?: unknown };
@@ -79,22 +83,51 @@ function useMotionHostProps<Props extends MotionProps>(
   >({});
   const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
 
-  const animationKey = motionDefinitionKey({ animate, transition, whileTap });
+  const resolvedInitial = resolveMotionDefinition(initial, variants, custom);
+  const resolvedAnimateDefinition = resolveMotionDefinition(
+    animate,
+    variants,
+    custom,
+  );
+  const resolvedTapDefinition = resolveMotionDefinition(
+    whileTap,
+    variants,
+    custom,
+  );
+  const resolvedInitialTarget = resolvedInitial === false
+    ? false
+    : splitMotionTarget(resolvedInitial, undefined).target;
+  const resolvedAnimate = splitMotionTarget(
+    resolvedAnimateDefinition,
+    transition,
+  );
+  const resolvedTap = splitMotionTarget(resolvedTapDefinition, transition);
+  const animationKey = motionDefinitionKey({
+    animate: resolvedAnimate,
+    whileTap: resolvedTap,
+  });
   const styleKey = motionDefinitionKey(style);
   const initialStyle = useMemo(
-    () => resolveInitialStyle(style, initial),
-    [initial, style],
+    () => resolveInitialStyle(style, resolvedInitialTarget),
+    [resolvedInitialTarget, style],
   );
   const initialValues = useMemo(
-    () => resolveInitialValues(style, initial),
-    [initial, style],
+    () => resolveInitialValues(style, resolvedInitialTarget),
+    [resolvedInitialTarget, style],
   );
-  const workletTransition = useMemo(
+  const workletAnimateTransition = useMemo(
     () =>
-      transition?.repeat === Number.POSITIVE_INFINITY
-        ? { ...transition, repeat: -1 }
-        : transition,
-    [transition],
+      resolvedAnimate.transition?.repeat === Number.POSITIVE_INFINITY
+        ? { ...resolvedAnimate.transition, repeat: -1 }
+        : resolvedAnimate.transition,
+    [resolvedAnimate.transition],
+  );
+  const workletTapTransition = useMemo(
+    () =>
+      resolvedTap.transition?.repeat === Number.POSITIVE_INFINITY
+        ? { ...resolvedTap.transition, repeat: -1 }
+        : resolvedTap.transition,
+    [resolvedTap.transition],
   );
   const motionValues = useMemo(
     () => collectMotionValues(style),
@@ -102,7 +135,11 @@ function useMotionHostProps<Props extends MotionProps>(
   );
 
   useEffect(() => {
-    if (!animate && !whileTap && Object.keys(motionValues).length === 0) {
+    if (
+      !resolvedAnimate.target
+      && !resolvedTap.target
+      && Object.keys(motionValues).length === 0
+    ) {
       return;
     }
     // Worklet hydration replaces MainThreadValue handles in captured objects.
@@ -225,9 +262,9 @@ function useMotionHostProps<Props extends MotionProps>(
     }
 
     void runOnMainThread(updateMotionStyles)(
-      animate,
-      whileTap,
-      workletTransition,
+      resolvedAnimate.target,
+      resolvedTap.target,
+      workletAnimateTransition,
       initialValues,
     );
 
@@ -254,7 +291,7 @@ function useMotionHostProps<Props extends MotionProps>(
 
   function startTapAnimation(event: MainThread.TouchEvent) {
     'main thread';
-    if (!whileTap) {
+    if (!resolvedTap.target) {
       return;
     }
     for (const animation of animationRef.current) {
@@ -267,13 +304,13 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
 
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
-    const resolvedTransition = workletTransition?.repeat === -1
-      ? { ...workletTransition, repeat: Number.POSITIVE_INFINITY }
-      : workletTransition;
+    const resolvedTransition = workletTapTransition?.repeat === -1
+      ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
+      : workletTapTransition;
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
     if (isLynxForWeb) {
-      const targetValues = whileTap as Record<string, unknown>;
+      const targetValues = resolvedTap.target as Record<string, unknown>;
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
@@ -290,13 +327,13 @@ function useMotionHostProps<Props extends MotionProps>(
     ) => Element;
     const element = new ElementConstructor(event.currentTarget);
     tapAnimationRef.current.push(
-      animateMotionTarget(element, whileTap, resolvedTransition),
+      animateMotionTarget(element, resolvedTap.target, resolvedTransition),
     );
   }
 
   function endTapAnimation(event: MainThread.TouchEvent) {
     'main thread';
-    if (!whileTap) {
+    if (!resolvedTap.target) {
       return;
     }
     for (const animation of tapAnimationRef.current) {
@@ -304,12 +341,14 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     tapAnimationRef.current = [];
 
-    const targetValues = whileTap as Record<string, unknown>;
-    const animateValues = animate as Record<string, unknown> | undefined;
+    const targetValues = resolvedTap.target as Record<string, unknown>;
+    const animateValues = resolvedAnimate.target as
+      | Record<string, unknown>
+      | undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
-    const resolvedTransition = workletTransition?.repeat === -1
-      ? { ...workletTransition, repeat: Number.POSITIVE_INFINITY }
-      : workletTransition;
+    const resolvedTransition = workletTapTransition?.repeat === -1
+      ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
+      : workletTapTransition;
     const restingValues: Record<string, unknown> = {};
     for (const key in targetValues) {
       let restingValue = animateValues?.[key] ?? initialValues[key];
@@ -355,7 +394,7 @@ function useMotionHostProps<Props extends MotionProps>(
     ...hostProps,
     style: initialStyle,
     'main-thread:ref': elementRef,
-    ...(whileTap
+    ...(resolvedTap.target
       ? {
         'main-thread:bindtouchstart': startTapAnimation,
         'main-thread:bindtouchend': endTapAnimation,

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -458,13 +458,8 @@ function useMotionHostProps<Props extends MotionProps>(
     if (!resolvedTap.target) {
       return;
     }
-    // Native Lynx and Lynx for Web dispatch both the main-thread and
-    // background touch bindings. The testing event bridge currently dispatches
-    // only the main-thread binding and leaves currentTarget unset, so forward
-    // the composed background callback in that incomplete bridge.
-    if (!event.currentTarget && bindTouchStart) {
-      void runOnBackground(bindTouchStart)(event);
-    }
+    const isLynxForWeb = typeof SystemInfo !== 'undefined'
+      && String(SystemInfo.platform) === 'web';
     tapActiveRef.current = true;
     for (const animation of animationRef.current) {
       animation.stop();
@@ -478,8 +473,6 @@ function useMotionHostProps<Props extends MotionProps>(
     const resolvedTransition = workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
       : workletTapTransition;
-    const isLynxForWeb = typeof SystemInfo !== 'undefined'
-      && String(SystemInfo.platform) === 'web';
     if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
       for (const key in targetValues) {
@@ -507,16 +500,8 @@ function useMotionHostProps<Props extends MotionProps>(
     if (!resolvedTap.target) {
       return;
     }
-    const isCancelled = String(
-      (event as unknown as { type?: unknown }).type,
-    ).toLowerCase().includes('cancel');
-    if (!event.currentTarget) {
-      if (isCancelled && bindTouchCancel) {
-        void runOnBackground(bindTouchCancel)(event);
-      } else if (!isCancelled && bindTouchEnd) {
-        void runOnBackground(bindTouchEnd)(event);
-      }
-    }
+    const isLynxForWeb = typeof SystemInfo !== 'undefined'
+      && String(SystemInfo.platform) === 'web';
     tapActiveRef.current = false;
     for (const animation of tapAnimationRef.current) {
       animation.stop();
@@ -555,8 +540,6 @@ function useMotionHostProps<Props extends MotionProps>(
         restingValues[key] = restingValue;
       }
     }
-    const isLynxForWeb = typeof SystemInfo !== 'undefined'
-      && String(SystemInfo.platform) === 'web';
     if (isLynxForWeb || !event.currentTarget) {
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -286,7 +286,7 @@ function useMotionHostProps<Props extends MotionProps>(
     ) {
       return;
     }
-    // Worklet hydration replaces MainThreadValue handles in captured objects.
+    // Worklet hydration replaces MainThreadObject handles in captured objects.
     // Capture a fresh record so Lynx for Web doesn't mutate the memoized source
     // that a later React render will reuse.
     const motionValueBindings = { ...motionValues };

--- a/packages/motion/src/declarative/style.ts
+++ b/packages/motion/src/declarative/style.ts
@@ -6,7 +6,14 @@ import type { MotionValue } from 'motion-dom';
 
 import type { CSSProperties } from '@lynx-js/types';
 
-import type { MotionStyle, MotionStyleValue, MotionTarget } from './types.js';
+import type {
+  MotionDefinition,
+  MotionStyle,
+  MotionStyleValue,
+  MotionTarget,
+  MotionTransition,
+  MotionVariants,
+} from './types.js';
 
 interface MainThreadValueHandle {
   readonly __MAIN_THREAD_VALUE__: true;
@@ -171,4 +178,48 @@ export function collectMotionValues(
 
 export function motionDefinitionKey(value: unknown): string {
   return JSON.stringify(value) ?? '';
+}
+
+export function resolveMotionDefinition(
+  definition: MotionDefinition | false | undefined,
+  variants: MotionVariants | undefined,
+  custom: unknown,
+): MotionTarget | false | undefined {
+  if (definition === false || definition === undefined) {
+    return definition;
+  }
+  if (typeof definition !== 'string' && !Array.isArray(definition)) {
+    return definition;
+  }
+
+  const labels = Array.isArray(definition) ? definition : [definition];
+  const resolved: MotionTarget = {};
+  for (const label of labels) {
+    const variant = variants?.[label];
+    if (!variant) {
+      continue;
+    }
+    Object.assign(
+      resolved,
+      typeof variant === 'function' ? variant(custom) : variant,
+    );
+  }
+  return resolved;
+}
+
+export function splitMotionTarget(
+  definition: MotionTarget | false | undefined,
+  fallbackTransition: MotionTransition | undefined,
+): {
+  target: MotionTarget | undefined;
+  transition: MotionTransition | undefined;
+} {
+  if (!definition) {
+    return { target: undefined, transition: fallbackTransition };
+  }
+  const { transition, ...target } = definition;
+  return {
+    target: target as MotionTarget,
+    transition: transition ?? fallbackTransition,
+  };
 }

--- a/packages/motion/src/declarative/style.ts
+++ b/packages/motion/src/declarative/style.ts
@@ -1,0 +1,174 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { MotionValue } from 'motion-dom';
+
+import type { CSSProperties } from '@lynx-js/types';
+
+import type { MotionStyle, MotionStyleValue, MotionTarget } from './types.js';
+
+interface MainThreadValueHandle {
+  readonly __MAIN_THREAD_VALUE__: true;
+  toJSON(): { _initValue: unknown; _wvid: number; _type?: string };
+}
+
+const transformAliases: Record<string, string> = {
+  x: 'translateX',
+  y: 'translateY',
+  z: 'translateZ',
+  transformPerspective: 'perspective',
+};
+
+const transformKeys = new Set([
+  'transformPerspective',
+  'x',
+  'y',
+  'z',
+  'translateX',
+  'translateY',
+  'translateZ',
+  'scale',
+  'scaleX',
+  'scaleY',
+  'scaleZ',
+  'rotate',
+  'rotateX',
+  'rotateY',
+  'rotateZ',
+  'skew',
+  'skewX',
+  'skewY',
+]);
+
+function isMainThreadValueHandle(
+  value: unknown,
+): value is MainThreadValueHandle {
+  return value !== null
+    && typeof value === 'object'
+    && (value as { __MAIN_THREAD_VALUE__?: unknown }).__MAIN_THREAD_VALUE__
+      === true;
+}
+
+function resolveStyleValue(value: unknown): unknown {
+  if (isMainThreadValueHandle(value)) {
+    return value.toJSON()._initValue;
+  }
+  if (Array.isArray(value)) {
+    return value.find(item => item !== null && item !== undefined);
+  }
+  return value;
+}
+
+function formatTransformValue(key: string, value: string | number): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (key.startsWith('scale')) {
+    return String(value);
+  }
+  if (key.startsWith('rotate') || key.startsWith('skew')) {
+    return `${value}deg`;
+  }
+  return `${value}px`;
+}
+
+function appendResolvedValues(
+  output: Record<string, unknown>,
+  transforms: Record<string, string | number>,
+  values: Record<string, unknown>,
+): void {
+  for (const key in values) {
+    const value = resolveStyleValue(values[key]);
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (
+      transformKeys.has(key)
+      && (typeof value === 'string' || typeof value === 'number')
+    ) {
+      transforms[key] = value;
+    } else {
+      output[key] = value;
+    }
+  }
+}
+
+export function resolveInitialStyle(
+  style: MotionStyle | string | undefined,
+  initial: MotionTarget | false | undefined,
+): CSSProperties | string | undefined {
+  if (typeof style === 'string') {
+    return style;
+  }
+
+  const output: Record<string, unknown> = {};
+  const transforms: Record<string, string | number> = {};
+  appendResolvedValues(
+    output,
+    transforms,
+    (style ?? {}) as Record<string, unknown>,
+  );
+  if (initial !== false) {
+    appendResolvedValues(
+      output,
+      transforms,
+      (initial ?? {}) as Record<string, unknown>,
+    );
+  }
+
+  const generatedTransform = Object.entries(transforms)
+    .map(([key, value]) => {
+      const name = transformAliases[key] ?? key;
+      return `${name}(${formatTransformValue(key, value)})`;
+    })
+    .join(' ');
+  if (generatedTransform) {
+    const existingTransform = output['transform'];
+    output['transform'] = typeof existingTransform === 'string'
+      ? `${existingTransform} ${generatedTransform}`
+      : generatedTransform;
+  }
+
+  return Object.keys(output).length > 0 ? output as CSSProperties : undefined;
+}
+
+export function resolveInitialValues(
+  style: MotionStyle | string | undefined,
+  initial: MotionTarget | false | undefined,
+): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  if (style && typeof style !== 'string') {
+    for (const key in style) {
+      values[key] = resolveStyleValue(style[key as keyof MotionStyle]);
+    }
+  }
+  if (initial !== false && initial) {
+    const initialValues = initial as Record<string, unknown>;
+    for (const key in initialValues) {
+      values[key] = resolveStyleValue(initialValues[key]);
+    }
+  }
+  return values;
+}
+
+export function collectMotionValues(
+  style: MotionStyle | string | undefined,
+): Record<string, MotionValue<string | number>> {
+  if (!style || typeof style === 'string') {
+    return {};
+  }
+
+  const values: Record<string, MotionValue<string | number>> = {};
+  for (const key in style) {
+    const value = style[key as keyof MotionStyle] as MotionStyleValue;
+    if (isMainThreadValueHandle(value)) {
+      values[key] = value as unknown as MotionValue<string | number>;
+    }
+  }
+  return values;
+}
+
+export function motionDefinitionKey(value: unknown): string {
+  return JSON.stringify(value) ?? '';
+}

--- a/packages/motion/src/declarative/style.ts
+++ b/packages/motion/src/declarative/style.ts
@@ -14,11 +14,10 @@ import type {
   MotionTransition,
   MotionVariants,
 } from './types.js';
-
-interface MainThreadValueHandle {
-  readonly __MAIN_THREAD_VALUE__: true;
-  toJSON(): { _initValue: unknown; _wvid: number; _type?: string };
-}
+import {
+  getMotionValueHandleInitialValue,
+  isMotionValueHandle,
+} from '../hooks/useMotionValue.js';
 
 const transformAliases: Record<string, string> = {
   x: 'translateX',
@@ -48,18 +47,9 @@ const transformKeys = new Set([
   'skewY',
 ]);
 
-function isMainThreadValueHandle(
-  value: unknown,
-): value is MainThreadValueHandle {
-  return value !== null
-    && typeof value === 'object'
-    && (value as { __MAIN_THREAD_VALUE__?: unknown }).__MAIN_THREAD_VALUE__
-      === true;
-}
-
 function resolveStyleValue(value: unknown): unknown {
-  if (isMainThreadValueHandle(value)) {
-    return value.toJSON()._initValue;
+  if (isMotionValueHandle(value)) {
+    return getMotionValueHandleInitialValue(value);
   }
   if (Array.isArray(value)) {
     return value.find(item => item !== null && item !== undefined);
@@ -169,8 +159,8 @@ export function collectMotionValues(
   const values: Record<string, MotionValue<string | number>> = {};
   for (const key in style) {
     const value = style[key as keyof MotionStyle] as MotionStyleValue;
-    if (isMainThreadValueHandle(value)) {
-      values[key] = value as unknown as MotionValue<string | number>;
+    if (isMotionValueHandle(value)) {
+      values[key] = value as MotionValue<string | number>;
     }
   }
   return values;

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -68,12 +68,18 @@ export interface MotionProps {
   animate?: MotionDefinition;
   /** Values animated while the element is being pressed. */
   whileTap?: MotionDefinition;
+  /** Values animated while a mouse-capable client hovers the element. */
+  whileHover?: MotionDefinition;
   /** Called when a press starts. */
   onTapStart?: (event: unknown, info: MotionTapInfo) => void;
   /** Called when a press ends successfully. */
   onTap?: (event: unknown, info: MotionTapInfo) => void;
   /** Called when a press is cancelled. */
   onTapCancel?: (event: unknown, info: MotionTapInfo) => void;
+  /** Called when hover starts on a mouse-capable client. */
+  onHoverStart?: (event: unknown) => void;
+  /** Called when hover ends on a mouse-capable client. */
+  onHoverEnd?: (event: unknown) => void;
   /** Named targets referenced by declarative definition props. */
   variants?: MotionVariants;
   /** Value passed to function variants. */

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -50,6 +50,8 @@ export interface MotionProps {
   initial?: MotionTarget | false;
   /** Values animated whenever this target changes. */
   animate?: MotionTarget;
+  /** Values animated while the element is being pressed. */
+  whileTap?: MotionTarget;
   /** Options used when animating to `animate`. */
   transition?: MotionTransition;
   /** Static styles and live MotionValue bindings. */

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type {
+  AnimationOptions,
+  DOMKeyframesDefinition,
+  MotionValue,
+} from 'motion-dom';
+
+import type { ComponentType, FunctionComponent } from '@lynx-js/react';
+import type { CSSProperties, IntrinsicElements } from '@lynx-js/types';
+
+export type MotionStyleValue =
+  | string
+  | number
+  | MotionValue<string | number>
+  | null
+  | undefined;
+
+/** Styles accepted by declarative Motion components. */
+export type MotionStyle =
+  & {
+    [Key in keyof CSSProperties]?:
+      | CSSProperties[Key]
+      | MotionValue<string | number>;
+  }
+  & {
+    x?: MotionStyleValue;
+    y?: MotionStyleValue;
+    z?: MotionStyleValue;
+    scale?: MotionStyleValue;
+    scaleX?: MotionStyleValue;
+    scaleY?: MotionStyleValue;
+    rotate?: MotionStyleValue;
+    rotateX?: MotionStyleValue;
+    rotateY?: MotionStyleValue;
+    rotateZ?: MotionStyleValue;
+  };
+
+/** Animatable style target for a declarative Motion component. */
+export type MotionTarget = DOMKeyframesDefinition;
+
+/** Transition options passed to Motion's animation engine. */
+export type MotionTransition = AnimationOptions;
+
+/** Motion-specific props shared by all declarative Motion components. */
+export interface MotionProps {
+  /** Values rendered before the first animation starts. */
+  initial?: MotionTarget | false;
+  /** Values animated whenever this target changes. */
+  animate?: MotionTarget;
+  /** Options used when animating to `animate`. */
+  transition?: MotionTransition;
+  /** Static styles and live MotionValue bindings. */
+  style?: MotionStyle | string;
+}
+
+export type MotionComponentProps<Props> =
+  & Omit<
+    Props,
+    keyof MotionProps | 'main-thread:ref'
+  >
+  & MotionProps;
+
+export type MotionViewProps = MotionComponentProps<IntrinsicElements['view']>;
+export type MotionTextProps = MotionComponentProps<IntrinsicElements['text']>;
+export type MotionImageProps = MotionComponentProps<IntrinsicElements['image']>;
+
+export interface MotionFactory {
+  view: FunctionComponent<MotionViewProps>;
+  text: FunctionComponent<MotionTextProps>;
+  image: FunctionComponent<MotionImageProps>;
+  create<Props extends { style?: unknown }>(
+    Component: ComponentType<Props>,
+  ): FunctionComponent<MotionComponentProps<Props>>;
+}

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -55,6 +55,11 @@ export type MotionVariants = Record<
   MotionTarget | ((custom: unknown) => MotionTarget)
 >;
 
+/** Pointer coordinates reported to declarative tap callbacks. */
+export interface MotionTapInfo {
+  point: { x: number; y: number };
+}
+
 /** Motion-specific props shared by all declarative Motion components. */
 export interface MotionProps {
   /** Values rendered before the first animation starts. */
@@ -63,6 +68,12 @@ export interface MotionProps {
   animate?: MotionDefinition;
   /** Values animated while the element is being pressed. */
   whileTap?: MotionDefinition;
+  /** Called when a press starts. */
+  onTapStart?: (event: unknown, info: MotionTapInfo) => void;
+  /** Called when a press ends successfully. */
+  onTap?: (event: unknown, info: MotionTapInfo) => void;
+  /** Called when a press is cancelled. */
+  onTapCancel?: (event: unknown, info: MotionTapInfo) => void;
   /** Named targets referenced by declarative definition props. */
   variants?: MotionVariants;
   /** Value passed to function variants. */

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -80,6 +80,10 @@ export interface MotionProps {
   onHoverStart?: (event: unknown) => void;
   /** Called when hover ends on a mouse-capable client. */
   onHoverEnd?: (event: unknown) => void;
+  /** Called when a declarative target starts animating. */
+  onAnimationStart?: (definition: MotionDefinition) => void;
+  /** Called after a declarative target finishes animating. */
+  onAnimationComplete?: (definition: MotionDefinition) => void;
   /** Named targets referenced by declarative definition props. */
   variants?: MotionVariants;
   /** Value passed to function variants. */

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -38,20 +38,35 @@ export type MotionStyle =
     rotateZ?: MotionStyleValue;
   };
 
-/** Animatable style target for a declarative Motion component. */
-export type MotionTarget = DOMKeyframesDefinition;
-
 /** Transition options passed to Motion's animation engine. */
 export type MotionTransition = AnimationOptions;
+
+/** Animatable style target for a declarative Motion component. */
+export type MotionTarget = DOMKeyframesDefinition & {
+  transition?: MotionTransition;
+};
+
+/** A named declarative target or a list of targets merged left-to-right. */
+export type MotionDefinition = MotionTarget | string | string[];
+
+/** A named target table. Function variants are resolved on the background thread. */
+export type MotionVariants = Record<
+  string,
+  MotionTarget | ((custom: unknown) => MotionTarget)
+>;
 
 /** Motion-specific props shared by all declarative Motion components. */
 export interface MotionProps {
   /** Values rendered before the first animation starts. */
-  initial?: MotionTarget | false;
+  initial?: MotionDefinition | false;
   /** Values animated whenever this target changes. */
-  animate?: MotionTarget;
+  animate?: MotionDefinition;
   /** Values animated while the element is being pressed. */
-  whileTap?: MotionTarget;
+  whileTap?: MotionDefinition;
+  /** Named targets referenced by declarative definition props. */
+  variants?: MotionVariants;
+  /** Value passed to function variants. */
+  custom?: unknown;
   /** Options used when animating to `animate`. */
   transition?: MotionTransition;
   /** Static styles and live MotionValue bindings. */

--- a/packages/motion/src/hooks/useMotionValue.ts
+++ b/packages/motion/src/hooks/useMotionValue.ts
@@ -4,17 +4,23 @@
 
 import type { MotionValue } from 'motion-dom';
 
-import { MainThreadValue, useMemo } from '@lynx-js/react';
+import {
+  defineMainThreadObjectType,
+  useMainThreadObject,
+} from '@lynx-js/react';
 
 import { motionValue } from '../polyfill/MotionValue.js' with { runtime: 'shared' };
 
 const MOTION_VALUE_TYPE = '@lynx-js/motion/MotionValue';
-
-class MotionValueHandle<T> extends MainThreadValue<T> {
-  constructor(initialValue: T) {
-    super(initialValue, MOTION_VALUE_TYPE);
-  }
-}
+const MotionValueType = defineMainThreadObjectType<
+  unknown,
+  MotionValue<unknown>
+>({
+  type: MOTION_VALUE_TYPE,
+  create: motionValue,
+  dispose: value => value.stop(),
+});
+const motionValueHandleInitialValues = new WeakMap<object, unknown>();
 
 /**
  * Create a Motion value that is retained on the main thread and can be used
@@ -24,8 +30,26 @@ class MotionValueHandle<T> extends MainThreadValue<T> {
  * @public
  */
 export function useMotionValue<T>(initialValue: T): MotionValue<T> {
-  return useMemo(() => {
-    MainThreadValue.register(MOTION_VALUE_TYPE, motionValue);
-    return new MotionValueHandle(initialValue) as unknown as MotionValue<T>;
-  }, []);
+  const value = useMainThreadObject(
+    MotionValueType,
+    initialValue,
+  ) as MotionValue<T>;
+  motionValueHandleInitialValues.set(value, initialValue);
+  return value;
+}
+
+/** @internal */
+export function isMotionValueHandle(
+  value: unknown,
+): value is MotionValue<unknown> {
+  return typeof value === 'object'
+    && value !== null
+    && motionValueHandleInitialValues.has(value);
+}
+
+/** @internal */
+export function getMotionValueHandleInitialValue(
+  value: MotionValue<unknown>,
+): unknown {
+  return motionValueHandleInitialValues.get(value);
 }

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -29,6 +29,7 @@ export type {
   MotionProps,
   MotionStyle,
   MotionStyleValue,
+  MotionTapInfo,
   MotionTarget,
   MotionTextProps,
   MotionTransition,

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -18,5 +18,18 @@ export {
 
 export { useMotionValueRef } from './hooks/useMotionValueRef.js';
 export { useMotionValue } from './hooks/useMotionValue.js';
+export { motion } from './declarative/motion.js';
 
 export type { MotionValue } from 'motion-dom';
+export type {
+  MotionComponentProps,
+  MotionFactory,
+  MotionImageProps,
+  MotionProps,
+  MotionStyle,
+  MotionStyleValue,
+  MotionTarget,
+  MotionTextProps,
+  MotionTransition,
+  MotionViewProps,
+} from './declarative/types.js';

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -23,6 +23,7 @@ export { motion } from './declarative/motion.js';
 export type { MotionValue } from 'motion-dom';
 export type {
   MotionComponentProps,
+  MotionDefinition,
   MotionFactory,
   MotionImageProps,
   MotionProps,
@@ -31,5 +32,6 @@ export type {
   MotionTarget,
   MotionTextProps,
   MotionTransition,
+  MotionVariants,
   MotionViewProps,
 } from './declarative/types.js';

--- a/packages/motion/src/polyfill/element.ts
+++ b/packages/motion/src/polyfill/element.ts
@@ -8,6 +8,10 @@ interface StyleObject {
   setProperty(property: string, value: string): void;
 }
 
+function toCssPropertyName(name: string): string {
+  return name.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+}
+
 export class ElementCompt {
   private element: MainThread.Element;
 
@@ -20,9 +24,12 @@ export class ElementCompt {
 
     return new Proxy(styleObject, {
       get: (_target, prop) => {
-        // @ts-expect-error Expected
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        return __GetComputedStyleByKey(this.element.element, prop as string);
+        const rawElement = (this.element as unknown as { element: never })
+          .element;
+        return __GetComputedStyleByKey(
+          rawElement,
+          toCssPropertyName(prop as string),
+        );
       },
     });
   }
@@ -34,7 +41,7 @@ export class ElementCompt {
       if (property === 'transform' && value === 'none') {
         return this.element.setStyleProperty('transform', 'scale(1, 1)');
       }
-      this.element.setStyleProperty(property, value);
+      this.element.setStyleProperty(toCssPropertyName(property), value);
     };
     return new Proxy(styleObject, {
       set: (target, prop, value) => {
@@ -43,7 +50,7 @@ export class ElementCompt {
             this.element.setStyleProperty('transform', 'scale(1, 1)');
             return true;
           }
-          this.element.setStyleProperty(prop, String(value));
+          this.element.setStyleProperty(toCssPropertyName(prop), String(value));
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           target[prop] = value;
         }
@@ -64,9 +71,11 @@ export class ElementCompt {
 
   // Individual style property getters and setters
   private getStyleProperty(name: string): string {
-    // @ts-expect-error Expected
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return __GetComputedStyleByKey(this.element.element, name);
+    const rawElement = (this.element as unknown as { element: never }).element;
+    return __GetComputedStyleByKey(
+      rawElement,
+      toCssPropertyName(name),
+    );
   }
 
   // Common style properties
@@ -74,7 +83,7 @@ export class ElementCompt {
     return this.getStyleProperty('backgroundColor');
   }
   set backgroundColor(value: string) {
-    this.element.setStyleProperty('backgroundColor', value);
+    this.element.setStyleProperty('background-color', value);
   }
 
   get color(): string {
@@ -88,7 +97,7 @@ export class ElementCompt {
     return this.getStyleProperty('fontSize');
   }
   set fontSize(value: string) {
-    this.element.setStyleProperty('fontSize', value);
+    this.element.setStyleProperty('font-size', value);
   }
 
   get width(): string {


### PR DESCRIPTION
## Summary

Implements the Motion portion of the MainThreadObject RFC.

- migrates `useMotionValue` from the legacy `MainThreadValue` subclass/registry path to a module-stable typed `MainThreadObjectType`
- preserves the public `MotionValue<T>` return type and runtime behavior
- removes React-internal marker/serialization duck typing from declarative styles; Motion now owns background-only initial-value metadata in a `WeakMap`
- lands the declarative Motion component surface used to validate MainThreadObject-backed style bindings, variants, tap/hover gestures, and animation lifecycle callbacks
- adds disposal through `MotionValue.stop()`

Part of #3446.
Implements #3448.
Stacked on #3453; please review this PR with base `agent/main-thread-object-core`.

## Migration

Before:

```ts
class MotionValueHandle<T> extends MainThreadValue<T> {}
MainThreadValue.register(TYPE, motionValue)
return new MotionValueHandle(initialValue)
```

After:

```ts
const MotionValueType = defineMainThreadObjectType({
  type: '@lynx-js/motion/MotionValue',
  create: motionValue,
  dispose: value => value.stop(),
})

return useMainThreadObject(MotionValueType, initialValue)
```

The old `MainThreadValue` subclass, manual registration, casts around its serialized shape, and `__MAIN_THREAD_VALUE__` marker checks are gone from Motion. Motion keeps only a private weak association from its own returned handle to the initial style value; this does not inspect ReactLynx internals or broaden handle access in the background runtime.

The upstream `motion-dom` factory and public `useMotionValue<T>(): MotionValue<T>` contract are unchanged.

## Review map

- `packages/motion/src/hooks/useMotionValue.ts`: typed object definition, hook migration, lifecycle disposal, Motion-owned metadata
- `packages/motion/src/declarative/style.ts`: initial style and binding collection without React handle duck typing
- `packages/motion/src/declarative/motion.tsx`: declarative binding integration
- `packages/motion/__tests__`: handle shape, main-thread realization identity/state, initial style, binding, gestures, variants, lifecycle
- `packages/motion/README.md` and `examples/motion`: public declarative API and examples

## Diff scope

Against `agent/main-thread-object-core`:

- 22 files
- 1,607 insertions
- 40 deletions

This includes the focused declarative Motion implementation plus the MainThreadObject migration commit. No ReactLynx Core files are modified in this stacked PR.

## Validation

Passed:

- `pnpm --filter @lynx-js/motion test` — 15 files, 117 tests
- focused declarative/hook runtime integration tests
- ReactLynx MainThreadObject runtime tests — 27 tests
- React transform suite — 80 passed, 10 repository-configured skips (including all 52 fixture tests)
- `pnpm --filter @lynx-js/motion build` — JS build, declaration generation, publint
- targeted ESLint
- full `pnpm dprint check`
- full `pnpm biome check`
- commit-time lint-staged ESLint/Biome/dprint checks
- `git diff --check`
- search confirms no legacy `MainThreadValue` or `__MAIN_THREAD_VALUE__` use remains in Motion/examples

Environment notes:

- the initial sandboxed transitive Turbo build reached 10/11 tasks and stopped in the unrelated `@lynx-js/rspeedy` publint temporary-tarball step; the directly relevant Motion build subsequently passed outside that sandbox
- a standalone `@lynx-js/reactlynx-testing-library` rebuild could not resolve its already-built workspace dependency `@lynx-js/testing-environment` in this worktree; the matching tested Core worktree artifact was used to bootstrap the test runner, after which the complete Motion suite passed

## Compatibility

- `useMotionValue` API and MotionValue behavior remain unchanged
- first-frame style resolution remains on the background side using Motion-owned metadata
- worklet hydration yields one real MotionValue per object ID and preserves that identity across handlers
- declarative binding is exercised through the public Motion component surface
