### PR TITLE
feat(motion): propagate delayChildren

### DIFF
--- a/.changeset/calm-cats-delay.md
+++ b/.changeset/calm-cats-delay.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": minor
+---
+
+Propagate numeric `delayChildren` through inherited declarative variant labels.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -46,7 +46,8 @@ The declarative layer currently supports:
 
 - object targets and string/array/function `variants` for `initial` and
   `animate`, including `custom`, target-local `transition`, and parent label
-  inheritance for base targets when a child does not define its own label
+  inheritance for base targets when a child does not define its own label;
+  numeric `delayChildren` also propagates through inherited labels
 - `initial={false}` to render the final `animate` keyframe without a mount
   animation while preserving later target updates
 - transform aliases, keyframes, repeat/reverse, colors, and live `MotionValue`
@@ -59,8 +60,8 @@ The declarative layer currently supports:
 
 It does **not** yet provide the complete `motion/react` declarative contract.
 In particular, focus/in-view/drag states and their animation lifecycle
-callbacks, animation controls, gesture propagation and variant orchestration
-(`when`, `delayChildren`, and `staggerChildren`), layout and
+callbacks, animation controls, gesture propagation and remaining variant
+orchestration (`when`, dynamic `delayChildren`, and `staggerChildren`), layout and
 shared-layout animations, `exit`, and `AnimatePresence` are not supported.
 Internal main-thread refs, handlers, and gestures also cannot yet be safely
 composed with every consumer-owned equivalent.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -190,6 +190,103 @@ describe('declarative Motion', () => {
     expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
   });
 
