### PR TITLE
perf(react): bound large hook profile details

### DIFF
--- a/.changeset/bounded-react-profile-detail.md
+++ b/.changeset/bounded-react-profile-detail.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/react": patch
+---
+
+Bound Snapshot profiling detail for large hook-state arrays to their length,
+plus key and shallow-diff information for the first 32 indices. Smaller arrays,
+ordinary objects, primitives, class state, and Element Template profiling
+retain their existing detail format.

--- a/.github/react-profile-detail.instructions.md
+++ b/.github/react-profile-detail.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "packages/react/runtime/src/{shared,snapshot}/**/*profile*.ts"
+---
+
+Keep large Snapshot hook-state array profiling bounded while constructing detail;
+do not stringify or enumerate the complete array and truncate afterward. Preserve
+the existing detail schema for smaller arrays, ordinary objects, primitives,
+class state, and Element Template profiling. Large array value records state
+only the original length and that element detail is omitted. Array key and
+shallow-diff records must state the omitted index count and that the tail was
+not inspected.

--- a/packages/react/runtime/__test__/snapshot/debug/profile-array-detail.test.ts
+++ b/packages/react/runtime/__test__/snapshot/debug/profile-array-detail.test.ts
@@ -1,0 +1,126 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  isLargeProfileArray,
+  PROFILE_ARRAY_DETAIL_PREFIX_ITEMS,
+  PROFILE_ARRAY_DETAIL_THRESHOLD,
+  summarizeLargeProfileArrayChangedKeys,
+  summarizeLargeProfileArrayKeys,
+  summarizeLargeProfileArrayValue,
+} from '../../../src/shared/profile-array-detail.js';
+
+describe('profile array detail', () => {
+  it('keeps the compatibility path through the threshold', () => {
+    expect(isLargeProfileArray(new Array(PROFILE_ARRAY_DETAIL_THRESHOLD)))
+      .toBe(false);
+    expect(
+      isLargeProfileArray(new Array(PROFILE_ARRAY_DETAIL_THRESHOLD + 1)),
+    ).toBe(true);
+    expect(isLargeProfileArray({ length: 10_000 })).toBe(false);
+  });
+
+  it('inspects only the configured index prefix', () => {
+    const value = new Array<unknown>(10_000);
+    value[0] = 1;
+    value[PROFILE_ARRAY_DETAIL_PREFIX_ITEMS - 1] = 'last';
+    value[PROFILE_ARRAY_DETAIL_PREFIX_ITEMS] = 'outside';
+    Object.defineProperty(value, 'extra', {
+      enumerable: true,
+      value: 'outside-prefix',
+    });
+
+    expect(JSON.parse(summarizeLargeProfileArrayKeys(value))).toEqual({
+      version: 1,
+      type: 'array-prefix',
+      length: 10_000,
+      keys: ['0', String(PROFILE_ARRAY_DETAIL_PREFIX_ITEMS - 1)],
+      omitted: 10_000 - PROFILE_ARRAY_DETAIL_PREFIX_ITEMS,
+      tail: 'not-inspected',
+    });
+
+    const summary = JSON.parse(summarizeLargeProfileArrayValue(value));
+    expect(summary).toEqual({
+      version: 1,
+      type: 'array',
+      length: 10_000,
+      detail: 'omitted',
+    });
+    expect(JSON.stringify(summary)).not.toContain('outside');
+  });
+
+  it('reports only shallow changes found in the inspected prefix', () => {
+    const current = Array.from({ length: 10_000 }, (_, index) => ({
+      index,
+    }));
+    const next = current.slice();
+    next[0] = { index: 0 };
+    next[10] = { index: 10 };
+    next[PROFILE_ARRAY_DETAIL_PREFIX_ITEMS] = {
+      index: PROFILE_ARRAY_DETAIL_PREFIX_ITEMS,
+    };
+
+    expect(
+      JSON.parse(summarizeLargeProfileArrayChangedKeys(current, next)),
+    ).toEqual({
+      version: 1,
+      type: 'array-prefix-diff',
+      currentLength: 10_000,
+      nextLength: 10_000,
+      keys: ['0', '10'],
+      omitted: 10_000 - PROFILE_ARRAY_DETAIL_PREFIX_ITEMS,
+      tail: 'not-inspected',
+    });
+  });
+
+  it('does not enumerate array items when summarizing values', () => {
+    let ownKeysCalls = 0;
+    const objectItem = new Proxy(
+      { hidden: true },
+      {
+        ownKeys(target) {
+          ownKeysCalls++;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+    const value = Array.from(
+      { length: PROFILE_ARRAY_DETAIL_THRESHOLD + 1 },
+      () => objectItem,
+    );
+
+    const summary = JSON.parse(summarizeLargeProfileArrayValue(value));
+    expect(summary).toEqual({
+      version: 1,
+      type: 'array',
+      length: PROFILE_ARRAY_DETAIL_THRESHOLD + 1,
+      detail: 'omitted',
+    });
+    expect(ownKeysCalls).toBe(0);
+  });
+
+  it('omits current length when the previous state is not an array', () => {
+    const next = Array.from(
+      { length: PROFILE_ARRAY_DETAIL_THRESHOLD + 1 },
+      (_, index) => index,
+    );
+
+    expect(
+      JSON.parse(summarizeLargeProfileArrayChangedKeys(null, next)),
+    ).toEqual({
+      version: 1,
+      type: 'array-prefix-diff',
+      nextLength: PROFILE_ARRAY_DETAIL_THRESHOLD + 1,
+      keys: Array.from(
+        { length: PROFILE_ARRAY_DETAIL_PREFIX_ITEMS },
+        (_, index) => String(index),
+      ),
+      omitted: PROFILE_ARRAY_DETAIL_THRESHOLD + 1
+        - PROFILE_ARRAY_DETAIL_PREFIX_ITEMS,
+      tail: 'not-inspected',
+    });
+  });
+});

--- a/packages/react/runtime/__test__/snapshot/debug/profile.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/debug/profile.test.jsx
@@ -117,24 +117,60 @@ describe('profile', () => {
     );
     triggerUpdate();
 
-    expect(profileMarkSpy.mock.calls).toMatchInlineSnapshot(`
-      [
-        [
-          "ReactLynx::setState",
-          {
-            "args": {
-              "changed (shallow diff) state keys": "["count"]",
-              "componentName": "ClassComponent",
-              "current state keys": "["count"]",
-              "currentValue": "{"count":0}",
-              "next state keys": "["count"]",
-              "nextValue": "{"count":1}",
-            },
-            "flowId": 666,
-          },
-        ],
-      ]
-    `);
+    expect(profileMarkSpy).toHaveBeenCalledTimes(1);
+    expect(profileMarkSpy.mock.calls[0]).toEqual([
+      'ReactLynx::setState',
+      {
+        flowId: 666,
+        args: {
+          componentName: 'ClassComponent',
+          'current state keys': '["count"]',
+          'next state keys': '["count"]',
+          'changed (shallow diff) state keys': '["count"]',
+          currentValue: '{"count":0}',
+          nextValue: '{"count":1}',
+        },
+      },
+    ]);
+  });
+
+  test('should keep class state detail compatible when it contains a large array', async () => {
+    const initialRows = Array.from({ length: 129 }, (_, index) => ({
+      id: index,
+      label: `row ${index}`,
+    }));
+    let triggerUpdate;
+    class ClassComponent extends Component {
+      state = {
+        rows: initialRows,
+      };
+
+      render() {
+        triggerUpdate = () =>
+          this.setState({
+            rows: this.state.rows.map((row, index) => index === 0 ? { ...row, label: 'changed' } : row),
+          });
+        return null;
+      }
+    }
+
+    render(<ClassComponent />, scratch);
+    triggerUpdate();
+
+    expect(lynx.performance.profileMark).toHaveBeenCalledTimes(1);
+    const [, options] = lynx.performance.profileMark.mock.calls[0];
+    expect(options.args['current state keys']).toBe('["rows"]');
+    expect(options.args['next state keys']).toBe('["rows"]');
+    expect(options.args['changed (shallow diff) state keys']).toBe('["rows"]');
+    expect(JSON.parse(options.args.currentValue).rows).toHaveLength(129);
+    expect(JSON.parse(options.args.currentValue).rows[128]).toEqual({
+      id: 128,
+      label: 'row 128',
+    });
+    expect(JSON.parse(options.args.nextValue).rows[0]).toEqual({
+      id: 0,
+      label: 'changed',
+    });
   });
 
   test('should trace useState updates in functional components', async () => {
@@ -181,55 +217,53 @@ describe('profile', () => {
     triggerUpdateObject();
     triggerUpdateObjectCircular();
 
-    expect(profileMarkSpy.mock.calls).toMatchInlineSnapshot(`
+    expect(profileMarkSpy.mock.calls).toEqual([
       [
-        [
-          "ReactLynx::hooks::setState",
-          {
-            "args": {
-              "changed (shallow diff) state keys": "[]",
-              "componentName": "App",
-              "current state keys": "[]",
-              "currentValue": "0",
-              "hookIdx": "0",
-              "next state keys": "[]",
-              "nextValue": "1",
-            },
-            "flowId": 666,
+        'ReactLynx::hooks::setState',
+        {
+          flowId: 666,
+          args: {
+            hookIdx: '0',
+            componentName: 'App',
+            'current state keys': '[]',
+            'next state keys': '[]',
+            'changed (shallow diff) state keys': '[]',
+            currentValue: '0',
+            nextValue: '1',
           },
-        ],
-        [
-          "ReactLynx::hooks::setState",
-          {
-            "args": {
-              "changed (shallow diff) state keys": "["count","newKey"]",
-              "componentName": "App",
-              "current state keys": "["count","unchanged"]",
-              "currentValue": "{"count":0,"unchanged":"unchanged"}",
-              "hookIdx": "1",
-              "next state keys": "["count","unchanged","newKey"]",
-              "nextValue": "{"count":1,"unchanged":"unchanged","newKey":"newValue"}",
-            },
-            "flowId": 666,
+        },
+      ],
+      [
+        'ReactLynx::hooks::setState',
+        {
+          flowId: 666,
+          args: {
+            hookIdx: '1',
+            componentName: 'App',
+            'current state keys': '["count","unchanged"]',
+            'next state keys': '["count","unchanged","newKey"]',
+            'changed (shallow diff) state keys': '["count","newKey"]',
+            currentValue: '{"count":0,"unchanged":"unchanged"}',
+            nextValue: '{"count":1,"unchanged":"unchanged","newKey":"newValue"}',
           },
-        ],
-        [
-          "ReactLynx::hooks::setState",
-          {
-            "args": {
-              "changed (shallow diff) state keys": "["count"]",
-              "componentName": "App",
-              "current state keys": "["count","circularKey"]",
-              "currentValue": "{"count":0,"circularKey":"[Unserializable: Circular]"}",
-              "hookIdx": "2",
-              "next state keys": "["count","circularKey"]",
-              "nextValue": "{"count":1,"circularKey":{"count":0,"circularKey":"[Unserializable: Circular]"}}",
-            },
-            "flowId": 666,
+        },
+      ],
+      [
+        'ReactLynx::hooks::setState',
+        {
+          flowId: 666,
+          args: {
+            hookIdx: '2',
+            componentName: 'App',
+            'current state keys': '["count","circularKey"]',
+            'next state keys': '["count","circularKey"]',
+            'changed (shallow diff) state keys': '["count"]',
+            currentValue: '{"count":0,"circularKey":"[Unserializable: Circular]"}',
+            nextValue: '{"count":1,"circularKey":{"count":0,"circularKey":"[Unserializable: Circular]"}}',
           },
-        ],
-      ]
-    `);
+        },
+      ],
+    ]);
   });
 
   test('should handle function values in useState', async () => {
@@ -250,25 +284,76 @@ describe('profile', () => {
     render(<App />, scratch);
     updateFunc();
 
-    expect(profileMarkSpy.mock.calls).toMatchInlineSnapshot(`
-      [
-        [
-          "ReactLynx::hooks::setState",
-          {
-            "args": {
-              "changed (shallow diff) state keys": "[]",
-              "componentName": "App",
-              "current state keys": "[]",
-              "currentValue": ""() => \\"A\\""",
-              "hookIdx": "0",
-              "next state keys": "[]",
-              "nextValue": ""() => \\"B\\""",
-            },
-            "flowId": 666,
-          },
-        ],
-      ]
-    `);
+    expect(profileMarkSpy.mock.calls[0]).toEqual([
+      'ReactLynx::hooks::setState',
+      {
+        flowId: 666,
+        args: {
+          hookIdx: '0',
+          componentName: 'App',
+          'current state keys': '[]',
+          'next state keys': '[]',
+          'changed (shallow diff) state keys': '[]',
+          currentValue: '"() => \\"A\\""',
+          nextValue: '"() => \\"B\\""',
+        },
+      },
+    ]);
+  });
+
+  test('should bound large array profile detail to an index prefix', async () => {
+    const initial = Array.from({ length: 129 }, (_, index) => ({
+      id: index,
+      label: `row ${index}`,
+    }));
+    let updateRows;
+    function App() {
+      const [rows, setRows] = useState(initial);
+      updateRows = () =>
+        setRows((current) => {
+          const next = current.slice();
+          next[0] = { id: 0, label: 'changed inside prefix' };
+          next[32] = { id: 32, label: 'changed outside prefix' };
+          return next;
+        });
+      return <text>{rows.length}</text>;
+    }
+
+    render(<App />, scratch);
+    updateRows();
+
+    expect(lynx.performance.profileMark).toHaveBeenCalledTimes(1);
+    const [traceName, options] = lynx.performance.profileMark.mock.calls[0];
+    expect(traceName).toBe('ReactLynx::hooks::setState');
+    expect(options.args.hookIdx).toBe('0');
+    expect(JSON.parse(options.args['current state keys'])).toEqual(
+      expect.objectContaining({
+        version: 1,
+        type: 'array-prefix',
+        length: 129,
+        omitted: 97,
+        tail: 'not-inspected',
+      }),
+    );
+    expect(
+      JSON.parse(options.args['changed (shallow diff) state keys']),
+    ).toEqual({
+      version: 1,
+      type: 'array-prefix-diff',
+      currentLength: 129,
+      nextLength: 129,
+      keys: ['0'],
+      omitted: 97,
+      tail: 'not-inspected',
+    });
+    const nextValue = JSON.parse(options.args.nextValue);
+    expect(nextValue).toEqual({
+      version: 1,
+      type: 'array',
+      length: 129,
+      detail: 'omitted',
+    });
+    expect(options.args.nextValue).not.toContain('changed outside prefix');
   });
 
   test('should handle missing component instance', async () => {

--- a/packages/react/runtime/src/shared/profile-array-detail.ts
+++ b/packages/react/runtime/src/shared/profile-array-detail.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const PROFILE_ARRAY_DETAIL_THRESHOLD = 128;
+export const PROFILE_ARRAY_DETAIL_PREFIX_ITEMS = 32;
+
+export function isLargeProfileArray(value: unknown): value is unknown[] {
+  return Array.isArray(value)
+    && value.length > PROFILE_ARRAY_DETAIL_THRESHOLD;
+}
+
+function prefixKeys(
+  value: unknown[],
+  previous?: unknown,
+): string[] {
+  const keys: string[] = [];
+  for (
+    let index = 0;
+    index < Math.min(value.length, PROFILE_ARRAY_DETAIL_PREFIX_ITEMS);
+    index++
+  ) {
+    if (
+      Object.prototype.propertyIsEnumerable.call(value, index)
+      && (previous === undefined
+        || (previous as Record<number, unknown> | null)?.[index]
+          !== value[index])
+    ) {
+      keys.push(String(index));
+    }
+  }
+  return keys;
+}
+
+export function summarizeLargeProfileArrayKeys(
+  value: unknown[],
+): string {
+  return JSON.stringify({
+    version: 1,
+    type: 'array-prefix',
+    length: value.length,
+    keys: prefixKeys(value),
+    omitted: Math.max(0, value.length - PROFILE_ARRAY_DETAIL_PREFIX_ITEMS),
+    tail: 'not-inspected',
+  });
+}
+
+export function summarizeLargeProfileArrayValue(
+  value: unknown[],
+): string {
+  return JSON.stringify({
+    version: 1,
+    type: 'array',
+    length: value.length,
+    detail: 'omitted',
+  });
+}
+
+export function summarizeLargeProfileArrayChangedKeys(
+  currentState: unknown,
+  nextState: unknown[],
+): string {
+  return JSON.stringify({
+    version: 1,
+    type: 'array-prefix-diff',
+    currentLength: Array.isArray(currentState)
+      ? currentState.length
+      : undefined,
+    nextLength: nextState.length,
+    keys: prefixKeys(nextState, currentState),
+    omitted: Math.max(0, nextState.length - PROFILE_ARRAY_DETAIL_PREFIX_ITEMS),
+    tail: 'not-inspected',
+  });
+}

--- a/packages/react/runtime/src/snapshot/debug/profileHooks.ts
+++ b/packages/react/runtime/src/snapshot/debug/profileHooks.ts
@@ -7,6 +7,12 @@ import type { ComponentClass, ComponentType, VNode } from 'preact';
 import type { TraceOption } from '@lynx-js/types';
 
 import {
+  isLargeProfileArray,
+  summarizeLargeProfileArrayChangedKeys,
+  summarizeLargeProfileArrayKeys,
+  summarizeLargeProfileArrayValue,
+} from '../../shared/profile-array-detail.js';
+import {
   COMMIT,
   COMPONENT,
   DIFF,
@@ -51,26 +57,42 @@ function buildSetStateProfileMarkArgs(
   type: string | ComponentType | undefined,
   currentState: unknown,
   nextState: unknown,
+  boundLargeArrays = false,
 ): Record<string, string> {
   const EMPTY_OBJ = {};
 
-  const currentStateObj = (currentState ?? EMPTY_OBJ) as Record<string, unknown>;
+  const currentStateObj = (currentState ?? EMPTY_OBJ) as Record<
+    string,
+    unknown
+  >;
   const nextStateObj = (nextState ?? EMPTY_OBJ) as Record<string, unknown>;
+  const boundCurrent = boundLargeArrays && isLargeProfileArray(currentState);
+  const boundNext = boundLargeArrays && isLargeProfileArray(nextState);
 
   return {
     componentName: (type && typeof type === 'function')
       ? getDisplayName(type as ComponentClass)
       : 'Unknown',
-    'current state keys': JSON.stringify(Object.keys(currentStateObj)),
-    'next state keys': JSON.stringify(Object.keys(nextStateObj)),
-    'changed (shallow diff) state keys': JSON.stringify(
-      // the setState is in assign manner, we assume nextState is a superset of currentState
-      Object.keys(nextStateObj).filter(
-        key => currentStateObj[key] !== nextStateObj[key],
+    'current state keys': boundCurrent
+      ? summarizeLargeProfileArrayKeys(currentState)
+      : JSON.stringify(Object.keys(currentStateObj)),
+    'next state keys': boundNext
+      ? summarizeLargeProfileArrayKeys(nextState)
+      : JSON.stringify(Object.keys(nextStateObj)),
+    'changed (shallow diff) state keys': boundNext
+      ? summarizeLargeProfileArrayChangedKeys(currentState, nextState)
+      : JSON.stringify(
+        // the setState is in assign manner, we assume nextState is a superset of currentState
+        Object.keys(nextStateObj).filter(
+          key => currentStateObj[key] !== nextStateObj[key],
+        ),
       ),
-    ),
-    currentValue: safeJsonStringify(format(currentState)),
-    nextValue: safeJsonStringify(format(nextState)),
+    currentValue: boundCurrent
+      ? summarizeLargeProfileArrayValue(currentState)
+      : safeJsonStringify(format(currentState)),
+    nextValue: boundNext
+      ? summarizeLargeProfileArrayValue(nextState)
+      : safeJsonStringify(format(nextState)),
   };
 }
 
@@ -189,6 +211,7 @@ export function initProfileHook(): void {
                         type,
                         currentValue,
                         nextValue,
+                        true,
                       ),
                     },
                   });


### PR DESCRIPTION
## Summary

- Bound Snapshot hook-state profiling detail only for arrays longer than 128 items.
- Preserve the first 32 indices for key and shallow-diff diagnostics without inspecting the tail.
- Keep smaller arrays, ordinary objects, primitives, class state, and Element Template profiling byte-compatible with the existing detail format.

## Performance evidence

A real production browser probe with a 10,000-item hook-state array reduced the create mark detail from 646,605 B to 932 B (-99.86%); the corresponding update detail was 1,146 B.

Five compiled micro runs measured the 10k detail path at roughly 8.6-9.4 ms before and 0.017 ms after.

This is a profiling-enabled-path optimization. The standalone rows-0 app artifact grows from 97,800 B to 99,343 B raw (+1.58%); the separate default-Web reachability PR #3558 will make this profile-only helper unreachable from default production Web bundles.

## Compatibility

- Threshold is strictly greater than 128; arrays at or below it retain the old format.
- Class state and ordinary objects retain their old key/value detail.
- Proxy ownKeys behavior is covered to ensure the bounded path does not enumerate a large tail.
- Element Template profiling is unchanged.

## Validation

- Focused profile tests: 14/14.
- Snapshot/worklet/guardrail suite: 97 files, 775 passed, 2 skipped, 4 todo.
- Coverage: 100% statements, branches, functions, and lines.
- Pre-commit ESLint, Biome, and dprint hooks passed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
