### PR TITLE
feat(motion): support declarative transitionEnd

### DIFF
--- a/.changeset/motion-transition-end.md
+++ b/.changeset/motion-transition-end.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Support declarative `transitionEnd` values and apply the latest target after animation completion.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -247,7 +247,7 @@ describe('declarative Motion', () => {
             initial={{ x: 0 }}
             animate={{
               x: step * 20,
-              transition: { duration: 0.01 },
+              transition: { type: false },
               transitionEnd: { x: step * 100 },
             }}
           />

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -99,6 +99,24 @@ describe('declarative Motion', () => {
     expect(splitMotionTarget(definition, { duration: 1 })).toEqual({
       target: { opacity: 0.5, x: 80 },
       transition: { duration: 0.2 },
+      transitionEnd: undefined,
+    });
+  });
+
+  test('separates transitionEnd from animated values', () => {
+    expect(
+      splitMotionTarget(
+        {
+          x: 20,
+          transition: { duration: 0.2 },
+          transitionEnd: { x: 100 },
+        },
+        undefined,
+      ),
+    ).toEqual({
+      target: { x: 20 },
+      transition: { duration: 0.2 },
+      transitionEnd: { x: 100 },
     });
   });
 
@@ -216,6 +234,45 @@ describe('declarative Motion', () => {
     });
     expect(getByTestId('box').getAttribute('style')).toContain(
       'translateX(40px)',
+    );
+  });
+
+  test('applies the latest transitionEnd after animation', async () => {
+    function App() {
+      const [step, setStep] = useState(0);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ x: 0 }}
+            animate={{
+              x: step * 20,
+              transition: { duration: 0.01 },
+              transitionEnd: { x: step * 100 },
+            }}
+          />
+          <view
+            data-testid='toggle'
+            bindtap={() => {
+              setStep(1);
+              setStep(2);
+            }}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateX(200px)',
     );
   });
 

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -321,6 +321,7 @@ function useMotionHostProps<Props extends MotionProps>(
       target: MotionTarget | undefined,
       interactionTarget: MotionTarget | undefined,
       hoverTarget: MotionTarget | undefined,
+      transitionEnd: Record<string, unknown> | undefined,
       options: MotionTransition | undefined,
       startingValues: Record<string, unknown>,
       shouldAnimate: boolean,
@@ -420,6 +421,7 @@ function useMotionHostProps<Props extends MotionProps>(
         }
       }
 
