### PR TITLE
fix(motion): support CSS custom properties

### DIFF
--- a/.changeset/motion-css-custom-properties.md
+++ b/.changeset/motion-css-custom-properties.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Preserve the `CSSStyleDeclaration.setProperty` contract so declarative Motion can animate CSS custom properties.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -9,6 +9,7 @@ import type { IntrinsicElements } from '@lynx-js/types';
 import { act, fireEvent, render } from '@lynx-js/react/testing-library';
 
 import { motion, useMotionValue } from '../src/index.js';
+import type { MotionStyle, MotionTarget } from '../src/declarative/types.js';
 import { ElementCompt } from '../src/polyfill/element.js';
 import {
   collectMotionValues,
@@ -57,6 +58,15 @@ describe('declarative Motion', () => {
       width: '100px',
       opacity: 1,
       transform: 'translateX(24px)',
+    });
+  });
+
+  test('preserves typed CSS custom properties in initial styles', () => {
+    const style: MotionStyle = { '--motion-color': '#fff' };
+    const target: MotionTarget = { '--motion-color': '#000' };
+
+    expect(resolveInitialStyle(style, target)).toEqual({
+      '--motion-color': '#000',
     });
   });
 

--- a/packages/motion/__tests__/element.test.tsx
+++ b/packages/motion/__tests__/element.test.tsx
@@ -84,6 +84,17 @@ describe('ElementCompt (unit tests)', () => {
     );
   });
 
+  test('style proxy setProperty preserves CSS custom property names', () => {
+    const compt = new ElementCompt(mockElement);
+
+    compt.style.setProperty('--motion-color', '#000');
+
+    expect(mockSetStyleProperty).toHaveBeenCalledWith(
+      '--motion-color',
+      '#000',
+    );
+  });
+
   test('style proxy set with transform=none should use scale(1,1)', () => {
     const compt = new ElementCompt(mockElement);
 

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -28,6 +28,7 @@ export type MotionStyle =
       | MotionValue<string>
       | MotionValue<number>;
   }
+  & Partial<Record<`--${string}`, MotionStyleValue>>
   & {
     x?: MotionStyleValue;
     y?: MotionStyleValue;

--- a/packages/motion/src/polyfill/element.ts
+++ b/packages/motion/src/polyfill/element.ts
@@ -57,6 +57,8 @@ export class ElementCompt {
         return true;
       },
       get: (_target, prop) => {
+        // motion-dom writes CSS custom properties through this Web API rather
+        // than assigning them as named properties on CSSStyleDeclaration.
         if (prop === 'setProperty') {
           return (property: string, value: string) => {
             styleObject.setProperty(property, value);

--- a/packages/motion/src/polyfill/element.ts
+++ b/packages/motion/src/polyfill/element.ts
@@ -57,6 +57,11 @@ export class ElementCompt {
         return true;
       },
       get: (_target, prop) => {
+        if (prop === 'setProperty') {
+          return (property: string, value: string) => {
+            styleObject.setProperty(property, value);
+          };
+        }
         if (typeof prop === 'string' && prop !== 'setProperty') {
           return this.getStyleProperty(prop);
         }


### PR DESCRIPTION
## Summary

- preserve `CSSStyleDeclaration.setProperty` on the Lynx element style proxy
- let upstream `motion-dom` animate CSS custom properties without an adapter-side animation path
- accept typed ``--${string}`` keys in declarative `MotionStyle`, matching upstream target types
- add direct runtime and type-contract regressions

## Stack

Temporarily targets `main` only to run the full stack HEAD through CI and pkg.pr.new. After immutable preview validation it will return to #3465 (`agent/motion-discrete-display-exit`) as its review base.

## Validation

- focused `ElementCompt` suite: 22/22 passed
- explicit ESLint: passed
- isolated CSS custom-property typecheck: passed
- consumer baseline: Web reaches `#000`; old Lynx package stays at `#fff` in 5/5 runs
- immutable preview validation pending for `9aff526bec`

## Upstream contract

`motion-dom` routes keys beginning with `--` through `element.style.setProperty(name, value)`. This patch restores that Web API contract in `ElementCompt`; it does not add a second animation engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added declarative Motion components with animated styles, variants, transitions, gestures, lifecycle callbacks, and MotionValue bindings.
  - Added `motion`, `motion.view`, and `useMotionValue` exports.
  - Added typed main-thread object APIs for stable, validated object handles and lifecycle management.
  - Added a selectable declarative Motion example.

- **Bug Fixes**
  - Improved CSS property handling, visibility during exit animations, animation cleanup, transition completion, and restoration of removed animation targets.

- **Documentation**
  - Expanded Motion usage guidance, supported features, limitations, and main-thread behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->