### PR TITLE
feat(motion): support declarative initial={false}

### DIFF
--- a/.changeset/motion-initial-false.md
+++ b/.changeset/motion-initial-false.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Support declarative `initial={false}` by rendering the final animate state without a mount animation while preserving later animate updates.

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -46,6 +46,8 @@ The declarative layer currently supports:
 
 - object targets and string/array/function `variants` for `initial` and
   `animate`, including `custom` and target-local `transition`
+- `initial={false}` to render the final `animate` keyframe without a mount
+  animation while preserving later target updates
 - transform aliases, keyframes, repeat/reverse, colors, and live `MotionValue`
   styles backed by the upstream Motion engine
 - `whileTap` with `onTapStart`, `onTap`, and `onTapCancel`

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -46,6 +46,20 @@ describe('declarative Motion', () => {
     });
   });
 
+  test('uses the final animate state when initial is false', () => {
+    expect(
+      resolveInitialStyle(
+        { width: '100px' },
+        false,
+        { opacity: [0, 1], x: [0, 24] },
+      ),
+    ).toEqual({
+      width: '100px',
+      opacity: 1,
+      transform: 'translateX(24px)',
+    });
+  });
+
   test('uses a MotionValue handle initial value in the first style', () => {
     let scale: ReturnType<typeof useMotionValue> | undefined;
     let initialStyle: ReturnType<typeof resolveInitialStyle>;
@@ -179,6 +193,58 @@ describe('declarative Motion', () => {
     expect(getByTestId('box').getAttribute('style')).toContain(
       'translateX(80px)',
     );
+  });
+
+  test('skips the mount animation when initial is false', async () => {
+    const onMountAnimationStart = vi.fn();
+    const onMountAnimationComplete = vi.fn();
+    const onUpdateAnimationStart = vi.fn();
+
+    function App() {
+      const [active, setActive] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={false}
+            animate={{ opacity: 1, x: active ? 48 : [0, 24] }}
+            transition={{ duration: 0.01 }}
+            onAnimationStart={active
+              ? onUpdateAnimationStart
+              : onMountAnimationStart}
+            onAnimationComplete={active ? undefined : onMountAnimationComplete}
+          />
+          <view
+            data-testid='toggle'
+            bindtap={() => setActive(true)}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateX(24px)',
+    );
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(onMountAnimationStart).not.toHaveBeenCalled();
+    expect(onMountAnimationComplete).not.toHaveBeenCalled();
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateX(48px)',
+    );
+    expect(onUpdateAnimationStart).toHaveBeenCalledOnce();
   });
 
   test('animates a MotionValue-backed style', async () => {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -129,6 +129,7 @@ function useMotionHostProps<Props extends MotionProps>(
     Record<string, MotionValue<string | number>>
   >({});
   const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
+  const hasMountedAnimationRef = useRef(false);
 
   const resolvedInitial = resolveMotionDefinition(initial, variants, custom);
   const resolvedAnimateDefinition = resolveMotionDefinition(
@@ -165,12 +166,22 @@ function useMotionHostProps<Props extends MotionProps>(
   });
   const styleKey = motionDefinitionKey(style);
   const initialStyle = useMemo(
-    () => resolveInitialStyle(style, resolvedInitialTarget),
-    [resolvedInitialTarget, style],
+    () =>
+      resolveInitialStyle(
+        style,
+        resolvedInitialTarget,
+        resolvedAnimate.target,
+      ),
+    [resolvedAnimate.target, resolvedInitialTarget, style],
   );
   const initialValues = useMemo(
-    () => resolveInitialValues(style, resolvedInitialTarget),
-    [resolvedInitialTarget, style],
+    () =>
+      resolveInitialValues(
+        style,
+        resolvedInitialTarget,
+        resolvedAnimate.target,
+      ),
+    [resolvedAnimate.target, resolvedInitialTarget, style],
   );
   const workletAnimateTransition = useMemo(
     () =>
@@ -290,6 +301,9 @@ function useMotionHostProps<Props extends MotionProps>(
     // Capture a fresh record so Lynx for Web doesn't mutate the memoized source
     // that a later React render will reuse.
     const motionValueBindings = { ...motionValues };
+    const shouldAnimateTarget = resolvedInitialTarget !== false
+      || hasMountedAnimationRef.current;
+    hasMountedAnimationRef.current = true;
 
     function updateMotionStyles(
       target: MotionTarget | undefined,
@@ -297,6 +311,7 @@ function useMotionHostProps<Props extends MotionProps>(
       hoverTarget: MotionTarget | undefined,
       options: MotionTransition | undefined,
       startingValues: Record<string, unknown>,
+      shouldAnimate: boolean,
     ) {
       'main thread';
 
@@ -390,7 +405,7 @@ function useMotionHostProps<Props extends MotionProps>(
         styleCleanupRef.current = styleEffect(element, values);
       }
 
-      if (target) {
+      if (target && shouldAnimate) {
         const targetValues = target as Record<string, unknown>;
         for (const key in targetValues) {
           const value = values[key];
@@ -429,6 +444,7 @@ function useMotionHostProps<Props extends MotionProps>(
       resolvedHover.target,
       workletAnimateTransition,
       initialValues,
+      shouldAnimateTarget,
     );
 
     function stopMotionStyles() {

--- a/packages/motion/src/declarative/style.ts
+++ b/packages/motion/src/declarative/style.ts
@@ -44,11 +44,22 @@ const transformKeys = new Set([
   'skewY',
 ]);
 
-function resolveStyleValue(value: unknown): unknown {
+function resolveStyleValue(
+  value: unknown,
+  useFinalKeyframe = false,
+): unknown {
   if (motionValueType.isHandle(value)) {
     return motionValueType.getInitialPayload(value);
   }
   if (Array.isArray(value)) {
+    if (useFinalKeyframe) {
+      for (let index = value.length - 1; index >= 0; index--) {
+        if (value[index] !== null && value[index] !== undefined) {
+          return value[index];
+        }
+      }
+      return undefined;
+    }
     return value.find(item => item !== null && item !== undefined);
   }
   return value;
@@ -71,9 +82,10 @@ function appendResolvedValues(
   output: Record<string, unknown>,
   transforms: Record<string, string | number>,
   values: Record<string, unknown>,
+  useFinalKeyframe = false,
 ): void {
   for (const key in values) {
-    const value = resolveStyleValue(values[key]);
+    const value = resolveStyleValue(values[key], useFinalKeyframe);
     if (value === undefined || value === null) {
       continue;
     }
@@ -91,6 +103,7 @@ function appendResolvedValues(
 export function resolveInitialStyle(
   style: MotionStyle | string | undefined,
   initial: MotionTarget | false | undefined,
+  animate?: MotionTarget,
 ): CSSProperties | string | undefined {
   if (typeof style === 'string') {
     return style;
@@ -103,7 +116,14 @@ export function resolveInitialStyle(
     transforms,
     (style ?? {}) as Record<string, unknown>,
   );
-  if (initial !== false) {
+  if (initial === false) {
+    appendResolvedValues(
+      output,
+      transforms,
+      (animate ?? {}) as Record<string, unknown>,
+      true,
+    );
+  } else {
     appendResolvedValues(
       output,
       transforms,
@@ -130,6 +150,7 @@ export function resolveInitialStyle(
 export function resolveInitialValues(
   style: MotionStyle | string | undefined,
   initial: MotionTarget | false | undefined,
+  animate?: MotionTarget,
 ): Record<string, unknown> {
   const values: Record<string, unknown> = {};
   if (style && typeof style !== 'string') {
@@ -137,7 +158,12 @@ export function resolveInitialValues(
       values[key] = resolveStyleValue(style[key as keyof MotionStyle]);
     }
   }
-  if (initial !== false && initial) {
+  if (initial === false && animate) {
+    const animateValues = animate as Record<string, unknown>;
+    for (const key in animateValues) {
+      values[key] = resolveStyleValue(animateValues[key], true);
+    }
+  } else if (initial) {
     const initialValues = initial as Record<string, unknown>;
     for (const key in initialValues) {
       values[key] = resolveStyleValue(initialValues[key]);


### PR DESCRIPTION
## What

Align declarative mount behavior with Motion's `initial={false}` contract: render the resolved `animate` target immediately and skip the initial mount animation.

## Stack

Canonical foundation: #3477 → #3509. This is the first conformance layer and supersedes #3457.

## Validation

- `@lynx-js/motion`: 15 test files, 132 tests passed on the complete stack
- package TypeScript check passed
- focused tests cover object and variant targets, static fallback, and live style bindings

## Confidence

**Very confident — ready to review.** This is a direct public Motion semantic with no Lynx platform conflict; the implementation stays within the declarative adapter.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Changeset added.
