### PR TITLE
refactor(react): reach lynx-core's app object through lynx.getApp()

### DIFF
--- a/.changeset/app-object-via-get-app.md
+++ b/.changeset/app-object-via-get-app.md
@@ -1,8 +1,7 @@
 ---
-"@lynx-js/react-runtime": patch
+"@lynx-js/react": patch
 "@lynx-js/cache-events-webpack-plugin": patch
 "@lynx-js/testing-environment": patch
-"@lynx-js/reactlynx-testing-library": patch
 ---
 
 Reach lynx-core's app object through `lynx.getApp()` instead of the

--- a/.changeset/app-object-via-get-app.md
+++ b/.changeset/app-object-via-get-app.md
@@ -1,0 +1,12 @@
+---
+"@lynx-js/react-runtime": patch
+"@lynx-js/cache-events-webpack-plugin": patch
+"@lynx-js/testing-environment": patch
+"@lynx-js/reactlynx-testing-library": patch
+---
+
+Reach lynx-core's app object through `lynx.getApp()` instead of the
+`lynxCoreInject` global the AMD wrapper injects. It is the same instance, so
+behavior is unchanged, and resolving it through `lynx` also stays correct once
+several cards share a runtime chunk. `@lynx-js/testing-environment` now exposes
+`lynx.getApp()` alongside the object it already provided.