+  test('propagates numeric delayChildren to a variant child', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: {},
+          visible: { transition: { delayChildren: 0.08 } },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ type: false }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 90));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
+  test('accumulates numeric delayChildren through variant descendants', async () => {
+    const delayedVariant = {
+      hidden: {},
+      visible: { transition: { delayChildren: 0.06 } },
+    };
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={delayedVariant}
+      >
+        <motion.view variants={delayedVariant}>
+          <motion.view
+            data-testid='child'
+            variants={{
+              hidden: { opacity: 0 },
+              visible: { opacity: 1 },
+            }}
+            transition={{ type: false }}
+          />
+        </motion.view>
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
+  test('explicit child animate starts a new delayChildren root', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        animate='visible'
+        variants={{
+          visible: { transition: { delayChildren: 0.2 } },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          initial='hidden'
+          animate='visible'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ type: false }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('separates transitionEnd from animated values', () => {
     expect(
       splitMotionTarget(

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -60,6 +60,7 @@ import type {
 interface MotionVariantContextValue {
   initial?: MotionDefinition | false;
   animate?: MotionDefinition;
+  delay?: number;
 }
 
 const MotionVariantContext = createContext<MotionVariantContextValue>({});
@@ -72,24 +73,44 @@ function isVariantLabel(
 
 function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   context: MotionVariantContextValue;
+  delay: number;
   props: Props;
+  resolvedAnimateDefinition: MotionTarget | false | undefined;
 } {
   const parent = useContext(MotionVariantContext);
   const initial = props.initial === undefined && isVariantLabel(parent.initial)
     ? parent.initial
     : props.initial;
-  const animate = props.animate === undefined && isVariantLabel(parent.animate)
+  const inheritsAnimate = props.animate === undefined
+    && isVariantLabel(parent.animate);
+  const animate = inheritsAnimate
     ? parent.animate
     : props.animate;
+  const resolvedAnimateDefinition = resolveMotionDefinition(
+    animate,
+    props.variants,
+    props.custom,
+  );
+  const resolvedAnimate = splitMotionTarget(
+    resolvedAnimateDefinition,
+    props.transition,
+  );
+  const inheritedDelay = inheritsAnimate ? parent.delay ?? 0 : 0;
+  const delayChildren = resolvedAnimate.transition?.delayChildren;
+  const childDelay = inheritedDelay
+    + (typeof delayChildren === 'number' ? delayChildren : 0);
   const context = useMemo<MotionVariantContextValue>(() => ({
     ...(isVariantLabel(initial) ? { initial } : {}),
     ...(isVariantLabel(animate) ? { animate } : {}),
-  }), [animate, initial]);
+    ...(childDelay ? { delay: childDelay } : {}),
+  }), [animate, childDelay, initial]);
   return {
     context,
+    delay: inheritedDelay,
     props: initial === props.initial && animate === props.animate
       ? props
       : { ...props, initial, animate },
+    resolvedAnimateDefinition,
   };
 }
 
@@ -137,6 +158,8 @@ function tapInfo(event: unknown) {
 
 function useMotionHostProps<Props extends MotionProps>(
   props: Props,
+  inheritedDelay = 0,
+  inheritedResolvedAnimate?: MotionTarget | false,
 ): PreparedHostProps {
   const {
     animate,
@@ -200,11 +223,8 @@ function useMotionHostProps<Props extends MotionProps>(
   const hadAnimateTargetRef = useRef(false);
 
   const resolvedInitial = resolveMotionDefinition(initial, variants, custom);
-  const resolvedAnimateDefinition = resolveMotionDefinition(
-    animate,
-    variants,
-    custom,
-  );
+  const resolvedAnimateDefinition = inheritedResolvedAnimate
+    ?? resolveMotionDefinition(animate, variants, custom);
   const resolvedTapDefinition = resolveMotionDefinition(
     whileTap,
     variants,
@@ -262,10 +282,18 @@ function useMotionHostProps<Props extends MotionProps>(
   );
   const workletAnimateTransition = useMemo(
     () =>
-      resolvedAnimate.transition?.repeat === Number.POSITIVE_INFINITY
-        ? { ...resolvedAnimate.transition, repeat: -1 }
-        : resolvedAnimate.transition,
-    [resolvedAnimate.transition],
+      inheritedDelay && resolvedAnimate.transition?.delay === undefined
+        ? {
+          ...resolvedAnimate.transition,
+          delay: inheritedDelay,
+          ...(resolvedAnimate.transition?.repeat === Number.POSITIVE_INFINITY
+            ? { repeat: -1 }
+            : {}),
+        }
+        : (resolvedAnimate.transition?.repeat === Number.POSITIVE_INFINITY
+          ? { ...resolvedAnimate.transition, repeat: -1 }
+          : resolvedAnimate.transition),
+    [inheritedDelay, resolvedAnimate.transition],
   );
   const workletInitialTransition = useMemo(
     () =>
@@ -1298,7 +1326,11 @@ function useMotionHostProps<Props extends MotionProps>(
 
 const MotionView: FunctionComponent<MotionViewProps> = (props) => {
   const inherited = useInheritedMotionProps(props);
-  const hostProps = useMotionHostProps(inherited.props);
+  const hostProps = useMotionHostProps(
+    inherited.props,
+    inherited.delay,
+    inherited.resolvedAnimateDefinition,
+  );
   const { children, ...elementProps } = hostProps;
   if (!shouldProvideVariantContext(props, inherited.context, children)) {
     return createElement('view', hostProps as IntrinsicElements['view']);
@@ -1315,7 +1347,11 @@ const MotionView: FunctionComponent<MotionViewProps> = (props) => {
 
 const MotionText: FunctionComponent<MotionTextProps> = (props) => {
   const inherited = useInheritedMotionProps(props);
-  const hostProps = useMotionHostProps(inherited.props);
+  const hostProps = useMotionHostProps(
+    inherited.props,
+    inherited.delay,
+    inherited.resolvedAnimateDefinition,
+  );
   const { children, ...elementProps } = hostProps;
   if (!shouldProvideVariantContext(props, inherited.context, children)) {
     return createElement('text', hostProps as IntrinsicElements['text']);
@@ -1332,7 +1368,11 @@ const MotionText: FunctionComponent<MotionTextProps> = (props) => {
 
 const MotionImage: FunctionComponent<MotionImageProps> = (props) => {
   const inherited = useInheritedMotionProps(props);
-  const hostProps = useMotionHostProps(inherited.props);
+  const hostProps = useMotionHostProps(
+    inherited.props,
+    inherited.delay,
+    inherited.resolvedAnimateDefinition,
+  );
   const { children, ...elementProps } = hostProps;
   if (!shouldProvideVariantContext(props, inherited.context, children)) {
     return createElement('image', hostProps as IntrinsicElements['image']);
@@ -1354,7 +1394,11 @@ function createMotionComponent<Props extends { style?: unknown }>(
     props,
   ) => {
     const inherited = useInheritedMotionProps(props);
-    const hostProps = useMotionHostProps(inherited.props);
+    const hostProps = useMotionHostProps(
+      inherited.props,
+      inherited.delay,
+      inherited.resolvedAnimateDefinition,
+    );
     const { children, ...componentProps } = hostProps;
     if (!shouldProvideVariantContext(props, inherited.context, children)) {
       return createElement(Component, hostProps as unknown as Props);


### PR DESCRIPTION
## Summary

- propagate numeric `delayChildren` through inherited base variant labels
- accumulate delay through uncontrolled descendants
- preserve Motion ownership: an explicit child `animate` starts a new controlling root
- continue to use each child's upstream MotionValue animation rather than introducing a second scheduler

## Upstream contracts

- `packages/framer-motion/src/motion/__tests__/delay.test.tsx` — `in variant children via delayChildren`
- `packages/framer-motion/src/motion/__tests__/variant.test.tsx` — `delay propagates throughout children`

## Validation

- @lynx-js/motion: 147/147
- package JS + declarations: generated successfully
- direct pnpm pack + publint tarball: All good
- full repository build is unavailable in this environment because cargo/Rust is not installed; the package build then reaches the known @publint/pack temporary-tarball hook failure after successful JS/declaration generation

## Scope boundary

This PR intentionally covers numeric `delayChildren` only. Dynamic `delayChildren: stagger()`, `staggerChildren`, `when`, controls, gesture propagation, child ordering, and subtree completion aggregation remain tracked in Huxpro/motion#10.

Stacked on #3492.