### PR TITLE
fix: apply React aliases to every bundler chain

### DIFF
--- a/.changeset/calm-taxis-resolve.md
+++ b/.changeset/calm-taxis-resolve.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-alias-rsbuild-plugin": patch
+---
+
+Apply ReactLynx aliases to every generated bundler chain so repeated Rsbuild config initialization, including Rstest, retains the plugin's resolve configuration.

--- a/packages/rspeedy/plugin-react-alias/src/index.ts
+++ b/packages/rspeedy/plugin-react-alias/src/index.ts
@@ -44,9 +44,9 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
         })
       })
 
-      api.modifyBundlerChain(async (chain, { isProd, environment, rspack }) => {
-        if (Object.hasOwn(environment, S_PLUGIN_REACT_ALIAS)) {
-          // This environment has already been processed
+      api.modifyBundlerChain(async (chain, { isProd, rspack }) => {
+        if (Object.hasOwn(chain, S_PLUGIN_REACT_ALIAS)) {
+          // This bundler chain has already been processed
           return
         }
         const resolve = createLazyResolver(
@@ -61,7 +61,7 @@ export function pluginReactAlias(options: Options): RsbuildPlugin {
           resolve,
         })
 
-        Object.defineProperty(environment, S_PLUGIN_REACT_ALIAS, {
+        Object.defineProperty(chain, S_PLUGIN_REACT_ALIAS, {
           value: true,
         })
         const [

--- a/packages/rspeedy/plugin-react-alias/test/index.test.ts
+++ b/packages/rspeedy/plugin-react-alias/test/index.test.ts
@@ -411,7 +411,7 @@ describe('React - alias', () => {
     ).toBe('preact/hooks/dist/hooks.mjs')
   })
 
-  test.skip('alias once', async () => {
+  test('applies aliases once per bundler chain', async () => {
     rstest.stubEnv('NODE_ENV', 'production')
     const { pluginReactAlias } = await import('../src/index.js')
 
@@ -443,22 +443,28 @@ describe('React - alias', () => {
               return pluginReactAlias({ LAYERS }).setup(api)
             },
           } satisfies RsbuildPlugin,
-          {
-            name: 'test2',
-            setup(api) {
-              expect(api.useExposed(Symbol.for('@lynx-js/plugin-react-alias')))
-                .toBe(true)
-            },
-          } satisfies RsbuildPlugin,
         ],
       },
       cwd: path.dirname(fileURLToPath(import.meta.url)),
     })
 
-    await rsbuild.initConfigs()
+    const [firstConfig] = await rsbuild.initConfigs()
+    const [secondConfig] = await rsbuild.initConfigs()
 
-    expect(layerGetter).toBeCalledTimes(2)
-    expect.assertions(2)
+    for (const config of [firstConfig, secondConfig]) {
+      if (!config?.resolve?.alias) {
+        expect.fail('should have config.resolve.alias')
+      }
+
+      expect(config.resolve.alias).toHaveProperty(
+        '@lynx-js/react$',
+        expect.stringContaining(
+          '/packages/react/runtime/lib/index.js'.replaceAll('/', path.sep),
+        ),
+      )
+    }
+
+    expect(layerGetter).toBeCalledTimes(4)
   })
 
   describe('with environments', () => {


### PR DESCRIPTION
## Summary

- scope ReactLynx alias deduplication to each bundler chain instead of the reusable Rsbuild environment
- preserve plugin-provided aliases when one Rsbuild instance initializes configs more than once, as Rstest does during discovery and compiler creation
- restore and strengthen the existing deduplication regression test to cover both duplicate plugin registration and repeated initConfigs calls
- add a patch changeset

## Root cause

Rstest initializes configs once while preparing its executor and again when creating the compiler. Rsbuild reuses the environment object across those calls but creates a fresh bundler chain. The environment-level marker therefore skipped the alias plugin on the second, compiler-facing chain.

## Test plan

- pnpm install --frozen-lockfile
- pnpm turbo build (69/69 tasks)
- pnpm --filter @lynx-js/react-alias-rsbuild-plugin exec rstest run test/index.test.ts (9/9 tests)
- pnpm dprint check
- Biome check over all Git-tracked and pending files
- NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint . (0 errors; existing warnings only)
- pnpm changeset status --since=upstream/main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved React alias handling when bundler configuration is initialized multiple times.
  - Prevented duplicate processing while ensuring React aliases remain applied across generated configurations.
  - Improved compatibility with testing and bundler initialization workflows.

- **Tests**
  - Added coverage for repeated initialization and multiple React alias plugins.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->