### PR TITLE
fix(motion): apply initial variant transition end

### DIFF
--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -960,6 +960,27 @@ describe('declarative Motion', () => {
     expect(onAnimationComplete).not.toHaveBeenCalled();
   });
 
+  test('applies transitionEnd from an initial variant on the first frame', () => {
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='box'
+        initial='visible'
+        variants={{
+          visible: {
+            opacity: 1,
+            transitionEnd: { display: 'none' },
+          },
+        }}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'display: none',
+    );
+  });
+
   test('animates a MotionValue-backed style', async () => {
     function App() {
       const value = useMotionValue(1);

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -254,7 +254,12 @@ function useMotionHostProps<Props extends MotionProps>(
     : splitMotionTarget(resolvedInitial, transition);
   const resolvedInitialTarget = resolvedInitial === false
     ? false
-    : resolvedInitialMotion?.target;
+    : (resolvedInitialMotion
+      ? {
+        ...resolvedInitialMotion.target,
+        ...resolvedInitialMotion.transitionEnd,
+      }
+      : undefined);
   const resolvedAnimate = splitMotionTarget(
     resolvedAnimateDefinition,
     transition,


### PR DESCRIPTION
## Summary

Apply a resolved initial variant's `transitionEnd` values on the first rendered frame, matching upstream Motion's `applies applyOnEnd if set on initial` contract.

## Stack

- base: validation rollup `agent/motion-complex-value-audit` (`dfb913f`)
- one semantic change and one package regression test

## Verification

- before fix on exact `dfb913f`: upstream Web computes `display: none`; Lynx-for-Web remains `display: flex`
- package declarative suite after fix: 42/42
- exact pkg.pr.new Hux validation will be attached after this branch is rolled into the validation publisher

This only changes initial target composition: `transitionEnd` overrides the normal initial target as upstream does. No new MTS or CSS path is introduced.