### PR TITLE
fix(web): bridge mouse pointers to touch events

### DIFF
--- a/.changeset/web-pointer-touch-stream.md
+++ b/.changeset/web-pointer-touch-stream.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Deliver mouse and pen Pointer Events through the Lynx touch event stream on
+Web while preserving native DOM touch and click delivery.

--- a/.github/web-core-pointer-touch.instructions.md
+++ b/.github/web-core-pointer-touch.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "packages/web-platform/{web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts,web-core/tests/**,web-core-e2e/tests/**}"
+---
+
+When bridging mouse or pen Pointer Events into Lynx touch events, ignore touch pointers because browsers also emit DOM touch events for them, retain the pointer-down Lynx target through move/end/cancel, and leave `bindtap` on the DOM click path so one physical click cannot synthesize a second tap.

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -714,6 +714,62 @@ test.describe('reactlynx3 tests', () => {
       },
     );
 
+    test('basic-pointer-touch-bridge', async ({ page }) => {
+      await goto(page, 'basic-pointer-touch-bridge');
+      const target = page.locator('#target');
+      await expect(target).toBeVisible();
+      const box = await target.boundingBox();
+      expect(box).not.toBeNull();
+      const x = box!.x + box!.width / 2;
+      const y = box!.y + box!.height / 2;
+
+      await page.mouse.move(x - 10, y);
+      await page.mouse.down();
+      await page.mouse.move(x + 10, y);
+      await page.mouse.up();
+
+      for (const realm of ['bts', 'mts']) {
+        await expect(page.locator(`#${realm}-start`)).toHaveText('1');
+        await expect(page.locator(`#${realm}-move`)).toHaveText('1');
+        await expect(page.locator(`#${realm}-end`)).toHaveText('1');
+        await expect(page.locator(`#${realm}-cancel`)).toHaveText('0');
+      }
+      await expect(page.locator('#tap')).toHaveText('1');
+    });
+
+    test(
+      'basic-pointer-touch-bridge-keeps-touch-single-delivery',
+      async ({ page, browserName, context }) => {
+        test.skip(browserName !== 'chromium', 'not support CDPsession');
+        await goto(page, 'basic-pointer-touch-bridge');
+        const box = await page.locator('#target').boundingBox();
+        expect(box).not.toBeNull();
+        const x = box!.x + box!.width / 2;
+        const y = box!.y + box!.height / 2;
+        const cdpSession = await context.newCDPSession(page);
+
+        await cdpSession.send('Input.dispatchTouchEvent', {
+          type: 'touchStart',
+          touchPoints: [{ x, y }],
+        });
+        await cdpSession.send('Input.dispatchTouchEvent', {
+          type: 'touchMove',
+          touchPoints: [{ x: x + 10, y }],
+        });
+        await cdpSession.send('Input.dispatchTouchEvent', {
+          type: 'touchEnd',
+          touchPoints: [{ x: x + 10, y }],
+        });
+
+        for (const realm of ['bts', 'mts']) {
+          await expect(page.locator(`#${realm}-start`)).toHaveText('1');
+          await expect(page.locator(`#${realm}-move`)).toHaveText('1');
+          await expect(page.locator(`#${realm}-end`)).toHaveText('1');
+          await expect(page.locator(`#${realm}-cancel`)).toHaveText('0');
+        }
+      },
+    );
+
     test(
       'basic-mts-bindtap-change-element-background',
       async ({ page }, { title }) => {

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-pointer-touch-bridge/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-pointer-touch-bridge/index.jsx
@@ -1,0 +1,70 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { root, runOnBackground, useState } from '@lynx-js/react';
+
+const initialCounts = {
+  btsStart: 0,
+  btsMove: 0,
+  btsEnd: 0,
+  btsCancel: 0,
+  mtsStart: 0,
+  mtsMove: 0,
+  mtsEnd: 0,
+  mtsCancel: 0,
+  tap: 0,
+};
+
+function App() {
+  const [counts, setCounts] = useState(initialCounts);
+  const record = (name) => {
+    setCounts(previous => ({
+      ...previous,
+      [name]: previous[name] + 1,
+    }));
+  };
+  return (
+    <view>
+      <view
+        id='target'
+        style={{
+          width: '160px',
+          height: '160px',
+          backgroundColor: 'pink',
+        }}
+        bindtouchstart={() => record('btsStart')}
+        bindtouchmove={() => record('btsMove')}
+        bindtouchend={() => record('btsEnd')}
+        bindtouchcancel={() => record('btsCancel')}
+        bindtap={() => record('tap')}
+        main-thread:bindtouchstart={() => {
+          'main thread';
+          runOnBackground(record)('mtsStart');
+        }}
+        main-thread:bindtouchmove={() => {
+          'main thread';
+          runOnBackground(record)('mtsMove');
+        }}
+        main-thread:bindtouchend={() => {
+          'main thread';
+          runOnBackground(record)('mtsEnd');
+        }}
+        main-thread:bindtouchcancel={() => {
+          'main thread';
+          runOnBackground(record)('mtsCancel');
+        }}
+      />
+      <text id='bts-start'>{String(counts.btsStart)}</text>
+      <text id='bts-move'>{String(counts.btsMove)}</text>
+      <text id='bts-end'>{String(counts.btsEnd)}</text>
+      <text id='bts-cancel'>{String(counts.btsCancel)}</text>
+      <text id='mts-start'>{String(counts.mtsStart)}</text>
+      <text id='mts-move'>{String(counts.mtsMove)}</text>
+      <text id='mts-end'>{String(counts.mtsEnd)}</text>
+      <text id='mts-cancel'>{String(counts.mtsCancel)}</text>
+      <text id='tap'>{String(counts.tap)}</text>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -3,12 +3,14 @@ import {
   beforeAll,
   beforeEach,
   describe,
+  afterEach,
   expect,
   rstest,
   test,
 } from '@rstest/core';
 import { createElementAPI } from '../ts/client/mainthread/elementAPIs/createElementAPI.js';
 import { WASMJSBinding } from '../ts/client/mainthread/elementAPIs/WASMJSBinding.js';
+import { __GetElementUniqueID } from '../ts/client/mainthread/elementAPIs/pureElementPAPIs.js';
 import { cssIdAttribute, lynxEntryNameAttribute } from '../ts/constants.js';
 import {
   createElementAPI as createServerElementAPI,
@@ -38,6 +40,184 @@ describe('Element APIs', () => {
       true,
       true,
     );
+  });
+  afterEach(() => {
+    mtsBinding.disposeEventListeners();
+  });
+
+  const makePointerEvent = (
+    type: string,
+    {
+      pointerId = 1,
+      pointerType = 'mouse',
+      clientX = 20,
+      clientY = 30,
+      pressure = 0.5,
+    }: {
+      pointerId?: number;
+      pointerType?: string;
+      clientX?: number;
+      clientY?: number;
+      pressure?: number;
+    } = {},
+  ) => {
+    const event = new MouseEvent(type, {
+      bubbles: true,
+      composed: true,
+      clientX,
+      clientY,
+    });
+    Object.defineProperties(event, {
+      pointerId: { value: pointerId },
+      pointerType: { value: pointerType },
+      pressure: { value: pressure },
+      width: { value: 4 },
+      height: { value: 6 },
+    });
+    return event;
+  };
+
+  test('maps a mouse pointer stream to touch events without synthesizing tap', () => {
+    const commonEventHandler = rstest.fn();
+    mtsBinding.wasmContext = Object.assign(mtsBinding.wasmContext || {}, {
+      common_event_handler: commonEventHandler,
+    }) as any;
+    for (
+      const eventName of [
+        'touchstart',
+        'touchmove',
+        'touchend',
+        'touchcancel',
+        'tap',
+      ]
+    ) {
+      mtsBinding.addEventListener(eventName);
+    }
+
+    const target = mtsGlobalThis.__CreateView(0);
+    rootDom.appendChild(target);
+    target.dispatchEvent(makePointerEvent('pointerdown', { pointerId: 7 }));
+    document.dispatchEvent(makePointerEvent('pointermove', {
+      pointerId: 7,
+      clientX: 25,
+      clientY: 35,
+    }));
+    document.dispatchEvent(makePointerEvent('pointerup', {
+      pointerId: 7,
+      clientX: 25,
+      clientY: 35,
+      pressure: 0,
+    }));
+
+    expect(commonEventHandler.mock.calls.map(call => call[0].type)).toEqual([
+      'touchstart',
+      'touchmove',
+      'touchend',
+    ]);
+    const [start, move, end] = commonEventHandler.mock.calls.map(
+      call => call[0],
+    );
+    expect(start.touches).toEqual([expect.objectContaining({
+      identifier: 7,
+      pointerType: 'mouse',
+      clientX: 20,
+      clientY: 30,
+      x: 20,
+      y: 30,
+      force: 0.5,
+      radiusX: 2,
+      radiusY: 3,
+    })]);
+    expect(move.changedTouches).toEqual([expect.objectContaining({
+      identifier: 7,
+      clientX: 25,
+      clientY: 35,
+    })]);
+    expect(end.touches).toEqual([]);
+    expect(end.targetTouches).toEqual([]);
+    expect(end.changedTouches).toEqual([expect.objectContaining({
+      identifier: 7,
+    })]);
+    const targetUniqueId = __GetElementUniqueID(target);
+    expect(commonEventHandler.mock.calls.map(call => [...call[1]])).toEqual([
+      [targetUniqueId],
+      [targetUniqueId],
+      [targetUniqueId],
+    ]);
+
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(commonEventHandler.mock.calls.map(call => call[0].type)).toEqual([
+      'touchstart',
+      'touchmove',
+      'touchend',
+      'tap',
+    ]);
+  });
+
+  test('keeps the pointer-down target through pen cancellation', () => {
+    const commonEventHandler = rstest.fn();
+    mtsBinding.wasmContext = Object.assign(mtsBinding.wasmContext || {}, {
+      common_event_handler: commonEventHandler,
+    }) as any;
+    for (const eventName of ['touchstart', 'touchmove', 'touchcancel']) {
+      mtsBinding.addEventListener(eventName);
+    }
+
+    const target = mtsGlobalThis.__CreateView(0);
+    rootDom.appendChild(target);
+    target.dispatchEvent(makePointerEvent('pointerdown', {
+      pointerId: 12,
+      pointerType: 'pen',
+    }));
+    target.remove();
+    document.dispatchEvent(makePointerEvent('pointercancel', {
+      pointerId: 12,
+      pointerType: 'pen',
+      pressure: 0,
+    }));
+    document.dispatchEvent(makePointerEvent('pointermove', {
+      pointerId: 12,
+      pointerType: 'pen',
+    }));
+
+    expect(commonEventHandler.mock.calls.map(call => call[0].type)).toEqual([
+      'touchstart',
+      'touchcancel',
+    ]);
+    expect(commonEventHandler.mock.calls[1]![0].changedTouches).toEqual([
+      expect.objectContaining({
+        identifier: 12,
+        pointerType: 'pen',
+      }),
+    ]);
+    expect([...commonEventHandler.mock.calls[1]![1]]).toEqual([
+      __GetElementUniqueID(target),
+    ]);
+  });
+
+  test('ignores touch PointerEvents while accepting the DOM touch event', () => {
+    const commonEventHandler = rstest.fn();
+    mtsBinding.wasmContext = Object.assign(mtsBinding.wasmContext || {}, {
+      common_event_handler: commonEventHandler,
+    }) as any;
+    mtsBinding.addEventListener('touchstart');
+
+    const target = mtsGlobalThis.__CreateView(0);
+    rootDom.appendChild(target);
+    target.dispatchEvent(makePointerEvent('pointerdown', {
+      pointerId: 19,
+      pointerType: 'touch',
+    }));
+    expect(commonEventHandler).not.toHaveBeenCalled();
+
+    const touchstart = new Event('touchstart', { bubbles: true }) as any;
+    touchstart.touches = [{ identifier: 19, clientX: 20, clientY: 30 }];
+    touchstart.targetTouches = touchstart.touches;
+    touchstart.changedTouches = touchstart.touches;
+    target.dispatchEvent(touchstart);
+
+    expect(commonEventHandler).toHaveBeenCalledTimes(1);
+    expect(commonEventHandler.mock.calls[0]![0].type).toBe('touchstart');
   });
   test('#commonEventHandler should filter out -1 uniqueId', () => {
     mtsBinding.wasmContext = Object.assign(mtsBinding.wasmContext || {}, {

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
@@ -7,6 +7,7 @@ import type {
   RustMainthreadContextBinding,
   CloneableObject,
   MainThreadGlobalThis,
+  MinimalRawEventObject,
 } from '../../../types/index.js';
 import {
   LynxEventNameToW3cCommon,
@@ -28,12 +29,45 @@ export type WASMJSBindingInjectedHandler = {
 };
 
 const DOCUMENT_LEVEL_EVENTS = new Set(['keydown', 'keyup']);
+const POINTER_DERIVED_TOUCH_EVENTS = new Set([
+  'touchstart',
+  'touchmove',
+  'touchend',
+  'touchcancel',
+]);
+
+type PointerTouch = {
+  identifier: number;
+  clientX: number;
+  clientY: number;
+  pageX: number;
+  pageY: number;
+  screenX: number;
+  screenY: number;
+  force: number;
+  radiusX: number;
+  radiusY: number;
+  rotationAngle: number;
+  pointerType: string;
+};
+
+type ActivePointerTouch = {
+  target: HTMLElement;
+  touch: PointerTouch;
+};
+
+type CommonDOMEvent = MinimalRawEventObject & {
+  bubbles: boolean;
+};
 
 export class WASMJSBinding implements RustMainthreadContextBinding {
   wasmContext: InstanceType<MainThreadWasmContext> | undefined;
   disposeWasmContext?: () => void;
   #addedEventListeners: Set<string> = new Set();
   #documentEventListeners: Set<string> = new Set();
+  #pointerTouchEventNames: Set<string> = new Set();
+  #activePointerTouches: Map<number, ActivePointerTouch> = new Map();
+  #pointerTouchListenersAdded = false;
   toBeEnabledElement: Set<HTMLElement> = new Set();
   toBeDisabledElement: Set<HTMLElement> = new Set();
 
@@ -211,8 +245,7 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     }
   }
 
-  #commonEventHandler = (event: Event) => {
-    const target = event.target as HTMLElement;
+  #dispatchCommonEvent(event: CommonDOMEvent, target: HTMLElement) {
     let bubblePath: Uint32Array = new Uint32Array(32);
     let bubblePathLength = 0;
     bubblePath;
@@ -248,10 +281,123 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
       eventObject.type,
       event.bubbles,
     );
+  }
+
+  #commonEventHandler = (event: Event) => {
+    this.#dispatchCommonEvent(event, event.target as HTMLElement);
   };
+
+  #toPointerTouch(event: PointerEvent): PointerTouch {
+    return {
+      identifier: event.pointerId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      pageX: event.pageX,
+      pageY: event.pageY,
+      screenX: event.screenX,
+      screenY: event.screenY,
+      force: event.pressure,
+      radiusX: event.width / 2,
+      radiusY: event.height / 2,
+      rotationAngle: 0,
+      pointerType: event.pointerType,
+    };
+  }
+
+  #dispatchPointerTouchEvent(
+    eventName: string,
+    pointerEvent: PointerEvent,
+    activePointer: ActivePointerTouch,
+    ended: boolean,
+  ) {
+    if (!this.#pointerTouchEventNames.has(eventName)) return;
+
+    const activeTouches = [...this.#activePointerTouches.values()]
+      .filter(({ touch }) =>
+        !ended || touch.identifier !== pointerEvent.pointerId
+      );
+    const event = {
+      type: eventName,
+      target: activePointer.target,
+      currentTarget: this.lynxViewInstance.rootDom,
+      isTrusted: pointerEvent.isTrusted,
+      timeStamp: pointerEvent.timeStamp,
+      bubbles: true,
+      touches: activeTouches.map(({ touch }) => touch),
+      targetTouches: activeTouches
+        .filter(({ target }) => target === activePointer.target)
+        .map(({ touch }) => touch),
+      changedTouches: [activePointer.touch],
+    } satisfies CommonDOMEvent;
+    this.#dispatchCommonEvent(event, activePointer.target);
+  }
+
+  #handlePointerDown = (event: PointerEvent) => {
+    // Browsers already emit DOM touch events for touch pointers. Bridging those
+    // pointer events as well would deliver every physical touch twice.
+    if (
+      event.pointerType === 'touch' || !(event.target instanceof HTMLElement)
+    ) {
+      return;
+    }
+    const activePointer = {
+      target: event.target,
+      touch: this.#toPointerTouch(event),
+    };
+    this.#activePointerTouches.set(event.pointerId, activePointer);
+    this.#dispatchPointerTouchEvent(
+      'touchstart',
+      event,
+      activePointer,
+      false,
+    );
+  };
+
+  #handlePointerContinuation = (event: PointerEvent) => {
+    const activePointer = this.#activePointerTouches.get(event.pointerId);
+    if (!activePointer) return;
+
+    activePointer.touch = this.#toPointerTouch(event);
+    const eventName = event.type === 'pointermove'
+      ? 'touchmove'
+      : event.type === 'pointerup'
+      ? 'touchend'
+      : 'touchcancel';
+    const ended = eventName === 'touchend' || eventName === 'touchcancel';
+    this.#dispatchPointerTouchEvent(
+      eventName,
+      event,
+      activePointer,
+      ended,
+    );
+    if (ended) {
+      this.#activePointerTouches.delete(event.pointerId);
+    }
+  };
+
+  #enablePointerTouchEvents(eventName: string) {
+    if (!POINTER_DERIVED_TOUCH_EVENTS.has(eventName)) return;
+    this.#pointerTouchEventNames.add(eventName);
+    if (this.#pointerTouchListenersAdded) return;
+
+    this.#pointerTouchListenersAdded = true;
+    this.lynxViewInstance.rootDom.addEventListener(
+      'pointerdown',
+      this.#handlePointerDown as EventListener,
+      { passive: true, capture: true },
+    );
+    for (const eventType of ['pointermove', 'pointerup', 'pointercancel']) {
+      document.addEventListener(
+        eventType,
+        this.#handlePointerContinuation as EventListener,
+        { passive: true, capture: true },
+      );
+    }
+  }
 
   addEventListener(eventName: string) {
     const w3cEventName = LynxEventNameToW3cCommon[eventName] ?? eventName;
+    this.#enablePointerTouchEvents(w3cEventName);
     if (this.#addedEventListeners.has(w3cEventName)) return;
     this.#addedEventListeners.add(w3cEventName);
     const isDocumentLevel = DOCUMENT_LEVEL_EVENTS.has(w3cEventName);
@@ -291,6 +437,23 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     }
     this.#addedEventListeners.clear();
     this.#documentEventListeners.clear();
+    if (this.#pointerTouchListenersAdded) {
+      this.lynxViewInstance.rootDom.removeEventListener(
+        'pointerdown',
+        this.#handlePointerDown as EventListener,
+        true,
+      );
+      for (const eventType of ['pointermove', 'pointerup', 'pointercancel']) {
+        document.removeEventListener(
+          eventType,
+          this.#handlePointerContinuation as EventListener,
+          true,
+        );
+      }
+    }
+    this.#pointerTouchListenersAdded = false;
+    this.#pointerTouchEventNames.clear();
+    this.#activePointerTouches.clear();
   }
 
   dispose() {


### PR DESCRIPTION
## What

Deliver mouse and pen Pointer Events through Lynx for Web's existing touch event stream so `bindtouch*` and `main-thread:bindtouch*` interactions work with desktop input. DOM `click` remains the only Web source for `bindtap`.

The shared `WASMJSBinding` event boundary now:

- translates pointer down/move/up/cancel into touchstart/move/end/cancel;
- retains the pointer-down Lynx target through the sequence;
- ignores `pointerType=touch`, because browsers also emit the existing DOM touch events;
- never synthesizes tap, preserving exactly one click-driven `bindtap`.

## Native semantics

This follows `lynx-family/lynx` `origin/develop` at `a573c3b8280180b59ca3da3e33d7a50192334cce`:

- `core/renderer/dom/fragment/event/platform_event_handler.cc`: `OnInputEvent` routes pointer actions to `HandlePointerDown`, `HandlePointerMove`, `HandlePointerUp`, and `HandlePointerCancel`; those dispatch `touchstart`, `touchmove`, `touchend`, and `touchcancel` through `DispatchPointerEvent`.
- The same file keeps gesture delivery separate: `OnTap` calls `DispatchGestureEvent(EVENT_TAP, ...)` and `DispatchGestureEvent(EVENT_CLICK, ...)`. The pointer-to-touch adapter therefore must not create another tap.
- `platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxView.java`: `dispatchTouchEvent(MotionEvent)` forwards the platform stream into Lynx.
- `platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/TouchEventDispatcher.java`: `mActiveUIMap`/`mActiveTargetMap` retain active targets, while tap/click are fired independently.

Downstream evidence: Huxpro/motion-lynx-harness#107 documents that Lynx for Web touch gestures had to be shimmed separately from DOM click and demonstrates the affected desktop interaction path.

## Stack

Stacked directly on #3515 (`f73c0e07a6e6170c408c0183ee2a94069f88cfda`), after #3477 and #3509.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo build`: 69/69 tasks passed
- `pnpm --filter @lynx-js/web-core test`: 20 files, 357 tests passed
- focused `tests/element-apis.spec.ts`: 91 tests passed
- Chromium Playwright, `--grep basic-pointer-touch-bridge --workers=1`: 2/2 passed
  - real `page.mouse` input reached both BTS and MTS start/move/end handlers and produced exactly one tap
  - CDP touch input remained one start/move/end delivery in both realms
- `pnpm dprint check` on all changed files: passed
- `pnpm biome check`: 2,261 files, passed
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint .`: 0 errors; 15 pre-existing warnings

## Checklist

- [x] Focused unit coverage added.
- [x] Real headless-browser regression coverage added.
- [x] Changeset added.
- [x] Repository guidance updated.
