### PR TITLE
feat(motion): report hover animation lifecycle

### DIFF
--- a/.changeset/motion-hover-animation-lifecycle.md
+++ b/.changeset/motion-hover-animation-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Report declarative animation lifecycle callbacks when hover targets apply and restore, including multi-property completion and interrupted animation suppression.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -52,10 +52,11 @@ The declarative layer currently supports:
   styles backed by the upstream Motion engine
 - `whileTap` with `onTapStart`, `onTap`, and `onTapCancel`
 - `whileHover` with `onHoverStart` and `onHoverEnd` on mouse-capable clients
-- `onAnimationStart` and `onAnimationComplete` for the base `animate` target
+- `onAnimationStart` and `onAnimationComplete` for base `animate`, `whileTap`,
+  and `whileHover` targets and their restorations
 
 It does **not** yet provide the complete `motion/react` declarative contract.
-In particular, focus/in-view/drag states, gesture animation lifecycle
+In particular, focus/in-view/drag states and their animation lifecycle
 callbacks, animation controls, propagated/orchestrated variants, layout and
 shared-layout animations, `exit`, and `AnimatePresence` are not supported.
 Internal main-thread refs, handlers, and gestures also cannot yet be safely

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -120,18 +120,20 @@ function useMotionHostProps<Props extends MotionProps>(
   const animationRef = useMainThreadRef<
     AnimationPlaybackControlsWithThen[]
   >([]);
-  const tapAnimationRef = useMainThreadRef<
+  const interactionAnimationRef = useMainThreadRef<
     AnimationPlaybackControlsWithThen[]
   >([]);
   const hoverActiveRef = useMainThreadRef(false);
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
-  const tapAnimationGenerationRef = useMainThreadRef(0);
-  const tapAnimationCompletionRef = useMainThreadRef<{
+  const interactionAnimationGenerationRef = useMainThreadRef(0);
+  const interactionAnimationCompletionRef = useMainThreadRef<{
     generation: number;
     pending: number;
   }>({ generation: 0, pending: 0 });
-  const tapAnimationValueKeysRef = useMainThreadRef<Record<string, true>>({});
+  const interactionAnimationValueKeysRef = useMainThreadRef<
+    Record<string, true>
+  >({});
   const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
@@ -339,15 +341,15 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       animationRef.current = [];
-      for (const animation of tapAnimationRef.current) {
+      for (const animation of interactionAnimationRef.current) {
         animation.stop();
       }
-      tapAnimationRef.current = [];
-      for (const key in tapAnimationValueKeysRef.current) {
+      interactionAnimationRef.current = [];
+      for (const key in interactionAnimationValueKeysRef.current) {
         (generatedValuesRef.current[key] ?? motionValueBindings[key])?.stop();
       }
-      tapAnimationValueKeysRef.current = {};
-      tapAnimationGenerationRef.current += 1;
+      interactionAnimationValueKeysRef.current = {};
+      interactionAnimationGenerationRef.current += 1;
       const animationGeneration = animationGenerationRef.current + 1;
       animationGenerationRef.current = animationGeneration;
       styleCleanupRef.current?.();
@@ -520,15 +522,15 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       animationRef.current = [];
-      for (const animation of tapAnimationRef.current) {
+      for (const animation of interactionAnimationRef.current) {
         animation.stop();
       }
-      tapAnimationRef.current = [];
-      for (const key in tapAnimationValueKeysRef.current) {
+      interactionAnimationRef.current = [];
+      for (const key in interactionAnimationValueKeysRef.current) {
         (generatedValuesRef.current[key] ?? motionValueBindings[key])?.stop();
       }
-      tapAnimationValueKeysRef.current = {};
-      tapAnimationGenerationRef.current += 1;
+      interactionAnimationValueKeysRef.current = {};
+      interactionAnimationGenerationRef.current += 1;
       styleCleanupRef.current?.();
       styleCleanupRef.current = null;
     }
@@ -552,16 +554,16 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     animationRef.current = [];
-    for (const animation of tapAnimationRef.current) {
+    for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
-    tapAnimationRef.current = [];
-    for (const key in tapAnimationValueKeysRef.current) {
+    interactionAnimationRef.current = [];
+    for (const key in interactionAnimationValueKeysRef.current) {
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
-    tapAnimationValueKeysRef.current = {};
-    const animationGeneration = tapAnimationGenerationRef.current + 1;
-    tapAnimationGenerationRef.current = animationGeneration;
+    interactionAnimationValueKeysRef.current = {};
+    const animationGeneration = interactionAnimationGenerationRef.current + 1;
+    interactionAnimationGenerationRef.current = animationGeneration;
     // Bind while the tap-start worklet is still executing on MTS; Motion calls
     // the returned dispatcher later from its animation scheduler.
     const reportAnimationComplete = onAnimationComplete
@@ -578,13 +580,14 @@ function useMotionHostProps<Props extends MotionProps>(
       const targetValues = resolvedTap.target as Record<string, unknown>;
       let pendingAnimationCount = 0;
       function reportTapAnimationComplete(definition: MotionDefinition) {
-        if (tapAnimationGenerationRef.current !== animationGeneration) {
+        if (interactionAnimationGenerationRef.current !== animationGeneration) {
           return;
         }
-        tapAnimationCompletionRef.current.pending -= 1;
+        interactionAnimationCompletionRef.current.pending -= 1;
         if (
-          tapAnimationCompletionRef.current.generation === animationGeneration
-          && tapAnimationCompletionRef.current.pending === 0
+          interactionAnimationCompletionRef.current.generation
+            === animationGeneration
+          && interactionAnimationCompletionRef.current.pending === 0
           && reportAnimationComplete
         ) {
           void reportAnimationComplete(definition);
@@ -596,7 +599,7 @@ function useMotionHostProps<Props extends MotionProps>(
           pendingAnimationCount += 1;
         }
       }
-      tapAnimationCompletionRef.current = {
+      interactionAnimationCompletionRef.current = {
         generation: animationGeneration,
         pending: pendingAnimationCount,
       };
@@ -621,9 +624,9 @@ function useMotionHostProps<Props extends MotionProps>(
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
           if (isLynxForWeb) {
-            tapAnimationValueKeysRef.current[key] = true;
+            interactionAnimationValueKeysRef.current[key] = true;
           } else if (value.animation) {
-            tapAnimationRef.current.push(value.animation);
+            interactionAnimationRef.current.push(value.animation);
           }
         }
       }
@@ -639,7 +642,7 @@ function useMotionHostProps<Props extends MotionProps>(
           ...resolvedTransition,
           onComplete: () => {
             if (
-              tapAnimationGenerationRef.current === animationGeneration
+              interactionAnimationGenerationRef.current === animationGeneration
               && reportAnimationComplete
             ) {
               void reportAnimationComplete(whileTap!);
@@ -647,7 +650,7 @@ function useMotionHostProps<Props extends MotionProps>(
           },
         },
       );
-      tapAnimationRef.current.push(animation);
+      interactionAnimationRef.current.push(animation);
       startedAnimationCount = 1;
     }
     if (startedAnimationCount > 0 && onAnimationStart) {
@@ -663,16 +666,16 @@ function useMotionHostProps<Props extends MotionProps>(
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
     tapActiveRef.current = false;
-    for (const animation of tapAnimationRef.current) {
+    for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
-    tapAnimationRef.current = [];
-    for (const key in tapAnimationValueKeysRef.current) {
+    interactionAnimationRef.current = [];
+    for (const key in interactionAnimationValueKeysRef.current) {
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
-    tapAnimationValueKeysRef.current = {};
-    const animationGeneration = tapAnimationGenerationRef.current + 1;
-    tapAnimationGenerationRef.current = animationGeneration;
+    interactionAnimationValueKeysRef.current = {};
+    const animationGeneration = interactionAnimationGenerationRef.current + 1;
+    interactionAnimationGenerationRef.current = animationGeneration;
     // Bind while the tap-end worklet is still executing on MTS; restoration
     // completion arrives later from Motion's animation scheduler.
     const reportAnimationComplete = onAnimationComplete
@@ -719,13 +722,14 @@ function useMotionHostProps<Props extends MotionProps>(
     if (isLynxForWeb || !event.currentTarget) {
       let pendingAnimationCount = 0;
       function reportTapAnimationComplete() {
-        if (tapAnimationGenerationRef.current !== animationGeneration) {
+        if (interactionAnimationGenerationRef.current !== animationGeneration) {
           return;
         }
-        tapAnimationCompletionRef.current.pending -= 1;
+        interactionAnimationCompletionRef.current.pending -= 1;
         if (
-          tapAnimationCompletionRef.current.generation === animationGeneration
-          && tapAnimationCompletionRef.current.pending === 0
+          interactionAnimationCompletionRef.current.generation
+            === animationGeneration
+          && interactionAnimationCompletionRef.current.pending === 0
           && reportAnimationComplete
         ) {
           void reportAnimationComplete(restingDefinition);
@@ -737,7 +741,7 @@ function useMotionHostProps<Props extends MotionProps>(
           pendingAnimationCount += 1;
         }
       }
-      tapAnimationCompletionRef.current = {
+      interactionAnimationCompletionRef.current = {
         generation: animationGeneration,
         pending: pendingAnimationCount,
       };
@@ -761,9 +765,9 @@ function useMotionHostProps<Props extends MotionProps>(
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
           if (isLynxForWeb) {
-            tapAnimationValueKeysRef.current[key] = true;
+            interactionAnimationValueKeysRef.current[key] = true;
           } else if (value.animation) {
-            tapAnimationRef.current.push(value.animation);
+            interactionAnimationRef.current.push(value.animation);
           }
         }
       }
@@ -779,7 +783,7 @@ function useMotionHostProps<Props extends MotionProps>(
           ...resolvedTransition,
           onComplete: () => {
             if (
-              tapAnimationGenerationRef.current === animationGeneration
+              interactionAnimationGenerationRef.current === animationGeneration
               && reportAnimationComplete
             ) {
               void reportAnimationComplete(restingDefinition);
@@ -787,7 +791,7 @@ function useMotionHostProps<Props extends MotionProps>(
           },
         },
       );
-      tapAnimationRef.current.push(animation);
+      interactionAnimationRef.current.push(animation);
       startedAnimationCount = 1;
     }
     if (startedAnimationCount > 0 && onAnimationStart) {
@@ -804,20 +808,25 @@ function useMotionHostProps<Props extends MotionProps>(
     if (tapActiveRef.current) {
       return;
     }
-    tapAnimationGenerationRef.current += 1;
+    const animationGeneration = interactionAnimationGenerationRef.current + 1;
+    interactionAnimationGenerationRef.current = animationGeneration;
     for (const animation of animationRef.current) {
       animation.stop();
     }
     animationRef.current = [];
-    for (const animation of tapAnimationRef.current) {
+    for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
-    tapAnimationRef.current = [];
-    for (const key in tapAnimationValueKeysRef.current) {
+    interactionAnimationRef.current = [];
+    for (const key in interactionAnimationValueKeysRef.current) {
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
-    tapAnimationValueKeysRef.current = {};
+    interactionAnimationValueKeysRef.current = {};
+    const reportAnimationComplete = onAnimationComplete
+      ? runOnBackground(onAnimationComplete)
+      : undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    let startedAnimationCount = 0;
     const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
       : workletHoverTransition) ?? {};
@@ -825,36 +834,81 @@ function useMotionHostProps<Props extends MotionProps>(
       && String(SystemInfo.platform) === 'web';
     if (isLynxForWeb) {
       const targetValues = resolvedHover.target as Record<string, unknown>;
+      let pendingAnimationCount = 0;
+      function reportHoverAnimationComplete() {
+        if (
+          interactionAnimationGenerationRef.current !== animationGeneration
+        ) {
+          return;
+        }
+        interactionAnimationCompletionRef.current.pending -= 1;
+        if (
+          interactionAnimationCompletionRef.current.generation
+            === animationGeneration
+          && interactionAnimationCompletionRef.current.pending === 0
+          && reportAnimationComplete
+        ) {
+          void reportAnimationComplete(whileHover!);
+        }
+      }
+      for (const key in targetValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value && targetValues[key] !== undefined) {
+          pendingAnimationCount += 1;
+        }
+      }
+      interactionAnimationCompletionRef.current = {
+        generation: animationGeneration,
+        pending: pendingAnimationCount,
+      };
+      startedAnimationCount = pendingAnimationCount;
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
         if (value && targetValue !== undefined) {
-          void value.start(
-            createMotionValueAnimation(
-              key,
-              value,
-              targetValue as never,
-              resolvedTransition as never,
-            ),
+          const startAnimation = createMotionValueAnimation(
+            key,
+            value,
+            targetValue as never,
+            resolvedTransition as never,
+          );
+          void value.start(complete =>
+            startAnimation(() => {
+              complete();
+              reportHoverAnimationComplete();
+            })
           );
           if (value.animation) {
-            tapAnimationRef.current.push(value.animation);
+            Object.defineProperty(value, 'animation', { enumerable: false });
           }
+          interactionAnimationValueKeysRef.current[key] = true;
         }
       }
-      return;
-    }
-    const ElementConstructor = globalThis.Element as unknown as new(
-      element: MainThread.Element,
-    ) => Element;
-    const element = new ElementConstructor(elementRef.current);
-    tapAnimationRef.current.push(
-      animateMotionTarget(
+    } else {
+      const ElementConstructor = globalThis.Element as unknown as new(
+        element: MainThread.Element,
+      ) => Element;
+      const element = new ElementConstructor(elementRef.current);
+      interactionAnimationRef.current.push(animateMotionTarget(
         element,
         resolvedHover.target,
-        resolvedTransition,
-      ),
-    );
+        {
+          ...resolvedTransition,
+          onComplete: () => {
+            if (
+              interactionAnimationGenerationRef.current === animationGeneration
+              && reportAnimationComplete
+            ) {
+              void reportAnimationComplete(whileHover!);
+            }
+          },
+        },
+      ));
+      startedAnimationCount = 1;
+    }
+    if (startedAnimationCount > 0 && onAnimationStart) {
+      void runOnBackground(onAnimationStart)(whileHover!);
+    }
   }
 
   function endHoverAnimation() {
@@ -866,20 +920,25 @@ function useMotionHostProps<Props extends MotionProps>(
     if (tapActiveRef.current) {
       return;
     }
-    tapAnimationGenerationRef.current += 1;
-    for (const animation of tapAnimationRef.current) {
+    const animationGeneration = interactionAnimationGenerationRef.current + 1;
+    interactionAnimationGenerationRef.current = animationGeneration;
+    for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
-    tapAnimationRef.current = [];
-    for (const key in tapAnimationValueKeysRef.current) {
+    interactionAnimationRef.current = [];
+    for (const key in interactionAnimationValueKeysRef.current) {
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
-    tapAnimationValueKeysRef.current = {};
+    interactionAnimationValueKeysRef.current = {};
+    const reportAnimationComplete = onAnimationComplete
+      ? runOnBackground(onAnimationComplete)
+      : undefined;
     const hoverValues = resolvedHover.target as Record<string, unknown>;
     const animateValues = resolvedAnimate.target as
       | Record<string, unknown>
       | undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    let startedAnimationCount = 0;
     const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
       : workletHoverTransition) ?? {};
@@ -902,32 +961,83 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
+    const restingDefinition: MotionDefinition = animate
+      ?? (restingValues as MotionTarget);
     if (isLynxForWeb) {
+      let pendingAnimationCount = 0;
+      function reportHoverAnimationComplete() {
+        if (
+          interactionAnimationGenerationRef.current !== animationGeneration
+        ) {
+          return;
+        }
+        interactionAnimationCompletionRef.current.pending -= 1;
+        if (
+          interactionAnimationCompletionRef.current.generation
+            === animationGeneration
+          && interactionAnimationCompletionRef.current.pending === 0
+          && reportAnimationComplete
+        ) {
+          void reportAnimationComplete(restingDefinition);
+        }
+      }
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          void value.start(
-            createMotionValueAnimation(
-              key,
-              value,
-              restingValues[key] as never,
-              resolvedTransition as never,
-            ),
-          );
-          if (value.animation) {
-            tapAnimationRef.current.push(value.animation);
-          }
+          pendingAnimationCount += 1;
         }
       }
-      return;
+      interactionAnimationCompletionRef.current = {
+        generation: animationGeneration,
+        pending: pendingAnimationCount,
+      };
+      startedAnimationCount = pendingAnimationCount;
+      for (const key in restingValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value) {
+          const startAnimation = createMotionValueAnimation(
+            key,
+            value,
+            restingValues[key] as never,
+            resolvedTransition as never,
+          );
+          void value.start(complete =>
+            startAnimation(() => {
+              complete();
+              reportHoverAnimationComplete();
+            })
+          );
+          if (value.animation) {
+            Object.defineProperty(value, 'animation', { enumerable: false });
+          }
+          interactionAnimationValueKeysRef.current[key] = true;
+        }
+      }
+    } else {
+      const ElementConstructor = globalThis.Element as unknown as new(
+        element: MainThread.Element,
+      ) => Element;
+      const element = new ElementConstructor(elementRef.current);
+      interactionAnimationRef.current.push(animateMotionTarget(
+        element,
+        restingValues,
+        {
+          ...resolvedTransition,
+          onComplete: () => {
+            if (
+              interactionAnimationGenerationRef.current === animationGeneration
+              && reportAnimationComplete
+            ) {
+              void reportAnimationComplete(restingDefinition);
+            }
+          },
+        },
+      ));
+      startedAnimationCount = 1;
     }
-    const ElementConstructor = globalThis.Element as unknown as new(
-      element: MainThread.Element,
-    ) => Element;
-    const element = new ElementConstructor(elementRef.current);
-    tapAnimationRef.current.push(
-      animateMotionTarget(element, restingValues, resolvedTransition),
-    );
+    if (startedAnimationCount > 0 && onAnimationStart) {
+      void runOnBackground(onAnimationStart)(restingDefinition);
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- report `onAnimationStart` and `onAnimationComplete` for `whileHover` activation and restoration
- aggregate multi-property completion and suppress stale callbacks when another interaction interrupts hover
- share interaction animation cancellation tracking with the preceding tap lifecycle layer
- document the exact declarative lifecycle boundary

## Why
Upstream Motion reports the applied hover definition and then the restored base definition through the animation lifecycle callbacks. Lynx already applied the visual hover states, but omitted these callbacks.

## Stack
- Base: #3483 (`agent/motion-gesture-lifecycle-final`)
- This PR contains only the hover lifecycle layer.

## Validation
- `pnpm --filter @lynx-js/motion test` — 130 passed
- `pnpm exec tsc -p packages/motion/tsconfig.json --noEmit`
- `pnpm exec dprint check ...`
- `pnpm --filter @lynx-js/motion build` — Publint passed
- Huxpro/motion dual-renderer headless harness — 42 passed, including exact `start:hover → complete:hover → start:rest → complete:rest` ordering and interruption suppression

## Conformance priority
Importance 3 · Lynx fit 4 · MTS 2 · ReactLynx 1 · CSS 0