### PR TITLE
feat(genui): configure playground server URL

### DIFF
--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -26,6 +26,13 @@ When serving the playground's native Lynx bundles as static Android test fixture
 
 ## Chat Page Architecture
 
+Use the build-time `GENUI_SERVER_URL` environment variable as the single
+default GenUI server origin for Chat, Bench, health checks, and preview payload
+publishing. Keep its fallback at `http://localhost:3060`, validate it as a
+credential-free HTTP(S) origin in the playground build configuration, and do
+not reintroduce separate hosted-server constants in individual frontend
+modules. URL query endpoint overrides may remain available for diagnosis.
+
 Load Create-tab model choices from the GenUI server's `GET /models` endpoint. Keep provider credentials, upstream model ids, and upstream base URLs out of playground state, persistence, controls, and request bodies; persist only the selected server-approved model name.
 
 Route all protocol Create tabs through `pages/chat/ChatPage.tsx`. Keep all shared React state, effects, conversation operations, provider controls, usage and preview metrics, streaming transport, examples, actions, and rendering in `pages/chat/ChatController.tsx`. Keep the shared conversation list, header, transcript/composer slots, resizable preview, delete confirmation, copy toast, and mobile tabs in `pages/chat/ChatWorkspace.tsx`, with styles in `pages/chat/ChatPage.css`.

--- a/packages/genui/playground/README.md
+++ b/packages/genui/playground/README.md
@@ -24,6 +24,7 @@ configuration:
 ```bash
 # 2. Start the GenUI server → http://localhost:3060
 GENUI_MODEL_CONFIG_JSON='{"GPT-5.4":{"model":"gpt-5.4","apiKey":"sk-...","baseURL":"https://api.openai.com/v1","api":"responses","default":true}}' \
+  LYNX_USE_PORT=3060 \
   pnpm -C packages/genui/server dev
 ```
 
@@ -35,13 +36,35 @@ Then start the playground and open the URL it prints (defaults to
 pnpm -C packages/genui/playground dev
 ```
 
-On `localhost`, the Create tab automatically targets your local server on
-`:3060`. To use the **hosted** agent without running a server of your own,
-append the endpoint override to the playground URL:
+The playground targets `http://localhost:3060` by default. Set the build-time
+`GENUI_SERVER_URL` environment variable to use another GenUI server origin:
+
+```bash
+GENUI_SERVER_URL=https://genui.example.com \
+  pnpm -C packages/genui/playground dev
+```
+
+The configured origin is shared by Create, Bench, health checks, and preview
+payload publishing. It must be an `http` or `https` origin without credentials,
+a path, query parameters, or a fragment.
+
+Create and Bench also retain their URL query overrides for local diagnosis:
 
 ```text
-?a2uiEndpoint=https://genui-server.vercel.app/a2ui/stream
+?a2uiEndpoint=http://localhost:3060/a2ui/stream
+?openuiEndpoint=http://localhost:3060/openui/stream
+?mcp-appsEndpoint=http://localhost:3060/mcp-apps/stream
+?a2uiBenchEndpoint=http://localhost:3060/a2ui/bench/jobs
 ```
+
+### Client environment
+
+| Variable                                 | Purpose                                     | Default                    |
+| ---------------------------------------- | ------------------------------------------- | -------------------------- |
+| `GENUI_SERVER_URL`                       | GenUI server origin used by all APIs        | `http://localhost:3060`    |
+| `PORT`                                   | Playground development server port          | `3000`                     |
+| `ASSET_PREFIX`                           | Hosted static asset prefix                  | —                          |
+| `A2UI_PLAYGROUND_CLIENT_PAYLOAD_PUBLISH` | Set to `0` to disable the dev payload store | enabled outside production |
 
 ### Server environment
 

--- a/packages/genui/playground/genui-server-url.ts
+++ b/packages/genui/playground/genui-server-url.ts
@@ -1,0 +1,37 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const DEFAULT_GENUI_SERVER_URL = 'http://localhost:3060';
+
+export function resolveGenuiServerUrl(raw: string | undefined): string {
+  const configured = raw?.trim();
+  const value = configured === undefined || configured === ''
+    ? DEFAULT_GENUI_SERVER_URL
+    : configured;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(
+      `GENUI_SERVER_URL must be a valid HTTP(S) origin, got ${
+        JSON.stringify(value)
+      }`,
+    );
+  }
+
+  if (
+    (url.protocol !== 'http:' && url.protocol !== 'https:')
+    || url.username
+    || url.password
+    || url.pathname !== '/'
+    || url.search
+    || url.hash
+  ) {
+    throw new Error(
+      'GENUI_SERVER_URL must be an HTTP(S) origin without credentials, path, query, or fragment',
+    );
+  }
+
+  return url.origin;
+}

