### PR TITLE
fix(motion): preserve explicit child mount animations

### DIFF
--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -152,7 +152,7 @@ describe('declarative Motion', () => {
       enableBackgroundThread: true,
     });
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 30));
+      await new Promise(resolve => setTimeout(resolve, 100));
     });
     expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
     expect(getByTestId('child').getAttribute('style')).toContain(
@@ -237,6 +237,31 @@ describe('declarative Motion', () => {
     expect(getByTestId('child').getAttribute('style')).toContain(
       'translateX(40px)',
     );
+  });
+
+  test('does not propagate initial false to an explicit child animate prop', async () => {
+    const onAnimationStart = vi.fn();
+    const { getByTestId } = render(
+      <motion.view initial={false} animate='visible'>
+        <motion.view
+          data-testid='child'
+          style={{ opacity: 1 }}
+          animate={{ opacity: 0.4 }}
+          transition={{ duration: 0.01 }}
+          onAnimationStart={onAnimationStart}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'opacity: 0.4',
+    );
+    expect(onAnimationStart).toHaveBeenCalledOnce();
   });
 
   test('propagates numeric delayChildren to a variant child', async () => {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -79,14 +79,14 @@ function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   resolvedAnimateDefinition: MotionTarget | false | undefined;
 } {
   const parent = useContext(MotionVariantContext);
-  const initial = props.inherit !== false
+  const inheritsAnimate = props.inherit !== false
+    && props.animate === undefined
+    && isVariantLabel(parent.animate);
+  const initial = inheritsAnimate
       && props.initial === undefined
       && (parent.initial === false || isVariantLabel(parent.initial))
     ? parent.initial
     : props.initial;
-  const inheritsAnimate = props.inherit !== false
-    && props.animate === undefined
-    && isVariantLabel(parent.animate);
   const animate = inheritsAnimate
     ? parent.animate
     : props.animate;


### PR DESCRIPTION
## Summary
- inherit parent `initial={false}` only when the child also inherits the parent animate label
- preserve mount animation ownership for children with their own object or explicit animate prop
- add a package regression that observes the child static first frame, animated target, and lifecycle start

## Why
Upstream Motion context applies parent `initial={false}` to inherited variant descendants, but does not rewrite an independently controlled child. The previous #3495 condition applied `initial={false}` to every child with no explicit initial, causing an explicit object animate target to render immediately without lifecycle.

## Verification
- `@lynx-js/motion` declarative suite: 41/41
- `@lynx-js/motion` build and declaration generation
- Publint passed

## Stack
Atomic follow-up stacked on #3495. Exact pkg.pr.new validation will be performed through validation-only #3491 after this PR publishes its head.