+      let motionElement: Element | undefined;
       if (Object.keys(values).length > 0) {
         // `mainThreadDependencies` installs ElementCompt as the main-thread
         // Element constructor. Construct it here instead of capturing another
@@ -428,8 +430,8 @@ function useMotionHostProps<Props extends MotionProps>(
         const ElementConstructor = globalThis.Element as unknown as new(
           element: MainThread.Element,
         ) => Element;
-        const element = new ElementConstructor(elementRef.current);
-        styleCleanupRef.current = styleEffect(element, values);
+        motionElement = new ElementConstructor(elementRef.current);
+        styleCleanupRef.current = styleEffect(motionElement, values);
       }
 
       if (shouldAnimate) {
@@ -458,10 +460,27 @@ function useMotionHostProps<Props extends MotionProps>(
           void runOnBackground(onAnimationStart)(animate);
         }
         void Promise.all(activeAnimations).then(() => {
-          if (
-            animationGenerationRef.current === animationGeneration
-            && onAnimationComplete
-          ) {
+          if (animationGenerationRef.current !== animationGeneration) {
+            return;
+          }
+          let addedValue = false;
+          for (const key in transitionEnd) {
+            const finalValue = transitionEnd[key];
+            let value = values[key];
+            if (!value && finalValue !== undefined) {
+              value = motionValue(finalValue as string | number);
+              generatedValuesRef.current[key] = value;
+              values[key] = value;
+              addedValue = true;
+            } else if (value && finalValue !== undefined) {
+              value.set(finalValue as never);
+            }
+          }
+          if (addedValue && motionElement) {
+            styleCleanupRef.current?.();
+            styleCleanupRef.current = styleEffect(motionElement, values);
+          }
+          if (onAnimationComplete) {
             void runOnBackground(onAnimationComplete)(animate);
           }
         });
@@ -472,6 +491,7 @@ function useMotionHostProps<Props extends MotionProps>(
       resolvedAnimate.target,
       resolvedTap.target,
       resolvedHover.target,
+      resolvedAnimate.transitionEnd,
       workletAnimateTransition,
       initialValues,
       shouldAnimateTarget,

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -434,19 +434,20 @@ function useMotionHostProps<Props extends MotionProps>(
         styleCleanupRef.current = styleEffect(motionElement, values);
       }
 
+      const completionPromises: Promise<void>[] = [];
       if (shouldAnimate) {
         for (const key in animationTargetValues) {
           const value = values[key];
           const targetValue = animationTargetValues[key];
           if (value && targetValue !== undefined) {
-            void value.start(
+            completionPromises.push(value.start(
               createMotionValueAnimation(
                 key,
                 value,
                 targetValue as never,
                 resolvedOptions as never,
               ),
-            );
+            ));
             if (value.animation) {
               animationRef.current.push(value.animation);
             }
@@ -455,11 +456,13 @@ function useMotionHostProps<Props extends MotionProps>(
       }
 
       const activeAnimations = [...animationRef.current];
-      if (activeAnimations.length > 0 && animate !== undefined) {
-        if (onAnimationStart) {
-          void runOnBackground(onAnimationStart)(animate);
-        }
-        void Promise.all(activeAnimations).then(() => {
+      if (
+        activeAnimations.length > 0 && animate !== undefined && onAnimationStart
+      ) {
+        void runOnBackground(onAnimationStart)(animate);
+      }
+      if (completionPromises.length > 0 && animate !== undefined) {
+        void Promise.all(completionPromises).then(() => {
           if (animationGenerationRef.current !== animationGeneration) {
             return;
           }

--- a/packages/motion/src/declarative/style.ts
+++ b/packages/motion/src/declarative/style.ts
@@ -229,13 +229,19 @@ export function splitMotionTarget(
 ): {
   target: MotionTarget | undefined;
   transition: MotionTransition | undefined;
+  transitionEnd: Record<string, unknown> | undefined;
 } {
   if (!definition) {
-    return { target: undefined, transition: fallbackTransition };
+    return {
+      target: undefined,
+      transition: fallbackTransition,
+      transitionEnd: undefined,
+    };
   }
-  const { transition, ...target } = definition;
+  const { transition, transitionEnd, ...target } = definition;
   return {
     target: target as MotionTarget,
     transition: transition ?? fallbackTransition,
+    transitionEnd,
   };
 }

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -6,6 +6,7 @@ import type {
   AnimationOptions,
   DOMKeyframesDefinition,
   MotionValue,
+  ResolvedValues,
 } from 'motion-dom';
 
 import type { ComponentType, FunctionComponent } from '@lynx-js/react';
@@ -46,6 +47,7 @@ export type MotionTransition = AnimationOptions;
 /** Animatable style target for a declarative Motion component. */
 export type MotionTarget = DOMKeyframesDefinition & {
   transition?: MotionTransition;
+  transitionEnd?: ResolvedValues;
 };
 
 /** A named declarative target or a list of targets merged left-to-right. */


### PR DESCRIPTION
## Summary
- expose upstream-compatible `transitionEnd` on declarative Motion targets
- keep `transitionEnd` out of animated key/value routing
- apply the latest completion values through existing MotionValues/styleEffect after the active animation generation completes
- prevent superseded animations from applying stale completion values

## Upstream contract
`packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx` — `uses transitionEnd on subsequent renders`

## Evidence
- immutable bd151a1 baseline: Web settles at transitionEnd 100/200; Lynx stops at animate target 20 (3/3 reproduced)
- package suite: 15 files / 123 tests passed
- local stacked consumer: transitionEnd + tap + hover stress 15/15
- local consumer evidence build passed
- package JS and declarations generated; known final publint pack hook still fails because its temp tarball is missing after pack exits 0

This is stacked on #3460. Consumer metrics remain unchanged until an immutable preview package is available.