### PR TITLE
feat: add example-react-signals

### DIFF
--- a/examples/react-signals/lynx.config.js
+++ b/examples/react-signals/lynx.config.js
@@ -1,0 +1,18 @@
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx(),
+    pluginQRCode({
+      schema(url) {
+        return `${url}?fullscreen=true`;
+      },
+    }),
+  ],
+  environments: {
+    web: {},
+    lynx: {},
+  },
+});

--- a/examples/react-signals/package.json
+++ b/examples/react-signals/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@lynx-js/example-react-signals",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "test:type": "tsc6 --noEmit"
+  },
+  "dependencies": {
+    "@lynx-js/react": "workspace:*",
+    "@lynx-js/react-signals": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
+    "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/types": "4.1.0",
+    "@types/react": "^19.2.18"
+  }
+}

--- a/examples/react-signals/src/App.css
+++ b/examples/react-signals/src/App.css
@@ -1,0 +1,68 @@
+page {
+  background-color: #f5f7fb;
+}
+
+.App {
+  min-height: 100vh;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.Title {
+  color: #111827;
+  font-size: 30px;
+  font-weight: 700;
+}
+
+.Description {
+  margin-top: 12px;
+  color: #6b7280;
+  font-size: 16px;
+}
+
+.CounterValueBlock {
+  width: 280px;
+  margin-top: 32px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid #dbe3f0;
+  border-radius: 16px;
+  background-color: #ffffff;
+}
+
+.CounterValueLabel {
+  color: #64748b;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.CounterValue {
+  margin-top: 12px;
+  color: #111827;
+  font-size: 64px;
+  font-weight: 700;
+}
+
+.CounterRenderCount {
+  margin-top: 8px;
+  color: #64748b;
+  font-size: 14px;
+}
+
+.Button {
+  margin-top: 32px;
+  padding: 14px 28px;
+  border-radius: 12px;
+  background-color: #2563eb;
+}
+
+.ButtonText {
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 600;
+}

--- a/examples/react-signals/src/App.tsx
+++ b/examples/react-signals/src/App.tsx
@@ -1,0 +1,40 @@
+import { useRef } from '@lynx-js/react';
+import { useSignal } from '@lynx-js/react-signals';
+import type { Signal } from '@lynx-js/react-signals';
+
+import './App.css';
+
+function CounterValue({ count }: { count: Signal<number> }) {
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+
+  return (
+    <view className='CounterValueBlock'>
+      <text className='CounterValueLabel'>CounterValue component</text>
+      <text className='CounterValue'>{count.value}</text>
+      <text className='CounterRenderCount'>
+        Render count: {renderCount.current}
+      </text>
+    </view>
+  );
+}
+
+export function App() {
+  const count = useSignal(0);
+
+  const increment = () => {
+    'background-only';
+    const previousValue = count.value;
+    count.value = previousValue + 1;
+  };
+
+  return (
+    <view className='App'>
+      <text className='Title'>ReactLynx Signals</text>
+      <CounterValue count={count} />
+      <view className='Button' bindtap={increment}>
+        <text className='ButtonText'>Increment</text>
+      </view>
+    </view>
+  );
+}

--- a/examples/react-signals/src/index.tsx
+++ b/examples/react-signals/src/index.tsx
@@ -1,0 +1,9 @@
+import { root } from '@lynx-js/react';
+
+import { App } from './App.jsx';
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}

--- a/examples/react-signals/src/rspeedy-env.d.ts
+++ b/examples/react-signals/src/rspeedy-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@lynx-js/rspeedy/client" />

--- a/examples/react-signals/tsconfig.json
+++ b/examples/react-signals/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+    "noEmit": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedDeclarations": false,
+  },
+  "include": ["src", "lynx.config.js"],
+  "references": [
+    { "path": "../../packages/react/tsconfig.json" },
+    { "path": "../../packages/rspeedy/core/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-qrcode/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-react/tsconfig.build.json" },
+  ],
+}

--- a/packages/react-signals/README.md
+++ b/packages/react-signals/README.md
@@ -1,6 +1,7 @@
 # `@lynx-js/react-signals`
 
-Thread-aware Preact Signals integration for ReactLynx.
+Thread-aware [Preact Signals](https://preactjs.com/blog/introducing-signals/)
+integration for ReactLynx.
 
 ```tsx
 import { signal, useSignal } from '@lynx-js/react-signals';
@@ -8,3 +9,15 @@ import { signal, useSignal } from '@lynx-js/react-signals';
 
 The ReactLynx build keeps Signals reactive on the background thread and uses
 static values during main-thread first-screen rendering.
+
+## Reading Signals in JSX
+
+ReactLynx does not currently support consuming a `Signal` directly in JSX. Read
+its value through `.value` instead:
+
+```tsx
+<text>Value: {count.value}</text>;
+```
+
+Reading `signal.value` while rendering a component subscribes that component to
+the Signal. When the value changes, the subscribed component re-renders.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,31 @@ importers:
         specifier: ^19.2.18
         version: 19.2.18
 
+  examples/react-signals:
+    dependencies:
+      '@lynx-js/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@lynx-js/react-signals':
+        specifier: workspace:*
+        version: link:../../packages/react-signals
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-qrcode
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      '@lynx-js/types':
+        specifier: 4.1.0
+        version: 4.1.0
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+
   examples/react-ui-sourcemap:
     dependencies:
       '@lynx-js/react':


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a React Signals counter example for Lynx, including interactive count updates and render-count visibility.
  * Added a runnable development and build setup for the example across web and Lynx environments.
  * Added QR-code launch links configured for fullscreen mode.

* **Documentation**
  * Clarified that Signals must be accessed through `.value` in JSX and explained the resulting subscription and re-render behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
