### PR TITLE
refactor: move the htmlPlugin default into @lynx-js/rsbuild-plugin

### DIFF
--- a/.changeset/move-html-plugin.md
+++ b/.changeset/move-html-plugin.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Move the `tools.htmlPlugin` default into `pluginLynx()`.

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -134,8 +134,6 @@ export function toRsbuildConfig(
 
       cssLoader: config.tools?.cssLoader,
 
-      htmlPlugin: false,
-
       rspack: config.tools?.rspack,
 
       swc: config.tools?.swc,

--- a/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
@@ -26,7 +26,11 @@ export function pluginOutput(): RsbuildPlugin {
             // `transform-block-scoping` pass handles user source separately.
             // Placed first so user-provided
             // `tools.rspack.output.environment.const` can opt out.
-            tools: { rspack: { output: { environment: { const: false } } } },
+            tools: {
+              // Lynx does not use HTML.
+              htmlPlugin: false,
+              rspack: { output: { environment: { const: false } } },
+            },
           },
           config,
           {

--- a/packages/rspeedy/plugin-lynx/test/output.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/output.plugin.test.ts
@@ -58,6 +58,13 @@ describe('pluginOutput', () => {
     expect(config.output?.environment?.const).toBe(false)
   })
 
+  test('does not emit HTML', async () => {
+    const rsbuild = await createStubRsbuild()
+    await rsbuild.unwrapConfig()
+
+    expect(rsbuild.getNormalizedConfig().tools?.htmlPlugin).toBe(false)
+  })
+
   test('user can opt out of const/let lowering', async () => {
     const rsbuild = await createStubRsbuild({
       tools: {


### PR DESCRIPTION
Lynx does not use HTML, so `tools.htmlPlugin` is disabled. That default lived in `toRsbuildConfig`, which means a raw `rsbuild` + `pluginLynx` build emits a `main.html` next to its assets. It is a Lynx platform fact rather than a Rspeedy option, so it moves into `pluginLynx()`.

Measured before and after on a raw `rsbuild` + `pluginLynx` build with a plain JS entry:

```
- dist/.rspeedy/main/main.css
- dist/static/js/main.<hash>.js
- dist/main.html          <- gone after this change
```

`tools.htmlPlugin` is not part of the Rspeedy config schema, so no Rspeedy user could set it and the behaviour there is unchanged. In the engine it sits next to the existing `output.environment.const` default, in the merge position that lets a raw Rsbuild user opt back in; verified that setting `tools.htmlPlugin: true` still resolves to `true`.

Verified: both test projects pass, both packages type-check, and `@examples/react` `main.lynx.bundle` is byte-identical to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The HTML plugin default is now managed by the Lynx plugin.
  * Generated Lynx builds continue to avoid incompatible modern JavaScript syntax in output.
  * Existing behavior is preserved while configuration is simplified.

* **Bug Fixes**
  * Prevented unintended HTML processing during Lynx builds.

* **Tests**
  * Added coverage confirming the HTML plugin is disabled by default in normalized configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->