### PR TITLE
fix(motion): report tap animation lifecycle

### DIFF
--- a/.changeset/motion-tap-animation-lifecycle.md
+++ b/.changeset/motion-tap-animation-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Report declarative animation lifecycle callbacks when tap targets apply and restore.

--- a/.changeset/motion-tap-animation-lifecycle.md
+++ b/.changeset/motion-tap-animation-lifecycle.md
@@ -2,4 +2,4 @@
 "@lynx-js/motion": patch
 ---
 
-Report declarative animation lifecycle callbacks when tap targets apply and restore.
+Report declarative animation lifecycle callbacks when tap targets apply and restore, including multi-property completion.

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -624,69 +624,6 @@ describe('declarative Motion', () => {
     );
   });
 
-  test('reports tap target and restoration animation lifecycle', async () => {
-    const onAnimationStart = vi.fn();
-    const onAnimationComplete = vi.fn();
-    const { getByTestId } = render(
-      <motion.view
-        data-testid='button'
-        initial={{ scale: 1, backgroundColor: '#ffffff' }}
-        whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
-        transition={{ duration: 0.01 }}
-        onAnimationStart={onAnimationStart}
-        onAnimationComplete={onAnimationComplete}
-      />,
-      { enableMainThread: true, enableBackgroundThread: true },
-    );
-
-    fireEvent.touchstart(getByTestId('button'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-    expect(onAnimationStart).toHaveBeenNthCalledWith(1, {
-      scale: 1.15,
-      backgroundColor: '#ffcc00',
-    });
-    expect(onAnimationComplete).toHaveBeenNthCalledWith(1, {
-      scale: 1.15,
-      backgroundColor: '#ffcc00',
-    });
-
-    fireEvent.touchend(getByTestId('button'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-    expect(onAnimationStart).toHaveBeenNthCalledWith(2, {
-      scale: 1,
-      backgroundColor: '#ffffff',
-    });
-    expect(onAnimationComplete).toHaveBeenNthCalledWith(2, {
-      scale: 1,
-      backgroundColor: '#ffffff',
-    });
-  });
-
-  test('does not complete an interrupted tap target', async () => {
-    const onAnimationComplete = vi.fn();
-    const { getByTestId } = render(
-      <motion.view
-        data-testid='button'
-        whileTap={{ scale: 1.15 }}
-        transition={{ duration: 0.08 }}
-        onAnimationComplete={onAnimationComplete}
-      />,
-      { enableMainThread: true, enableBackgroundThread: true },
-    );
-
-    fireEvent.touchstart(getByTestId('button'));
-    fireEvent.touchend(getByTestId('button'));
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 120));
-    });
-    expect(onAnimationComplete).toHaveBeenCalledOnce();
-    expect(onAnimationComplete).toHaveBeenCalledWith({ scale: 1 });
-  });
-
   test('composes gesture callbacks with external host handlers', () => {
     const onTapStart = vi.fn();
     const onTap = vi.fn();

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -618,7 +618,9 @@ describe('declarative Motion', () => {
       await new Promise(resolve => setTimeout(resolve, 50));
     });
 
-    expect(getByTestId('button').getAttribute('style')).toContain('scale(1');
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'transform: scale(1, 1);',
+    );
     expect(getByTestId('button').getAttribute('style')).toContain(
       'rgb(255, 255, 255)',
     );
@@ -650,7 +652,7 @@ describe('declarative Motion', () => {
       await new Promise(resolve => setTimeout(resolve, 300));
     });
     expect(getByTestId('button').getAttribute('style')).toContain(
-      'scale(1',
+      'transform: scale(1, 1);',
     );
     expect(getByTestId('button').getAttribute('style')).toContain(
       'rgb(255, 255, 255)',

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -624,6 +624,36 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('restores every value after interrupting a tap animation', async () => {
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        style={{ scale: 1, backgroundColor: '#ffffff' }}
+        whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
+        transition={{ duration: 0.2 }}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 300));
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'scale(1',
+    );
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'rgb(255, 255, 255)',
+    );
+  });
+
   test('composes gesture callbacks with external host handlers', () => {
     const onTapStart = vi.fn();
     const onTap = vi.fn();

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -624,6 +624,69 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('reports tap target and restoration animation lifecycle', async () => {
+    const onAnimationStart = vi.fn();
+    const onAnimationComplete = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        initial={{ scale: 1, backgroundColor: '#ffffff' }}
+        whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
+        transition={{ duration: 0.01 }}
+        onAnimationStart={onAnimationStart}
+        onAnimationComplete={onAnimationComplete}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(onAnimationStart).toHaveBeenNthCalledWith(1, {
+      scale: 1.15,
+      backgroundColor: '#ffcc00',
+    });
+    expect(onAnimationComplete).toHaveBeenNthCalledWith(1, {
+      scale: 1.15,
+      backgroundColor: '#ffcc00',
+    });
+
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    expect(onAnimationStart).toHaveBeenNthCalledWith(2, {
+      scale: 1,
+      backgroundColor: '#ffffff',
+    });
+    expect(onAnimationComplete).toHaveBeenNthCalledWith(2, {
+      scale: 1,
+      backgroundColor: '#ffffff',
+    });
+  });
+
+  test('does not complete an interrupted tap target', async () => {
+    const onAnimationComplete = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        whileTap={{ scale: 1.15 }}
+        transition={{ duration: 0.08 }}
+        onAnimationComplete={onAnimationComplete}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 120));
+    });
+    expect(onAnimationComplete).toHaveBeenCalledOnce();
+    expect(onAnimationComplete).toHaveBeenCalledWith({ scale: 1 });
+  });
+
   test('composes gesture callbacks with external host handlers', () => {
     const onTapStart = vi.fn();
     const onTap = vi.fn();

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -642,6 +642,9 @@ describe('declarative Motion', () => {
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 10));
     });
