### PR TITLE
fix(motion): accept typed style MotionValues

### DIFF
--- a/packages/motion/src/declarative/types.ts
+++ b/packages/motion/src/declarative/types.ts
@@ -14,7 +14,8 @@ import type { CSSProperties, IntrinsicElements } from '@lynx-js/types';
 export type MotionStyleValue =
   | string
   | number
-  | MotionValue<string | number>
+  | MotionValue<string>
+  | MotionValue<number>
   | null
   | undefined;
 
@@ -23,7 +24,8 @@ export type MotionStyle =
   & {
     [Key in keyof CSSProperties]?:
       | CSSProperties[Key]
-      | MotionValue<string | number>;
+      | MotionValue<string>
+      | MotionValue<number>;
   }
   & {
     x?: MotionStyleValue;


### PR DESCRIPTION
## What

Accept upstream `MotionValue<string | number>` values in declarative `style` typings, including transform aliases, without weakening the underlying Lynx CSS property types.

## Stack

Depends on #3515. Supersedes #3458.

## Validation

- `@lynx-js/motion`: 15 test files, 132 tests passed on the complete stack
- package TypeScript check passed
- compile-time coverage exercises ordinary CSS properties and transform aliases

## Confidence

**Very confident — ready to review.** This closes a type-level conformance gap and does not add a runtime compatibility path.

## Checklist

- [x] Tests updated.
- [ ] Documentation not required.
- [x] Changeset added.
