### PR TITLE
fix(rspeedy): bind dev server to IP wildcards

### DIFF
--- a/.changeset/fix-rspeedy-ip-wildcard.md
+++ b/.changeset/fix-rspeedy-ip-wildcard.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Bind the default Rspeedy development server to an IP-family wildcard address while continuing to advertise a concrete local address. IPv6-only hosts now accept loopback connections through `localhost` in addition to connections through their detected network address.

--- a/.github/rspeedy-networking.instructions.md
+++ b/.github/rspeedy-networking.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/rspeedy/core/**/dev.plugin*.ts"
+---
+
+Keep automatically selected dev-server bind addresses separate from client-facing hostnames. Bind IPv4 on `0.0.0.0` and IPv6 on `::`, while using the detected concrete address for asset and HMR URLs. Do not narrow the listener to the advertised address because loopback clients use a different local address.

--- a/packages/rspeedy/core/src/config/server/index.ts
+++ b/packages/rspeedy/core/src/config/server/index.ts
@@ -141,7 +141,7 @@ export interface Server {
    * @defaultValue "0.0.0.0"
    *
    * @remarks
-   * During `rspeedy dev`, if `server.host` is unset, the dev plugin resolves dev-server-related URLs and client host settings with a detected non-loopback IPv4 address, such as `192.168.1.50`. It falls back to an eligible IPv6 address, then to an IPv4 loopback address when no non-loopback IP is available. If you have multiple network interfaces, set `server.host` explicitly to choose the desired address.
+   * During `rspeedy dev`, if `server.host` is unset, the dev plugin keeps the server bound to the IPv4 wildcard address while resolving dev-server-related URLs and client host settings with a detected non-loopback IPv4 address, such as `192.168.1.50`. If no eligible IPv4 address exists, it binds to the IPv6 wildcard address and uses a detected IPv6 address for URLs. It falls back to an IPv4 loopback URL when no non-loopback IP is available. If you have multiple network interfaces, set `server.host` explicitly to choose the desired address.
    *
    * @example
    *

--- a/packages/rspeedy/core/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/core/src/plugins/dev.plugin.ts
@@ -20,7 +20,8 @@ import type { ExposedAPI } from '../index.js'
 import { isLynx } from '../utils/is-lynx.js'
 import { ProvidePlugin } from '../webpack/ProvidePlugin.js'
 
-const DEFAULT_SERVER_HOST = '0.0.0.0'
+const DEFAULT_IPV4_SERVER_HOST = '0.0.0.0'
+const DEFAULT_IPV6_SERVER_HOST = '::'
 
 type RsbuildServerHost = NonNullable<RsbuildConfig['server']>['host']
 
@@ -407,19 +408,22 @@ async function resolveHostname(
   originalHost: string | undefined,
 ): Promise<{ bindHost?: string, hostname: string }> {
   const hostname = formatHostname(host)
-  if (originalHost !== undefined || hostname !== DEFAULT_SERVER_HOST) {
+  if (originalHost !== undefined || hostname !== DEFAULT_IPV4_SERVER_HOST) {
     return { hostname }
   }
 
   const ipv4Hostname = await findIp('v4')
   if (ipv4Hostname) {
-    return { hostname: ipv4Hostname }
+    return {
+      bindHost: DEFAULT_IPV4_SERVER_HOST,
+      hostname: ipv4Hostname,
+    }
   }
 
   const ipv6Hostname = await findIp('v6')
   if (ipv6Hostname) {
     return {
-      bindHost: stripHostnameBrackets(ipv6Hostname),
+      bindHost: DEFAULT_IPV6_SERVER_HOST,
       hostname: ipv6Hostname,
     }
   }
@@ -430,7 +434,7 @@ async function resolveHostname(
 
 function formatHostname(host: RsbuildServerHost | undefined): string {
   if (host === true || host === undefined) {
-    return DEFAULT_SERVER_HOST
+    return DEFAULT_IPV4_SERVER_HOST
   }
   if (host === false) {
     return 'localhost'
@@ -439,13 +443,6 @@ function formatHostname(host: RsbuildServerHost | undefined): string {
     return `[${host}]`
   }
   return host
-}
-
-function stripHostnameBrackets(hostname: string): string {
-  if (hostname.startsWith('[') && hostname.endsWith(']')) {
-    return hostname.slice(1, -1)
-  }
-  return hostname
 }
 
 function getNetworkPriority(name: string, address: string): number {

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -59,6 +59,7 @@ describe('Plugins - Dev', () => {
     expect(isIPv4(hostname)).toBe(true)
     expect(pathname).toBe('/')
 
+    expect(rsbuild.getRsbuildConfig().server!.host).toBe('0.0.0.0')
     expect(isIPv4(rsbuild.getRsbuildConfig().dev!.client!.host!)).toBe(true)
 
     assert(config.resolve?.alias)
@@ -96,7 +97,7 @@ describe('Plugins - Dev', () => {
     const config = await rsbuild.unwrapConfig()
 
     expect(config.output?.publicPath).toBe('http://[fd00::1]:3000/')
-    expect(rsbuild.getRsbuildConfig().server!.host).toBe('fd00::1')
+    expect(rsbuild.getRsbuildConfig().server!.host).toBe('::')
     expect(rsbuild.getRsbuildConfig().dev!.client!.host).toBe('[fd00::1]')
   })
 


### PR DESCRIPTION
## Summary

- Keep automatically selected dev-server bind addresses separate from client-facing hostnames.
- Bind the IPv4 path to `0.0.0.0` and the IPv6-only fallback to `::`, while continuing to advertise a concrete local address for asset and HMR URLs.
- Add regression assertions, configuration documentation, a patch changeset, and a networking maintenance instruction.

## Validation

- `pnpm dprint check`
- Targeted `pnpm biome check` for the changed TypeScript files
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint .` (no errors; 15 pre-existing warnings)
- `NODE_OPTIONS=--max-old-space-size=32768 TURBO_TELEMETRY_DISABLED=1 pnpm turbo build` (70/70 tasks)
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm --filter @lynx-js/rspeedy test` (411 passed, 2 skipped)
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm --filter @lynx-js/rspeedy test:type`
- `NODE_OPTIONS=--max-old-space-size=32768 TURBO_TELEMETRY_DISABLED=1 pnpm turbo api-extractor -- --local`
- `pnpm changeset status --since=upstream/main`
- Rootless isolated IPv4 and IPv6-only network namespace checks: both the detected concrete address and `localhost` returned HTTP 200; listeners were `0.0.0.0:3000` and `*:3000` respectively.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development server networking for IPv4 and IPv6 environments.
  * Local development URLs now advertise a reachable concrete address while the server binds to the appropriate wildcard address.
  * Added support for `localhost` loopback connections on IPv6-only hosts.

* **Documentation**
  * Clarified development server host and address behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->