### PR TITLE
refactor: move the CSS minimizer into @lynx-js/rsbuild-plugin

### DIFF
--- a/.changeset/move-css-minimizer.md
+++ b/.changeset/move-css-minimizer.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Move the cssnano-based CSS minimizer into `pluginLynx()`.

--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -56,12 +56,12 @@
     "@lynx-js/debug-metadata-rsbuild-plugin": "workspace:^",
     "@lynx-js/rsbuild-plugin": "workspace:*",
     "@rsbuild/core": "catalog:rsbuild",
-    "@rsbuild/plugin-css-minimizer": "2.0.1",
     "@rsdoctor/rspack-plugin": "~1.6.1"
   },
   "devDependencies": {
     "@lynx-js/test-tools": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
+    "@rsbuild/plugin-css-minimizer": "2.0.1",
     "@rsdoctor/core": "~1.6.1",
     "@rstest/core": "catalog:rstest",
     "@swc/core": "^1.15.47",

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -56,12 +56,4 @@ export async function applyDefaultPlugins(
   }
 
   await Promise.all(promises)
-
-  // If no `@rsbuild/plugin-css-minimizer` is applied, apply it
-  const { pluginCssMinimizer, PLUGIN_CSS_MINIMIZER_NAME } = await import(
-    '@rsbuild/plugin-css-minimizer'
-  )
-  if (!rsbuildInstance.isPluginExists(PLUGIN_CSS_MINIMIZER_NAME)) {
-    rsbuildInstance.addPlugins([pluginCssMinimizer()])
-  }
 }

--- a/packages/rspeedy/plugin-lynx/package.json
+++ b/packages/rspeedy/plugin-lynx/package.json
@@ -43,7 +43,8 @@
     "@lynx-js/chunk-loading-webpack-plugin": "workspace:^",
     "@lynx-js/web-rsbuild-server-middleware": "workspace:*",
     "@lynx-js/webpack-dev-transport": "workspace:^",
-    "@lynx-js/websocket": "workspace:^"
+    "@lynx-js/websocket": "workspace:^",
+    "@rsbuild/plugin-css-minimizer": "2.0.1"
   },
   "devDependencies": {
     "@lynx-js/test-tools": "workspace:*",

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -4,6 +4,7 @@
 import type { RsbuildPlugin } from '@rsbuild/core'
 
 import { pluginChunkLoading } from './plugins/chunkLoading.plugin.js'
+import { pluginCssMinimizer } from './plugins/cssMinimizer.plugin.js'
 import { pluginDev } from './plugins/dev.plugin.js'
 import { pluginMinify } from './plugins/minify.plugin.js'
 import { pluginOptimization } from './plugins/optimization.plugin.js'
@@ -20,6 +21,7 @@ import { pluginTarget } from './plugins/target.plugin.js'
 export function pluginLynx(): RsbuildPlugin[] {
   return [
     pluginChunkLoading(),
+    pluginCssMinimizer(),
     pluginDev(),
     pluginMinify(),
     pluginOptimization(),

--- a/packages/rspeedy/plugin-lynx/src/plugins/cssMinimizer.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/cssMinimizer.plugin.ts
@@ -1,0 +1,20 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { RsbuildPlugin } from '@rsbuild/core'
+
+export function pluginCssMinimizer(): RsbuildPlugin {
+  return {
+    name: 'lynx:rsbuild:css-minimizer',
+    async setup(api) {
+      // If no `@rsbuild/plugin-css-minimizer` is applied, apply it
+      const { pluginCssMinimizer, PLUGIN_CSS_MINIMIZER_NAME } = await import(
+        '@rsbuild/plugin-css-minimizer'
+      )
+      if (!api.isPluginExists(PLUGIN_CSS_MINIMIZER_NAME)) {
+        await pluginCssMinimizer().setup(api)
+      }
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1522,9 +1522,6 @@ importers:
       '@rsbuild/core':
         specifier: catalog:rsbuild
         version: 2.1.10(core-js@3.50.0)
-      '@rsbuild/plugin-css-minimizer':
-        specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.10(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/rspack-plugin':
         specifier: ~1.6.1
         version: 1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
@@ -1538,6 +1535,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
         version: 7.58.12(@types/node@24.13.3)
+      '@rsbuild/plugin-css-minimizer':
+        specifier: 2.0.1
+        version: 2.0.1(@rsbuild/core@2.1.10(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@rsdoctor/core':
         specifier: ~1.6.1
         version: 1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
@@ -1747,6 +1747,9 @@ importers:
       '@lynx-js/websocket':
         specifier: workspace:^
         version: link:../websocket
+      '@rsbuild/plugin-css-minimizer':
+        specifier: 2.0.1
+        version: 2.0.1(@rsbuild/core@2.1.10(core-js@3.50.0))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
     devDependencies:
       '@lynx-js/test-tools':
         specifier: workspace:*


### PR DESCRIPTION
Moves the CSS minimizer registration from `applyDefaultPlugins` into `pluginLynx()`, together with its dependency.

Rspeedy replaces Rsbuild v2's built-in LightningCSS minimizer with the cssnano-based one from `@rsbuild/plugin-css-minimizer`, because several LightningCSS transforms are equivalent on the Web but produce CSS that Lynx cannot handle. That is a Lynx constraint rather than a Rspeedy product decision, so it belongs to the engine. Today a raw `rsbuild` + `pluginLynx` user keeps the LightningCSS minimizer and hits those transforms.

The registration itself is unchanged, including the `isPluginExists` guard that lets a user supply their own configured `pluginCssMinimizer`. The only difference is how it is expressed: the plugin API has `isPluginExists` but no `addPlugins`, so the guarded registration runs the upstream plugin's own `setup` instead of adding it to the instance. No behaviour or option handling is reimplemented here.

`@rsbuild/plugin-css-minimizer` moves from `@lynx-js/rspeedy` dependencies to `@lynx-js/rsbuild-plugin`, and stays as a devDependency of `@lynx-js/rspeedy` because its tests import it directly.

Verified: both test projects pass unchanged, including the existing `custom css minimizer` test in `@lynx-js/rspeedy` that pins the user-supplied-plugin behaviour, and `@examples/react` `main.lynx.bundle` is byte-identical to `main`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSS minimization is now included automatically through the Lynx plugin.
  * Existing CSS minimizer configurations are preserved to avoid duplicate processing.

* **Bug Fixes**
  * Improved CSS optimization setup for more consistent production builds.

* **Chores**
  * Updated release metadata for patch versions of the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->