### PR TITLE
feat: render PerformancePanel based on lynx.performance.createObserver

### DIFF
--- a/.github/vanilla-example.instructions.md
+++ b/.github/vanilla-example.instructions.md
@@ -2,4 +2,7 @@
 applyTo: "examples/vanilla/**"
 ---
 
-Create the page with `__CreatePage`, then append an `__CreateView` content container and put flex or linear layout styles on that container. On Web, the page root is a plain `div`, while Lynx-transformed flex custom properties are consumed by Lynx container elements; applying `flex-direction` directly to the page root can therefore fall back to a horizontal row.
+- Create the page with `__CreatePage`, append an `__CreateView` content container, and apply layout styles to the container. Applying `flex-direction` directly to the page root can produce a horizontal layout on Web.
+- Register performance observers when the background module initializes and disconnect them during lifetime cleanup so startup entries are not missed.
+- For each measured update, generate pipeline options on the background thread, set their origin, DSL, and stage, start the pipeline, bind a unique `__lynx_timing_flag`, send the options with the UI patch, and pass them to `__FlushElementTree`. Report `pipelineEnd - pipelineStart`, then remove the pending update.
+- Use `__lynx_timing_actual_fmp` only for the page's one-time Actual FMP. Keep complete performance entries on the background thread and send only formatted summaries to the main thread to avoid measurement feedback loops.

--- a/examples/vanilla/README.md
+++ b/examples/vanilla/README.md
@@ -2,6 +2,21 @@
 
 This example renders a counter directly with Element PAPI and TypeScript, without ReactLynx, JSX, or a virtual DOM. A `tap` event starts on the main thread, increments the counter on the background thread, and sends the new value back for the main thread to render.
 
