### PR TITLE
feat(motion): report hover animation lifecycle

### DIFF
--- a/.changeset/motion-hover-animation-lifecycle.md
+++ b/.changeset/motion-hover-animation-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/motion": patch
+---
+
+Report declarative animation lifecycle callbacks when hover targets apply and restore, including multi-property completion and interrupted animation suppression.

--- a/examples/motion/src/Declarative/Example.tsx
+++ b/examples/motion/src/Declarative/Example.tsx
@@ -6,6 +6,11 @@ import './styles.css';
 export default function DeclarativeExample() {
   const [active, setActive] = useState(false);
   const scale = useMotionValue(1);
+  const [interaction, setInteraction] = useState('idle');
+  const [tapCount, setTapCount] = useState(0);
+  const [hoverCount, setHoverCount] = useState(0);
+  const [animationStarts, setAnimationStarts] = useState(0);
+  const [animationCompletes, setAnimationCompletes] = useState(0);
 
   function pulse() {
     'main thread';
@@ -32,7 +37,44 @@ export default function DeclarativeExample() {
         className='declarative-button'
         bindtap={() => setActive(value => !value)}
       >
-        <text>{active ? 'Move back' : 'Move with declarative props'}</text>
+        <text className='declarative-button-label'>
+          {active ? 'Move back' : 'Move with declarative props'}
+        </text>
+      </view>
+      <view className='gesture-probe'>
+        <motion.view
+          id='gesture-lifecycle-card'
+          className='gesture-card'
+          animate={{ scale: 1, backgroundColor: '#20242c' }}
+          whileHover={{ scale: 1.06, backgroundColor: '#334155' }}
+          whileTap={{ scale: 0.94, backgroundColor: '#0f766e' }}
+          transition={{ duration: 0.12 }}
+          onHoverStart={() => {
+            setInteraction('hover');
+            setHoverCount(value => value + 1);
+          }}
+          onHoverEnd={() => setInteraction('idle')}
+          onTapStart={() => setInteraction('press')}
+          onTap={() => {
+            setInteraction('hover');
+            setTapCount(value => value + 1);
+          }}
+          onTapCancel={() => setInteraction('idle')}
+          onAnimationStart={() => setAnimationStarts(value => value + 1)}
+          onAnimationComplete={() => setAnimationCompletes(value => value + 1)}
+        >
+          <text className='gesture-card-title'>Interaction lifecycle</text>
+          <text id='gesture-state' className='gesture-card-state'>
+            {interaction}
+          </text>
+        </motion.view>
+        <view className='gesture-metrics'>
+          <text id='gesture-tap-count'>tap {tapCount}</text>
+          <text id='gesture-hover-count'>hover {hoverCount}</text>
+          <text id='gesture-animation-counts'>
+            animation {animationStarts}/{animationCompletes}
+          </text>
+        </view>
       </view>
     </view>
   );

--- a/examples/motion/src/Declarative/styles.css
+++ b/examples/motion/src/Declarative/styles.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 48px;
+  gap: 24px;
   overflow: hidden;
 }
 
@@ -23,4 +23,48 @@
   padding: 12px 20px;
   background-color: #222;
   color: white;
+}
+
+.declarative-button-label {
+  color: #f8fafc;
+  font-size: 16px;
+}
+
+.gesture-probe {
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.gesture-card {
+  width: 320px;
+  height: 112px;
+  border-radius: 20px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.gesture-card-title {
+  color: #f8fafc;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.gesture-card-state {
+  color: #99f6e4;
+  font-size: 16px;
+}
+
+.gesture-metrics {
+  width: 320px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  color: #334155;
+  font-size: 16px;
 }

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -52,10 +52,11 @@ The declarative layer currently supports:
   styles backed by the upstream Motion engine
 - `whileTap` with `onTapStart`, `onTap`, and `onTapCancel`
 - `whileHover` with `onHoverStart` and `onHoverEnd` on mouse-capable clients
-- `onAnimationStart` and `onAnimationComplete` for the base `animate` target
+- `onAnimationStart` and `onAnimationComplete` for base `animate`, `whileTap`,
+  and `whileHover` targets and their restorations
 
 It does **not** yet provide the complete `motion/react` declarative contract.
-In particular, focus/in-view/drag states, gesture animation lifecycle
+In particular, focus/in-view/drag states and their animation lifecycle
 callbacks, animation controls, propagated/orchestrated variants, layout and
 shared-layout animations, `exit`, and `AnimatePresence` are not supported.
 Internal main-thread refs, handlers, and gestures also cannot yet be safely

--- a/packages/motion/__tests__/declarative.test.tsx
+++ b/packages/motion/__tests__/declarative.test.tsx
@@ -701,6 +701,63 @@ describe('declarative Motion', () => {
     );
   });
 
+  test('reports hover entry and restoration starts for every value', async () => {
+    const onAnimationStart = vi.fn();
+    const { getByTestId } = render(
+      <motion.view
+        data-testid='button'
+        animate={{ scale: 1, backgroundColor: '#ffffff' }}
+        whileHover={{ scale: 1.1, backgroundColor: '#ffcc00' }}
+        transition={{ duration: 0.08 }}
+        onAnimationStart={onAnimationStart}
+      />,
+      { enableMainThread: true, enableBackgroundThread: true },
+    );
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+    onAnimationStart.mockClear();
+
+    fireEvent.layoutchange(getByTestId('button'), {
+      detail: { left: 0, right: 100, top: 0, bottom: 100 },
+    });
+    fireEvent.mousemove(getByTestId('button'), {
+      eventType: 'global-bindEvent',
+      x: 50,
+      y: 50,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 180));
+    });
+
+    expect(onAnimationStart).toHaveBeenCalledTimes(1);
+    expect(onAnimationStart).toHaveBeenLastCalledWith({
+      scale: 1.1,
+      backgroundColor: '#ffcc00',
+    });
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'transform: scale(1.1);',
+    );
+    expect(getByTestId('button').getAttribute('style')).toContain(
+      'rgb(255, 204, 0)',
+    );
+    fireEvent.mousemove(getByTestId('button'), {
+      eventType: 'global-bindEvent',
+      x: 150,
+      y: 150,
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 180));
+    });
+
+    expect(onAnimationStart).toHaveBeenCalledTimes(2);
+    expect(onAnimationStart).toHaveBeenLastCalledWith({
+      scale: 1,
+      backgroundColor: '#ffffff',
+    });
+  });
+
   test('composes gesture callbacks with external host handlers', () => {
     const onTapStart = vi.fn();
     const onTap = vi.fn();

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -845,7 +845,8 @@ function useMotionHostProps<Props extends MotionProps>(
     if (tapActiveRef.current) {
       return;
     }
-    interactionAnimationGenerationRef.current += 1;
+    const animationGeneration = interactionAnimationGenerationRef.current + 1;
+    interactionAnimationGenerationRef.current = animationGeneration;
     for (const animation of animationRef.current) {
       animation.stop();
     }
@@ -858,7 +859,11 @@ function useMotionHostProps<Props extends MotionProps>(
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
     interactionAnimationValueKeysRef.current = {};
+    const reportAnimationComplete = onAnimationComplete
+      ? runOnBackground(onAnimationComplete)
+      : undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    let startedAnimationCount = 0;
     const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
       : workletHoverTransition) ?? {};
@@ -866,36 +871,81 @@ function useMotionHostProps<Props extends MotionProps>(
       && String(SystemInfo.platform) === 'web';
     if (isLynxForWeb) {
       const targetValues = resolvedHover.target as Record<string, unknown>;
+      let pendingAnimationCount = 0;
+      function reportHoverAnimationComplete() {
+        if (
+          interactionAnimationGenerationRef.current !== animationGeneration
+        ) {
+          return;
+        }
+        interactionAnimationCompletionRef.current.pending -= 1;
+        if (
+          interactionAnimationCompletionRef.current.generation
+            === animationGeneration
+          && interactionAnimationCompletionRef.current.pending === 0
+          && reportAnimationComplete
+        ) {
+          void reportAnimationComplete(whileHover!);
+        }
+      }
+      for (const key in targetValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value && targetValues[key] !== undefined) {
+          pendingAnimationCount += 1;
+        }
+      }
+      interactionAnimationCompletionRef.current = {
+        generation: animationGeneration,
+        pending: pendingAnimationCount,
+      };
+      startedAnimationCount = pendingAnimationCount;
       for (const key in targetValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         const targetValue = targetValues[key];
         if (value && targetValue !== undefined) {
-          void value.start(
-            createMotionValueAnimation(
-              key,
-              value,
-              targetValue as never,
-              resolvedTransition as never,
-            ),
+          const startAnimation = createMotionValueAnimation(
+            key,
+            value,
+            targetValue as never,
+            resolvedTransition as never,
+          );
+          void value.start(complete =>
+            startAnimation(() => {
+              complete();
+              reportHoverAnimationComplete();
+            })
           );
           if (value.animation) {
-            interactionAnimationRef.current.push(value.animation);
+            Object.defineProperty(value, 'animation', { enumerable: false });
           }
+          interactionAnimationValueKeysRef.current[key] = true;
         }
       }
-      return;
-    }
-    const ElementConstructor = globalThis.Element as unknown as new(
-      element: MainThread.Element,
-    ) => Element;
-    const element = new ElementConstructor(elementRef.current);
-    interactionAnimationRef.current.push(
-      animateMotionTarget(
+    } else {
+      const ElementConstructor = globalThis.Element as unknown as new(
+        element: MainThread.Element,
+      ) => Element;
+      const element = new ElementConstructor(elementRef.current);
+      interactionAnimationRef.current.push(animateMotionTarget(
         element,
         resolvedHover.target,
-        resolvedTransition,
-      ),
-    );
+        {
+          ...resolvedTransition,
+          onComplete: () => {
+            if (
+              interactionAnimationGenerationRef.current === animationGeneration
+              && reportAnimationComplete
+            ) {
+              void reportAnimationComplete(whileHover!);
+            }
+          },
+        },
+      ));
+      startedAnimationCount = 1;
+    }
+    if (startedAnimationCount > 0 && onAnimationStart) {
+      void runOnBackground(onAnimationStart)(whileHover!);
+    }
   }
 
   function endHoverAnimation() {
@@ -907,7 +957,8 @@ function useMotionHostProps<Props extends MotionProps>(
     if (tapActiveRef.current) {
       return;
     }
-    interactionAnimationGenerationRef.current += 1;
+    const animationGeneration = interactionAnimationGenerationRef.current + 1;
+    interactionAnimationGenerationRef.current = animationGeneration;
     for (const animation of interactionAnimationRef.current) {
       animation.stop();
     }
@@ -916,11 +967,15 @@ function useMotionHostProps<Props extends MotionProps>(
       (generatedValuesRef.current[key] ?? motionValues[key])?.stop();
     }
     interactionAnimationValueKeysRef.current = {};
+    const reportAnimationComplete = onAnimationComplete
+      ? runOnBackground(onAnimationComplete)
+      : undefined;
     const hoverValues = resolvedHover.target as Record<string, unknown>;
     const animateValues = resolvedAnimate.target as
       | Record<string, unknown>
       | undefined;
     const animateMotionTarget = animateValue as unknown as AnimateMotionTarget;
+    let startedAnimationCount = 0;
     const resolvedTransition = (workletHoverTransition?.repeat === -1
       ? { ...workletHoverTransition, repeat: Number.POSITIVE_INFINITY }
       : workletHoverTransition) ?? {};
@@ -943,32 +998,83 @@ function useMotionHostProps<Props extends MotionProps>(
     }
     const isLynxForWeb = typeof SystemInfo !== 'undefined'
       && String(SystemInfo.platform) === 'web';
+    const restingDefinition: MotionDefinition = animate
+      ?? (restingValues as MotionTarget);
     if (isLynxForWeb) {
+      let pendingAnimationCount = 0;
+      function reportHoverAnimationComplete() {
+        if (
+          interactionAnimationGenerationRef.current !== animationGeneration
+        ) {
+          return;
+        }
+        interactionAnimationCompletionRef.current.pending -= 1;
+        if (
+          interactionAnimationCompletionRef.current.generation
+            === animationGeneration
+          && interactionAnimationCompletionRef.current.pending === 0
+          && reportAnimationComplete
+        ) {
+          void reportAnimationComplete(restingDefinition);
+        }
+      }
       for (const key in restingValues) {
         const value = generatedValuesRef.current[key] ?? motionValues[key];
         if (value) {
-          void value.start(
-            createMotionValueAnimation(
-              key,
-              value,
-              restingValues[key] as never,
-              resolvedTransition as never,
-            ),
-          );
-          if (value.animation) {
-            interactionAnimationRef.current.push(value.animation);
-          }
+          pendingAnimationCount += 1;
         }
       }
-      return;
+      interactionAnimationCompletionRef.current = {
+        generation: animationGeneration,
+        pending: pendingAnimationCount,
+      };
+      startedAnimationCount = pendingAnimationCount;
+      for (const key in restingValues) {
+        const value = generatedValuesRef.current[key] ?? motionValues[key];
+        if (value) {
+          const startAnimation = createMotionValueAnimation(
+            key,
+            value,
+            restingValues[key] as never,
+            resolvedTransition as never,
+          );
+          void value.start(complete =>
+            startAnimation(() => {
+              complete();
+              reportHoverAnimationComplete();
+            })
+          );
+          if (value.animation) {
+            Object.defineProperty(value, 'animation', { enumerable: false });
+          }
+          interactionAnimationValueKeysRef.current[key] = true;
+        }
+      }
+    } else {
+      const ElementConstructor = globalThis.Element as unknown as new(
+        element: MainThread.Element,
+      ) => Element;
+      const element = new ElementConstructor(elementRef.current);
+      interactionAnimationRef.current.push(animateMotionTarget(
+        element,
+        restingValues,
+        {
+          ...resolvedTransition,
+          onComplete: () => {
+            if (
+              interactionAnimationGenerationRef.current === animationGeneration
+              && reportAnimationComplete
+            ) {
+              void reportAnimationComplete(restingDefinition);
+            }
+          },
+        },
+      ));
+      startedAnimationCount = 1;
     }
-    const ElementConstructor = globalThis.Element as unknown as new(
-      element: MainThread.Element,
-    ) => Element;
-    const element = new ElementConstructor(elementRef.current);
-    interactionAnimationRef.current.push(
-      animateMotionTarget(element, restingValues, resolvedTransition),
-    );
+    if (startedAnimationCount > 0 && onAnimationStart) {
+      void runOnBackground(onAnimationStart)(restingDefinition);
+    }
   }
 
   return {


### PR DESCRIPTION
## What

Extend animation lifecycle reporting to hover-driven animations and add a readable interaction probe showing idle/hover/press state, gesture counts, and animation start/completion counts.

## Stack

Depends on #3523. Supersedes #3484.

## Validation

- `@lynx-js/motion`: 15 test files, 132 tests passed on the complete stack
- package TypeScript check passed
- headless Chromium verifies idle → hover → press → release → leave with 5/5 animation lifecycles and no console errors

## Confidence

**OK — stays draft.** Web/headless behavior is solid, but hover is meaningful only on pointer-capable Lynx clients and shares the cross-thread interruption/ownership complexity of tap lifecycle. Native proof awaits a current Sandbox host SDK.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Changeset added.
