### PR TITLE
fix(genui): harden playground input boundaries

### DIFF
--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -20,6 +20,12 @@ When automating A2UI preview benchmarks, wrap `render.html` in a parent iframe w
 
 Treat Bench reports as a protocol-neutral product area. Use `#/bench` as the canonical Runner route, keep `#/bench/runner` as a compatibility alias, and publish studies under phase routes such as `#/bench/phase-1`. This leaves later phases free to compare A2UI with other protocols. Keep legacy `#/a2ui/bench` hashes only as compatibility inputs. This route guidance does not apply to the A2UI server API paths under `/a2ui/bench/jobs`.
 
+### Preview Security Boundaries
+
+Treat `render.html` as an executable preview boundary. Load only same-origin HTTP(S) `.web.js` bundles, accept control messages only from its same-origin parent window, and send parent messages to an explicit origin instead of `*`. Validate demo ids as simple slugs before building `demos/<id>.json` fetch paths.
+
+When validating origin-only configuration values, reject raw `?` and `#` delimiters before constructing `URL`; the URL parser canonicalizes bare delimiters into empty `search` and `hash` values. When applying untrusted A2UI data-model updates or imported snapshots to JavaScript objects, discard `__proto__`, `constructor`, and `prototype` keys at every depth and reject paths containing those segments.
+
 ### Native Test Bundles
 
 When serving the playground's native Lynx bundles as static Android test fixtures, keep HMR/React refresh out of `a2ui.lynx.js` and `openui.lynx.js`. The Android Lynx runtime does not provide globals such as `__prefresh_utils__` or Node's `process`, so normalize `process.env.NODE_ENV` at build time and disable HMR for these bundles instead of relying on the caller's `NODE_ENV`.

--- a/packages/genui/playground/genui-server-url.ts
+++ b/packages/genui/playground/genui-server-url.ts
@@ -9,6 +9,15 @@ export function resolveGenuiServerUrl(raw: string | undefined): string {
   const value = configured === undefined || configured === ''
     ? DEFAULT_GENUI_SERVER_URL
     : configured;
+
+  // URL canonicalization drops bare delimiters (`http://host/?` becomes an
+  // empty search string, for example), so reject them before parsing.
+  if (value.includes('?') || value.includes('#')) {
+    throw new Error(
+      'GENUI_SERVER_URL must be an HTTP(S) origin without credentials, path, query, or fragment',
+    );
+  }
+
   let url: URL;
   try {
     url = new URL(value);

--- a/packages/genui/playground/src/config/genuiServer.test.ts
+++ b/packages/genui/playground/src/config/genuiServer.test.ts
@@ -31,4 +31,11 @@ describe('GenUI server URL configuration', () => {
     expect(() => resolveGenuiServerUrl('file:///tmp/genui'))
       .toThrow('GENUI_SERVER_URL must be an HTTP(S) origin');
   });
+
+  test('rejects bare query and fragment delimiters', () => {
+    expect(() => resolveGenuiServerUrl('https://genui.example.com/?'))
+      .toThrow('GENUI_SERVER_URL must be an HTTP(S) origin');
+    expect(() => resolveGenuiServerUrl('https://genui.example.com/#'))
+      .toThrow('GENUI_SERVER_URL must be an HTTP(S) origin');
+  });
 });

--- a/packages/genui/playground/src/hooks/useConversation.ts
+++ b/packages/genui/playground/src/hooks/useConversation.ts
@@ -25,6 +25,7 @@ import type {
   PreviewPayloadUrls,
   PreviewPerformanceMetrics,
 } from '../storage/types.js';
