### PR TITLE
fix(motion): report tap animation lifecycle

### DIFF
--- a/.changeset/motion-tap-animation-lifecycle.md
+++ b/.changeset/motion-tap-animation-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Report declarative animation lifecycle callbacks when tap targets apply and restore.

--- a/.changeset/motion-tap-animation-lifecycle.md
+++ b/.changeset/motion-tap-animation-lifecycle.md
@@ -2,4 +2,4 @@
 "@lynx-js/motion": patch
 ---
 
-Report declarative animation lifecycle callbacks when tap targets apply and restore.
+Report declarative animation lifecycle callbacks when tap targets apply and restore, including multi-property completion.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -576,69 +576,6 @@ describe('declarative Motion', () => {
     );
   });
 
-  test('reports tap target and restoration animation lifecycle', async () => {
-    const onAnimationStart = vi.fn();
-    const onAnimationComplete = vi.fn();
-    const { getByTestId } = render(
-      <motion.view
-        data-testid='button'
-        initial={{ scale: 1, backgroundColor: '#ffffff' }}
-        whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
-        transition={{ duration: 0.01 }}
-        onAnimationStart={onAnimationStart}
-        onAnimationComplete={onAnimationComplete}
-      />,
-      { enableMainThread: true, enableBackgroundThread: true },
-    );
-
-    fireEvent.touchstart(getByTestId('button'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-    expect(onAnimationStart).toHaveBeenNthCalledWith(1, {
-      scale: 1.15,
-      backgroundColor: '#ffcc00',
-    });
-    expect(onAnimationComplete).toHaveBeenNthCalledWith(1, {
-      scale: 1.15,
-      backgroundColor: '#ffcc00',
-    });
-
-    fireEvent.touchend(getByTestId('button'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-    expect(onAnimationStart).toHaveBeenNthCalledWith(2, {
-      scale: 1,
-      backgroundColor: '#ffffff',
-    });
-    expect(onAnimationComplete).toHaveBeenNthCalledWith(2, {
-      scale: 1,
-      backgroundColor: '#ffffff',
-    });
-  });
-
-  test('does not complete an interrupted tap target', async () => {
-    const onAnimationComplete = vi.fn();
-    const { getByTestId } = render(
-      <motion.view
-        data-testid='button'
-        whileTap={{ scale: 1.15 }}
-        transition={{ duration: 0.08 }}
-        onAnimationComplete={onAnimationComplete}
-      />,
-      { enableMainThread: true, enableBackgroundThread: true },
-    );
-
-    fireEvent.touchstart(getByTestId('button'));
-    fireEvent.touchend(getByTestId('button'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 120));
-    });
-    expect(onAnimationComplete).toHaveBeenCalledOnce();
-    expect(onAnimationComplete).toHaveBeenCalledWith({ scale: 1 });
-  });
-
   test('composes gesture callbacks with external host handlers', () => {
     const onTapStart = vi.fn();
     const onTap = vi.fn();

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -576,6 +576,69 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('reports tap target and restoration animation lifecycle', async () => {
+    const onAnimationStart = vi.fn();
+    const onAnimationComplete = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        initial={{ scale: 1, backgroundColor: '#ffffff' }}
+        whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
+        transition={{ duration: 0.01 }}
+        onAnimationStart={onAnimationStart}
+        onAnimationComplete={onAnimationComplete}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(onAnimationStart).toHaveBeenNthCalledWith(1, {
+      scale: 1.15,
+      backgroundColor: '#ffcc00',
+    });
+    expect(onAnimationComplete).toHaveBeenNthCalledWith(1, {
+      scale: 1.15,
+      backgroundColor: '#ffcc00',
+    });
+
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(onAnimationStart).toHaveBeenNthCalledWith(2, {
+      scale: 1,
+      backgroundColor: '#ffffff',
+    });
+    expect(onAnimationComplete).toHaveBeenNthCalledWith(2, {
+      scale: 1,
+      backgroundColor: '#ffffff',
+    });
+  });
+
+  test('does not complete an interrupted tap target', async () => {
+    const onAnimationComplete = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        whileTap={{ scale: 1.15 }}
+        transition={{ duration: 0.08 }}
+        onAnimationComplete={onAnimationComplete}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 120));
+    });
+    expect(onAnimationComplete).toHaveBeenCalledOnce();
+    expect(onAnimationComplete).toHaveBeenCalledWith({ scale: 1 });
+  });
+
   test('composes gesture callbacks with external host handlers', () => {
     const onTapStart = vi.fn();
     const onTap = vi.fn();

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -548,7 +548,8 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    // Bind on MTS before Motion's scheduler invokes completion asynchronously.
+    // Bind while the tap-start worklet is still executing on MTS; Motion calls
+    // the returned dispatcher later from its animation scheduler.
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;
@@ -653,7 +654,8 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    // Bind on MTS before Motion's scheduler invokes completion asynchronously.
+    // Bind while the tap-end worklet is still executing on MTS; restoration
+    // completion arrives later from Motion's animation scheduler.
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -544,7 +544,7 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    const completionPromises: Promise<void>[] = [];
+    const animatedValues: MotionValue<string | number>[] = [];
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
@@ -568,7 +568,18 @@ function useMotionHostProps<Props extends MotionProps>(
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          completionPromises.push(completion);
+          animatedValues.push(value);
+          void completion.then(() => {
+            if (tapAnimationGenerationRef.current !== animationGeneration) {
+              return;
+            }
+            if (
+              !animatedValues.some(value => value.isAnimating())
+              && onAnimationComplete
+            ) {
+              void runOnBackground(onAnimationComplete)(whileTap!);
+            }
+          });
           if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
@@ -585,18 +596,20 @@ function useMotionHostProps<Props extends MotionProps>(
         resolvedTransition,
       );
       tapAnimationRef.current.push(animation);
-      completionPromises.push(Promise.resolve(animation).then(() => undefined));
-    }
-    if (completionPromises.length > 0 && onAnimationStart) {
-      void runOnBackground(onAnimationStart)(whileTap!);
-    }
-    if (completionPromises.length > 0 && onAnimationComplete) {
-      void Promise.all(completionPromises).then(() => {
+      void animation.then(() => {
         if (tapAnimationGenerationRef.current !== animationGeneration) {
           return;
         }
-        void runOnBackground(onAnimationComplete)(whileTap!);
+        if (onAnimationComplete) {
+          void runOnBackground(onAnimationComplete)(whileTap!);
+        }
       });
+    }
+    if (
+      (animatedValues.length > 0 || tapAnimationRef.current.length > 0)
+      && onAnimationStart
+    ) {
+      void runOnBackground(onAnimationStart)(whileTap!);
     }
   }
 
@@ -614,7 +627,7 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    const completionPromises: Promise<void>[] = [];
+    const animatedValues: MotionValue<string | number>[] = [];
     const targetValues = resolvedTap.target as Record<string, unknown>;
     const restingTarget = hoverActiveRef.current && resolvedHover.target
       ? resolvedHover.target
@@ -667,7 +680,18 @@ function useMotionHostProps<Props extends MotionProps>(
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          completionPromises.push(completion);
+          animatedValues.push(value);
+          void completion.then(() => {
+            if (tapAnimationGenerationRef.current !== animationGeneration) {
+              return;
+            }
+            if (
+              !animatedValues.some(value => value.isAnimating())
+              && onAnimationComplete
+            ) {
+              void runOnBackground(onAnimationComplete)(restingDefinition);
+            }
+          });
           if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
@@ -684,18 +708,20 @@ function useMotionHostProps<Props extends MotionProps>(
         resolvedTransition,
       );
       tapAnimationRef.current.push(animation);
-      completionPromises.push(Promise.resolve(animation).then(() => undefined));
-    }
-    if (completionPromises.length > 0 && onAnimationStart) {
-      void runOnBackground(onAnimationStart)(restingDefinition);
-    }
-    if (completionPromises.length > 0 && onAnimationComplete) {
-      void Promise.all(completionPromises).then(() => {
+      void animation.then(() => {
         if (tapAnimationGenerationRef.current !== animationGeneration) {
           return;
         }
-        void runOnBackground(onAnimationComplete)(restingDefinition);
+        if (onAnimationComplete) {
+          void runOnBackground(onAnimationComplete)(restingDefinition);
+        }
       });
+    }
+    if (
+      (animatedValues.length > 0 || tapAnimationRef.current.length > 0)
+      && onAnimationStart
+    ) {
+      void runOnBackground(onAnimationStart)(restingDefinition);
     }
   }
 

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -41,6 +41,7 @@ import {
 } from './style.js';
 import type {
   MotionComponentProps,
+  MotionDefinition,
   MotionFactory,
   MotionImageProps,
   MotionProps,
@@ -125,6 +126,7 @@ function useMotionHostProps<Props extends MotionProps>(
   const hoverActiveRef = useMainThreadRef(false);
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
+  const tapAnimationGenerationRef = useMainThreadRef(0);
   const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
@@ -336,6 +338,7 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       tapAnimationRef.current = [];
+      tapAnimationGenerationRef.current += 1;
       const animationGeneration = animationGenerationRef.current + 1;
       animationGenerationRef.current = animationGeneration;
       styleCleanupRef.current?.();
@@ -511,6 +514,7 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       tapAnimationRef.current = [];
+      tapAnimationGenerationRef.current += 1;
       styleCleanupRef.current?.();
       styleCleanupRef.current = null;
     }
@@ -538,17 +542,22 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
+    const animationGeneration = tapAnimationGenerationRef.current + 1;
+    tapAnimationGenerationRef.current = animationGeneration;
+    const completionPromises: Promise<void>[] = [];
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
       : workletTapTransition) ?? {};
+    // Keep animation handles out of the MTS snapshot captured by a ReactLynx
+    // rerender triggered from lifecycle callbacks.
     if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
         if (value && targetValue !== undefined) {
-          void value.start(
+          const completion = value.start(
             createMotionValueAnimation(
               key,
               value,
@@ -557,19 +566,38 @@ function useMotionHostProps<Props extends MotionProps>(
             ),
           );
           if (value.animation) {
+            Object.defineProperty(value, 'animation', { enumerable: false });
+          }
+          completionPromises.push(completion);
+          if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
         }
       }
-      return;
+    } else {
+      const ElementConstructor = globalThis.Element as unknown as new(
+        element: MainThread.Element,
+      ) => Element;
+      const element = new ElementConstructor(event.currentTarget);
+      const animation = animateMotionTarget(
+        element,
+        resolvedTap.target,
+        resolvedTransition,
+      );
+      tapAnimationRef.current.push(animation);
+      completionPromises.push(Promise.resolve(animation).then(() => undefined));
     }
-    const ElementConstructor = globalThis.Element as unknown as new(
-      element: MainThread.Element,
-    ) => Element;
-    const element = new ElementConstructor(event.currentTarget);
-    tapAnimationRef.current.push(
-      animateMotionTarget(element, resolvedTap.target, resolvedTransition),
-    );
+    if (completionPromises.length > 0 && onAnimationStart) {
+      void runOnBackground(onAnimationStart)(whileTap!);
+    }
+    if (completionPromises.length > 0 && onAnimationComplete) {
+      void Promise.all(completionPromises).then(() => {
+        if (tapAnimationGenerationRef.current !== animationGeneration) {
+          return;
+        }
+        void runOnBackground(onAnimationComplete)(whileTap!);
+      });
+    }
   }
 
   function endTapAnimation(event: MainThread.TouchEvent) {
@@ -584,6 +612,9 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
+    const animationGeneration = tapAnimationGenerationRef.current + 1;
+    tapAnimationGenerationRef.current = animationGeneration;
+    const completionPromises: Promise<void>[] = [];
     const targetValues = resolvedTap.target as Record<string, unknown>;
     const restingTarget = hoverActiveRef.current && resolvedHover.target
       ? resolvedHover.target
@@ -617,11 +648,15 @@ function useMotionHostProps<Props extends MotionProps>(
         restingValues[key] = restingValue;
       }
     }
+    const restingDefinition: MotionDefinition = hoverActiveRef.current
+        && whileHover !== undefined
+      ? whileHover
+      : animate ?? (restingValues as MotionTarget);
     if (isLynxForWeb || !event.currentTarget) {
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          void value.start(
+          const completion = value.start(
             createMotionValueAnimation(
               key,
               value,
@@ -630,19 +665,38 @@ function useMotionHostProps<Props extends MotionProps>(
             ),
           );
           if (value.animation) {
+            Object.defineProperty(value, 'animation', { enumerable: false });
+          }
+          completionPromises.push(completion);
+          if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
         }
       }
-      return;
+    } else {
+      const ElementConstructor = globalThis.Element as unknown as new(
+        element: MainThread.Element,
+      ) => Element;
+      const element = new ElementConstructor(event.currentTarget);
+      const animation = animateMotionTarget(
+        element,
+        restingValues,
+        resolvedTransition,
+      );
+      tapAnimationRef.current.push(animation);
+      completionPromises.push(Promise.resolve(animation).then(() => undefined));
     }
-    const ElementConstructor = globalThis.Element as unknown as new(
-      element: MainThread.Element,
-    ) => Element;
-    const element = new ElementConstructor(event.currentTarget);
-    tapAnimationRef.current.push(
-      animateMotionTarget(element, restingValues, resolvedTransition),
-    );
+    if (completionPromises.length > 0 && onAnimationStart) {
+      void runOnBackground(onAnimationStart)(restingDefinition);
+    }
+    if (completionPromises.length > 0 && onAnimationComplete) {
+      void Promise.all(completionPromises).then(() => {
+        if (tapAnimationGenerationRef.current !== animationGeneration) {
+          return;
+        }
+        void runOnBackground(onAnimationComplete)(restingDefinition);
+      });
+    }
   }
 
   function startHoverAnimation() {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -127,6 +127,10 @@ function useMotionHostProps<Props extends MotionProps>(
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
   const tapAnimationGenerationRef = useMainThreadRef(0);
+  const tapAnimationCompletionRef = useMainThreadRef<{
+    generation: number;
+    pending: number;
+  }>({ generation: 0, pending: 0 });
   const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
@@ -544,7 +548,9 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    const animatedValues: MotionValue<string | number>[] = [];
+    const reportAnimationComplete = onAnimationComplete
+      ? runOnBackground(onAnimationComplete)
+      : undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
@@ -553,33 +559,49 @@ function useMotionHostProps<Props extends MotionProps>(
     // rerender triggered from lifecycle callbacks.
     if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
+      let animationCount = 0;
+      function reportTapAnimationComplete(definition: MotionDefinition) {
+        if (tapAnimationGenerationRef.current !== animationGeneration) {
+          return;
+        }
+        tapAnimationCompletionRef.current.pending -= 1;
+        if (
+          tapAnimationCompletionRef.current.generation === animationGeneration
+          && tapAnimationCompletionRef.current.pending === 0
+          && reportAnimationComplete
+        ) {
+          void reportAnimationComplete(definition);
+        }
+      }
+      for (const key in targetValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value && targetValues[key] !== undefined) {
+          animationCount += 1;
+        }
+      }
+      tapAnimationCompletionRef.current = {
+        generation: animationGeneration,
+        pending: animationCount,
+      };
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
         if (value && targetValue !== undefined) {
-          const completion = value.start(
-            createMotionValueAnimation(
-              key,
-              value,
-              targetValue as never,
-              resolvedTransition as never,
-            ),
+          const startAnimation = createMotionValueAnimation(
+            key,
+            value,
+            targetValue as never,
+            resolvedTransition as never,
+          );
+          void value.start(complete =>
+            startAnimation(() => {
+              complete();
+              reportTapAnimationComplete(whileTap!);
+            })
           );
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          animatedValues.push(value);
-          void completion.then(() => {
-            if (tapAnimationGenerationRef.current !== animationGeneration) {
-              return;
-            }
-            if (
-              !animatedValues.some(value => value.isAnimating())
-              && onAnimationComplete
-            ) {
-              void runOnBackground(onAnimationComplete)(whileTap!);
-            }
-          });
           if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
@@ -593,20 +615,23 @@ function useMotionHostProps<Props extends MotionProps>(
       const animation = animateMotionTarget(
         element,
         resolvedTap.target,
-        resolvedTransition,
+        {
+          ...resolvedTransition,
+          onComplete: () => {
+            if (
+              tapAnimationGenerationRef.current === animationGeneration
+              && reportAnimationComplete
+            ) {
+              void reportAnimationComplete(whileTap!);
+            }
+          },
+        },
       );
       tapAnimationRef.current.push(animation);
-      void animation.then(() => {
-        if (tapAnimationGenerationRef.current !== animationGeneration) {
-          return;
-        }
-        if (onAnimationComplete) {
-          void runOnBackground(onAnimationComplete)(whileTap!);
-        }
-      });
     }
     if (
-      (animatedValues.length > 0 || tapAnimationRef.current.length > 0)
+      (Object.keys(resolvedTap.target).length > 0
+        || tapAnimationRef.current.length > 0)
       && onAnimationStart
     ) {
       void runOnBackground(onAnimationStart)(whileTap!);
@@ -627,7 +652,9 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    const animatedValues: MotionValue<string | number>[] = [];
+    const reportAnimationComplete = onAnimationComplete
+      ? runOnBackground(onAnimationComplete)
+      : undefined;
     const targetValues = resolvedTap.target as Record<string, unknown>;
     const restingTarget = hoverActiveRef.current && resolvedHover.target
       ? resolvedHover.target
@@ -666,32 +693,48 @@ function useMotionHostProps<Props extends MotionProps>(
       ? whileHover
       : animate ?? (restingValues as MotionTarget);
     if (isLynxForWeb || !event.currentTarget) {
+      let animationCount = 0;
+      function reportTapAnimationComplete() {
+        if (tapAnimationGenerationRef.current !== animationGeneration) {
+          return;
+        }
+        tapAnimationCompletionRef.current.pending -= 1;
+        if (
+          tapAnimationCompletionRef.current.generation === animationGeneration
+          && tapAnimationCompletionRef.current.pending === 0
+          && reportAnimationComplete
+        ) {
+          void reportAnimationComplete(restingDefinition);
+        }
+      }
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          const completion = value.start(
-            createMotionValueAnimation(
-              key,
-              value,
-              restingValues[key] as never,
-              resolvedTransition as never,
-            ),
+          animationCount += 1;
+        }
+      }
+      tapAnimationCompletionRef.current = {
+        generation: animationGeneration,
+        pending: animationCount,
+      };
+      for (const key in restingValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value) {
+          const startAnimation = createMotionValueAnimation(
+            key,
+            value,
+            restingValues[key] as never,
+            resolvedTransition as never,
+          );
+          void value.start(complete =>
+            startAnimation(() => {
+              complete();
+              reportTapAnimationComplete();
+            })
           );
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          animatedValues.push(value);
-          void completion.then(() => {
-            if (tapAnimationGenerationRef.current !== animationGeneration) {
-              return;
-            }
-            if (
-              !animatedValues.some(value => value.isAnimating())
-              && onAnimationComplete
-            ) {
-              void runOnBackground(onAnimationComplete)(restingDefinition);
-            }
-          });
           if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
@@ -705,20 +748,23 @@ function useMotionHostProps<Props extends MotionProps>(
       const animation = animateMotionTarget(
         element,
         restingValues,
-        resolvedTransition,
+        {
+          ...resolvedTransition,
+          onComplete: () => {
+            if (
+              tapAnimationGenerationRef.current === animationGeneration
+              && reportAnimationComplete
+            ) {
+              void reportAnimationComplete(restingDefinition);
+            }
+          },
+        },
       );
       tapAnimationRef.current.push(animation);
-      void animation.then(() => {
-        if (tapAnimationGenerationRef.current !== animationGeneration) {
-          return;
-        }
-        if (onAnimationComplete) {
-          void runOnBackground(onAnimationComplete)(restingDefinition);
-        }
-      });
     }
     if (
-      (animatedValues.length > 0 || tapAnimationRef.current.length > 0)
+      (Object.keys(restingValues).length > 0
+        || tapAnimationRef.current.length > 0)
       && onAnimationStart
     ) {
       void runOnBackground(onAnimationStart)(restingDefinition);

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -548,6 +548,7 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
+    // Bind on MTS before Motion's scheduler invokes completion asynchronously.
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;
@@ -652,6 +653,7 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
+    // Bind on MTS before Motion's scheduler invokes completion asynchronously.
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;


### PR DESCRIPTION
## Summary

- report `onAnimationStart` / `onAnimationComplete` for `whileTap` activation and restoration
- aggregate multi-property completion and suppress stale completion after interruption
- preserve active hover/animate/base fallback definition semantics

## Conformance priority

Importance 4 / Lynx fit 4 / MTS 2 / ReactLynx 1 / CSS 0.

## Validation

- Motion declarative regression 20/20
- TypeScript project check
- ESLint, Biome, dprint pre-commit checks
- immutable preview dual-renderer lifecycle case is the acceptance gate

Temporarily based on `main` for full CI/pkg.pr.new, then stacked on #3478. Supersedes #3479 and #3481 because GitHub did not emit main Test checks for their updated HEADs.