### PR TITLE
feat(genui): configure model providers by name

### DIFF
--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -26,6 +26,8 @@ When serving the playground's native Lynx bundles as static Android test fixture
 
 ## Chat Page Architecture
 
+Load Create-tab model choices from the GenUI server's `GET /models` endpoint. Keep provider credentials, upstream model ids, and upstream base URLs out of playground state, persistence, controls, and request bodies; persist only the selected server-approved model name.
+
 Route all protocol Create tabs through `pages/chat/ChatPage.tsx`. Keep all shared React state, effects, conversation operations, provider controls, usage and preview metrics, streaming transport, examples, actions, and rendering in `pages/chat/ChatController.tsx`. Keep the shared conversation list, header, transcript/composer slots, resizable preview, delete confirmation, copy toast, and mobile tabs in `pages/chat/ChatWorkspace.tsx`, with styles in `pages/chat/ChatPage.css`.
 
 Keep `pages/chat/a2ui.ts`, `pages/chat/openui.ts`, and `pages/chat/mcp-apps.ts` as hook-free, JSX-free protocol adapters. They may define protocol request bodies, stream reducers, history conversion, persistence payloads, artifacts, examples, preview sources, and action conversion, but must not duplicate the controller's React state or host-side effects.

--- a/.github/genui-server.instructions.md
+++ b/.github/genui-server.instructions.md
@@ -10,7 +10,7 @@ Keep shared agent-service contracts and helpers in `service/common`. `ChatMessag
 
 Keep public provider integrations vendor-neutral. Do not commit deployment-only gateway rewrites, private hostnames, environment-specific authentication conventions, or credentials; inject those only through the deployment environment.
 
-Configure GenUI providers only through `GENUI_MODEL_CONFIG_JSON` as an object keyed by public model name. Give every value its own upstream `model`, credentials, base URL, and optional API style, reasoning effort, and default marker. Keep `GET /models` limited to those public names and the default name; never expose upstream model ids, credentials, or base URLs. Resolve an ordinary client model selection through its configured name before creating the provider.
+Configure GenUI providers only through `GENUI_MODEL_CONFIG_JSON` as an object keyed by public model name. Give every value its own upstream `model`, credentials, base URL, and optional API style, reasoning effort, and default marker. Keep public responses, including `GET /models` and health endpoints, limited to public model names and readiness metadata; never expose upstream model ids, credentials, base URLs, or API styles. Redact those private configuration values from upstream errors before logging or returning them to clients. Resolve an ordinary client model selection through its configured name before creating the provider.
 
 Use `app/common/sse.ts` for standard SSE frames and response headers. Pass event IDs or additional headers through its options instead of cloning the SSE framing and header literals in individual functions.
 

--- a/.github/genui-server.instructions.md
+++ b/.github/genui-server.instructions.md
@@ -10,6 +10,8 @@ Keep shared agent-service contracts and helpers in `service/common`. `ChatMessag
 
 Keep public provider integrations vendor-neutral. Do not commit deployment-only gateway rewrites, private hostnames, environment-specific authentication conventions, or credentials; inject those only through the deployment environment.
 
+Configure GenUI providers only through `GENUI_MODEL_CONFIG_JSON` as an object keyed by public model name. Give every value its own upstream `model`, credentials, base URL, and optional API style, reasoning effort, and default marker. Keep `GET /models` limited to those public names and the default name; never expose upstream model ids, credentials, or base URLs. Resolve an ordinary client model selection through its configured name before creating the provider.
+
 Use `app/common/sse.ts` for standard SSE frames and response headers. Pass event IDs or additional headers through its options instead of cloning the SSE framing and header literals in individual functions.
 
 Build `genui-server` as an executable ESM Hono server through `rslib.config.ts`. Each protocol `route.ts` default-exports a Hono sub-application, `src/app.ts` composes the route tree and common HTTP fallbacks, and `src/index.ts` starts `@hono/node-server` and owns graceful process shutdown. Do not export endpoint request functions or add a custom router or Node/FaaS transport adapter. Keep business handlers based on standard Web `Request` and `Response` internally.

--- a/packages/genui/playground/README.md
+++ b/packages/genui/playground/README.md
@@ -18,11 +18,13 @@ pnpm install
 ```
 
 The **Create** (chat) tab talks to the GenUI server for agent responses and
-preview publishing. Start it on port `3060` with at least an OpenAI key:
+preview publishing. Start it on port `3060` with one server-owned model
+configuration:
 
 ```bash
 # 2. Start the GenUI server → http://localhost:3060
