### PR TITLE
feat: support grid-lanes on web (#8621)

### DIFF
--- a/.changeset/calm-lanes-web-elements.md
+++ b/.changeset/calm-lanes-web-elements.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-elements": minor
+---
+
+Document native browser support for grid-lanes containers.

--- a/.changeset/clean-lanes-template.md
+++ b/.changeset/clean-lanes-template.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": minor
+---
+
+Enable grid-lanes CSS encoding in generated Lynx bundles.

--- a/.changeset/fair-peers-css-extract.md
+++ b/.changeset/fair-peers-css-extract.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/css-extract-webpack-plugin": patch
+---
+
+Accept `@lynx-js/template-webpack-plugin` 0.16 as a compatible peer dependency.

--- a/.changeset/gentle-peers-react-webpack.md
+++ b/.changeset/gentle-peers-react-webpack.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Accept `@lynx-js/template-webpack-plugin` 0.16 as a compatible peer dependency.

--- a/.changeset/tidy-lanes-web-core.md
+++ b/.changeset/tidy-lanes-web-core.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Support direct browser pass-through for the grid-lanes display mode and flow-tolerance property ID 237 without linear cascade leakage.

--- a/packages/web-platform/web-core-e2e/playwright.config.ts
+++ b/packages/web-platform/web-core-e2e/playwright.config.ts
@@ -16,4 +16,21 @@ import { playwrightConfigCommon } from '@lynx-js/playwright-fixtures';
  */
 export default defineConfig({
   ...playwrightConfigCommon,
+  projects: playwrightConfigCommon.projects?.map(project =>
+    project.name === 'chromium'
+      ? {
+        ...project,
+        use: {
+          ...project.use,
+          launchOptions: {
+            ...project.use?.launchOptions,
+            args: [
+              ...(project.use?.launchOptions?.args ?? []),
+              '--enable-blink-features=CSSGridLanesLayout',
+            ],
+          },
+        },
+      }
+      : project
+  ),
 });

--- a/packages/web-platform/web-core-e2e/shell-project/index.ts
+++ b/packages/web-platform/web-core-e2e/shell-project/index.ts
@@ -1,6 +1,105 @@
 import type { LynxViewElement } from '@lynx-js/web-core/client';
 import './index.css';
 
+type GridLanesBoxModel = {
+  width: number;
+  height: number;
+  content: number[];
+  padding: number[];
+  border: number[];
+  margin: number[];
+};
+
+declare global {
+  var __collectGridLanesModeBGeometry:
+    | (() => Record<string, GridLanesBoxModel>)
+    | undefined;
+}
+
+const toQuad = (left: number, top: number, right: number, bottom: number) => [
+  left,
+  top,
+  right,
+  top,
+  right,
+  bottom,
+  left,
+  bottom,
+];
+
+const collectGridLanesModeBGeometry = () => {
+  const number = (value: string) => Number.parseFloat(value) || 0;
+  const taggedElements: Element[] = [];
+  const visit = (root: Document | ShadowRoot) => {
+    for (const element of root.querySelectorAll('*')) {
+      if (element.hasAttribute('lynx-test-tag')) {
+        taggedElements.push(element);
+      }
+      if (element.shadowRoot) {
+        visit(element.shadowRoot);
+      }
+    }
+  };
+  visit(document);
+
+  return Object.fromEntries(taggedElements.map((element) => {
+    const rect = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    const borderLeft = number(style.borderLeftWidth);
+    const borderTop = number(style.borderTopWidth);
+    const borderRight = number(style.borderRightWidth);
+    const borderBottom = number(style.borderBottomWidth);
+    const paddingLeft = number(style.paddingLeft);
+    const paddingTop = number(style.paddingTop);
+    const paddingRight = number(style.paddingRight);
+    const paddingBottom = number(style.paddingBottom);
+    const marginLeft = number(style.marginLeft);
+    const marginTop = number(style.marginTop);
+    const marginRight = number(style.marginRight);
+    const marginBottom = number(style.marginBottom);
+    const paddingBox = {
+      left: rect.left + borderLeft,
+      top: rect.top + borderTop,
+      right: rect.right - borderRight,
+      bottom: rect.bottom - borderBottom,
+    };
+    const contentBox = {
+      left: paddingBox.left + paddingLeft,
+      top: paddingBox.top + paddingTop,
+      right: paddingBox.right - paddingRight,
+      bottom: paddingBox.bottom - paddingBottom,
+    };
+    return [
+      element.getAttribute('lynx-test-tag'),
+      {
+        width: rect.width,
+        height: rect.height,
+        content: toQuad(
+          contentBox.left,
+          contentBox.top,
+          contentBox.right,
+          contentBox.bottom,
+        ),
+        padding: toQuad(
+          paddingBox.left,
+          paddingBox.top,
+          paddingBox.right,
+          paddingBox.bottom,
+        ),
+        border: toQuad(rect.left, rect.top, rect.right, rect.bottom),
+        margin: toQuad(
+          rect.left - marginLeft,
+          rect.top - marginTop,
+          rect.right + marginRight,
+          rect.bottom + marginBottom,
+        ),
+      },
+    ];
+  }));
+};
+
+globalThis.__collectGridLanesModeBGeometry = collectGridLanesModeBGeometry;
+
 export const lynxViewTests = (
   lynxView?: LynxViewElement | undefined,
 ) => {

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -105,6 +105,52 @@ test.describe('reactlynx3 tests', () => {
       await expect(target).toHaveCSS('background-color', 'rgb(255, 192, 203)');
     });
 
+    test(
+      'basic-grid-lanes',
+      async ({ page, browserName }, { title }) => {
+        await goto(page, title);
+        const target = page.locator('#grid-lanes');
+
+        const support = await page.evaluate(() => ({
+          gridLanes: CSS.supports('display', 'grid-lanes'),
+          flowTolerance: CSS.supports('flow-tolerance', '12px'),
+        }));
+        if (support.flowTolerance) {
+          await expect(target).toHaveCSS('flow-tolerance', '12px');
+        }
+
+        const grid = page.locator('#grid');
+        await expect(grid).toHaveCSS('display', 'grid');
+
+        if (browserName === 'chromium' || browserName === 'webkit') {
+          expect(support.gridLanes).toBe(true);
+        }
+        if (support.gridLanes) {
+          await expect(target).toHaveCSS('display', 'grid-lanes');
+        } else {
+          await expect(target).toHaveCSS('display', 'flex');
+          await expect(target).not.toHaveCSS('display', 'grid');
+          await expect(target).not.toHaveCSS('display', 'masonry');
+        }
+
+        const geometry = await page.evaluate(() =>
+          globalThis.__collectGridLanesModeBGeometry?.()
+        );
+        expect(geometry).toBeDefined();
+        expect(geometry).toEqual(expect.objectContaining({
+          'grid-lanes': expect.any(Object),
+          'item-a': expect.any(Object),
+          'item-b': expect.any(Object),
+          'item-c': expect.any(Object),
+        }));
+        const itemB = geometry!['item-b'];
+        const itemC = geometry!['item-c'];
+        if (support.gridLanes) {
+          expect(itemC.content[1]).toBeLessThan(itemB.content[5]);
+        }
+      },
+    );
+
     test('basic-reload', async ({ page }, { title }) => {
       await goto(page, title);
       await wait(100);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-grid-lanes/index.css
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-grid-lanes/index.css
@@ -1,0 +1,43 @@
+/* Copyright 2026 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. */
+.page {
+  width: 320px;
+}
+
+.grid-lanes,
+.grid {
+  width: 320px;
+  grid-template-columns: repeat(2, 150px);
+  column-gap: 20px;
+  row-gap: 8px;
+  flex-direction: column-reverse;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.grid-lanes {
+  display: grid-lanes;
+  flow-tolerance: 12px;
+}
+
+.grid {
+  display: grid;
+}
+
+.item {
+  width: 150px;
+  background-color: green;
+}
+
+.item-a {
+  height: 40px;
+}
+
+.item-b {
+  height: 80px;
+}
+
+.item-c {
+  height: 60px;
+}

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-grid-lanes/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-grid-lanes/index.jsx
@@ -1,0 +1,28 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root } from '@lynx-js/react';
+import './index.css';
+
+function App() {
+  return (
+    <view className='page'>
+      <view
+        id='grid-lanes'
+        className='grid-lanes'
+        lynx-test-tag='grid-lanes'
+      >
+        <view id='item-a' className='item item-a' lynx-test-tag='item-a' />
+        <view id='item-b' className='item item-b' lynx-test-tag='item-b' />
+        <view id='item-c' className='item item-c' lynx-test-tag='item-c' />
+      </view>
+      <view id='grid' className='grid'>
+        <view className='item item-a' />
+        <view className='item item-b' />
+      </view>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core/src/main_thread/server/main_thread_server_context.rs
+++ b/packages/web-platform/web-core/src/main_thread/server/main_thread_server_context.rs
@@ -579,6 +579,19 @@ mod tests {
   }
 
   #[test]
+  fn test_numeric_grid_lanes_properties() {
+    let mut ctx = MainThreadServerContext::new("".to_string(), true, false, false, false);
+    let div_id = ctx.create_element("div".to_string(), None, None, None);
+
+    ctx.set_inline_styles_number_key(div_id, 24, Some("grid-lanes".to_string()));
+    ctx.set_inline_styles_number_key(div_id, 237, Some("12px".to_string()));
+
+    let html = ctx.generate_html(div_id);
+    assert!(html.contains("display:grid-lanes;"));
+    assert!(html.contains("flow-tolerance:12px;"));
+  }
+
+  #[test]
   fn test_component_css_id() {
     let mut ctx = MainThreadServerContext::new("".to_string(), true, false, false, false);
     // Create a component with component_css_id = 42

--- a/packages/web-platform/web-core/src/style_transformer/inline_style.rs
+++ b/packages/web-platform/web-core/src/style_transformer/inline_style.rs
@@ -132,6 +132,13 @@ mod tests {
   }
 
   #[test]
+  fn test_display_grid_lanes_passes_through() {
+    let source = "display:grid-lanes;flow-tolerance:12px;";
+    let result = transform_inline_style_string(source, &TransformerConfig::default());
+    assert_eq!(result, source);
+  }
+
+  #[test]
   fn transform_color_normal() {
     let source = "color:blue;";
     let result = transform_inline_style_string(source, &TransformerConfig::default());

--- a/packages/web-platform/web-core/src/style_transformer/rules.rs
+++ b/packages/web-platform/web-core/src/style_transformer/rules.rs
@@ -344,6 +344,12 @@ mod tests {
   }
 
   #[test]
+  fn test_replace_rule_display_grid_lanes_passes_through() {
+    let result = get_replace_rule_value(&CSSPropertyEnum::Display.into(), "grid-lanes");
+    assert_eq!(result, None);
+  }
+
+  #[test]
   fn test_replace_rule_name_not_match() {
     let result = get_replace_rule_value(&CSSPropertyEnum::Height.into(), "linear");
     assert_eq!(result, None);

--- a/packages/web-platform/web-core/src/template/template_sections/style_info/css_property.rs
+++ b/packages/web-platform/web-core/src/template/template_sections/style_info/css_property.rs
@@ -225,10 +225,32 @@ const STYLE_PROPERTY_MAP: &[&str] = &[
   "hyphens",
   "-x-app-region",
   "-x-animation-color-interpolation",
-  "-x-handle-color",
   "-x-handle-size",
-  "offset-path",
+  "-x-handle-color",
   "offset-distance",
+  "offset-path",
+  "offset-rotate",
+  "font-variation-settings",
+  "font-feature-settings",
+  "font-optical-sizing",
+  "-x-placeholder-color",
+  "-x-placeholder-font-family",
+  "-x-placeholder-font-size",
+  "-x-placeholder-font-weight",
+  "-x-placeholder-font-style",
+  "pointer-events",
+  "-x-auto-font-size-line-ranges",
+  "grid-column",
+  "grid-row",
+  "mask-composite",
+  "x-caret-gradient",
+  "x-caret-width",
+  "x-caret-height",
+  "x-caret-radius",
+  "text-decoration-thickness",
+  "-x-text-decoration-width",
+  "-x-text-decoration-gap",
+  "flow-tolerance",
 ];
 
 lazy_static! {
@@ -457,15 +479,37 @@ pub enum CSSPropertyEnum {
   Hyphens = 209,
   XAppRegion = 210,
   XAnimationColorInterpolation = 211,
-  XHandleColor = 212,
-  XHandleSize = 213,
-  OffsetPath = 214,
-  OffsetDistance = 215,
+  XHandleSize = 212,
+  XHandleColor = 213,
+  OffsetDistance = 214,
+  OffsetPath = 215,
+  OffsetRotate = 216,
+  FontVariationSettings = 217,
+  FontFeatureSettings = 218,
+  FontOpticalSizing = 219,
+  XPlaceholderColor = 220,
+  XPlaceholderFontFamily = 221,
+  XPlaceholderFontSize = 222,
+  XPlaceholderFontWeight = 223,
+  XPlaceholderFontStyle = 224,
+  PointerEvents = 225,
+  XAutoFontSizeLineRanges = 226,
+  GridColumn = 227,
+  GridRow = 228,
+  MaskComposite = 229,
+  XCaretGradient = 230,
+  XCaretWidth = 231,
+  XCaretHeight = 232,
+  XCaretRadius = 233,
+  TextDecorationThickness = 234,
+  XTextDecorationWidth = 235,
+  XTextDecorationGap = 236,
+  FlowTolerance = 237,
 }
 
 impl CSSPropertyEnum {
   pub fn from_id(id: usize) -> Self {
-    if id <= CSSPropertyEnum::OffsetDistance as usize {
+    if id <= CSSPropertyEnum::FlowTolerance as usize {
       unsafe { std::mem::transmute::<u32, CSSPropertyEnum>(id as u32) }
     } else {
       CSSPropertyEnum::Unknown
@@ -642,6 +686,34 @@ mod tests {
       .position(|&s| s == "display")
       .unwrap();
     assert_eq!(display_idx, CSSPropertyEnum::Display as usize);
+    assert_eq!(
+      STYLE_PROPERTY_MAP[CSSPropertyEnum::XHandleSize as usize],
+      "-x-handle-size"
+    );
+    assert_eq!(
+      STYLE_PROPERTY_MAP[CSSPropertyEnum::XHandleColor as usize],
+      "-x-handle-color"
+    );
+    assert_eq!(
+      STYLE_PROPERTY_MAP[CSSPropertyEnum::OffsetDistance as usize],
+      "offset-distance"
+    );
+    assert_eq!(
+      STYLE_PROPERTY_MAP[CSSPropertyEnum::OffsetPath as usize],
+      "offset-path"
+    );
+    assert_eq!(
+      STYLE_PROPERTY_MAP[CSSPropertyEnum::FlowTolerance as usize],
+      "flow-tolerance"
+    );
+    assert_eq!(CSSProperty::from(212).to_string(), "-x-handle-size");
+    assert_eq!(CSSProperty::from(213).to_string(), "-x-handle-color");
+    assert_eq!(CSSProperty::from(214).to_string(), "offset-distance");
+    assert_eq!(CSSProperty::from(215).to_string(), "offset-path");
+    assert_eq!(
+      CSSProperty::from(237),
+      CSSProperty::from(CSSPropertyEnum::FlowTolerance)
+    );
 
     assert_eq!(
       CSSProperty::from(9999),

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -1589,6 +1589,17 @@ describe('Element APIs', () => {
     expect(inlineStyle).toContain('flex-shrink');
   });
 
+  test('__AddInlineStyle supports the grid-lanes display id', () => {
+    const root = mtsGlobalThis.__CreatePage('page', 0);
+    const view = mtsGlobalThis.__CreateView(0);
+    mtsGlobalThis.__SetID(view, 'target');
+    mtsGlobalThis.__AddInlineStyle(view, 24, 'grid-lanes');
+    mtsGlobalThis.__AppendElement(root, view);
+    mtsGlobalThis.__FlushElementTree();
+    const inlineStyle = rootDom.querySelector('#target')?.getAttribute('style');
+    expect(inlineStyle).toContain('display: grid-lanes');
+  });
+
   test('event upper case `Tap` works', () => {
     rstest.spyOn(mtsBinding, 'addEventListener');
     rstest.spyOn(mtsBinding, 'publishEvent');

--- a/packages/web-platform/web-elements/README.md
+++ b/packages/web-platform/web-elements/README.md
@@ -1,5 +1,16 @@
 # @lynx-js/web-elements
 
+## Grid lanes support
+
+`display: grid-lanes` uses the browser's native implementation when
+`CSS.supports('display', 'grid-lanes')` is true. Chromium requires the
+`CSSGridLanesLayout` feature flag until the feature is enabled by default.
+Safari 26.4 and later use the native value without a flag.
+
+Lynx for Web passes the value through without translating it to `masonry` or
+`grid`. On browsers that do not support `grid-lanes`, the declaration remains
+unsupported and normal CSS invalid-value handling applies.
+
 It provides the custom-element implementation of Lynx Elements in Web.
 
 So far, support compared to Lynx Elements on the client:

--- a/packages/webpack/css-extract-webpack-plugin/package.json
+++ b/packages/webpack/css-extract-webpack-plugin/package.json
@@ -55,7 +55,7 @@
     "sass-loader": "^17.0.0"
   },
   "peerDependencies": {
-    "@lynx-js/template-webpack-plugin": "^0.14.0 || ^0.15.0"
+    "@lynx-js/template-webpack-plugin": "^0.14.0 || ^0.15.0 || ^0.16.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/0.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.css.hot-update.json, size: 1542
+- Manifest: main.css.hot-update.json, size: 1574
 
 ## Manifest
 
@@ -38,6 +38,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/1.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1542
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1574
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1080
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/basic/__snapshot__/rspack/2.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1542
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1574
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1080
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/0.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.css.hot-update.json, size: 1542
+- Manifest: main.css.hot-update.json, size: 1570
 
 ## Manifest
 
@@ -38,6 +38,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/1.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1542
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1574
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1080
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/enable-css-selector/__snapshot__/rspack/2.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1814
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1846
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1080
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/0.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.css.hot-update.json, size: 1722
+- Manifest: main.css.hot-update.json, size: 1754
 
 ## Manifest
 
@@ -38,6 +38,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/1.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1722
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1754
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1093
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/css/scoped/__snapshot__/rspack/2.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 2034
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 2066
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1093
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/bundle-splitting/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/bundle-splitting/__snapshot__/rspack/0.snap.txt
@@ -7,9 +7,9 @@
 - Bundle: async/common.js
 - Bundle: async/lazy.js
 - Bundle: entry.js
-- Manifest: async/common.css.hot-update.json, size: 1248
-- Manifest: async/lazy.css.hot-update.json, size: 1554
-- Manifest: entry.css.hot-update.json, size: 1822
+- Manifest: async/common.css.hot-update.json, size: 1280
+- Manifest: async/lazy.css.hot-update.json, size: 1586
+- Manifest: entry.css.hot-update.json, size: 1850
 
 ## Manifest
 
@@ -42,6 +42,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -98,6 +99,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -186,6 +188,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/0.snap.txt
@@ -14,10 +14,10 @@
 - Bundle: main3/template.js
 - Bundle: main4.js
 - Bundle: main4/template.js
-- Manifest: index.css.hot-update.json, size: 2470
-- Manifest: main2.css.hot-update.json, size: 2470
-- Manifest: main3.css.hot-update.json, size: 2470
-- Manifest: main4.css.hot-update.json, size: 2470
+- Manifest: index.css.hot-update.json, size: 2502
+- Manifest: main2.css.hot-update.json, size: 2502
+- Manifest: main3.css.hot-update.json, size: 2502
+- Manifest: main4.css.hot-update.json, size: 2502
 
 ## Manifest
 
@@ -50,6 +50,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -213,6 +214,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -376,6 +378,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -539,6 +542,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/1.snap.txt
@@ -14,13 +14,13 @@
 - Bundle: main3/template.js
 - Bundle: main4.js
 - Bundle: main4/template.js
-- Manifest: index.LAST_HASH.css.hot-update.json, size: 2470
+- Manifest: index.LAST_HASH.css.hot-update.json, size: 2502
 - Manifest: index.LAST_HASH.hot-update.json, size: 29
-- Manifest: main2.LAST_HASH.css.hot-update.json, size: 2470
+- Manifest: main2.LAST_HASH.css.hot-update.json, size: 2502
 - Manifest: main2.LAST_HASH.hot-update.json, size: 29
-- Manifest: main3.LAST_HASH.css.hot-update.json, size: 2470
+- Manifest: main3.LAST_HASH.css.hot-update.json, size: 2502
 - Manifest: main3.LAST_HASH.hot-update.json, size: 29
-- Manifest: main4.LAST_HASH.css.hot-update.json, size: 2470
+- Manifest: main4.LAST_HASH.css.hot-update.json, size: 2502
 - Manifest: main4.LAST_HASH.hot-update.json, size: 29
 - Update: index.LAST_HASH.hot-update.js, size: 358
 - Update: main2.LAST_HASH.hot-update.js, size: 358
@@ -58,6 +58,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -235,6 +236,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -412,6 +414,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -589,6 +592,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/chunk-splitting/__snapshot__/rspack/2.snap.txt
@@ -14,13 +14,13 @@
 - Bundle: main3/template.js
 - Bundle: main4.js
 - Bundle: main4/template.js
-- Manifest: index.LAST_HASH.css.hot-update.json, size: 2470
+- Manifest: index.LAST_HASH.css.hot-update.json, size: 2502
 - Manifest: index.LAST_HASH.hot-update.json, size: 29
-- Manifest: main2.LAST_HASH.css.hot-update.json, size: 2470
+- Manifest: main2.LAST_HASH.css.hot-update.json, size: 2502
 - Manifest: main2.LAST_HASH.hot-update.json, size: 29
-- Manifest: main3.LAST_HASH.css.hot-update.json, size: 2470
+- Manifest: main3.LAST_HASH.css.hot-update.json, size: 2502
 - Manifest: main3.LAST_HASH.hot-update.json, size: 29
-- Manifest: main4.LAST_HASH.css.hot-update.json, size: 2470
+- Manifest: main4.LAST_HASH.css.hot-update.json, size: 2502
 - Manifest: main4.LAST_HASH.hot-update.json, size: 29
 - Update: index.LAST_HASH.hot-update.js, size: 358
 - Update: main2.LAST_HASH.hot-update.js, size: 358
@@ -58,6 +58,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -235,6 +236,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -412,6 +414,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,
@@ -589,6 +592,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/0.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.css.hot-update.json, size: 1870
+- Manifest: main.css.hot-update.json, size: 1898
 
 ## Manifest
 
@@ -38,6 +38,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/1.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1870
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1902
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1207
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/default/__snapshot__/rspack/2.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1870
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1902
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1207
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/0.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main/main.css.hot-update.json, size: 1870
+- Manifest: main/main.css.hot-update.json, size: 1898
 
 ## Manifest
 
@@ -38,6 +38,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Manifest: main/main.LAST_HASH.css.hot-update.json, size: 1870
+- Manifest: main/main.LAST_HASH.css.hot-update.json, size: 1902
 - Update: main.LAST_HASH.hot-update.js, size: 1212
 
 ## Manifest
@@ -54,6 +54,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/filename/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Manifest: main/main.LAST_HASH.css.hot-update.json, size: 1870
+- Manifest: main/main.LAST_HASH.css.hot-update.json, size: 1902
 - Update: main.LAST_HASH.hot-update.js, size: 1212
 
 ## Manifest
@@ -54,6 +54,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/0.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: pages/main/pages/main.css.hot-update.json, size: 1870
+- Manifest: pages/main/pages/main.css.hot-update.json, size: 1898
 
 ## Manifest
 
@@ -38,6 +38,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: pages/main.LAST_HASH.hot-update.json, size: 34
-- Manifest: pages/main/pages/main.LAST_HASH.css.hot-update.json, size: 1870
+- Manifest: pages/main/pages/main.LAST_HASH.css.hot-update.json, size: 1902
 - Update: pages/main.LAST_HASH.hot-update.js, size: 1236
 
 ## Manifest
@@ -54,6 +54,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/hot-update-json/nested/__snapshot__/rspack/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: rspack-bundle.js
 - Manifest: pages/main.LAST_HASH.hot-update.json, size: 34
-- Manifest: pages/main/pages/main.LAST_HASH.css.hot-update.json, size: 1870
+- Manifest: pages/main/pages/main.LAST_HASH.css.hot-update.json, size: 1902
 - Update: pages/main.LAST_HASH.hot-update.js, size: 1236
 
 ## Manifest
@@ -54,6 +54,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/0.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.css.hot-update.json, size: 1870
+- Manifest: main.css.hot-update.json, size: 1898
 
 ## Manifest
 
@@ -38,6 +38,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/1.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1870
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1902
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1207
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/basic/__snapshot__/rspack/2.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1870
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1902
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1207
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/0.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/0.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.css.hot-update.json, size: 1858
+- Manifest: main.css.hot-update.json, size: 1890
 
 ## Manifest
 
@@ -38,6 +38,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/1.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/1.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1862
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1890
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1286
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/2.snap.txt
+++ b/packages/webpack/css-extract-webpack-plugin/test/hotCases/modules/export-default/__snapshot__/rspack/2.snap.txt
@@ -5,7 +5,7 @@
 
 ## Asset Files
 - Bundle: rspack-bundle.js
-- Manifest: main.LAST_HASH.css.hot-update.json, size: 1862
+- Manifest: main.LAST_HASH.css.hot-update.json, size: 1890
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
 - Update: main.LAST_HASH.hot-update.js, size: 1286
 
@@ -40,6 +40,7 @@
         "enableNativeList": true,
         "enableNewSticky": true,
         "flexBasisZeroPercent": true,
+        "enableGridLanes": true,
         "enableGridPlacementShorthands": true,
         "syncXElementRegistry": true,
         "enableA11y": true,

--- a/packages/webpack/react-webpack-plugin/package.json
+++ b/packages/webpack/react-webpack-plugin/package.json
@@ -54,7 +54,7 @@
     "swc-loader": "^0.2.7"
   },
   "peerDependencies": {
-    "@lynx-js/template-webpack-plugin": "^0.13.0 || ^0.14.0 || ^0.15.0"
+    "@lynx-js/template-webpack-plugin": "^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
   },
   "peerDependenciesMeta": {
     "@lynx-js/react": {

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -1007,6 +1007,7 @@ class LynxTemplatePluginImpl {
 
     const intermediatePosix = intermediate.replace(/\\/g, '/');
 
+    const enableGridLanes = true;
     const encodeRawData: EncodeRawData = {
       compilerOptions: {
         enableFiberArch: true,
@@ -1035,6 +1036,7 @@ class LynxTemplatePluginImpl {
           enableNativeList: true,
           enableNewSticky: true,
           flexBasisZeroPercent: true,
+          enableGridLanes,
           enableGridPlacementShorthands: true,
           syncXElementRegistry: true,
           enableA11y,

--- a/packages/webpack/template-webpack-plugin/test/__snapshots__/cases.test.ts.snap
+++ b/packages/webpack/template-webpack-plugin/test/__snapshots__/cases.test.ts.snap
@@ -24,6 +24,7 @@ exports[`template > templateCases-cases/defaults/config > should pass 1`] = `
   enableA11y: true,
   enableAccessibilityElement: false,
   enableCSSInheritance: false,
+  enableGridLanes: true,
   enableGridPlacementShorthands: true,
   enableNativeList: true,
   enableNewGesture: false,

--- a/packages/webpack/template-webpack-plugin/test/basic.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/basic.test.ts
@@ -29,6 +29,39 @@ type DiagnosticError = Error & {
 };
 
 describe('LynxTemplatePlugin', () => {
+  test('enables grid lanes in the default page config', async () => {
+    let enableGridLanes: unknown;
+    const stats = await runWebpack({
+      context: dirname(fileURLToPath(import.meta.url)),
+      mode: 'development',
+      devtool: false,
+      output: {
+        iife: false,
+      },
+      entry: './fixtures/basic.tsx',
+      plugins: [
+        new LynxTemplatePlugin(),
+        function(this: Compiler) {
+          this.hooks.thisCompilation.tap('test', (compilation) => {
+            const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+              compilation,
+            );
+            hooks.beforeEncode.tap('test', (options) => {
+              enableGridLanes =
+                options.encodeData.sourceContent.config['enableGridLanes'];
+              return options;
+            });
+          });
+        },
+        new LynxEncodePlugin(),
+      ],
+    });
+
+    expect([...stats.compilation.errors]).toEqual([]);
+    expect(stats.compilation.children.flatMap(i => [...i.errors])).toEqual([]);
+    expect(enableGridLanes).toBe(true);
+  });
+
   test('build with custom lepus', async () => {
     const stats = await runWebpack({
       context: dirname(fileURLToPath(import.meta.url)),

--- a/packages/webpack/template-webpack-plugin/test/cases/defaults/config/index.js
+++ b/packages/webpack/template-webpack-plugin/test/cases/defaults/config/index.js
@@ -10,6 +10,8 @@ it('should match default pageConfig', async () => {
   );
 
   const { sourceContent } = JSON.parse(tasmJSON);
+  const { enableGridLanes } = sourceContent.config;
 
-  expect(sourceContent['config']).toMatchSnapshot();
+  expect(sourceContent.config).toMatchSnapshot();
+  expect(enableGridLanes).toBe(true);
 });


### PR DESCRIPTION
## Summary

- add `grid-lanes` and `flow-tolerance` support to Lynx for Web's numeric CSS table
- pass `display: grid-lanes` directly to the browser without translating it to `masonry` or `grid`
- enable Grid Lanes encoding in the template plugin and cover the same-bundle Mode B geometry path in Playwright

## Review scope

Tailwind preset utilities were removed from this PR at reviewer request. They live in the stacked draft Huxpro/lynx-stack#1 for separate extended review.

The style transformer does not emulate layout and has no Grid Lanes replace rule. `display: grid-lanes` passes through unchanged. Browsers with native support use it; unsupported browsers follow normal CSS invalid-value handling and do not receive an automatic `masonry` or plain-`grid` fallback. Plain `display: grid` also passes through unchanged.

## Dependency

This is M5 of lynx-family/lynx#8615 and closes lynx-family/lynx#8621.

Final toolchain version pins remain blocked on M1 package publication. This PR should not land before those artifacts are available and the exact pins are updated.

## Validation

- Web Core Rust style-transform focused suite — 81/81 passed
- Web Core tests — 355/355 passed
- Web Core E2E focused Turbo build — 18/18 tasks passed
- `basic-grid-lanes` Mode B — Chromium, WebKit, and Firefox 3/3 passed on rebased current main
- Template plugin focused tests — 6/6 passed
- changed-file dprint checks passed
- fallback variable/CSS references removed from the Web platform tree

The direct-pass-through patch was range-diff verified as identical after rebasing onto current main (`9c2be3e`), then revalidated with Rust 81/81, SSR 1/1, web-core 403/403, and a 2/2 Web Core dependency-closure build. Fresh CI is running on rebased head `ba35406ea`.

## Checklist

- [x] Tests updated.
- [x] Package and website documentation updated for direct browser pass-through.
- [x] Changesets added for the packages remaining in this PR.


