### PR TITLE
feat(motion): support variant inheritance opt-out

### DIFF
--- a/.changeset/fair-birds-inherit.md
+++ b/.changeset/fair-birds-inherit.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": minor
+---
+
+Support `inherit={false}` to stop parent variant labels propagating through a declarative Motion component.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -47,6 +47,7 @@ The declarative layer currently supports:
 - object targets and string/array/function `variants` for `initial` and
   `animate`, including `custom`, target-local `transition`, and parent label
   inheritance for base targets when a child does not define its own label;
+  `inherit={false}` prevents labels propagating through a variant boundary;
   numeric `delayChildren` also propagates through inherited labels
 - `initial={false}` to render the final `animate` keyframe without a mount
   animation while preserving later target updates

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -190,6 +190,34 @@ describe('declarative Motion', () => {
     expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
   });
 
+  test('inherit false prevents parent variant labels reaching descendants', async () => {
+    const { getByTestId } = render(
+      <motion.view initial='hidden'>
+        <motion.view inherit={false} variants={{}}>
+          <motion.view
+            data-testid='child'
+            style={{ opacity: 0.5, x: 10 }}
+            variants={{ hidden: { opacity: 0, x: -20 } }}
+            transition={{ type: false }}
+          />
+        </motion.view>
+      </motion.view>,
+      {
+        enableMainThread: true,
+        enableBackgroundThread: true,
+      },
+    );
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'opacity: 0.5',
+    );
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'translateX(10px)',
+    );
+  });
+
   test('propagates numeric delayChildren to a variant child', async () => {
     const { getByTestId } = render(
       <motion.view

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -63,6 +63,7 @@ interface MotionVariantContextValue {
   delay?: number;
 }
 
+const emptyMotionVariantContext: MotionVariantContextValue = {};
 const MotionVariantContext = createContext<MotionVariantContextValue>({});
 
 function isVariantLabel(
@@ -78,10 +79,13 @@ function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   resolvedAnimateDefinition: MotionTarget | false | undefined;
 } {
   const parent = useContext(MotionVariantContext);
-  const initial = props.initial === undefined && isVariantLabel(parent.initial)
+  const initial = props.inherit !== false
+      && props.initial === undefined
+      && isVariantLabel(parent.initial)
     ? parent.initial
     : props.initial;
-  const inheritsAnimate = props.animate === undefined
+  const inheritsAnimate = props.inherit !== false
+    && props.animate === undefined
     && isVariantLabel(parent.animate);
   const animate = inheritsAnimate
     ? parent.animate
@@ -122,7 +126,16 @@ function shouldProvideVariantContext(
   return children !== undefined
     && props.whileTap === undefined
     && props.whileHover === undefined
-    && (isVariantLabel(context.initial) || isVariantLabel(context.animate));
+    && (props.inherit === false
+      || isVariantLabel(context.initial)
+      || isVariantLabel(context.animate));
+}
+
+function variantContextValue(
+  props: MotionProps,
+  context: MotionVariantContextValue,
+): MotionVariantContextValue {
+  return props.inherit === false ? emptyMotionVariantContext : context;
 }
 
 type PreparedHostProps = Record<string, unknown> & {
@@ -164,6 +177,7 @@ function useMotionHostProps<Props extends MotionProps>(
   const {
     animate,
     initial,
+    inherit: _inherit,
     style,
     transition,
     whileTap,
@@ -1339,7 +1353,7 @@ const MotionView: FunctionComponent<MotionViewProps> = (props) => {
     'view',
     elementProps as IntrinsicElements['view'],
     createElement(MotionVariantContext.Provider, {
-      value: inherited.context,
+      value: variantContextValue(props, inherited.context),
       children: children as ReactNode,
     }),
   );
@@ -1360,7 +1374,7 @@ const MotionText: FunctionComponent<MotionTextProps> = (props) => {
     'text',
     elementProps as IntrinsicElements['text'],
     createElement(MotionVariantContext.Provider, {
-      value: inherited.context,
+      value: variantContextValue(props, inherited.context),
       children: children as ReactNode,
     }),
   );
@@ -1381,7 +1395,7 @@ const MotionImage: FunctionComponent<MotionImageProps> = (props) => {
     'image',
     elementProps as IntrinsicElements['image'],
     createElement(MotionVariantContext.Provider, {
-      value: inherited.context,
+      value: variantContextValue(props, inherited.context),
       children: children as ReactNode,
     }),
   );
@@ -1407,7 +1421,7 @@ function createMotionComponent<Props extends { style?: unknown }>(
       Component,
       componentProps as unknown as Props,
       createElement(MotionVariantContext.Provider, {
-        value: inherited.context,
+        value: variantContextValue(props, inherited.context),
         children: children as ReactNode,
       }),
     );

--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -71,6 +71,8 @@ export interface MotionProps {
   initial?: MotionDefinition | false;
   /** Values animated whenever this target changes. */
   animate?: MotionDefinition;
+  /** Whether parent variant labels propagate through this component. */
+  inherit?: boolean;
   /** Values animated while the element is being pressed. */
   whileTap?: MotionDefinition;
   /** Values animated while a mouse-capable client hovers the element. */


### PR DESCRIPTION
## Summary

- add the upstream-compatible declarative `inherit` prop
- make `inherit={false}` publish an empty variant context so parent labels do not propagate through that component
- keep the prop out of host forwarding
- add a package test proving an inherited `initial` label stops at the boundary

## Stack

- base: #3493 (`agent/motion-delay-children`)
- this PR is one atomic Motion contract

## Validation

- `@lynx-js/motion`: 148/148 tests
- dprint + Biome: pass
- motion API extractor/type build: pass
- JS/declaration build completes; direct packed tarball passes publint
- required full Turbo build attempted; this local environment lacks `cargo`, so it stops in pre-existing Rust/wasm dependencies before the Motion package build

## Priority and scope

I4 / F5 / MTS1 / ReactLynx1 / CSS0. This is a context opt-out with no new animation engine, host API, MTS callable, CSS behavior, Full Demo, or native boundary. Parent-driven dynamic orchestration is intentionally still tracked in Hux issue #10.