-OPENAI_API_KEY=sk-... pnpm -C packages/genui/server dev
+GENUI_MODEL_CONFIG_JSON='{"GPT-5.4":{"model":"gpt-5.4","apiKey":"sk-...","baseURL":"https://api.openai.com/v1","api":"responses","default":true}}' \
+  pnpm -C packages/genui/server dev
 ```
 
 Then start the playground and open the URL it prints (defaults to
@@ -45,13 +47,15 @@ append the endpoint override to the playground URL:
 
 | Variable                                                                     | Purpose                                            | Default             |
 | ---------------------------------------------------------------------------- | -------------------------------------------------- | ------------------- |
-| `OPENAI_API_KEY`                                                             | Agent model access (required for the Create tab)   | —                   |
-| `OPENAI_MODEL`                                                               | Model id                                           | `gpt-4o-mini`       |
-| `OPENAI_BASE_URL`                                                            | Custom OpenAI-compatible endpoint                  | OpenAI              |
+| `GENUI_MODEL_CONFIG_JSON`                                                    | Map of model names to provider configurations      | —                   |
 | `UI_JUDGE_SERVER_URL`                                                        | Rust UI Judge sidecar for Bench scoring            | disabled            |
 | `UI_JUDGE_BUNDLE_URL`                                                        | `a2ui.lynx.js` bundle rendered by UI Judge         | hosted GenUI bundle |
 | `SUPABASE_URL`, `SUPABASE_S3_ACCESS_KEY_ID`, `SUPABASE_S3_SECRET_ACCESS_KEY` | Short, shareable preview URLs via Supabase Storage | in-memory dev store |
 | `PEXELS_API_KEY`                                                             | Stock-image search in generated UIs                | —                   |
+
+The Create tab loads its model selector from the server's `GET /models`
+endpoint. Provider credentials, upstream model ids, and upstream API URLs
+remain server-only.
 
 Bench probes `UI_JUDGE_SERVER_URL/health` once per job and reports Judge as
 enabled only when that sidecar is ready. See

--- a/packages/genui/playground/src/pages/BenchPage.tsx
+++ b/packages/genui/playground/src/pages/BenchPage.tsx
@@ -365,9 +365,7 @@ interface BenchHealth {
   ok: boolean;
   provider?: string;
   hasKey?: boolean;
-  baseURL?: string;
-  model?: string;
-  api?: 'chat' | 'responses';
+  modelName?: string;
 }
 
 type BenchHealthError =
@@ -4619,7 +4617,7 @@ export function BenchPage({
                         <div>
                           <span>Model</span>
                           <strong>
-                            {benchHealth?.model
+                            {benchHealth?.modelName
                               ?? benchText(
                                 locale,
                                 '服务端默认',

--- a/packages/genui/playground/src/pages/chat/ChatController.tsx
+++ b/packages/genui/playground/src/pages/chat/ChatController.tsx
@@ -681,6 +681,21 @@ export function ChatController<
   useEffect(() => () => abortOperations(), [abortOperations]);
 
   useEffect(() => {
+    const loadSettings = adapter.settings?.load;
+    if (!loadSettings) return;
+    const controller = new AbortController();
+    void loadSettings(settingsRef.current, host, controller.signal).then(
+      (next) => {
+        if (!controller.signal.aborted) setSettings(next);
+      },
+      () => {
+        // Abort-driven rejections are expected when the protocol changes.
+      },
+    );
+    return () => controller.abort();
+  }, [adapter.settings, host]);
+
+  useEffect(() => {
     const settingsAdapter = adapter.settings;
     if (!settingsAdapter) return;
     try {
@@ -1588,7 +1603,7 @@ export function ChatController<
                       type={control.kind}
                       placeholder={control.placeholder}
                       value={control.value}
-                      disabled={busy}
+                      disabled={busy || control.disabled}
                       onChange={(event) =>
                         updateSetting(control.id, event.target.value)}
                     />
@@ -1604,7 +1619,7 @@ export function ChatController<
                     className='chatProviderSelect'
                     aria-label={control.label}
                     value={control.value}
-                    disabled={busy}
+                    disabled={busy || control.disabled}
                     onChange={(event) =>
                       updateSetting(control.id, event.target.value)}
                   >

--- a/packages/genui/playground/src/pages/chat/a2ui.ts
+++ b/packages/genui/playground/src/pages/chat/a2ui.ts
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 import {
   CHAT_PROVIDER_SETTINGS_ADAPTER,
-  filterProviderRequestOptionsForEndpoint,
   getA2UIActionEndpoint,
   getChatEndpoint,
   parseTokenUsage,
@@ -477,11 +476,7 @@ export const A2UI_CHAT_ADAPTER = {
   settings: CHAT_PROVIDER_SETTINGS_ADAPTER,
   createRequest({ prompt, conversation, settings, host }) {
     const url = getChatEndpoint('a2ui', host);
-    const provider = filterProviderRequestOptionsForEndpoint(
-      toProviderRequestOptions(settings),
-      url,
-      host,
-    );
+    const provider = toProviderRequestOptions(settings);
     return {
       url,
       method: 'POST',
@@ -641,11 +636,7 @@ export const A2UI_CHAT_ADAPTER = {
     request({ action, conversation, settings, host }) {
       const chatEndpoint = getChatEndpoint('a2ui', host);
       const url = getA2UIActionEndpoint(chatEndpoint);
-      const provider = filterProviderRequestOptionsForEndpoint(
-        toProviderRequestOptions(settings),
-        url,
-        host,
-      );
+      const provider = toProviderRequestOptions(settings);
       return {
         url,
         method: 'POST',

--- a/packages/genui/playground/src/pages/chat/adapters.test.ts
+++ b/packages/genui/playground/src/pages/chat/adapters.test.ts
@@ -10,6 +10,14 @@ import {
   WEATHER_RESOURCE_URI,
 } from './mcp-apps.js';
 import { OPENUI_CHAT_ADAPTER } from './openui.js';
+import {
+  compactProviderLabel,
+  createDefaultProviderSettings,
+  getModelsEndpoint,
+  loadProviderSettings,
+  parseStoredProviderSettings,
+  toProviderRequestOptions,
+} from './shared.js';
 import { PRODUCT_API_NAME } from '../../../lynx-src/mcp-apps/product/api.js';
 import { WEATHER_API_NAME } from '../../../lynx-src/mcp-apps/weather/api.js';
 import { PROTOCOLS } from '../../utils/protocol.js';
@@ -22,6 +30,74 @@ const reduceOpenUIStream = OPENUI_CHAT_ADAPTER.stream.reduce.bind(
 );
 
 describe('chat protocol adapters', () => {
+  test('starts with an unloaded server-backed model list', () => {
+    const settings = createDefaultProviderSettings();
+    expect(settings).toEqual({
+      model: '',
+      models: [],
+      status: 'idle',
+    });
+    expect(compactProviderLabel(settings)).toBe('Loading models');
+    expect(toProviderRequestOptions(settings)).toEqual({});
+
+    expect(parseStoredProviderSettings(JSON.stringify({
+      preset: 'gpt-5.5',
+      baseURL: 'https://api.openai.com/v1',
+      model: 'gpt-5.5',
+    }))).toEqual(settings);
+  });
+
+  test('loads the model list and default model from the server', async () => {
+    const host = {
+      origin: 'http://localhost:3000',
+      hostname: 'localhost',
+      protocol: 'http:',
+      search: '',
+      baseUrl: 'http://localhost:3000/',
+    };
+    const fetchModels = rs.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        defaultModel: 'Doubao Seed',
+        models: [
+          { id: 'Doubao Seed', label: 'Doubao Seed' },
+          { id: 'Doubao Pro', label: 'Doubao Pro' },
+        ],
+      }),
+    }));
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { fetch: fetchModels },
+    });
+
+    try {
+      const settings = await loadProviderSettings(
+        createDefaultProviderSettings(),
+        host,
+        new AbortController().signal,
+      );
+      expect(getModelsEndpoint(host)).toBe('http://localhost:3060/models');
+      expect(settings).toEqual({
+        model: 'Doubao Seed',
+        models: [
+          { id: 'Doubao Seed', label: 'Doubao Seed' },
+          { id: 'Doubao Pro', label: 'Doubao Pro' },
+        ],
+        status: 'ready',
+      });
+      expect(compactProviderLabel(settings)).toBe('Doubao Seed');
+      expect(toProviderRequestOptions(settings)).toEqual({
+        model: 'Doubao Seed',
+      });
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
+  });
+
   test('reduces an A2UI stream without duplicating incremental messages', () => {
     let state = A2UI_CHAT_ADAPTER.stream.initial();
 
@@ -291,10 +367,9 @@ describe('chat protocol adapters', () => {
         prompt: 'Weather in Hangzhou',
         conversation: { history: [], dataModel: {} },
         settings: {
-          preset: 'gpt-5.5',
-          apiKey: '',
-          baseURL: 'https://api.openai.com/v1',
           model: 'gpt-5.5',
+          models: [{ id: 'gpt-5.5', label: 'gpt5.5' }],
+          status: 'ready',
         },
         host,
         signal,

--- a/packages/genui/playground/src/pages/chat/adapters.test.ts
+++ b/packages/genui/playground/src/pages/chat/adapters.test.ts
@@ -98,6 +98,85 @@ describe('chat protocol adapters', () => {
     }
   });
 
+  test('surfaces a model-list HTTP error without retaining models', async () => {
+    const host = {
+      origin: 'http://localhost:3000',
+      hostname: 'localhost',
+      protocol: 'http:',
+      search: '',
+      baseUrl: 'http://localhost:3000/',
+    };
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        fetch: rs.fn(async () => ({
+          ok: false,
+          json: async () => ({ error: 'Model service unavailable' }),
+        })),
+      },
+    });
+
+    try {
+      await expect(loadProviderSettings(
+        createDefaultProviderSettings(),
+        host,
+        new AbortController().signal,
+      )).resolves.toEqual({
+        model: '',
+        models: [],
+        status: 'error',
+        error: 'Model service unavailable',
+      });
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
+  });
+
+  test('rejects an invalid model-list response without retaining models', async () => {
+    const host = {
+      origin: 'http://localhost:3000',
+      hostname: 'localhost',
+      protocol: 'http:',
+      search: '',
+      baseUrl: 'http://localhost:3000/',
+    };
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        fetch: rs.fn(async () => ({
+          ok: true,
+          json: async () => ({
+            defaultModel: 'Missing',
+            models: [{ id: 'Doubao Seed', label: 'Doubao Seed' }],
+          }),
+        })),
+      },
+    });
+
+    try {
+      await expect(loadProviderSettings(
+        createDefaultProviderSettings(),
+        host,
+        new AbortController().signal,
+      )).resolves.toEqual({
+        model: '',
+        models: [],
+        status: 'error',
+        error: 'The model list response is invalid',
+      });
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
+  });
+
   test('reduces an A2UI stream without duplicating incremental messages', () => {
     let state = A2UI_CHAT_ADAPTER.stream.initial();
 

--- a/packages/genui/playground/src/pages/chat/adapters.test.ts
+++ b/packages/genui/playground/src/pages/chat/adapters.test.ts
@@ -77,7 +77,10 @@ describe('chat protocol adapters', () => {
         host,
         new AbortController().signal,
       );
-      expect(getModelsEndpoint(host)).toBe('http://localhost:3060/models');
+      const modelsEndpoint = getModelsEndpoint(host);
+      expect(modelsEndpoint).toBe('http://localhost:3060/models');
+      expect(fetchModels).toHaveBeenCalledTimes(1);
+      expect(fetchModels.mock.calls[0]?.[0]).toBe(modelsEndpoint);
       expect(settings).toEqual({
         model: 'Doubao Seed',
         models: [
@@ -461,6 +464,7 @@ describe('chat protocol adapters', () => {
       expect(chatRequest).toMatchObject({
         url: 'https://genui-server.vercel.app/mcp-apps/stream',
         body: {
+          model: 'gpt-5.5',
           registry: {
             protocolVersion: '2025-11-25',
             appProtocolVersion: '2026-01-26',

--- a/packages/genui/playground/src/pages/chat/mcp-apps.ts
+++ b/packages/genui/playground/src/pages/chat/mcp-apps.ts
@@ -23,7 +23,6 @@ import type {
 
 import {
   CHAT_PROVIDER_SETTINGS_ADAPTER,
-  filterProviderRequestOptionsForEndpoint,
   getChatEndpoint,
   parseTokenUsage,
   toProviderRequestOptions,
@@ -570,11 +569,7 @@ export const MCP_APPS_CHAT_ADAPTER = {
   async createRequest({ prompt, conversation, settings, host, signal }) {
     const url = getChatEndpoint('mcp-apps', host);
     const registration = await fetchRegistration(url, signal);
-    const provider = filterProviderRequestOptionsForEndpoint(
-      toProviderRequestOptions(settings),
-      url,
-      host,
-    );
+    const provider = toProviderRequestOptions(settings);
     return {
       url,
       method: 'POST',

--- a/packages/genui/playground/src/pages/chat/openui.ts
+++ b/packages/genui/playground/src/pages/chat/openui.ts
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 import {
   CHAT_PROVIDER_SETTINGS_ADAPTER,
-  filterProviderRequestOptionsForEndpoint,
   getChatEndpoint,
   parseTokenUsage,
   toProviderRequestOptions,
@@ -212,11 +211,7 @@ function createOpenUIRequest(
   host: ChatHost,
 ): ChatHttpRequest {
   const endpoint = getChatEndpoint('openui', host);
-  const providerOptions = filterProviderRequestOptionsForEndpoint(
-    toProviderRequestOptions(settings),
-    endpoint,
-    host,
-  );
+  const providerOptions = toProviderRequestOptions(settings);
   return {
     url: endpoint,
     method: 'POST' as const,

--- a/packages/genui/playground/src/pages/chat/shared.ts
+++ b/packages/genui/playground/src/pages/chat/shared.ts
@@ -18,38 +18,30 @@ export const CHAT_PROVIDER_SETTINGS_STORAGE_KEY =
 export const LEGACY_A2UI_PROVIDER_SETTINGS_STORAGE_KEY =
   'a2ui-playground-provider-settings';
 
-export const PROVIDER_PRESETS = [
-  { id: 'gpt-5.4', label: 'gpt5.4', model: 'gpt-5.4' },
-  { id: 'gpt-5.5', label: 'gpt5.5', model: 'gpt-5.5' },
-  { id: 'custom', label: 'Custom API key', model: '' },
-] as const;
-
-export type ProviderPresetId = (typeof PROVIDER_PRESETS)[number]['id'];
+export interface ProviderModel {
+  id: string;
+  label: string;
+}
 
 export interface ProviderSettings {
-  preset: ProviderPresetId;
-  apiKey: string;
-  baseURL: string;
   model: string;
+  models: readonly ProviderModel[];
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  error?: string;
 }
 
 export interface ProviderRequestOptions {
-  apiKey?: string;
-  baseURL?: string;
   model?: string;
 }
 
 export interface PersistedProviderSettings {
-  baseURL: string;
   model: string;
-  preset?: ProviderPresetId;
 }
 
 const DEFAULT_PROVIDER_SETTINGS: Readonly<ProviderSettings> = {
-  preset: 'gpt-5.5',
-  apiKey: '',
-  baseURL: 'https://api.openai.com/v1',
-  model: 'gpt-5.5',
+  model: '',
+  models: [],
+  status: 'idle',
 };
 
 export const EMPTY_CHAT_TOKEN_USAGE: Readonly<ChatTokenUsage> = {
@@ -59,13 +51,7 @@ export const EMPTY_CHAT_TOKEN_USAGE: Readonly<ChatTokenUsage> = {
 };
 
 export function createDefaultProviderSettings(): ProviderSettings {
-  return { ...DEFAULT_PROVIDER_SETTINGS };
-}
-
-export function isProviderPresetId(
-  value: unknown,
-): value is ProviderPresetId {
-  return PROVIDER_PRESETS.some((item) => item.id === value);
+  return { ...DEFAULT_PROVIDER_SETTINGS, models: [] };
 }
 
 export function parseProviderSettings(value: unknown): ProviderSettings {
@@ -73,18 +59,15 @@ export function parseProviderSettings(value: unknown): ProviderSettings {
     return createDefaultProviderSettings();
   }
 
-  const record = value as Partial<Record<keyof ProviderSettings, unknown>>;
+  const record = value as Record<string, unknown>;
+  const isLegacyDefault = record.preset === 'gpt-5.5'
+    && record.baseURL === 'https://api.openai.com/v1'
+    && record.model === 'gpt-5.5';
   return {
-    preset: isProviderPresetId(record.preset)
-      ? record.preset
-      : DEFAULT_PROVIDER_SETTINGS.preset,
-    apiKey: '',
-    baseURL: typeof record.baseURL === 'string'
-      ? record.baseURL
-      : DEFAULT_PROVIDER_SETTINGS.baseURL,
-    model: typeof record.model === 'string'
+    ...createDefaultProviderSettings(),
+    model: !isLegacyDefault && typeof record.model === 'string'
       ? record.model
-      : DEFAULT_PROVIDER_SETTINGS.model,
+      : '',
   };
 }
 
@@ -104,38 +87,94 @@ export function parseStoredProviderSettings(
 export function serializeProviderSettings(
   settings: ProviderSettings,
 ): PersistedProviderSettings {
-  return {
-    baseURL: settings.baseURL,
-    model: settings.model,
-    preset: settings.preset,
-  };
+  return { model: settings.model };
 }
 
 export function compactProviderLabel(settings: ProviderSettings): string {
-  if (settings.preset === 'custom') {
-    const customModel = settings.model.trim();
-    return customModel.length > 0 ? customModel : 'Custom model';
-  }
-  const preset = PROVIDER_PRESETS.find((item) => item.id === settings.preset);
-  return preset?.model ?? 'Server default';
+  return settings.models.find((item) => item.id === settings.model)?.label
+    ?? (settings.status === 'error' ? 'Models unavailable' : 'Loading models');
 }
 
 export function toProviderRequestOptions(
   settings: ProviderSettings,
 ): ProviderRequestOptions {
-  if (settings.preset !== 'custom') {
-    const preset = PROVIDER_PRESETS.find((item) => item.id === settings.preset);
-    return preset?.model ? { model: preset.model } : {};
-  }
-
-  const apiKey = settings.apiKey.trim();
-  const baseURL = settings.baseURL.trim();
   const model = settings.model.trim();
-  return {
-    ...(apiKey ? { apiKey } : {}),
-    ...(baseURL ? { baseURL } : {}),
-    ...(model ? { model } : {}),
-  };
+  return model ? { model } : {};
+}
+
+function parseModelsResponse(value: unknown): {
+  defaultModel: string;
+  models: ProviderModel[];
+} {
+  if (!value || typeof value !== 'object') {
+    throw new Error('The model list response is invalid');
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.defaultModel !== 'string' || !Array.isArray(record.models)
+  ) {
+    throw new Error('The model list response is invalid');
+  }
+  const models = record.models.flatMap((item): ProviderModel[] => {
+    if (!item || typeof item !== 'object') return [];
+    const model = item as Record<string, unknown>;
+    return typeof model.id === 'string' && typeof model.label === 'string'
+      ? [{ id: model.id, label: model.label }]
+      : [];
+  });
+  if (
+    models.length !== record.models.length
+    || !models.some((item) => item.id === record.defaultModel)
+  ) {
+    throw new Error('The model list response is invalid');
+  }
+  return { defaultModel: record.defaultModel, models };
+}
+
+export function getModelsEndpoint(host: ChatHost): string {
+  const endpoint = new URL(getChatEndpoint('a2ui', host));
+  endpoint.pathname = '/models';
+  endpoint.search = '';
+  endpoint.hash = '';
+  return endpoint.toString();
+}
+
+export async function loadProviderSettings(
+  settings: ProviderSettings,
+  host: ChatHost,
+  signal: AbortSignal,
+): Promise<ProviderSettings> {
+  try {
+    const response = await window.fetch(getModelsEndpoint(host), {
+      headers: { Accept: 'application/json' },
+      signal,
+    });
+    const payload: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = payload && typeof payload === 'object'
+        ? (payload as Record<string, unknown>).error
+        : undefined;
+      throw new Error(
+        typeof error === 'string' ? error : 'Failed to load model list',
+      );
+    }
+    const { defaultModel, models } = parseModelsResponse(payload);
+    return {
+      model: models.some((item) => item.id === settings.model)
+        ? settings.model
+        : defaultModel,
+      models,
+      status: 'ready',
+    };
+  } catch (error) {
+    if (signal.aborted) throw error;
+    return {
+      ...settings,
+      models: [],
+      status: 'error',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 export const CHAT_PROVIDER_SETTINGS_ADAPTER = {
@@ -146,51 +185,32 @@ export const CHAT_PROVIDER_SETTINGS_ADAPTER = {
   initial: createDefaultProviderSettings,
   parseStored: parseStoredProviderSettings,
   serialize: serializeProviderSettings,
+  load: loadProviderSettings,
   controls(settings) {
-    const controls = [
-      {
-        id: 'preset',
-        label: 'Provider preset',
-        value: settings.preset,
-        kind: 'select' as const,
-        options: PROVIDER_PRESETS.map((preset) => ({
-          value: preset.id,
-          label: preset.label,
-        })),
-      },
-    ];
-    if (settings.preset !== 'custom') return controls;
     return [
-      ...controls,
-      {
-        id: 'baseURL',
-        label: 'Provider base URL',
-        value: settings.baseURL,
-        kind: 'text' as const,
-        placeholder: 'Base URL',
-      },
       {
         id: 'model',
-        label: 'Provider model',
+        label: 'Model',
         value: settings.model,
-        kind: 'text' as const,
-        placeholder: 'Model',
-      },
-      {
-        id: 'apiKey',
-        label: 'Provider API key',
-        value: settings.apiKey,
-        kind: 'password' as const,
-        placeholder: 'API key for local endpoint',
+        kind: 'select' as const,
+        disabled: settings.status !== 'ready',
+        options: settings.models.length > 0
+          ? settings.models.map((model) => ({
+            value: model.id,
+            label: model.label,
+          }))
+          : [{
+            value: '',
+            label: settings.status === 'error'
+              ? (settings.error ?? 'Models unavailable')
+              : 'Loading models...',
+          }],
       },
     ];
   },
   update(settings, id, next) {
-    if (id === 'preset' && isProviderPresetId(next)) {
-      return { ...settings, preset: next };
-    }
-    if (id === 'apiKey' || id === 'baseURL' || id === 'model') {
-      return { ...settings, [id]: next };
+    if (id === 'model' && settings.models.some((item) => item.id === next)) {
+      return { ...settings, model: next };
     }
     return settings;
   },
@@ -335,30 +355,6 @@ export function getChatEndpoint(
 
 export function getA2UIActionEndpoint(chatEndpoint: string): string {
   return chatEndpoint.replace(/\/a2ui\/stream$/u, '/a2ui/action/stream');
-}
-
-export function canForwardApiKeyToEndpoint(
-  raw: string,
-  host: Pick<ChatHost, 'origin'>,
-): boolean {
-  try {
-    const endpoint = new URL(raw, host.origin);
-    return endpoint.protocol === 'http:'
-      && endpoint.port === LOCAL_GENUI_SERVER_PORT
-      && isDevHost(endpoint.hostname);
-  } catch {
-    return false;
-  }
-}
-
-export function filterProviderRequestOptionsForEndpoint(
-  options: ProviderRequestOptions,
-  endpoint: string,
-  host: Pick<ChatHost, 'origin'>,
-): ProviderRequestOptions {
-  if (canForwardApiKeyToEndpoint(endpoint, host)) return options;
-  const { apiKey: _apiKey, ...safeOptions } = options;
-  return safeOptions;
 }
 
 export function targetOriginForUrl(

--- a/packages/genui/playground/src/pages/chat/type.ts
+++ b/packages/genui/playground/src/pages/chat/type.ts
@@ -123,6 +123,7 @@ export interface ChatSettingControl {
   label: string;
   value: string;
   kind: 'select' | 'text' | 'password';
+  disabled?: boolean;
   placeholder?: string;
   options?: readonly ChatSettingOption[];
 }
@@ -132,6 +133,11 @@ export interface ChatSettingsAdapter<TSettings> {
   initial: () => TSettings;
   parseStored: (raw: unknown) => TSettings;
   serialize: (value: TSettings) => unknown;
+  load?: (
+    value: TSettings,
+    host: ChatHost,
+    signal: AbortSignal,
+  ) => Promise<TSettings>;
   controls: (value: TSettings) => readonly ChatSettingControl[];
   update: (value: TSettings, id: string, next: string) => TSettings;
   badge: (value: TSettings) => string;

--- a/packages/genui/server/AGENTS.md
+++ b/packages/genui/server/AGENTS.md
@@ -18,20 +18,32 @@ For multi-instance deployments, place a shared rate limiter (e.g. an API
 gateway or Redis-backed limiter) in front of this server when global rate
 limits are required.
 
-## Required Environment Variables
+## Required Model Configuration
 
-Before starting this server, explicitly provide these three environment
-variables:
+Before starting this server, provide the provider credentials, endpoint, and
+model list through one JSON environment variable:
 
 ```bash
