### PR TITLE
fix(react): make isValidElement recognize main-thread vnodes

### DIFF
--- a/.changeset/lepus-vnode-react-element-typeof.md
+++ b/.changeset/lepus-vnode-react-element-typeof.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Tag main-thread vnodes with `$$typeof: Symbol.for('react.element')` so `isValidElement` recognizes them, matching the background thread.

--- a/packages/react/runtime/__test__/snapshot/jsx-runtime-lepus.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/jsx-runtime-lepus.test.jsx
@@ -1,5 +1,8 @@
+import { isValidElement as coreIsValidElement } from 'preact';
+import { isValidElement } from 'preact/compat';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { cloneElement, createElement } from '../../lepus';
 import { jsx } from '../../lepus/jsx-runtime';
 import { SnapshotInstance, snapshotCreatorMap } from '../../src/snapshot';
 
@@ -51,5 +54,24 @@ describe('lepus jsx-runtime createVNode', () => {
   it('should return undefined for non-string/non-function types', () => {
     const vnode = jsx(null, {});
     expect(vnode).toBeUndefined();
+  });
+
+  it('should create vnodes that isValidElement recognizes', () => {
+    function Foo() {
+      return null;
+    }
+
+    expect(isValidElement(jsx('view', {}))).toBe(true);
+    expect(isValidElement(jsx(Foo, {}))).toBe(true);
+    expect(isValidElement(createElement('view', {}))).toBe(true);
+    expect(isValidElement(createElement(Foo, {}))).toBe(true);
+    expect(isValidElement(cloneElement(jsx(Foo, {}), { foo: 1 }))).toBe(true);
+  });
+
+  it('should not make SnapshotInstance a preact vnode', () => {
+    // `renderToOpcodes` tells a preact vnode from a SnapshotInstance with
+    // preact core's `isValidElement`, which keys on `constructor` rather than
+    // `$$typeof`, so tagging the latter must not disturb it.
+    expect(coreIsValidElement(jsx('view', {}))).toBe(false);
   });
 });

--- a/packages/react/runtime/__test__/snapshot/utils/setup.js
+++ b/packages/react/runtime/__test__/snapshot/utils/setup.js
@@ -4,6 +4,7 @@
 import { __injectElementApi } from './inject.ts';
 import '../../../src/lynx.ts';
 import { document } from '../../../src/document.ts';
+import { SnapshotInstance } from '../../../src/snapshot/index.ts';
 
 import { afterEach, expect } from 'vitest';
 
@@ -15,6 +16,18 @@ function inject() {
 }
 
 inject();
