### PR TITLE
fix(motion): suppress completion after unmount

### DIFF
--- a/.changeset/motion-unmount-cancellation.md
+++ b/.changeset/motion-unmount-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Suppress stale declarative animation completion callbacks after a component unmounts.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -276,6 +276,39 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('does not complete an animation after unmount', async () => {
+    const onAnimationComplete = vi.fn();
+    function App() {
+      const [visible, setVisible] = useState(true);
+      return (
+        <view>
+          {visible
+            ? (
+              <motion.view
+                data-testid='box'
+                initial={{ x: 0 }}
+                animate={{ x: 40 }}
+                transition={{ duration: 0.08 }}
+                onAnimationComplete={onAnimationComplete}
+              />
+            )
+            : null}
+          <view data-testid='toggle' bindtap={() => setVisible(false)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 120));
+    });
+    expect(onAnimationComplete).not.toHaveBeenCalled();
+  });
+
   test('restores a static style when its animate value is removed', async () => {
     function App() {
       const [ownsOpacity, setOwnsOpacity] = useState(true);

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -41,6 +41,7 @@ import {
 } from './style.js';
 import type {
   MotionComponentProps,
+  MotionDefinition,
   MotionFactory,
   MotionImageProps,
   MotionProps,
@@ -136,6 +137,7 @@ function useMotionHostProps<Props extends MotionProps>(
   const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
   const hasMountedAnimationRef = useRef(false);
   const hadAnimateTargetRef = useRef(false);
+  const backgroundAnimationGenerationRef = useRef(0);
 
   const resolvedInitial = resolveMotionDefinition(initial, variants, custom);
   const resolvedAnimateDefinition = resolveMotionDefinition(
@@ -295,6 +297,9 @@ function useMotionHostProps<Props extends MotionProps>(
     : undefined;
 
   useEffect(() => {
+    const backgroundAnimationGeneration =
+      backgroundAnimationGenerationRef.current + 1;
+    backgroundAnimationGenerationRef.current = backgroundAnimationGeneration;
     const hadAnimateTarget = hadAnimateTargetRef.current;
     hadAnimateTargetRef.current = Boolean(
       resolvedAnimate.target
@@ -316,6 +321,18 @@ function useMotionHostProps<Props extends MotionProps>(
     const shouldAnimateTarget = resolvedInitialTarget !== false
       || hasMountedAnimationRef.current;
     hasMountedAnimationRef.current = true;
+
+    function completeAnimationOnBackground(
+      expectedGeneration: number,
+      definition: MotionDefinition,
+    ) {
+      if (
+        backgroundAnimationGenerationRef.current === expectedGeneration
+        && onAnimationComplete
+      ) {
+        onAnimationComplete(definition);
+      }
+    }
 
     function updateMotionStyles(
       target: MotionTarget | undefined,
@@ -484,7 +501,10 @@ function useMotionHostProps<Props extends MotionProps>(
             styleCleanupRef.current = styleEffect(motionElement, values);
           }
           if (onAnimationComplete) {
-            void runOnBackground(onAnimationComplete)(animate);
+            void runOnBackground(completeAnimationOnBackground)(
+              backgroundAnimationGeneration,
+              animate,
+            );
           }
         });
       }
@@ -516,6 +536,7 @@ function useMotionHostProps<Props extends MotionProps>(
     }
 
     return () => {
+      backgroundAnimationGenerationRef.current += 1;
       void runOnMainThread(stopMotionStyles)();
     };
     // Serialized targets and value IDs avoid restarting unchanged inline


### PR DESCRIPTION
## Summary

- suppress declarative `onAnimationComplete` callbacks after the component unmounts or its animation effect is replaced
- invalidate background-thread completion with an effect generation before scheduling main-thread cleanup
- add a dual-thread regression test for active-animation unmount

## Root cause

Animation completion originates on the main thread and is forwarded back to the background thread. Unmount cleanup also crosses the thread boundary, so a completed main-thread promise could enqueue a stale callback after ReactLynx had already removed the component.

## Validation

- upstream `animate-prop.test.tsx` contract reproduced in the consumer harness: baseline Lynx completed after unmount in 3/3 runs while Web suppressed completion
- `pnpm --filter @lynx-js/motion test`: 15 files, 124 tests passed
- focused lint, Biome, dprint, and diff checks passed
- local Web/Lynx consumer hypothesis plus hover regression: 10/10 across 5 repeats
- consumer evidence build passed

Native device verification was attempted because this crosses lifecycle/thread boundaries, but the available Sandbox Explorer runtime fails to register handlers before application code with `ReferenceError: queueMicrotask is not defined`. That environment mismatch is recorded as a native-evidence blocker, not as a Motion pass or platform-conformance blocker.

Consumer metrics remain unchanged until an immutable preview package is available.
