### PR TITLE
feat(web-core): implement lynx.addFont(fontFace, callback) on web

### DIFF
--- a/.changeset/web-gap-add-font.md
+++ b/.changeset/web-gap-add-font.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Implement `lynx.addFont(fontFace, callback)` on web. The font is registered via the standard `FontFace` API against the lynx-view's owner document (`document.fonts` isn't scoped per shadow root, and that's also the document the rendered elements resolve fonts against), and `callback` fires once the font has finished loading.

--- a/.changeset/web-gap-add-font.md
+++ b/.changeset/web-gap-add-font.md
@@ -2,4 +2,4 @@
 "@lynx-js/web-core": minor
 ---
 
-Implement `lynx.addFont(fontFace, callback)` on web. The font is registered via the standard `FontFace` API against the lynx-view's owner document (`document.fonts` isn't scoped per shadow root, and that's also the document the rendered elements resolve fonts against), and `callback` fires once the font has finished loading.
+Implement `lynx.addFont(fontFace, callback)` on web. The font is registered via the standard `FontFace` API against the lynx-view's owner document (`document.fonts` isn't scoped per shadow root, and that's also the document the rendered elements resolve fonts against), and `callback` fires once the font has finished loading. Registering the same font twice against a document — which is what a `lynx.reload()` re-running the card's `lynx.addFont()` calls amounts to — reuses the existing `FontFace` instead of appending another one.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -467,6 +467,23 @@ test.describe('reactlynx3 tests', () => {
       await expect(await target.getAttribute('style')).toContain('pink');
     });
 
