### PR TITLE
fix(motion): suppress completion after unmount

### DIFF
--- a/.changeset/motion-unmount-cancellation.md
+++ b/.changeset/motion-unmount-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Suppress stale declarative animation completion callbacks after a component unmounts.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -294,6 +294,39 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('does not complete an animation after unmount', async () => {
+    const onAnimationComplete = vi.fn();
+    function App() {
+      const [visible, setVisible] = useState(true);
+      return (
+        <view>
+          {visible
+            ? (
+              <motion.view
+                data-testid='box'
+                initial={{ x: 0 }}
+                animate={{ x: 40 }}
+                transition={{ duration: 0.08 }}
+                onAnimationComplete={onAnimationComplete}
+              />
+            )
+            : null}
+          <view data-testid='toggle' bindtap={() => setVisible(false)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 120));
+    });
+    expect(onAnimationComplete).not.toHaveBeenCalled();
+  });
+
   test('restores a static style when its animate value is removed', async () => {
     function App() {
       const [ownsOpacity, setOwnsOpacity] = useState(true);

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -345,6 +345,13 @@ function useMotionHostProps<Props extends MotionProps>(
     ) {
       'main thread';
 
+      // Bind the background dispatcher while this function is synchronously
+      // executing on MTS. The animation promise can settle after the test or
+      // Web runtime has restored its background-thread execution context.
+      const reportAnimationComplete = onAnimationComplete
+        ? runOnBackground(completeAnimationOnBackground)
+        : undefined;
+
       for (const animation of animationRef.current) {
         animation.stop();
       }
@@ -510,8 +517,8 @@ function useMotionHostProps<Props extends MotionProps>(
             styleCleanupRef.current?.();
             styleCleanupRef.current = styleEffect(motionElement, values);
           }
-          if (onAnimationComplete) {
-            void runOnBackground(completeAnimationOnBackground)(
+          if (reportAnimationComplete) {
+            void reportAnimationComplete(
               backgroundAnimationGeneration,
               animate,
             );

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -41,6 +41,7 @@ import {
 } from './style.js';
 import type {
   MotionComponentProps,
+  MotionDefinition,
   MotionFactory,
   MotionImageProps,
   MotionProps,
@@ -136,6 +137,7 @@ function useMotionHostProps<Props extends MotionProps>(
   const styleCleanupRef = useMainThreadRef<(() => void) | null>(null);
   const hasMountedAnimationRef = useRef(false);
   const hadAnimateTargetRef = useRef(false);
+  const backgroundAnimationGenerationRef = useRef(0);
 
   const resolvedInitial = resolveMotionDefinition(initial, variants, custom);
   const resolvedAnimateDefinition = resolveMotionDefinition(
@@ -295,6 +297,9 @@ function useMotionHostProps<Props extends MotionProps>(
     : undefined;
 
   useEffect(() => {
+    const backgroundAnimationGeneration =
+      backgroundAnimationGenerationRef.current + 1;
+    backgroundAnimationGenerationRef.current = backgroundAnimationGeneration;
     const hadAnimateTarget = hadAnimateTargetRef.current;
     hadAnimateTargetRef.current = Boolean(
       resolvedAnimate.target
@@ -316,6 +321,18 @@ function useMotionHostProps<Props extends MotionProps>(
     const shouldAnimateTarget = resolvedInitialTarget !== false
       || hasMountedAnimationRef.current;
     hasMountedAnimationRef.current = true;
+
+    function completeAnimationOnBackground(
+      expectedGeneration: number,
+      definition: MotionDefinition,
+    ) {
+      if (
+        backgroundAnimationGenerationRef.current === expectedGeneration
+        && onAnimationComplete
+      ) {
+        onAnimationComplete(definition);
+      }
+    }
 
     function updateMotionStyles(
       target: MotionTarget | undefined,
@@ -494,7 +511,10 @@ function useMotionHostProps<Props extends MotionProps>(
             styleCleanupRef.current = styleEffect(motionElement, values);
           }
           if (onAnimationComplete) {
-            void runOnBackground(onAnimationComplete)(animate);
+            void runOnBackground(completeAnimationOnBackground)(
+              backgroundAnimationGeneration,
+              animate,
+            );
           }
         });
       }
@@ -526,6 +546,7 @@ function useMotionHostProps<Props extends MotionProps>(
     }
 
     return () => {
+      backgroundAnimationGenerationRef.current += 1;
       void runOnMainThread(stopMotionStyles)();
     };
     // Serialized targets and value IDs avoid restarting unchanged inline


### PR DESCRIPTION
## What

Cancel declarative completion work after unmount and bind the background notification function synchronously on the main thread before entering the asynchronous continuation.

## Stack

Depends on #3519. Supersedes #3463.

## Validation

- `@lynx-js/motion`: 15 test files, 132 tests passed on the complete stack
- package TypeScript check passed
- tests cover unmount cancellation and stale completion suppression

## Confidence

**Very confident — ready to review.** The earlier thread-affinity risk is removed: `runOnBackground` is bound while still on MTS, then invoked after completion.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Changeset added.
