### PR TITLE
feat(web-core): support lynx.reload(value) on web

### DIFF
--- a/.changeset/web-gap-reload-with-data.md
+++ b/.changeset/web-gap-reload-with-data.md
@@ -2,4 +2,6 @@
 "@lynx-js/web-core": minor
 ---
 
-`lynx.reload()` now accepts the same `(value, callback)` signature as native: an optional `value` object becomes the reloaded page's new initial data, and `callback` fires once the reload has finished rendering. Previously `lynx.reload()` ignored both arguments and only reloaded with the existing data.
+`lynx.reload(value)` now accepts the optional `value` argument, which becomes the reloaded page's new initial data — previously it was ignored and the page always reloaded with the existing data. `LynxViewElement.reload(value)` takes the same optional argument.
+
+The `callback` argument documented for native remains unsupported on web and now logs a warning when passed: reloading disposes the background thread the callback belongs to, so nothing scheduled there can observe the reloaded page.

--- a/.changeset/web-gap-reload-with-data.md
+++ b/.changeset/web-gap-reload-with-data.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": minor
+---
+
+`lynx.reload()` now accepts the same `(value, callback)` signature as native: an optional `value` object becomes the reloaded page's new initial data, and `callback` fires once the reload has finished rendering. Previously `lynx.reload()` ignored both arguments and only reloaded with the existing data.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -467,6 +467,25 @@ test.describe('reactlynx3 tests', () => {
       await expect(await target.getAttribute('style')).toContain('pink');
     });
 
