### PR TITLE
fix(motion): accept typed style MotionValues

### DIFF
--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -14,7 +14,8 @@ import type { CSSProperties, IntrinsicElements } from '@lynx-js/types';
 export type MotionStyleValue =
   | string
   | number
-  | MotionValue<string | number>
+  | MotionValue<string>
+  | MotionValue<number>
   | null
   | undefined;
 
@@ -23,7 +24,8 @@ export type MotionStyle =
   & {
     [Key in keyof CSSProperties]?:
       | CSSProperties[Key]
-      | MotionValue<string | number>;
+      | MotionValue<string>
+      | MotionValue<number>;
   }
   & {
     x?: MotionStyleValue;


### PR DESCRIPTION
## Summary

Allow the documented declarative `style={{ scale: useMotionValue(1) }}` pattern to type-check.

`MotionValue` is invariant, so `MotionValue<number>` and `MotionValue<string>` are not assignable to `MotionValue<string | number>`. The public `MotionStyle` types currently reject the exact handles returned by `useMotionValue(1)` even though runtime support and the README example already exist.

This changes only the public type union to accept `MotionValue<number>` and `MotionValue<string>` individually. There is no runtime change.

## Validation

- `pnpm --filter @lynx-js/motion test`: 119/119
- declaration generation succeeds and emits the corrected union
- the final package build reaches publint, then hits the repository environment's existing missing temporary packed-tarball failure; compilation and declarations complete before that unrelated step

Stacked on #3457.