+## Performance evaluation
+
+An early [PerformanceObserver](https://lynxjs.org/zh/api/lynx-api/performance-api/performance-observer.html)
+listens for `pipeline` entries and displays two categories:
+
+- Initial rendering: [LoadBundleEntry](https://lynxjs.org/zh/api/lynx-api/performance-api/performance-entry/load-bundle-entry.html)
+  `lynxFcp` duration
+- Update rendering: [PipelineEntry](https://lynxjs.org/zh/api/lynx-api/performance-api/performance-entry/pipeline-entry.html)
+  measures each explicitly started update from `pipelineStart` to `pipelineEnd`
+
+Tap **Click me** to measure one update pipeline. Each update uses a unique
+timing flag and forwards its generated pipeline options to the Element PAPI
+flush. Full entries remain on the background thread; only formatted summaries
+are sent to the main thread.
+
 ## Run
 
 From the repository root:

--- a/examples/vanilla/src/background.ts
+++ b/examples/vanilla/src/background.ts
@@ -1,18 +1,150 @@
-import type { CounterPatch } from './events.js';
+import type {
+  LoadBundleEntry,
+  PerformanceObserver as LynxPerformanceObserver,
+  PerformanceEntry,
+  PipelineEntry,
+} from '@lynx-js/types/background';
+
+import type {
+  CounterPatch,
+  PerformancePatch,
+  PipelineOptions,
+} from './events.js';
 import {
+  counterTimingFlagPrefix,
   counterUpdatedEventName,
   destroyLifetimeEventName,
   incrementCounterEventName,
+  performanceUpdatedEventName,
 } from './events.js';
 
 const mainThread = lynx.getCoreContext();
 
 let count = 0;
+let performanceObserver: LynxPerformanceObserver | undefined;
+const pendingUpdates = new Set<string>();
+
+function formatMilliseconds(value: unknown): string {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? `${value.toFixed(2)} ms`
+    : 'n/a';
+}
+
+function formatDuration(start: unknown, end: unknown): string {
+  if (
+    typeof start !== 'number'
+    || typeof end !== 'number'
+    || !Number.isFinite(start)
+    || !Number.isFinite(end)
+    || end < start
+  ) {
+    return 'n/a';
+  }
+  return formatMilliseconds(end - start);
+}
+
+function reportPerformance(
+  patch: PerformancePatch,
+): void {
+  mainThread.dispatchEvent({
+    type: performanceUpdatedEventName,
+    data: patch,
+  });
+}
+
+function reportInitialRender(entry: LoadBundleEntry): void {
+  reportPerformance({
+    kind: 'initialRender',
+    summary: `Initial render: Lynx FCP ${
+      formatMilliseconds(entry.lynxFcp.duration)
+    }`,
+  });
+}
+
+function beginUpdatePipeline(timingFlag: string): PipelineOptions | undefined {
+  if (
+    typeof lynx.performance._generatePipelineOptions !== 'function'
+    || typeof lynx.performance._onPipelineStart !== 'function'
+    || typeof lynx.performance._bindPipelineIdWithTimingFlag !== 'function'
+  ) {
+    console.warn('[performance] Pipeline timing APIs are unavailable.');
+    return undefined;
+  }
+
+  const pipelineOptions = lynx.performance._generatePipelineOptions();
+  pipelineOptions.needTimestamps = true;
+  pipelineOptions.pipelineOrigin = 'updateTriggeredByBts';
+  pipelineOptions.dsl = 'vanilla';
+  pipelineOptions.stage = 'update';
+  pipelineOptions.timingFlag = timingFlag;
+
+  lynx.performance._onPipelineStart(
+    pipelineOptions.pipelineID,
+    pipelineOptions,
+  );
+  lynx.performance._bindPipelineIdWithTimingFlag(
+    pipelineOptions.pipelineID,
+    timingFlag,
+  );
+  return pipelineOptions;
+}
+
+function reportPipelineUpdate(entry: PipelineEntry): void {
+  if (!pendingUpdates.has(entry.identifier)) {
+    return;
+  }
+
+  pendingUpdates.delete(entry.identifier);
+  reportPerformance({
+    kind: 'update',
+    summary: `Update: Pipeline ${
+      formatDuration(entry.pipelineStart, entry.pipelineEnd)
+    }`,
+  });
+}
+
+function onPerformanceEntry(entry: PerformanceEntry): void {
+  console.info(
+    `[performance] ${entry.entryType}.${entry.name}: ${JSON.stringify(entry)}`,
+  );
+
+  if (entry.entryType !== 'pipeline') {
+    return;
+  }
+
+  if (entry.name === 'loadBundle') {
+    reportInitialRender(entry as LoadBundleEntry);
+    return;
+  }
+
+  reportPipelineUpdate(entry as PipelineEntry);
+}
+
+function setupPerformanceObserver(): void {
+  if (typeof lynx.performance?.createObserver !== 'function') {
+    console.warn('[performance] PerformanceObserver is unavailable.');
+    return;
+  }
+
+  performanceObserver = lynx.performance.createObserver(onPerformanceEntry);
+  performanceObserver.observe(['pipeline']);
+}
 
 function onIncrementCounter(): void {
-  count += 1;
+  const nextCount = count + 1;
+  const timingFlag = `${counterTimingFlagPrefix}${nextCount}`;
+  const pipelineOptions = beginUpdatePipeline(timingFlag);
+  console.info(
+    `[performance] beginUpdatePipeline: ${JSON.stringify(pipelineOptions)}`,
+  );
+  if (!pipelineOptions) {
+    return;
+  }
 
-  const patch: CounterPatch = { count };
+  count = nextCount;
+  pendingUpdates.add(timingFlag);
+
+  const patch: CounterPatch = { count, pipelineOptions };
   mainThread.dispatchEvent({
     type: counterUpdatedEventName,
     data: patch,
@@ -20,6 +152,9 @@ function onIncrementCounter(): void {
 }
 
 function cleanup(): void {
+  performanceObserver?.disconnect();
+  performanceObserver = undefined;
+  pendingUpdates.clear();
   mainThread.removeEventListener(
     incrementCounterEventName,
     onIncrementCounter,
@@ -27,5 +162,6 @@ function cleanup(): void {
   mainThread.removeEventListener(destroyLifetimeEventName, cleanup);
 }
 
+setupPerformanceObserver();
 mainThread.addEventListener(incrementCounterEventName, onIncrementCounter);
 mainThread.addEventListener(destroyLifetimeEventName, cleanup);

--- a/examples/vanilla/src/events.ts
+++ b/examples/vanilla/src/events.ts
@@ -1,7 +1,24 @@
 export const counterUpdatedEventName = 'CounterUpdated';
+export const counterTimingFlagPrefix = 'vanilla_counter_update_';
 export const destroyLifetimeEventName = '__DestroyLifetime';
 export const incrementCounterEventName = 'IncrementCounter';
+export const performanceUpdatedEventName = 'PerformanceUpdated';
+
+export type PipelineOptions = Record<string, unknown> & {
+  dsl: string;
+  needTimestamps: boolean;
+  pipelineID: string;
+  pipelineOrigin: string;
+  stage: string;
+  timingFlag: string;
+};
 
 export interface CounterPatch {
   count: number;
+  pipelineOptions: PipelineOptions;
+}
+
+export interface PerformancePatch {
+  kind: 'initialRender' | 'update';
+  summary: string;
 }

--- a/examples/vanilla/src/main-thread.ts
+++ b/examples/vanilla/src/main-thread.ts
@@ -1,10 +1,11 @@
 import type { ElementRef } from '@lynx-js/type-element-api';
 
-import type { CounterPatch } from './events.js';
+import type { CounterPatch, PerformancePatch } from './events.js';
 import {
   counterUpdatedEventName,
   destroyLifetimeEventName,
   incrementCounterEventName,
+  performanceUpdatedEventName,
 } from './events.js';
 
 const page = __CreatePage('0', 0);
@@ -20,6 +21,10 @@ const backgroundThread = lynx.getJSContext();
 
 let button: ElementRef | undefined;
 let counterText: ElementRef | undefined;
+let initialRenderText: ElementRef | undefined;
+let updateText: ElementRef | undefined;
+
+const tapEventOptions = {};
 
 function replaceText(text: ElementRef, value: string): void {
   __ReplaceElements(
@@ -38,12 +43,77 @@ function onTap(): void {
 
 function onCounterUpdated(event: { data: unknown }): void {
   const patch = event.data as Partial<CounterPatch> | undefined;
-  if (typeof patch?.count !== 'number' || !counterText) {
+  if (
+    typeof patch?.count !== 'number'
+    || !counterText
+  ) {
     return;
   }
 
   replaceText(counterText, `Clicked ${patch.count} times`);
+  __FlushElementTree(page, { pipelineOptions: patch.pipelineOptions ?? {} });
+}
+
+function onPerformanceUpdated(event: { data: unknown }): void {
+  const patch = event.data as Partial<PerformancePatch> | undefined;
+  if (typeof patch?.summary !== 'string') {
+    return;
+  }
+
+  let target: ElementRef | undefined;
+  switch (patch.kind) {
+    case 'initialRender':
+      target = initialRenderText;
+      break;
+    case 'update':
+      target = updateText;
+      break;
+  }
+
+  if (!target) {
+    return;
+  }
+
+  replaceText(target, patch.summary);
   __FlushElementTree();
+}
+
+function renderPerformancePanel(content: ElementRef): void {
+  const performancePanel = __CreateView(pageId);
+  __SetClasses(performancePanel, 'performance-panel');
+  __AppendElement(content, performancePanel);
+
+  const performanceTitle = __CreateText(pageId);
+  __SetClasses(performanceTitle, 'performance-title');
+  __AppendElement(
+    performanceTitle,
+    __CreateRawText('Performance API'),
+  );
+  __AppendElement(performancePanel, performanceTitle);
+
+  initialRenderText = __CreateText(pageId);
+  __SetClasses(initialRenderText, 'performance-row');
+  __AppendElement(
+    initialRenderText,
+    __CreateRawText('Initial render: waiting for loadBundle...'),
+  );
+  __AppendElement(performancePanel, initialRenderText);
+
+  updateText = __CreateText(pageId);
+  __SetClasses(updateText, 'performance-row');
+  __AppendElement(
+    updateText,
+    __CreateRawText('Update: tap the button to measure the pipeline'),
+  );
+  __AppendElement(performancePanel, updateText);
+
+  const performanceHint = __CreateText(pageId);
+  __SetClasses(performanceHint, 'performance-hint');
+  __AppendElement(
+    performanceHint,
+    __CreateRawText('Full entries are logged on the background thread.'),
+  );
+  __AppendElement(performancePanel, performanceHint);
 }
 
 function renderPage(): void {
@@ -74,7 +144,8 @@ function renderPage(): void {
   __AppendElement(button, buttonLabel);
   __AppendElement(content, button);
 
-  __AddEventListener(button, 'tap', onTap, {});
+  __AddEventListener(button, 'tap', onTap, tapEventOptions);
+  renderPerformancePanel(content);
 }
 
 function cleanup(): void {
@@ -86,17 +157,27 @@ function cleanup(): void {
     counterUpdatedEventName,
     onCounterUpdated,
   );
+  backgroundThread.removeEventListener(
+    performanceUpdatedEventName,
+    onPerformanceUpdated,
+  );
   engine.removeEventListener('__RenderPage', renderPage);
   engine.removeEventListener(destroyLifetimeEventName, cleanup);
 
   if (button) {
-    __RemoveEventListener(button, 'tap', onTap);
+    __RemoveEventListener(button, 'tap', onTap, tapEventOptions);
   }
 
   button = undefined;
   counterText = undefined;
+  initialRenderText = undefined;
+  updateText = undefined;
 }
 
 backgroundThread.addEventListener(counterUpdatedEventName, onCounterUpdated);
+backgroundThread.addEventListener(
+  performanceUpdatedEventName,
+  onPerformanceUpdated,
+);
 engine.addEventListener('__RenderPage', renderPage);
 engine.addEventListener(destroyLifetimeEventName, cleanup);

--- a/examples/vanilla/src/rspeedy-env.d.ts
+++ b/examples/vanilla/src/rspeedy-env.d.ts
@@ -3,6 +3,22 @@
 import type { ElementRef } from '@lynx-js/type-element-api';
 import type { LynxSetTimeout } from '@lynx-js/types';
 
+import type { PipelineOptions } from './events.js';
+
+declare module '@lynx-js/types/background' {
+  interface Performance {
+    _bindPipelineIdWithTimingFlag?(
+      pipelineID: string,
+      timingFlag: string,
+    ): void;
+    _generatePipelineOptions?(): PipelineOptions;
+    _onPipelineStart?(
+      pipelineID: string,
+      options?: PipelineOptions,
+    ): void;
+  }
+}
+
 declare global {
   const setTimeout: LynxSetTimeout;
 

--- a/examples/vanilla/src/style.css
+++ b/examples/vanilla/src/style.css
@@ -47,3 +47,36 @@
   font-size: 18px;
   font-weight: 700;
 }
+
+.performance-panel {
+  width: 320px;
+  margin-top: 32px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #2c3040;
+  border-radius: 12px;
+  background-color: #191b22;
+}
+
+.performance-title {
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.performance-row {
+  margin-top: 10px;
+  color: #c8cce0;
+  font-size: 14px;
+  line-height: 20px;
+  white-space: normal;
+}
+
+.performance-hint {
+  margin-top: 14px;
+  color: #858ba3;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: normal;
+}


### PR DESCRIPTION
in bts

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a performance panel showing initial-render and update timing summaries.
  * Added pipeline performance measurement for counter updates triggered by taps.
  * Added formatted performance metrics and status updates between background and main views.

* **Documentation**
  * Documented pipeline performance evaluation and measurement behavior.
  * Clarified layout, observer lifecycle, timing, and Actual FMP handling guidance.

* **Style**
  * Added styling for the performance panel, including titles, data rows, and hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
