### PR TITLE
test(motion): cover discrete visibility exits

### DIFF
--- a/.changeset/motion-discrete-display-test.md
+++ b/.changeset/motion-discrete-display-test.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Preserve discrete display visibility until declarative exit animations complete.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -231,6 +231,44 @@ describe('declarative Motion', () => {
     expect(getByTestId('box').getAttribute('style')).toContain('display: none');
   });
 
+  test('switches visibility to hidden only after an opacity exit completes', async () => {
+    function App() {
+      const [hidden, setHidden] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ visibility: 'visible', opacity: 1 }}
+            animate={hidden
+              ? { visibility: 'hidden', opacity: 0 }
+              : { visibility: 'visible', opacity: 1 }}
+            transition={{ duration: 0.08, ease: 'linear' }}
+          />
+          <view data-testid='toggle' bindtap={() => setHidden(true)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'visibility: visible',
+    );
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'visibility: hidden',
+    );
+  });
+
   test('routes value-specific transitions by animated property', async () => {
     function App() {
       const [active, setActive] = useState(false);

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -195,6 +195,42 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('switches display to none only after an opacity exit completes', async () => {
+    function App() {
+      const [hidden, setHidden] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ display: 'block', opacity: 1 }}
+            animate={hidden
+              ? { display: 'none', opacity: 0 }
+              : { display: 'block', opacity: 1 }}
+            transition={{ duration: 0.08, ease: 'linear' }}
+          />
+          <view data-testid='toggle' bindtap={() => setHidden(true)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'display: block',
+    );
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('display: none');
+  });
+
   test('routes value-specific transitions by animated property', async () => {
     function App() {
       const [active, setActive] = useState(false);


### PR DESCRIPTION
## Summary

- lock upstream discrete `display` and `visibility` exit contracts into the declarative Motion package suite
- verify each property remains active during an opacity exit and switches to its terminal hidden value only when the animation completes

## Why this is test-only

Both behaviors are already fixed by the property-aware MotionValue animation path introduced in stacked PR #3459. Passing the property name into upstream `motion-dom` selects its existing discrete visibility mixer, so no Lynx-specific animation engine is needed.

The immutable `bd151a1` package still uses the older property-agnostic path: both consumer reproductions fail 5/5 by hiding immediately. The current stack passes both cases.

## Validation

- `pnpm --filter @lynx-js/motion test`: 15 files, 126 tests passed
- local current-stack Web/Lynx visibility case plus hover regression: 10/10 across 5 repeats
- local current-stack Web/Lynx display case plus hover regression: 10/10 across 5 repeats
- consumer evidence builds passed
- no native run: these are CSS value-mixing contracts with no gesture, layout, measurement, lifecycle, or platform thread boundary

Consumer metrics remain unchanged until an immutable preview for the stack verifies these exact package paths.
