### PR TITLE
feat(motion): honor value-specific beforeChildren timing

### DIFF
--- a/.changeset/motion-before-children.md
+++ b/.changeset/motion-before-children.md
@@ -2,4 +2,4 @@
 "@lynx-js/motion": patch
 ---
 
-Honor `when: "beforeChildren"` for declarative variants with a non-repeating, explicit parent duration.
+Honor `when: "beforeChildren"` for declarative variants whose non-repeating parent values have explicit durations.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -50,8 +50,8 @@ The declarative layer currently supports:
   `inherit={false}` prevents labels propagating through a variant boundary;
   parent `initial={false}` also suppresses inherited child mount animations;
   numeric `delayChildren` also propagates through inherited labels;
-  `when: "beforeChildren"` waits for a parent's non-repeating,
-  explicit-duration target
+  `when: "beforeChildren"` waits for a parent's non-repeating target whose
+  animated values all have explicit durations
   before starting inherited children
 - `initial={false}` to render the final `animate` keyframe without a mount
   animation while preserving later target updates

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -507,6 +507,83 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('waits for the longest explicit value transition before children', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: { opacity: 0, x: 0 },
+          visible: {
+            opacity: 1,
+            x: 100,
+            transition: {
+              when: 'beforeChildren',
+              opacity: { duration: 0.02 },
+              x: { delay: 0.04, duration: 0.08 },
+            },
+          },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ type: false }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 70));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 90));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
+  test('does not claim beforeChildren when one value has automatic timing', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: { opacity: 0, x: 0 },
+          visible: {
+            opacity: 1,
+            x: 100,
+            transition: {
+              when: 'beforeChildren',
+              opacity: { duration: 1 },
+              x: { type: 'spring' },
+            },
+          },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ type: false }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('does not delay children for an empty beforeChildren parent target', async () => {
     const { getByTestId } = render(
       <motion.view

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -13,6 +13,7 @@ import type {
 } from 'motion-dom';
 import {
   animateMotionValue as createMotionValueAnimation,
+  getValueTransition,
   motionValue,
   styleEffect,
 } from 'motion-dom' with {
@@ -72,6 +73,39 @@ function isVariantLabel(
   return typeof definition === 'string' || Array.isArray(definition);
 }
 
+function getExplicitTargetDuration(
+  target: MotionTarget | undefined,
+  transition: MotionTransition | undefined,
+): number {
+  if (!target || !transition) {
+    return 0;
+  }
+  let longestDuration = 0;
+  let targetCount = 0;
+  for (const key in target) {
+    targetCount += 1;
+    const valueTransition = getValueTransition(
+      transition,
+      key,
+    ) as MotionTransition;
+    if (
+      typeof valueTransition?.duration !== 'number'
+      || valueTransition.type === false
+      || valueTransition.repeat !== undefined
+    ) {
+      return 0;
+    }
+    longestDuration = Math.max(
+      longestDuration,
+      valueTransition.duration
+        + (typeof valueTransition.delay === 'number'
+          ? valueTransition.delay
+          : 0),
+    );
+  }
+  return targetCount > 0 ? longestDuration : 0;
+}
+
 function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   context: MotionVariantContextValue;
   delay: number;
@@ -102,18 +136,12 @@ function useInheritedMotionProps<Props extends MotionProps>(props: Props): {
   );
   const inheritedDelay = inheritsAnimate ? parent.delay ?? 0 : 0;
   const delayChildren = resolvedAnimate.transition?.delayChildren;
-  const animateTargetCount = resolvedAnimate.target
-    ? Object.keys(resolvedAnimate.target).length
-    : 0;
-  const animateDelay = resolvedAnimate.transition?.delay;
   const beforeChildrenDelay = resolvedAnimate.transition?.when
-        === 'beforeChildren'
-      && typeof resolvedAnimate.transition.duration === 'number'
-      && resolvedAnimate.transition.type !== false
-      && resolvedAnimate.transition.repeat === undefined
-      && animateTargetCount > 0
-    ? resolvedAnimate.transition.duration
-      + (typeof animateDelay === 'number' ? animateDelay : 0)
+      === 'beforeChildren'
+    ? getExplicitTargetDuration(
+      resolvedAnimate.target,
+      resolvedAnimate.transition,
+    )
     : 0;
   const childDelay = inheritedDelay
     + beforeChildrenDelay


### PR DESCRIPTION
## Summary

Extend #3504's explicit-duration `when: "beforeChildren"` slice to value-specific parent transitions.

Instead of reading only top-level `duration`/`delay`, this uses upstream Motion's `getValueTransition` routing for every animated key and delays inherited children until the longest explicit value window completes. If any parent value is automatic, instant, or repeating, the adapter still makes no orchestration claim.

Stacked on #3504.

## Verification

- new exact tests:
  - waits for the longest value-specific `delay + duration`
  - refuses the claim when one parent value uses automatic spring timing
- declarative: 50/50
- full Motion package: 159/159
- commit hooks: ESLint, Biome, dprint pass
- Motion Rslib build, declarations, Publint pass
- full Turbo build remains environment-blocked before Motion by missing `cargo` in React transform/Web Core WASM tasks

This narrows the remaining issue #10 boundary to automatic/repeating completion, `afterChildren`, dynamic stagger, controls, and gesture propagation. Consumer immutable-package proof will be added after pkg.pr.new publishes this head.