### PR TITLE
feat(motion): propagate parent variant labels

### DIFF
--- a/.changeset/motion-variant-label-propagation.md
+++ b/.changeset/motion-variant-label-propagation.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Propagate parent initial and animate variant labels to declarative Motion children.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -45,7 +45,8 @@ export function Card({ selected }: { selected: boolean }) {
 The declarative layer currently supports:
 
 - object targets and string/array/function `variants` for `initial` and
-  `animate`, including `custom` and target-local `transition`
+  `animate`, including `custom`, target-local `transition`, and parent label
+  inheritance for base targets when a child does not define its own label
 - `initial={false}` to render the final `animate` keyframe without a mount
   animation while preserving later target updates
 - transform aliases, keyframes, repeat/reverse, colors, and live `MotionValue`
@@ -58,7 +59,8 @@ The declarative layer currently supports:
 
 It does **not** yet provide the complete `motion/react` declarative contract.
 In particular, focus/in-view/drag states and their animation lifecycle
-callbacks, animation controls, propagated/orchestrated variants, layout and
+callbacks, animation controls, gesture propagation and variant orchestration
+(`when`, `delayChildren`, and `staggerChildren`), layout and
 shared-layout animations, `exit`, and `AnimatePresence` are not supported.
 Internal main-thread refs, handlers, and gestures also cannot yet be safely
 composed with every consumer-owned equivalent.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -127,6 +127,69 @@ describe('declarative Motion', () => {
     });
   });
 
