### PR TITLE
fix(motion): apply transitionEnd-only gestures

### DIFF
--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -607,6 +607,65 @@ describe('declarative Motion', () => {
     expect(getByTestId('button').getAttribute('style')).toContain('opacity: 1');
   });
 
+  test('applies a transitionEnd-only tap definition', async () => {
+    const lifecycle: string[] = [];
+    const onAnimationStart = vi.fn((value: MotionTarget) => {
+      lifecycle.push(`start:${String(value.transitionEnd !== undefined)}`);
+    });
+    const onAnimationComplete = vi.fn((value: MotionTarget) => {
+      lifecycle.push(`complete:${String(value.transitionEnd !== undefined)}`);
+    });
+    const definition = { transitionEnd: { opacity: 0.4 } };
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        style={{ opacity: 1 }}
+        whileTap={definition}
+        transition={{ type: false }}
+        onAnimationStart={onAnimationStart}
+        onAnimationComplete={onAnimationComplete}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await Promise.resolve();
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'opacity: 0.4',
+    );
+    expect(lifecycle).toEqual(['start:true', 'complete:true']);
+    expect(onAnimationStart).toHaveBeenCalledWith(definition);
+    expect(onAnimationComplete).toHaveBeenCalledWith(definition);
+
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain('opacity: 1');
+  });
+
+  test('does not apply a stale transitionEnd-only tap after release', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        style={{ opacity: 1 }}
+        whileTap={{ transitionEnd: { opacity: 0.4 } }}
+        transition={{ type: false }}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('uses the initial transition when a tap restores its base value', async () => {
     const { getByTestId } = render(
       <motion.view

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -609,12 +609,31 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     let startedAnimationCount = 0;
+    let completeTapWithoutAnimation: (() => void) | undefined;
     const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
       : workletTapTransition) ?? {};
     // Keep animation handles out of the MTS snapshot captured by a ReactLynx
     // rerender triggered from lifecycle callbacks.
-    if (isLynxForWeb || !event.currentTarget) {
+    if (
+      Object.keys(resolvedTap.target).length === 0
+      && resolvedTap.transitionEnd
+      && Object.keys(resolvedTap.transitionEnd).length > 0
+    ) {
+      startedAnimationCount = 1;
+      completeTapWithoutAnimation = () => {
+        if (reportAnimationComplete) {
+          void reportAnimationComplete(whileTap!);
+        }
+        requestAnimationFrame(() => {
+          if (
+            interactionAnimationGenerationRef.current === animationGeneration
+          ) {
+            applyTapTransitionEnd();
+          }
+        });
+      };
+    } else if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
       let pendingAnimationCount = 0;
       function reportTapAnimationComplete(definition: MotionDefinition) {
@@ -697,6 +716,9 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     if (startedAnimationCount > 0 && onAnimationStart) {
       void runOnBackground(onAnimationStart)(whileTap!);
+    }
+    if (completeTapWithoutAnimation) {
+      completeTapWithoutAnimation();
     }
   }
 
@@ -902,12 +924,31 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     let startedAnimationCount = 0;
+    let completeHoverWithoutAnimation: (() => void) | undefined;
     const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
       : workletHoverTransition) ?? {};
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
-    if (isLynxForWeb) {
+    if (
+      Object.keys(resolvedHover.target).length === 0
+      && resolvedHover.transitionEnd
+      && Object.keys(resolvedHover.transitionEnd).length > 0
+    ) {
+      startedAnimationCount = 1;
+      completeHoverWithoutAnimation = () => {
+        if (reportAnimationComplete) {
+          void reportAnimationComplete(whileHover!);
+        }
+        requestAnimationFrame(() => {
+          if (
+            interactionAnimationGenerationRef.current === animationGeneration
+          ) {
+            applyHoverTransitionEnd();
+          }
+        });
+      };
+    } else if (isLynxForWeb) {
       const targetValues = resolvedHover.target as Record<string, unknown>;
       let pendingAnimationCount = 0;
       function reportHoverAnimationComplete() {
@@ -987,6 +1028,9 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     if (startedAnimationCount > 0 && onAnimationStart) {
       void runOnBackground(onAnimationStart)(whileHover!);
+    }
+    if (completeHoverWithoutAnimation) {
+      completeHoverWithoutAnimation();
     }
   }
 


### PR DESCRIPTION
## What changed

- apply `whileTap` and `whileHover` definitions that only contain `transitionEnd`
- preserve Motion lifecycle callbacks even when the gesture has no animated target values
- defer the final write to the next main-thread frame and suppress stale writes after gesture exit
- add package regressions for application, lifecycle order, restoration, and interruption

## Why

Upstream `motion-dom` schedules `transitionEnd` even when `animateTarget` creates no animations. The Lynx declarative gesture path previously treated an empty target as a no-op, so a valid `transitionEnd`-only gesture never applied.

This PR is stacked on #3486.

## Validation

- `@lynx-js/motion`: 134/134 tests
- TypeScript: pass
- dprint: pass
- package build + publint: pass
- local hypothesis only: Web/Lynx dual-renderer focused gesture suite 5/5
- local hypothesis only: full dual-renderer suite 43/43

Immutable `pkg.pr.new` evidence will be added when the exact package is available. No consumer metrics or conformance status are moved before that gate.

## Priority

I2 / F5 / M1 / R0 / C0. This is an upstream-specified long-tail gesture target shape with low architecture conflict. It extends an existing usage pattern, so it does not add a separate Full Demo.
