### PR TITLE
refactor(react): receive lifecycle and globalProps via CoreContext events

### DIFF
--- a/.changeset/react-core-context-events.md
+++ b/.changeset/react-core-context-events.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Subscribe to `__OnLifecycleEvent` and `__NotifyGlobalPropsUpdated` on `lynx.getCoreContext()` instead of overriding `tt.OnLifecycleEvent` / `tt.updateGlobalProps`. The engine already dispatches both as CoreContext message events, so the `tt` hop was pure indirection. Listener registration is now idempotent, as is `addCtxNotFoundEventListener`, which previously reported the same error twice when the runtime was initialized more than once.

--- a/packages/react/runtime/__test__/snapshot/lifecycle.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle.test.jsx
@@ -7,6 +7,7 @@ import { waitSchedule } from './utils/nativeMethod';
 import { globalCommitTaskMap, replaceCommitHook } from '../../src/snapshot/lifecycle/patch/commit';
 import { deinitGlobalSnapshotPatch, initGlobalSnapshotPatch } from '../../src/snapshot/lifecycle/patch/snapshotPatch';
 import { LifecycleConstant } from '../../src/snapshot/lifecycle/constant';
+import { injectTt } from '../../src/snapshot/lynx/tt';
 import { CATCH_ERROR } from '../../src/shared/render-constants';
 import { __root } from '../../src/root';
 import { setupPage, backgroundSnapshotInstanceManager } from '../../src/snapshot';
@@ -369,6 +370,10 @@ describe('componentWillUnmount', () => {
 
     lynxCoreInject.tt.callDestroyLifetimeFun();
     expect(willUnmount).toHaveBeenCalledTimes(2);
+
+    // `callDestroyLifetimeFun` tears down the engine event listeners; the
+    // suites below keep driving the same module-level runtime, so re-init.
+    injectTt();
   });
 });
 

--- a/packages/react/runtime/__test__/snapshot/utils/runtimeProxy.ts
+++ b/packages/react/runtime/__test__/snapshot/utils/runtimeProxy.ts
@@ -71,3 +71,26 @@ const jsContext = new EventEmitter('jsContext');
 
 globalThis.lynx.getCoreContext = vi.fn(() => coreContext);
 globalThis.lynx.getJSContext = vi.fn(() => jsContext);
+
+/**
+ * Emulate the engine delivering a `CoreContext -> JSContext` message event,
+ * the way `tasm_mediator.cc` / `bts_runtime.cc` do in production. Tests keep
+ * calling `lynxCoreInject.tt.OnLifecycleEvent(...)` as their "the engine fired
+ * this" entry point; the runtime now receives it through `getCoreContext()`.
+ */
+function emulateEngineEvent(type: string, data: unknown) {
+  // Deliver synchronously on the caller's thread, matching how lynx-core
+  // forwards the event today. Going through `dispatchEvent` would toggle the
+  // thread globals and change the timing these tests were written against.
+  const listeners = coreContext.listeners[getType('jsContext', type)];
+  listeners?.forEach((listener: (event: { data: unknown }) => void) => {
+    listener({ data });
+  });
+}
+
+globalThis.lynxCoreInject.tt.OnLifecycleEvent = vi.fn((data) => {
+  emulateEngineEvent('__OnLifecycleEvent', data);
+});
+globalThis.lynxCoreInject.tt.updateGlobalProps = vi.fn((data) => {
+  emulateEngineEvent('__NotifyGlobalPropsUpdated', data);
+});

