### PR TITLE
test(motion): cover initial false beforeChildren mount

### DIFF
--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -344,6 +344,38 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('initial false skips a beforeChildren mount delay', async () => {
+    const onAnimationStart = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        initial={false}
+        animate='visible'
+        variants={{
+          visible: {
+            x: 100,
+            transition: { duration: 1, when: 'beforeChildren' },
+          },
+        }}
+      >
+        <motion.view
+          data-testid='child'
+          variants={{ visible: { opacity: 0.9 } }}
+          transition={{ duration: 1 }}
+          onAnimationStart={onAnimationStart}
+        />
+      </motion.view>,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    expect(getByTestId('child').getAttribute('style')).toContain(
+      'opacity: 0.9',
+    );
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(onAnimationStart).not.toHaveBeenCalled();
+  });
+
   test('does not propagate initial false to an explicit child animate prop', async () => {
     const onAnimationStart = vi.fn();
     const { getByTestId } = render(


### PR DESCRIPTION
## Summary

Add a regression for the upstream composition of `initial={false}` with explicit `when: "beforeChildren"`.

On mount, the inherited child must render its visible variant immediately and must not report an animation start. The parent orchestration window must not manufacture a child delay when mount animation is disabled.

Stacked on #3507. This is test-only because the current implementation already conforms.

## Verification

- exact new regression passes
- declarative: 52/52
- full Motion package: 161/161
- commit hooks: ESLint, Biome, dprint pass

No capability or loss metric moves from this package-only regression; consumer dual-renderer evidence follows separately.