### PR TITLE
test(motion): cover discrete visibility exits

### DIFF
--- a/.changeset/motion-discrete-display-test.md
+++ b/.changeset/motion-discrete-display-test.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Preserve discrete display visibility until declarative exit animations complete.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -213,6 +213,42 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('switches display to none only after an opacity exit completes', async () => {
+    function App() {
+      const [hidden, setHidden] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ display: 'block', opacity: 1 }}
+            animate={hidden
+              ? { display: 'none', opacity: 0 }
+              : { display: 'block', opacity: 1 }}
+            transition={{ duration: 0.08, ease: 'linear' }}
+          />
+          <view data-testid='toggle' bindtap={() => setHidden(true)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'display: block',
+    );
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain('display: none');
+  });
+
   test('routes value-specific transitions by animated property', async () => {
     function App() {
       const [active, setActive] = useState(false);

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -249,6 +249,44 @@ describe('declarative Motion', () => {
     expect(getByTestId('box').getAttribute('style')).toContain('display: none');
   });
 
+  test('switches visibility to hidden only after an opacity exit completes', async () => {
+    function App() {
+      const [hidden, setHidden] = useState(false);
+      return (
+        <view>
+          <motion.view
+            data-testid='box'
+            initial={{ visibility: 'visible', opacity: 1 }}
+            animate={hidden
+              ? { visibility: 'hidden', opacity: 0 }
+              : { visibility: 'visible', opacity: 1 }}
+            transition={{ duration: 0.08, ease: 'linear' }}
+          />
+          <view data-testid='toggle' bindtap={() => setHidden(true)} />
+        </view>
+      );
+    }
+
+    const { getByTestId } = render(<App />, {
+      enableMainThread: true,
+      enableBackgroundThread: true,
+    });
+
+    fireEvent.tap(getByTestId('toggle'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 30));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'visibility: visible',
+    );
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 80));
+    });
+    expect(getByTestId('box').getAttribute('style')).toContain(
+      'visibility: hidden',
+    );
+  });
+
   test('routes value-specific transitions by animated property', async () => {
     function App() {
       const [active, setActive] = useState(false);


### PR DESCRIPTION
## What

Prove that discrete `display` and `visibility` values conform through the existing upstream Motion plus `transitionEnd` path. This layer intentionally adds no new runtime behavior: the result is that this usage pattern needs no Lynx-specific compatibility code.

## Stack

Depends on #3520. Supersedes #3465.

## Validation

- `@lynx-js/motion`: 15 test files, 132 tests passed on the complete stack
- package TypeScript check passed
- focused tests prove the upstream engine plus `transitionEnd` path handles the two discrete properties

## Confidence

**Very confident — ready to review.** The tests close a platform-risk question: both discrete properties work through the canonical path without an MTS, ReactLynx, or CSS workaround. Keeping this as a small checkpoint makes that zero-code compatibility result visible and independently reversible.

## Checklist

- [x] Tests updated.
- [ ] Documentation not required.
- [ ] Changeset not required (tests only).