+    test('basic-lynx-reload-with-data', async ({ page }, { title }) => {
+      let callbackFired = false;
+      page.on('console', (message) => {
+        if (message.text() === 'reload callback fired') {
+          callbackFired = true;
+        }
+      });
+      await goto(page, title);
+      await wait(100);
+      const target = page.locator('#target');
+      await expect(await target.getAttribute('style')).toContain('pink');
+      await target.click();
+      await wait(200);
+      // The new value passed to `lynx.reload()` becomes the reloaded page's
+      // `initData`, and the callback only fires once that reload settles.
+      await expect(await target.getAttribute('style')).toContain('green');
+      await expect(callbackFired).toBe(true);
+    });
+
     test(
       'basic-wrapper-element-do-not-impact-layout',
       async ({ page }, { title }) => {

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -468,12 +468,6 @@ test.describe('reactlynx3 tests', () => {
     });
 
     test('basic-lynx-reload-with-data', async ({ page }, { title }) => {
-      let callbackFired = false;
-      page.on('console', (message) => {
-        if (message.text() === 'reload callback fired') {
-          callbackFired = true;
-        }
-      });
       await goto(page, title);
       await wait(100);
       const target = page.locator('#target');
@@ -481,9 +475,8 @@ test.describe('reactlynx3 tests', () => {
       await target.click();
       await wait(200);
       // The new value passed to `lynx.reload()` becomes the reloaded page's
-      // `initData`, and the callback only fires once that reload settles.
+      // `initData`.
       await expect(await target.getAttribute('style')).toContain('green');
-      await expect(callbackFired).toBe(true);
     });
 
     test(

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-lynx-reload-with-data/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-lynx-reload-with-data/index.jsx
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, useInitData } from '@lynx-js/react';
+function App() {
+  const initData = useInitData();
+  return (
+    <view
+      id='target'
+      bindTap={() => {
+        lynx.reload({ mockData: 'reloaded' }, () => {
+          console.log('reload callback fired');
+        });
+      }}
+      style={{
+        height: '100px',
+        width: '100px',
+        background: initData?.mockData === 'reloaded' ? 'green' : 'pink',
+      }}
+    />
+  );
+}
+root.render(<App />);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-lynx-reload-with-data/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-lynx-reload-with-data/index.jsx
@@ -8,9 +8,7 @@ function App() {
     <view
       id='target'
       bindTap={() => {
-        lynx.reload({ mockData: 'reloaded' }, () => {
-          console.log('reload callback fired');
-        });
+        lynx.reload({ mockData: 'reloaded' });
       }}
       style={{
         height: '100px',

--- a/packages/web-platform/web-core/tests/register-reload-handler.spec.ts
+++ b/packages/web-platform/web-core/tests/register-reload-handler.spec.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import './jsdom.js';
+import { describe, expect, test } from '@rstest/core';
+import { registerReloadHandler } from '../ts/client/mainthread/crossThreadHandlers/registerReloadHandler.js';
+import { reloadEndpoint } from '../ts/client/endpoints.js';
+import type { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.js';
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+
+/**
+ * `registerReloadHandler` is the main-thread side of `lynx.reload()`. It
+ * forwards the optional new initial data to `LynxViewElement.reload()` and
+ * hands the RPC layer that call's promise, so the background thread's
+ * `lynx.reload(value, callback)` only invokes `callback` once the reloaded
+ * page has actually finished rendering.
+ */
+describe('registerReloadHandler', () => {
+  test('forwards the reload value to the parent lynx-view and awaits it', async () => {
+    let handler: (value: unknown) => unknown = () => {
+      throw new Error('reload handler was never registered');
+    };
+    const rpc = {
+      registerHandler: (
+        endpoint: { name: string },
+        fn: (value: unknown) => unknown,
+      ) => {
+        expect(endpoint.name).toBe(reloadEndpoint.name);
+        handler = fn;
+      },
+    } as unknown as Rpc;
+
+    const calls: unknown[] = [];
+    let resolveReload!: () => void;
+    const lynxViewInstance = {
+      parentDom: {
+        reload: (value: unknown) => {
+          calls.push(value);
+          return new Promise<void>((resolve) => {
+            resolveReload = resolve;
+          });
+        },
+      },
+    } as unknown as LynxViewInstance;
+
+    registerReloadHandler(rpc, lynxViewInstance);
+
+    let settled = false;
+    const returned = Promise.resolve(handler({ mockData: 'reloaded' })).then(
+      () => {
+        settled = true;
+      },
+    );
+
+    expect(calls).toStrictEqual([{ mockData: 'reloaded' }]);
+    expect(settled).toBe(false);
+
+    resolveReload();
+    await returned;
+
+    expect(settled).toBe(true);
+  });
+
+  test('reloads with no new data when the background thread omits a value', () => {
+    let handler: (value: unknown) => unknown = () => {
+      throw new Error('reload handler was never registered');
+    };
+    const rpc = {
+      registerHandler: (
+        _endpoint: { name: string },
+        fn: (value: unknown) => unknown,
+      ) => {
+        handler = fn;
+      },
+    } as unknown as Rpc;
+
+    const calls: unknown[] = [];
+    const lynxViewInstance = {
+      parentDom: {
+        reload: (value: unknown) => {
+          calls.push(value);
+        },
+      },
+    } as unknown as LynxViewInstance;
+
+    registerReloadHandler(rpc, lynxViewInstance);
+    handler(undefined);
+
+    expect(calls).toStrictEqual([undefined]);
+  });
+});

--- a/packages/web-platform/web-core/tests/register-reload-handler.spec.ts
+++ b/packages/web-platform/web-core/tests/register-reload-handler.spec.ts
@@ -9,14 +9,14 @@ import type { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.
 import type { Rpc } from '@lynx-js/web-worker-rpc';
 
 /**
- * `registerReloadHandler` is the main-thread side of `lynx.reload()`. It
- * forwards the optional new initial data to `LynxViewElement.reload()` and
- * hands the RPC layer that call's promise, so the background thread's
- * `lynx.reload(value, callback)` only invokes `callback` once the reloaded
- * page has actually finished rendering.
+ * `registerReloadHandler` is the main-thread side of `lynx.reload()`. The
+ * background thread has no DOM, so the optional new initial data has to be
+ * forwarded here, to the `<lynx-view>` element that owns `initData`.
  */
 describe('registerReloadHandler', () => {
-  test('forwards the reload value to the parent lynx-view and awaits it', async () => {
+  const createRpc = (
+    onRegister?: (endpoint: { name: string }) => void,
+  ): { rpc: Rpc; getHandler: () => (value: unknown) => unknown } => {
     let handler: (value: unknown) => unknown = () => {
       throw new Error('reload handler was never registered');
     };
@@ -25,54 +25,38 @@ describe('registerReloadHandler', () => {
         endpoint: { name: string },
         fn: (value: unknown) => unknown,
       ) => {
-        expect(endpoint.name).toBe(reloadEndpoint.name);
+        onRegister?.(endpoint);
         handler = fn;
       },
     } as unknown as Rpc;
+    return { rpc, getHandler: () => handler };
+  };
+
+  test('forwards the reload value to the parent lynx-view', () => {
+    let registeredEndpointName: string | undefined;
+    const { rpc, getHandler } = createRpc((endpoint) => {
+      registeredEndpointName = endpoint.name;
+    });
 
     const calls: unknown[] = [];
-    let resolveReload!: () => void;
     const lynxViewInstance = {
       parentDom: {
         reload: (value: unknown) => {
           calls.push(value);
-          return new Promise<void>((resolve) => {
-            resolveReload = resolve;
-          });
         },
       },
     } as unknown as LynxViewInstance;
 
     registerReloadHandler(rpc, lynxViewInstance);
+    expect(registeredEndpointName).toBe(reloadEndpoint.name);
 
-    let settled = false;
-    const returned = Promise.resolve(handler({ mockData: 'reloaded' })).then(
-      () => {
-        settled = true;
-      },
-    );
+    getHandler()({ mockData: 'reloaded' });
 
     expect(calls).toStrictEqual([{ mockData: 'reloaded' }]);
-    expect(settled).toBe(false);
-
-    resolveReload();
-    await returned;
-
-    expect(settled).toBe(true);
   });
 
   test('reloads with no new data when the background thread omits a value', () => {
-    let handler: (value: unknown) => unknown = () => {
-      throw new Error('reload handler was never registered');
-    };
-    const rpc = {
-      registerHandler: (
-        _endpoint: { name: string },
-        fn: (value: unknown) => unknown,
-      ) => {
-        handler = fn;
-      },
-    } as unknown as Rpc;
+    const { rpc, getHandler } = createRpc();
 
     const calls: unknown[] = [];
     const lynxViewInstance = {
@@ -84,8 +68,25 @@ describe('registerReloadHandler', () => {
     } as unknown as LynxViewInstance;
 
     registerReloadHandler(rpc, lynxViewInstance);
-    handler(undefined);
+    getHandler()(undefined);
 
     expect(calls).toStrictEqual([undefined]);
+  });
+
+  test('returns nothing so the RPC layer does not try to reply', () => {
+    // `reloadEndpoint` is declared without a return value: the reload disposes
+    // the calling background thread, so a reply would be posted to a closed
+    // port. Returning `parentDom.reload()`'s value here would make the handler
+    // look awaitable and hide that.
+    const { rpc, getHandler } = createRpc();
+    const lynxViewInstance = {
+      parentDom: {
+        reload: () => Promise.resolve('should not be forwarded'),
+      },
+    } as unknown as LynxViewInstance;
+
+    registerReloadHandler(rpc, lynxViewInstance);
+
+    expect(getHandler()({ mockData: 'reloaded' })).toBeUndefined();
   });
 });

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
@@ -72,9 +72,18 @@ export function createBackgroundLynx(
       ) => void,
     ) => nativeApp.queryComponent(source, callback),
     reload: (value?: Cloneable, callback?: () => void) => {
-      mainThreadRpc.invoke(reloadEndpoint, [value]).then(() => {
-        callback?.();
-      });
+      mainThreadRpc.invoke(reloadEndpoint, [value]);
+      if (callback) {
+        // The reload tears this background thread down (the worker is
+        // terminated and the RPC port closed), so nothing that runs here
+        // survives long enough to observe the reloaded page. Native keeps its
+        // JS runtime across a reload and can invoke the callback; web cannot,
+        // so say so instead of leaving a callback that silently never fires.
+        console.warn(
+          '[lynx-web] the `callback` of `lynx.reload()` is not supported on web: '
+            + 'reloading disposes the background thread the callback belongs to.',
+        );
+      }
     },
     fetchBundle(url: string) {
       return fetchExternalBundle(url);

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
@@ -71,8 +71,10 @@ export function createBackgroundLynx(
         },
       ) => void,
     ) => nativeApp.queryComponent(source, callback),
-    reload: () => {
-      mainThreadRpc.invoke(reloadEndpoint, []);
+    reload: (value?: Cloneable, callback?: () => void) => {
+      mainThreadRpc.invoke(reloadEndpoint, [value]).then(() => {
+        callback?.();
+      });
     },
     fetchBundle(url: string) {
       return fetchExternalBundle(url);

--- a/packages/web-platform/web-core/ts/client/endpoints.ts
+++ b/packages/web-platform/web-core/ts/client/endpoints.ts
@@ -237,6 +237,6 @@ export const updateBTSChunkEndpoint = createRpcEndpoint<
 >('updateBTSChunkEndpoint', false, true);
 
 export const reloadEndpoint = createRpcEndpoint<
-  [],
+  [value: Cloneable | undefined],
   void
->('reload', false, false);
+>('reload', false, true);

--- a/packages/web-platform/web-core/ts/client/endpoints.ts
+++ b/packages/web-platform/web-core/ts/client/endpoints.ts
@@ -236,7 +236,13 @@ export const updateBTSChunkEndpoint = createRpcEndpoint<
   void
 >('updateBTSChunkEndpoint', false, true);
 
+/**
+ * Fire-and-forget on purpose: the reload disposes the calling card's
+ * background thread (`BackgroundThread[Symbol.asyncDispose]` terminates the
+ * worker and closes the message port), so a reply sent once the reload has
+ * finished would arrive on a closed port and never be observed.
+ */
 export const reloadEndpoint = createRpcEndpoint<
   [value: Cloneable | undefined],
   void
->('reload', false, true);
+>('reload', false, false);

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
@@ -390,15 +390,15 @@ export class LynxViewElement extends HTMLElement {
    * @public
    * @method
    * reload the current page
-   * @param value [optional] the new initial data to use for the reloaded page.
-   * When omitted, the current `initData` is kept.
+   * @param value [optional] the new initial data for the reloaded page. When
+   * omitted, the current `initData` is kept.
    */
   reload(value?: Cloneable) {
     if (value !== undefined) {
       this.#initData = value;
     }
     this.removeAttribute('ssr');
-    return this.#render();
+    this.#render();
   }
 
   /**
@@ -509,65 +509,58 @@ export class LynxViewElement extends HTMLElement {
         await this.#disposeInstance();
       }
       const mtsRealmPromise = createIFrameRealm(this.shadowRoot!);
-      // `reload()` awaits `#render()` to know when the reloaded page is ready
-      // (so it can resolve the `lynx.reload()` callback), so this needs to
-      // resolve once the deferred work below actually finishes rather than
-      // as soon as it's scheduled.
-      await new Promise<void>((resolve) => {
-        queueMicrotask(async () => {
-          if (this.injectStyleRules && this.injectStyleRules.length > 0) {
-            const styleSheet = new CSSStyleSheet();
-            for (const rule of this.injectStyleRules) {
-              styleSheet.insertRule(rule);
-            }
-            this.shadowRoot!.adoptedStyleSheets = this.shadowRoot!
-              .adoptedStyleSheets.concat(styleSheet);
+      queueMicrotask(async () => {
+        if (this.injectStyleRules && this.injectStyleRules.length > 0) {
+          const styleSheet = new CSSStyleSheet();
+          for (const rule of this.injectStyleRules) {
+            styleSheet.insertRule(rule);
           }
-          const mtsRealm = await mtsRealmPromise;
-          if (this.#url) {
-            const lynxViewInstance = import(
-              /* webpackChunkName: "web-core-main-chunk" */
-              /* webpackFetchPriority: "high" */
-              './LynxViewInstance.js'
-            ).then(({ LynxViewInstance }) => {
-              const isSSR = this.hasAttribute('ssr');
-              if (isSSR) {
-                this.removeAttribute('ssr');
-              }
+          this.shadowRoot!.adoptedStyleSheets = this.shadowRoot!
+            .adoptedStyleSheets.concat(styleSheet);
+        }
+        const mtsRealm = await mtsRealmPromise;
+        if (this.#url) {
+          const lynxViewInstance = import(
+            /* webpackChunkName: "web-core-main-chunk" */
+            /* webpackFetchPriority: "high" */
+            './LynxViewInstance.js'
+          ).then(({ LynxViewInstance }) => {
+            const isSSR = this.hasAttribute('ssr');
+            if (isSSR) {
+              this.removeAttribute('ssr');
+            }
 
-              return new LynxViewInstance(
-                this,
-                this.initData,
-                this.globalProps,
-                this.#url!,
-                this.shadowRoot!,
-                mtsRealm,
-                isSSR,
-                lynxGroupId,
-                this.nativeModulesMap,
-                this.napiModulesMap,
-                this.#initI18nResources,
-                this.transformVW,
-                this.transformVH,
-                this.transformREM,
-                this.browserConfig,
-              );
-            });
-            templateManager.fetchBundle(
-              this.#url,
-              lynxViewInstance,
+            return new LynxViewInstance(
+              this,
+              this.initData,
+              this.globalProps,
+              this.#url!,
+              this.shadowRoot!,
+              mtsRealm,
+              isSSR,
+              lynxGroupId,
+              this.nativeModulesMap,
+              this.napiModulesMap,
+              this.#initI18nResources,
               this.transformVW,
               this.transformVH,
               this.transformREM,
-              undefined, // overrideConfig
+              this.browserConfig,
             );
+          });
+          templateManager.fetchBundle(
+            this.#url,
+            lynxViewInstance,
+            this.transformVW,
+            this.transformVH,
+            this.transformREM,
+            undefined, // overrideConfig
+          );
 
-            const lynxGroupId = this.lynxGroupId;
-            this.#instance = await lynxViewInstance;
-            this.#rendering = false;
-          }
-          resolve();
-        });
+          const lynxGroupId = this.lynxGroupId;
+          this.#instance = await lynxViewInstance;
+          this.#rendering = false;
+        }
       });
     }
   }

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
@@ -390,10 +390,15 @@ export class LynxViewElement extends HTMLElement {
    * @public
    * @method
    * reload the current page
+   * @param value [optional] the new initial data to use for the reloaded page.
+   * When omitted, the current `initData` is kept.
    */
-  reload() {
+  reload(value?: Cloneable) {
+    if (value !== undefined) {
+      this.#initData = value;
+    }
     this.removeAttribute('ssr');
-    this.#render();
+    return this.#render();
   }
 
   /**
@@ -504,58 +509,65 @@ export class LynxViewElement extends HTMLElement {
         await this.#disposeInstance();
       }
       const mtsRealmPromise = createIFrameRealm(this.shadowRoot!);
-      queueMicrotask(async () => {
-        if (this.injectStyleRules && this.injectStyleRules.length > 0) {
-          const styleSheet = new CSSStyleSheet();
-          for (const rule of this.injectStyleRules) {
-            styleSheet.insertRule(rule);
-          }
-          this.shadowRoot!.adoptedStyleSheets = this.shadowRoot!
-            .adoptedStyleSheets.concat(styleSheet);
-        }
-        const mtsRealm = await mtsRealmPromise;
-        if (this.#url) {
-          const lynxViewInstance = import(
-            /* webpackChunkName: "web-core-main-chunk" */
-            /* webpackFetchPriority: "high" */
-            './LynxViewInstance.js'
-          ).then(({ LynxViewInstance }) => {
-            const isSSR = this.hasAttribute('ssr');
-            if (isSSR) {
-              this.removeAttribute('ssr');
+      // `reload()` awaits `#render()` to know when the reloaded page is ready
+      // (so it can resolve the `lynx.reload()` callback), so this needs to
+      // resolve once the deferred work below actually finishes rather than
+      // as soon as it's scheduled.
+      await new Promise<void>((resolve) => {
+        queueMicrotask(async () => {
+          if (this.injectStyleRules && this.injectStyleRules.length > 0) {
+            const styleSheet = new CSSStyleSheet();
+            for (const rule of this.injectStyleRules) {
+              styleSheet.insertRule(rule);
             }
+            this.shadowRoot!.adoptedStyleSheets = this.shadowRoot!
+              .adoptedStyleSheets.concat(styleSheet);
+          }
+          const mtsRealm = await mtsRealmPromise;
+          if (this.#url) {
+            const lynxViewInstance = import(
+              /* webpackChunkName: "web-core-main-chunk" */
+              /* webpackFetchPriority: "high" */
+              './LynxViewInstance.js'
+            ).then(({ LynxViewInstance }) => {
+              const isSSR = this.hasAttribute('ssr');
+              if (isSSR) {
+                this.removeAttribute('ssr');
+              }
 
-            return new LynxViewInstance(
-              this,
-              this.initData,
-              this.globalProps,
-              this.#url!,
-              this.shadowRoot!,
-              mtsRealm,
-              isSSR,
-              lynxGroupId,
-              this.nativeModulesMap,
-              this.napiModulesMap,
-              this.#initI18nResources,
+              return new LynxViewInstance(
+                this,
+                this.initData,
+                this.globalProps,
+                this.#url!,
+                this.shadowRoot!,
+                mtsRealm,
+                isSSR,
+                lynxGroupId,
+                this.nativeModulesMap,
+                this.napiModulesMap,
+                this.#initI18nResources,
+                this.transformVW,
+                this.transformVH,
+                this.transformREM,
+                this.browserConfig,
+              );
+            });
+            templateManager.fetchBundle(
+              this.#url,
+              lynxViewInstance,
               this.transformVW,
               this.transformVH,
               this.transformREM,
-              this.browserConfig,
+              undefined, // overrideConfig
             );
-          });
-          templateManager.fetchBundle(
-            this.#url,
-            lynxViewInstance,
-            this.transformVW,
-            this.transformVH,
-            this.transformREM,
-            undefined, // overrideConfig
-          );
 
-          const lynxGroupId = this.lynxGroupId;
-          this.#instance = await lynxViewInstance;
-          this.#rendering = false;
-        }
+            const lynxGroupId = this.lynxGroupId;
+            this.#instance = await lynxViewInstance;
+            this.#rendering = false;
+          }
+          resolve();
+        });
       });
     }
   }

--- a/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerReloadHandler.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerReloadHandler.ts
@@ -12,8 +12,6 @@ export function registerReloadHandler(
 ) {
   rpc.registerHandler(
     reloadEndpoint,
-    () => {
-      lynxViewInstance.parentDom.reload();
-    },
+    (value) => lynxViewInstance.parentDom.reload(value),
   );
 }

--- a/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerReloadHandler.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerReloadHandler.ts
@@ -12,6 +12,8 @@ export function registerReloadHandler(
 ) {
   rpc.registerHandler(
     reloadEndpoint,
-    (value) => lynxViewInstance.parentDom.reload(value),
+    (value) => {
+      lynxViewInstance.parentDom.reload(value);
+    },
   );
 }


### PR DESCRIPTION
@coderabbitai summary

## What

Closes part of a real web platform gap: [`lynx-api/lynx/reload`](https://lynxjs.org/api/lynx-api/lynx/lynx-reload) is supported on android/ios/harmony/clay, and the top-line &#34;reload the current page&#34; behavior already worked on web via `LynxViewElement.reload()` — but `lynx.reload(value, callback)` silently dropped both documented parameters:

- `value`: the new initial data the reloaded page should use. **This PR wires it up.**
- `callback`: invoked once the reload finishes. **This one cannot work on web** — see below.

### Why `callback` is not implemented

`lynx.reload()` disposes the calling card&#39;s background thread: `LynxViewElement.#render()` → `#disposeInstance()` → `LynxViewInstance[Symbol.asyncDispose]()` → `BackgroundThread[Symbol.asyncDispose]()`, which terminates the worker and closes the RPC message port. The callback is a closure living in exactly that runtime, and any RPC reply sent once the reload has finished is posted to a dead port.

An earlier revision of this PR made the reload endpoint awaitable and called `callback` on the reply. Running the new e2e case showed what the design predicts: the `initData` half worked, the callback never fired. Native keeps its JS runtime across a reload, which is why the callback is deliverable there and not here.

So `lynx.reload()` now accepts `callback` for signature compatibility and logs a warning when one is passed, instead of leaving a callback that silently never runs.

## How

The background thread has no DOM, so the reload has to round-trip to the main thread where the `<lynx-view>` element lives — same shape as the existing `invokeUIMethod`/`selectComponent` RPC endpoints:

- **`endpoints.ts`**: `reloadEndpoint` now carries an optional `Cloneable` value. It stays fire-and-forget, with a comment recording why a reply would be unobservable.
- **`registerReloadHandler.ts`** (main thread): forwards the value to `LynxViewElement.reload(value)`.
- **`LynxView.ts`**: `reload(value)` sets `#initData` before re-rendering when a value is given. `#render()` is untouched.
- **`createBackgroundLynx.ts`**: `lynx.reload(value, callback)` invokes the RPC with `value`, and warns if a `callback` was passed.

SSR doesn&#39;t need a stub — `reload` is background-thread only (like `reportError`/`getSharedData`), and SSR&#39;s `createServerLynx.ts` only implements `MainThreadLynx`, which doesn&#39;t declare `reload`.

## Test plan

- New unit tests (`register-reload-handler.spec.ts`): the main-thread handler forwards the value to `parentDom.reload()`, passes `undefined` through unchanged when the background thread omits one, and returns nothing so the RPC layer doesn&#39;t try to reply.
- New e2e case (`basic-lynx-reload-with-data`): exercises the full background → main-thread round trip — `lynx.reload({ mockData: &#39;reloaded&#39; })` updates `useInitData()` on the reloaded page.
- e2e run locally (chromium): `basic-lynx-reload-with-data`, `basic-lynx-reload`, `basic-reload` and `basic-reload-page-only-one` all pass.
- Full `web-core` unit suite: 357/357 passing.
- `tsc -b`, `dprint check` and `eslint` clean on all touched files.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). — the upstream docs already document this signature; the unsupported `callback` is called out in the changeset and in a code comment.
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

Found via the weekly Lynx Web Platform gap audit.