### PR TITLE
feat(genui): add public conversation privacy notice

### DIFF
--- a/packages/genui/playground/src/components/Icon.tsx
+++ b/packages/genui/playground/src/components/Icon.tsx
@@ -26,6 +26,7 @@ import {
   Sparkles,
   Sun,
   Trash2,
+  TriangleAlert,
   X,
   Zap,
 } from 'lucide-react';
@@ -51,6 +52,7 @@ export {
   Sparkles,
   Sun,
   Trash2,
+  TriangleAlert,
   X,
   Zap,
 };

--- a/packages/genui/playground/src/pages/chat/ChatController.tsx
+++ b/packages/genui/playground/src/pages/chat/ChatController.tsx
@@ -26,7 +26,7 @@ import type {
 } from './type.js';
 import { Button } from '../../components/Button.js';
 import { useCopyToast } from '../../components/CopyToast.js';
-import { Send, Sparkles, Zap } from '../../components/Icon.js';
+import { Send, Sparkles, TriangleAlert, Zap } from '../../components/Icon.js';
 import type { MobilePaneTab } from '../../components/MobileTabBar.js';
 import type {
   PreviewMetricName,
@@ -1579,6 +1579,20 @@ export function ChatController<
               </>
             )
             : null}
+          <aside className='chatPrivacyNotice' aria-label='Privacy notice'>
+            <TriangleAlert
+              className='chatPrivacyNoticeIcon'
+              size={16}
+              strokeWidth={2}
+              aria-hidden='true'
+            />
+            <p className='chatPrivacyNoticeText'>
+              <strong>Privacy notice:</strong>{' '}
+              Conversations in this playground are public and will be
+              transmitted to mainland China for processing. Do not include
+              personal, confidential, or sensitive information.
+            </p>
+          </aside>
           <div className='chatComposer'>
             <textarea
               className='chatInput'

--- a/packages/genui/playground/src/pages/chat/ChatPage.css
+++ b/packages/genui/playground/src/pages/chat/ChatPage.css
@@ -1177,6 +1177,33 @@
   -webkit-box-orient: vertical;
 }
 
+.chatPrivacyNotice {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 9px 11px;
+  border: 1px solid color-mix(in srgb, #d97706 36%, var(--geist-border));
+  border-radius: var(--geist-radius-md);
+  background: color-mix(in srgb, #f59e0b 9%, var(--geist-background));
+  color: color-mix(in srgb, #b45309 72%, var(--geist-foreground));
+}
+
+.chatPrivacyNoticeIcon {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.chatPrivacyNoticeText {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.chatPrivacyNoticeText strong {
+  color: color-mix(in srgb, #b45309 84%, var(--geist-foreground));
+  font-weight: 700;
+}
+
 .chatComposer {
   display: flex;
   flex-direction: column;
@@ -1540,6 +1567,16 @@
   .chatInputArea {
     padding: 8px 14px 10px;
     gap: 8px;
+  }
+
+  .chatPrivacyNotice {
+    gap: 7px;
+    padding: 7px 9px;
+  }
+
+  .chatPrivacyNoticeText {
+    font-size: 10.5px;
+    line-height: 1.4;
   }
 
   /* Instant examples: same horizontal rail, but each tile is smaller


### PR DESCRIPTION
## Summary

- add a persistent privacy notice above the GenUI Playground chat composer
- state that playground conversations are public and transmitted to mainland China for processing
- warn users not to include personal, confidential, or sensitive information
- style the notice for light, dark, desktop, and mobile layouts

<img width="1503" height="1038" alt="image" src="https://github.com/user-attachments/assets/eb7fc68d-be17-4785-99c6-25e0d3f2631e" />



## Why

Users should understand the visibility and data-transfer implications before submitting a prompt. Placing the notice immediately above the composer keeps it visible at the point of entry across A2UI, OpenUI, and MCP Apps.

## Validation

- `pnpm turbo build`
- `pnpm -C packages/genui/playground test` (127 tests)
- targeted ESLint, Biome, and dprint checks
- desktop and 390px mobile browser layout checks

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a privacy notice above the chat composer explaining that conversations are public and processed in mainland China.
  - Warns users not to include personal, confidential, or sensitive information.
  - Added responsive styling for clear display on desktop and mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->