### PR TITLE
fix(motion): restore gesture transition ownership

### DIFF
--- a/.changeset/motion-gesture-rest-transition.md
+++ b/.changeset/motion-gesture-rest-transition.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Restore tap and hover values with the active lower-priority target transition instead of reusing the exiting gesture transition.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -607,6 +607,31 @@ describe('declarative Motion', () => {
     expect(getByTestId('button').getAttribute('style')).toContain('opacity: 1');
   });
 
+  test('uses the initial transition when a tap restores its base value', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        initial={{ opacity: 1, transition: { type: false } }}
+        whileTap={{ opacity: 0.5, transition: { duration: 1 } }}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('button').getAttribute('style')).not.toContain(
+      'opacity: 1',
+    );
+
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('restores every value after interrupting a tap animation', async () => {
     const { getByTestId } = render(
       <motion.view

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -162,9 +162,12 @@ function useMotionHostProps<Props extends MotionProps>(
     variants,
     custom,
   );
+  const resolvedInitialMotion = resolvedInitial === false
+    ? undefined
+    : splitMotionTarget(resolvedInitial, transition);
   const resolvedInitialTarget = resolvedInitial === false
     ? false
-    : splitMotionTarget(resolvedInitial, undefined).target;
+    : resolvedInitialMotion?.target;
   const resolvedAnimate = splitMotionTarget(
     resolvedAnimateDefinition,
     transition,
@@ -204,6 +207,13 @@ function useMotionHostProps<Props extends MotionProps>(
         ? { ...resolvedAnimate.transition, repeat: -1 }
         : resolvedAnimate.transition,
     [resolvedAnimate.transition],
+  );
+  const workletInitialTransition = useMemo(
+    () =>
+      resolvedInitialMotion?.transition?.repeat === Number.POSITIVE_INFINITY
+        ? { ...resolvedInitialMotion.transition, repeat: -1 }
+        : resolvedInitialMotion?.transition,
+    [resolvedInitialMotion?.transition],
   );
   const workletTapTransition = useMemo(
     () =>
@@ -727,7 +737,9 @@ function useMotionHostProps<Props extends MotionProps>(
     let startedAnimationCount = 0;
     const restingTransition = hoverActiveRef.current && resolvedHover.target
       ? workletHoverTransition
-      : workletTapTransition;
+      : (resolvedAnimate.target
+        ? workletAnimateTransition
+        : workletInitialTransition);
     const resolvedTransition = (restingTransition?.repeat === -1
       ? { ...restingTransition, repeat: Number.POSITIVE_INFINITY }
       : restingTransition) ?? {};
@@ -1009,9 +1021,12 @@ function useMotionHostProps<Props extends MotionProps>(
       | undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     let startedAnimationCount = 0;
-    const resolvedTransition = (workletHoverTransition?.repeat === -1
-      ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
-      : workletHoverTransition) ?? {};
+    const restingTransition = resolvedAnimate.target
+      ? workletAnimateTransition
+      : workletInitialTransition;
+    const resolvedTransition = (restingTransition?.repeat === -1
+      ? { ...restingTransition, repeat: Number.POSITIVE_INFINITY }
+      : restingTransition) ?? {};
     const restingValues: Record<string, unknown> = {};
     for (const key in hoverValues) {
       let restingValue = animateValues?.[key] ?? initialValues[key];


### PR DESCRIPTION
## Summary
- restore tap and hover values with the active lower-priority target transition
- preserve hover transition ownership when tap releases over an active hover
- otherwise prefer the base animate transition, then the initial/component fallback transition

## Why
Upstream animation state assigns transitions to the target being restored. When gesture-owned keys fall back to the base style, it uses the initial transition if present. Lynx previously reused the exiting tap/hover transition, producing different release timing.

## Stack
- Base: #3485 (`agent/motion-gesture-transition-end`)
- This PR contains only gesture restoration transition ownership.

## Validation
- `@lynx-js/motion`: 132/132 tests
- TypeScript, dprint, package build, Publint: pass
- Huxpro/motion dual-renderer headless harness: 42/42
- tap→rest and hover→rest both reach an instant base transition inside a strict 30ms window on Web and Lynx
- slow restoration interruption regression remains green

## Conformance priority
Importance 4 · Lynx fit 5 · MTS 1 · ReactLynx 0 · CSS 0. No platform blocker and no new Full Demo.