### PR TITLE
feat(motion): wait for finite beforeChildren repeats

### DIFF
--- a/.changeset/motion-before-children.md
+++ b/.changeset/motion-before-children.md
@@ -2,4 +2,4 @@
 "@lynx-js/motion": patch
 ---
 
-Honor `when: "beforeChildren"` for declarative variants whose non-repeating parent values have explicit durations.
+Honor `when: "beforeChildren"` for declarative variants whose finite parent values have explicit durations.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -50,8 +50,8 @@ The declarative layer currently supports:
   `inherit={false}` prevents labels propagating through a variant boundary;
   parent `initial={false}` also suppresses inherited child mount animations;
   numeric `delayChildren` also propagates through inherited labels;
-  `when: "beforeChildren"` waits for a parent's non-repeating target whose
-  animated values all have explicit durations
+  `when: "beforeChildren"` waits for a parent's finite target whose animated
+  values all have explicit durations
   before starting inherited children
 - `initial={false}` to render the final `animate` keyframe without a mount
   animation while preserving later target updates
@@ -66,7 +66,7 @@ The declarative layer currently supports:
 It does **not** yet provide the complete `motion/react` declarative contract.
 In particular, focus/in-view/drag states and their animation lifecycle
 callbacks, animation controls, gesture propagation and remaining variant
-orchestration (`when: "afterChildren"`, automatic-duration or repeating
+orchestration (`when: "afterChildren"`, automatic-duration or infinite
 `when: "beforeChildren"`, dynamic `delayChildren`, and `staggerChildren`),
 layout and shared-layout animations, `exit`, and `AnimatePresence` are not
 supported.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -584,6 +584,47 @@ describe('declarative Motion', () => {
     expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
   });
 
+  test('waits for a finite repeating parent before starting children', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: { x: 0 },
+          visible: {
+            x: 100,
+            transition: {
+              duration: 0.04,
+              repeat: 1,
+              repeatDelay: 0.03,
+              when: 'beforeChildren',
+            },
+          },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          variants={{
+            hidden: { opacity: 0 },
+            visible: { opacity: 1 },
+          }}
+          transition={{ type: false }}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 70));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 0');
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('does not delay children for an empty beforeChildren parent target', async () => {
     const { getByTestId } = render(
       <motion.view
@@ -614,7 +655,7 @@ describe('declarative Motion', () => {
     expect(getByTestId('child').getAttribute('style')).toContain('opacity: 1');
   });
 
-  test('does not claim repeating beforeChildren completion timing', async () => {
+  test('does not claim infinite beforeChildren completion timing', async () => {
     const { getByTestId } = render(
       <motion.view
         initial='hidden'
@@ -625,7 +666,7 @@ describe('declarative Motion', () => {
             x: 100,
             transition: {
               duration: 1,
-              repeat: 1,
+              repeat: Number.POSITIVE_INFINITY,
               when: 'beforeChildren',
             },
           },

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -91,13 +91,20 @@ function getExplicitTargetDuration(
     if (
       typeof valueTransition?.duration !== 'number'
       || valueTransition.type === false
-      || valueTransition.repeat !== undefined
     ) {
       return 0;
     }
+    const repeat = valueTransition.repeat ?? 0;
+    if (!Number.isFinite(repeat) || repeat < 0) {
+      return 0;
+    }
+    const repeatDelay = typeof valueTransition.repeatDelay === 'number'
+      ? valueTransition.repeatDelay
+      : 0;
     longestDuration = Math.max(
       longestDuration,
-      valueTransition.duration
+      valueTransition.duration * (repeat + 1)
+        + repeatDelay * repeat
         + (typeof valueTransition.delay === 'number'
           ? valueTransition.delay
           : 0),


### PR DESCRIPTION
## Summary

Extend the explicit `when: "beforeChildren"` completion window to finite repeats.

For each parent value, the adapter now computes:

`delay + duration × (repeat + 1) + repeatDelay × repeat`

and still takes the longest value-specific window. Infinite repeat and automatic timing remain unclaimed.

Stacked on #3506.

## Verification

- finite repeat + repeatDelay holds the child until the parent completes
- Infinity remains excluded and starts no fake wait
- declarative: 51/51
- full Motion package: 160/160
- commit hooks: ESLint, Biome, dprint pass
- Rslib build, declarations, Publint pass

Consumer immutable-package proof will follow after the validation rollup publishes this head.