### PR TITLE
fix(motion): apply gesture transitionEnd values

### DIFF
--- a/.changeset/motion-gesture-transition-end.md
+++ b/.changeset/motion-gesture-transition-end.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Apply declarative transitionEnd values after tap and hover animations while restoring lower-priority values when each gesture ends.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -52,6 +52,7 @@ The declarative layer currently supports:
   styles backed by the upstream Motion engine
 - `whileTap` with `onTapStart`, `onTap`, and `onTapCancel`
 - `whileHover` with `onHoverStart` and `onHoverEnd` on mouse-capable clients
+- target-local `transitionEnd` for base, tap, and hover animations
 - `onAnimationStart` and `onAnimationComplete` for base `animate`, `whileTap`,
   and `whileHover` targets and their restorations
 

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -578,6 +578,35 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('applies and restores a tap transitionEnd value', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        style={{ opacity: 1 }}
+        whileTap={{
+          opacity: 0.5,
+          transitionEnd: { opacity: 0.75 },
+        }}
+        transition={{ duration: 0.01 }}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'opacity: 0.75',
+    );
+
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('restores every value after interrupting a tap animation', async () => {
     const { getByTestId } = render(
       <motion.view

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -569,6 +569,34 @@ function useMotionHostProps<Props extends MotionProps>(
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;
+    function applyTapTransitionEnd() {
+      const transitionEnd = resolvedTap.transitionEnd;
+      if (!transitionEnd) {
+        return;
+      }
+      let addedValue = false;
+      for (const key in transitionEnd) {
+        const finalValue = transitionEnd[key];
+        let value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (!value && finalValue !== undefined) {
+          value = motionValue(finalValue as string | number);
+          generatedValuesRef.current[key] = value;
+          addedValue = true;
+        } else if (value && finalValue !== undefined) {
+          value.set(finalValue as never);
+        }
+      }
+      if (addedValue && elementRef.current) {
+        const ElementConstructor = globalThis.Element as unknown as new(
+          element: MainThread.Element,
+        ) => Element;
+        styleCleanupRef.current?.();
+        styleCleanupRef.current = styleEffect(
+          new ElementConstructor(elementRef.current),
+          { ...motionValues, ...generatedValuesRef.current },
+        );
+      }
+    }
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     let startedAnimationCount = 0;
     const resolvedTransition = (workletTapTransition?.repeat === -1
@@ -588,9 +616,11 @@ function useMotionHostProps<Props extends MotionProps>(
           interactionAnimationCompletionRef.current.generation
             === animationGeneration
           && interactionAnimationCompletionRef.current.pending === 0
-          && reportAnimationComplete
         ) {
-          void reportAnimationComplete(definition);
+          applyTapTransitionEnd();
+          if (reportAnimationComplete) {
+            void reportAnimationComplete(definition);
+          }
         }
       }
       for (const key in targetValues) {
@@ -643,9 +673,11 @@ function useMotionHostProps<Props extends MotionProps>(
           onComplete: () => {
             if (
               interactionAnimationGenerationRef.current === animationGeneration
-              && reportAnimationComplete
             ) {
-              void reportAnimationComplete(whileTap!);
+              applyTapTransitionEnd();
+              if (reportAnimationComplete) {
+                void reportAnimationComplete(whileTap!);
+              }
             }
           },
         },
@@ -681,7 +713,10 @@ function useMotionHostProps<Props extends MotionProps>(
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;
-    const targetValues = resolvedTap.target as Record<string, unknown>;
+    const targetValues = {
+      ...resolvedTap.target,
+      ...resolvedTap.transitionEnd,
+    } as Record<string, unknown>;
     const restingTarget = hoverActiveRef.current && resolvedHover.target
       ? resolvedHover.target
       : resolvedAnimate.target;
@@ -825,6 +860,34 @@ function useMotionHostProps<Props extends MotionProps>(
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;
+    function applyHoverTransitionEnd() {
+      const transitionEnd = resolvedHover.transitionEnd;
+      if (!transitionEnd) {
+        return;
+      }
+      let addedValue = false;
+      for (const key in transitionEnd) {
+        const finalValue = transitionEnd[key];
+        let value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (!value && finalValue !== undefined) {
+          value = motionValue(finalValue as string | number);
+          generatedValuesRef.current[key] = value;
+          addedValue = true;
+        } else if (value && finalValue !== undefined) {
+          value.set(finalValue as never);
+        }
+      }
+      if (addedValue && elementRef.current) {
+        const ElementConstructor = globalThis.Element as unknown as new(
+          element: MainThread.Element,
+        ) => Element;
+        styleCleanupRef.current?.();
+        styleCleanupRef.current = styleEffect(
+          new ElementConstructor(elementRef.current),
+          { ...motionValues, ...generatedValuesRef.current },
+        );
+      }
+    }
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     let startedAnimationCount = 0;
     const resolvedTransition = (workletHoverTransition?.repeat === -1
@@ -846,9 +909,11 @@ function useMotionHostProps<Props extends MotionProps>(
           interactionAnimationCompletionRef.current.generation
             === animationGeneration
           && interactionAnimationCompletionRef.current.pending === 0
-          && reportAnimationComplete
         ) {
-          void reportAnimationComplete(whileHover!);
+          applyHoverTransitionEnd();
+          if (reportAnimationComplete) {
+            void reportAnimationComplete(whileHover!);
+          }
         }
       }
       for (const key in targetValues) {
@@ -897,9 +962,11 @@ function useMotionHostProps<Props extends MotionProps>(
           onComplete: () => {
             if (
               interactionAnimationGenerationRef.current === animationGeneration
-              && reportAnimationComplete
             ) {
-              void reportAnimationComplete(whileHover!);
+              applyHoverTransitionEnd();
+              if (reportAnimationComplete) {
+                void reportAnimationComplete(whileHover!);
+              }
             }
           },
         },
@@ -933,7 +1000,10 @@ function useMotionHostProps<Props extends MotionProps>(
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;
-    const hoverValues = resolvedHover.target as Record<string, unknown>;
+    const hoverValues = {
+      ...resolvedHover.target,
+      ...resolvedHover.transitionEnd,
+    } as Record<string, unknown>;
     const animateValues = resolvedAnimate.target as
       | Record<string, unknown>
       | undefined;


### PR DESCRIPTION
## Summary
- apply target-local `transitionEnd` after `whileTap` and `whileHover` animations finish
- wait for every animated property before committing final values
- suppress stale final writes with the existing interaction generation guard
- restore lower-priority hover/animate/style values when each gesture ends

## Why
Upstream Motion applies a gesture variant's `transitionEnd` only after that gesture animation completes, then unapplies it when the gesture exits. Lynx already parsed `transitionEnd` but only consumed it for base `animate`.

## Stack
- Base: #3484 (`agent/motion-hover-animation-lifecycle`)
- This PR contains only gesture `transitionEnd` behavior.

## Validation
- `@lynx-js/motion`: 131/131 tests
- TypeScript and dprint: pass
- package build + Publint: pass
- Huxpro/motion dual-renderer headless harness: 42/42
- real browser tap: opacity 0.5 → transitionEnd 0.75 → rest 1
- real browser hover: opacity 0.9 → transitionEnd 0.8 → rest 1

## Conformance priority
Importance 3 · Lynx fit 5 · MTS 1 · ReactLynx 0 · CSS 0. No platform blocker and no new Full Demo; this completes semantics in the existing gesture pattern.