### PR TITLE
feat(motion): propagate initial false to variant children

### DIFF
--- a/.changeset/tidy-cats-initial.md
+++ b/.changeset/tidy-cats-initial.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": minor
+---
+
+Propagate `initial={false}` through inherited declarative variant labels.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -48,6 +48,7 @@ The declarative layer currently supports:
   `animate`, including `custom`, target-local `transition`, and parent label
   inheritance for base targets when a child does not define its own label;
   `inherit={false}` prevents labels propagating through a variant boundary;
+  parent `initial={false}` also suppresses inherited child mount animations;
   numeric `delayChildren` also propagates through inherited labels
 - `initial={false}` to render the final `animate` keyframe without a mount
   animation while preserving later target updates

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -218,6 +218,27 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('propagates initial false to an inherited variant child', async () => {
+    const { getByTestId } = render(
+      <motion.view initial={false} animate='visible'>
+        <motion.view
+          data-testid='child'
+          variants={{
+            hidden: { opacity: 0, x: -20 },
+            visible: { opacity: 1, x: 40 },
+          }}
+          transition={{ duration: 0.2 }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'translateX(40px)',
+    );
+  });
+
   test('propagates numeric delayChildren to a variant child', async () => {
     const { getByTestId } = render(
       <motion.view

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -81,7 +81,7 @@ function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   const parent = useContext(MotionVariantContext);
   const initial = props.inherit !== false
       && props.initial === undefined
-      && isVariantLabel(parent.initial)
+      && (parent.initial === false || isVariantLabel(parent.initial))
     ? parent.initial
     : props.initial;
   const inheritsAnimate = props.inherit !== false
@@ -104,7 +104,7 @@ function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   const childDelay = inheritedDelay
     + (typeof delayChildren === 'number' ? delayChildren : 0);
   const context = useMemo<MotionVariantContextValue>(() => ({
-    ...(isVariantLabel(initial) ? { initial } : {}),
+    ...(initial === false || isVariantLabel(initial) ? { initial } : {}),
     ...(isVariantLabel(animate) ? { animate } : {}),
     ...(childDelay ? { delay: childDelay } : {}),
   }), [animate, childDelay, initial]);


### PR DESCRIPTION
## Summary

- include `initial={false}` in the declarative variant context
- let inherited variant children render their final animate keyframe on the first frame without a mount animation
- add a focused package test for the parent/child contract

## Stack

- base: #3494 (`agent/motion-variant-inherit-opt-out`)
- this PR is one atomic Motion contract

## Validation

- `@lynx-js/motion`: 149/149 tests
- JS/declaration build + publint: pass
- pre-commit ESLint/Biome/dprint: pass

## Priority and scope

I5 / F5 / MTS1 / ReactLynx1 / CSS0. This extends the existing variant context and upstream MotionValue path; it adds no animation engine, host API, MTS callable, CSS behavior, Full Demo, or native boundary.
