### PR TITLE
feat(motion): support explicit beforeChildren timing

### DIFF
--- a/.changeset/motion-before-children.md
+++ b/.changeset/motion-before-children.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Honor `when: "beforeChildren"` for declarative variants with a non-repeating, explicit parent duration.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -49,7 +49,10 @@ The declarative layer currently supports:
   inheritance for base targets when a child does not define its own label;
   `inherit={false}` prevents labels propagating through a variant boundary;
   parent `initial={false}` also suppresses inherited child mount animations;
-  numeric `delayChildren` also propagates through inherited labels
+  numeric `delayChildren` also propagates through inherited labels;
+  `when: "beforeChildren"` waits for a parent's non-repeating,
+  explicit-duration target
+  before starting inherited children
 - `initial={false}` to render the final `animate` keyframe without a mount
   animation while preserving later target updates
 - transform aliases, keyframes, repeat/reverse, colors, and live `MotionValue`
@@ -63,8 +66,10 @@ The declarative layer currently supports:
 It does **not** yet provide the complete `motion/react` declarative contract.
 In particular, focus/in-view/drag states and their animation lifecycle
 callbacks, animation controls, gesture propagation and remaining variant
-orchestration (`when`, dynamic `delayChildren`, and `staggerChildren`), layout and
-shared-layout animations, `exit`, and `AnimatePresence` are not supported.
+orchestration (`when: "afterChildren"`, automatic-duration or repeating
+`when: "beforeChildren"`, dynamic `delayChildren`, and `staggerChildren`),
+layout and shared-layout animations, `exit`, and `AnimatePresence` are not
+supported.
 Internal main-thread refs, handlers, and gestures also cannot yet be safely
 composed with every consumer-owned equivalent.
 

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -438,6 +438,140 @@ describe('declarative Motion', () => {
     expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
   });
 
+  test('finishes a parent variant before starting children', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: { x: 0 },
+          visible: {
+            x: 100,
+            transition: { duration: 0.1, when: 'beforeChildren' },
+          },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ duration: 0.01 }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 40));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
+  test('keeps an inherited child at its style value while beforeChildren runs', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={{
+          visible: {
+            opacity: 1,
+            transition: { duration: 1, when: 'beforeChildren' },
+          },
+        }}
+      >
+        <motion.view>
+          <motion.view
+            data-testid='child'
+            style={{ opacity: 0.1 }}
+            variants={{
+              visible: { opacity: 1 },
+            }}
+          />
+        </motion.view>
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 200));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'opacity: 0.1',
+    );
+  });
+
+  test('does not delay children for an empty beforeChildren parent target', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: {},
+          visible: {
+            transition: { duration: 1, when: 'beforeChildren' },
+          },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ type: false }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
+  test('does not claim repeating beforeChildren completion timing', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: { x: 0 },
+          visible: {
+            x: 100,
+            transition: {
+              duration: 1,
+              repeat: 1,
+              when: 'beforeChildren',
+            },
+          },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ type: false }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('explicit child animate starts a new delayChildren root', async () => {
     const { getByTestId } = render(
       <motion.view

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -102,7 +102,21 @@ function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   );
   const inheritedDelay = inheritsAnimate ? parent.delay ?? 0 : 0;
   const delayChildren = resolvedAnimate.transition?.delayChildren;
+  const animateTargetCount = resolvedAnimate.target
+    ? Object.keys(resolvedAnimate.target).length
+    : 0;
+  const animateDelay = resolvedAnimate.transition?.delay;
+  const beforeChildrenDelay = resolvedAnimate.transition?.when
+        === 'beforeChildren'
+      && typeof resolvedAnimate.transition.duration === 'number'
+      && resolvedAnimate.transition.type !== false
+      && resolvedAnimate.transition.repeat === undefined
+      && animateTargetCount > 0
+    ? resolvedAnimate.transition.duration
+      + (typeof animateDelay === 'number' ? animateDelay : 0)
+    : 0;
   const childDelay = inheritedDelay
+    + beforeChildrenDelay
     + (typeof delayChildren === 'number' ? delayChildren : 0);
   const context = useMemo<MotionVariantContextValue>(() => ({
     ...(initial === false || isVariantLabel(initial) ? { initial } : {}),


### PR DESCRIPTION
## Summary

Add the explicit-duration, non-repeating slice of upstream Motion's `when: "beforeChildren"` contract.

A parent variant now contributes its explicit numeric delay and duration to the existing inherited variant context, so inherited descendants start after the parent timing window. Empty-target and repeating parents are deliberately excluded.

Stacked on #3499. Remaining automatic/repeating duration, `afterChildren`, dynamic delay/stagger, controls, and gesture propagation stay tracked in Huxpro/motion#10.

## Verification

- exact package tests: 4/4
- declarative package suite: 48/48
- full motion package suite: 157/157
- Rslib build, declarations, and Publint: pass
- immutable validation package: `51d11ee` for motion/react/react-umd, matching `x-commit-key`
- consumer old/new proof: old `ed0c9f2` Lynx jumped the inherited child to opacity 1 at 200ms while Web held 0.1; `51d11ee` holds both at 0.1 and settles only after the 600ms parent duration
- consumer focused headless: 1/1
- consumer complete headless: 74/74
- Android Explorer loads the exact bundle and exposes initial child opacity 0.1; its SDK 0.0.1 did not dispatch either DevTool tap or scaled ADB touch into the page, so native timing remains unclaimed

Consumer evidence: Huxpro/motion#95.