### PR TITLE
fix(genui): shim dirname in server ESM bundle

### DIFF
--- a/.github/genui-server.instructions.md
+++ b/.github/genui-server.instructions.md
@@ -20,6 +20,8 @@ Use `app/common/sse.ts` for standard SSE frames and response headers. Pass event
 
 Build `genui-server` as an executable ESM Hono server through `rslib.config.ts`. Each protocol `route.ts` default-exports a Hono sub-application, `src/app.ts` composes the route tree and common HTTP fallbacks, and `src/index.ts` starts `@hono/node-server` and owns graceful process shutdown. Do not export endpoint request functions or add a custom router or Node/FaaS transport adapter. Keep business handlers based on standard Web `Request` and `Response` internally.
 
+Keep Rslib's ESM `__dirname` shim enabled while bundling runtime dependencies with `autoExternal: false`. The Volcengine TOS SDK transitively loads `tos-crc64-js`, whose CommonJS initialization reads `__dirname`; leaving that identifier unshimmed makes the executable ESM bundle fail during startup.
+
 Read the server port from `LYNX_USE_PORT`, defaulting to `3000`; do not use `PORT` as a compatibility fallback.
 
 Read the bind address from `LYNX_USE_HOST`, defaulting to the IPv6 unspecified address `::` so Node accepts both IPv6 and IPv4 connections through its dual-stack listener; do not use `HOST` as a compatibility fallback. Format IPv6 addresses with brackets when logging HTTP URLs.

--- a/packages/genui/server/rslib.config.ts
+++ b/packages/genui/server/rslib.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
       syntax: 'es2022',
       bundle: true,
       dts: false,
+      shims: {
+        esm: {
+          __dirname: true,
+        },
+      },
       source: {
         entry: {
           index: './src/index.ts',


### PR DESCRIPTION
## Summary

- enable Rslib's ESM `__dirname` shim for the bundled GenUI server
- document why the shim must remain enabled while runtime dependencies are bundled

## Root cause

The Volcengine TOS SDK transitively loads `tos-crc64-js`, whose CommonJS initialization reads `__dirname`. Because the GenUI server bundles runtime dependencies into an ESM executable with `autoExternal: false`, the identifier remained undefined and the process crashed before the HTTP server could start.

The shim makes Rslib translate the CommonJS global to an ESM-safe value derived from `import.meta.url`. This does not broaden the server's supported Node.js versions; Node.js 22 and 24 remain the supported release lines.

## Impact

The generated `packages/genui/server/dist/index.js` can initialize the TOS SDK dependency chain without throwing `ReferenceError: __dirname is not defined in ES module scope`.

## Validation

- `pnpm turbo build` — 70/70 tasks passed
- `pnpm --filter a2ui-server test` — 105/105 tests passed
- `pnpm --filter a2ui-server lint`
- `DPRINT_CACHE_DIR=/tmp/dprint-cache pnpm dprint check packages/genui/server/rslib.config.ts .github/genui-server.instructions.md`
- started the generated ESM bundle on an ephemeral local port and verified graceful SIGINT shutdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server bundling to ensure cloud storage functionality initializes successfully.
  - Resolved compatibility issues related to ESM path handling in bundled deployments.

- **Documentation**
  - Updated bundling guidance to reflect the required configuration for reliable server builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->