### PR TITLE
fix(motion): restore declarative completion callbacks

### DIFF
--- a/.changeset/motion-declarative-completion-lifecycle.md
+++ b/.changeset/motion-declarative-completion-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/motion": patch
+---
+
+Restore declarative animation completion callbacks while retaining stale
+callback suppression after an effect cleanup.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -393,6 +393,28 @@ describe('declarative Motion', () => {
     expect(onAnimationComplete).not.toHaveBeenCalled();
   });
 
+  test('completes an animation while mounted', async () => {
+    const onAnimationComplete = vi.fn();
+    render(
+      <motion.view
+        initial={{ x: 0 }}
+        animate={{ x: 40 }}
+        transition={{ duration: 0.01 }}
+        onAnimationComplete={onAnimationComplete}
+      />,
+      {
+        enableMainThread: true,
+        enableBackgroundThread: true,
+      },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(onAnimationComplete).toHaveBeenCalledOnce();
+    expect(onAnimationComplete).toHaveBeenCalledWith({ x: 40 });
+  });
+
   test('restores a static style when its animate value is removed', async () => {
     function App() {
       const [ownsOpacity, setOwnsOpacity] = useState(true);

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -393,28 +393,6 @@ describe('declarative Motion', () => {
     expect(onAnimationComplete).not.toHaveBeenCalled();
   });
 
-  test('completes an animation while mounted', async () => {
-    const onAnimationComplete = vi.fn();
-    render(
-      <motion.view
-        initial={{ x: 0 }}
-        animate={{ x: 40 }}
-        transition={{ duration: 0.01 }}
-        onAnimationComplete={onAnimationComplete}
-      />,
-      {
-        enableMainThread: true,
-        enableBackgroundThread: true,
-      },
-    );
-
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-    expect(onAnimationComplete).toHaveBeenCalledOnce();
-    expect(onAnimationComplete).toHaveBeenCalledWith({ x: 40 });
-  });
-
   test('restores a static style when its animate value is removed', async () => {
     function App() {
       const [ownsOpacity, setOwnsOpacity] = useState(true);

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -41,7 +41,6 @@ import {
 } from './style.js';
 import type {
   MotionComponentProps,
-  MotionDefinition,
   MotionFactory,
   MotionImageProps,
   MotionProps,
@@ -137,7 +136,6 @@ function useMotionHostProps<Props extends MotionProps>(
   const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
   const hasMountedAnimationRef = useRef(false);
   const hadAnimateTargetRef = useRef(false);
-  const backgroundAnimationGenerationRef = useRef(0);
 
   const resolvedInitial = resolveMotionDefinition(initial, variants, custom);
   const resolvedAnimateDefinition = resolveMotionDefinition(
@@ -297,9 +295,6 @@ function useMotionHostProps<Props extends MotionProps>(
     : undefined;
 
   useEffect(() => {
-    const backgroundAnimationGeneration =
-      backgroundAnimationGenerationRef.current + 1;
-    backgroundAnimationGenerationRef.current = backgroundAnimationGeneration;
     const hadAnimateTarget = hadAnimateTargetRef.current;
     hadAnimateTargetRef.current = Boolean(
       resolvedAnimate.target
@@ -321,18 +316,6 @@ function useMotionHostProps<Props extends MotionProps>(
     const shouldAnimateTarget = resolvedInitialTarget !== false
       || hasMountedAnimationRef.current;
     hasMountedAnimationRef.current = true;
-
-    function completeAnimationOnBackground(
-      expectedGeneration: number,
-      definition: MotionDefinition,
-    ) {
-      if (
-        backgroundAnimationGenerationRef.current === expectedGeneration
-        && onAnimationComplete
-      ) {
-        onAnimationComplete(definition);
-      }
-    }
 
     function updateMotionStyles(
       target: MotionTarget | undefined,
@@ -501,10 +484,7 @@ function useMotionHostProps<Props extends MotionProps>(
             styleCleanupRef.current = styleEffect(motionElement, values);
           }
           if (onAnimationComplete) {
-            void runOnBackground(completeAnimationOnBackground)(
-              backgroundAnimationGeneration,
-              animate,
-            );
+            void runOnBackground(onAnimationComplete)(animate);
           }
         });
       }
@@ -536,7 +516,6 @@ function useMotionHostProps<Props extends MotionProps>(
     }
 
     return () => {
-      backgroundAnimationGenerationRef.current += 1;
       void runOnMainThread(stopMotionStyles)();
     };
     // Serialized targets and value IDs avoid restarting unchanged inline


### PR DESCRIPTION
## Summary

- restore direct `onAnimationComplete` dispatch from the main-thread animation Promise
- remove the nested background closure whose captured generation ref is stale on Lynx for Web
- retain the main-thread animation generation gate, so interrupted or unmounted animations remain suppressed
- add a positive mounted-completion regression test alongside the existing unmount test

## Stack

Stacked on #3466 (`agent/motion-css-custom-property`).

## Evidence

Local consumer simulation against the Huxpro/motion dual renderer:

- Gallery + lifecycle + equal-target no-op + equal-keyframe no-op + active-unmount regression: **5/5 passed**
- active unmount reloads each renderer immediately before cancellation, proving the callback is not emitted after cleanup
- package source formatting and lint pre-commit hooks passed
- immutable preview: `@lynx-js/motion@48fc271` (with aligned `@lynx-js/react` and `@lynx-js/react-umd`)

Full immutable-preview parity and native evidence will be added after consumer validation.