### PR TITLE
fix(webpack): register element templates collected from the background build

### DIFF
--- a/.changeset/element-template-merge.md
+++ b/.changeset/element-template-merge.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-webpack-plugin": patch
+---
+
+Collect element templates from the background build as well, so a template the main-thread bundle does not reach is still registered for it.

--- a/packages/webpack/react-webpack-plugin/src/loaders/background.ts
+++ b/packages/webpack/react-webpack-plugin/src/loaders/background.ts
@@ -9,6 +9,7 @@ import {
   DEFINES_FOR_SNAPSHOT_BUILD_INFO,
   DEFINES_FOR_WORKLET_BUILD_INFO,
 } from '../Defines.js';
+import { ELEMENT_TEMPLATE_BUILD_INFO } from './main-thread.js';
 import { getBackgroundTransformOptions } from './options.js';
 import type { ReactLoaderOptions } from './options.js';
 
@@ -95,6 +96,11 @@ const backgroundLoader: LoaderDefinitionFunction<ReactLoaderOptions> = function(
     _module?: { buildInfo?: Record<string, unknown> };
   })._module?.buildInfo;
   if (buildInfo) {
+    if (result.elementTemplates && result.elementTemplates.length > 0) {
+      buildInfo[ELEMENT_TEMPLATE_BUILD_INFO] = result.elementTemplates;
+    } else {
+      delete buildInfo[ELEMENT_TEMPLATE_BUILD_INFO];
+    }
     if (result.definesForSnapshot) {
       buildInfo[DEFINES_FOR_SNAPSHOT_BUILD_INFO] = result.definesForSnapshot;
     }

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/index.jsx
@@ -1,0 +1,14 @@
+import { Suspense, lazy } from '@lynx-js/react';
+
+const Lazy = lazy(() => import('./lazy.jsx'));
+
+export default function App() {
+  return (
+    <view>
+      <text text='main-bundle-content' />
+      <Suspense fallback={null}>
+        <Lazy />
+      </Suspense>
+    </view>
+  );
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/lazy.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/lazy.jsx
@@ -1,0 +1,3 @@
+export default function LazyCard() {
+  return <text text='lazy-only-content' />;
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/rspack.config.js
@@ -37,6 +37,12 @@ export default {
      * @param {import('@rspack/core').Compiler} compiler
      */
     (compiler) => {
+      let encodedMainTemplate = false;
+
+      compiler.hooks.afterEmit.tap('element-template-lazy-scope-test', () => {
+        expect(encodedMainTemplate).toBe(true);
+      });
+
       compiler.hooks.thisCompilation.tap(
         'element-template-lazy-scope-test',
         (compilation) => {
@@ -48,6 +54,7 @@ export default {
               (chunkGroup) => chunkGroup.name === 'main__main-thread',
             );
             if (isMainTemplate) {
+              encodedMainTemplate = true;
               const templates = JSON.stringify(args.encodeData.elementTemplate);
 
               expect(templates).toContain('main-bundle-content');

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/rspack.config.js
@@ -1,0 +1,63 @@
+import { expect } from '@rstest/core';
+
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { createConfig } from '../../../create-react-config.js';
+
+const config = createConfig(
+  {
+    experimental_useElementTemplate: true,
+  },
+  {
+    experimental_useElementTemplate: true,
+    mainThreadChunks: [
+      'main__main-thread.js',
+      '.rspeedy/lazy-bundle/lazy.jsx/main-thread.js',
+    ],
+  },
+);
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: import.meta.dirname,
+  ...config,
+  plugins: [
+    ...config.plugins,
+    new LynxEncodePlugin(),
+    new LynxTemplatePlugin({
+      ...LynxTemplatePlugin.defaultOptions,
+      chunks: ['main__main-thread', 'main__background'],
+      filename: 'main/template.js',
+      intermediate: '.rspeedy/main',
+    }),
+    /**
+     * @param {import('@rspack/core').Compiler} compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap(
+        'element-template-lazy-scope-test',
+        (compilation) => {
+          const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+            compilation,
+          );
+          hooks.beforeEncode.tap('element-template-lazy-scope-test', (args) => {
+            const isMainTemplate = args.chunkGroups.some(
+              (chunkGroup) => chunkGroup.name === 'main__main-thread',
+            );
+            if (isMainTemplate) {
+              const templates = JSON.stringify(args.encodeData.elementTemplate);
+
+              expect(templates).toContain('main-bundle-content');
+              expect(templates).not.toContain('lazy-only-content');
+            }
+
+            return args;
+          });
+        },
+      );
+    },
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates-lazy/test.config.cjs
@@ -1,0 +1,1 @@
+module.exports = { bundlePath: [] };

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/deferred.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/deferred.jsx
@@ -1,0 +1,3 @@
+export function Deferred() {
+  return <text text='deferred-content' />;
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/index.jsx
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/index.jsx
@@ -1,0 +1,9 @@
+import { Deferred } from './deferred.jsx';
+
+export function App() {
+  return (
+    <view>
+      {__MAIN_THREAD__ ? <text text='main-thread-shell' /> : <Deferred />}
+    </view>
+  );
+}

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/rspack.config.js
@@ -35,10 +35,19 @@ export default {
             compilation,
           );
           hooks.beforeEncode.tap('element-template-merge-test', (args) => {
-            const templates = JSON.stringify(args.encodeData.elementTemplate);
+            const elementTemplate = args.encodeData.elementTemplate ?? {};
+            const templates = JSON.stringify(elementTemplate);
 
             expect(templates).toContain('main-thread-shell');
             expect(templates).toContain('deferred-content');
+
+            // Both threads compile the shared `<view>` wrapper, and the
+            // content-hash id makes that one entry rather than two.
+            expect(
+              Object.keys(elementTemplate).filter((id) =>
+                id !== '_et_builtin_raw_text'
+              ),
+            ).toHaveLength(3);
 
             return args;
           });

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/rspack.config.js
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/rspack.config.js
@@ -1,0 +1,49 @@
+import { expect } from '@rstest/core';
+
+import {
+  LynxEncodePlugin,
+  LynxTemplatePlugin,
+} from '@lynx-js/template-webpack-plugin';
+
+import { createConfig } from '../../../create-react-config.js';
+
+const defaultConfig = createConfig(
+  {
+    experimental_useElementTemplate: true,
+  },
+  {
+    experimental_useElementTemplate: true,
+  },
+);
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  context: import.meta.dirname,
+  ...defaultConfig,
+  plugins: [
+    ...(defaultConfig.plugins ?? []),
+    new LynxTemplatePlugin(),
+    new LynxEncodePlugin(),
+    /**
+     * @param {import('@rspack/core').Compiler} compiler
+     */
+    (compiler) => {
+      compiler.hooks.thisCompilation.tap(
+        'element-template-merge-test',
+        (compilation) => {
+          const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
+            compilation,
+          );
+          hooks.beforeEncode.tap('element-template-merge-test', (args) => {
+            const templates = JSON.stringify(args.encodeData.elementTemplate);
+
+            expect(templates).toContain('main-thread-shell');
+            expect(templates).toContain('deferred-content');
+
+            return args;
+          });
+        },
+      );
+    },
+  ],
+};

--- a/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/test.config.cjs
+++ b/packages/webpack/react-webpack-plugin/test/cases/element-template/merge-templates/test.config.cjs
@@ -1,0 +1,1 @@
+module.exports = { bundlePath: [] };


### PR DESCRIPTION
## Summary

Element templates were only ever collected from the main-thread build: `lynx:element-templates` is written by the main-thread loader alone, so `beforeEncode` could only see templates belonging to modules the main-thread module graph reaches. Whatever the background renders but the main thread never imports had no template in the encoded bundle, and building those elements when the background hands over its first patch had nothing to build from — the element-template counterpart of the `Snapshot not found` that #3393 fixed for the snapshot backend.

The background loader now stores its templates the same way, so the existing per-entrypoint collection picks them up. Merging stays id-keyed and is safe by construction: element-template ids are content hashes, so the same id carries the same template on both threads, and the collision check in `mergeElementTemplate` keeps that assumption honest.

Reaching this needs no new API — it is the same shape as the definition merge in #3393, one layer lower.

## Reproducing it without the fix

The gap is not tied to any one feature. A plain thread conditional is enough:

```jsx
<view>
  {__MAIN_THREAD__ ? <text text='main-thread-shell' /> : <Deferred />}
</view>
```

`<Deferred />`'s module leaves the main-thread bundle, and with it its template. The same happens for a subtree dropped by `sideEffects` shaking. `merge-templates` pins this: it fails on `main` and passes here.

## Tests

- `element-template/merge-templates` — a deferred subtree's template reaches the encoded bundle. Negative-validated: reverting the loader change fails this case and only this case.
- `element-template/merge-templates-lazy` — a lazy component's template still does not leak into the main bundle. The collection is scoped per entrypoint chunk group, and this pins that the extra background modules do not widen it.
- The existing `element-template/basic` case asserts an exact template count and is unchanged, which is the evidence that the two threads produce byte-identical templates for a shared id rather than colliding.

## Not covered

A lazy bundle's own encode currently receives an empty template map — its chunk groups are unnamed, and the collector keys on entrypoint names. That predates this change and is untouched by it; element templates inside lazy bundles need their own fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved element-template generation so content from deferred and lazily loaded components is correctly collected and merged into the appropriate output.
  * Prevented lazy-only content from appearing in the main template when it should remain separate.

* **Tests**
  * Added coverage for merged templates, lazy loading, deferred content, and background builds.

* **Chores**
  * Documented the change in the upcoming patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->