### PR TITLE
fix(motion): restore values removed from animate

### DIFF
--- a/.changeset/motion-removed-animate-values.md
+++ b/.changeset/motion-removed-animate-values.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Restore static style values when their declarative animate targets are removed.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -275,6 +275,68 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('uses the current initial value when a value leaves animate', async () => {
+    function App() {
+      const [active, setActive] = useState(true);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ opacity: active ? 0 : 0.5 }}
+            animate={active ? { opacity: 1 } : {}}
+            transition={{ type: false }}
+          />
+          <view data-testid='toggle' bindtap={() => setActive(false)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 0.5');
+  });
+
+  test('keeps the current value when it leaves animate and initial', async () => {
+    function App() {
+      const [active, setActive] = useState(true);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={active ? { opacity: 0 } : {}}
+            animate={active ? { opacity: 1 } : {}}
+            transition={{ type: false }}
+          />
+          <view data-testid='toggle' bindtap={() => setActive(false)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+  });
+
   test('skips the mount animation when initial is false', async () => {
     const onMountAnimationStart = vi.fn();
     const onMountAnimationComplete = vi.fn();

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -237,6 +237,44 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('restores a static style when its animate value is removed', async () => {
+    function App() {
+      const [ownsOpacity, setOwnsOpacity] = useState(true);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            style={{ opacity: 0.35 }}
+            animate={ownsOpacity ? { opacity: 1 } : {}}
+            transition={{ type: false }}
+          />
+          <view
+            data-testid='toggle'
+            bindtap={() => setOwnsOpacity(false)}
+          />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('opacity: 1');
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'opacity: 0.35',
+    );
+  });
+
   test('skips the mount animation when initial is false', async () => {
     const onMountAnimationStart = vi.fn();
     const onMountAnimationComplete = vi.fn();

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -351,8 +351,18 @@ function useMotionHostProps<Props extends MotionProps>(
       const targetValues = (target ?? {}) as Record<string, unknown>;
       const animationTargetValues: Record<string, unknown> = {};
       for (const key in animateTargetKeysRef.current) {
-        if (!(key in targetValues) && startingValues[key] !== undefined) {
-          animationTargetValues[key] = startingValues[key];
+        if (!(key in targetValues)) {
+          if (startingValues[key] === undefined) {
+            const retainedValue = generatedValuesRef.current[key];
+            if (retainedValue) {
+              retainedValue.stop();
+              const retainedSnapshot = motionValue(retainedValue.get());
+              generatedValuesRef.current[key] = retainedSnapshot;
+              values[key] = retainedSnapshot;
+            }
+          } else {
+            animationTargetValues[key] = startingValues[key];
+          }
         }
       }
       animateTargetKeysRef.current = {};

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -125,6 +125,7 @@ function useMotionHostProps<Props extends MotionProps>(
   const hoverActiveRef = useMainThreadRef(false);
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
+  const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
   >(null);
@@ -134,6 +135,7 @@ function useMotionHostProps<Props extends MotionProps>(
   >({});
   const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
   const hasMountedAnimationRef = useRef(false);
+  const hadAnimateTargetRef = useRef(false);
 
   const resolvedInitial = resolveMotionDefinition(initial, variants, custom);
   const resolvedAnimateDefinition = resolveMotionDefinition(
@@ -293,11 +295,17 @@ function useMotionHostProps<Props extends MotionProps>(
     : undefined;
 
   useEffect(() => {
+    const hadAnimateTarget = hadAnimateTargetRef.current;
+    hadAnimateTargetRef.current = Boolean(
+      resolvedAnimate.target
+        && Object.keys(resolvedAnimate.target).length > 0,
+    );
     if (
       !resolvedAnimate.target
       && !resolvedTap.target
       && !resolvedHover.target
       && Object.keys(motionValues).length === 0
+      && !hadAnimateTarget
     ) {
       return;
     }
@@ -340,7 +348,23 @@ function useMotionHostProps<Props extends MotionProps>(
         ? { ...options, repeat: Number.POSITIVE_INFINITY }
         : options) ?? {};
       const values = { ...motionValueBindings };
-      const targets = [target, interactionTarget, hoverTarget];
+      const targetValues = (target ?? {}) as Record<string, unknown>;
+      const animationTargetValues: Record<string, unknown> = {};
+      for (const key in animateTargetKeysRef.current) {
+        if (!(key in targetValues) && startingValues[key] !== undefined) {
+          animationTargetValues[key] = startingValues[key];
+        }
+      }
+      animateTargetKeysRef.current = {};
+      for (const key in targetValues) {
+        animateTargetKeysRef.current[key] = true;
+        animationTargetValues[key] = targetValues[key];
+      }
+      const targets = [
+        animationTargetValues,
+        interactionTarget,
+        hoverTarget,
+      ];
       for (const definition of targets) {
         if (!definition) {
           continue;
@@ -408,11 +432,10 @@ function useMotionHostProps<Props extends MotionProps>(
         styleCleanupRef.current = styleEffect(element, values);
       }
 
-      if (target && shouldAnimate) {
-        const targetValues = target as Record<string, unknown>;
-        for (const key in targetValues) {
+      if (shouldAnimate) {
+        for (const key in animationTargetValues) {
           const value = values[key];
-          const targetValue = targetValues[key];
+          const targetValue = animationTargetValues[key];
           if (value && targetValue !== undefined) {
             void value.start(
               createMotionValueAnimation(


### PR DESCRIPTION
## What

Restore the rendered style fallback when a value disappears from `animate`, matching Motion's behavior instead of leaving the last animated value attached indefinitely.

## Stack

Depends on #3517. Supersedes #3489.

## Validation

- `@lynx-js/motion`: 15 test files, 132 tests passed on the complete stack
- package TypeScript check passed
- tests cover removed target values and retention across subsequent renders

## Confidence

**Very confident — ready to review.** This is deterministic adapter state reconciliation with no platform-specific approximation.

## Checklist

- [x] Tests updated.
- [ ] Documentation not required.
- [x] Changeset added.