+  test('propagates a parent variant label to children', async () => {
+    function App() {
+      const [active, setActive] = useState(false);
+      return (
+        <view>
+          <motion.view animate={active ? 'visible' : 'hidden'}>
+            <motion.view
+              data-testid='child'
+              variants={{
+                hidden: { opacity: 0, x: -20 },
+                visible: { opacity: 1, x: 40 },
+              }}
+              transition={{ type: false }}
+            />
+          </motion.view>
+          <view data-testid='toggle' bindtap={() => setActive(true)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'translateX(-20px)',
+    );
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'translateX(40px)',
+    );
+  });
+
+  test('an explicit child animate prop overrides a propagated label', async () => {
+    const { getByTestId } = render(
+      <motion.view animate='visible'>
+        <motion.view
+          data-testid='child'
+          animate='hidden'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ type: false }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+  });
+
   test('separates transitionEnd from animated values', () => {
     expect(
       splitMotionTarget(

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -19,11 +19,17 @@ import {
   runtime: 'shared',
 };
 
-import type { ComponentType, FunctionComponent } from '@lynx-js/react';
+import type {
+  ComponentType,
+  FunctionComponent,
+  ReactNode,
+} from '@lynx-js/react';
 import {
+  createContext,
   createElement,
   runOnBackground,
   runOnMainThread,
+  useContext,
   useEffect,
   useMainThreadRef,
   useMemo,
@@ -50,6 +56,53 @@ import type {
   MotionTransition,
   MotionViewProps,
 } from './types.js';
+
+interface MotionVariantContextValue {
+  initial?: MotionDefinition | false;
+  animate?: MotionDefinition;
+}
+
+const MotionVariantContext = createContext<MotionVariantContextValue>({});
+
+function isVariantLabel(
+  definition: MotionDefinition | false | undefined,
+): definition is string | string[] {
+  return typeof definition === 'string' || Array.isArray(definition);
+}
+
+function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
+  context: MotionVariantContextValue;
+  props: Props;
+} {
+  const parent = useContext(MotionVariantContext);
+  const initial = props.initial === undefined && isVariantLabel(parent.initial)
+    ? parent.initial
+    : props.initial;
+  const animate = props.animate === undefined && isVariantLabel(parent.animate)
+    ? parent.animate
+    : props.animate;
+  const context = useMemo<MotionVariantContextValue>(() => ({
+    ...(isVariantLabel(initial) ? { initial } : {}),
+    ...(isVariantLabel(animate) ? { animate } : {}),
+  }), [animate, initial]);
+  return {
+    context,
+    props: initial === props.initial && animate === props.animate
+      ? props
+      : { ...props, initial, animate },
+  };
+}
+
+function shouldProvideVariantContext(
+  props: MotionProps,
+  context: MotionVariantContextValue,
+  children: unknown,
+): boolean {
+  return children !== undefined
+    && props.whileTap === undefined
+    && props.whileHover === undefined
+    && (isVariantLabel(context.initial) || isVariantLabel(context.animate));
+}
 
 type PreparedHostProps = Record<string, unknown> & {
   style?: MotionProps['style'];
@@ -1244,18 +1297,54 @@ function useMotionHostProps<Props extends MotionProps>(
 }
 
 const MotionView: FunctionComponent<MotionViewProps> = (props) => {
-  const hostProps = useMotionHostProps(props);
-  return createElement('view', hostProps as IntrinsicElements['view']);
+  const inherited = useInheritedMotionProps(props);
+  const hostProps = useMotionHostProps(inherited.props);
+  const { children, ...elementProps } = hostProps;
+  if (!shouldProvideVariantContext(props, inherited.context, children)) {
+    return createElement('view', hostProps as IntrinsicElements['view']);
+  }
+  return createElement(
+    'view',
+    elementProps as IntrinsicElements['view'],
+    createElement(MotionVariantContext.Provider, {
+      value: inherited.context,
+      children: children as ReactNode,
+    }),
+  );
 };
 
 const MotionText: FunctionComponent<MotionTextProps> = (props) => {
-  const hostProps = useMotionHostProps(props);
-  return createElement('text', hostProps as IntrinsicElements['text']);
+  const inherited = useInheritedMotionProps(props);
+  const hostProps = useMotionHostProps(inherited.props);
+  const { children, ...elementProps } = hostProps;
+  if (!shouldProvideVariantContext(props, inherited.context, children)) {
+    return createElement('text', hostProps as IntrinsicElements['text']);
+  }
+  return createElement(
+    'text',
+    elementProps as IntrinsicElements['text'],
+    createElement(MotionVariantContext.Provider, {
+      value: inherited.context,
+      children: children as ReactNode,
+    }),
+  );
 };
 
 const MotionImage: FunctionComponent<MotionImageProps> = (props) => {
-  const hostProps = useMotionHostProps(props);
-  return createElement('image', hostProps as IntrinsicElements['image']);
+  const inherited = useInheritedMotionProps(props);
+  const hostProps = useMotionHostProps(inherited.props);
+  const { children, ...elementProps } = hostProps;
+  if (!shouldProvideVariantContext(props, inherited.context, children)) {
+    return createElement('image', hostProps as IntrinsicElements['image']);
+  }
+  return createElement(
+    'image',
+    elementProps as IntrinsicElements['image'],
+    createElement(MotionVariantContext.Provider, {
+      value: inherited.context,
+      children: children as ReactNode,
+    }),
+  );
 };
 
 function createMotionComponent<Props extends { style?: unknown }>(
@@ -1264,8 +1353,20 @@ function createMotionComponent<Props extends { style?: unknown }>(
   const MotionComponent: FunctionComponent<MotionComponentProps<Props>> = (
     props,
   ) => {
-    const hostProps = useMotionHostProps(props);
-    return createElement(Component, hostProps as Props);
+    const inherited = useInheritedMotionProps(props);
+    const hostProps = useMotionHostProps(inherited.props);
+    const { children, ...componentProps } = hostProps;
+    if (!shouldProvideVariantContext(props, inherited.context, children)) {
+      return createElement(Component, hostProps as unknown as Props);
+    }
+    return createElement(
+      Component,
+      componentProps as unknown as Props,
+      createElement(MotionVariantContext.Provider, {
+        value: inherited.context,
+        children: children as ReactNode,
+      }),
+    );
   };
   return MotionComponent;
 }


### PR DESCRIPTION
## Summary

Propagate parent `initial`/`animate` variant labels to declarative Motion children through background ReactLynx context.

This intentionally closes only the common upstream contracts:

- `child animates to set variant`
- child explicit `animate` overrides the inherited label
- reactive parent label changes reach descendants

It does not claim animation controls, gesture-state propagation, `when`, `delayChildren`, `staggerChildren`, or subtree lifecycle aggregation. Those remain in Huxpro/motion#10.

## Architecture

The label is React render state, so background React context is sufficient. Animation generators, MotionValues, transitions, and style effects remain upstream Motion code; no visual-element clone or second animation engine is introduced.

## Verification

- `@lynx-js/motion` package tests: 144/144
- focused declarative tests: 35/35
- declaration output generated successfully
- direct packed-tarball publint: all good
- repository formatter/lint hooks: pass

Priority: I5 / F4 / MTS1 / ReactLynx1 / CSS0.
