### PR TITLE
fix(genui): inject Pages server URL at build time

### DIFF
--- a/.github/genui-playground-website.instructions.md
+++ b/.github/genui-playground-website.instructions.md
@@ -1,7 +1,7 @@
 ---
-applyTo: ".github/workflows/workflow-website.yml,packages/genui/playground/**"
+applyTo: ".github/workflows/workflow-website.yml,.github/workflows/deploy-main.yml,packages/genui/playground/**"
 ---
 
 The hosted GenUI playground is deployed by building `packages/genui/playground` and copying its full `dist` directory into `website/doc_build/genui` in `.github/workflows/workflow-website.yml`. When adding another hosted route alias such as `/zh/genui`, copy the full `dist` directory to that route as well instead of adding only an HTML redirect, because the playground opens `render.html`, demo JSON, and bundle files relative to the current route.
 
-Keep the website build job attached to the `github-pages` environment and explicitly map its `GENUI_SERVER_URL` configuration variable into the GenUI playground build step. Environment-level configuration variables are not automatically exported to the runner, and the deploy job is too late to change a server URL compiled into the static bundle.
+Keep the reusable website build free of deployment environments because it also runs for pull-request and merge-group refs. For Pages deployments, load the environment-scoped `GENUI_SERVER_URL` in a `deploy-main.yml` pre-build configuration job and pass it to the reusable workflow as an input, then explicitly map that input into the GenUI playground build step. The deployment job is too late to change a server URL compiled into the static bundle.

--- a/.github/genui-playground-website.instructions.md
+++ b/.github/genui-playground-website.instructions.md
@@ -3,3 +3,5 @@ applyTo: ".github/workflows/workflow-website.yml,packages/genui/playground/**"
 ---
 
 The hosted GenUI playground is deployed by building `packages/genui/playground` and copying its full `dist` directory into `website/doc_build/genui` in `.github/workflows/workflow-website.yml`. When adding another hosted route alias such as `/zh/genui`, copy the full `dist` directory to that route as well instead of adding only an HTML redirect, because the playground opens `render.html`, demo JSON, and bundle files relative to the current route.
+
+Keep the website build job attached to the `github-pages` environment and explicitly map its `GENUI_SERVER_URL` configuration variable into the GenUI playground build step. Environment-level configuration variables are not automatically exported to the runner, and the deploy job is too late to change a server URL compiled into the static bundle.

--- a/.github/genui-playground-website.instructions.md
+++ b/.github/genui-playground-website.instructions.md
@@ -1,7 +1,7 @@
 ---
-applyTo: ".github/workflows/workflow-website.yml,.github/workflows/deploy-main.yml,packages/genui/playground/**"
+applyTo: ".github/workflows/workflow-website.yml,packages/genui/playground/**"
 ---
 
 The hosted GenUI playground is deployed by building `packages/genui/playground` and copying its full `dist` directory into `website/doc_build/genui` in `.github/workflows/workflow-website.yml`. When adding another hosted route alias such as `/zh/genui`, copy the full `dist` directory to that route as well instead of adding only an HTML redirect, because the playground opens `render.html`, demo JSON, and bundle files relative to the current route.
 
-Keep the reusable website build free of deployment environments because it also runs for pull-request and merge-group refs. For Pages deployments, load the environment-scoped `GENUI_SERVER_URL` in a `deploy-main.yml` pre-build configuration job and pass it to the reusable workflow as an input, then explicitly map that input into the GenUI playground build step. The deployment job is too late to change a server URL compiled into the static bundle.
+Keep the reusable website build free of deployment environments because it also runs for pull-request and merge-group refs. Configure the public GenUI server origin as the repository-level `GENUI_SERVER_URL` Actions variable and explicitly map it into the GenUI playground build step; environment-level variables are unavailable unless the build itself targets that protected environment.

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -249,27 +249,11 @@ jobs:
       - name: publish canary packages
         run: |
           pnpm --recursive publish --no-git-checks --access public
-  website-config:
-    if: github.repository == 'lynx-family/lynx-stack'
-    environment: github-pages
-    permissions: {}
-    runs-on: ubuntu-26.04
-    outputs:
-      genui_server_url: ${{ steps.config.outputs.genui_server_url }}
-    steps:
-      - name: Load GenUI server URL
-        id: config
-        env:
-          GENUI_SERVER_URL: ${{ vars.GENUI_SERVER_URL }}
-        run: |
-          printf 'genui_server_url=%s\n' "$GENUI_SERVER_URL" >> "$GITHUB_OUTPUT"
   website-build:
