### PR TITLE
fix(motion): restore inherited removed values

### DIFF
--- a/.changeset/bright-moles-restore.md
+++ b/.changeset/bright-moles-restore.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Restore transform identity values when inherited variants remove keys from memoized children.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -4,7 +4,7 @@
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { useState } from '@lynx-js/react';
+import { memo, useState } from '@lynx-js/react';
 import type { IntrinsicElements } from '@lynx-js/types';
 import { act, fireEvent, render } from '@lynx-js/react/testing-library';
 
@@ -214,6 +214,64 @@ describe('declarative Motion', () => {
       await new Promise(resolve => setTimeout(resolve, 30));
     });
     expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+  });
+
+  test('restores an inherited value when a memoized child does not render with its parent', async () => {
+    const Child = memo(() => (
+      <motion.view
+        data-testid='child'
+        variants={{
+          visible: { x: 100, opacity: 1 },
+          hidden: { opacity: 0 },
+        }}
+        transition={{ type: false }}
+      />
+    ));
+
+    function App() {
+      const [visible, setVisible] = useState(false);
+      return (
+        <view>
+          <motion.view
+            initial={{ x: 0 }}
+            animate={visible ? 'visible' : 'hidden'}
+          >
+            <Child />
+          </motion.view>
+          <view
+            data-testid='toggle'
+            bindtap={() => setVisible(value => !value)}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'translateX(100px)',
+    );
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+    expect(getByTestId('child').getAttribute('style')).not.toContain(
+      'translateX(100px)',
+    );
   });
 
   test('an explicit child animate prop overrides a propagated label', async () => {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -460,6 +460,7 @@ function useMotionHostProps<Props extends MotionProps>(
       options: MotionTransition | undefined,
       startingValues: Record<string, unknown>,
       removedTargetFallbackValues: Record<string, unknown>,
+      restoreRemovedTargetIdentity: boolean,
       shouldAnimate: boolean,
     ) {
       'main thread';
@@ -499,6 +500,25 @@ function useMotionHostProps<Props extends MotionProps>(
       for (const key in animateTargetKeysRef.current) {
         if (!(key in ownedTargetValues)) {
           if (removedTargetFallbackValues[key] === undefined) {
+            if (
+              restoreRemovedTargetIdentity
+              && (key === 'opacity'
+                || key === 'x'
+                || key === 'y'
+                || key === 'z'
+                || key === 'translateX'
+                || key === 'translateY'
+                || key === 'translateZ'
+                || key.startsWith('scale')
+                || key.startsWith('rotate')
+                || key.startsWith('skew'))
+            ) {
+              animationTargetValues[key] = key === 'opacity'
+                  || key.startsWith('scale')
+                ? 1
+                : 0;
+              continue;
+            }
             const retainedValue = generatedValuesRef.current[key];
             if (retainedValue) {
               retainedValue.stop();
@@ -687,6 +707,7 @@ function useMotionHostProps<Props extends MotionProps>(
       workletAnimateTransition,
       initialValues,
       removedAnimateFallbackValues,
+      inheritsAnimate,
       shouldAnimateTarget,
     );
 


### PR DESCRIPTION
## Summary

- restore identity values when an inherited variant removes transform keys from a child
- keep static style fallback from #3498 higher priority than the identity fallback
- cover a memoized child that does not render in lockstep with its parent

## Upstream contract

`packages/framer-motion/src/motion/__tests__/variant.test.tsx` — `Children correctly animate to removed values even when not rendering along with parents`

Before this patch, `hidden → visible → hidden` left a memoized child at `x=100` on Lynx while Web restored `x=0`.

## Verification

- declarative package suite: 44/44
- complete `@lynx-js/motion` suite: 153/153
- declaration generation succeeds
- ESLint and staged Biome/dprint checks pass
- independent `npm pack --dry-run`: succeeds

The Rslib build emits JS and declarations, then the local Publint post-build step hits the existing missing temporary tarball issue; independent packing succeeds.

## Stack

Base: #3498 (`agent/motion-inherited-variant-style-fallback`)
