### PR TITLE
fix(motion): restore inherited variant style fallback

### DIFF
--- a/.changeset/sharp-rabbits-inherit.md
+++ b/.changeset/sharp-rabbits-inherit.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Restore child style values when an inherited variant removes an animated key.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -169,6 +169,53 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('restores child style when an inherited variant removes a value', async () => {
+    function App() {
+      const [phase, setPhase] = useState(0);
+      const label = phase === 0 ? 'a' : phase === 1 ? 'b' : 'c';
+      return (
+        <view>
+          <motion.view initial='a' animate={label}>
+            <motion.view
+              data-testid='child'
+              style={{ opacity: 0 }}
+              variants={{
+                a: { opacity: 0.5 },
+                b: { opacity: 1 },
+                c: {},
+              }}
+              transition={{ type: false }}
+            />
+          </motion.view>
+          <view
+            data-testid='toggle'
+            bindtap={() => setPhase(value => value + 1)}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'opacity: 0.5',
+    );
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+  });
+
   test('an explicit child animate prop overrides a propagated label', async () => {
     const { getByTestId } = render(
       <motion.view animate='visible'>

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -75,6 +75,7 @@ function isVariantLabel(
 function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   context: MotionVariantContextValue;
   delay: number;
+  inheritsAnimate: boolean;
   props: Props;
   resolvedAnimateDefinition: MotionTarget | false | undefined;
 } {
@@ -111,6 +112,7 @@ function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   return {
     context,
     delay: inheritedDelay,
+    inheritsAnimate,
     props: initial === props.initial && animate === props.animate
       ? props
       : { ...props, initial, animate },
@@ -173,6 +175,7 @@ function useMotionHostProps<Props extends MotionProps>(
   props: Props,
   inheritedDelay = 0,
   inheritedResolvedAnimate?: MotionTarget | false,
+  inheritsAnimate = false,
 ): PreparedHostProps {
   const {
     animate,
@@ -298,6 +301,13 @@ function useMotionHostProps<Props extends MotionProps>(
         initialFalseAnimateTarget,
       ),
     [initialFalseAnimateTarget, resolvedInitialTarget, style],
+  );
+  const removedAnimateFallbackValues = useMemo(
+    () =>
+      inheritsAnimate
+        ? resolveInitialValues(style, undefined)
+        : initialValues,
+    [inheritsAnimate, initialValues, style],
   );
   const workletAnimateTransition = useMemo(
     () =>
@@ -449,6 +459,7 @@ function useMotionHostProps<Props extends MotionProps>(
       transitionEnd: Record<string, unknown> | undefined,
       options: MotionTransition | undefined,
       startingValues: Record<string, unknown>,
+      removedTargetFallbackValues: Record<string, unknown>,
       shouldAnimate: boolean,
     ) {
       'main thread';
@@ -487,7 +498,7 @@ function useMotionHostProps<Props extends MotionProps>(
       const animationTargetValues: Record<string, unknown> = {};
       for (const key in animateTargetKeysRef.current) {
         if (!(key in ownedTargetValues)) {
-          if (startingValues[key] === undefined) {
+          if (removedTargetFallbackValues[key] === undefined) {
             const retainedValue = generatedValuesRef.current[key];
             if (retainedValue) {
               retainedValue.stop();
@@ -496,7 +507,7 @@ function useMotionHostProps<Props extends MotionProps>(
               values[key] = retainedSnapshot;
             }
           } else {
-            animationTargetValues[key] = startingValues[key];
+            animationTargetValues[key] = removedTargetFallbackValues[key];
           }
         }
       }
@@ -675,6 +686,7 @@ function useMotionHostProps<Props extends MotionProps>(
       resolvedAnimate.transitionEnd,
       workletAnimateTransition,
       initialValues,
+      removedAnimateFallbackValues,
       shouldAnimateTarget,
     );
 
@@ -1349,6 +1361,7 @@ const MotionView: FunctionComponent<MotionViewProps> = (props) => {
     inherited.props,
     inherited.delay,
     inherited.resolvedAnimateDefinition,
+    inherited.inheritsAnimate,
   );
   const { children, ...elementProps } = hostProps;
   if (!shouldProvideVariantContext(props, inherited.context, children)) {
@@ -1370,6 +1383,7 @@ const MotionText: FunctionComponent<MotionTextProps> = (props) => {
     inherited.props,
     inherited.delay,
     inherited.resolvedAnimateDefinition,
+    inherited.inheritsAnimate,
   );
   const { children, ...elementProps } = hostProps;
   if (!shouldProvideVariantContext(props, inherited.context, children)) {
@@ -1391,6 +1405,7 @@ const MotionImage: FunctionComponent<MotionImageProps> = (props) => {
     inherited.props,
     inherited.delay,
     inherited.resolvedAnimateDefinition,
+    inherited.inheritsAnimate,
   );
   const { children, ...elementProps } = hostProps;
   if (!shouldProvideVariantContext(props, inherited.context, children)) {
@@ -1417,6 +1432,7 @@ function createMotionComponent<Props extends { style?: unknown }>(
       inherited.props,
       inherited.delay,
       inherited.resolvedAnimateDefinition,
+      inherited.inheritsAnimate,
     );
     const { children, ...componentProps } = hostProps;
     if (!shouldProvideVariantContext(props, inherited.context, children)) {


### PR DESCRIPTION
## Summary

Restore a child's static style when a value disappears from an inherited parent variant.

## Root cause

The removed-key path used the child's complete initial snapshot as its fallback. For an inherited label, that snapshot contains the initial variant value, but upstream Motion intentionally falls back to the child `style` value when a later parent variant omits the key.

This change explicitly carries inherited-animation ownership into the host hook and separates:

- initial values used as animation starting values; and
- values used only when a previously animated key is removed.

Direct `animate` targets keep their existing initial-value fallback semantics.

## Stack

- Base: #3497 (`agent/motion-initial-transition-end`)
- This PR is one atomic ReactLynx ownership fix; no MTS, CSS, or native host change.

## Validation

- new package regression: `a(0.5) → b(1) → c({})` restores child `style.opacity=0`
- declarative suite: 43/43
- complete `@lynx-js/motion` suite: 152/152
- pre-commit ESLint/Biome/dprint: pass
- declaration build: pass
- `pnpm pack`: pass
- Rslib's Publint post-build step is locally blocked by its temp-tarball lookup even though independent pack succeeds; recorded rather than hidden

Consumer validation with an immutable preview package will be attached after the validation rollup publishes this commit.