+import { applyDataModel, cloneDataModel } from '../utils/dataModel.js';
 
 export interface ModelChatMessage {
   role: 'user' | 'assistant' | 'system';
@@ -82,25 +83,6 @@ export interface UseConversationReturn {
 const MAX_CONVERSATION_TURNS = 20;
 const MAX_CONVERSATION_CHARS = 16_000;
 
-function cloneDataModel(
-  value: Record<string, unknown>,
-): Record<string, unknown> {
-  try {
-    return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
-
-function cloneDataValue(value: unknown): unknown {
-  if (value === null || typeof value !== 'object') return value;
-  try {
-    return JSON.parse(JSON.stringify(value)) as unknown;
-  } catch {
-    return value;
-  }
-}
-
 function clonePreviewPerformanceMetrics(
   value: PreviewPerformanceMetrics | null | undefined,
 ): PreviewPerformanceMetrics | undefined {
@@ -132,41 +114,6 @@ function truncateConversationHistory(
   }
 
   return kept;
-}
-
-function applyDataModel(
-  model: Record<string, unknown>,
-  path: string,
-  value: unknown,
-): void {
-  if (!path || path === '/' || path === '') {
-    for (const key of Object.keys(model)) {
-      delete model[key];
-    }
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      Object.assign(model, cloneDataValue(value) as Record<string, unknown>);
-    }
-    return;
-  }
-
-  const parts = path.replace(/^\//u, '').split('/').filter(Boolean);
-  let cursor = model;
-  for (let i = 0; i < parts.length - 1; i++) {
-    const key = parts[i];
-    if (!key) continue;
-    if (typeof cursor[key] !== 'object' || cursor[key] === null) {
-      cursor[key] = {};
-    }
-    cursor = cursor[key] as Record<string, unknown>;
-  }
-
-  const last = parts[parts.length - 1];
-  if (!last) return;
-  if (value === undefined) {
-    delete cursor[last];
-  } else {
-    cursor[last] = cloneDataValue(value);
-  }
 }
 
 function applyA2UIMessagesToSnapshot(

--- a/packages/genui/playground/src/pages/demos/DemosPage.tsx
+++ b/packages/genui/playground/src/pages/demos/DemosPage.tsx
@@ -284,14 +284,17 @@ function DemosPageContent<
           status,
         },
       },
-      '*',
+      window.location.origin,
     );
   }, []);
 
   const sendPlaybackControl = useCallback((action: 'pause' | 'resume') => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
-    win.postMessage({ type: 'A2UI_PLAYBACK_CONTROL', action }, '*');
+    win.postMessage(
+      { type: 'A2UI_PLAYBACK_CONTROL', action },
+      window.location.origin,
+    );
   }, []);
 
   const handlePlay = useCallback(() => {

--- a/packages/genui/playground/src/render.tsx
+++ b/packages/genui/playground/src/render.tsx
@@ -21,6 +21,11 @@ import { mcpAppDemo } from './mock/basic/mcp-app.js';
 import { decodeBase64Url } from './utils/base64url.js';
 import { DEFAULT_A2UI_DEMO_URL } from './utils/demoUrl.js';
 import {
+  isTrustedPreviewMessage,
+  resolveDemoMessagesUrl,
+  resolveTrustedPreviewBundleUrl,
+} from './utils/previewSecurity.js';
+import {
   RENDER_INIT_DATA_QUERY_PARAM,
   RENDER_METRIC_ID_QUERY_PARAM,
 } from './utils/renderUrl.js';
@@ -103,6 +108,11 @@ interface ReplayMessagesMessage {
 
 const TTI_IDLE_WINDOW_MS = 500;
 const TTI_READY_FALLBACK_MS = 1200;
+
+function postToParent(message: unknown): void {
+  if (!window.parent || window.parent === window) return;
+  window.parent.postMessage(message, window.location.origin);
+}
 
 interface LynxViewElement extends HTMLElement {
   initData?: InitData;
@@ -382,7 +392,7 @@ function Render() {
       metric,
       value: Math.max(0, Math.round(value)),
     };
-    window.parent.postMessage(message, '*');
+    postToParent(message);
   }, [previewMetricId]);
 
   const clearTtiTimer = useCallback(() => {
@@ -433,7 +443,7 @@ function Render() {
 
   const postRenderReady = useCallback(() => {
     if (!window.parent || window.parent === window) return;
-    window.parent.postMessage({ type: 'A2UI_RENDER_READY' }, '*');
+    postToParent({ type: 'A2UI_RENDER_READY' });
     scheduleFcpFallbackMetric();
     if (initDataRef.current?.protocol !== 'a2ui') {
       scheduleFmpMetric();
@@ -571,7 +581,12 @@ function Render() {
     let cancelled = false;
     void (async () => {
       try {
-        const res = await window.fetch(`./demos/${demo}.json`);
+        const demoMessagesUrl = resolveDemoMessagesUrl(
+          demo,
+          window.location.href,
+        );
+        if (!demoMessagesUrl) return;
+        const res = await window.fetch(demoMessagesUrl);
         if (!res.ok || cancelled) return;
         const messages = (await res.json()) as unknown;
         if (!cancelled) {
@@ -641,33 +656,18 @@ function Render() {
             clearTtiTimer();
           }
         }
-        if (window.parent && window.parent !== window) {
-          window.parent.postMessage(
-            {
-              type: 'A2UI_PLAYBACK_SYNC',
-              data,
-            },
-            '*',
-          );
-        }
+        postToParent({
+          type: 'A2UI_PLAYBACK_SYNC',
+          data,
+        });
         return;
       }
       if (name === 'A2UI_USER_ACTION') {
-        if (window.parent && window.parent !== window) {
-          window.parent.postMessage(
-            { type: 'A2UI_USER_ACTION', action: data },
-            '*',
-          );
-        }
+        postToParent({ type: 'A2UI_USER_ACTION', action: data });
         return;
       }
       if (name === 'OPENUI_USER_ACTION') {
-        if (window.parent && window.parent !== window) {
-          window.parent.postMessage(
-            { type: 'OPENUI_USER_ACTION', action: data },
-            '*',
-          );
-        }
+        postToParent({ type: 'OPENUI_USER_ACTION', action: data });
         return;
       }
     };
@@ -684,6 +684,35 @@ function Render() {
 
   useEffect(() => {
     const handleMessage = (e: MessageEvent<unknown>) => {
+      if (!isTrustedPreviewMessage(e, window.location.origin)) return;
+
+      if (
+        e.data
+        && typeof e.data === 'object'
+        && (e.data as UserActionMessage).type === 'A2UI_USER_ACTION'
+      ) {
+        postToParent(e.data);
+        return;
+      }
+      if (
+        e.data
+        && typeof e.data === 'object'
+        && (e.data as OpenUIUserActionMessage).type === 'OPENUI_USER_ACTION'
+      ) {
+        postToParent(e.data);
+        return;
+      }
+
+      if (
+        !isTrustedPreviewMessage(
+          e,
+          window.location.origin,
+          window.parent,
+        )
+      ) {
+        return;
+      }
+
       if (
         e.data
         && typeof e.data === 'object'
@@ -693,26 +722,6 @@ function Render() {
         lynxView?.sendGlobalEvent?.('A2UI_PLAYBACK_PROGRESS', [
           (e.data as PlaybackProgressMessage).data,
         ]);
-        return;
-      }
-      if (
-        e.data
-        && typeof e.data === 'object'
-        && (e.data as UserActionMessage).type === 'A2UI_USER_ACTION'
-      ) {
-        if (window.parent && window.parent !== window) {
-          window.parent.postMessage(e.data, '*');
-        }
-        return;
-      }
-      if (
-        e.data
-        && typeof e.data === 'object'
-        && (e.data as OpenUIUserActionMessage).type === 'OPENUI_USER_ACTION'
-      ) {
-        if (window.parent && window.parent !== window) {
-          window.parent.postMessage(e.data, '*');
-        }
         return;
       }
       if (
@@ -844,12 +853,17 @@ function Render() {
     };
   }, []);
 
+  const bundleUrl = resolveTrustedPreviewBundleUrl(
+    initData?.demoUrl ?? DEFAULT_A2UI_DEMO_URL,
+    window.location.href,
+  ) ?? new URL(DEFAULT_A2UI_DEMO_URL, window.location.href).toString();
+
   return createElement('lynx-view', {
     ref: lynxViewRef,
     className: 'renderLynx',
     style: { height: '100%' },
     'thread-strategy': 'multi-thread',
-    url: initData?.demoUrl ?? DEFAULT_A2UI_DEMO_URL,
+    url: bundleUrl,
   });
 }
 

--- a/packages/genui/playground/src/utils/dataModel.test.ts
+++ b/packages/genui/playground/src/utils/dataModel.test.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { applyDataModel, cloneDataModel } from './dataModel.js';
+
+describe('safe data model updates', () => {
+  test('applies ordinary nested updates', () => {
+    const model: Record<string, unknown> = {};
+    applyDataModel(model, '/profile/name', 'Lynx');
+    expect(model).toEqual({ profile: { name: 'Lynx' } });
+  });
+
+  test('rejects prototype-polluting update paths', () => {
+    const model: Record<string, unknown> = {};
+    applyDataModel(model, '/__proto__/polluted', true);
+    applyDataModel(model, '/constructor/prototype/polluted', true);
+    expect(model).toEqual({});
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  test('removes unsafe keys from replacement values and snapshots', () => {
+    const value = JSON.parse(
+      '{"safe":{"value":1},"__proto__":{"polluted":true},"constructor":{"prototype":{"polluted":true}}}',
+    ) as Record<string, unknown>;
+    const model: Record<string, unknown> = {};
+
+    applyDataModel(model, '/', value);
+
+    expect(model).toEqual({ safe: { value: 1 } });
+    expect(cloneDataModel(value)).toEqual({ safe: { value: 1 } });
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+});

--- a/packages/genui/playground/src/utils/dataModel.ts
+++ b/packages/genui/playground/src/utils/dataModel.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const UNSAFE_OBJECT_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function sanitizeJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => sanitizeJsonValue(item));
+  if (!isRecord(value)) return value;
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (UNSAFE_OBJECT_KEYS.has(key)) continue;
+    sanitized[key] = sanitizeJsonValue(child);
+  }
+  return sanitized;
+}
+
+function cloneDataValue(value: unknown): unknown {
+  try {
+    return sanitizeJsonValue(JSON.parse(JSON.stringify(value)) as unknown);
+  } catch {
+    return undefined;
+  }
+}
+
+export function cloneDataModel(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const cloned = cloneDataValue(value);
+  return isRecord(cloned) ? cloned : {};
+}
+
+export function applyDataModel(
+  model: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  if (!path || path === '/') {
+    for (const key of Object.keys(model)) delete model[key];
+    const cloned = cloneDataValue(value);
+    if (!isRecord(cloned)) return;
+    for (const [key, child] of Object.entries(cloned)) {
+      model[key] = child;
+    }
+    return;
+  }
+
+  const parts = path.replace(/^\//u, '').split('/').filter(Boolean);
+  if (parts.some((part) => UNSAFE_OBJECT_KEYS.has(part))) return;
+
+  let cursor = model;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i];
+    if (!key) continue;
+    const child = Object.prototype.hasOwnProperty.call(cursor, key)
+      ? cursor[key]
+      : undefined;
+    if (!isRecord(child)) cursor[key] = {};
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+
+  const last = parts[parts.length - 1];
+  if (!last) return;
+  if (value === undefined) {
+    delete cursor[last];
+  } else {
+    cursor[last] = cloneDataValue(value);
+  }
+}

--- a/packages/genui/playground/src/utils/previewSecurity.test.ts
+++ b/packages/genui/playground/src/utils/previewSecurity.test.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  isTrustedPreviewMessage,
+  resolveDemoMessagesUrl,
+  resolveTrustedPreviewBundleUrl,
+} from './previewSecurity.js';
+
+describe('preview security', () => {
+  const pageUrl = 'https://playground.example.com/genui/render.html';
+
+  test('allows same-origin web preview bundles', () => {
+    expect(resolveTrustedPreviewBundleUrl('./a2ui.web.js', pageUrl)).toBe(
+      'https://playground.example.com/genui/a2ui.web.js',
+    );
+  });
+
+  test('rejects executable cross-origin or non-HTTP(S) bundle URLs', () => {
+    expect(
+      resolveTrustedPreviewBundleUrl(
+        'https://attacker.example/payload.web.js',
+        pageUrl,
+      ),
+    ).toBe(null);
+    expect(resolveTrustedPreviewBundleUrl('javascript:alert(1)', pageUrl))
+      .toBe(null);
+    expect(
+      resolveTrustedPreviewBundleUrl(
+        'https://user:password@playground.example.com/genui/a2ui.web.js',
+        pageUrl,
+      ),
+    ).toBe(null);
+  });
+
+  test('rejects bundle query and fragment delimiters before parsing', () => {
+    expect(resolveTrustedPreviewBundleUrl('./a2ui.web.js?', pageUrl)).toBe(
+      null,
+    );
+    expect(resolveTrustedPreviewBundleUrl('./a2ui.web.js#', pageUrl)).toBe(
+      null,
+    );
+  });
+
+  test('builds demo payload URLs only from safe identifiers', () => {
+    expect(resolveDemoMessagesUrl('citywalk-list', pageUrl)).toBe(
+      'https://playground.example.com/genui/demos/citywalk-list.json',
+    );
+    expect(resolveDemoMessagesUrl('../models', pageUrl)).toBe(null);
+    expect(resolveDemoMessagesUrl('demo?admin=1', pageUrl)).toBe(null);
+    expect(resolveDemoMessagesUrl('demo#payload', pageUrl)).toBe(null);
+  });
+
+  test('requires the expected origin and optional source window', () => {
+    const parent = {};
+    const event = {
+      origin: 'https://playground.example.com',
+      source: parent,
+    };
+    expect(
+      isTrustedPreviewMessage(
+        event,
+        'https://playground.example.com',
+        parent,
+      ),
+    ).toBe(true);
+    expect(
+      isTrustedPreviewMessage(
+        { ...event, origin: 'https://attacker.example' },
+        'https://playground.example.com',
+        parent,
+      ),
+    ).toBe(false);
+    expect(
+      isTrustedPreviewMessage(
+        { ...event, source: {} },
+        'https://playground.example.com',
+        parent,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/genui/playground/src/utils/previewSecurity.ts
+++ b/packages/genui/playground/src/utils/previewSecurity.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const SAFE_DEMO_ID = /^[a-z0-9][a-z0-9-]{0,127}$/u;
+
+interface MessageIdentity {
+  origin: string;
+  source: unknown;
+}
+
+export function isTrustedPreviewMessage(
+  event: MessageIdentity,
+  expectedOrigin: string,
+  expectedSource?: unknown,
+): boolean {
+  return event.origin === expectedOrigin
+    && (expectedSource === undefined || event.source === expectedSource);
+}
+
+export function resolveTrustedPreviewBundleUrl(
+  raw: string | undefined,
+  pageUrl: string,
+): string | null {
+  const value = raw?.trim();
+  if (!value || value.includes('?') || value.includes('#')) return null;
+
+  try {
+    const page = new URL(pageUrl);
+    const bundle = new URL(value, page);
+    if (
+      (bundle.protocol !== 'http:' && bundle.protocol !== 'https:')
+      || bundle.username
+      || bundle.password
+      || bundle.origin !== page.origin
+      || !bundle.pathname.endsWith('.web.js')
+    ) {
+      return null;
+    }
+    return bundle.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function resolveDemoMessagesUrl(
+  raw: string | null,
+  pageUrl: string,
+): string | null {
+  const demoId = raw?.trim();
+  if (!demoId || !SAFE_DEMO_ID.test(demoId)) return null;
+
+  try {
+    return new URL(`./demos/${demoId}.json`, pageUrl).toString();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Reject raw `?` and `#` delimiters in `GENUI_SERVER_URL` before WHATWG URL canonicalization, including the bare-delimiter cases from review.
- Treat `render.html` as an executable boundary: allow only same-origin HTTP(S) `.web.js` bundles, validate demo ids before constructing JSON fetch paths, authenticate inbound window messages, and use explicit target origins.
- Prevent prototype pollution while replaying A2UI data-model updates or importing conversation snapshots by rejecting `__proto__`, `constructor`, and `prototype` keys and path segments.
- Document these GenUI playground security invariants and add focused regression tests.

## Root cause

The URL checks inspected parsed `URL.search` and `URL.hash`, but the parser canonicalizes bare delimiters to empty strings. Separately, preview bundle/message inputs were treated as trusted without enforcing the iframe trust boundary, and snapshot replay wrote model-controlled paths into ordinary JavaScript objects.

## Impact

Malformed origin-only configuration now fails early. Crafted preview links cannot load cross-origin executable bundles, traverse demo asset paths, or inject control messages from another origin. Untrusted A2UI data cannot mutate object prototypes through snapshot reconstruction.

## Security review

The GenUI source scan also covered raw HTML DOM sinks, dynamic code execution, dynamic links/resources, URL trust checks, and remaining `postMessage` call sites. No active `dangerouslySetInnerHTML`, raw DOM HTML injection, `eval`, or `new Function` usage was found; remaining active window messaging uses explicit origins and source checks where messages drive actions.

## Validation

- `pnpm turbo build --output-logs=errors-only` (70/70 tasks)
- `pnpm -C packages/genui/playground test` (136/136 tests)
- Targeted `pnpm biome check`
- Targeted `pnpm eslint`
- `git diff --check`

## Stack

This is an independent follow-up to #3532. After that PR merged, this branch was rebased onto the updated `main`, so the original PR history remains unchanged and this diff contains only the security hardening.