--- a/packages/react/runtime/__test__/core/globalProps.test.ts
+++ b/packages/react/runtime/__test__/core/globalProps.test.ts
@@ -12,20 +12,20 @@ import { LynxTestEventEmitter } from '../test-utils/lynx-event-emitter.js';
 
 describe('core/globalProps', () => {
   let originalGlobalProps: typeof lynx.__globalProps;
-  let originalEmitter: typeof lynxCoreInject.tt.GlobalEventEmitter;
+  let originalEmitter: LynxApp['GlobalEventEmitter'];
   let emitter: LynxTestEventEmitter;
 
   beforeEach(() => {
     originalGlobalProps = lynx.__globalProps;
-    originalEmitter = lynxCoreInject.tt.GlobalEventEmitter;
+    originalEmitter = lynx.getApp().GlobalEventEmitter;
     emitter = new LynxTestEventEmitter();
     lynx.__globalProps = {};
-    lynxCoreInject.tt.GlobalEventEmitter = emitter as typeof lynxCoreInject.tt.GlobalEventEmitter;
+    lynx.getApp().GlobalEventEmitter = emitter as LynxApp['GlobalEventEmitter'];
   });
 
   afterEach(() => {
     lynx.__globalProps = originalGlobalProps;
-    lynxCoreInject.tt.GlobalEventEmitter = originalEmitter;
+    lynx.getApp().GlobalEventEmitter = originalEmitter;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });

--- a/packages/react/runtime/__test__/element-template/imports/suspense-lazy.test.ts
+++ b/packages/react/runtime/__test__/element-template/imports/suspense-lazy.test.ts
@@ -130,7 +130,7 @@ describe('element-template Suspense and lazy imports', () => {
 
     originalQueryComponent = (lynx as LynxWithDynamicImportMocks).QueryComponent;
     originalRequireModuleAsync = (lynx as LynxWithDynamicImportMocks).requireModuleAsync;
-    originalGetDynamicComponentExports = (lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    originalGetDynamicComponentExports = (lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: DynamicExportsGetter;
     }).getDynamicComponentExports;
     originalLazyTargetDescriptors = captureLazyTargetDescriptors();
@@ -144,7 +144,7 @@ describe('element-template Suspense and lazy imports', () => {
       originalRequireModuleAsync,
     );
     restoreProperty(
-      lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+      lynx.getApp() as LynxApp & {
         getDynamicComponentExports?: DynamicExportsGetter;
       },
       'getDynamicComponentExports',
@@ -181,7 +181,7 @@ describe('element-template Suspense and lazy imports', () => {
     });
     const getDynamicComponentExports = vi.fn((schema: string) => makeExports(schema));
     (lynx as LynxWithDynamicImportMocks).QueryComponent = QueryComponent;
-    (lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    (lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: DynamicExportsGetter;
     }).getDynamicComponentExports = getDynamicComponentExports;
 

--- a/packages/react/runtime/__test__/element-template/lynx/env.test.ts
+++ b/packages/react/runtime/__test__/element-template/lynx/env.test.ts
@@ -96,7 +96,7 @@ describe('setupLynxEnv', () => {
 
   it('merges initData and updateData in JS env', () => {
     envManager.resetEnv('background');
-    globalThis.lynxCoreInject.tt._params = {
+    globalThis.lynx.getApp()._params = {
       initData: { answer: 41, stale: true },
       updateData: { answer: 42, fresh: true },
     };
@@ -114,7 +114,7 @@ describe('setupLynxEnv', () => {
 
   it('falls back to empty initData when reading params throws', () => {
     envManager.resetEnv('background');
-    Object.defineProperty(globalThis.lynxCoreInject.tt, '_params', {
+    Object.defineProperty(globalThis.lynx.getApp(), '_params', {
       configurable: true,
       get() {
         throw new Error('boom');
@@ -128,7 +128,7 @@ describe('setupLynxEnv', () => {
 
   it('treats missing initData and updateData params as empty objects in JS env', () => {
     envManager.resetEnv('background');
-    Object.defineProperty(globalThis.lynxCoreInject.tt, '_params', {
+    Object.defineProperty(globalThis.lynx.getApp(), '_params', {
       configurable: true,
       value: {
         initData: undefined,

--- a/packages/react/runtime/__test__/element-template/lynx/lazy-bundle.test.ts
+++ b/packages/react/runtime/__test__/element-template/lynx/lazy-bundle.test.ts
@@ -66,7 +66,7 @@ describe('element-template loadLazyBundle', () => {
     originalQueryComponent = g.__QueryComponent;
     originalLynxQueryComponent = (lynx as LynxWithQuery).QueryComponent;
     originalGetNativeLynx = lynx.getNativeLynx;
-    originalGetDynamicComponentExports = (lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    originalGetDynamicComponentExports = (lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: DynamicExportsGetter;
     }).getDynamicComponentExports;
   });
@@ -76,7 +76,7 @@ describe('element-template loadLazyBundle', () => {
     restoreProperty(lynx as LynxWithQuery, 'QueryComponent', originalLynxQueryComponent);
     lynx.getNativeLynx = originalGetNativeLynx;
     restoreProperty(
-      lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+      lynx.getApp() as LynxApp & {
         getDynamicComponentExports?: DynamicExportsGetter;
       },
       'getDynamicComponentExports',
@@ -186,7 +186,7 @@ describe('element-template loadLazyBundle', () => {
     });
     const getDynamicComponentExports = vi.fn((schema: string) => makeExports(schema));
     (lynx as LynxWithQuery).QueryComponent = QueryComponent;
-    (lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    (lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: DynamicExportsGetter;
     }).getDynamicComponentExports = getDynamicComponentExports;
 
@@ -211,7 +211,7 @@ describe('element-template loadLazyBundle', () => {
     });
     const getDynamicComponentExports = vi.fn((schema: string) => makeExports(schema));
     (lynx as LynxWithQuery).QueryComponent = QueryComponent;
-    (lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    (lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: DynamicExportsGetter;
     }).getDynamicComponentExports = getDynamicComponentExports;
 
@@ -246,7 +246,7 @@ describe('element-template loadLazyBundle', () => {
     });
     const getDynamicComponentExports = vi.fn(() => undefined);
     (lynx as LynxWithQuery).QueryComponent = QueryComponent;
-    (lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    (lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: DynamicExportsGetter;
     }).getDynamicComponentExports = getDynamicComponentExports;
 
@@ -269,7 +269,7 @@ describe('element-template loadLazyBundle', () => {
       ({
         QueryComponent: nativeQueryComponent,
       }) as ReturnType<typeof lynx.getNativeLynx>;
-    (lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    (lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: DynamicExportsGetter;
     }).getDynamicComponentExports = getDynamicComponentExports;
 

--- a/packages/react/runtime/__test__/element-template/native/index.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/index.test.ts
@@ -195,14 +195,14 @@ describe('element-template native index wiring', () => {
     expect(initProfileHook).toHaveBeenCalledTimes(1);
     expect(setupLynxEnv).toHaveBeenCalledTimes(1);
     expect(resetEventStateForRuntime).toHaveBeenCalledTimes(1);
-    expect(globalThis.lynxCoreInject.tt.callDestroyLifetimeFun).toBe(callDestroyLifetimeFun);
-    expect(globalThis.lynxCoreInject.tt.publishEvent).toBe(publishEvent);
-    expect(globalThis.lynxCoreInject.tt.publicComponentEvent).toBe(publicComponentEvent);
-    expect(globalThis.lynxCoreInject.tt.updateGlobalProps).toEqual(expect.any(Function));
-    expect(globalThis.lynxCoreInject.tt.updateCardData).toBe(updateCardData);
-    expect(globalThis.lynxCoreInject.tt.onAppReload).toBe(reloadBackground);
+    expect(globalThis.lynx.getApp().callDestroyLifetimeFun).toBe(callDestroyLifetimeFun);
+    expect(globalThis.lynx.getApp().publishEvent).toBe(publishEvent);
+    expect(globalThis.lynx.getApp().publicComponentEvent).toBe(publicComponentEvent);
+    expect(globalThis.lynx.getApp().updateGlobalProps).toEqual(expect.any(Function));
+    expect(globalThis.lynx.getApp().updateCardData).toBe(updateCardData);
+    expect(globalThis.lynx.getApp().onAppReload).toBe(reloadBackground);
 
-    globalThis.lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+    globalThis.lynx.getApp().updateGlobalProps({ theme: 'light' });
     expect(updateGlobalProps).toHaveBeenCalledWith(
       { theme: 'light' },
       { forceRerender: expect.any(Function) },

--- a/packages/react/runtime/__test__/element-template/runtime/background/global-props.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/global-props.test.tsx
@@ -44,7 +44,7 @@ async function setupGlobalPropsRuntime(mode: 'reactive' | 'event') {
   envManager.setUseElementTemplate(true);
 
   const baseLynx = globalThis.lynx;
-  const originalGlobalEventEmitter = globalThis.lynxCoreInject.tt.GlobalEventEmitter;
+  const originalGlobalEventEmitter = globalThis.lynx.getApp().GlobalEventEmitter;
   vi.stubGlobal('lynx', {
     ...baseLynx,
     __globalProps: { theme: 'dark', stable: true },
@@ -55,7 +55,7 @@ async function setupGlobalPropsRuntime(mode: 'reactive' | 'event') {
       return baseLynx.getJSModule?.(moduleName);
     },
   });
-  globalThis.lynxCoreInject.tt.GlobalEventEmitter = emitter as typeof lynxCoreInject.tt.GlobalEventEmitter;
+  globalThis.lynx.getApp().GlobalEventEmitter = emitter as LynxApp['GlobalEventEmitter'];
 
   const et = await import('../../../../src/element-template/index.js');
 
@@ -75,7 +75,7 @@ async function setupGlobalPropsRuntime(mode: 'reactive' | 'event') {
       envManager.switchToBackground();
       resetElementTemplateHydrationListener();
       resetElementTemplateCommitState();
-      globalThis.lynxCoreInject.tt.GlobalEventEmitter = originalGlobalEventEmitter;
+      globalThis.lynx.getApp().GlobalEventEmitter = originalGlobalEventEmitter;
     },
   };
 }
@@ -102,7 +102,7 @@ describe('ElementTemplate background GlobalProps', () => {
       runtime.root.render(createElement(App));
       runtime.updateEvents.length = 0;
 
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       await waitForRender();
 
       expect(lynx.__globalProps).toEqual({ theme: 'light', stable: true });
@@ -130,7 +130,7 @@ describe('ElementTemplate background GlobalProps', () => {
       runtime.updateEvents.length = 0;
 
       const previousGlobalProps = lynx.__globalProps;
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       await waitForRender();
 
       expect(lynx.__globalProps).not.toBe(previousGlobalProps);
@@ -161,7 +161,7 @@ describe('ElementTemplate background GlobalProps', () => {
       runtime.root.render(createElement(App));
       runtime.updateEvents.length = 0;
 
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       await waitForRender();
 
       expect(changed).toHaveBeenCalledWith(lynx.__globalProps);

--- a/packages/react/runtime/__test__/element-template/runtime/background/global-props/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/global-props/compiled-fixtures.test.tsx
@@ -71,7 +71,7 @@ async function settleInitialHydration(envManager: InstanceType<typeof ElementTem
 describe('Compiled ET GlobalProps update fixtures', () => {
   const envManager = new ElementTemplateEnvManager();
   let originalLynx: typeof lynx;
-  let originalGlobalEventEmitter: typeof lynxCoreInject.tt.GlobalEventEmitter;
+  let originalGlobalEventEmitter: LynxApp['GlobalEventEmitter'];
   let emitter: InstanceType<typeof LynxTestEventEmitter>;
   let updateEvents: ElementTemplateUpdateCommitContext[] = [];
 
@@ -91,7 +91,7 @@ describe('Compiled ET GlobalProps update fixtures', () => {
         return baseLynx.getJSModule?.(moduleName);
       },
     });
-    globalThis.lynxCoreInject.tt.GlobalEventEmitter = emitter as typeof lynxCoreInject.tt.GlobalEventEmitter;
+    globalThis.lynx.getApp().GlobalEventEmitter = emitter as LynxApp['GlobalEventEmitter'];
   }
 
   function renderFixtureOnBackground(
@@ -112,7 +112,7 @@ describe('Compiled ET GlobalProps update fixtures', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     originalLynx = globalThis.lynx;
-    originalGlobalEventEmitter = globalThis.lynxCoreInject.tt.GlobalEventEmitter;
+    originalGlobalEventEmitter = globalThis.lynx.getApp().GlobalEventEmitter;
     emitter = new LynxTestEventEmitter();
     updateEvents = [];
     resetElementTemplateCommitState();
@@ -139,7 +139,7 @@ describe('Compiled ET GlobalProps update fixtures', () => {
     resetElementTemplateCommitState();
     envManager.setUseElementTemplate(false);
     globalThis.__GLOBAL_PROPS_MODE__ = 'event';
-    globalThis.lynxCoreInject.tt.GlobalEventEmitter = originalGlobalEventEmitter;
+    globalThis.lynx.getApp().GlobalEventEmitter = originalGlobalEventEmitter;
     vi.stubGlobal('lynx', originalLynx);
   });
 
@@ -157,7 +157,7 @@ describe('Compiled ET GlobalProps update fixtures', () => {
     await settleInitialHydration(envManager);
     updateEvents = [];
 
-    lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+    lynx.getApp().updateGlobalProps({ theme: 'light' });
     await waitForRender();
 
     envManager.switchToMainThread();
@@ -182,7 +182,7 @@ describe('Compiled ET GlobalProps update fixtures', () => {
     updateEvents = [];
 
     const previousGlobalProps = lynx.__globalProps;
-    lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+    lynx.getApp().updateGlobalProps({ theme: 'light' });
     await waitForRender();
 
     expect(lynx.__globalProps).not.toBe(previousGlobalProps);
@@ -209,7 +209,7 @@ describe('Compiled ET GlobalProps update fixtures', () => {
     await settleInitialHydration(envManager);
     updateEvents = [];
 
-    lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+    lynx.getApp().updateGlobalProps({ theme: 'light' });
     await waitForRender();
 
     expect(changed).toHaveBeenCalledWith(lynx.__globalProps);

--- a/packages/react/runtime/__test__/element-template/runtime/background/suspense.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/suspense.test.tsx
@@ -770,7 +770,7 @@ describe('ElementTemplate Suspense background lifecycle', () => {
     const lynxWithQuery = lynx as typeof lynx & {
       QueryComponent?: (source: string, callback: QueryComponentCallback) => void;
     };
-    const ttWithDynamic = lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    const ttWithDynamic = lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: (schema: string) => { default: ComponentType<Record<string, never>> } | undefined;
     };
     const originalQueryComponent = lynxWithQuery.QueryComponent;
@@ -852,7 +852,7 @@ describe('ElementTemplate Suspense background lifecycle', () => {
     const lynxWithQuery = lynx as typeof lynx & {
       QueryComponent?: (source: string, callback: QueryComponentCallback) => void;
     };
-    const ttWithDynamic = lynxCoreInject.tt as typeof lynxCoreInject.tt & {
+    const ttWithDynamic = lynx.getApp() as LynxApp & {
       getDynamicComponentExports?: (schema: string) => { default: ComponentType<Record<string, never>> } | undefined;
     };
     const originalQueryComponent = lynxWithQuery.QueryComponent;

--- a/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
@@ -564,7 +564,7 @@ describe('ElementTemplate hydration listener', () => {
     backgroundRoot.appendChild(after);
     const oldId = after.instanceId;
 
-    const tt = (globalThis as unknown as { lynxCoreInject: { tt: TTMock } }).lynxCoreInject.tt;
+    const tt = lynx.getApp() as unknown as TTMock;
     tt.callDestroyLifetimeFun?.();
 
     envManager.switchToMainThread();

--- a/packages/react/runtime/__test__/element-template/test-utils/debug/renderFixtureRunner.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/debug/renderFixtureRunner.ts
@@ -155,19 +155,7 @@ async function runCompiledRenderFixture(options: {
   globalThis.__MAIN_THREAD__ = true;
   globalThis.__BACKGROUND__ = false;
 
-  const globalWithInject = globalThis as typeof globalThis & {
-    lynxCoreInject?: {
-      tt?: {
-        _params?: {
-          initData: Record<string, unknown>;
-          updateData: Record<string, unknown>;
-        };
-      };
-    };
-  };
-  globalWithInject.lynxCoreInject ??= {};
-  globalWithInject.lynxCoreInject.tt ??= {};
-  globalWithInject.lynxCoreInject.tt._params ??= { initData: {}, updateData: {} };
+  lynx.getApp()._params ??= { initData: {}, updateData: {} };
 
   const installed = installMockNativePapi({ clearTemplatesOnCleanup: true });
   const nativeLog = installed.nativeLog as unknown[];

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/globals.js
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/globals.js
@@ -23,10 +23,10 @@ export function injectGlobals() {
   globalThis.SystemInfo = {
     lynxSdkVersion: '4.0',
   };
-  globalThis.lynxCoreInject = {};
-  globalThis.lynxCoreInject.tt = {};
+  const lynxApp = {};
 
   installPerformanceGlobals();
+  globalThis.lynx.getApp = () => lynxApp;
 
   globalThis.requestAnimationFrame = setTimeout;
   globalThis.cancelAnimationFrame = clearTimeout;

--- a/packages/react/runtime/__test__/element-template/test-utils/setup.js
+++ b/packages/react/runtime/__test__/element-template/test-utils/setup.js
@@ -32,7 +32,7 @@ afterEach(() => {
   g.__BACKGROUND__ = true;
 
   try {
-    g.lynxCoreInject?.tt?.callDestroyLifetimeFun?.();
+    g.lynx?.getApp?.().callDestroyLifetimeFun?.();
   } catch {}
 
   g.__LEPUS__ = true;

--- a/packages/react/runtime/__test__/snapshot/clone.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/clone.test.jsx
@@ -889,7 +889,7 @@ describe('clone element', () => {
     render(clone, __root);
 
     // hydrate
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
     // rLynxChange
     globalEnvManager.switchToMainThread();
@@ -936,7 +936,7 @@ describe('clone element', () => {
     render(clone, __root);
 
     // hydrate
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
     // rLynxChange
     globalEnvManager.switchToMainThread();

--- a/packages/react/runtime/__test__/snapshot/compat/initData.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/compat/initData.test.jsx
@@ -85,7 +85,7 @@ describe('withInitDataInState', () => {
   const _App = withInitDataInState(App);
   it('should inject `__initData` to `state` of component', async () => {
     render(<_App />, scratch);
-    const tt = lynxCoreInject.tt;
+    const tt = lynx.getApp();
     expect(app.state).toMatchInlineSnapshot(`{}`);
     tt.updateCardData({
       key2: 'value2',
@@ -113,7 +113,7 @@ describe('withInitDataInState', () => {
   it('updateCardData twice', async () => {
     const _App = withInitDataInState(App);
     render(<_App />, scratch);
-    const tt = lynxCoreInject.tt;
+    const tt = lynx.getApp();
     expect(app.state).toMatchInlineSnapshot(`{}`);
     tt.updateCardData({
       key3: 'value3',
@@ -151,7 +151,7 @@ describe('withInitDataInState', () => {
   });
 
   it('resets initData and strips timing flag before emitting data changes', () => {
-    const tt = lynxCoreInject.tt;
+    const tt = lynx.getApp();
     const emitter = lynx.getJSModule('GlobalEventEmitter');
     const listener = vi.fn();
     const originalReportError = lynx.reportError;

--- a/packages/react/runtime/__test__/snapshot/createElement.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/createElement.test.jsx
@@ -93,7 +93,7 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -230,10 +230,10 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
-    lynxCoreInject.tt.publishEvent('-2:0:bindtap', 'data');
+    lynx.getApp().publishEvent('-2:0:bindtap', 'data');
     expect(handleTap).toHaveBeenCalledTimes(1);
     expect(handleTap).toHaveBeenCalledWith('data');
   });
@@ -276,7 +276,7 @@ describe('createElement', () => {
     render(<App />, __root);
 
     // LifecycleConstant.firstScreen
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
     // rLynxChange
     globalEnvManager.switchToMainThread();
@@ -526,7 +526,7 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -645,7 +645,7 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -776,7 +776,7 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -864,7 +864,7 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -951,7 +951,7 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -1072,7 +1072,7 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -1195,7 +1195,7 @@ describe('createElement', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange

--- a/packages/react/runtime/__test__/snapshot/delayed-lifecycle-events.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/delayed-lifecycle-events.test.jsx
@@ -37,7 +37,7 @@ describe('delayedLifecycleEvents', () => {
         ],
       ]
     `);
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     expect(delayedLifecycleEvents).toMatchInlineSnapshot(`
       [
         [

--- a/packages/react/runtime/__test__/snapshot/event.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/event.test.jsx
@@ -85,7 +85,7 @@ describe('eventUpdate', () => {
 
     // LifecycleConstant.firstScreen
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls).toMatchInlineSnapshot(`
         [
           [
@@ -110,7 +110,7 @@ describe('eventUpdate', () => {
       `);
     }
 
-    lynxCoreInject.tt.publishEvent('-2:1:', 'data');
+    lynx.getApp().publishEvent('-2:1:', 'data');
     expect(handleTap1).toHaveBeenCalledTimes(0);
     expect(handleTap2).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledWith('data');
@@ -118,7 +118,7 @@ describe('eventUpdate', () => {
 
     const reportError = lynx.reportError;
     lynx.reportError = vi.fn();
-    lynxCoreInject.tt.publishEvent('-2:0:', 'data');
+    lynx.getApp().publishEvent('-2:0:', 'data');
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(lynx.reportError).toHaveBeenCalledTimes(1);
     expect(lynx.reportError).toHaveBeenCalledWith(
@@ -177,7 +177,7 @@ describe('eventUpdate', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -254,7 +254,7 @@ describe('eventUpdate', () => {
     `);
     globalEnvManager.switchToBackground();
 
-    lynxCoreInject.tt.publishEvent('-2:1:', 'data');
+    lynx.getApp().publishEvent('-2:1:', 'data');
     expect(handleTap1).toHaveBeenCalledTimes(0);
     expect(handleTap2).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledWith('data');
@@ -290,7 +290,7 @@ describe('eventUpdate', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).toMatchInlineSnapshot(
         `"{"patchList":[{"snapshotPatch":[],"id":3}]}"`,
       );
@@ -346,7 +346,7 @@ describe('eventUpdate', () => {
     `);
     globalEnvManager.switchToBackground();
 
-    lynxCoreInject.tt.publishEvent('3:0:', 'data');
+    lynx.getApp().publishEvent('3:0:', 'data');
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap1).toHaveBeenCalledWith('data');
   });
@@ -409,7 +409,7 @@ describe('eventUpdate', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).toMatchInlineSnapshot(
         `"{"patchList":[{"snapshotPatch":[],"id":4}]}"`,
       );
@@ -421,12 +421,12 @@ describe('eventUpdate', () => {
     }
 
     globalEnvManager.switchToBackground();
-    lynxCoreInject.tt.publishEvent('-2:0:', 'data1');
+    lynx.getApp().publishEvent('-2:0:', 'data1');
     expect(handleTap2).toHaveBeenCalledTimes(0);
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap1).toHaveBeenCalledWith('data1');
 
-    lynxCoreInject.tt.publishEvent('-2:1:', 'data2');
+    lynx.getApp().publishEvent('-2:1:', 'data2');
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledWith('data2');
@@ -440,12 +440,12 @@ describe('eventUpdate', () => {
     snapshotPatchApply(patch);
     globalEnvManager.switchToBackground();
 
-    lynxCoreInject.tt.publishEvent('-2:0:', 'data3');
+    lynx.getApp().publishEvent('-2:0:', 'data3');
     expect(handleTap2).toHaveBeenCalledTimes(0);
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap1).toHaveBeenCalledWith('data3');
 
-    lynxCoreInject.tt.publishEvent('-2:1:', 'data4');
+    lynx.getApp().publishEvent('-2:1:', 'data4');
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledWith('data4');
@@ -505,7 +505,7 @@ describe('eventUpdate', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).toMatchInlineSnapshot(
         `"{"patchList":[{"snapshotPatch":[3,-2,1,"-2:1:"],"id":5}]}"`,
       );
@@ -518,12 +518,12 @@ describe('eventUpdate', () => {
 
     globalEnvManager.switchToBackground();
 
-    lynxCoreInject.tt.publishEvent('-2:0:', 'data1');
+    lynx.getApp().publishEvent('-2:0:', 'data1');
     expect(handleTap2).toHaveBeenCalledTimes(0);
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap1).toHaveBeenCalledWith('data1');
 
-    lynxCoreInject.tt.publishEvent('-2:1:', 'data2');
+    lynx.getApp().publishEvent('-2:1:', 'data2');
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledWith('data2');
@@ -587,7 +587,7 @@ describe('eventUpdate', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).toMatchInlineSnapshot(
         `"{"patchList":[{"snapshotPatch":[],"id":6}]}"`,
       );
@@ -720,7 +720,7 @@ describe('event in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).toMatchInlineSnapshot(
         `"{"patchList":[{"snapshotPatch":[],"id":7}]}"`,
       );
@@ -757,7 +757,7 @@ describe('event in spread', () => {
     }
 
     globalEnvManager.switchToBackground();
-    lynxCoreInject.tt.publishEvent('-2:1:bindtouchstart', 'data');
+    lynx.getApp().publishEvent('-2:1:bindtouchstart', 'data');
     expect(handleTouchStart).toHaveBeenCalledTimes(1);
     expect(handleTouchStart).toHaveBeenCalledWith('data');
     handleTouchStart.mockReset();
@@ -818,15 +818,15 @@ describe('event in spread', () => {
     `);
     globalEnvManager.switchToBackground();
 
-    lynxCoreInject.tt.publishEvent('-2:0:bindtap', 'data');
+    lynx.getApp().publishEvent('-2:0:bindtap', 'data');
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap1).toHaveBeenCalledWith('data');
 
-    lynxCoreInject.tt.publishEvent('-2:1:bindtap', 'data');
+    lynx.getApp().publishEvent('-2:1:bindtap', 'data');
     expect(handleTap2).toHaveBeenCalledTimes(1);
     expect(handleTap2).toHaveBeenCalledWith('data');
 
-    lynxCoreInject.tt.publishEvent('-2:1:bindtouchstart', 'data');
+    lynx.getApp().publishEvent('-2:1:bindtouchstart', 'data');
     expect(handleTouchStart).toHaveBeenCalledTimes(1);
     expect(handleTouchStart).toHaveBeenCalledWith('data');
 
@@ -918,7 +918,7 @@ describe('event in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).toMatchInlineSnapshot(
         `"{"patchList":[{"snapshotPatch":[],"id":8}]}"`,
       );
@@ -975,7 +975,7 @@ describe('event in spread', () => {
     `);
     globalEnvManager.switchToBackground();
 
-    lynxCoreInject.tt.publishEvent('3:0:bindtap', 'data');
+    lynx.getApp().publishEvent('3:0:bindtap', 'data');
     expect(handleTap1).toHaveBeenCalledTimes(1);
     expect(handleTap1).toHaveBeenCalledWith('data');
   });
@@ -1115,9 +1115,9 @@ describe('event when firstScreenSyncTiming is jsReady', () => {
       `);
     }
 
-    lynxCoreInject.tt.publishEvent('-3:0:', 'event 1');
-    lynxCoreInject.tt.publishEvent('-6:0:', 'event 2');
-    lynxCoreInject.tt.publishEvent('-9:0:', 'event 3');
+    lynx.getApp().publishEvent('-3:0:', 'event 1');
+    lynx.getApp().publishEvent('-6:0:', 'event 2');
+    lynx.getApp().publishEvent('-9:0:', 'event 3');
 
     // background render
     {
@@ -1142,7 +1142,7 @@ describe('event when firstScreenSyncTiming is jsReady', () => {
       // LifecycleConstant.firstScreen
       globalEnvManager.switchToBackground();
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(rLynxFirstScreen).toMatchInlineSnapshot(`
         [
           [
@@ -1250,14 +1250,14 @@ describe('call `root.render()` async', () => {
       __root[CHILDREN] = null;
     }
 
-    lynxCoreInject.tt.publishEvent('-3:0:', 'event 1');
+    lynx.getApp().publishEvent('-3:0:', 'event 1');
 
     // hydrate
     {
       // LifecycleConstant.firstScreen
       globalEnvManager.switchToBackground();
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
 
       expect(delayedLifecycleEvents).toMatchInlineSnapshot(`
         [

--- a/packages/react/runtime/__test__/snapshot/gesture.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/gesture.test.jsx
@@ -111,7 +111,7 @@ describe('Gesture', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -245,7 +245,7 @@ describe('Gesture', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -340,7 +340,7 @@ describe('Gesture', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -495,7 +495,7 @@ describe('Gesture', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -617,7 +617,7 @@ describe('Gesture', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -731,7 +731,7 @@ describe('Gesture in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -862,7 +862,7 @@ describe('Gesture in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -972,7 +972,7 @@ describe('Gesture in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -1095,7 +1095,7 @@ describe('Gesture in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -1171,7 +1171,7 @@ describe('Gesture in spread', () => {
     }
 
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
@@ -1265,7 +1265,7 @@ describe('Gesture in spread', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
@@ -1353,7 +1353,7 @@ describe('Gesture in spread', () => {
     }
 
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];

--- a/packages/react/runtime/__test__/snapshot/lazy.test.js
+++ b/packages/react/runtime/__test__/snapshot/lazy.test.js
@@ -1,6 +1,6 @@
 import '../../lazy/import.js';
 
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, onTestFinished, test, vi } from 'vitest';
 import * as ReactExports from '../../lazy/react.js';
 import * as ReactCompatExports from '../../lazy/compat.js';
 import * as ReactLepusExports from '../../lazy/react-lepus.js';
@@ -141,6 +141,7 @@ describe('Lazy Exports', () => {
 
     const lynx = {};
     vi.stubGlobal('lynx', lynx);
+    onTestFinished(() => vi.unstubAllGlobals());
     vi.stubGlobal('__LEPUS__', false);
 
     const { target } = await import('../../lazy/target.js');
@@ -179,12 +180,12 @@ describe('Lazy Exports', () => {
   });
 
   test('throws before ET lazy import initializes ET runtime under a Snapshot template', async () => {
-    const originalUpdateCardData = lynxCoreInject.tt.updateCardData;
+    const originalUpdateCardData = lynx.getApp().updateCardData;
 
     await expect(import('../../lazy/element-template-import.js')).rejects.toThrow(
       'Snapshot and Element Template templates cannot share lazy bundles.',
     );
-    expect(lynxCoreInject.tt.updateCardData).toBe(originalUpdateCardData);
+    expect(lynx.getApp().updateCardData).toBe(originalUpdateCardData);
   });
 
   test('throws when an ET runtime marker imports the Snapshot standalone lazy entry', async () => {

--- a/packages/react/runtime/__test__/snapshot/lifecycle.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle.test.jsx
@@ -367,7 +367,7 @@ describe('componentWillUnmount', () => {
 
     expect(willUnmount).toHaveBeenCalledTimes(1);
 
-    lynxCoreInject.tt.callDestroyLifetimeFun();
+    lynx.getApp().callDestroyLifetimeFun();
     expect(willUnmount).toHaveBeenCalledTimes(2);
   });
 });
@@ -470,7 +470,7 @@ describe('useState', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
 
       // rLynxChange
@@ -531,7 +531,7 @@ describe('useState', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
 
       // rLynxChange

--- a/packages/react/runtime/__test__/snapshot/lifecycle/destroy.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/destroy.test.jsx
@@ -36,7 +36,7 @@ describe('Destroy', () => {
     render(h(Comp), __root);
     await Promise.resolve().then(() => {});
 
-    expect(() => lynxCoreInject.tt.callDestroyLifetimeFun()).toThrow('???');
+    expect(() => lynx.getApp().callDestroyLifetimeFun()).toThrow('???');
 
     await Promise.resolve().then(() => {});
     expect(callback).toHaveBeenCalledTimes(1);

--- a/packages/react/runtime/__test__/snapshot/lifecycle/emptyPatch.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/emptyPatch.test.jsx
@@ -37,7 +37,7 @@ function mountAndHydrate(jsx) {
   globalEnvManager.switchToBackground();
   render(jsx, __root);
 
-  lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+  lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
   globalEnvManager.switchToMainThread();
   globalThis.__FlushElementTree = vi.fn();

--- a/packages/react/runtime/__test__/snapshot/lifecycle/isRendering.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/isRendering.test.jsx
@@ -105,7 +105,7 @@ describe('isRendering in background', () => {
     expect(isRendering.value).toBe(false);
 
     isRenderingValue = false;
-    lynxCoreInject.tt.onAppReload({ text: 'World' });
+    lynx.getApp().onAppReload({ text: 'World' });
     await waitSchedule();
     expect(isRenderingValue).toBe(true);
     expect(isRendering.value).toBe(false);

--- a/packages/react/runtime/__test__/snapshot/lifecycle/reload.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/reload.test.jsx
@@ -92,7 +92,7 @@ describe('reload', () => {
     {
       // LifecycleConstant.firstScreen
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
@@ -291,7 +291,7 @@ describe('reload', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.onAppReload({ text: 'Enjoy' });
+      lynx.getApp().onAppReload({ text: 'Enjoy' });
       expect(lynx.getNativeApp().callLepusMethod).not.toBeCalled();
     }
 
@@ -312,7 +312,7 @@ describe('reload', () => {
         ]
       `);
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
@@ -500,7 +500,7 @@ describe('reload', () => {
     {
       // LifecycleConstant.firstScreen
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
@@ -709,7 +709,7 @@ describe('reload', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.onAppReload({ text: 'Enjoy' });
+      lynx.getApp().onAppReload({ text: 'Enjoy' });
       expect(lynx.getNativeApp().callLepusMethod).not.toBeCalled();
     }
 
@@ -730,7 +730,7 @@ describe('reload', () => {
         ]
       `);
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
@@ -917,7 +917,7 @@ describe('reload', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
 
       // rLynxChange
@@ -1290,7 +1290,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
       globalEnvManager.switchToBackground();
       expect(globalThis.__OnLifecycleEvent).toHaveBeenCalledTimes(1);
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(rLynxFirstScreen).toMatchInlineSnapshot(`
         [
           [
@@ -1499,7 +1499,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
       // LifecycleConstant.firstScreen
       globalEnvManager.switchToBackground();
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(rLynxFirstScreen).toMatchInlineSnapshot(`
         [
           [
@@ -1664,7 +1664,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
       // LifecycleConstant.firstScreen
       globalEnvManager.switchToBackground();
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(rLynxFirstScreen).toMatchInlineSnapshot(`
         [
           [
@@ -1861,7 +1861,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
       globalEnvManager.switchToBackground();
       expect(globalThis.__OnLifecycleEvent).toHaveBeenCalledTimes(1);
       const rLynxFirstScreen = globalThis.__OnLifecycleEvent.mock.calls[0];
-      lynxCoreInject.tt.OnLifecycleEvent(...rLynxFirstScreen);
+      lynx.getApp().OnLifecycleEvent(...rLynxFirstScreen);
       expect(rLynxFirstScreen).toMatchInlineSnapshot(`
         [
           [

--- a/packages/react/runtime/__test__/snapshot/lifecycle/updateData.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/updateData.test.jsx
@@ -104,7 +104,7 @@ describe('triggerDataUpdated', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls).toMatchInlineSnapshot(`
         [
           [
@@ -160,7 +160,7 @@ describe('triggerDataUpdated', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateCardData({ msg: 'update' });
+      lynx.getApp().updateCardData({ msg: 'update' });
       await waitSchedule();
 
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
@@ -254,7 +254,7 @@ describe('triggerDataUpdated', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -300,7 +300,7 @@ describe('triggerDataUpdated', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateCardData({ msg: 'update' });
+      lynx.getApp().updateCardData({ msg: 'update' });
       await waitSchedule();
 
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(3);
@@ -453,7 +453,7 @@ describe('triggerDataUpdated', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -499,7 +499,7 @@ describe('triggerDataUpdated', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateCardData({ msg: 'update' });
+      lynx.getApp().updateCardData({ msg: 'update' });
       await waitSchedule();
 
       // duplicated because of https://github.com/preactjs/preact/pull/4724
@@ -666,7 +666,7 @@ describe('triggerDataUpdated', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -700,7 +700,7 @@ describe('triggerDataUpdated', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateCardData({ msg: 'update' });
+      lynx.getApp().updateCardData({ msg: 'update' });
       await waitSchedule();
 
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
@@ -842,7 +842,7 @@ describe('triggerDataUpdated when jsReady is enabled', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateCardData({ msg: 'update' });
+      lynx.getApp().updateCardData({ msg: 'update' });
       await waitSchedule();
 
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(0);
@@ -878,7 +878,7 @@ describe('triggerDataUpdated when jsReady is enabled', () => {
     {
       globalEnvManager.switchToBackground();
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -1107,7 +1107,7 @@ describe('flush pending `renderComponent` before hydrate', () => {
       globalEnvManager.switchToBackground();
 
       const spy = vi.spyOn(Component.prototype, 'setState');
-      lynxCoreInject.tt.updateCardData({ msg: 'update' });
+      lynx.getApp().updateCardData({ msg: 'update' });
       expect(spy).toBeCalled();
       spy.mockRestore();
     }
@@ -1116,7 +1116,7 @@ describe('flush pending `renderComponent` before hydrate', () => {
     {
       globalEnvManager.switchToBackground();
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -1209,7 +1209,7 @@ describe('flush pending `renderComponent` before hydrate', () => {
       globalEnvManager.switchToBackground();
       // LifecycleConstant.firstScreen
       const spy = vi.spyOn(lynx, 'reportError');
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(spy.mock.calls).toMatchInlineSnapshot(`
         [
           [
@@ -1404,12 +1404,12 @@ describe('firstScreenSyncTiming - manual', () => {
     // hydrate
     {
       globalEnvManager.switchToBackground();
-      lynxCoreInject.tt.updateCardData({
+      lynx.getApp().updateCardData({
         msg: 'update2',
         ready: true,
       });
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls.map(call => call[0])).toMatchInlineSnapshot(`
         [
           "rLynxFirstScreenSyncReady",

--- a/packages/react/runtime/__test__/snapshot/lifecycle/updateGlobalProps.event.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/updateGlobalProps.event.test.jsx
@@ -78,7 +78,7 @@ describe('updateGlobalProps event mode', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -94,7 +94,7 @@ describe('updateGlobalProps event mode', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       await waitSchedule();
 
       // rLynxChange should be called
@@ -164,7 +164,7 @@ describe('updateGlobalProps event mode', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -180,7 +180,7 @@ describe('updateGlobalProps event mode', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       await waitSchedule();
 
       // rLynxChange should be called

--- a/packages/react/runtime/__test__/snapshot/lifecycle/updateGlobalProps.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/updateGlobalProps.test.jsx
@@ -71,7 +71,7 @@ describe('updateGlobalProps', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -99,7 +99,7 @@ describe('updateGlobalProps', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       await waitSchedule();
 
       globalEnvManager.switchToMainThread();
@@ -156,7 +156,7 @@ describe('updateGlobalProps', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -184,7 +184,7 @@ describe('updateGlobalProps', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       await waitSchedule();
 
       globalEnvManager.switchToMainThread();
@@ -255,7 +255,7 @@ describe('updateGlobalProps', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -283,7 +283,7 @@ describe('updateGlobalProps', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       expect(count).toBe(1);
       expect(dataTheme).toBe('light');
       expect(globalPropsTheme).toBe('light');
@@ -342,7 +342,7 @@ describe('updateGlobalProps', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -358,7 +358,7 @@ describe('updateGlobalProps', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynxCoreInject.tt.updateGlobalProps({ theme: 'light' });
+      lynx.getApp().updateGlobalProps({ theme: 'light' });
       await waitSchedule();
 
       // No rLynxChange should be called because it skips runWithForce

--- a/packages/react/runtime/__test__/snapshot/lynx/component-compat.test.ts
+++ b/packages/react/runtime/__test__/snapshot/lynx/component-compat.test.ts
@@ -13,7 +13,7 @@ import { NEXT_STATE } from '../../../src/shared/render-constants';
 describe('installComponentCompat', () => {
   let originalJS: boolean;
   let originalDisableWarning: boolean | undefined;
-  let originalTT: any;
+  let originalGetApp: any;
   let originalReportError: typeof lynx.reportError;
   let originalGetElementById: typeof lynx.getElementById;
   let originalCreateSelectorQuery: typeof lynx.createSelectorQuery;
@@ -26,7 +26,7 @@ describe('installComponentCompat', () => {
   beforeEach(() => {
     originalJS = __JS__;
     originalDisableWarning = globalThis.__DISABLE_CREATE_SELECTOR_QUERY_INCOMPATIBLE_WARNING__;
-    originalTT = lynxCoreInject.tt;
+    originalGetApp = lynx.getApp;
     originalReportError = lynx.reportError;
     originalGetElementById = lynx.getElementById;
     originalCreateSelectorQuery = lynx.createSelectorQuery;
@@ -45,7 +45,7 @@ describe('installComponentCompat', () => {
   afterEach(() => {
     globalThis.__JS__ = originalJS;
     globalThis.__DISABLE_CREATE_SELECTOR_QUERY_INCOMPATIBLE_WARNING__ = originalDisableWarning;
-    lynxCoreInject.tt = originalTT;
+    lynx.getApp = originalGetApp;
     lynx.reportError = originalReportError;
     lynx.getElementById = originalGetElementById;
     lynx.createSelectorQuery = originalCreateSelectorQuery;
@@ -88,7 +88,7 @@ describe('installComponentCompat', () => {
     const selectorQuery = {};
     const element = {};
 
-    lynxCoreInject.tt = {
+    const app = {
       _nativeApp: nativeApp,
       _reactLynx: {
         ReactComponent: {
@@ -102,6 +102,7 @@ describe('installComponentCompat', () => {
       registerModule: vi.fn(),
       getJSModule: vi.fn(() => GlobalEventEmitter),
     };
+    lynx.getApp = () => app as unknown as LynxApp;
     lynx.getElementById = vi.fn(() => element);
     lynx.createSelectorQuery = vi.fn(() => selectorQuery);
 
@@ -109,13 +110,13 @@ describe('installComponentCompat', () => {
 
     const component = new Component({}, {}) as any;
 
-    expect(component._reactAppInstance).toBe(lynxCoreInject.tt);
+    expect(component._reactAppInstance).toBe(lynx.getApp());
     expect(component.getNodeRef('#target', true)).toEqual({
       receiver: {
         _type: '',
         _nativeApp: nativeApp,
         _uiModule: uiModule,
-        _reactAppInstance: lynxCoreInject.tt,
+        _reactAppInstance: lynx.getApp(),
       },
       selector: '#target',
       single: true,
@@ -125,13 +126,13 @@ describe('installComponentCompat', () => {
         _type: '',
         _nativeApp: nativeApp,
         _uiModule: uiModule,
-        _reactAppInstance: lynxCoreInject.tt,
+        _reactAppInstance: lynx.getApp(),
       },
       selector: '#root',
     });
 
     component.registerModule('module', module);
-    expect(lynxCoreInject.tt.registerModule).toHaveBeenCalledWith('module', module);
+    expect(lynx.getApp().registerModule).toHaveBeenCalledWith('module', module);
     expect(component.getJSModule('GlobalEventEmitter')).toBe(GlobalEventEmitter);
 
     const listener = vi.fn();

--- a/packages/react/runtime/__test__/snapshot/lynx/dynamic-import.test.ts
+++ b/packages/react/runtime/__test__/snapshot/lynx/dynamic-import.test.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-/* global lynx, lynxCoreInject, _ReportError */
+/* global lynx, _ReportError */
 
 function restoreProperty(target, key, value) {
   if (value === undefined) {
@@ -25,14 +25,14 @@ describe('dynamic import helpers', () => {
     vi.stubGlobal('__JS__', true);
     originalQueryComponent = lynx.QueryComponent;
     originalRequireModuleAsync = lynx.requireModuleAsync;
-    originalGetDynamicComponentExports = lynxCoreInject.tt.getDynamicComponentExports;
+    originalGetDynamicComponentExports = lynx.getApp().getDynamicComponentExports;
   });
 
   afterEach(() => {
     restoreProperty(lynx, 'QueryComponent', originalQueryComponent);
     restoreProperty(lynx, 'requireModuleAsync', originalRequireModuleAsync);
     restoreProperty(
-      lynxCoreInject.tt,
+      lynx.getApp(),
       'getDynamicComponentExports',
       originalGetDynamicComponentExports,
     );
@@ -82,7 +82,7 @@ describe('dynamic import helpers', () => {
       data: schema,
     }));
     lynx.QueryComponent = QueryComponent;
-    lynxCoreInject.tt.getDynamicComponentExports = getDynamicComponentExports;
+    lynx.getApp().getDynamicComponentExports = getDynamicComponentExports;
 
     const { __dynamicImport } = await import(
       '../../../src/core/lynx/dynamic-import.js'

--- a/packages/react/runtime/__test__/snapshot/lynx/lazy-bundle-fetchbundle.test.js
+++ b/packages/react/runtime/__test__/snapshot/lynx/lazy-bundle-fetchbundle.test.js
@@ -626,8 +626,7 @@ describe('mode + QueryComponent — dev throw', () => {
       .stubGlobal('__BACKGROUND__', true)
       .stubGlobal('__JS__', true)
       .stubGlobal('__LAZY_BUNDLE_FETCHER__', 'QueryComponent')
-      .stubGlobal('lynx', { QueryComponent: vi.fn() })
-      .stubGlobal('lynxCoreInject', { tt: { getDynamicComponentExports: vi.fn() } });
+      .stubGlobal('lynx', { QueryComponent: vi.fn(), getApp: () => ({ getDynamicComponentExports: vi.fn() }) });
   });
 
   test('__DEV__ + mode set → throws', async () => {

--- a/packages/react/runtime/__test__/snapshot/lynx/lazy-bundle.test.js
+++ b/packages/react/runtime/__test__/snapshot/lynx/lazy-bundle.test.js
@@ -220,8 +220,7 @@ describe('loadLazyBundle', () => {
         .stubGlobal('__JS__', true)
         // Force the QueryComponent fetcher path (see main-thread block).
         .stubGlobal('__LAZY_BUNDLE_FETCHER__', 'QueryComponent')
-        .stubGlobal('lynx', { QueryComponent })
-        .stubGlobal('lynxCoreInject', { tt: { getDynamicComponentExports } });
+        .stubGlobal('lynx', { QueryComponent, getApp: () => ({ getDynamicComponentExports }) });
     });
 
     test('blocking QueryComponent', async () => {
@@ -542,7 +541,10 @@ describe('loadLazyBundle', () => {
       QueryComponent.mockImplementation((source, callback) => {
         callback({ code: 0, detail: { schema: source } });
       });
-      vi.stubGlobal('lynx', { getNativeLynx: () => ({ QueryComponent }) });
+      vi.stubGlobal('lynx', {
+        getNativeLynx: () => ({ QueryComponent }),
+        getApp: () => ({ getDynamicComponentExports }),
+      });
       const { loadLazyBundle } = await import('../../../src/core/lynx/lazy-bundle');
 
       const promise = loadLazyBundle('foo');

--- a/packages/react/runtime/__test__/snapshot/lynx/portals.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lynx/portals.test.jsx
@@ -63,7 +63,7 @@ function mountAndHydrate(jsx) {
   render(jsx, __root);
 
   // LifecycleConstant.firstScreen
-  lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+  lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
   // hydrate patch -> main thread
   globalEnvManager.switchToMainThread();

--- a/packages/react/runtime/__test__/snapshot/lynx/suspense.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lynx/suspense.test.jsx
@@ -95,7 +95,7 @@ describe('suspense', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -217,7 +217,7 @@ describe('suspense', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -404,7 +404,7 @@ describe('suspense', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -555,7 +555,7 @@ describe('suspense', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -729,7 +729,7 @@ describe('suspense', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -867,7 +867,7 @@ describe('suspense', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -1053,7 +1053,7 @@ describe('suspense', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -1173,7 +1173,7 @@ describe('suspense', () => {
     // hydrate and render children
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -1260,7 +1260,7 @@ describe('suspense', () => {
     // hydrate and render error fallback
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -1345,7 +1345,7 @@ describe('suspense', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -1480,7 +1480,7 @@ describe('suspense', () => {
     {
       // LifecycleConstant.firstScreen
       globalEnvManager.switchToBackground();
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
 
       // rLynxChange
@@ -1553,7 +1553,7 @@ describe('suspense', () => {
     }
 
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toBeCalledTimes(1);
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
 

--- a/packages/react/runtime/__test__/snapshot/lynx/timing.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lynx/timing.test.jsx
@@ -80,7 +80,7 @@ describe('setState timing api', () => {
     render(<Comp />, __root);
 
     // LifecycleConstant.firstScreen
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
     mtCallbacks = [];
     comp.setState({
@@ -181,7 +181,7 @@ describe('attribute timing api', () => {
     globalEnvManager.switchToBackground();
     render(<Comp />, __root);
     // LifecycleConstant.firstScreen
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     lynx.performance.__functionCallHistory = [];
 
     mtCallbacks = [];
@@ -333,7 +333,7 @@ describe('attribute timing api', () => {
     render(<Comp />, __root);
 
     // LifecycleConstant.firstScreen
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     lynx.performance.__functionCallHistory = [];
 
     mtCallbacks = [];
@@ -440,7 +440,7 @@ describe('attribute timing api', () => {
 
     mtCallbacks = [];
     // LifecycleConstant.firstScreen
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     await waitSchedule();
 
     expect(lynx.performance.__functionCallHistory).toMatchInlineSnapshot(`
@@ -544,7 +544,7 @@ describe('attribute timing api', () => {
     globalEnvManager.switchToBackground();
     render(<Comp />, __root);
     // LifecycleConstant.firstScreen
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     lynx.performance.__functionCallHistory = [];
 
     // update xxx
@@ -716,7 +716,7 @@ describe('attribute timing api', () => {
     globalEnvManager.switchToBackground();
     render(<Comp />, __root);
     // LifecycleConstant.firstScreen
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     lynx.performance.__functionCallHistory = [];
 
     {
@@ -935,7 +935,7 @@ describe('timing api compatibility', () => {
     globalEnvManager.switchToBackground();
     render(<Comp />, __root);
     // LifecycleConstant.firstScreen
-    lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+    lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     lynx.performance.__functionCallHistory = [];
 
     mtCallbacks = [];

--- a/packages/react/runtime/__test__/snapshot/mtf-execid-churn.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/mtf-execid-churn.test.jsx
@@ -78,7 +78,7 @@ describe('Patch size / execId churn', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
@@ -133,7 +133,7 @@ describe('Patch size / execId churn', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];
@@ -194,7 +194,7 @@ describe('Patch size / execId churn', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       globalEnvManager.switchToMainThread();
       const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls[0];

--- a/packages/react/runtime/__test__/snapshot/page.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/page.test.jsx
@@ -203,7 +203,7 @@ describe('support <page /> element attributes', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange
@@ -361,7 +361,7 @@ describe('support <page /> element attributes', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange

--- a/packages/react/runtime/__test__/snapshot/ref.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/ref.test.jsx
@@ -185,7 +185,7 @@ describe('element ref', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -275,7 +275,7 @@ describe('element ref', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -343,7 +343,7 @@ describe('element ref', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -415,7 +415,7 @@ describe('element ref', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -537,7 +537,7 @@ describe('element ref', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).toMatchInlineSnapshot(
         `"{"patchList":[{"snapshotPatch":[3,-2,0,null],"id":2}]}"`,
@@ -642,7 +642,7 @@ describe('element ref', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
 
       // rLynxChange
@@ -807,7 +807,7 @@ describe('element ref', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
 
       // rLynxChange
@@ -935,7 +935,7 @@ describe('element ref', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1].data).toMatchInlineSnapshot(
         `"{"patchList":[{"snapshotPatch":[0,"__snapshot_a94a8_test_18",3,4,3,[1],1,-2,3,null,0],"id":2}]}"`,
@@ -1033,7 +1033,7 @@ describe('element ref in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
 
       // rLynxChange
@@ -1146,7 +1146,7 @@ describe('element ref in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
       expect(ref1.mock.calls).toMatchInlineSnapshot(`
         [
@@ -1254,7 +1254,7 @@ describe('element ref in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
       expect(ref1.mock.calls).toMatchInlineSnapshot(`
         [
@@ -1651,7 +1651,7 @@ describe('ui operations', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
       expect(lynx.createSelectorQuery().constructor.execLog.mock.calls).toMatchInlineSnapshot(`
         [
@@ -1703,7 +1703,7 @@ describe('ui operations', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
       expect(lynx.createSelectorQuery().constructor.execLog.mock.calls).toMatchInlineSnapshot(`
         [
@@ -1763,7 +1763,7 @@ describe('ui operations', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
       expect(lynx.createSelectorQuery().constructor.execLog.mock.calls).toMatchInlineSnapshot(`
         [
@@ -1883,7 +1883,7 @@ describe('ui operations', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
       expect(lynx.createSelectorQuery().constructor.execLog.mock.calls).toMatchInlineSnapshot(`[]`);
 
@@ -1946,7 +1946,7 @@ describe('ui operations', () => {
 
     // hydrate
     {
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
       expect(lynx.createSelectorQuery().constructor.execLog.mock.calls).toMatchInlineSnapshot(`[]`);
 

--- a/packages/react/runtime/__test__/snapshot/render.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/render.test.jsx
@@ -118,7 +118,7 @@ describe('dual-thread render', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
     }
 
     // rLynxChange

--- a/packages/react/runtime/__test__/snapshot/utils/globals.js
+++ b/packages/react/runtime/__test__/snapshot/utils/globals.js
@@ -152,12 +152,12 @@ function injectGlobals() {
   globalThis.__GLOBAL_PROPS_MODE__ = 'reactive';
   globalThis.__EXPERIMENTAL_TRANSFORM_BUILTIN_ATTRIBUTE_NAMES__ = false;
   globalThis.globDynamicComponentEntry = '__Card__';
-  globalThis.lynxCoreInject = {};
-  globalThis.lynxCoreInject.tt = {
+  const lynxApp = {
     GlobalEventEmitter: getJSModule('GlobalEventEmitter'),
   };
   globalThis.lynx = {
     queueMicrotask: Promise.prototype.then.bind(Promise.resolve()),
+    getApp: () => lynxApp,
     getNativeApp: () => app,
     getNative: () => native,
     performance,

--- a/packages/react/runtime/__test__/snapshot/utils/nativeMethod.ts
+++ b/packages/react/runtime/__test__/snapshot/utils/nativeMethod.ts
@@ -404,7 +404,7 @@ export const elementTree = new (class {
     const eventHandler = e.props?.event?.[`${eventType}:${eventName}`];
     if (eventHandler) {
       // @ts-ignore
-      globalThis.lynxCoreInject.tt.publishEvent(eventHandler, data);
+      globalThis.lynx.getApp().publishEvent(eventHandler, data);
     }
   }
 

--- a/packages/react/runtime/__test__/snapshot/worklet/runOnMainThread.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/worklet/runOnMainThread.test.jsx
@@ -242,7 +242,7 @@ describe('runOnMainThread', () => {
     // 4. hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -319,7 +319,7 @@ describe('runOnMainThread', () => {
     // 3. hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();

--- a/packages/react/runtime/__test__/snapshot/worklet/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/worklet/workletRef.test.jsx
@@ -93,7 +93,7 @@ describe('WorkletRef in js', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -185,7 +185,7 @@ describe('WorkletRef in js', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -238,7 +238,7 @@ describe('WorkletRef in js', () => {
     {
       // LifecycleConstant.firstScreen
       globalEnvManager.switchToBackground();
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();

--- a/packages/react/runtime/__test__/snapshot/workletEvent.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/workletEvent.test.jsx
@@ -76,7 +76,7 @@ describe('WorkletEvent', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -183,7 +183,7 @@ describe('WorkletEvent', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -290,7 +290,7 @@ describe('WorkletEvent', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -374,7 +374,7 @@ describe('WorkletEvent', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -458,7 +458,7 @@ describe('WorkletEvent', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -604,7 +604,7 @@ describe('WorkletEvent in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -715,7 +715,7 @@ describe('WorkletEvent in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -826,7 +826,7 @@ describe('WorkletEvent in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -913,7 +913,7 @@ describe('WorkletEvent in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -1043,7 +1043,7 @@ describe('WorkletEvent in list', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
 
       // rLynxChange

--- a/packages/react/runtime/__test__/snapshot/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/workletRef.test.jsx
@@ -83,7 +83,7 @@ describe('WorkletRef', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -266,7 +266,7 @@ describe('WorkletRef', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls).toMatchInlineSnapshot(`
         [
           [
@@ -480,7 +480,7 @@ describe('WorkletRef', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();
@@ -666,7 +666,7 @@ describe('WorkletRef in list', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
       globalThis.__OnLifecycleEvent.mockClear();
 
       // rLynxChange
@@ -763,7 +763,7 @@ describe('WorkletRef in spread', () => {
     // hydrate
     {
       // LifecycleConstant.firstScreen
-      lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+      lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
       // rLynxChange
       globalEnvManager.switchToMainThread();

--- a/packages/react/runtime/src/core/component.ts
+++ b/packages/react/runtime/src/core/component.ts
@@ -40,15 +40,15 @@ function reportRefDeprecationError(fnName: string, newFnName: string) {
 }
 
 function getReactAppInstance(): ReactAppInstance {
-  return lynxCoreInject.tt as unknown as ReactAppInstance;
+  return lynx.getApp() as unknown as ReactAppInstance;
 }
 
 function getLegacyNativeApp(): LegacyNativeApp {
-  return (lynxCoreInject.tt as any)._nativeApp;
+  return (lynx.getApp() as any)._nativeApp;
 }
 
 function getLegacyReactComponent(): LegacyReactComponent {
-  return (lynxCoreInject.tt as any)._reactLynx.ReactComponent.prototype;
+  return (lynx.getApp() as any)._reactLynx.ReactComponent.prototype;
 }
 
 function createLegacyComponentReceiver(

--- a/packages/react/runtime/src/core/globalProps.ts
+++ b/packages/react/runtime/src/core/globalProps.ts
@@ -65,7 +65,7 @@ export function updateGlobalProps(
     }
   }
 
-  lynxCoreInject.tt.GlobalEventEmitter.emit('onGlobalPropsChanged', [lynx.__globalProps]);
+  lynx.getApp().GlobalEventEmitter.emit('onGlobalPropsChanged', [lynx.__globalProps]);
 }
 
 function warnGlobalPropsMode(): void {

--- a/packages/react/runtime/src/core/lynx/lazy-bundle.ts
+++ b/packages/react/runtime/src/core/lynx/lazy-bundle.ts
@@ -153,7 +153,7 @@ export const loadLazyBundle: <
         const { code, detail } = result;
         if (code === 0) {
           const { schema } = detail;
-          const exports = lynxCoreInject.tt.getDynamicComponentExports(schema);
+          const exports = lynx.getApp().getDynamicComponentExports(schema);
           // `code === 0` means that the lazy bundle has been successfully parsed. However,
           // its javascript files may still fail to run, which would prevent the retrieval of the exports object.
           if (exports) {

--- a/packages/react/runtime/src/element-template/lynx/env.ts
+++ b/packages/react/runtime/src/element-template/lynx/env.ts
@@ -10,10 +10,7 @@ export function setupLynxEnv(): void {
     let updateData: Record<string, unknown> = {};
 
     try {
-      const params = (lynxCoreInject as {
-        tt?: { _params?: { initData?: Record<string, unknown>; updateData?: Record<string, unknown> } };
-      })
-        ?.tt?._params;
+      const params = lynx.getApp()._params;
       if (params) {
         initData = params.initData ?? {};
         updateData = params.updateData ?? {};

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -68,12 +68,12 @@ function init(): void {
     setupBackgroundElementTemplateDocument();
     installElementTemplateHydrationListener();
     resetEventStateForRuntime();
-    lynxCoreInject.tt.callDestroyLifetimeFun = callDestroyLifetimeFun;
-    lynxCoreInject.tt.publishEvent = publishEvent;
-    lynxCoreInject.tt.publicComponentEvent = publicComponentEvent;
-    lynxCoreInject.tt.updateGlobalProps = updateGlobalProps;
-    lynxCoreInject.tt.updateCardData = updateCardData;
-    lynxCoreInject.tt.onAppReload = reloadBackground;
+    lynx.getApp().callDestroyLifetimeFun = callDestroyLifetimeFun;
+    lynx.getApp().publishEvent = publishEvent;
+    lynx.getApp().publicComponentEvent = publicComponentEvent;
+    lynx.getApp().updateGlobalProps = updateGlobalProps;
+    lynx.getApp().updateCardData = updateCardData;
+    lynx.getApp().onAppReload = reloadBackground;
     installElementTemplateRenderScopeHooks();
     installElementTemplateCommitHook();
     if (process.env['NODE_ENV'] !== 'test') {

--- a/packages/react/runtime/src/snapshot/lynx/env.ts
+++ b/packages/react/runtime/src/snapshot/lynx/env.ts
@@ -6,7 +6,7 @@ import type { DataProcessorDefinition } from '../../lynx-api.js';
 
 export function setupLynxEnv(): void {
   if (!__LEPUS__) {
-    const { initData, updateData } = lynxCoreInject.tt._params;
+    const { initData, updateData } = lynx.getApp()._params;
     lynx.__initData = { ...initData, ...updateData };
     lynx.registerDataProcessors = function() {};
   }

--- a/packages/react/runtime/src/snapshot/lynx/tt.ts
+++ b/packages/react/runtime/src/snapshot/lynx/tt.ts
@@ -38,7 +38,7 @@ import { sendMTRefInitValueToMainThread } from '../worklet/ref/updateInitValue.j
 export { runWithForce };
 
 function injectTt(): void {
-  const tt = lynxCoreInject.tt;
+  const tt = lynx.getApp();
   tt.OnLifecycleEvent = onLifecycleEvent;
   tt.publishEvent = delayedPublishEvent;
   tt.publicComponentEvent = delayedPublicComponentEvent;
@@ -150,8 +150,8 @@ function onLifecycleEventImpl(type: LifecycleConstant, data: unknown): void {
         delayedEvents.length = 0;
       }
 
-      lynxCoreInject.tt.publishEvent = publishEvent;
-      lynxCoreInject.tt.publicComponentEvent = publicComponentEvent;
+      lynx.getApp().publishEvent = publishEvent;
+      lynx.getApp().publicComponentEvent = publicComponentEvent;
 
       // console.debug("********** After hydration:");
       // printSnapshotInstance(__root as BackgroundSnapshotInstance);
@@ -187,7 +187,7 @@ function onLifecycleEventImpl(type: LifecycleConstant, data: unknown): void {
     }
     case LifecycleConstant.publishEvent: {
       const { handlerName, data: d } = data as { handlerName: string; data: EventDataType };
-      lynxCoreInject.tt.publishEvent(handlerName, d);
+      lynx.getApp().publishEvent(handlerName, d);
       break;
     }
   }
@@ -208,7 +208,7 @@ function flushDelayedLifecycleEvents(): void {
 }
 
 function publishEvent(handlerName: string, data: EventDataType) {
-  lynxCoreInject.tt.callBeforePublishEvent?.(data);
+  lynx.getApp().callBeforePublishEvent?.(data);
   let snapshotId: number | undefined;
   const getSnapshotId = () => snapshotId ??= Number(handlerName.split(':')[0]);
   const eventHandler = backgroundSnapshotInstanceManager.getValueBySign(

--- a/packages/react/runtime/types/types.d.ts
+++ b/packages/react/runtime/types/types.d.ts
@@ -222,7 +222,7 @@ declare global {
     updateCardData: (newData: Record<string, any>, options?: Record<string, unknown>) => void;
     onAppReload: (updateData: Record<string, any>) => void;
     processCardConfig: () => void;
-    callBeforePublishEvent: (data: unknown) => void;
+    callBeforePublishEvent?: (data: unknown) => void;
     getDynamicComponentExports: (schema: string) => { default: React.ComponentType<any> } | null | undefined;
     GlobalEventEmitter: EventEmitter;
   }

--- a/packages/react/runtime/types/types.d.ts
+++ b/packages/react/runtime/types/types.d.ts
@@ -208,25 +208,23 @@ declare global {
     [prop: string]: unknown;
   }
 
-  namespace lynxCoreInject {
-    const tt: {
-      _params: {
-        initData: Record<string, any>;
-        updateData: Record<string, any>;
-      };
-
-      OnLifecycleEvent: ([type, data]: [LifecycleConstant, unknown]) => void;
-      publishEvent: (handlerName: string, data: EventDataType) => void;
-      publicComponentEvent: (componentId: string, handlerName: string, data: EventDataType) => void;
-      callDestroyLifetimeFun: () => void;
-      updateGlobalProps: (newData: Record<string, unknown>) => void;
-      updateCardData: (newData: Record<string, any>, options?: Record<string, unknown>) => void;
-      onAppReload: (updateData: Record<string, any>) => void;
-      processCardConfig: () => void;
-      callBeforePublishEvent: (data: unknown) => void;
-      getDynamicComponentExports: (schema: string) => { default: React.ComponentType<any> } | null | undefined;
-      GlobalEventEmitter: EventEmitter;
+  declare interface LynxApp {
+    _params: {
+      initData: Record<string, any>;
+      updateData: Record<string, any>;
     };
+
+    OnLifecycleEvent: ([type, data]: [LifecycleConstant, unknown]) => void;
+    publishEvent: (handlerName: string, data: EventDataType) => void;
+    publicComponentEvent: (componentId: string, handlerName: string, data: EventDataType) => void;
+    callDestroyLifetimeFun: () => void;
+    updateGlobalProps: (newData: Record<string, unknown>) => void;
+    updateCardData: (newData: Record<string, any>, options?: Record<string, unknown>) => void;
+    onAppReload: (updateData: Record<string, any>) => void;
+    processCardConfig: () => void;
+    callBeforePublishEvent: (data: unknown) => void;
+    getDynamicComponentExports: (schema: string) => { default: React.ComponentType<any> } | null | undefined;
+    GlobalEventEmitter: EventEmitter;
   }
 
   declare interface PipelineOptions {
@@ -236,8 +234,6 @@ declare global {
     dsl: string;
     stage: string;
   }
-
-  declare let lynxCoreInject: any;
 
   interface ISystemInfo {
     osVersion: string;
@@ -304,6 +300,7 @@ declare module '@lynx-js/types/background' {
 
     getNativeApp(): NativeApp;
     getNativeLynx(): NativeLynx;
+    getApp(): LynxApp;
     reportError(e: Error): void;
     QueryComponent?(source: string, callback: (result: any) => void): void;
     loadLazyBundle?<T extends { default: React.ComponentType<any> }>(

--- a/packages/react/testing-library/src/setupFiles/common/runtime-setup.js
+++ b/packages/react/testing-library/src/setupFiles/common/runtime-setup.js
@@ -89,13 +89,13 @@ globalThis.onInjectBackgroundThreadGlobals = (target) => {
 
   // TODO: can we only inject to target(mainThread.globalThis) instead of globalThis?
   // packages/react/runtime/src/lynx.ts
-  // intercept lynxCoreInject assignments to lynxTestingEnv.backgroundThread.globalThis.lynxCoreInject
-  const oldLynxCoreInject = globalThis.lynxCoreInject;
-  globalThis.lynxCoreInject = target.lynxCoreInject;
+  // point `lynx` at the target thread so injectTt assigns onto its app object
+  const oldLynx = globalThis.lynx;
+  globalThis.lynx = target.lynx;
   try {
     injectTt();
   } finally {
-    globalThis.lynxCoreInject = oldLynxCoreInject;
+    globalThis.lynx = oldLynx;
   }
 
   // re-init global snapshot patch to undefined

--- a/packages/testing-library/testing-environment/src/index.ts
+++ b/packages/testing-library/testing-environment/src/index.ts
@@ -521,6 +521,7 @@ function injectBackgroundThreadGlobals(target?: any, polyfills?: any) {
 
   const globalEventEmitter = new GlobalEventEmitter();
   target.lynx = {
+    getApp: () => target.lynxCoreInject.tt,
     getNativeApp: () => app,
     performance,
     createSelectorQuery: (() => {

--- a/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsSetupListRuntimeModule.ts
+++ b/packages/webpack/cache-events-webpack-plugin/src/LynxCacheEventsSetupListRuntimeModule.ts
@@ -83,7 +83,7 @@ export function createLynxCacheEventsSetupListRuntimeModule(
           `{
       name: 'ttMethod',
       setup: () => {
-        const tt = lynxCoreInject.tt;
+        const tt = lynx.getApp();
         const methodsToMock = [
           'OnLifecycleEvent',
           'publishEvent',
@@ -133,7 +133,7 @@ export function createLynxCacheEventsSetupListRuntimeModule(
           `{
       name: 'performanceEvent',
       setup: () => {
-          const tt = lynxCoreInject.tt;
+          const tt = lynx.getApp();
           const lynxPerformanceListenerKeys = {
             onPerformance: 'lynx.performance.onPerformanceEvent',
             onSetup: 'lynx.performance.timing.onSetup',

--- a/packages/webpack/cache-events-webpack-plugin/test/LynxCacheEventsSetupListRuntimeModule.test.ts
+++ b/packages/webpack/cache-events-webpack-plugin/test/LynxCacheEventsSetupListRuntimeModule.test.ts
@@ -47,9 +47,7 @@ interface RuntimeSandbox {
   __webpack_require__: {
     lynx_ce?: RuntimeCache;
   };
-  lynxCoreInject: {
-    tt: TtMethods;
-  };
+  lynx: { getApp: () => TtMethods };
   loadDynamicComponent?: (...args: unknown[]) => unknown;
   renderPage?: (...args: unknown[]) => unknown;
   processData?: (data: unknown) => unknown;
@@ -82,11 +80,10 @@ function createRuntimeSandbox(options: {
     throw new Error('Expected generated runtime code');
   }
 
+  const app = options.tt ?? {};
   const sandbox: RuntimeSandbox = {
     __webpack_require__: {},
-    lynxCoreInject: {
-      tt: options.tt ?? {},
-    },
+    lynx: { getApp: () => app },
   };
   if (options.loadDynamicComponent) {
     sandbox.loadDynamicComponent = options.loadDynamicComponent;
@@ -133,7 +130,7 @@ describe('LynxCacheEventsSetupListRuntimeModule', () => {
     runtimeCache.cachedActions = [];
 
     const cleanup = getSetupItem(runtimeCache, 'ttMethod').setup();
-    sandbox.lynxCoreInject.tt.publishEvent?.('event-name', { foo: 'bar' });
+    sandbox.lynx.getApp().publishEvent?.('event-name', { foo: 'bar' });
 
     expect(originalPublishEvent).not.toHaveBeenCalled();
     expect(runtimeCache.cachedActions).toEqual([
@@ -154,7 +151,7 @@ describe('LynxCacheEventsSetupListRuntimeModule', () => {
       foo: 'bar',
     });
 
-    sandbox.lynxCoreInject.tt.publishEvent?.('event-name-2');
+    sandbox.lynx.getApp().publishEvent?.('event-name-2');
 
     expect(originalPublishEvent).toHaveBeenCalledTimes(2);
     expect(originalPublishEvent).toHaveBeenLastCalledWith('event-name-2');

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/async-external-entry/test.config.cjs
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/async-external-entry/test.config.cjs
@@ -7,5 +7,6 @@ module.exports = {
     global.lynxCoreInject = {
       tt: {},
     };
+    global.lynx = { ...global.lynx, getApp: () => global.lynxCoreInject.tt };
   },
 };

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting-with-setupListTransformer/test.config.cjs
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting-with-setupListTransformer/test.config.cjs
@@ -8,6 +8,7 @@ module.exports = {
       tt: {},
     };
     global.lynx = {
+      getApp: () => global.lynxCoreInject.tt,
       requireModuleAsync: (_request, callback) => {
         callback(null, {
           ids: ['0'],

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting/test.config.cjs
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/cache-events/chunk-splitting/test.config.cjs
@@ -8,6 +8,7 @@ module.exports = {
       tt: {},
     };
     global.lynx = {
+      getApp: () => global.lynxCoreInject.tt,
       requireModuleAsync: (_request, callback) => {
         callback(null, {
           ids: ['0'],

--- a/packages/webpack/cache-events-webpack-plugin/test/cases/not-cache-events/lazy-bundle/test.config.cjs
+++ b/packages/webpack/cache-events-webpack-plugin/test/cases/not-cache-events/lazy-bundle/test.config.cjs
@@ -8,6 +8,7 @@ module.exports = {
       tt: {},
     };
     global.lynx = {
+      getApp: () => global.lynxCoreInject.tt,
       requireModuleAsync: (_request, callback) => {
         callback(null, {
           ids: ['0'],

--- a/packages/webpack/externals-loading-webpack-plugin/test/helpers/setup-env.js
+++ b/packages/webpack/externals-loading-webpack-plugin/test/helpers/setup-env.js
@@ -39,6 +39,7 @@ function __injectGlobals(target) {
 
   target.lynxCoreInject = {};
   target.lynxCoreInject.tt = {};
+  target.lynx.getApp = () => target.lynxCoreInject.tt;
 
   target.__LoadStyleSheet = () => {
     return {};

--- a/packages/webpack/react-refresh-webpack-plugin/test/setup-env.js
+++ b/packages/webpack/react-refresh-webpack-plugin/test/setup-env.js
@@ -22,6 +22,7 @@ function __injectGlobals(target) {
   };
   target.lynxCoreInject = {};
   target.lynxCoreInject.tt = {};
+  target.lynx.getApp = () => target.lynxCoreInject.tt;
   target.lynxCoreInject.tt.publicComponentEvent = () => void 0;
   target.lynxCoreInject.tt._params = { updateData: {} };
   target.__OnLifecycleEventQueue = [];

--- a/packages/webpack/react-webpack-plugin/test/cases/define/disable-create-selector-query-false/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/define/disable-create-selector-query-false/index.jsx
@@ -9,13 +9,15 @@ it('__DISABLE_CREATE_SELECTOR_QUERY_INCOMPATIBLE_WARNING__ should be false', () 
 it('should report error when this.getNodeRef is called', () => {
   const c = new Component({});
 
+  const app = lynx.getApp();
   vi.stubGlobal('lynx', {
     reportError: vi.fn(),
+    getApp: () => app,
   });
 
   const getNodeRef = vi.fn();
 
-  lynxCoreInject.tt._reactLynx = {
+  app._reactLynx = {
     ReactComponent: class {
       getNodeRef() {
         getNodeRef();

--- a/packages/webpack/react-webpack-plugin/test/cases/define/disable-create-selector-query/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/define/disable-create-selector-query/index.jsx
@@ -9,13 +9,15 @@ it('__DISABLE_CREATE_SELECTOR_QUERY_INCOMPATIBLE_WARNING__ should be true', () =
 it('should not report error when this.getNodeRef is called', () => {
   const c = new Component({});
 
+  const app = lynx.getApp();
   vi.stubGlobal('lynx', {
     reportError: vi.fn(),
+    getApp: () => app,
   });
 
   const getNodeRef = vi.fn();
 
-  lynxCoreInject.tt._reactLynx = {
+  app._reactLynx = {
     ReactComponent: class {
       getNodeRef() {
         getNodeRef();

--- a/packages/webpack/react-webpack-plugin/test/setup-env.js
+++ b/packages/webpack/react-webpack-plugin/test/setup-env.js
@@ -13,6 +13,7 @@ function __injectGlobals(target) {
   target.lynx = {};
   target.lynxCoreInject = {};
   target.lynxCoreInject.tt = {};
+  target.lynx.getApp = () => target.lynxCoreInject.tt;
   target.lynxCoreInject.tt.publicComponentEvent = () => void 0;
   target.lynxCoreInject.tt._params = { updateData: {} };
   target.lynxCoreInject.tt._nativeApp = {


### PR DESCRIPTION
## Summary

The runtime reached lynx-core's app object through the `lynxCoreInject` global that the AMD wrapper injects. `lynx.getApp()` returns that same instance and has existed since the first open-source commit, so every reference now goes through it: the app-level callback assignments in `injectTt` and the element-template `init`, `setupLynxEnv`'s init-data params, the before-publish hook, the global-props emitter, the lazy-bundle exports and the ReactLynx 2 class-component compat.

Resolving through `lynx` also stays correct once several cards share a runtime chunk, where the injected global is whichever card evaluated it first.

The global's type declaration is replaced by a `LynxApp` interface returned from `lynx.getApp()`, so `lynxCoreInject` is now absent from the package including its tests.

No behavior change: the same object receives the same assignments under the same names.

### Notes for reviewers

- `lynx.getApp()` is not part of `@lynx-js/types`, so this PR declares it in the runtime's own `types/types.d.ts` — the same place the `lynxCoreInject` shape was declared. Both accesses are equally untyped upstream; this one at least goes through `lynx`.
- It has been a public constructor member of lynx-core's `Lynx` class since the first open-source commit (`@lynx-js/lynx-core@0.1.1`), and the class needs it to implement `setTimeout` and friends. I could not check pre-open-source 2.x cores from the repo, so if anyone knows of a supported engine without it, say so — a missing `getApp` would throw at `injectTt` rather than fail quietly.
- `@lynx-js/testing-environment` gains `lynx.getApp()`; anything that reaches into `lynxTestingEnv.backgroundThread.lynxCoreInject.tt` keeps working, since both point at the same object.

### Left alone deliberately

`lynxCoreInject` also names the parameter the AMD wrapper passes to a bundle, which is a different thing from the global. Those stay: `runtime-wrapper-webpack-plugin` (which defines the wrapper), `web-platform/web-core` (which implements it for the web), the `react/transform` extract-str output, and the REPL examples that demonstrate the protocol. `plugin-debug-metadata`'s release banner also stays, because its `lynxCoreInject` branch is the fallback for engines older than 2.13 — older than `getApp` itself.

## Verification

`packages/react/runtime` suites all green (770 + 49 + 692) with the 100% coverage gate satisfied.

Verified on a physical Android device (Pixel 5) with the `examples/react` app: the eight callbacks land on `lynx.getApp()` under the engine's own names, and first screen, the post-hydration `publishEvent` swap, a tap reaching the background thread and card destruction all behave as before.
