### PR TITLE
fix(motion): restore removed animate values

### DIFF
--- a/.changeset/motion-removed-animate-values.md
+++ b/.changeset/motion-removed-animate-values.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Restore static style values when their declarative animate targets are removed.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -219,6 +219,44 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('restores a static style when its animate value is removed', async () => {
+    function App() {
+      const [ownsOpacity, setOwnsOpacity] = useState(true);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            style={{ opacity: 0.35 }}
+            animate={ownsOpacity ? { opacity: 1 } : {}}
+            transition={{ type: false }}
+          />
+          <view
+            data-testid='toggle'
+            bindtap={() => setOwnsOpacity(false)}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'opacity: 0.35',
+    );
+  });
+
   test('skips the mount animation when initial is false', async () => {
     const onMountAnimationStart = vi.fn();
     const onMountAnimationComplete = vi.fn();

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -125,6 +125,7 @@ function useMotionHostProps<Props extends MotionProps>(
   const hoverActiveRef = useMainThreadRef(false);
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
+  const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
   >(null);
@@ -134,6 +135,7 @@ function useMotionHostProps<Props extends MotionProps>(
   >({});
   const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
   const hasMountedAnimationRef = useRef(false);
+  const hadAnimateTargetRef = useRef(false);
 
   const resolvedInitial = resolveMotionDefinition(initial, variants, custom);
   const resolvedAnimateDefinition = resolveMotionDefinition(
@@ -293,11 +295,17 @@ function useMotionHostProps<Props extends MotionProps>(
     : undefined;
 
   useEffect(() => {
+    const hadAnimateTarget = hadAnimateTargetRef.current;
+    hadAnimateTargetRef.current = Boolean(
+      resolvedAnimate.target
+        && Object.keys(resolvedAnimate.target).length > 0,
+    );
     if (
       !resolvedAnimate.target
       && !resolvedTap.target
       && !resolvedHover.target
       && Object.keys(motionValues).length === 0
+      && !hadAnimateTarget
     ) {
       return;
     }
@@ -340,7 +348,23 @@ function useMotionHostProps<Props extends MotionProps>(
         ? { ...options, repeat: Number.POSITIVE_INFINITY }
         : options) ?? {};
       const values = { ...motionValueBindings };
-      const targets = [target, interactionTarget, hoverTarget];
+      const targetValues = (target ?? {}) as Record<string, unknown>;
+      const animationTargetValues: Record<string, unknown> = {};
+      for (const key in animateTargetKeysRef.current) {
+        if (!(key in targetValues) && startingValues[key] !== undefined) {
+          animationTargetValues[key] = startingValues[key];
+        }
+      }
+      animateTargetKeysRef.current = {};
+      for (const key in targetValues) {
+        animateTargetKeysRef.current[key] = true;
+        animationTargetValues[key] = targetValues[key];
+      }
+      const targets = [
+        animationTargetValues,
+        interactionTarget,
+        hoverTarget,
+      ];
       for (const definition of targets) {
         if (!definition) {
           continue;
@@ -408,11 +432,10 @@ function useMotionHostProps<Props extends MotionProps>(
         styleCleanupRef.current = styleEffect(element, values);
       }
 
-      if (target && shouldAnimate) {
-        const targetValues = target as Record<string, unknown>;
-        for (const key in targetValues) {
+      if (shouldAnimate) {
+        for (const key in animationTargetValues) {
           const value = values[key];
-          const targetValue = targetValues[key];
+          const targetValue = animationTargetValues[key];
           if (value && targetValue !== undefined) {
             void value.start(
               createMotionValueAnimation(


### PR DESCRIPTION
## Summary

- track the previous base animate target keys on the main thread
- when a key disappears, animate its owned MotionValue back to the resolved static style/initial value
- keep interaction targets separate so tap/hover ownership is unchanged
- reuse upstream `animateMotionValue` for restoration

## Upstream contract

`packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx` — **when value is removed from animate, animate back to value read from DOM**.

The Lynx adapter already has the resolved static style value, so it restores that value without introducing DOM reads.

## Stack

Stacked on #3459.

## Validation

- package suite: 15 files / 121 tests passed
- local same-stack consumer: removed value + `transition.default` + tap + hover, 20/20
- evidence build: passed
- no native API boundary introduced

Consumer conformance metrics remain unchanged until an immutable preview is available.