### PR TITLE
fix(web): use live bounds for motion hover

### DIFF
--- a/.changeset/web-motion-live-hover.md
+++ b/.changeset/web-motion-live-hover.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/motion": patch
+"@lynx-js/web-core": patch
+---
+
+Keep Web hover hit testing aligned with live element bounds after scrolling or layout shifts, including pointer movement outside the Lynx view.

--- a/packages/motion/src/declarative/motion.tsx
+++ b/packages/motion/src/declarative/motion.tsx
@@ -119,6 +119,7 @@ function useMotionHostProps<Props extends MotionProps>(
     AnimationPlaybackControlsWithThen[]
   >([]);
   const hoverActiveRef = useMainThreadRef(false);
+  const hoverActiveWebRef = useMainThreadRef(false);
   const tapActiveRef = useMainThreadRef(false);
   const animationGenerationRef = useMainThreadRef(0);
   const hoverLayoutRef = useRef<
@@ -232,10 +233,14 @@ function useMotionHostProps<Props extends MotionProps>(
     onHoverStart,
     onHoverEnd,
   ].some(Boolean);
-  const bindLayoutChange = hasHoverInteraction || externalLayoutChange
+  const isLynxForWeb = typeof SystemInfo !== 'undefined'
+    && String(SystemInfo.platform) === 'web';
+  const usesBackgroundHoverHitTesting = hasHoverInteraction && !isLynxForWeb;
+  const bindLayoutChange = usesBackgroundHoverHitTesting
+      || externalLayoutChange
     ? (event: unknown) => {
       externalLayoutChange?.(event);
-      if (!hasHoverInteraction) {
+      if (!usesBackgroundHoverHitTesting) {
         return;
       }
       const detail = (event as {
@@ -256,11 +261,12 @@ function useMotionHostProps<Props extends MotionProps>(
       }
     }
     : undefined;
-  const bindGlobalMouseMove = hasHoverInteraction || externalGlobalMouseMove
+  const bindGlobalMouseMove = usesBackgroundHoverHitTesting
+      || externalGlobalMouseMove
     ? (event: unknown) => {
       externalGlobalMouseMove?.(event);
       const layout = hoverLayoutRef.current;
-      if (!hasHoverInteraction || !layout) {
+      if (!usesBackgroundHoverHitTesting || !layout) {
         return;
       }
       const mouseEvent = event as { x?: unknown; y?: unknown };
@@ -685,6 +691,56 @@ function useMotionHostProps<Props extends MotionProps>(
     );
   }
 
+  function bindGlobalMouseMoveOnWeb(event: unknown) {
+    'main thread';
+    if (
+      typeof SystemInfo === 'undefined'
+      || String(SystemInfo.platform) !== 'web'
+      || !elementRef.current
+    ) {
+      return;
+    }
+    const mouseEvent = event as { x?: unknown; y?: unknown };
+    const x = mouseEvent.x;
+    const y = mouseEvent.y;
+    if (typeof x !== 'number' || typeof y !== 'number') {
+      return;
+    }
+    void elementRef.current.invoke('boundingClientRect').then(
+      (data) => {
+        const layout = data as Record<string, unknown>;
+        const isInside = typeof layout['left'] === 'number'
+          && typeof layout['right'] === 'number'
+          && typeof layout['top'] === 'number'
+          && typeof layout['bottom'] === 'number'
+          && x >= layout['left']
+          && x <= layout['right']
+          && y >= layout['top']
+          && y <= layout['bottom'];
+        if (isInside === hoverActiveWebRef.current) {
+          return;
+        }
+        hoverActiveWebRef.current = isInside;
+        if (isInside) {
+          if (onHoverStart) {
+            void runOnBackground(onHoverStart)(event);
+          }
+          if (resolvedHover.target) {
+            startHoverAnimation();
+          }
+        } else {
+          if (onHoverEnd) {
+            void runOnBackground(onHoverEnd)(event);
+          }
+          if (resolvedHover.target) {
+            endHoverAnimation();
+          }
+        }
+      },
+      () => undefined,
+    );
+  }
+
   return {
     ...hostProps,
     style: initialStyle,
@@ -695,6 +751,9 @@ function useMotionHostProps<Props extends MotionProps>(
     ...(bindLayoutChange ? { bindlayoutchange: bindLayoutChange } : {}),
     ...(bindGlobalMouseMove
       ? { 'global-bindmousemove': bindGlobalMouseMove }
+      : {}),
+    ...(hasHoverInteraction && isLynxForWeb
+      ? { 'main-thread:global-bindmousemove': bindGlobalMouseMoveOnWeb }
       : {}),
     ...(resolvedTap.target
       ? {

--- a/packages/web-platform/web-core-e2e/package.json
+++ b/packages/web-platform/web-core-e2e/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@lynx-js/external-bundle-rsbuild-plugin": "workspace:*",
     "@lynx-js/lynx-bundle-rslib-config": "workspace:*",
+    "@lynx-js/motion": "workspace:*",
     "@lynx-js/playwright-fixtures": "workspace:*",
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",

--- a/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx.spec.ts
@@ -770,6 +770,89 @@ test.describe('reactlynx3 tests', () => {
       },
     );
 
+    test('basic-motion-hover-live-rect', async ({ page }) => {
+      await goto(page, 'basic-motion-hover-live-rect');
+      const scroller = page.locator('#scroller');
+      const scrollTarget = page.locator('#scroll-target');
+      const shiftTarget = page.locator('#shift-target');
+      await expect(scrollTarget).toBeVisible();
+
+      const initialScrollBox = await scrollTarget.boundingBox();
+      expect(initialScrollBox).not.toBeNull();
+      const scrollX = initialScrollBox!.x + initialScrollBox!.width / 2;
+      const scrollY = initialScrollBox!.y + initialScrollBox!.height / 2;
+      await page.mouse.move(scrollX, scrollY);
+      await expect(scrollTarget).toHaveCSS(
+        'background-color',
+        'rgb(0, 255, 0)',
+      );
+
+      await scroller.evaluate((element) => {
+        element.scrollTop = 140;
+      });
+      await page.mouse.move(scrollX + 1, scrollY);
+      await expect(scrollTarget).toHaveCSS(
+        'background-color',
+        'rgb(255, 0, 0)',
+      );
+
+      const shiftedScrollBox = await scrollTarget.boundingBox();
+      expect(shiftedScrollBox).not.toBeNull();
+      await page.mouse.move(
+        shiftedScrollBox!.x + shiftedScrollBox!.width / 2,
+        shiftedScrollBox!.y + shiftedScrollBox!.height / 2,
+      );
+      await expect(scrollTarget).toHaveCSS(
+        'background-color',
+        'rgb(0, 255, 0)',
+      );
+      await page.mouse.move(
+        shiftedScrollBox!.x + shiftedScrollBox!.width + 10,
+        shiftedScrollBox!.y + shiftedScrollBox!.height / 2,
+      );
+      await expect(scrollTarget).toHaveCSS(
+        'background-color',
+        'rgb(255, 0, 0)',
+      );
+
+      const initialShiftBox = await shiftTarget.boundingBox();
+      expect(initialShiftBox).not.toBeNull();
+      const shiftX = initialShiftBox!.x + initialShiftBox!.width / 2;
+      const shiftY = initialShiftBox!.y + initialShiftBox!.height / 2;
+      await page.mouse.move(shiftX, shiftY);
+      await expect(shiftTarget).toHaveCSS(
+        'background-color',
+        'rgb(0, 255, 0)',
+      );
+      await page.locator('#shift-control').dispatchEvent('click');
+      await page.mouse.move(shiftX + 1, shiftY);
+      await expect(shiftTarget).toHaveCSS(
+        'background-color',
+        'rgb(255, 0, 0)',
+      );
+
+      const shiftedBox = await shiftTarget.boundingBox();
+      expect(shiftedBox).not.toBeNull();
+      await page.mouse.move(
+        shiftedBox!.x + shiftedBox!.width / 2,
+        shiftedBox!.y + shiftedBox!.height / 2,
+      );
+      await expect(shiftTarget).toHaveCSS(
+        'background-color',
+        'rgb(0, 255, 0)',
+      );
+      const lynxViewBox = await page.locator('lynx-view').boundingBox();
+      expect(lynxViewBox).not.toBeNull();
+      await page.mouse.move(
+        lynxViewBox!.x + lynxViewBox!.width / 2,
+        lynxViewBox!.y + lynxViewBox!.height + 20,
+      );
+      await expect(shiftTarget).toHaveCSS(
+        'background-color',
+        'rgb(255, 0, 0)',
+      );
+    });
+
     test(
       'basic-mts-bindtap-change-element-background',
       async ({ page }, { title }) => {

--- a/packages/web-platform/web-core-e2e/tests/reactlynx/basic-motion-hover-live-rect/index.jsx
+++ b/packages/web-platform/web-core-e2e/tests/reactlynx/basic-motion-hover-live-rect/index.jsx
@@ -1,0 +1,46 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { motion } from '@lynx-js/motion';
+import { root, useState } from '@lynx-js/react';
+
+function App() {
+  const [shifted, setShifted] = useState(false);
+  return (
+    <view>
+      <scroll-view
+        id='scroller'
+        scroll-y
+        style={{ width: '240px', height: '180px', backgroundColor: '#eeeeee' }}
+      >
+        <view style={{ height: '100px' }} />
+        <motion.view
+          id='scroll-target'
+          style={{ width: '120px', height: '80px', backgroundColor: '#ff0000' }}
+          whileHover={{ backgroundColor: '#00ff00' }}
+          transition={{ duration: 0 }}
+        />
+        <view style={{ height: '300px' }} />
+      </scroll-view>
+      <view
+        id='shift-control'
+        style={{ width: '100px', height: '40px' }}
+        bindtap={() => setShifted(value => !value)}
+      />
+      <motion.view
+        id='shift-target'
+        style={{
+          position: 'relative',
+          left: shifted ? '180px' : '0px',
+          width: '120px',
+          height: '80px',
+          backgroundColor: '#ff0000',
+        }}
+        whileHover={{ backgroundColor: '#00ff00' }}
+        transition={{ duration: 0 }}
+      />
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -219,6 +219,61 @@ describe('Element APIs', () => {
     expect(commonEventHandler).toHaveBeenCalledTimes(1);
     expect(commonEventHandler.mock.calls[0]![0].type).toBe('touchstart');
   });
+
+  test('continues global mousemove outside the Lynx view without duplicating in-view delivery', () => {
+    const commonEventHandler = rstest.fn();
+    mtsBinding.wasmContext = Object.assign(mtsBinding.wasmContext || {}, {
+      common_event_handler: commonEventHandler,
+    }) as any;
+    mtsBinding.addEventListener('mousemove');
+
+    const target = mtsGlobalThis.__CreateView(0);
+    rootDom.appendChild(target);
+    target.dispatchEvent(
+      new MouseEvent('mousemove', {
+        bubbles: true,
+        composed: true,
+        clientX: 20,
+        clientY: 30,
+      }),
+    );
+
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(
+      new MouseEvent('mousemove', {
+        bubbles: true,
+        composed: true,
+        clientX: 200,
+        clientY: 300,
+      }),
+    );
+
+    expect(commonEventHandler).toHaveBeenCalledTimes(2);
+    expect([...commonEventHandler.mock.calls[0]![1]]).toEqual([
+      __GetElementUniqueID(target),
+    ]);
+    expect([...commonEventHandler.mock.calls[1]![1]]).toEqual([]);
+    expect(commonEventHandler.mock.calls.map(call => ({
+      type: call[0].type,
+      x: call[0].x,
+      y: call[0].y,
+    }))).toEqual([
+      { type: 'mousemove', x: 20, y: 30 },
+      { type: 'mousemove', x: 200, y: 300 },
+    ]);
+
+    commonEventHandler.mockClear();
+    mtsBinding.disposeEventListeners();
+    outside.dispatchEvent(
+      new MouseEvent('mousemove', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    expect(commonEventHandler).not.toHaveBeenCalled();
+    outside.remove();
+  });
   test('#commonEventHandler should filter out -1 uniqueId', () => {
     mtsBinding.wasmContext = Object.assign(mtsBinding.wasmContext || {}, {
       common_event_handler: rstest.fn(),

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
@@ -29,6 +29,7 @@ export type WASMJSBindingInjectedHandler = {
 };
 
 const DOCUMENT_LEVEL_EVENTS = new Set(['keydown', 'keyup']);
+const OUTSIDE_VIEW_CONTINUATION_EVENTS = new Set(['mousemove']);
 const POINTER_DERIVED_TOUCH_EVENTS = new Set([
   'touchstart',
   'touchmove',
@@ -68,6 +69,7 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
   #pointerTouchEventNames: Set<string> = new Set();
   #activePointerTouches: Map<number, ActivePointerTouch> = new Map();
   #pointerTouchListenersAdded = false;
+  #outsideViewEventListeners: Set<string> = new Set();
   toBeEnabledElement: Set<HTMLElement> = new Set();
   toBeDisabledElement: Set<HTMLElement> = new Set();
 
@@ -287,6 +289,16 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     this.#dispatchCommonEvent(event, event.target as HTMLElement);
   };
 
+  #outsideViewEventHandler = (event: Event) => {
+    if (event.composedPath().includes(this.lynxViewInstance.rootDom)) {
+      return;
+    }
+    const target = event.target instanceof HTMLElement
+      ? event.target
+      : document.documentElement;
+    this.#dispatchCommonEvent(event, target);
+  };
+
   #toPointerTouch(event: PointerEvent): PointerTouch {
     return {
       identifier: event.pointerId,
@@ -416,6 +428,14 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
           capture: true,
         },
       );
+      if (OUTSIDE_VIEW_CONTINUATION_EVENTS.has(w3cEventName)) {
+        this.#outsideViewEventListeners.add(w3cEventName);
+        document.addEventListener(
+          w3cEventName,
+          this.#outsideViewEventHandler,
+          { passive: true },
+        );
+      }
     }
   }
 
@@ -437,6 +457,13 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     }
     this.#addedEventListeners.clear();
     this.#documentEventListeners.clear();
+    for (const eventName of this.#outsideViewEventListeners) {
+      document.removeEventListener(
+        eventName,
+        this.#outsideViewEventHandler,
+      );
+    }
+    this.#outsideViewEventListeners.clear();
     if (this.#pointerTouchListenersAdded) {
       this.lynxViewInstance.rootDom.removeEventListener(
         'pointerdown',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2218,6 +2218,9 @@ importers:
       '@lynx-js/lynx-bundle-rslib-config':
         specifier: workspace:*
         version: link:../../rspeedy/lynx-bundle-rslib-config
+      '@lynx-js/motion':
+        specifier: workspace:*
+        version: link:../../motion
       '@lynx-js/playwright-fixtures':
         specifier: workspace:*
         version: link:../playwright-fixtures


### PR DESCRIPTION
## Summary

- use a Web-only main-thread global mousemove handler in Motion and read `boundingClientRect` through the live main-thread `Element.invoke()` PAPI on every move
- leave native/background hover behavior on its existing `bindlayoutchange` + `global-bindmousemove` path
- continue Web `mousemove` at document level after the pointer leaves the Lynx view, filtering the Shadow DOM composed path so in-view movement is delivered exactly once
- add Web Core unit coverage and real Chromium coverage for scroll, element/view leave, re-entry, and a pure positional layout shift

## Native semantics

This follows native live Lynx-view-relative geometry rather than introducing a Web-only coordinate model:

- `lynx/core/renderer/worklet/lepus_element.cc`: `LepusElement::GetBoundingClientRect()` reads `Element::GetRectToLynxView()`.
- `lynx/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/ui/LynxBaseUI.java`: `boundingClientRect()` resolves current layout before `boundingClientRectInner()`; `getBoundingClientRect()` walks the current hierarchy and subtracts parent scroll offsets.

Verified against `lynx/develop` at `a573c3b8280180b59ca3da3e33d7a50192334cce`.

Downstream reproduction evidence: Huxpro/motion-lynx-harness#107 reports `whileHover` working at the initial scroll position and failing after scroll because cached layout rects were compared with live mouse coordinates. This PR removes that downstream shim requirement.

## Validation

- `pnpm install --frozen-lockfile`
- `TURBO_TELEMETRY_DISABLED=1 NODE_OPTIONS=--max-old-space-size=32768 pnpm turbo build` — 69/69 tasks passed
- `TURBO_TELEMETRY_DISABLED=1 NODE_OPTIONS=--max-old-space-size=32768 pnpm turbo build --filter=@lynx-js/motion --filter=@lynx-js/web-core-e2e` — 19/19 tasks passed after the implementation fix
- `TURBO_TELEMETRY_DISABLED=1 NODE_OPTIONS=--max-old-space-size=32768 pnpm turbo build --filter=@lynx-js/motion` — 14/14 tasks passed
- `pnpm --filter @lynx-js/motion exec vitest run __tests__/declarative.test.tsx` — 12/12 passed
- `pnpm --filter @lynx-js/web-core exec rstest tests/element-apis.spec.ts` — 92/92 passed
- `pnpm --filter @lynx-js/web-core-e2e exec playwright test tests/reactlynx.spec.ts --grep 'basic-motion-hover-live-rect' --project=chromium` — 1/1 passed with real Playwright mouse input
- `pnpm dprint fmt`
- targeted ESLint on changed source/tests — 0 errors

## Stack

- Base: #3567 (`agent/web-pointer-touch-bridge`, `34ce6b5124c2dfc3a0fde6ca567d1db8972e8462`)
- This PR: `7183f022c6e9b5e0aab1abe45a1d8a35c52be1c2`
