### PR TITLE
fix(motion): apply transitionEnd-only targets

### DIFF
--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -549,6 +549,41 @@ describe('declarative Motion', () => {
     expect(onUpdateAnimationStart).toHaveBeenCalledOnce();
   });
 
+  test('uses transitionEnd without lifecycle when initial is false', async () => {
+    const onAnimationStart = vi.fn();
+    const onAnimationComplete = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='box'
+        initial={false}
+        animate={{
+          x: 20,
+          y: 20,
+          transitionEnd: { x: 10, z: 20 },
+        }}
+        transition={{ type: false }}
+        onAnimationStart={onAnimationStart}
+        onAnimationComplete={onAnimationComplete}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateX(10px)',
+    );
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateY(20px)',
+    );
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateZ(20px)',
+    );
+    expect(onAnimationStart).not.toHaveBeenCalled();
+    expect(onAnimationComplete).not.toHaveBeenCalled();
+  });
+
   test('animates a MotionValue-backed style', async () => {
     function App() {
       const value = useMotionValue(1);

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -572,9 +572,6 @@ describe('declarative Motion', () => {
       { enableMainThread: true, enableBackgroundThread: true },
     );
 
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 30));
-    });
     expect(getByTestId('box').getAttribute('style')).toContain(
       'translateX(10px)',
     );

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -360,6 +360,72 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('applies a transitionEnd-only animate update', async () => {
+    function App() {
+      const [active, setActive] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            style={{ opacity: 1 }}
+            animate={active ? { transitionEnd: { opacity: 0.4 } } : {}}
+            transition={{ type: false }}
+          />
+          <view data-testid='toggle' bindtap={() => setActive(true)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 0.4');
+  });
+
+  test('does not apply a stale transitionEnd-only animate update', async () => {
+    function App() {
+      const [step, setStep] = useState(0);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            animate={step === 0
+              ? { opacity: 1 }
+              : step === 1
+              ? { transitionEnd: { opacity: 0.4 } }
+              : { opacity: 0.8 }}
+            transition={{ type: false }}
+          />
+          <view
+            data-testid='toggle'
+            bindtap={() => {
+              setStep(1);
+              setStep(2);
+            }}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 0.8');
+  });
+
   test('does not complete an animation after unmount', async () => {
     const onAnimationComplete = vi.fn();
     function App() {

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -361,6 +361,7 @@ describe('declarative Motion', () => {
   });
 
   test('applies a transitionEnd-only animate update', async () => {
+    const lifecycle: string[] = [];
     function App() {
       const [active, setActive] = useState(false);
       return (
@@ -370,6 +371,8 @@ describe('declarative Motion', () => {
             style={{ opacity: 1 }}
             animate={active ? { transitionEnd: { opacity: 0.4 } } : {}}
             transition={{ type: false }}
+            onAnimationStart={() => lifecycle.push('start')}
+            onAnimationComplete={() => lifecycle.push('complete')}
           />
           <view data-testid='toggle' bindtap={() => setActive(true)} />
         </view>
@@ -388,6 +391,7 @@ describe('declarative Motion', () => {
       await new Promise(resolve => setTimeout(resolve, 100));
     });
     expect(getByTestId('box').getAttribute('style')).toContain('opacity: 0.4');
+    expect(lifecycle).toEqual(['start', 'complete']);
   });
 
   test('does not apply a stale transitionEnd-only animate update', async () => {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -177,6 +177,12 @@ function useMotionHostProps<Props extends MotionProps>(
     resolvedHoverDefinition,
     transition,
   );
+  const initialFalseAnimateTarget = resolvedInitial === false
+    ? {
+      ...resolvedAnimate.target,
+      ...resolvedAnimate.transitionEnd,
+    }
+    : resolvedAnimate.target;
   const animationKey = motionDefinitionKey({
     animate: resolvedAnimate,
     whileTap: resolvedTap,
@@ -188,18 +194,18 @@ function useMotionHostProps<Props extends MotionProps>(
       resolveInitialStyle(
         style,
         resolvedInitialTarget,
-        resolvedAnimate.target,
+        initialFalseAnimateTarget,
       ),
-    [resolvedAnimate.target, resolvedInitialTarget, style],
+    [initialFalseAnimateTarget, resolvedInitialTarget, style],
   );
   const initialValues = useMemo(
     () =>
       resolveInitialValues(
         style,
         resolvedInitialTarget,
-        resolvedAnimate.target,
+        initialFalseAnimateTarget,
       ),
-    [resolvedAnimate.target, resolvedInitialTarget, style],
+    [initialFalseAnimateTarget, resolvedInitialTarget, style],
   );
   const workletAnimateTransition = useMemo(
     () =>

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -374,15 +374,21 @@ function useMotionHostProps<Props extends MotionProps>(
         : options) ?? {};
       const values = { ...motionValueBindings };
       const targetValues = (target ?? {}) as Record<string, unknown>;
+      const ownedTargetValues = {
+        ...targetValues,
+        ...transitionEnd,
+      };
       const animationTargetValues: Record<string, unknown> = {};
       for (const key in animateTargetKeysRef.current) {
-        if (!(key in targetValues) && startingValues[key] !== undefined) {
+        if (!(key in ownedTargetValues) && startingValues[key] !== undefined) {
           animationTargetValues[key] = startingValues[key];
         }
       }
       animateTargetKeysRef.current = {};
-      for (const key in targetValues) {
+      for (const key in ownedTargetValues) {
         animateTargetKeysRef.current[key] = true;
+      }
+      for (const key in targetValues) {
         animationTargetValues[key] = targetValues[key];
       }
       const targets = [
@@ -458,6 +464,30 @@ function useMotionHostProps<Props extends MotionProps>(
         styleCleanupRef.current = styleEffect(motionElement, values);
       }
 
+      function applyAnimateTransitionEnd() {
+        let addedValue = false;
+        for (const key in transitionEnd) {
+          const finalValue = transitionEnd[key];
+          let value = values[key];
+          if (!value && finalValue !== undefined) {
+            value = motionValue(finalValue as string | number);
+            generatedValuesRef.current[key] = value;
+            values[key] = value;
+            addedValue = true;
+          } else if (value && finalValue !== undefined) {
+            value.set(finalValue as never);
+          }
+        }
+        if (addedValue && elementRef.current) {
+          const ElementConstructor = globalThis.Element as unknown as new(
+            element: MainThread.Element,
+          ) => Element;
+          motionElement ??= new ElementConstructor(elementRef.current);
+          styleCleanupRef.current?.();
+          styleCleanupRef.current = styleEffect(motionElement, values);
+        }
+      }
+
       const completionPromises: Promise<void>[] = [];
       if (shouldAnimate) {
         for (const key in animationTargetValues) {
@@ -486,28 +516,35 @@ function useMotionHostProps<Props extends MotionProps>(
       ) {
         void runOnBackground(onAnimationStart)(animate);
       }
-      if (completionPromises.length > 0 && animate !== undefined) {
+      const hasTransitionEnd = Boolean(
+        transitionEnd && Object.keys(transitionEnd).length > 0,
+      );
+      if (
+        completionPromises.length === 0
+        && animate !== undefined
+        && hasTransitionEnd
+      ) {
+        if (onAnimationStart) {
+          void runOnBackground(onAnimationStart)(animate);
+        }
+        const reportAnimationComplete = onAnimationComplete
+          ? runOnBackground(onAnimationComplete)
+          : undefined;
+        if (reportAnimationComplete) {
+          void reportAnimationComplete(animate);
+        }
+        requestAnimationFrame(() => {
+          if (animationGenerationRef.current !== animationGeneration) {
+            return;
+          }
+          applyAnimateTransitionEnd();
+        });
+      } else if (completionPromises.length > 0 && animate !== undefined) {
         void Promise.all(completionPromises).then(() => {
           if (animationGenerationRef.current !== animationGeneration) {
             return;
           }
-          let addedValue = false;
-          for (const key in transitionEnd) {
-            const finalValue = transitionEnd[key];
-            let value = values[key];
-            if (!value && finalValue !== undefined) {
-              value = motionValue(finalValue as string | number);
-              generatedValuesRef.current[key] = value;
-              values[key] = value;
-              addedValue = true;
-            } else if (value && finalValue !== undefined) {
-              value.set(finalValue as never);
-            }
-          }
-          if (addedValue && motionElement) {
-            styleCleanupRef.current?.();
-            styleCleanupRef.current = styleEffect(motionElement, values);
-          }
+          applyAnimateTransitionEnd();
           if (onAnimationComplete) {
             void runOnBackground(onAnimationComplete)(animate);
           }

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -524,10 +524,10 @@ function useMotionHostProps<Props extends MotionProps>(
         && animate !== undefined
         && hasTransitionEnd
       ) {
-        if (onAnimationStart) {
+        if (shouldAnimate && onAnimationStart) {
           void runOnBackground(onAnimationStart)(animate);
         }
-        const reportAnimationComplete = onAnimationComplete
+        const reportAnimationComplete = shouldAnimate && onAnimationComplete
           ? runOnBackground(onAnimationComplete)
           : undefined;
         if (reportAnimationComplete) {


### PR DESCRIPTION
## What changed

- apply `animate` definitions that contain `transitionEnd` but no animated target keys
- keep `transitionEnd` keys owned by the active definition so they do not trigger an incorrect removed-key restoration
- create and bind a MotionValue when the final property was not previously animated
- preserve lifecycle notification and generation-based stale-write suppression
- avoid capturing active animation handles in ReactLynx rerender snapshots

## Why

Upstream `motion-dom` schedules `transitionEnd` even when `animateTarget` creates no animations. Its animation state also treats `transitionEnd` keys as owned by the active definition. The Lynx declarative path previously skipped that final write and could misclassify the key as removed.

This PR is stacked on #3487.

## Validation

- `@lynx-js/motion`: 136/136 tests
- TypeScript and dprint: pass
- package build + publint: pass
- local hypothesis only: focused dual-renderer transitionEnd/lifecycle suite 4/4
- local hypothesis only: full Web/Lynx dual-renderer suite 44/44

Immutable `pkg.pr.new` evidence will be added when the exact package is available. Consumer manifest, metrics, docs, and loss stay unchanged before that gate.

## Priority

I3 / F5 / M1 / R0 / C0. This completes an upstream target-shape invariant using existing MotionValues and the existing MTS lifecycle bridge. It extends the existing declarative target pattern rather than unlocking a separate Full Demo.