--- a/packages/react/runtime/src/snapshot/lifecycle/patch/error.ts
+++ b/packages/react/runtime/src/snapshot/lifecycle/patch/error.ts
@@ -51,6 +51,9 @@ export function reportCtxNotFound(data: CtxNotFoundData): void {
 }
 
 export function addCtxNotFoundEventListener(): void {
+  // Guard against double registration (re-init / reload would otherwise
+  // report the same error twice).
+  removeCtxNotFoundEventListener();
   ctxNotFoundEventListener = (e) => {
     reportCtxNotFound(e.data as CtxNotFoundData);
   };

--- a/packages/react/runtime/src/snapshot/lynx/tt.ts
+++ b/packages/react/runtime/src/snapshot/lynx/tt.ts
@@ -37,17 +37,54 @@ import { sendMTRefInitValueToMainThread } from '../worklet/ref/updateInitValue.j
 
 export { runWithForce };
 
+/**
+ * Engine events the runtime subscribes to instead of patching `tt`.
+ *
+ * The engine dispatches both as `CoreContext -> JSContext` message events
+ * (`tasm_mediator.cc`, `bts_runtime.cc`); lynx-core only forwards them to
+ * `tt.OnLifecycleEvent` / `tt.updateGlobalProps`, whose base implementations
+ * are empty. Listening directly removes that indirection.
+ */
+const enum CoreContextEvent {
+  onLifecycleEvent = '__OnLifecycleEvent',
+  notifyGlobalPropsUpdated = '__NotifyGlobalPropsUpdated',
+}
+
+function onLifecycleEventMessage(event: { data: [LifecycleConstant, unknown] }): void {
+  onLifecycleEvent(event.data);
+}
+
+function onGlobalPropsUpdatedMessage(event: { data: Record<string, any> }): void {
+  updateGlobalProps(event.data);
+}
+
+let engineListenersRegistered = false;
+
 function injectTt(): void {
+  const coreContext = lynx.getCoreContext();
+  // Assigning to `tt` was idempotent; adding listeners is not.
+  if (!engineListenersRegistered) {
+    engineListenersRegistered = true;
+    coreContext.addEventListener(CoreContextEvent.onLifecycleEvent, onLifecycleEventMessage);
+    coreContext.addEventListener(CoreContextEvent.notifyGlobalPropsUpdated, onGlobalPropsUpdatedMessage);
+  }
+
+  // The rest are still invoked by the engine as direct property lookups on
+  // the app object (`js_app.cc`), so they have to stay on `tt` for now.
   const tt = lynxCoreInject.tt;
-  tt.OnLifecycleEvent = onLifecycleEvent;
   tt.publishEvent = delayedPublishEvent;
   tt.publicComponentEvent = delayedPublicComponentEvent;
   tt.callDestroyLifetimeFun = () => {
+    engineListenersRegistered = false;
+    coreContext.removeEventListener(CoreContextEvent.onLifecycleEvent, onLifecycleEventMessage);
+    coreContext.removeEventListener(
+      CoreContextEvent.notifyGlobalPropsUpdated,
+      onGlobalPropsUpdatedMessage,
+    );
     removeCtxNotFoundEventListener();
     destroyWorklet();
     destroyBackground();
   };
-  tt.updateGlobalProps = updateGlobalProps;
   tt.updateCardData = updateCardData;
   tt.onAppReload = reloadBackground;
   tt.processCardConfig = () => {

--- a/packages/react/runtime/vitest.config.ts
+++ b/packages/react/runtime/vitest.config.ts
@@ -174,8 +174,10 @@ export default defineConfig({
     },
     setupFiles: [
       path.join(__dirname, './__test__/snapshot/utils/globals.js'),
-      path.join(__dirname, './__test__/snapshot/utils/setup.js'),
+      // Must precede `setup.js`: importing the runtime injects listeners on
+      // `lynx.getCoreContext()`, which this file stubs.
       path.join(__dirname, './__test__/snapshot/utils/runtimeProxy.ts'),
+      path.join(__dirname, './__test__/snapshot/utils/setup.js'),
     ],
   },
 });


### PR DESCRIPTION
## Summary

`injectTt` patches eight callbacks onto `lynxCoreInject.tt`. Two of them never needed `tt` at all: the engine already dispatches them as `CoreContext -> JSContext` message events, and lynx-core merely forwards those events to `tt.OnLifecycleEvent` / `tt.updateGlobalProps`, whose base implementations in `BaseApp` are empty. This PR subscribes to the events directly and drops that hop.

```
engine dispatches CoreContext MessageEvent
  -> lynx-core listener -> this.OnLifecycleEvent / this.updateGlobalProps   (empty base impls)
    -> ReactLynx overrides them via injectTt                                 <- removed
```

Two robustness fixes fall out of the change:

- Assigning to `tt` was idempotent; `addEventListener` is not. Registration is now guarded and removed on destroy.
- `addCtxNotFoundEventListener` had the same problem: initializing the runtime twice made a single ctx-not-found error get reported twice. It is now idempotent too.

## What can and cannot move off `tt`

| `tt` callback | How the engine invokes it | lynx-core base impl | Can move to CoreContext? |
| --- | --- | --- | --- |
| `OnLifecycleEvent` | `__OnLifecycleEvent` message event (`tasm_mediator.cc`) | empty | ✅ done here |
| `updateGlobalProps` | `__NotifyGlobalPropsUpdated` message event (`bts_runtime.cc`) | empty | ✅ done here |
| `publishEvent` | direct property lookup on the app object (`js_app.cc`) | none | ❌ needs an engine-side event |
| `publicComponentEvent` | direct property lookup (`js_app.cc`) | none | ❌ needs an engine-side event |
| `updateCardData` | direct property lookup (`js_app.cc`) | none | ❌ needs an engine-side event |
| `onAppReload` | direct property lookup (`js_app.cc`) | none | ❌ needs an engine-side event |
| `processCardConfig` | direct property lookup (`js_app.cc`) | none | ❌ already a no-op here, but the property must exist |
| `callDestroyLifetimeFun` | global function -> `appInstance.callDestroyLifetimeFun()` | none | ❌ needs an engine-side event |

The remaining six are fetched by the engine as function properties on the app object rather than delivered as events, so they cannot be migrated from the framework side alone. Each would need the engine to dispatch a message event, plus one `addInternalEventListener` entry in lynx-core — the same shape the two migrated callbacks already use.

## Tests

- `@lynx-js/react` runtime: 820 passing.
- `@lynx-js/reactlynx-testing-library`: 159 passing.
- Test-harness updates: the runtime proxy stub now loads before the runtime is imported (a stub has to exist before the module under test registers on it), and it emulates the engine delivering the two events, so the ~100 existing `lynxCoreInject.tt.OnLifecycleEvent(...)` call sites stay unchanged while exercising the new path. `lifecycle.test.jsx` re-runs `injectTt()` after it calls `callDestroyLifetimeFun`, since destroy now tears the listeners down and the suites below reuse the same module-level runtime.

## Device verification

Lynx Explorer on a Pixel 4 XL, `examples/react` served from a dev server: the page renders, and tapping the logo swaps it (Lynx mark -> React mark) with no JS errors in logcat. That interaction only works once hydration has completed, so the first-screen lifecycle event is confirmed to arrive through the new listener.

`__NotifyGlobalPropsUpdated` is covered by unit tests but not yet on-device: the engine only dispatches it after the runtime has started (before that the props are passed through `init_global_props_`), and triggering a post-load update needs DevTool, which would not attach on this build. Happy to add that run if someone can reproduce it.