+
+// A SnapshotInstance carries `$$typeof` so that `isValidElement` accepts it,
+// which would otherwise make pretty-format print it as a React element and hide
+// its fields. Keep printing it as a plain object.
+expect.addSnapshotSerializer({
+  test(val) {
+    return val instanceof SnapshotInstance;
+  },
+  print(val, serialize) {
+    return serialize(val.toJSON());
+  },
+});
 
 expect.addSnapshotSerializer({
   test(val) {

--- a/packages/react/runtime/lepus/jsx-runtime/index.js
+++ b/packages/react/runtime/lepus/jsx-runtime/index.js
@@ -3,6 +3,22 @@
 // LICENSE file in the root directory of this source tree.
 import { CHILDREN, COMPONENT, DIFF, DIRTY, DOM, FLAGS, INDEX, PARENT, SnapshotInstance } from '@lynx-js/react/internal';
 
+// Kept in sync with `REACT_ELEMENT_TYPE` in preact/compat, whose `isValidElement`
+// compares against it. Inlined rather than imported so the main thread does not
+// have to pull in compat.
+const REACT_ELEMENT_TYPE = Symbol.for('react.element');
+
+// A SnapshotInstance is the main thread's element, so it has to satisfy
+// `isValidElement` too. Assigning per instance would add a property after the
+// constructor has run, which costs a shape transition on a hot path, so put it
+// on the prototype instead. Writable, so that the `$$typeof: undefined` in
+// `renderToOpcodes` can still shadow it.
+Object.defineProperty(SnapshotInstance.prototype, '$$typeof', {
+  value: REACT_ELEMENT_TYPE,
+  writable: true,
+  configurable: true,
+});
+
 function createVNode(type, props, _key) {
   if (typeof type === 'string') {
     const r = new SnapshotInstance(type);
@@ -58,6 +74,7 @@ function createVNode(type, props, _key) {
       // __v: --vnodeId,
       [INDEX]: -1,
       [FLAGS]: 0,
+      $$typeof: REACT_ELEMENT_TYPE,
     };
   }
 }


### PR DESCRIPTION
## Problem

`isValidElement` returns `false` for anything created by the lepus JSX runtime, so it does not work on the main thread.

`preact/compat` does not put `$$typeof` on vnodes in `createElement`; it stamps it from an `options.vnode` hook:

```js
// preact/compat/src/render.js
options.vnode = vnode => {
  vnode.$$typeof = REACT_ELEMENT_TYPE;
  if (oldVNodeHook) oldVNodeHook(vnode);
};
```

and its `isValidElement` compares against exactly that:

```js
// preact/compat/src/index.js
function isValidElement(element) {
  return !!element && element.$$typeof === REACT_ELEMENT_TYPE;
}
```

`lepus/jsx-runtime` builds vnodes directly and never goes through that hook, so the property is missing on the main thread while being present on the background thread. Both host elements and components are affected.

## Impact

Libraries that validate their children break when rendered on the main thread. Concretely, `@react-navigation/core` checks every child of a navigator with `isValidElement` and otherwise throws:

> A navigator can only contain `Screen`, `Group` or `React.Fragment` as its direct children

The usual workaround is to skip rendering the component on the main thread entirely:

```js
function Navigator(props) {
  if (__MAIN_THREAD__) {
    return null;
  }
  return <NavigatorImpl {...props} />;
}
```

which costs first-screen direct rendering and makes the main-thread and background snapshot trees disagree at hydrate time.

## Fix

Tag both branches of `createVNode` with `$$typeof: Symbol.for('react.element')`.

The component branch carries it in its object literal, so it is part of the vnode's initial shape. `SnapshotInstance` gets it on the prototype instead of per instance, so no element pays for a property store or a shape transition — assigning it after the constructor has run measured ~5% on a tight creation loop, while the prototype form is indistinguishable from baseline. It is writable so that the `$$typeof: undefined` in `renderToOpcodes` still shadows it.

`Symbol.for('react.element')` is inlined rather than imported from `preact/compat` so the main thread does not have to pull compat in.

`lepus/index.js`'s `createElement` and `cloneElement` both delegate to `createVNode`, and `lepus/jsx-dev-runtime` re-exports it, so they are all covered.

### Why this does not disturb `renderToOpcodes`

`renderToOpcodes` tells a preact vnode from a `SnapshotInstance`:

```js
// hack for runtime test
if (process.env['NODE_ENV'] === 'test' && isValidElement(vnode) && typeof vnode.type === 'string') {
  vnode = Object.assign(new SnapshotInstance(type), vnode, { $$typeof: undefined });
}
```

That `isValidElement` is imported from `preact`, not `preact/compat`, and preact core keys on `constructor === undefined` rather than on `$$typeof`. A `SnapshotInstance` is a class instance, so it still fails that check. There is a test covering this.

### Snapshot serializer

Tagging a `SnapshotInstance` makes pretty-format claim it with its React-element plugin, which prints `<__snapshot_xxx />` and hides `id` / `values` / `extraProps` — 24 inline snapshots across 4 files would have degraded into a less specific form. Marking the property non-enumerable does not help, since the plugin reads it directly.

Added a snapshot serializer alongside the existing `RefProxy` one that keeps `SnapshotInstance` printing through its `toJSON`, which is what pretty-format's `callToJSON` was already doing. No existing snapshot changes.

## Test

Added to `__test__/snapshot/jsx-runtime-lepus.test.jsx`, asserting through the real `isValidElement` from `preact/compat` rather than a hardcoded symbol, so it also catches the constant drifting apart:

```js
expect(isValidElement(jsx('view', {}))).toBe(true);
expect(isValidElement(jsx(Foo, {}))).toBe(true);
expect(isValidElement(createElement('view', {}))).toBe(true);
expect(isValidElement(createElement(Foo, {}))).toBe(true);
expect(isValidElement(cloneElement(jsx(Foo, {}), { foo: 1 }))).toBe(true);
```

plus one pinning the `renderToOpcodes` discriminator:

```js
expect(coreIsValidElement(jsx('view', {}))).toBe(false);
```

Verified the first fails without the runtime change and passes with it. `test:snapshot` (96 files / 775 tests), `test:core` and `test:et` all pass, with no snapshot updates.


## On the CodSpeed report

Two runs, two almost disjoint sets of regressions:

| Run | Regressed |
| --- | --- |
| `32f3683`, tagged per instance | `transform 1000 view elements` -35% / -25%, `003-hello-list__main-thread-serializeRoot` -22.6% / -17.2%, `basic-performance-div-1000` -20.9%, `015-attrs-component-hydrate` -5.55% |
| `f9abd86`, tagged on the prototype | `008-many-use-state__main-thread-transferRoot` -15.1%, `basic-performance-div-100` -14.6%, `007-four-layer-views__main-thread-transferRoot` -6.3%, `015-attrs-component-hydrate` -5.66% |

The two largest from the first run are reported as untouched in the second, and the second run's largest were untouched in the first. A real regression would land on the same benchmarks both times.

The first run's largest, `transform 1000 view elements`, lives in `packages/react/transform/__test__/basic.bench.js`, which only imports `transformReactLynx` from the SWC binding and never loads the runtime, so this change cannot reach it at all. CodSpeed also flags `Unknown Walltime execution environment detected` and `Different runtime environments detected` on both runs.

One benchmark is consistent across both: `015-attrs-component-hydrate`, at -5.55% and -5.66%. That path builds component vnodes, which carry `$$typeof` as one extra property in their object literal — the irreducible cost of being recognizable by `isValidElement`. `SnapshotInstance` no longer pays anything, since it is tagged on the prototype.

Happy to re-measure on a macro runner if that would help.