-    needs: [build-all, website-config]
+    needs: build-all
     if: github.repository == 'lynx-family/lynx-stack'
     uses: ./.github/workflows/workflow-website.yml
     permissions: {}
-    with:
-      genui_server_url: ${{ needs.website-config.outputs.genui_server_url }}
   website-deploy:
     timeout-minutes: 10
     needs: website-build

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -249,11 +249,27 @@ jobs:
       - name: publish canary packages
         run: |
           pnpm --recursive publish --no-git-checks --access public
+  website-config:
+    if: github.repository == 'lynx-family/lynx-stack'
+    environment: github-pages
+    permissions: {}
+    runs-on: ubuntu-26.04
+    outputs:
+      genui_server_url: ${{ steps.config.outputs.genui_server_url }}
+    steps:
+      - name: Load GenUI server URL
+        id: config
+        env:
+          GENUI_SERVER_URL: ${{ vars.GENUI_SERVER_URL }}
+        run: |
+          printf 'genui_server_url=%s\n' "$GENUI_SERVER_URL" >> "$GITHUB_OUTPUT"
   website-build:
-    needs: build-all
+    needs: [build-all, website-config]
     if: github.repository == 'lynx-family/lynx-stack'
     uses: ./.github/workflows/workflow-website.yml
     permissions: {}
+    with:
+      genui_server_url: ${{ needs.website-config.outputs.genui_server_url }}
   website-deploy:
     timeout-minutes: 10
     needs: website-build

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -8,6 +8,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   build:
+    environment: github-pages
     permissions: {}
     runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
@@ -49,6 +50,8 @@ jobs:
         run: |
           pnpm --filter genui-playground build:lynx
       - name: Build GenUI Playground
+        env:
+          GENUI_SERVER_URL: ${{ vars.GENUI_SERVER_URL }}
         run: |
           BASE_PATH='${{ steps.pages.outputs.base_path }}'
           export ASSET_PREFIX="${BASE_PATH%/}/genui/"

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -2,13 +2,17 @@ name: Website
 
 on:
   workflow_call:
+    inputs:
+      genui_server_url:
+        description: GenUI server origin embedded in the hosted playground
+        required: false
+        type: string
 
 env:
   CI: 1
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   build:
-    environment: github-pages
     permissions: {}
     runs-on: lynx-ubuntu-26.04-medium
     timeout-minutes: 10
@@ -51,7 +55,7 @@ jobs:
           pnpm --filter genui-playground build:lynx
       - name: Build GenUI Playground
         env:
-          GENUI_SERVER_URL: ${{ vars.GENUI_SERVER_URL }}
+          GENUI_SERVER_URL: ${{ inputs.genui_server_url }}
         run: |
           BASE_PATH='${{ steps.pages.outputs.base_path }}'
           export ASSET_PREFIX="${BASE_PATH%/}/genui/"

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -2,11 +2,6 @@ name: Website
 
 on:
   workflow_call:
-    inputs:
-      genui_server_url:
-        description: GenUI server origin embedded in the hosted playground
-        required: false
-        type: string
 
 env:
   CI: 1
@@ -55,7 +50,7 @@ jobs:
           pnpm --filter genui-playground build:lynx
       - name: Build GenUI Playground
         env:
-          GENUI_SERVER_URL: ${{ inputs.genui_server_url }}
+          GENUI_SERVER_URL: ${{ vars.GENUI_SERVER_URL }}
         run: |
           BASE_PATH='${{ steps.pages.outputs.base_path }}'
           export ASSET_PREFIX="${BASE_PATH%/}/genui/"


### PR DESCRIPTION
## Summary

- map the repository-level `GENUI_SERVER_URL` Actions variable into the GenUI playground build step
- keep the reusable website build independent of the protected `github-pages` environment
- document the repository-variable requirement for hosted playground builds

## Why

#3532 made the playground consume `GENUI_SERVER_URL` at build time, but GitHub configuration variables are not automatically exported as runner environment variables. The Pages deployment job receives an already-built static artifact, so its environment cannot change the server URL embedded in the bundle.

## Impact

PR and merge-queue website builds no longer target a protected deployment environment. Main-branch Pages builds consume the repository variable before uploading the static artifact, while the existing `website-deploy` job remains protected by `github-pages`.

## Validation

- parsed the workflows and asserted that the shared build has no environment, the repository variable is mapped into the build step, and the final deploy job still targets `github-pages`
- `pnpm dprint check --incremental=false .github/workflows/workflow-website.yml .github/workflows/deploy-main.yml .github/genui-playground-website.instructions.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the GenUI Playground website build to use the repository’s `GENUI_SERVER_URL` setting.
  * Documented deployment configuration requirements for reusable website builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->