### PR TITLE
fix(motion): render initial transform origin

### DIFF
--- a/.changeset/motion-transform-origin-initial.md
+++ b/.changeset/motion-transform-origin-initial.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Render declarative transform origin aliases in the initial style snapshot.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -47,6 +47,20 @@ describe('declarative Motion', () => {
     });
   });
 
+  test('resolves initial transform origin aliases with upstream defaults', () => {
+    expect(
+      resolveInitialStyle(
+        undefined,
+        { originX: 0.2, originY: '60%', originZ: 10 },
+      ),
+    ).toEqual({
+      transformOrigin: '20% 60% 10px',
+    });
+    expect(resolveInitialStyle(undefined, { originX: 0 })).toEqual({
+      transformOrigin: '0% 50% 0',
+    });
+  });
+
   test('uses the final animate state when initial is false', () => {
     expect(
       resolveInitialStyle(
@@ -428,6 +442,40 @@ describe('declarative Motion', () => {
       await new Promise(resolve => setTimeout(resolve, 30));
     });
     expect(getByTestId('box').getAttribute('style')).toContain('opacity: 0.8');
+  });
+
+  test('animates transform origin aliases', async () => {
+    function App() {
+      const [active, setActive] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ originX: 0, originY: 0 }}
+            animate={active
+              ? { originX: 1, originY: 1 }
+              : { originX: 0, originY: 0 }}
+            transition={{ type: false }}
+          />
+          <view data-testid='toggle' bindtap={() => setActive(true)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'transform-origin: 0% 0%',
+    );
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'transform-origin: 100% 100%',
+    );
   });
 
   test('restores a value removed from animate to its initial value', async () => {

--- a/packages/motion/src/declarative/style.ts
+++ b/packages/motion/src/declarative/style.ts
@@ -81,6 +81,16 @@ function formatTransformValue(key: string, value: string | number): string {
   return `${value}px`;
 }
 
+function formatTransformOriginValue(
+  key: 'originX' | 'originY' | 'originZ',
+  value: string | number,
+): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return key === 'originZ' ? `${value}px` : `${value * 100}%`;
+}
+
 function appendResolvedValues(
   output: Record<string, unknown>,
   transforms: Record<string, string | number>,
@@ -114,24 +124,30 @@ export function resolveInitialStyle(
 
   const output: Record<string, unknown> = {};
   const transforms: Record<string, string | number> = {};
-  appendResolvedValues(
-    output,
-    transforms,
-    (style ?? {}) as Record<string, unknown>,
-  );
+  const transformOrigin: Partial<
+    Record<'originX' | 'originY' | 'originZ', string | number>
+  > = {};
+  const appendInitialValues = (
+    values: Record<string, unknown>,
+    useFinalKeyframe = false,
+  ) => {
+    const { originX, originY, originZ, ...rest } = values;
+    appendResolvedValues(output, transforms, rest, useFinalKeyframe);
+    for (const [key, value] of Object.entries({ originX, originY, originZ })) {
+      const resolvedValue = resolveStyleValue(value, useFinalKeyframe);
+      if (
+        typeof resolvedValue === 'string'
+        || typeof resolvedValue === 'number'
+      ) {
+        transformOrigin[key as keyof typeof transformOrigin] = resolvedValue;
+      }
+    }
+  };
+  appendInitialValues((style ?? {}) as Record<string, unknown>);
   if (initial === false) {
-    appendResolvedValues(
-      output,
-      transforms,
-      (animate ?? {}) as Record<string, unknown>,
-      true,
-    );
+    appendInitialValues((animate ?? {}) as Record<string, unknown>, true);
   } else {
-    appendResolvedValues(
-      output,
-      transforms,
-      (initial ?? {}) as Record<string, unknown>,
-    );
+    appendInitialValues((initial ?? {}) as Record<string, unknown>);
   }
 
   const generatedTransform = Object.entries(transforms)
@@ -145,6 +161,16 @@ export function resolveInitialStyle(
     output['transform'] = typeof existingTransform === 'string'
       ? `${existingTransform} ${generatedTransform}`
       : generatedTransform;
+  }
+  if (Object.keys(transformOrigin).length > 0) {
+    const originX = transformOrigin.originX ?? '50%';
+    const originY = transformOrigin.originY ?? '50%';
+    const originZ = transformOrigin.originZ ?? '0';
+    output['transformOrigin'] = [
+      formatTransformOriginValue('originX', originX),
+      formatTransformOriginValue('originY', originY),
+      formatTransformOriginValue('originZ', originZ),
+    ].join(' ');
   }
 
   return Object.keys(output).length > 0 ? output as CSSProperties : undefined;


### PR DESCRIPTION
## Summary

- render `originX`, `originY`, and `originZ` aliases into the first `transform-origin` style snapshot
- match upstream percentage, pixel, and missing-axis defaults
- keep subsequent updates on the existing upstream `motion-dom` styleEffect path

## Upstream conformance

Mirrors `build-styles.test.ts` (`Builds transformOrigin with correct default value types`): `{ originX: 0.2, originY: "60%", originZ: 10 }` renders `20% 60% 10px`.

## Verification

- `@lynx-js/motion`: 142/142 package tests
- focused Web/Lynx headless transform-origin hypothesis: 1/1
- focused transform-origin + removed-target + gesture regression: 3/3
- full Web/Lynx suite: new case passes through its final assertions on isolated rerun; the initial full run exposed a harness timing assertion and the existing CDP retry double-tap flake, both tightened in the consumer hypothesis

Priority: I3 / F5 / M1 / R0 / C1. No Full Demo: this improves a compositional transform detail but does not unlock a broad new usage pattern.