+    test('basic-lynx-add-font', async ({ page }, { title }) => {
+      await goto(page, title);
+      await wait(100);
+      const isRegisteredBefore = await page.evaluate(() =>
+        document.fonts.check('1em "Add Font E2E"')
+      );
+      expect(isRegisteredBefore).toBe(false);
+      await page.locator('#target').click();
+      await wait(500);
+      const isRegisteredAfter = await page.evaluate(() =>
+        document.fonts.check('1em "Add Font E2E"')
+      );
+      expect(isRegisteredAfter).toBe(true);
+      await expect(await page.locator('#target').getAttribute('style'))
+        .toContain('Add Font E2E');
+    });
+
     test(
       'basic-wrapper-element-do-not-impact-layout',
       async ({ page }, { title }) => {

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -468,18 +468,30 @@ test.describe('reactlynx3 tests', () => {
     });
 
     test('basic-lynx-add-font', async ({ page }, { title }) => {
+      // `document.fonts.check()` is no help here: it answers "can this text be
+      // rendered now", which is already `true` for a family nothing has
+      // registered, because the text falls back to a system font. Inspect the
+      // font set itself instead.
+      const addedFonts = () =>
+        page.evaluate(() =>
+          Array.from(document.fonts, font => ({
+            // Safari serializes `family` as a quoted CSS <family-name>.
+            family: font.family.replace(/^['"]|['"]$/g, ''),
+            status: font.status,
+          })).filter(font => font.family === 'Add Font E2E')
+        );
       await goto(page, title);
       await wait(100);
-      const isRegisteredBefore = await page.evaluate(() =>
-        document.fonts.check('1em "Add Font E2E"')
-      );
-      expect(isRegisteredBefore).toBe(false);
+      expect(await addedFonts()).toStrictEqual([]);
       await page.locator('#target').click();
-      await wait(500);
-      const isRegisteredAfter = await page.evaluate(() =>
-        document.fonts.check('1em "Add Font E2E"')
-      );
-      expect(isRegisteredAfter).toBe(true);
+      // Polled rather than waited out: registering the font fetches it over
+      // the network, so how long it takes is not ours to guess.
+      await expect.poll(addedFonts).toStrictEqual([{
+        family: 'Add Font E2E',
+        status: 'loaded',
+      }]);
+      // The style update is gated on `lynx.addFont`'s callback, so this also
+      // covers the callback firing.
       await expect(await page.locator('#target').getAttribute('style'))
         .toContain('Add Font E2E');
     });

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-lynx-add-font/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-lynx-add-font/index.jsx
@@ -11,7 +11,10 @@ function App() {
         lynx.addFont(
           {
             'font-family': 'Add Font E2E',
-            'src': 'url("../../../resources/PressStart2P-Regular.ttf")',
+            // Served from `web-core-e2e`'s `resources/` by the dev server's
+            // `publicDir`. Absolute, because a `FontFace` `src` is resolved
+            // against the host page, not against this bundle.
+            'src': 'url("/resources/PressStart2P-Regular.ttf")',
           },
           () => {
             setLoaded(true);

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-lynx-add-font/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-lynx-add-font/index.jsx
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useState, root } from '@lynx-js/react';
+function App() {
+  const [loaded, setLoaded] = useState(false);
+  return (
+    <text
+      id='target'
+      bindTap={() => {
+        lynx.addFont(
+          {
+            'font-family': 'Add Font E2E',
+            'src': 'url("../../../resources/PressStart2P-Regular.ttf")',
+          },
+          () => {
+            setLoaded(true);
+          },
+        );
+      }}
+      style={{
+        fontFamily: loaded ? 'Add Font E2E' : 'initial',
+      }}
+    >
+      hello
+    </text>
+  );
+}
+root.render(<App />);

--- a/packages/web-platform/web-core/tests/register-add-font-handler.spec.ts
+++ b/packages/web-platform/web-core/tests/register-add-font-handler.spec.ts
@@ -1,0 +1,125 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import './jsdom.js';
+import { describe, expect, rstest, test } from '@rstest/core';
+import { registerAddFontHandler } from '../ts/client/mainthread/crossThreadHandlers/registerAddFontHandler.js';
+import { addFontEndpoint } from '../ts/client/endpoints.js';
+import type { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.js';
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+
+/**
+ * `registerAddFontHandler` is the main-thread side of `lynx.addFont()`. The
+ * background thread has no DOM, so registering the `FontFace` has to happen
+ * here, against the lynx-view's owner document — `document.fonts` isn't
+ * scoped per shadow root, so that's also the document the rendered elements
+ * actually resolve fonts against.
+ */
+describe('registerAddFontHandler', () => {
+  test('registers a FontFace on the owner document and awaits it loading', async () => {
+    let handler: (fontFace: unknown) => unknown = () => {
+      throw new Error('addFont handler was never registered');
+    };
+    const rpc = {
+      registerHandler: (
+        endpoint: { name: string },
+        fn: (fontFace: unknown) => unknown,
+      ) => {
+        expect(endpoint.name).toBe(addFontEndpoint.name);
+        handler = fn;
+      },
+    } as unknown as Rpc;
+
+    const added: unknown[] = [];
+    let resolveLoad!: () => void;
+    class FakeFontFace {
+      family: string;
+      src: string;
+      constructor(family: string, src: string) {
+        this.family = family;
+        this.src = src;
+      }
+      load() {
+        return new Promise<void>((resolve) => {
+          resolveLoad = resolve;
+        });
+      }
+    }
+    const fontsAdd = rstest.fn((fontFace: unknown) => added.push(fontFace));
+    const lynxViewInstance = {
+      rootDom: {
+        ownerDocument: {
+          defaultView: { FontFace: FakeFontFace },
+          fonts: { add: fontsAdd },
+        },
+      },
+    } as unknown as LynxViewInstance;
+
+    registerAddFontHandler(rpc, lynxViewInstance);
+
+    let settled = false;
+    const returned = Promise.resolve(
+      handler({ 'font-family': 'CustomFont', 'src': 'url("xxx")' }),
+    ).then(() => {
+      settled = true;
+    });
+
+    expect(added).toHaveLength(1);
+    expect((added[0] as FakeFontFace).family).toBe('CustomFont');
+    expect((added[0] as FakeFontFace).src).toBe('url("xxx")');
+    expect(settled).toBe(false);
+
+    resolveLoad();
+    await returned;
+
+    expect(settled).toBe(true);
+  });
+
+  test('logs but still settles when the font fails to load', async () => {
+    let handler: (fontFace: unknown) => unknown = () => {
+      throw new Error('addFont handler was never registered');
+    };
+    const rpc = {
+      registerHandler: (
+        _endpoint: { name: string },
+        fn: (fontFace: unknown) => unknown,
+      ) => {
+        handler = fn;
+      },
+    } as unknown as Rpc;
+
+    const failure = new Error('network error');
+    class FakeFontFace {
+      constructor(
+        public family: string,
+        public src: string,
+      ) {}
+      load() {
+        return Promise.reject(failure);
+      }
+    }
+    const lynxViewInstance = {
+      rootDom: {
+        ownerDocument: {
+          defaultView: { FontFace: FakeFontFace },
+          fonts: { add: () => {} },
+        },
+      },
+    } as unknown as LynxViewInstance;
+
+    const consoleError = rstest.spyOn(console, 'error').mockImplementation(
+      () => {},
+    );
+
+    registerAddFontHandler(rpc, lynxViewInstance);
+
+    await expect(
+      handler({ 'font-family': 'CustomFont', 'src': 'url("xxx")' }),
+    ).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0]?.[1]).toBe(failure);
+
+    consoleError.mockRestore();
+  });
+});

--- a/packages/web-platform/web-core/tests/register-add-font-handler.spec.ts
+++ b/packages/web-platform/web-core/tests/register-add-font-handler.spec.ts
@@ -8,6 +8,75 @@ import { addFontEndpoint } from '../ts/client/endpoints.js';
 import type { LynxViewInstance } from '../ts/client/mainthread/LynxViewInstance.js';
 import type { Rpc } from '@lynx-js/web-worker-rpc';
 
+class FakeFontFace {
+  #settle: (() => void) | undefined;
+  #loadPromise: Promise<void> | undefined;
+  constructor(
+    public family: string,
+    public src: string,
+    private failure?: unknown,
+  ) {}
+  /**
+   * Like the real `FontFace.load()`, repeated calls hand back the same promise
+   * instead of starting a second load.
+   */
+  load() {
+    this.#loadPromise ??= this.failure
+      ? Promise.reject(this.failure)
+      : new Promise<void>((resolve) => {
+        this.#settle = resolve;
+      });
+    return this.#loadPromise;
+  }
+  finishLoading() {
+    this.#settle?.();
+  }
+}
+
+/**
+ * A stand-in for one host document: the `FontFace` constructor lives on the
+ * document's own `defaultView`, and `document.fonts` is the set the handler
+ * registers into. A fresh one per test doubles as a fresh key for the
+ * handler's per-document bookkeeping.
+ */
+function createFakeDocument(failure?: unknown) {
+  const added: FakeFontFace[] = [];
+  const doc = {
+    defaultView: {
+      FontFace: class extends FakeFontFace {
+        constructor(family: string, src: string) {
+          super(family, src, failure);
+        }
+      },
+    },
+    fonts: { add: (fontFace: FakeFontFace) => added.push(fontFace) },
+  };
+  return { doc, added };
+}
+
+function registerHandlerFor(
+  doc: unknown,
+  onRegister?: (endpoint: { name: string }) => void,
+) {
+  let handler: (fontFace: unknown) => unknown = () => {
+    throw new Error('addFont handler was never registered');
+  };
+  const rpc = {
+    registerHandler: (
+      endpoint: { name: string },
+      fn: (fontFace: unknown) => unknown,
+    ) => {
+      onRegister?.(endpoint);
+      handler = fn;
+    },
+  } as unknown as Rpc;
+  registerAddFontHandler(
+    rpc,
+    { rootDom: { ownerDocument: doc } } as unknown as LynxViewInstance,
+  );
+  return (fontFace: unknown) => handler(fontFace);
+}
+
 /**
  * `registerAddFontHandler` is the main-thread side of `lynx.addFont()`. The
  * background thread has no DOM, so registering the `FontFace` has to happen
@@ -17,104 +86,67 @@ import type { Rpc } from '@lynx-js/web-worker-rpc';
  */
 describe('registerAddFontHandler', () => {
   test('registers a FontFace on the owner document and awaits it loading', async () => {
-    let handler: (fontFace: unknown) => unknown = () => {
-      throw new Error('addFont handler was never registered');
-    };
-    const rpc = {
-      registerHandler: (
-        endpoint: { name: string },
-        fn: (fontFace: unknown) => unknown,
-      ) => {
-        expect(endpoint.name).toBe(addFontEndpoint.name);
-        handler = fn;
-      },
-    } as unknown as Rpc;
-
-    const added: unknown[] = [];
-    let resolveLoad!: () => void;
-    class FakeFontFace {
-      family: string;
-      src: string;
-      constructor(family: string, src: string) {
-        this.family = family;
-        this.src = src;
-      }
-      load() {
-        return new Promise<void>((resolve) => {
-          resolveLoad = resolve;
-        });
-      }
-    }
-    const fontsAdd = rstest.fn((fontFace: unknown) => added.push(fontFace));
-    const lynxViewInstance = {
-      rootDom: {
-        ownerDocument: {
-          defaultView: { FontFace: FakeFontFace },
-          fonts: { add: fontsAdd },
-        },
-      },
-    } as unknown as LynxViewInstance;
-
-    registerAddFontHandler(rpc, lynxViewInstance);
+    let registeredEndpointName: string | undefined;
+    const { doc, added } = createFakeDocument();
+    const invoke = registerHandlerFor(doc, (endpoint) => {
+      registeredEndpointName = endpoint.name;
+    });
+    expect(registeredEndpointName).toBe(addFontEndpoint.name);
 
     let settled = false;
     const returned = Promise.resolve(
-      handler({ 'font-family': 'CustomFont', 'src': 'url("xxx")' }),
+      invoke({ 'font-family': 'CustomFont', 'src': 'url("xxx")' }),
     ).then(() => {
       settled = true;
     });
 
     expect(added).toHaveLength(1);
-    expect((added[0] as FakeFontFace).family).toBe('CustomFont');
-    expect((added[0] as FakeFontFace).src).toBe('url("xxx")');
+    expect(added[0]!.family).toBe('CustomFont');
+    expect(added[0]!.src).toBe('url("xxx")');
     expect(settled).toBe(false);
 
-    resolveLoad();
+    added[0]!.finishLoading();
     await returned;
 
     expect(settled).toBe(true);
   });
 
-  test('logs but still settles when the font fails to load', async () => {
-    let handler: (fontFace: unknown) => unknown = () => {
-      throw new Error('addFont handler was never registered');
-    };
-    const rpc = {
-      registerHandler: (
-        _endpoint: { name: string },
-        fn: (fontFace: unknown) => unknown,
-      ) => {
-        handler = fn;
-      },
-    } as unknown as Rpc;
+  test('registers the same font only once per document', async () => {
+    // `document.fonts` outlives the card: a `lynx.reload()` re-runs the card's
+    // `lynx.addFont()` calls against the same document, and appending the same
+    // face again on every reload would grow the set without bound.
+    const { doc, added } = createFakeDocument();
+    const invoke = registerHandlerFor(doc);
+    const descriptor = { 'font-family': 'CustomFont', 'src': 'url("xxx")' };
 
+    const first = Promise.resolve(invoke(descriptor));
+    const second = Promise.resolve(invoke(descriptor));
+    expect(added).toHaveLength(1);
+
+    added[0]!.finishLoading();
+    await Promise.all([first, second]);
+
+    // A different `src` for the same family is a different font, so it is
+    // registered rather than silently ignored.
+    const third = Promise.resolve(
+      invoke({ 'font-family': 'CustomFont', 'src': 'url("yyy")' }),
+    );
+    expect(added).toHaveLength(2);
+    added[1]!.finishLoading();
+    await third;
+  });
+
+  test('logs but still settles when the font fails to load', async () => {
     const failure = new Error('network error');
-    class FakeFontFace {
-      constructor(
-        public family: string,
-        public src: string,
-      ) {}
-      load() {
-        return Promise.reject(failure);
-      }
-    }
-    const lynxViewInstance = {
-      rootDom: {
-        ownerDocument: {
-          defaultView: { FontFace: FakeFontFace },
-          fonts: { add: () => {} },
-        },
-      },
-    } as unknown as LynxViewInstance;
+    const { doc } = createFakeDocument(failure);
+    const invoke = registerHandlerFor(doc);
 
     const consoleError = rstest.spyOn(console, 'error').mockImplementation(
       () => {},
     );
 
-    registerAddFontHandler(rpc, lynxViewInstance);
-
     await expect(
-      handler({ 'font-family': 'CustomFont', 'src': 'url("xxx")' }),
+      invoke({ 'font-family': 'CustomFont', 'src': 'url("xxx")' }),
     ).resolves.toBeUndefined();
 
     expect(consoleError).toHaveBeenCalledTimes(1);

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createBackgroundLynx.ts
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import {
+  addFontEndpoint,
   dispatchCoreContextOnBackgroundEndpoint,
   dispatchDevtoolEventOnBackgroundEndpoint,
   dispatchDevtoolEventOnMainThreadEndpoint,
@@ -10,6 +11,7 @@ import {
   fetchExternalBundleEndpoint,
   reloadEndpoint,
 } from '../../endpoints.js';
+import type { FontFaceDescriptor } from '../../endpoints.js';
 import type { Rpc } from '@lynx-js/web-worker-rpc';
 import { createGetCustomSection } from './crossThreadHandlers/createGetCustomSection.js';
 import { createElement } from './createElement.js';
@@ -73,6 +75,11 @@ export function createBackgroundLynx(
     ) => nativeApp.queryComponent(source, callback),
     reload: () => {
       mainThreadRpc.invoke(reloadEndpoint, []);
+    },
+    addFont: (fontFace: FontFaceDescriptor, callback?: () => void) => {
+      mainThreadRpc.invoke(addFontEndpoint, [fontFace]).then(() => {
+        callback?.();
+      });
     },
     fetchBundle(url: string) {
       return fetchExternalBundle(url);

--- a/packages/web-platform/web-core/ts/client/endpoints.ts
+++ b/packages/web-platform/web-core/ts/client/endpoints.ts
@@ -240,3 +240,13 @@ export const reloadEndpoint = createRpcEndpoint<
   [],
   void
 >('reload', false, false);
+
+export interface FontFaceDescriptor {
+  'font-family': string;
+  'src': string;
+}
+
+export const addFontEndpoint = createRpcEndpoint<
+  [fontFace: FontFaceDescriptor],
+  void
+>('addFont', false, true);

--- a/packages/web-platform/web-core/ts/client/mainthread/Background.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/Background.ts
@@ -46,6 +46,7 @@ import { registerTriggerElementMethodEndpointHandler } from './crossThreadHandle
 import { registerNapiModulesCallHandler } from './crossThreadHandlers/registerNapiModulesCallHandler.js';
 import { registerNativeModulesCallHandler } from './crossThreadHandlers/registerNativeModulesCallHandler.js';
 import { registerReloadHandler } from './crossThreadHandlers/registerReloadHandler.js';
+import { registerAddFontHandler } from './crossThreadHandlers/registerAddFontHandler.js';
 
 function createWebWorker(): Worker {
   return new Worker(
@@ -275,6 +276,7 @@ export class BackgroundThread implements AsyncDisposable {
       },
     );
     registerReloadHandler(this.#rpc, this.#lynxViewInstance);
+    registerAddFontHandler(this.#rpc, this.#lynxViewInstance);
     registerGetPathInfoHandler(this.#rpc, this.#lynxViewInstance);
     registerInvokeUIMethodHandler(this.#rpc, this.#lynxViewInstance);
     registerNapiModulesCallHandler(this.#rpc, this.#lynxViewInstance);

--- a/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerAddFontHandler.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerAddFontHandler.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { Rpc } from '@lynx-js/web-worker-rpc';
+import { addFontEndpoint } from '../../endpoints.js';
+import type { LynxViewInstance } from '../LynxViewInstance.js';
+
+export function registerAddFontHandler(
+  rpc: Rpc,
+  lynxViewInstance: LynxViewInstance,
+) {
+  rpc.registerHandler(
+    addFontEndpoint,
+    (fontFace) => {
+      // The background thread has no DOM, and `document.fonts` isn't scoped
+      // per shadow root, so the font is registered against the lynx-view's
+      // owner document (the host page) — the same document that actually
+      // renders the elements in its shadow tree.
+      const doc = lynxViewInstance.rootDom.ownerDocument;
+      const FontFaceCtor = doc.defaultView!.FontFace;
+      const fontFaceObject = new FontFaceCtor(
+        fontFace['font-family'],
+        fontFace['src'],
+      );
+      doc.fonts.add(fontFaceObject);
+      return fontFaceObject.load().then(
+        () => {},
+        (error) => {
+          console.error(`[lynx-web] lynx.addFont failed to load`, error);
+        },
+      );
+    },
+  );
+}

--- a/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerAddFontHandler.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerAddFontHandler.ts
@@ -6,6 +6,17 @@ import type { Rpc } from '@lynx-js/web-worker-rpc';
 import { addFontEndpoint } from '../../endpoints.js';
 import type { LynxViewInstance } from '../LynxViewInstance.js';
 
+/**
+ * The fonts `lynx.addFont()` has already registered, per document.
+ *
+ * `document.fonts` outlives the card that filled it: a `lynx.reload()` (or a
+ * second card on the page) re-runs the card's `lynx.addFont()` calls against
+ * the same document, so without this the same font face would be appended
+ * again on every reload. Keyed by descriptor, so a genuinely different `src`
+ * for the same family still registers.
+ */
+const registeredFonts: WeakMap<Document, Map<string, FontFace>> = new WeakMap();
+
 export function registerAddFontHandler(
   rpc: Rpc,
   lynxViewInstance: LynxViewInstance,
@@ -18,12 +29,31 @@ export function registerAddFontHandler(
       // owner document (the host page) — the same document that actually
       // renders the elements in its shadow tree.
       const doc = lynxViewInstance.rootDom.ownerDocument;
-      const FontFaceCtor = doc.defaultView!.FontFace;
-      const fontFaceObject = new FontFaceCtor(
-        fontFace['font-family'],
-        fontFace['src'],
-      );
-      doc.fonts.add(fontFaceObject);
+      const family = fontFace['font-family'];
+      const src = fontFace['src'];
+      const key = `${family}\0${src}`;
+
+      let documentFonts = registeredFonts.get(doc);
+      if (!documentFonts) {
+        documentFonts = new Map();
+        registeredFonts.set(doc, documentFonts);
+      }
+
+      let fontFaceObject = documentFonts.get(key);
+      if (!fontFaceObject) {
+        // Build the `FontFace` from the owner document's own realm: a card
+        // rendered inside an iframe must not hand that document a constructor
+        // from another window.
+        const FontFaceCtor = doc.defaultView?.FontFace ?? FontFace;
+        fontFaceObject = new FontFaceCtor(family, src);
+        doc.fonts.add(fontFaceObject);
+        documentFonts.set(key, fontFaceObject);
+      }
+
+      // Resolve only once the font is usable, so the background thread's
+      // `callback` isn't called on a font the page still can't render with.
+      // A failed load resolves too — a dangling callback would be worse than
+      // one that fires for a font that turned out to be unreachable.
       return fontFaceObject.load().then(
         () => {},
         (error) => {


### PR DESCRIPTION
@coderabbitai summary

## What

Closes a real web platform gap: [`lynx-api/lynx/addFont`](https://lynxjs.org/api/lynx-api/lynx/lynx-add-font) is supported on android/ios/harmony/clay but was entirely unimplemented on web.

`lynx.addFont({ &#39;font-family&#39;: ..., src: ... }, callback?)` registers a font face for use by the card. The doc&#39;s `src` value is already a CSS `url()`/`local()` string — the same shape the standard `FontFace` constructor&#39;s second argument takes — so this maps onto the browser&#39;s Font Loading API almost directly.

## How

The background thread has no DOM, so registration has to round-trip to the main thread, following the same shape as the existing `reload`/`invokeUIMethod` RPC endpoints:

- **`endpoints.ts`**: new `addFontEndpoint` RPC endpoint, taking a `{ &#39;font-family&#39;, src }` descriptor.
- **`registerAddFontHandler.ts`** (new, main thread): builds a `FontFace` from the lynx-view&#39;s owner document&#39;s `defaultView`, adds it to that document&#39;s `document.fonts` — font faces aren&#39;t scoped per shadow root, and that&#39;s also the document the rendered elements actually resolve fonts against — and awaits `fontFace.load()` before resolving, so the callback only fires once the font is actually usable. A failed load is logged, not thrown, so the callback isn&#39;t left dangling.
- **`Background.ts`**: registers the new handler alongside the other cross-thread handlers.
- **`createBackgroundLynx.ts`**: wires `lynx.addFont(fontFace, callback)` via the new endpoint, invoking `callback` once the main thread confirms the font loaded.

`document.fonts` outlives the card that filled it, so each `(document, descriptor)` pair is registered at most once: a `lynx.reload()` re-running the card&#39;s `lynx.addFont()` calls reuses the existing `FontFace` instead of appending another face to the host page every time.

SSR doesn&#39;t need a stub — `addFont` is background-thread only (like `reload`/`reportError`/`getSharedData`), and SSR&#39;s `createServerLynx.ts` only implements `MainThreadLynx`.

## Test plan

- New unit tests (`register-add-font-handler.spec.ts`): the handler adds a `FontFace` built from the owner document&#39;s `FontFace` constructor to that document&#39;s font set and awaits its `load()` before resolving; the same descriptor twice registers one face; a failed load still resolves (logged, not thrown).
- New e2e case (`basic-lynx-add-font`), reusing the existing `PressStart2P-Regular.ttf` test font: registers a font via `lynx.addFont` and asserts the font appears in `document.fonts` with status `loaded`, plus that the callback-gated style update applies the new `font-family`.
  - The first revision asserted on `document.fonts.check()` and failed in CI. `check()` answers &#34;can this text render now&#34;, which is already `true` for a family nothing has registered because the text falls back to a system font — so the pre-click assertion failed and the post-click one proved nothing. It now inspects the font set itself, and polls instead of waiting out a fixed 500ms for a network fetch.
  - The font `src` is now absolute (`/resources/...`): a `FontFace` `src` resolves against the host page, not the bundle, so the relative path only worked by `..` clamping at the server root.
- e2e run locally (chromium): `basic-lynx-add-font` and `basic-element-text-extra-font-family` pass.
- Full `web-core` unit suite: 357/357 passing.
- `tsc -b`, `dprint check` and `eslint` clean on all touched files.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). — no doc changes needed; the upstream docs already document this signature, this PR only makes web match it.
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

Found via the weekly Lynx Web Platform gap audit.