-export OPENAI_API_KEY="..."
-export OPENAI_BASE_URL="..."
-export OPENAI_MODEL="..."
+export GENUI_MODEL_CONFIG_JSON='{
+  "GPT-5.4": {
+    "model": "gpt-5.4",
+    "apiKey": "...",
+    "baseURL": "https://api.openai.com/v1",
+    "api": "responses",
+    "default": true
+  }
+}'
 ```
 
-- `OPENAI_API_KEY` is required by the OpenAI provider.
-- `OPENAI_BASE_URL` selects the OpenAI-compatible API endpoint.
-- `OPENAI_MODEL` selects the model used by the A2UI agent.
+- Each top-level key is the public model name returned to the playground.
+- Each value requires `model`, `apiKey`, and `baseURL`, so models may use
+  independent upstream ids, credentials, and endpoints.
+- `api` is optional and accepts `chat` or `responses`.
+- `default: true` is optional. When omitted, the first entry is the default.
+- `reasoningEffort` is optional per model.
+
+`GET /models` exposes only the top-level names and default selection. It must
+never expose `model`, `apiKey`, or `baseURL` to the playground.
 
 Image components are resolved after A2UI validation. To enable query-matched
 stock images, provide a Pexels API key:

--- a/packages/genui/server/agent/openai-provider.ts
+++ b/packages/genui/server/agent/openai-provider.ts
@@ -6,6 +6,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import type { AgentConfig } from '@mastra/core/agent';
 
 import { isOfficialOpenAIBaseURL } from './openai-utils';
+import { resolveModelConfig } from '../service/common/model-config.js';
 import type { ChatMessage } from '../service/common/types';
 
 export interface OpenAIProviderOptions {
@@ -14,8 +15,6 @@ export interface OpenAIProviderOptions {
   model?: string | undefined;
   api?: 'chat' | 'responses' | undefined;
 }
-
-const DEFAULT_MODEL = 'gpt-4o-mini';
 
 interface LLMProvider {
   provider: ReturnType<typeof createOpenAI>;
@@ -33,13 +32,6 @@ type CompatChatMessage =
 
 interface CompatRequestBody {
   messages?: CompatChatMessage[];
-}
-
-interface OpenAIEnv {
-  OPENAI_API_KEY?: string | undefined;
-  OPENAI_API_STYLE?: 'chat' | 'responses' | undefined;
-  OPENAI_BASE_URL?: string | undefined;
-  OPENAI_MODEL?: string | undefined;
 }
 
 function createCompatFetch(): typeof fetch {
@@ -71,20 +63,16 @@ function createCompatFetch(): typeof fetch {
 export function createLLMProvider(
   opts: OpenAIProviderOptions = {},
 ): LLMProvider {
-  const env = process.env as OpenAIEnv;
-  const apiKey = opts.apiKey ?? env.OPENAI_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      'OpenAI credentials not provided: set OPENAI_API_KEY env var or pass apiKey',
-    );
-  }
-  const baseURL = opts.baseURL ?? env.OPENAI_BASE_URL
-    ?? 'https://api.openai.com/v1';
-  const model = opts.model ?? env.OPENAI_MODEL ?? DEFAULT_MODEL;
+  const resolved = resolveModelConfig(opts.model);
+  const apiKey = opts.apiKey ?? resolved.config.apiKey;
+  const baseURL = opts.baseURL ?? resolved.config.baseURL;
+  const model = opts.model && opts.model !== resolved.name
+    ? opts.model
+    : resolved.config.model;
 
   const isOfficial = isOfficialOpenAIBaseURL(baseURL);
   const api = opts.api
-    ?? env.OPENAI_API_STYLE
+    ?? resolved.config.api
     ?? (isOfficial ? 'responses' : 'chat');
 
   const providerSettings = {

--- a/packages/genui/server/app/a2ui/action/stream/route.ts
+++ b/packages/genui/server/app/a2ui/action/stream/route.ts
@@ -20,6 +20,10 @@ import {
   resolveStaticA2UIImageComponent,
 } from '../../../../agent/image-resolver';
 import { getA2UIAgentService } from '../../../../service/a2ui-agent';
+import {
+  configuredApiStyle,
+  defaultModelName,
+} from '../../../../service/common/model-config.js';
 import type {
   ChatMessage,
   OpenAIReasoningEffort,
@@ -346,8 +350,8 @@ async function postA2UIActionStream(req: Request) {
             finishReason,
             hasUsage: usage !== undefined,
             catalogId: catalog.id,
-            model: opts.model ?? process.env.OPENAI_MODEL ?? 'default',
-            api: opts.api ?? process.env.OPENAI_API_STYLE ?? 'default',
+            model: opts.model ?? defaultModelName() ?? 'default',
+            api: opts.api ?? configuredApiStyle(opts.model) ?? 'default',
             ...usageMetrics,
           });
           let repair:
@@ -494,8 +498,8 @@ async function postA2UIActionStream(req: Request) {
             repairAttempted: repair?.attempted ?? false,
             repairOk: repair?.ok,
             catalogId: catalog.id,
-            model: opts.model ?? process.env.OPENAI_MODEL ?? 'default',
-            api: opts.api ?? process.env.OPENAI_API_STYLE ?? 'default',
+            model: opts.model ?? defaultModelName() ?? 'default',
+            api: opts.api ?? configuredApiStyle(opts.model) ?? 'default',
             ...usageMetrics,
             requestId,
           });

--- a/packages/genui/server/app/a2ui/health/route.ts
+++ b/packages/genui/server/app/a2ui/health/route.ts
@@ -5,27 +5,37 @@
 import { Hono } from 'hono';
 
 import { isOfficialOpenAIBaseURL } from '../../../agent/openai-utils';
+import { readModelConfig } from '../../../service/common/model-config.js';
 import { jsonWithCors } from '../../common/cors';
 
 function getA2UIHealth(req: Request) {
+  const result = readModelConfig();
+  if (!result.ok) {
+    return jsonWithCors(req, {
+      ok: false,
+      provider: 'openai',
+      hasKey: false,
+      error: result.error,
+    });
+  }
+
+  const { defaultModel, models } = result.config;
   const {
-    OPENAI_API_KEY,
-    OPENAI_API_STYLE,
-    OPENAI_BASE_URL,
-    OPENAI_MODEL,
-  } = process.env;
-  const hasKey = !!OPENAI_API_KEY;
-  const baseURL = OPENAI_BASE_URL ?? 'https://api.openai.com/v1';
+    apiKey,
+    api: configuredApi,
+    baseURL,
+    model,
+  } = models[defaultModel]!;
   const isOfficial = isOfficialOpenAIBaseURL(baseURL);
-  const api = (OPENAI_API_STYLE as 'chat' | 'responses' | undefined)
-    ?? (isOfficial ? 'responses' : 'chat');
+  const api = configuredApi ?? (isOfficial ? 'responses' : 'chat');
 
   return jsonWithCors(req, {
-    ok: hasKey,
+    ok: true,
     provider: 'openai',
-    hasKey,
+    hasKey: Boolean(apiKey),
     baseURL,
-    model: OPENAI_MODEL ?? 'gpt-4o-mini',
+    modelName: defaultModel,
+    model,
     api,
   });
 }

--- a/packages/genui/server/app/a2ui/health/route.ts
+++ b/packages/genui/server/app/a2ui/health/route.ts
@@ -4,7 +4,6 @@
 
 import { Hono } from 'hono';
 
-import { isOfficialOpenAIBaseURL } from '../../../agent/openai-utils';
 import { readModelConfig } from '../../../service/common/model-config.js';
 import { jsonWithCors } from '../../common/cors';
 
@@ -20,23 +19,13 @@ function getA2UIHealth(req: Request) {
   }
 
   const { defaultModel, models } = result.config;
-  const {
-    apiKey,
-    api: configuredApi,
-    baseURL,
-    model,
-  } = models[defaultModel]!;
-  const isOfficial = isOfficialOpenAIBaseURL(baseURL);
-  const api = configuredApi ?? (isOfficial ? 'responses' : 'chat');
+  const { apiKey } = models[defaultModel]!;
 
   return jsonWithCors(req, {
     ok: true,
     provider: 'openai',
     hasKey: Boolean(apiKey),
-    baseURL,
     modelName: defaultModel,
-    model,
-    api,
   });
 }
 

--- a/packages/genui/server/app/a2ui/stream/route.ts
+++ b/packages/genui/server/app/a2ui/stream/route.ts
@@ -20,6 +20,10 @@ import {
 } from '../../../agent/image-resolver';
 import { getA2UIAgentService } from '../../../service/a2ui-agent';
 import {
+  configuredApiStyle,
+  defaultModelName,
+} from '../../../service/common/model-config.js';
+import {
   validateConversation,
   validateMessages,
 } from '../../common/chat-validation';
@@ -282,8 +286,8 @@ async function postA2UIStream(req: Request) {
             finishReason,
             hasUsage: usage !== undefined,
             catalogId: catalog.id,
-            model: opts.model ?? process.env.OPENAI_MODEL ?? 'default',
-            api: opts.api ?? process.env.OPENAI_API_STYLE ?? 'default',
+            model: opts.model ?? defaultModelName() ?? 'default',
+            api: opts.api ?? configuredApiStyle(opts.model) ?? 'default',
             ...usageMetrics,
           });
           let repair:
@@ -419,8 +423,8 @@ async function postA2UIStream(req: Request) {
             repairAttempted: repair?.attempted ?? false,
             repairOk: repair?.ok,
             catalogId: catalog.id,
-            model: opts.model ?? process.env.OPENAI_MODEL ?? 'default',
-            api: opts.api ?? process.env.OPENAI_API_STYLE ?? 'default',
+            model: opts.model ?? defaultModelName() ?? 'default',
+            api: opts.api ?? configuredApiStyle(opts.model) ?? 'default',
             ...usageMetrics,
             requestId,
           });

--- a/packages/genui/server/app/common/errors.ts
+++ b/packages/genui/server/app/common/errors.ts
@@ -2,9 +2,16 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { redactModelConfigSecrets } from '../../service/common/model-config.js';
+
 export function errorMessage(
   err: unknown,
 ): { message: string; name?: string } {
-  if (err instanceof Error) return { message: err.message, name: err.name };
-  return { message: String(err) };
+  if (err instanceof Error) {
+    return {
+      message: redactModelConfigSecrets(err.message),
+      name: redactModelConfigSecrets(err.name),
+    };
+  }
+  return { message: redactModelConfigSecrets(String(err)) };
 }

--- a/packages/genui/server/app/common/provider-options.ts
+++ b/packages/genui/server/app/common/provider-options.ts
@@ -6,6 +6,7 @@ import type {
   ChatOptions,
   OpenAIReasoningEffort,
 } from '../../service/common/types';
+import { configuredModelName } from '../../service/common/model-config.js';
 
 export interface ProviderOptionsBody {
   resourceId?: string;
@@ -24,7 +25,7 @@ export function pickProviderOptions(body: ProviderOptionsBody): ChatOptions {
   const allowOverride = clientOverridesAllowed();
   return {
     resourceId: body.resourceId,
-    model: allowOverride ? body.model : undefined,
+    model: allowOverride ? body.model : configuredModelName(body.model),
     apiKey: allowOverride ? body.apiKey : undefined,
     baseURL: allowOverride ? body.baseURL : undefined,
     api: allowOverride ? body.api : undefined,

--- a/packages/genui/server/app/common/provider-options.ts
+++ b/packages/genui/server/app/common/provider-options.ts
@@ -2,11 +2,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { configuredModelName } from '../../service/common/model-config.js';
 import type {
   ChatOptions,
   OpenAIReasoningEffort,
 } from '../../service/common/types';
-import { configuredModelName } from '../../service/common/model-config.js';
 
 export interface ProviderOptionsBody {
   resourceId?: string;

--- a/packages/genui/server/app/models/route.ts
+++ b/packages/genui/server/app/models/route.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Hono } from 'hono';
+
+import { readModelConfig } from '../../service/common/model-config.js';
+import { jsonWithCors } from '../common/cors.js';
+
+function getModels(req: Request) {
+  const result = readModelConfig();
+  if (!result.ok) {
+    return jsonWithCors(
+      req,
+      { ok: false, error: result.error },
+      { status: 503 },
+    );
+  }
+
+  return jsonWithCors(req, {
+    defaultModel: result.config.defaultModel,
+    models: Object.keys(result.config.models).map((name) => ({
+      id: name,
+      label: name,
+    })),
+  });
+}
+
+const route = new Hono();
+
+route.get('/', (context) => getModels(context.req.raw));
+
+export default route;

--- a/packages/genui/server/service/a2ui-bench-redaction.ts
+++ b/packages/genui/server/service/a2ui-bench-redaction.ts
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import type { BenchProviderConfig } from './a2ui-bench-types';
+import { redactModelConfigSecrets } from './common/model-config.js';
 
 const PRIVATE_FIELD_NAMES = new Set([
   'apikey',
@@ -40,7 +41,7 @@ export function redactBenchText(
   ) {
     redacted = redacted.replaceAll(secret, '[REDACTED]');
   }
-  return redacted
+  return redactModelConfigSecrets(redacted)
     .replace(/\bBearer\s+[^\s,;"']+/giu, 'Bearer [REDACTED]')
     .replace(
       /([?&](?:access_token|api[_-]?key|key|token)=)[^&#\s"'<>]*/giu,

--- a/packages/genui/server/service/a2ui-bench-runner.ts
+++ b/packages/genui/server/service/a2ui-bench-runner.ts
@@ -26,6 +26,7 @@ import type {
   BenchScenarioRequest,
 } from './a2ui-bench-types';
 import type { ChatMessage } from './common/types';
+import { defaultModelName } from './common/model-config.js';
 import { createA2UIBenchAdapter } from './genui-bench/a2ui-adapter';
 import type {
   ProtocolBenchAdapter,
@@ -375,7 +376,7 @@ async function runA2UINativeOne(
       repeatIndex: item.repeatIndex,
       status: runOk ? 'complete' : 'failed',
       ok: runOk,
-      model: model ?? process.env.OPENAI_MODEL ?? 'server default',
+      model: model ?? defaultModelName() ?? 'server default',
       catalog: catalogLabel,
       tokens: result.usage.reduce<number>(
         (total, usage) => total + parseTotalTokens(usage),
@@ -442,7 +443,7 @@ async function runA2UINativeOne(
       repeatIndex: item.repeatIndex,
       status: 'failed',
       ok: false,
-      model: model ?? process.env.OPENAI_MODEL ?? 'server default',
+      model: model ?? defaultModelName() ?? 'server default',
       catalog: catalogLabel,
       tokens: 0,
       agentMs: Math.round(agentMs),
@@ -590,7 +591,7 @@ async function runProtocolAdapterOne(
       repeatIndex: item.repeatIndex,
       status: runOk ? 'complete' : 'failed',
       ok: runOk,
-      model: model ?? process.env.OPENAI_MODEL ?? 'server default',
+      model: model ?? defaultModelName() ?? 'server default',
       catalog: catalogLabel,
       tokens,
       agentMs: Math.round(agentMs),
@@ -662,7 +663,7 @@ async function runProtocolAdapterOne(
       repeatIndex: item.repeatIndex,
       status: 'failed',
       ok: false,
-      model: model ?? process.env.OPENAI_MODEL ?? 'server default',
+      model: model ?? defaultModelName() ?? 'server default',
       catalog: catalogLabel,
       tokens: 0,
       agentMs: Math.round(agentMs),
@@ -871,7 +872,7 @@ function buildReport(
     settings: request.settings,
     env: {
       model: request.provider.model
-        ?? process.env.OPENAI_MODEL
+        ?? defaultModelName()
         ?? 'server default',
     },
     capabilities: {

--- a/packages/genui/server/service/a2ui-bench-runner.ts
+++ b/packages/genui/server/service/a2ui-bench-runner.ts
@@ -25,8 +25,8 @@ import type {
   BenchRunResult,
   BenchScenarioRequest,
 } from './a2ui-bench-types';
-import type { ChatMessage } from './common/types';
 import { defaultModelName } from './common/model-config.js';
+import type { ChatMessage } from './common/types';
 import { createA2UIBenchAdapter } from './genui-bench/a2ui-adapter';
 import type {
   ProtocolBenchAdapter,

--- a/packages/genui/server/service/common/model-config.ts
+++ b/packages/genui/server/service/common/model-config.ts
@@ -1,0 +1,209 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { OpenAIReasoningEffort } from './types.js';
+
+export const GENUI_MODEL_CONFIG_ENV = 'GENUI_MODEL_CONFIG_JSON';
+
+const REASONING_EFFORTS = new Set<OpenAIReasoningEffort>([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+]);
+
+export interface ConfiguredModel {
+  apiKey: string;
+  baseURL: string;
+  model: string;
+  api?: 'chat' | 'responses';
+  default?: true;
+  reasoningEffort?: OpenAIReasoningEffort;
+}
+
+export interface GenUIModelConfig {
+  defaultModel: string;
+  models: Record<string, ConfiguredModel>;
+}
+
+export interface ResolvedModelConfig {
+  name: string;
+  config: ConfiguredModel;
+}
+
+type ModelConfigResult =
+  | { ok: true; config: GenUIModelConfig }
+  | { ok: false; error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requiredString(
+  record: Record<string, unknown>,
+  key: string,
+): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function parseConfiguredModel(
+  name: string,
+  value: unknown,
+): ConfiguredModel {
+  if (!isRecord(value)) {
+    throw new Error(`model ${JSON.stringify(name)} must be an object`);
+  }
+
+  const apiKey = requiredString(value, 'apiKey');
+  const baseURL = requiredString(value, 'baseURL');
+  const model = requiredString(value, 'model');
+  let parsedBaseURL: URL;
+  try {
+    parsedBaseURL = new URL(baseURL);
+  } catch {
+    throw new Error(
+      `model ${JSON.stringify(name)} baseURL must be a valid URL`,
+    );
+  }
+  if (
+    parsedBaseURL.protocol !== 'http:' && parsedBaseURL.protocol !== 'https:'
+  ) {
+    throw new Error(
+      `model ${JSON.stringify(name)} baseURL must use http or https`,
+    );
+  }
+
+  const api = value.api;
+  if (api !== undefined && api !== 'chat' && api !== 'responses') {
+    throw new Error(
+      `model ${JSON.stringify(name)} api must be either chat or responses`,
+    );
+  }
+  const isDefault = value.default;
+  if (isDefault !== undefined && typeof isDefault !== 'boolean') {
+    throw new Error(`model ${JSON.stringify(name)} default must be a boolean`);
+  }
+  const reasoningEffort = value.reasoningEffort;
+  if (
+    reasoningEffort !== undefined
+    && !REASONING_EFFORTS.has(reasoningEffort as OpenAIReasoningEffort)
+  ) {
+    throw new Error(
+      `model ${JSON.stringify(name)} reasoningEffort is invalid`,
+    );
+  }
+
+  return {
+    apiKey,
+    baseURL,
+    model,
+    ...(api === undefined ? {} : { api }),
+    ...(isDefault === true ? { default: true as const } : {}),
+    ...(reasoningEffort === undefined
+      ? {}
+      : { reasoningEffort: reasoningEffort as OpenAIReasoningEffort }),
+  };
+}
+
+export function parseModelConfig(raw: string | undefined): GenUIModelConfig {
+  if (!raw) {
+    throw new Error(`${GENUI_MODEL_CONFIG_ENV} is required`);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error(`${GENUI_MODEL_CONFIG_ENV} must contain valid JSON`);
+  }
+  if (!isRecord(value)) {
+    throw new Error(`${GENUI_MODEL_CONFIG_ENV} must contain a JSON object`);
+  }
+
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    throw new Error(
+      `${GENUI_MODEL_CONFIG_ENV} must configure at least one model`,
+    );
+  }
+
+  const models: Record<string, ConfiguredModel> = {};
+  const defaultModels: string[] = [];
+  for (const [name, modelValue] of entries) {
+    if (name.trim().length === 0 || name.trim() !== name) {
+      throw new Error(
+        'model names must be non-empty and have no surrounding whitespace',
+      );
+    }
+    const model = parseConfiguredModel(name, modelValue);
+    models[name] = model;
+    if (model.default) defaultModels.push(name);
+  }
+  if (defaultModels.length > 1) {
+    throw new Error('only one configured model may be marked as default');
+  }
+
+  return {
+    defaultModel: defaultModels[0] ?? entries[0]![0],
+    models,
+  };
+}
+
+export function readModelConfig(): ModelConfigResult {
+  try {
+    return {
+      ok: true,
+      config: parseModelConfig(process.env[GENUI_MODEL_CONFIG_ENV]),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function getModelConfig(): GenUIModelConfig {
+  const result = readModelConfig();
+  if (!result.ok) throw new Error(result.error);
+  return result.config;
+}
+
+export function resolveModelConfig(
+  name?: string,
+): ResolvedModelConfig {
+  const config = getModelConfig();
+  const resolvedName = name && config.models[name] ? name : config.defaultModel;
+  return { name: resolvedName, config: config.models[resolvedName]! };
+}
+
+export function configuredModelName(
+  name: string | undefined,
+): string | undefined {
+  if (!name) return undefined;
+  const result = readModelConfig();
+  return result.ok && result.config.models[name] ? name : undefined;
+}
+
+export function defaultModelName(): string | undefined {
+  const result = readModelConfig();
+  return result.ok ? result.config.defaultModel : undefined;
+}
+
+export function configuredApiStyle(
+  name?: string,
+): 'chat' | 'responses' | undefined {
+  const result = readModelConfig();
+  if (!result.ok) return undefined;
+  const resolvedName = name && result.config.models[name]
+    ? name
+    : result.config.defaultModel;
+  return result.config.models[resolvedName]!.api;
+}

--- a/packages/genui/server/service/common/model-config.ts
+++ b/packages/genui/server/service/common/model-config.ts
@@ -134,7 +134,7 @@ export function parseModelConfig(raw: string | undefined): GenUIModelConfig {
     );
   }
 
-  const models: Record<string, ConfiguredModel> = {};
+  const models = Object.create(null) as Record<string, ConfiguredModel>;
   const defaultModels: string[] = [];
   for (const [name, modelValue] of entries) {
     if (name.trim().length === 0 || name.trim() !== name) {
@@ -168,6 +168,56 @@ export function readModelConfig(): ModelConfigResult {
       error: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function addSensitiveVariants(values: Set<string>, value: string): void {
+  if (!value) return;
+  values.add(value);
+  values.add(encodeURIComponent(value));
+  values.add(JSON.stringify(value).slice(1, -1));
+  try {
+    values.add(decodeURIComponent(value));
+  } catch {
+    // Keep the original variants when the value is not URL encoded.
+  }
+}
+
+export function redactModelConfigSecrets(message: string): string {
+  const result = readModelConfig();
+  if (!result.ok) return message;
+
+  const sensitiveValues = new Set<string>();
+  for (const config of Object.values(result.config.models)) {
+    addSensitiveVariants(sensitiveValues, config.apiKey);
+    addSensitiveVariants(sensitiveValues, config.baseURL);
+    addSensitiveVariants(sensitiveValues, config.model);
+    try {
+      const url = new URL(config.baseURL);
+      addSensitiveVariants(sensitiveValues, url.origin);
+      addSensitiveVariants(sensitiveValues, url.host);
+      addSensitiveVariants(sensitiveValues, url.hostname);
+      addSensitiveVariants(sensitiveValues, url.username);
+      addSensitiveVariants(sensitiveValues, url.password);
+      for (const value of url.searchParams.values()) {
+        addSensitiveVariants(sensitiveValues, value);
+      }
+    } catch {
+      // parseConfiguredModel already validates this URL.
+    }
+  }
+
+  return [...sensitiveValues]
+    .filter(Boolean)
+    .sort((left, right) => right.length - left.length)
+    .reduce(
+      (redacted, sensitive) => redacted.replaceAll(sensitive, '[REDACTED]'),
+      message,
+    )
+    .replace(/\bBearer\s+[^\s,;"']+/giu, 'Bearer [REDACTED]')
+    .replace(
+      /([?&](?:access_token|api[_-]?key|key|token)=)[^&#\s"'<>]*/giu,
+      '$1[REDACTED]',
+    );
 }
 
 export function getModelConfig(): GenUIModelConfig {

--- a/packages/genui/server/service/common/provider.ts
+++ b/packages/genui/server/service/common/provider.ts
@@ -4,6 +4,7 @@
 
 import { createHash } from 'node:crypto';
 
+import { readModelConfig } from './model-config.js';
 import type { ChatOptions, OpenAIReasoningEffort } from './types';
 
 const REASONING_EFFORTS = new Set<OpenAIReasoningEffort>([
@@ -133,9 +134,13 @@ export function resolveReasoningEffort(
 ): OpenAIReasoningEffort | undefined {
   const explicit = parseReasoningEffort(opts.reasoningEffort);
   if (explicit !== undefined) return explicit;
-  return opts.inheritReasoningEffort === false
-    ? undefined
-    : parseReasoningEffort(process.env.OPENAI_REASONING_EFFORT);
+  if (opts.inheritReasoningEffort === false) return undefined;
+  const config = readModelConfig();
+  if (!config.ok) return undefined;
+  const modelName = opts.model && config.config.models[opts.model]
+    ? opts.model
+    : config.config.defaultModel;
+  return config.config.models[modelName]!.reasoningEffort;
 }
 
 export function buildResourceRunOptions(

--- a/packages/genui/server/service/common/types.ts
+++ b/packages/genui/server/service/common/types.ts
@@ -29,7 +29,7 @@ export interface ChatOptions {
   reasoningEffort?: OpenAIReasoningEffort | undefined;
   /**
    * Set to false for controlled runs that must not inherit the process-wide
-   * OPENAI_REASONING_EFFORT setting.
+   * reasoningEffort from the selected GENUI_MODEL_CONFIG_JSON entry.
    */
   inheritReasoningEffort?: boolean | undefined;
   onPerformanceEvent?: (

--- a/packages/genui/server/src/app.ts
+++ b/packages/genui/server/src/app.ts
@@ -17,6 +17,7 @@ import a2uiStreamRoute from '../app/a2ui/stream/route.js';
 import { corsPreflight, jsonWithCors } from '../app/common/cors.js';
 import mcpAppsMetadataRoute from '../app/mcp-apps/metadata/route.js';
 import mcpAppsStreamRoute from '../app/mcp-apps/stream/route.js';
+import modelsRoute from '../app/models/route.js';
 import openuiPayloadRoute from '../app/openui/payload/route.js';
 import openuiStreamRoute from '../app/openui/stream/route.js';
 
@@ -34,6 +35,7 @@ app.route('/a2ui/payload', a2uiPayloadRoute);
 app.route('/a2ui/stream', a2uiStreamRoute);
 app.route('/mcp-apps/metadata', mcpAppsMetadataRoute);
 app.route('/mcp-apps/stream', mcpAppsStreamRoute);
+app.route('/models', modelsRoute);
 app.route('/openui/payload', openuiPayloadRoute);
 app.route('/openui/stream', openuiStreamRoute);
 

--- a/packages/genui/server/src/app.ts
+++ b/packages/genui/server/src/app.ts
@@ -15,6 +15,7 @@ import a2uiHealthRoute from '../app/a2ui/health/route.js';
 import a2uiPayloadRoute from '../app/a2ui/payload/route.js';
 import a2uiStreamRoute from '../app/a2ui/stream/route.js';
 import { corsPreflight, jsonWithCors } from '../app/common/cors.js';
+import { errorMessage } from '../app/common/errors.js';
 import mcpAppsMetadataRoute from '../app/mcp-apps/metadata/route.js';
 import mcpAppsStreamRoute from '../app/mcp-apps/stream/route.js';
 import modelsRoute from '../app/models/route.js';
@@ -77,7 +78,7 @@ app.onError((error, context) => {
     );
   }
 
-  console.error(error);
+  console.error(errorMessage(error));
   return jsonWithCors(
     context.req.raw,
     { ok: false, error: 'internal server error' },

--- a/packages/genui/server/test/app.test.ts
+++ b/packages/genui/server/test/app.test.ts
@@ -10,6 +10,7 @@ import {
 import { createAdaptorServer } from '@hono/node-server';
 import { describe, expect, test } from '@rstest/core';
 
+import { GENUI_MODEL_CONFIG_ENV } from '../service/common/model-config.js';
 import app from '../src/app.js';
 
 describe('Hono application', () => {
@@ -25,6 +26,51 @@ describe('Hono application', () => {
     await expect(response.json()).resolves.toMatchObject({
       provider: 'openai',
     });
+  });
+
+  test('returns the configured public model list without provider secrets', async () => {
+    const previous = process.env[GENUI_MODEL_CONFIG_ENV];
+    process.env[GENUI_MODEL_CONFIG_ENV] = JSON.stringify({
+      'Doubao Seed': {
+        apiKey: 'seed-secret',
+        baseURL: 'https://seed.example.com/api/v3',
+        model: 'doubao-seed-upstream',
+        api: 'chat',
+        default: true,
+      },
+      'Doubao Pro': {
+        apiKey: 'pro-secret',
+        baseURL: 'https://pro.example.com/api/v3',
+        model: 'doubao-pro-upstream',
+      },
+    });
+    try {
+      const response = await app.request('/models', {
+        headers: { Origin: 'http://localhost:3000' },
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+        'http://localhost:3000',
+      );
+      const payload = await response.json();
+      expect(payload).toEqual({
+        defaultModel: 'Doubao Seed',
+        models: [
+          { id: 'Doubao Seed', label: 'Doubao Seed' },
+          { id: 'Doubao Pro', label: 'Doubao Pro' },
+        ],
+      });
+      const serializedPayload = JSON.stringify(payload);
+      expect(serializedPayload).not.toContain('seed-secret');
+      expect(serializedPayload).not.toContain('seed.example.com');
+      expect(serializedPayload).not.toContain('doubao-seed-upstream');
+    } finally {
+      if (previous === undefined) {
+        delete process.env[GENUI_MODEL_CONFIG_ENV];
+      } else {
+        process.env[GENUI_MODEL_CONFIG_ENV] = previous;
+      }
+    }
   });
 
   test('allows IPv6 loopback origins during local development', async () => {

--- a/packages/genui/server/test/app.test.ts
+++ b/packages/genui/server/test/app.test.ts
@@ -28,7 +28,7 @@ describe('Hono application', () => {
     });
   });
 
-  test('returns the configured public model list without provider secrets', async () => {
+  test('returns only public model metadata from discovery endpoints', async () => {
     const previous = process.env[GENUI_MODEL_CONFIG_ENV];
     process.env[GENUI_MODEL_CONFIG_ENV] = JSON.stringify({
       'Doubao Seed': {
@@ -64,6 +64,23 @@ describe('Hono application', () => {
       expect(serializedPayload).not.toContain('seed-secret');
       expect(serializedPayload).not.toContain('seed.example.com');
       expect(serializedPayload).not.toContain('doubao-seed-upstream');
+
+      const healthResponse = await app.request('/a2ui/health', {
+        headers: { Origin: 'http://localhost:3000' },
+      });
+      expect(healthResponse.status).toBe(200);
+      const healthPayload: unknown = await healthResponse.json();
+      expect(healthPayload).toEqual({
+        ok: true,
+        provider: 'openai',
+        hasKey: true,
+        modelName: 'Doubao Seed',
+      });
+      const serializedHealth = JSON.stringify(healthPayload);
+      expect(serializedHealth).not.toContain('seed-secret');
+      expect(serializedHealth).not.toContain('seed.example.com');
+      expect(serializedHealth).not.toContain('doubao-seed-upstream');
+      expect(serializedHealth).not.toContain('"api"');
     } finally {
       if (previous === undefined) {
         delete process.env[GENUI_MODEL_CONFIG_ENV];

--- a/packages/genui/server/test/app.test.ts
+++ b/packages/genui/server/test/app.test.ts
@@ -52,7 +52,7 @@ describe('Hono application', () => {
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
         'http://localhost:3000',
       );
-      const payload = await response.json();
+      const payload: unknown = await response.json();
       expect(payload).toEqual({
         defaultModel: 'Doubao Seed',
         models: [

--- a/packages/genui/server/test/model-config.test.ts
+++ b/packages/genui/server/test/model-config.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import { createLLMProvider } from '../agent/openai-provider.js';
+import { pickProviderOptions } from '../app/common/provider-options.js';
+import {
+  GENUI_MODEL_CONFIG_ENV,
+  parseModelConfig,
+} from '../service/common/model-config.js';
+
+const CONFIG = {
+  'Doubao Seed': {
+    apiKey: 'seed-secret',
+    baseURL: 'https://seed.example.com/api/v3',
+    model: 'doubao-seed-upstream',
+    api: 'chat',
+    default: true,
+    reasoningEffort: 'medium',
+  },
+  'Doubao Pro': {
+    apiKey: 'pro-secret',
+    baseURL: 'https://pro.example.com/api/v3',
+    model: 'doubao-pro-upstream',
+    api: 'responses',
+  },
+};
+
+describe('GenUI model configuration', () => {
+  test('parses a provider config map keyed by public model name', () => {
+    expect(parseModelConfig(JSON.stringify(CONFIG))).toEqual({
+      defaultModel: 'Doubao Seed',
+      models: CONFIG,
+    });
+  });
+
+  test('defaults to the first model and rejects multiple defaults', () => {
+    expect(
+      parseModelConfig(JSON.stringify({
+        Doubao: {
+          apiKey: 'server-secret',
+          baseURL: 'https://example.com/v1',
+          model: 'doubao-seed',
+        },
+      })).defaultModel,
+    ).toBe('Doubao');
+
+    expect(() =>
+      parseModelConfig(JSON.stringify({
+        ...CONFIG,
+        'Doubao Pro': { ...CONFIG['Doubao Pro'], default: true },
+      }))
+    ).toThrow('only one configured model may be marked as default');
+  });
+
+  test('resolves a model name to its independent upstream configuration', () => {
+    const previous = process.env[GENUI_MODEL_CONFIG_ENV];
+    process.env[GENUI_MODEL_CONFIG_ENV] = JSON.stringify(CONFIG);
+    try {
+      expect(createLLMProvider({ model: 'Doubao Pro' })).toMatchObject({
+        model: 'doubao-pro-upstream',
+        api: 'responses',
+        baseURL: 'https://pro.example.com/api/v3',
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env[GENUI_MODEL_CONFIG_ENV];
+      } else {
+        process.env[GENUI_MODEL_CONFIG_ENV] = previous;
+      }
+    }
+  });
+
+  test('allows configured model selection without exposing provider overrides', () => {
+    const previous = process.env[GENUI_MODEL_CONFIG_ENV];
+    const previousAllowOverride = process.env.A2UI_ALLOW_CLIENT_OVERRIDE;
+    process.env[GENUI_MODEL_CONFIG_ENV] = JSON.stringify(CONFIG);
+    delete process.env.A2UI_ALLOW_CLIENT_OVERRIDE;
+    try {
+      expect(pickProviderOptions({
+        apiKey: 'client-secret',
+        baseURL: 'https://untrusted.example.com/v1',
+        model: 'Doubao Pro',
+        api: 'responses',
+      })).toEqual({
+        resourceId: undefined,
+        model: 'Doubao Pro',
+        apiKey: undefined,
+        baseURL: undefined,
+        api: undefined,
+        reasoningEffort: undefined,
+      });
+      expect(pickProviderOptions({ model: 'Unknown Model' }).model).toBe(
+        undefined,
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env[GENUI_MODEL_CONFIG_ENV];
+      } else {
+        process.env[GENUI_MODEL_CONFIG_ENV] = previous;
+      }
+      if (previousAllowOverride === undefined) {
+        delete process.env.A2UI_ALLOW_CLIENT_OVERRIDE;
+      } else {
+        process.env.A2UI_ALLOW_CLIENT_OVERRIDE = previousAllowOverride;
+      }
+    }
+  });
+});

--- a/packages/genui/server/test/model-config.test.ts
+++ b/packages/genui/server/test/model-config.test.ts
@@ -5,10 +5,14 @@
 import { describe, expect, test } from '@rstest/core';
 
 import { createLLMProvider } from '../agent/openai-provider.js';
+import { errorMessage } from '../app/common/errors.js';
 import { pickProviderOptions } from '../app/common/provider-options.js';
+import { redactBenchText } from '../service/a2ui-bench-redaction.js';
 import {
   GENUI_MODEL_CONFIG_ENV,
+  configuredModelName,
   parseModelConfig,
+  resolveModelConfig,
 } from '../service/common/model-config.js';
 
 const CONFIG = {
@@ -105,6 +109,54 @@ describe('GenUI model configuration', () => {
         delete process.env.A2UI_ALLOW_CLIENT_OVERRIDE;
       } else {
         process.env.A2UI_ALLOW_CLIENT_OVERRIDE = previousAllowOverride;
+      }
+    }
+  });
+
+  test('rejects inherited object property names as model selections', () => {
+    const parsed = parseModelConfig(JSON.stringify(CONFIG));
+    expect(Object.getPrototypeOf(parsed.models)).toBeNull();
+
+    const previous = process.env[GENUI_MODEL_CONFIG_ENV];
+    process.env[GENUI_MODEL_CONFIG_ENV] = JSON.stringify(CONFIG);
+    try {
+      expect(configuredModelName('toString')).toBeUndefined();
+      expect(pickProviderOptions({ model: 'toString' }).model).toBeUndefined();
+      expect(resolveModelConfig('toString')).toEqual({
+        name: 'Doubao Seed',
+        config: CONFIG['Doubao Seed'],
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env[GENUI_MODEL_CONFIG_ENV];
+      } else {
+        process.env[GENUI_MODEL_CONFIG_ENV] = previous;
+      }
+    }
+  });
+
+  test('redacts private model configuration from client-visible errors', () => {
+    const previous = process.env[GENUI_MODEL_CONFIG_ENV];
+    process.env[GENUI_MODEL_CONFIG_ENV] = JSON.stringify(CONFIG);
+    try {
+      const privateMessage =
+        'Doubao Seed failed at https://seed.example.com/api/v3 '
+        + 'for doubao-seed-upstream with seed-secret and Bearer session-token';
+      const publicMessage =
+        'Doubao Seed failed at [REDACTED] for [REDACTED] with [REDACTED] '
+        + 'and Bearer [REDACTED]';
+      const upstreamError = new Error(privateMessage);
+      upstreamError.name = 'ProviderError seed-secret';
+      expect(errorMessage(upstreamError)).toEqual({
+        message: publicMessage,
+        name: 'ProviderError [REDACTED]',
+      });
+      expect(redactBenchText(privateMessage, {})).toBe(publicMessage);
+    } finally {
+      if (previous === undefined) {
+        delete process.env[GENUI_MODEL_CONFIG_ENV];
+      } else {
+        process.env[GENUI_MODEL_CONFIG_ENV] = previous;
       }
     }
   });


### PR DESCRIPTION
## Summary

- add a server-owned `GET /models` API and load the Create-tab model selector from it
- configure providers through one `GENUI_MODEL_CONFIG_JSON` object keyed by public model name
- resolve each selected name to its own upstream model id, API key, base URL, API style, and reasoning effort
- keep provider credentials, upstream endpoints, and upstream model ids out of playground state and `/models` responses

## Why

The playground previously carried provider configuration and a hard-coded model list. That duplicated server configuration, exposed fields the client did not need, and could not safely represent multiple models backed by different providers or credentials.

This change makes the server the single source of truth. The browser submits only a configured public model name, while the server validates the name and resolves the corresponding private provider configuration.

## Configuration

```json
{
  "Doubao": {
    "model": "ep-example",
    "apiKey": "...",
    "baseURL": "https://example.com/v1",
    "api": "chat",
    "default": true
  }
}
```

## Validation

- `pnpm --filter a2ui-server test` (99 tests)
- `pnpm --filter genui-playground test` (119 tests)
- `pnpm turbo build --concurrency=1` (67 tasks)
- local API, CORS, and browser verification with the model selector loaded from `GET /models`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-managed model configuration with selectable public model names.
  * Added a `/models` endpoint listing available models and the default selection without exposing credentials or provider details.
  * Playground model choices now load dynamically from the server.

* **Bug Fixes**
  * Improved settings loading, validation, fallback selection, and disabled-state handling.
  * Ensured requests consistently use the selected model and server-configured provider settings.
  * Improved redaction of sensitive configuration in errors and benchmark output.

* **Documentation**
  * Updated setup and configuration guidance for server-managed models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->