### PR TITLE
fix(motion): retain values removed from animate

### DIFF
--- a/.changeset/motion-removed-target-retention.md
+++ b/.changeset/motion-removed-target-retention.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Retain the current MotionValue when a property is removed from both `animate` and `initial`.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -430,6 +430,99 @@ describe('declarative Motion', () => {
     expect(getByTestId('box').getAttribute('style')).toContain('opacity: 0.8');
   });
 
+  test('restores a value removed from animate to its initial value', async () => {
+    function App() {
+      const [active, setActive] = useState(true);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ opacity: 0 }}
+            animate={active ? { opacity: 1 } : {}}
+            transition={{ type: false }}
+          />
+          <view data-testid='toggle' bindtap={() => setActive(false)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 0');
+  });
+
+  test('uses the current initial value when a value leaves animate', async () => {
+    function App() {
+      const [active, setActive] = useState(true);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ opacity: active ? 0 : 0.5 }}
+            animate={active ? { opacity: 1 } : {}}
+            transition={{ type: false }}
+          />
+          <view data-testid='toggle' bindtap={() => setActive(false)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 0.5');
+  });
+
+  test('keeps the current value when it leaves both animate and initial', async () => {
+    function App() {
+      const [active, setActive] = useState(true);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={active ? { opacity: 0 } : {}}
+            animate={active ? { opacity: 1 } : {}}
+            transition={{ type: false }}
+          />
+          <view data-testid='toggle' bindtap={() => setActive(false)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('does not complete an animation after unmount', async () => {
     const onAnimationComplete = vi.fn();
     function App() {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -386,8 +386,18 @@ function useMotionHostProps<Props extends MotionProps>(
       };
       const animationTargetValues: Record<string, unknown> = {};
       for (const key in animateTargetKeysRef.current) {
-        if (!(key in ownedTargetValues) && startingValues[key] !== undefined) {
-          animationTargetValues[key] = startingValues[key];
+        if (!(key in ownedTargetValues)) {
+          if (startingValues[key] === undefined) {
+            const retainedValue = generatedValuesRef.current[key];
+            if (retainedValue) {
+              retainedValue.stop();
+              const retainedSnapshot = motionValue(retainedValue.get());
+              generatedValuesRef.current[key] = retainedSnapshot;
+              values[key] = retainedSnapshot;
+            }
+          } else {
+            animationTargetValues[key] = startingValues[key];
+          }
         }
       }
       animateTargetKeysRef.current = {};


### PR DESCRIPTION
## Summary

- match upstream Motion ownership when a key is removed from `animate`
- restore the current `initial` value when present
- retain the current MotionValue snapshot when the key leaves both `animate` and `initial`
- keep the retained value serializable for later Lynx main-thread gesture snapshots

## Upstream conformance

Mirrors the three adjacent `animate` prop contracts in `packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx`:

- restore the originally defined initial value
- restore the currently defined initial value
- perform no animation when removed from both animate and initial

## Verification

- `@lynx-js/motion`: 140/140 package tests
- focused Web/Lynx headless hypothesis: 1/1
- focused retained-value + transitionEnd-only gesture regression: 2/2
- full Web/Lynx suite: new case passes; 44/45 total with one pre-existing CDP touch retry double-dispatch flake, which passes 1/1 on isolated rerun
- package artifact publint: all good

Priority: I4 / F5 / M2 / R0 / C0. This closes a common conditional-target pattern but does not justify a separate Full Demo.