### PR TITLE
fix(motion): route value-specific transitions

### DIFF
--- a/.changeset/motion-value-specific-transitions.md
+++ b/.changeset/motion-value-specific-transitions.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Route declarative value-specific transitions by animated property so options such as per-value delays and durations match upstream Motion behavior.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -195,6 +195,48 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('routes value-specific transitions by animated property', async () => {
+    function App() {
+      const [active, setActive] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ opacity: 0, x: 0 }}
+            animate={{ opacity: active ? 1 : 0, x: active ? 40 : 0 }}
+            transition={{
+              opacity: { duration: 0.01, ease: 'linear' },
+              x: { delay: 0.08, duration: 0.01, ease: 'linear' },
+            }}
+          />
+          <view data-testid='toggle' bindtap={() => setActive(true)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 40));
+    });
+
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+    expect(getByTestId('box').getAttribute('style')).not.toContain(
+      'translateX(40px)',
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'translateX(40px)',
+    );
+  });
+
   test('skips the mount animation when initial is false', async () => {
     const onMountAnimationStart = vi.fn();
     const onMountAnimationComplete = vi.fn();

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -336,9 +336,9 @@ function useMotionHostProps<Props extends MotionProps>(
         return;
       }
 
-      const resolvedOptions = options?.repeat === -1
+      const resolvedOptions = (options?.repeat === -1
         ? { ...options, repeat: Number.POSITIVE_INFINITY }
-        : options;
+        : options) ?? {};
       const values = { ...motionValueBindings };
       const targets = [target, interactionTarget, hoverTarget];
       for (const definition of targets) {
@@ -493,9 +493,9 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     tapAnimationRef.current = [];
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
-    const resolvedTransition = workletTapTransition?.repeat === -1
+    const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
-      : workletTapTransition;
+      : workletTapTransition) ?? {};
     if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
       for (const key in targetValues) {
@@ -549,9 +549,9 @@ function useMotionHostProps<Props extends MotionProps>(
     const restingTransition = hoverActiveRef.current && resolvedHover.target
       ? workletHoverTransition
       : workletTapTransition;
-    const resolvedTransition = restingTransition?.repeat === -1
+    const resolvedTransition = (restingTransition?.repeat === -1
       ? { ...restingTransition, repeat: Number.POSITIVE_INFINITY }
-      : restingTransition;
+      : restingTransition) ?? {};
     const restingValues: Record<string, unknown> = {};
     for (const key in targetValues) {
       let restingValue = animateValues?.[key] ?? initialValues[key];
@@ -617,9 +617,9 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     tapAnimationRef.current = [];
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
-    const resolvedTransition = workletHoverTransition?.repeat === -1
+    const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
-      : workletHoverTransition;
+      : workletHoverTransition) ?? {};
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
     if (isLynxForWeb) {
@@ -674,9 +674,9 @@ function useMotionHostProps<Props extends MotionProps>(
       | Record<string, unknown>
       | undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
-    const resolvedTransition = workletHoverTransition?.repeat === -1
+    const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
-      : workletHoverTransition;
+      : workletHoverTransition) ?? {};
     const restingValues: Record<string, unknown> = {};
     for (const key in hoverValues) {
       let restingValue = animateValues?.[key] ?? initialValues[key];

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -11,7 +11,11 @@ import type {
   AnimationPlaybackControlsWithThen,
   MotionValue,
 } from 'motion-dom';
-import { motionValue, styleEffect } from 'motion-dom' with {
+import {
+  animateMotionValue as createMotionValueAnimation,
+  motionValue,
+  styleEffect,
+} from 'motion-dom' with {
   runtime: 'shared',
 };
 
@@ -332,7 +336,6 @@ function useMotionHostProps<Props extends MotionProps>(
         return;
       }
 
-      const animateMotionValue = animateValue as unknown as AnimateMotionTarget;
       const resolvedOptions = options?.repeat === -1
         ? { ...options, repeat: Number.POSITIVE_INFINITY }
         : options;
@@ -411,13 +414,17 @@ function useMotionHostProps<Props extends MotionProps>(
           const value = values[key];
           const targetValue = targetValues[key];
           if (value && targetValue !== undefined) {
-            animationRef.current.push(
-              animateMotionValue(
+            void value.start(
+              createMotionValueAnimation(
+                key,
                 value,
-                targetValue,
-                resolvedOptions,
+                targetValue as never,
+                resolvedOptions as never,
               ),
             );
+            if (value.animation) {
+              animationRef.current.push(value.animation);
+            }
           }
         }
       }
@@ -495,9 +502,17 @@ function useMotionHostProps<Props extends MotionProps>(
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
         if (value && targetValue !== undefined) {
-          tapAnimationRef.current.push(
-            animateMotionTarget(value, targetValue, resolvedTransition),
+          void value.start(
+            createMotionValueAnimation(
+              key,
+              value,
+              targetValue as never,
+              resolvedTransition as never,
+            ),
           );
+          if (value.animation) {
+            tapAnimationRef.current.push(value.animation);
+          }
         }
       }
       return;
@@ -560,9 +575,17 @@ function useMotionHostProps<Props extends MotionProps>(
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          tapAnimationRef.current.push(
-            animateMotionTarget(value, restingValues[key], resolvedTransition),
+          void value.start(
+            createMotionValueAnimation(
+              key,
+              value,
+              restingValues[key] as never,
+              resolvedTransition as never,
+            ),
           );
+          if (value.animation) {
+            tapAnimationRef.current.push(value.animation);
+          }
         }
       }
       return;
@@ -605,9 +628,17 @@ function useMotionHostProps<Props extends MotionProps>(
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
         if (value && targetValue !== undefined) {
-          tapAnimationRef.current.push(
-            animateMotionTarget(value, targetValue, resolvedTransition),
+          void value.start(
+            createMotionValueAnimation(
+              key,
+              value,
+              targetValue as never,
+              resolvedTransition as never,
+            ),
           );
+          if (value.animation) {
+            tapAnimationRef.current.push(value.animation);
+          }
         }
       }
       return;
@@ -669,9 +700,17 @@ function useMotionHostProps<Props extends MotionProps>(
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          tapAnimationRef.current.push(
-            animateMotionTarget(value, restingValues[key], resolvedTransition),
+          void value.start(
+            createMotionValueAnimation(
+              key,
+              value,
+              restingValues[key] as never,
+              resolvedTransition as never,
+            ),
           );
+          if (value.animation) {
+            tapAnimationRef.current.push(value.animation);
+          }
         }
       }
       return;


### PR DESCRIPTION
## What

Route value-specific transition options such as `transition.opacity` and `transition.x` to their corresponding upstream Motion animations while retaining the default transition fallback.

## Stack

Depends on #3516. Supersedes #3459.

## Validation

- `@lynx-js/motion`: 15 test files, 132 tests passed on the complete stack
- package TypeScript check passed
- tests cover value-specific overrides, default fallback, and hydrated transition objects

## Confidence

**Very confident — ready to review.** The behavior delegates to upstream Motion options after a small adapter-side routing step; no MTS, ReactLynx, or CSS workaround is introduced.

## Checklist

- [x] Tests updated.
- [ ] Documentation not required.
- [x] Changeset added.