--- a/packages/genui/playground/rsbuild.config.ts
+++ b/packages/genui/playground/rsbuild.config.ts
@@ -11,7 +11,10 @@ import { defineConfig } from '@rsbuild/core';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+import { resolveGenuiServerUrl } from './genui-server-url.js';
+
 const PORT = Number(process.env.PORT ?? 3000);
+const GENUI_SERVER_URL = resolveGenuiServerUrl(process.env.GENUI_SERVER_URL);
 const PHASE_TWO_SCREENSHOT_DIRECTORY = fileURLToPath(
   new URL('./src/pages/bench/assets/phase-two/screenshots', import.meta.url),
 );
@@ -241,6 +244,7 @@ export default defineConfig({
       __A2UI_PLAYGROUND_CLIENT_PAYLOAD_STORE__: JSON.stringify(
         CLIENT_PAYLOAD_STORE_ENABLED,
       ),
+      __GENUI_SERVER_URL__: JSON.stringify(GENUI_SERVER_URL),
     },
     entry: {
       index: './src/entry.tsx',

--- a/packages/genui/playground/rstest.config.ts
+++ b/packages/genui/playground/rstest.config.ts
@@ -3,7 +3,14 @@
 // LICENSE file in the root directory of this source tree.
 import { defineConfig } from '@rstest/core';
 
+import { DEFAULT_GENUI_SERVER_URL } from './genui-server-url.js';
+
 export default defineConfig({
   name: 'genui/genui-playground',
   include: ['src/**/*.test.ts'],
+  source: {
+    define: {
+      __GENUI_SERVER_URL__: JSON.stringify(DEFAULT_GENUI_SERVER_URL),
+    },
+  },
 });

--- a/packages/genui/playground/src/config/genuiServer.test.ts
+++ b/packages/genui/playground/src/config/genuiServer.test.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import { GENUI_SERVER_URL, buildGenuiServerUrl } from './genuiServer.js';
+import {
+  DEFAULT_GENUI_SERVER_URL,
+  resolveGenuiServerUrl,
+} from '../../genui-server-url.js';
+
+describe('GenUI server URL configuration', () => {
+  test('defaults to localhost and builds server endpoint URLs', () => {
+    expect(resolveGenuiServerUrl(undefined)).toBe(DEFAULT_GENUI_SERVER_URL);
+    expect(GENUI_SERVER_URL).toBe(DEFAULT_GENUI_SERVER_URL);
+    expect(buildGenuiServerUrl('/a2ui/stream')).toBe(
+      'http://localhost:3060/a2ui/stream',
+    );
+  });
+
+  test('normalizes a configured HTTP(S) origin', () => {
+    expect(resolveGenuiServerUrl(' https://genui.example.com/ ')).toBe(
+      'https://genui.example.com',
+    );
+  });
+
+  test('rejects a configured URL with non-origin components', () => {
+    expect(() => resolveGenuiServerUrl('https://genui.example.com/api'))
+      .toThrow('GENUI_SERVER_URL must be an HTTP(S) origin');
+    expect(() => resolveGenuiServerUrl('file:///tmp/genui'))
+      .toThrow('GENUI_SERVER_URL must be an HTTP(S) origin');
+  });
+});

--- a/packages/genui/playground/src/config/genuiServer.ts
+++ b/packages/genui/playground/src/config/genuiServer.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+declare const __GENUI_SERVER_URL__: string;
+
+export const GENUI_SERVER_URL = __GENUI_SERVER_URL__;
+
+export function buildGenuiServerUrl(path: string): string {
+  return new URL(path.replace(/^\/+/, ''), `${GENUI_SERVER_URL}/`).toString();
+}

--- a/packages/genui/playground/src/pages/BenchPage.tsx
+++ b/packages/genui/playground/src/pages/BenchPage.tsx
@@ -24,6 +24,10 @@ import {
   Zap,
 } from '../components/Icon.js';
 import { PageHeader } from '../components/PageHeader.js';
+import {
+  GENUI_SERVER_URL,
+  buildGenuiServerUrl,
+} from '../config/genuiServer.js';
 import { copyToClipboard } from '../utils/clipboard.js';
 import type { BenchLocale } from './bench/benchLocale.js';
 
@@ -624,7 +628,6 @@ const SCREENSHOT_DIALOG_WIDTH_STORAGE_KEY =
 const EVENT_SOURCE_CLOSED_READY_STATE = 2;
 const BENCH_HISTORY_STORAGE_KEY = 'a2ui-bench-history';
 const BENCH_HISTORY_LIMIT = 20;
-const ONLINE_A2UI_SERVER_ORIGIN = 'https://genui-server.vercel.app';
 const LOCAL_A2UI_SERVER_PORT = '3060';
 
 const DEFAULT_GROUPS: BenchGroup[] = [
@@ -843,15 +846,15 @@ function isDevHost(hostname: string): boolean {
   );
 }
 
-function isTrustedOnlineEndpoint(endpoint: URL): boolean {
-  return endpoint.origin === ONLINE_A2UI_SERVER_ORIGIN;
+function isConfiguredServerEndpoint(endpoint: URL): boolean {
+  return endpoint.origin === GENUI_SERVER_URL;
 }
 
 function resolveTrustedA2UIEndpoint(raw: string): string | null {
   try {
     const endpoint = new URL(raw, window.location.origin);
     if (endpoint.origin === window.location.origin) return endpoint.toString();
-    if (isTrustedOnlineEndpoint(endpoint)) return endpoint.toString();
+    if (isConfiguredServerEndpoint(endpoint)) return endpoint.toString();
     const isTrustedDevEndpoint = endpoint.protocol === 'http:'
       && endpoint.port === LOCAL_A2UI_SERVER_PORT
       && isDevHost(endpoint.hostname);
@@ -886,12 +889,7 @@ function getA2UIBenchJobsEndpoint(): string {
     if (trustedEndpoint) return toBenchJobsEndpoint(trustedEndpoint);
   }
 
-  if (
-    window.location.protocol === 'http:' && isDevHost(window.location.hostname)
-  ) {
-    return `http://${window.location.hostname}:${LOCAL_A2UI_SERVER_PORT}/a2ui/bench/jobs`;
-  }
-  return `${ONLINE_A2UI_SERVER_ORIGIN}/a2ui/bench/jobs`;
+  return buildGenuiServerUrl('a2ui/bench/jobs');
 }
 
 function getA2UIBenchHealthEndpoint(): string {
@@ -902,7 +900,7 @@ function getA2UIBenchHealthEndpoint(): string {
     url.search = '';
     return url.toString();
   } catch {
-    return `${ONLINE_A2UI_SERVER_ORIGIN}/a2ui/health`;
+    return buildGenuiServerUrl('a2ui/health');
   }
 }
 
@@ -914,9 +912,9 @@ function getA2UIBenchReportEndpoint(jobId: string): string {
     url.search = '';
     return url.toString();
   } catch {
-    return `${ONLINE_A2UI_SERVER_ORIGIN}/a2ui/bench/jobs/${
-      encodeURIComponent(jobId)
-    }/report`;
+    return buildGenuiServerUrl(
+      `a2ui/bench/jobs/${encodeURIComponent(jobId)}/report`,
+    );
   }
 }
 
@@ -999,9 +997,13 @@ function getA2UIPlaygroundBaseUrl(): string {
 function canForwardApiKeyToEndpoint(raw: string): boolean {
   try {
     const endpoint = new URL(raw, window.location.origin);
-    return endpoint.protocol === 'http:'
+    const isConfiguredDevEndpoint = endpoint.origin === GENUI_SERVER_URL
+      && endpoint.protocol === 'http:'
+      && isDevHost(endpoint.hostname);
+    const isLegacyDevEndpoint = endpoint.protocol === 'http:'
       && endpoint.port === LOCAL_A2UI_SERVER_PORT
       && isDevHost(endpoint.hostname);
+    return isConfiguredDevEndpoint || isLegacyDevEndpoint;
   } catch {
     return false;
   }

--- a/packages/genui/playground/src/pages/chat/adapters.test.ts
+++ b/packages/genui/playground/src/pages/chat/adapters.test.ts
@@ -458,11 +458,11 @@ describe('chat protocol adapters', () => {
       });
       expect(fetchMetadata).toHaveBeenCalledTimes(1);
       expect(fetchMetadata.mock.calls[0]?.[0]).toBe(
-        'https://genui-server.vercel.app/mcp-apps/metadata',
+        'http://localhost:3060/mcp-apps/metadata',
       );
       expect(fetchMetadata.mock.calls[0]?.[1]).toMatchObject({ signal });
       expect(chatRequest).toMatchObject({
-        url: 'https://genui-server.vercel.app/mcp-apps/stream',
+        url: 'http://localhost:3060/mcp-apps/stream',
         body: {
           model: 'gpt-5.5',
           registry: {

--- a/packages/genui/playground/src/pages/chat/shared.test.ts
+++ b/packages/genui/playground/src/pages/chat/shared.test.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { describe, expect, test } from '@rstest/core';
 
-import { parseTokenUsage } from './shared.js';
+import { getChatEndpoint, parseTokenUsage } from './shared.js';
 
 describe('shared chat helpers', () => {
   test('parses OpenAI-style input and output token keys', () => {
@@ -16,5 +16,25 @@ describe('shared chat helpers', () => {
       completionTokens: 3,
       totalTokens: 5,
     });
+  });
+
+  test('uses the configured localhost server by default', () => {
+    expect(getChatEndpoint('a2ui', {
+      baseUrl: 'https://playground.example.com/',
+      hostname: 'playground.example.com',
+      origin: 'https://playground.example.com',
+      protocol: 'https:',
+      search: '',
+    })).toBe('http://localhost:3060/a2ui/stream');
+  });
+
+  test('preserves a trusted query endpoint override', () => {
+    expect(getChatEndpoint('openui', {
+      baseUrl: 'http://localhost:3000/',
+      hostname: 'localhost',
+      origin: 'http://localhost:3000',
+      protocol: 'http:',
+      search: '?openuiEndpoint=http%3A%2F%2F127.0.0.1%3A3060%2Fopenui%2Fstream',
+    })).toBe('http://127.0.0.1:3060/openui/stream');
   });
 });

--- a/packages/genui/playground/src/pages/chat/shared.ts
+++ b/packages/genui/playground/src/pages/chat/shared.ts
@@ -7,10 +7,13 @@ import type {
   ChatSseEvent,
   ChatTokenUsage,
 } from './type.js';
+import {
+  GENUI_SERVER_URL,
+  buildGenuiServerUrl,
+} from '../../config/genuiServer.js';
 import type { ProtocolName } from '../../utils/protocol.js';
 import { isDevHost } from '../../utils/publishPayload.js';
 
-export const ONLINE_GENUI_SERVER_ORIGIN = 'https://genui-server.vercel.app';
 export const LOCAL_GENUI_SERVER_PORT = '3060';
 
 export const CHAT_PROVIDER_SETTINGS_STORAGE_KEY =
@@ -323,7 +326,7 @@ export function resolveTrustedChatEndpoint(
   try {
     const endpoint = new URL(raw, host.origin);
     if (endpoint.origin === host.origin) return endpoint.toString();
-    if (endpoint.origin === ONLINE_GENUI_SERVER_ORIGIN) {
+    if (endpoint.origin === GENUI_SERVER_URL) {
       return endpoint.toString();
     }
 
@@ -347,10 +350,7 @@ export function getChatEndpoint(
     const trustedEndpoint = resolveTrustedChatEndpoint(fromQuery, host);
     if (trustedEndpoint) return trustedEndpoint;
   }
-  if (host.protocol === 'http:' && isDevHost(host.hostname)) {
-    return `http://${host.hostname}:${LOCAL_GENUI_SERVER_PORT}/${protocol}/stream`;
-  }
-  return `${ONLINE_GENUI_SERVER_ORIGIN}/${protocol}/stream`;
+  return buildGenuiServerUrl(`${protocol}/stream`);
 }
 
 export function getA2UIActionEndpoint(chatEndpoint: string): string {

--- a/packages/genui/playground/src/utils/publishPayload.test.ts
+++ b/packages/genui/playground/src/utils/publishPayload.test.ts
@@ -42,7 +42,7 @@ describe('payload publishing', () => {
         });
 
       expect(fetchPayload.mock.calls[0]?.[0]).toBe(
-        'https://genui-server.vercel.app/a2ui/payload',
+        'http://localhost:3060/a2ui/payload',
       );
       expect(fetchPayload.mock.calls[0]?.[1]).toMatchObject({ method: 'PUT' });
       expect(JSON.parse(String(fetchPayload.mock.calls[0]?.[1]?.body))).toEqual(
@@ -52,7 +52,7 @@ describe('payload publishing', () => {
         },
       );
       expect(fetchPayload.mock.calls[1]?.[0]).toBe(
-        'https://genui-server.vercel.app/openui/payload',
+        'http://localhost:3060/openui/payload',
       );
       expect(fetchPayload.mock.calls[1]?.[1]).toMatchObject({ method: 'PUT' });
       expect(JSON.parse(String(fetchPayload.mock.calls[1]?.[1]?.body))).toEqual(

--- a/packages/genui/playground/src/utils/publishPayload.ts
+++ b/packages/genui/playground/src/utils/publishPayload.ts
@@ -2,8 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-const ONLINE_A2UI_SERVER_ORIGIN = 'https://genui-server.vercel.app';
-const LOCAL_A2UI_SERVER_PORT = '3060';
+import { buildGenuiServerUrl } from '../config/genuiServer.js';
 
 export interface PublishedPayload {
   messagesUrl: string;
@@ -26,21 +25,11 @@ export function isDevHost(hostname: string): boolean {
 }
 
 export function getA2UIPayloadEndpoint(): string {
-  if (
-    window.location.protocol === 'http:' && isDevHost(window.location.hostname)
-  ) {
-    return `http://${window.location.hostname}:${LOCAL_A2UI_SERVER_PORT}/a2ui/payload`;
-  }
-  return `${ONLINE_A2UI_SERVER_ORIGIN}/a2ui/payload`;
+  return buildGenuiServerUrl('a2ui/payload');
 }
 
 export function getOpenUIPayloadEndpoint(): string {
-  if (
-    window.location.protocol === 'http:' && isDevHost(window.location.hostname)
-  ) {
-    return `http://${window.location.hostname}:${LOCAL_A2UI_SERVER_PORT}/openui/payload`;
-  }
-  return `${ONLINE_A2UI_SERVER_ORIGIN}/openui/payload`;
+  return buildGenuiServerUrl('openui/payload');
 }
 
 /**


### PR DESCRIPTION
## Summary

- Default the GenUI playground backend to `http://localhost:3060`.
- Add build-time `GENUI_SERVER_URL` validation and injection, then use it consistently for Chat, Bench, health checks, reports, and payload publishing.
- Preserve diagnostic query overrides and document local/deployment configuration.

## Why

The client previously embedded `https://genui-server.vercel.app` in multiple modules. That made local-first usage depend on host-specific branching and prevented deployments from selecting one backend consistently.

## Impact

Deployments can set `GENUI_SERVER_URL=<origin>` at build time. Without it, all client API flows use `http://localhost:3060`. Invalid values containing credentials, paths, query strings, or fragments are rejected during configuration.

## Validation

- `pnpm turbo build`
- `pnpm -C packages/genui/playground test` (127 tests)
- Targeted `pnpm biome check`
- Targeted `pnpm eslint`
- `GENUI_SERVER_URL=https://genui.example.test pnpm -C packages/genui/playground build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared GenUI server configuration with a localhost default.
  * Added validation for HTTP(S) server origins and support for diagnostic query-parameter overrides.
  * Chat, Bench, health checks, and preview publishing now use the configured server consistently.
* **Documentation**
  * Updated playground setup guidance for configuring the GenUI server.
* **Bug Fixes**
  * Improved endpoint normalization and support for local development servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->