+    expect(getByTestId('button').getAttribute('style')).not.toContain(
+      'rgb(255, 255, 255)',
+    );
     fireEvent.touchend(getByTestId('button'));
     await act(async () => {
       await new Promise(resolve => setTimeout(resolve, 300));

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -659,6 +659,48 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('reports tap target and restoration animation starts', async () => {
+    const onAnimationStart = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        initial={{ scale: 1, backgroundColor: '#ffffff' }}
+        whileTap={{ scale: 1.15, backgroundColor: '#ffcc00' }}
+        transition={{ duration: 0.08 }}
+        onAnimationStart={onAnimationStart}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    fireEvent.touchstart(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 180));
+    });
+    expect(onAnimationStart).toHaveBeenNthCalledWith(1, {
+      scale: 1.15,
+      backgroundColor: '#ffcc00',
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'scale(1.15',
+    );
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'rgb(255, 204, 0)',
+    );
+
+    fireEvent.touchend(getByTestId('button'));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 180));
+    });
+    expect(onAnimationStart).toHaveBeenNthCalledWith(2, {
+      scale: 1,
+      backgroundColor: '#ffffff',
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain('scale(1');
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'rgb(255, 255, 255)',
+    );
+  });
+
   test('composes gesture callbacks with external host handlers', () => {
     const onTapStart = vi.fn();
     const onTap = vi.fn();

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -131,6 +131,7 @@ function useMotionHostProps<Props extends MotionProps>(
     generation: number;
     pending: number;
   }>({ generation: 0, pending: 0 });
+  const tapAnimationValueKeysRef = useMainThreadRef<Record<string, true>>({});
   const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
@@ -365,6 +366,10 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       tapAnimationRef.current = [];
+      for (const key in tapAnimationValueKeysRef.current) {
+        (generatedValuesRef.current[key] ?? motionValueBindings[key])?.stop();
+      }
+      tapAnimationValueKeysRef.current = {};
       tapAnimationGenerationRef.current += 1;
       const animationGeneration = animationGenerationRef.current + 1;
       animationGenerationRef.current = animationGeneration;
@@ -495,9 +500,10 @@ function useMotionHostProps<Props extends MotionProps>(
         }
       }
 
-      const activeAnimations = [...animationRef.current];
       if (
-        activeAnimations.length > 0 && animate !== undefined && onAnimationStart
+        completionPromises.length > 0
+        && animate !== undefined
+        && onAnimationStart
       ) {
         void runOnBackground(onAnimationStart)(animate);
       }
@@ -554,6 +560,10 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       tapAnimationRef.current = [];
+      for (const key in tapAnimationValueKeysRef.current) {
+        (generatedValuesRef.current[key] ?? motionValueBindings[key])?.stop();
+      }
+      tapAnimationValueKeysRef.current = {};
       tapAnimationGenerationRef.current += 1;
       styleCleanupRef.current?.();
       styleCleanupRef.current = null;
@@ -583,6 +593,10 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
+    for (const key in tapAnimationValueKeysRef.current) {
+      (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
+    }
+    tapAnimationValueKeysRef.current = {};
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
     // Bind while the tap-start worklet is still executing on MTS; Motion calls
@@ -591,6 +605,7 @@ function useMotionHostProps<Props extends MotionProps>(
       ? runOnBackground(onAnimationComplete)
       : undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    let startedAnimationCount = 0;
     const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
       : workletTapTransition) ?? {};
@@ -622,6 +637,7 @@ function useMotionHostProps<Props extends MotionProps>(
         generation: animationGeneration,
         pending: pendingAnimationCount,
       };
+      startedAnimationCount = pendingAnimationCount;
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
@@ -641,7 +657,9 @@ function useMotionHostProps<Props extends MotionProps>(
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          if (!isLynxForWeb && value.animation) {
+          if (isLynxForWeb) {
+            tapAnimationValueKeysRef.current[key] = true;
+          } else if (value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
         }
@@ -667,12 +685,9 @@ function useMotionHostProps<Props extends MotionProps>(
         },
       );
       tapAnimationRef.current.push(animation);
+      startedAnimationCount = 1;
     }
-    if (
-      (Object.keys(resolvedTap.target).length > 0
-        || tapAnimationRef.current.length > 0)
-      && onAnimationStart
-    ) {
+    if (startedAnimationCount > 0 && onAnimationStart) {
       void runOnBackground(onAnimationStart)(whileTap!);
     }
   }
@@ -689,6 +704,10 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
+    for (const key in tapAnimationValueKeysRef.current) {
+      (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
+    }
+    tapAnimationValueKeysRef.current = {};
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
     // Bind while the tap-end worklet is still executing on MTS; restoration
@@ -704,6 +723,7 @@ function useMotionHostProps<Props extends MotionProps>(
       | Record<string, unknown>
       | undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    let startedAnimationCount = 0;
     const restingTransition = hoverActiveRef.current && resolvedHover.target
       ? workletHoverTransition
       : workletTapTransition;
@@ -758,6 +778,7 @@ function useMotionHostProps<Props extends MotionProps>(
         generation: animationGeneration,
         pending: pendingAnimationCount,
       };
+      startedAnimationCount = pendingAnimationCount;
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
@@ -776,7 +797,9 @@ function useMotionHostProps<Props extends MotionProps>(
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          if (!isLynxForWeb && value.animation) {
+          if (isLynxForWeb) {
+            tapAnimationValueKeysRef.current[key] = true;
+          } else if (value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
         }
@@ -802,12 +825,9 @@ function useMotionHostProps<Props extends MotionProps>(
         },
       );
       tapAnimationRef.current.push(animation);
+      startedAnimationCount = 1;
     }
-    if (
-      (Object.keys(restingValues).length > 0
-        || tapAnimationRef.current.length > 0)
-      && onAnimationStart
-    ) {
+    if (startedAnimationCount > 0 && onAnimationStart) {
       void runOnBackground(onAnimationStart)(restingDefinition);
     }
   }
@@ -829,6 +849,10 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
+    for (const key in tapAnimationValueKeysRef.current) {
+      (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
+    }
+    tapAnimationValueKeysRef.current = {};
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
@@ -882,6 +906,10 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
+    for (const key in tapAnimationValueKeysRef.current) {
+      (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
+    }
+    tapAnimationValueKeysRef.current = {};
     const hoverValues = resolvedHover.target as Record<string, unknown>;
     const animateValues = resolvedAnimate.target as
       | Record<string, unknown>

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -126,6 +126,7 @@ function useMotionHostProps<Props extends MotionProps>(
   const hoverActiveRef = useMainThreadRef(false);
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
+  const tapAnimationGenerationRef = useMainThreadRef(0);
   const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
@@ -360,6 +361,7 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       tapAnimationRef.current = [];
+      tapAnimationGenerationRef.current += 1;
       const animationGeneration = animationGenerationRef.current + 1;
       animationGenerationRef.current = animationGeneration;
       styleCleanupRef.current?.();
@@ -548,6 +550,7 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       tapAnimationRef.current = [];
+      tapAnimationGenerationRef.current += 1;
       styleCleanupRef.current?.();
       styleCleanupRef.current = null;
     }
@@ -576,17 +579,22 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
+    const animationGeneration = tapAnimationGenerationRef.current + 1;
+    tapAnimationGenerationRef.current = animationGeneration;
+    const completionPromises: Promise<void>[] = [];
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
       : workletTapTransition) ?? {};
+    // Keep animation handles out of the MTS snapshot captured by a ReactLynx
+    // rerender triggered from lifecycle callbacks.
     if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
         if (value && targetValue !== undefined) {
-          void value.start(
+          const completion = value.start(
             createMotionValueAnimation(
               key,
               value,
@@ -595,19 +603,38 @@ function useMotionHostProps<Props extends MotionProps>(
             ),
           );
           if (value.animation) {
+            Object.defineProperty(value, 'animation', { enumerable: false });
+          }
+          completionPromises.push(completion);
+          if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
         }
       }
-      return;
+    } else {
+      const ElementConstructor = globalThis.Element as unknown as new(
+        element: MainThread.Element,
+      ) => Element;
+      const element = new ElementConstructor(event.currentTarget);
+      const animation = animateMotionTarget(
+        element,
+        resolvedTap.target,
+        resolvedTransition,
+      );
+      tapAnimationRef.current.push(animation);
+      completionPromises.push(Promise.resolve(animation).then(() => undefined));
     }
-    const ElementConstructor = globalThis.Element as unknown as new(
-      element: MainThread.Element,
-    ) => Element;
-    const element = new ElementConstructor(event.currentTarget);
-    tapAnimationRef.current.push(
-      animateMotionTarget(element, resolvedTap.target, resolvedTransition),
-    );
+    if (completionPromises.length > 0 && onAnimationStart) {
+      void runOnBackground(onAnimationStart)(whileTap!);
+    }
+    if (completionPromises.length > 0 && onAnimationComplete) {
+      void Promise.all(completionPromises).then(() => {
+        if (tapAnimationGenerationRef.current !== animationGeneration) {
+          return;
+        }
+        void runOnBackground(onAnimationComplete)(whileTap!);
+      });
+    }
   }
 
   function endTapAnimation(event: MainThread.TouchEvent) {
@@ -622,6 +649,9 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     tapAnimationRef.current = [];
+    const animationGeneration = tapAnimationGenerationRef.current + 1;
+    tapAnimationGenerationRef.current = animationGeneration;
+    const completionPromises: Promise<void>[] = [];
     const targetValues = resolvedTap.target as Record<string, unknown>;
     const restingTarget = hoverActiveRef.current && resolvedHover.target
       ? resolvedHover.target
@@ -655,11 +685,15 @@ function useMotionHostProps<Props extends MotionProps>(
         restingValues[key] = restingValue;
       }
     }
+    const restingDefinition: MotionDefinition = hoverActiveRef.current
+        && whileHover !== undefined
+      ? whileHover
+      : animate ?? (restingValues as MotionTarget);
     if (isLynxForWeb || !event.currentTarget) {
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          void value.start(
+          const completion = value.start(
             createMotionValueAnimation(
               key,
               value,
@@ -668,19 +702,38 @@ function useMotionHostProps<Props extends MotionProps>(
             ),
           );
           if (value.animation) {
+            Object.defineProperty(value, 'animation', { enumerable: false });
+          }
+          completionPromises.push(completion);
+          if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
         }
       }
-      return;
+    } else {
+      const ElementConstructor = globalThis.Element as unknown as new(
+        element: MainThread.Element,
+      ) => Element;
+      const element = new ElementConstructor(event.currentTarget);
+      const animation = animateMotionTarget(
+        element,
+        restingValues,
+        resolvedTransition,
+      );
+      tapAnimationRef.current.push(animation);
+      completionPromises.push(Promise.resolve(animation).then(() => undefined));
     }
-    const ElementConstructor = globalThis.Element as unknown as new(
-      element: MainThread.Element,
-    ) => Element;
-    const element = new ElementConstructor(event.currentTarget);
-    tapAnimationRef.current.push(
-      animateMotionTarget(element, restingValues, resolvedTransition),
-    );
+    if (completionPromises.length > 0 && onAnimationStart) {
+      void runOnBackground(onAnimationStart)(restingDefinition);
+    }
+    if (completionPromises.length > 0 && onAnimationComplete) {
+      void Promise.all(completionPromises).then(() => {
+        if (tapAnimationGenerationRef.current !== animationGeneration) {
+          return;
+        }
+        void runOnBackground(onAnimationComplete)(restingDefinition);
+      });
+    }
   }
 
   function startHoverAnimation() {

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -581,7 +581,7 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    const completionPromises: Promise<void>[] = [];
+    const animatedValues: MotionValue<string | number>[] = [];
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
@@ -605,7 +605,18 @@ function useMotionHostProps<Props extends MotionProps>(
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          completionPromises.push(completion);
+          animatedValues.push(value);
+          void completion.then(() => {
+            if (tapAnimationGenerationRef.current !== animationGeneration) {
+              return;
+            }
+            if (
+              !animatedValues.some(value => value.isAnimating())
+              && onAnimationComplete
+            ) {
+              void runOnBackground(onAnimationComplete)(whileTap!);
+            }
+          });
           if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
@@ -622,18 +633,20 @@ function useMotionHostProps<Props extends MotionProps>(
         resolvedTransition,
       );
       tapAnimationRef.current.push(animation);
-      completionPromises.push(Promise.resolve(animation).then(() => undefined));
-    }
-    if (completionPromises.length > 0 && onAnimationStart) {
-      void runOnBackground(onAnimationStart)(whileTap!);
-    }
-    if (completionPromises.length > 0 && onAnimationComplete) {
-      void Promise.all(completionPromises).then(() => {
+      void animation.then(() => {
         if (tapAnimationGenerationRef.current !== animationGeneration) {
           return;
         }
-        void runOnBackground(onAnimationComplete)(whileTap!);
+        if (onAnimationComplete) {
+          void runOnBackground(onAnimationComplete)(whileTap!);
+        }
       });
+    }
+    if (
+      (animatedValues.length > 0 || tapAnimationRef.current.length > 0)
+      && onAnimationStart
+    ) {
+      void runOnBackground(onAnimationStart)(whileTap!);
     }
   }
 
@@ -651,7 +664,7 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    const completionPromises: Promise<void>[] = [];
+    const animatedValues: MotionValue<string | number>[] = [];
     const targetValues = resolvedTap.target as Record<string, unknown>;
     const restingTarget = hoverActiveRef.current && resolvedHover.target
       ? resolvedHover.target
@@ -704,7 +717,18 @@ function useMotionHostProps<Props extends MotionProps>(
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          completionPromises.push(completion);
+          animatedValues.push(value);
+          void completion.then(() => {
+            if (tapAnimationGenerationRef.current !== animationGeneration) {
+              return;
+            }
+            if (
+              !animatedValues.some(value => value.isAnimating())
+              && onAnimationComplete
+            ) {
+              void runOnBackground(onAnimationComplete)(restingDefinition);
+            }
+          });
           if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
@@ -721,18 +745,20 @@ function useMotionHostProps<Props extends MotionProps>(
         resolvedTransition,
       );
       tapAnimationRef.current.push(animation);
-      completionPromises.push(Promise.resolve(animation).then(() => undefined));
-    }
-    if (completionPromises.length > 0 && onAnimationStart) {
-      void runOnBackground(onAnimationStart)(restingDefinition);
-    }
-    if (completionPromises.length > 0 && onAnimationComplete) {
-      void Promise.all(completionPromises).then(() => {
+      void animation.then(() => {
         if (tapAnimationGenerationRef.current !== animationGeneration) {
           return;
         }
-        void runOnBackground(onAnimationComplete)(restingDefinition);
+        if (onAnimationComplete) {
+          void runOnBackground(onAnimationComplete)(restingDefinition);
+        }
       });
+    }
+    if (
+      (animatedValues.length > 0 || tapAnimationRef.current.length > 0)
+      && onAnimationStart
+    ) {
+      void runOnBackground(onAnimationStart)(restingDefinition);
     }
   }
 

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -120,18 +120,20 @@ function useMotionHostProps<Props extends MotionProps>(
   const animationRef = useMainThreadRef<
     AnimationPlaybackControlsWithThen[]
   >([]);
-  const tapAnimationRef = useMainThreadRef<
+  const interactionAnimationRef = useMainThreadRef<
     AnimationPlaybackControlsWithThen[]
   >([]);
   const hoverActiveRef = useMainThreadRef(false);
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
-  const tapAnimationGenerationRef = useMainThreadRef(0);
-  const tapAnimationCompletionRef = useMainThreadRef<{
+  const interactionAnimationGenerationRef = useMainThreadRef(0);
+  const interactionAnimationCompletionRef = useMainThreadRef<{
     generation: number;
     pending: number;
   }>({ generation: 0, pending: 0 });
-  const tapAnimationValueKeysRef = useMainThreadRef<Record<string, true>>({});
+  const interactionAnimationValueKeysRef = useMainThreadRef<
+    Record<string, true>
+  >({});
   const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
@@ -362,15 +364,15 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       animationRef.current = [];
-      for (const animation of tapAnimationRef.current) {
+      for (const animation of interactionAnimationRef.current) {
         animation.stop();
       }
-      tapAnimationRef.current = [];
-      for (const key in tapAnimationValueKeysRef.current) {
+      interactionAnimationRef.current = [];
+      for (const key in interactionAnimationValueKeysRef.current) {
         (generatedValuesRef.current[key] ?? motionValueBindings[key])?.stop();
       }
-      tapAnimationValueKeysRef.current = {};
-      tapAnimationGenerationRef.current += 1;
+      interactionAnimationValueKeysRef.current = {};
+      interactionAnimationGenerationRef.current += 1;
       const animationGeneration = animationGenerationRef.current + 1;
       animationGenerationRef.current = animationGeneration;
       styleCleanupRef.current?.();
@@ -556,15 +558,15 @@ function useMotionHostProps<Props extends MotionProps>(
         animation.stop();
       }
       animationRef.current = [];
-      for (const animation of tapAnimationRef.current) {
+      for (const animation of interactionAnimationRef.current) {
         animation.stop();
       }
-      tapAnimationRef.current = [];
-      for (const key in tapAnimationValueKeysRef.current) {
+      interactionAnimationRef.current = [];
+      for (const key in interactionAnimationValueKeysRef.current) {
         (generatedValuesRef.current[key] ?? motionValueBindings[key])?.stop();
       }
-      tapAnimationValueKeysRef.current = {};
-      tapAnimationGenerationRef.current += 1;
+      interactionAnimationValueKeysRef.current = {};
+      interactionAnimationGenerationRef.current += 1;
       styleCleanupRef.current?.();
       styleCleanupRef.current = null;
     }
@@ -589,16 +591,16 @@ function useMotionHostProps<Props extends MotionProps>(
       animation.stop();
     }
     animationRef.current = [];
-    for (const animation of tapAnimationRef.current) {
+    for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
-    tapAnimationRef.current = [];
-    for (const key in tapAnimationValueKeysRef.current) {
+    interactionAnimationRef.current = [];
+    for (const key in interactionAnimationValueKeysRef.current) {
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
-    tapAnimationValueKeysRef.current = {};
-    const animationGeneration = tapAnimationGenerationRef.current + 1;
-    tapAnimationGenerationRef.current = animationGeneration;
+    interactionAnimationValueKeysRef.current = {};
+    const animationGeneration = interactionAnimationGenerationRef.current + 1;
+    interactionAnimationGenerationRef.current = animationGeneration;
     // Bind while the tap-start worklet is still executing on MTS; Motion calls
     // the returned dispatcher later from its animation scheduler.
     const reportAnimationComplete = onAnimationComplete
@@ -615,13 +617,14 @@ function useMotionHostProps<Props extends MotionProps>(
       const targetValues = resolvedTap.target as Record<string, unknown>;
       let pendingAnimationCount = 0;
       function reportTapAnimationComplete(definition: MotionDefinition) {
-        if (tapAnimationGenerationRef.current !== animationGeneration) {
+        if (interactionAnimationGenerationRef.current !== animationGeneration) {
           return;
         }
-        tapAnimationCompletionRef.current.pending -= 1;
+        interactionAnimationCompletionRef.current.pending -= 1;
         if (
-          tapAnimationCompletionRef.current.generation === animationGeneration
-          && tapAnimationCompletionRef.current.pending === 0
+          interactionAnimationCompletionRef.current.generation
+            === animationGeneration
+          && interactionAnimationCompletionRef.current.pending === 0
           && reportAnimationComplete
         ) {
           void reportAnimationComplete(definition);
@@ -633,7 +636,7 @@ function useMotionHostProps<Props extends MotionProps>(
           pendingAnimationCount += 1;
         }
       }
-      tapAnimationCompletionRef.current = {
+      interactionAnimationCompletionRef.current = {
         generation: animationGeneration,
         pending: pendingAnimationCount,
       };
@@ -658,9 +661,9 @@ function useMotionHostProps<Props extends MotionProps>(
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
           if (isLynxForWeb) {
-            tapAnimationValueKeysRef.current[key] = true;
+            interactionAnimationValueKeysRef.current[key] = true;
           } else if (value.animation) {
-            tapAnimationRef.current.push(value.animation);
+            interactionAnimationRef.current.push(value.animation);
           }
         }
       }
@@ -676,7 +679,7 @@ function useMotionHostProps<Props extends MotionProps>(
           ...resolvedTransition,
           onComplete: () => {
             if (
-              tapAnimationGenerationRef.current === animationGeneration
+              interactionAnimationGenerationRef.current === animationGeneration
               && reportAnimationComplete
             ) {
               void reportAnimationComplete(whileTap!);
@@ -684,7 +687,7 @@ function useMotionHostProps<Props extends MotionProps>(
           },
         },
       );
-      tapAnimationRef.current.push(animation);
+      interactionAnimationRef.current.push(animation);
       startedAnimationCount = 1;
     }
     if (startedAnimationCount > 0 && onAnimationStart) {
@@ -700,16 +703,16 @@ function useMotionHostProps<Props extends MotionProps>(
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
     tapActiveRef.current = false;
-    for (const animation of tapAnimationRef.current) {
+    for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
-    tapAnimationRef.current = [];
-    for (const key in tapAnimationValueKeysRef.current) {
+    interactionAnimationRef.current = [];
+    for (const key in interactionAnimationValueKeysRef.current) {
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
-    tapAnimationValueKeysRef.current = {};
-    const animationGeneration = tapAnimationGenerationRef.current + 1;
-    tapAnimationGenerationRef.current = animationGeneration;
+    interactionAnimationValueKeysRef.current = {};
+    const animationGeneration = interactionAnimationGenerationRef.current + 1;
+    interactionAnimationGenerationRef.current = animationGeneration;
     // Bind while the tap-end worklet is still executing on MTS; restoration
     // completion arrives later from Motion's animation scheduler.
     const reportAnimationComplete = onAnimationComplete
@@ -756,13 +759,14 @@ function useMotionHostProps<Props extends MotionProps>(
     if (isLynxForWeb || !event.currentTarget) {
       let pendingAnimationCount = 0;
       function reportTapAnimationComplete() {
-        if (tapAnimationGenerationRef.current !== animationGeneration) {
+        if (interactionAnimationGenerationRef.current !== animationGeneration) {
           return;
         }
-        tapAnimationCompletionRef.current.pending -= 1;
+        interactionAnimationCompletionRef.current.pending -= 1;
         if (
-          tapAnimationCompletionRef.current.generation === animationGeneration
-          && tapAnimationCompletionRef.current.pending === 0
+          interactionAnimationCompletionRef.current.generation
+            === animationGeneration
+          && interactionAnimationCompletionRef.current.pending === 0
           && reportAnimationComplete
         ) {
           void reportAnimationComplete(restingDefinition);
@@ -774,7 +778,7 @@ function useMotionHostProps<Props extends MotionProps>(
           pendingAnimationCount += 1;
         }
       }
-      tapAnimationCompletionRef.current = {
+      interactionAnimationCompletionRef.current = {
         generation: animationGeneration,
         pending: pendingAnimationCount,
       };
@@ -798,9 +802,9 @@ function useMotionHostProps<Props extends MotionProps>(
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
           if (isLynxForWeb) {
-            tapAnimationValueKeysRef.current[key] = true;
+            interactionAnimationValueKeysRef.current[key] = true;
           } else if (value.animation) {
-            tapAnimationRef.current.push(value.animation);
+            interactionAnimationRef.current.push(value.animation);
           }
         }
       }
@@ -816,7 +820,7 @@ function useMotionHostProps<Props extends MotionProps>(
           ...resolvedTransition,
           onComplete: () => {
             if (
-              tapAnimationGenerationRef.current === animationGeneration
+              interactionAnimationGenerationRef.current === animationGeneration
               && reportAnimationComplete
             ) {
               void reportAnimationComplete(restingDefinition);
@@ -824,7 +828,7 @@ function useMotionHostProps<Props extends MotionProps>(
           },
         },
       );
-      tapAnimationRef.current.push(animation);
+      interactionAnimationRef.current.push(animation);
       startedAnimationCount = 1;
     }
     if (startedAnimationCount > 0 && onAnimationStart) {
@@ -841,19 +845,19 @@ function useMotionHostProps<Props extends MotionProps>(
     if (tapActiveRef.current) {
       return;
     }
-    tapAnimationGenerationRef.current += 1;
+    interactionAnimationGenerationRef.current += 1;
     for (const animation of animationRef.current) {
       animation.stop();
     }
     animationRef.current = [];
-    for (const animation of tapAnimationRef.current) {
+    for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
-    tapAnimationRef.current = [];
-    for (const key in tapAnimationValueKeysRef.current) {
+    interactionAnimationRef.current = [];
+    for (const key in interactionAnimationValueKeysRef.current) {
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
-    tapAnimationValueKeysRef.current = {};
+    interactionAnimationValueKeysRef.current = {};
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
@@ -875,7 +879,7 @@ function useMotionHostProps<Props extends MotionProps>(
             ),
           );
           if (value.animation) {
-            tapAnimationRef.current.push(value.animation);
+            interactionAnimationRef.current.push(value.animation);
           }
         }
       }
@@ -885,7 +889,7 @@ function useMotionHostProps<Props extends MotionProps>(
       element: MainThread.Element,
     ) => Element;
     const element = new ElementConstructor(elementRef.current);
-    tapAnimationRef.current.push(
+    interactionAnimationRef.current.push(
       animateMotionTarget(
         element,
         resolvedHover.target,
@@ -903,15 +907,15 @@ function useMotionHostProps<Props extends MotionProps>(
     if (tapActiveRef.current) {
       return;
     }
-    tapAnimationGenerationRef.current += 1;
-    for (const animation of tapAnimationRef.current) {
+    interactionAnimationGenerationRef.current += 1;
+    for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
-    tapAnimationRef.current = [];
-    for (const key in tapAnimationValueKeysRef.current) {
+    interactionAnimationRef.current = [];
+    for (const key in interactionAnimationValueKeysRef.current) {
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
-    tapAnimationValueKeysRef.current = {};
+    interactionAnimationValueKeysRef.current = {};
     const hoverValues = resolvedHover.target as Record<string, unknown>;
     const animateValues = resolvedAnimate.target as
       | Record<string, unknown>
@@ -952,7 +956,7 @@ function useMotionHostProps<Props extends MotionProps>(
             ),
           );
           if (value.animation) {
-            tapAnimationRef.current.push(value.animation);
+            interactionAnimationRef.current.push(value.animation);
           }
         }
       }
@@ -962,7 +966,7 @@ function useMotionHostProps<Props extends MotionProps>(
       element: MainThread.Element,
     ) => Element;
     const element = new ElementConstructor(elementRef.current);
-    tapAnimationRef.current.push(
+    interactionAnimationRef.current.push(
       animateMotionTarget(element, restingValues, resolvedTransition),
     );
   }

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -585,7 +585,8 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    // Bind on MTS before Motion's scheduler invokes completion asynchronously.
+    // Bind while the tap-start worklet is still executing on MTS; Motion calls
+    // the returned dispatcher later from its animation scheduler.
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;
@@ -690,7 +691,8 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    // Bind on MTS before Motion's scheduler invokes completion asynchronously.
+    // Bind while the tap-end worklet is still executing on MTS; restoration
+    // completion arrives later from Motion's animation scheduler.
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -598,7 +598,7 @@ function useMotionHostProps<Props extends MotionProps>(
     // rerender triggered from lifecycle callbacks.
     if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
-      let animationCount = 0;
+      let pendingAnimationCount = 0;
       function reportTapAnimationComplete(definition: MotionDefinition) {
         if (tapAnimationGenerationRef.current !== animationGeneration) {
           return;
@@ -615,12 +615,12 @@ function useMotionHostProps<Props extends MotionProps>(
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value && targetValues[key] !== undefined) {
-          animationCount += 1;
+          pendingAnimationCount += 1;
         }
       }
       tapAnimationCompletionRef.current = {
         generation: animationGeneration,
-        pending: animationCount,
+        pending: pendingAnimationCount,
       };
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
@@ -734,7 +734,7 @@ function useMotionHostProps<Props extends MotionProps>(
       ? whileHover
       : animate ?? (restingValues as MotionTarget);
     if (isLynxForWeb || !event.currentTarget) {
-      let animationCount = 0;
+      let pendingAnimationCount = 0;
       function reportTapAnimationComplete() {
         if (tapAnimationGenerationRef.current !== animationGeneration) {
           return;
@@ -751,12 +751,12 @@ function useMotionHostProps<Props extends MotionProps>(
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          animationCount += 1;
+          pendingAnimationCount += 1;
         }
       }
       tapAnimationCompletionRef.current = {
         generation: animationGeneration,
-        pending: animationCount,
+        pending: pendingAnimationCount,
       };
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -841,6 +841,7 @@ function useMotionHostProps<Props extends MotionProps>(
     if (tapActiveRef.current) {
       return;
     }
+    tapAnimationGenerationRef.current += 1;
     for (const animation of animationRef.current) {
       animation.stop();
     }
@@ -902,6 +903,7 @@ function useMotionHostProps<Props extends MotionProps>(
     if (tapActiveRef.current) {
       return;
     }
+    tapAnimationGenerationRef.current += 1;
     for (const animation of tapAnimationRef.current) {
       animation.stop();
     }

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -127,6 +127,10 @@ function useMotionHostProps<Props extends MotionProps>(
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
   const tapAnimationGenerationRef = useMainThreadRef(0);
+  const tapAnimationCompletionRef = useMainThreadRef<{
+    generation: number;
+    pending: number;
+  }>({ generation: 0, pending: 0 });
   const animateTargetKeysRef = useMainThreadRef<Record<string, true>>({});
   const hoverLayoutRef = useRef<
     { left: number; right: number; top: number; bottom: number } | null
@@ -581,7 +585,9 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    const animatedValues: MotionValue<string | number>[] = [];
+    const reportAnimationComplete = onAnimationComplete
+      ? runOnBackground(onAnimationComplete)
+      : undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
     const resolvedTransition = (workletTapTransition?.repeat === -1
       ? { ...workletTapTransition, repeat: Number.POSITIVE_INFINITY }
@@ -590,33 +596,49 @@ function useMotionHostProps<Props extends MotionProps>(
     // rerender triggered from lifecycle callbacks.
     if (isLynxForWeb || !event.currentTarget) {
       const targetValues = resolvedTap.target as Record<string, unknown>;
+      let animationCount = 0;
+      function reportTapAnimationComplete(definition: MotionDefinition) {
+        if (tapAnimationGenerationRef.current !== animationGeneration) {
+          return;
+        }
+        tapAnimationCompletionRef.current.pending -= 1;
+        if (
+          tapAnimationCompletionRef.current.generation === animationGeneration
+          && tapAnimationCompletionRef.current.pending === 0
+          && reportAnimationComplete
+        ) {
+          void reportAnimationComplete(definition);
+        }
+      }
+      for (const key in targetValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value && targetValues[key] !== undefined) {
+          animationCount += 1;
+        }
+      }
+      tapAnimationCompletionRef.current = {
+        generation: animationGeneration,
+        pending: animationCount,
+      };
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
         if (value && targetValue !== undefined) {
-          const completion = value.start(
-            createMotionValueAnimation(
-              key,
-              value,
-              targetValue as never,
-              resolvedTransition as never,
-            ),
+          const startAnimation = createMotionValueAnimation(
+            key,
+            value,
+            targetValue as never,
+            resolvedTransition as never,
+          );
+          void value.start(complete =>
+            startAnimation(() => {
+              complete();
+              reportTapAnimationComplete(whileTap!);
+            })
           );
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          animatedValues.push(value);
-          void completion.then(() => {
-            if (tapAnimationGenerationRef.current !== animationGeneration) {
-              return;
-            }
-            if (
-              !animatedValues.some(value => value.isAnimating())
-              && onAnimationComplete
-            ) {
-              void runOnBackground(onAnimationComplete)(whileTap!);
-            }
-          });
           if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
@@ -630,20 +652,23 @@ function useMotionHostProps<Props extends MotionProps>(
       const animation = animateMotionTarget(
         element,
         resolvedTap.target,
-        resolvedTransition,
+        {
+          ...resolvedTransition,
+          onComplete: () => {
+            if (
+              tapAnimationGenerationRef.current === animationGeneration
+              && reportAnimationComplete
+            ) {
+              void reportAnimationComplete(whileTap!);
+            }
+          },
+        },
       );
       tapAnimationRef.current.push(animation);
-      void animation.then(() => {
-        if (tapAnimationGenerationRef.current !== animationGeneration) {
-          return;
-        }
-        if (onAnimationComplete) {
-          void runOnBackground(onAnimationComplete)(whileTap!);
-        }
-      });
     }
     if (
-      (animatedValues.length > 0 || tapAnimationRef.current.length > 0)
+      (Object.keys(resolvedTap.target).length > 0
+        || tapAnimationRef.current.length > 0)
       && onAnimationStart
     ) {
       void runOnBackground(onAnimationStart)(whileTap!);
@@ -664,7 +689,9 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
-    const animatedValues: MotionValue<string | number>[] = [];
+    const reportAnimationComplete = onAnimationComplete
+      ? runOnBackground(onAnimationComplete)
+      : undefined;
     const targetValues = resolvedTap.target as Record<string, unknown>;
     const restingTarget = hoverActiveRef.current && resolvedHover.target
       ? resolvedHover.target
@@ -703,32 +730,48 @@ function useMotionHostProps<Props extends MotionProps>(
       ? whileHover
       : animate ?? (restingValues as MotionTarget);
     if (isLynxForWeb || !event.currentTarget) {
+      let animationCount = 0;
+      function reportTapAnimationComplete() {
+        if (tapAnimationGenerationRef.current !== animationGeneration) {
+          return;
+        }
+        tapAnimationCompletionRef.current.pending -= 1;
+        if (
+          tapAnimationCompletionRef.current.generation === animationGeneration
+          && tapAnimationCompletionRef.current.pending === 0
+          && reportAnimationComplete
+        ) {
+          void reportAnimationComplete(restingDefinition);
+        }
+      }
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          const completion = value.start(
-            createMotionValueAnimation(
-              key,
-              value,
-              restingValues[key] as never,
-              resolvedTransition as never,
-            ),
+          animationCount += 1;
+        }
+      }
+      tapAnimationCompletionRef.current = {
+        generation: animationGeneration,
+        pending: animationCount,
+      };
+      for (const key in restingValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value) {
+          const startAnimation = createMotionValueAnimation(
+            key,
+            value,
+            restingValues[key] as never,
+            resolvedTransition as never,
+          );
+          void value.start(complete =>
+            startAnimation(() => {
+              complete();
+              reportTapAnimationComplete();
+            })
           );
           if (value.animation) {
             Object.defineProperty(value, 'animation', { enumerable: false });
           }
-          animatedValues.push(value);
-          void completion.then(() => {
-            if (tapAnimationGenerationRef.current !== animationGeneration) {
-              return;
-            }
-            if (
-              !animatedValues.some(value => value.isAnimating())
-              && onAnimationComplete
-            ) {
-              void runOnBackground(onAnimationComplete)(restingDefinition);
-            }
-          });
           if (!isLynxForWeb && value.animation) {
             tapAnimationRef.current.push(value.animation);
           }
@@ -742,20 +785,23 @@ function useMotionHostProps<Props extends MotionProps>(
       const animation = animateMotionTarget(
         element,
         restingValues,
-        resolvedTransition,
+        {
+          ...resolvedTransition,
+          onComplete: () => {
+            if (
+              tapAnimationGenerationRef.current === animationGeneration
+              && reportAnimationComplete
+            ) {
+              void reportAnimationComplete(restingDefinition);
+            }
+          },
+        },
       );
       tapAnimationRef.current.push(animation);
-      void animation.then(() => {
-        if (tapAnimationGenerationRef.current !== animationGeneration) {
-          return;
-        }
-        if (onAnimationComplete) {
-          void runOnBackground(onAnimationComplete)(restingDefinition);
-        }
-      });
     }
     if (
-      (animatedValues.length > 0 || tapAnimationRef.current.length > 0)
+      (Object.keys(restingValues).length > 0
+        || tapAnimationRef.current.length > 0)
       && onAnimationStart
     ) {
       void runOnBackground(onAnimationStart)(restingDefinition);

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -585,6 +585,7 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
+    // Bind on MTS before Motion's scheduler invokes completion asynchronously.
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;
@@ -689,6 +690,7 @@ function useMotionHostProps<Props extends MotionProps>(
     tapAnimationRef.current = [];
     const animationGeneration = tapAnimationGenerationRef.current + 1;
     tapAnimationGenerationRef.current = animationGeneration;
+    // Bind on MTS before Motion's scheduler invokes completion asynchronously.
     const reportAnimationComplete = onAnimationComplete
       ? runOnBackground(onAnimationComplete)
       : undefined;


### PR DESCRIPTION
## What

Report `onAnimationStart`/`onAnimationComplete` for tap-driven animations, including interruption ownership and restoration ordering.

## Stack

Depends on #3522. Supersedes #3483.

## Validation

- `@lynx-js/motion`: 15 test files, 132 tests passed on the complete stack
- package TypeScript check passed
- headless Chromium probe verifies press/release state, callbacks, and final scale/color

## Confidence

**OK — stays draft.** The behavior is correct in headless validation, but lifecycle completion crosses the MTS/background boundary and gesture interruption ownership remains more complex than base animation callbacks. Native validation is additionally blocked by the available Lynx Sandbox client's obsolete SDK/runtime contract.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Changeset added.
