### PR TITLE
refactor: read the bundle filename from the Rsbuild config

### DIFF
--- a/.changeset/read-bundle-filename-from-rsbuild-config.md
+++ b/.changeset/read-bundle-filename-from-rsbuild-config.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Read the bundle filename from the Rsbuild config instead of the Rspeedy API.

--- a/packages/rspeedy/core/src/config/defaults.ts
+++ b/packages/rspeedy/core/src/config/defaults.ts
@@ -65,7 +65,7 @@ function getEnableChunkSplitting(config: Config): boolean {
 
 const DEFAULT_FILENAME = '[name].[platform].bundle'
 
-function getFilename(filename: string | Filename | undefined): Filename {
+export function getFilename(filename: string | Filename | undefined): Filename {
   if (typeof filename === 'string') {
     return {
       bundle: filename,

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -6,6 +6,7 @@ import type { ConsoleType, RsbuildConfig, SourceMap } from '@rsbuild/core'
 import type { UndefinedOnPartialDeep } from 'type-fest'
 
 import { toRsbuildEntry } from './entry.js'
+import { getFilename } from '../defaults.js'
 import type { Config } from '../index.js'
 
 // This is the default value from lynx-speedy.
@@ -49,9 +50,11 @@ export function toRsbuildConfig(
 
       distPath: config.output?.distPath,
 
-      filename: typeof config.output?.filename === 'object'
-        ? config.output.filename
-        : undefined,
+      // The string form carries the same `bundle`/`template` meaning, so it is
+      // resolved here instead of being dropped.
+      filename: typeof config.output?.filename === 'string'
+        ? getFilename(config.output.filename)
+        : config.output?.filename,
 
       filenameHash: config.output?.filenameHash,
 

--- a/packages/rspeedy/core/test/config/rsbuild.test.ts
+++ b/packages/rspeedy/core/test/config/rsbuild.test.ts
@@ -527,13 +527,16 @@ describe('Config - toRsBuildConfig', () => {
       expect(rsbuildConfig.output?.filename).toHaveProperty('css', 'style.css')
     })
 
-    test('transform output.filename string is not forwarded', () => {
+    test('transform output.filename string', () => {
       const rsbuildConfig = toRsbuildConfig({
         output: {
           filename: 'main.bundle',
         },
       })
-      expect(rsbuildConfig.output?.filename).toBeUndefined()
+      expect(rsbuildConfig.output?.filename).toStrictEqual({
+        bundle: 'main.bundle',
+        template: 'main.bundle',
+      })
     })
 
     test('transform output.inlineScripts', () => {

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -12,7 +12,7 @@ import type {
 import type { UndefinedOnPartialDeep } from 'type-fest'
 
 import { LAYERS, ReactWebpackPlugin } from '@lynx-js/react-webpack-plugin'
-import type { ExposedAPI } from '@lynx-js/rspeedy'
+import type { ExposedAPI, Filename } from '@lynx-js/rspeedy'
 import { RuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
 import {
   LynxEncodePlugin,
@@ -77,6 +77,9 @@ export function applyEntry(
       ? api.useExposed<ExposedAPI>(Symbol.for('rspeedy.api'))?.config
       : undefined
 
+    const bundleFilenameConfig = api.getRsbuildConfig('original').output
+      ?.filename as Filename | undefined
+
     const isRspeedy = api.context.callerName === 'rspeedy'
     if (isRspeedy) {
       const entries = chain.entryPoints.entries() ?? {}
@@ -93,11 +96,8 @@ export function applyEntry(
       Object.entries(entries).forEach(([entryName, entryPoint]) => {
         const { imports } = getChunks(entryName, entryPoint.values())
 
-        const bundleFilename =
-          typeof rspeedyConfig?.output?.filename === 'object'
-            ? rspeedyConfig.output.filename.bundle
-              ?? rspeedyConfig.output.filename.template
-            : rspeedyConfig?.output?.filename
+        const bundleFilename = bundleFilenameConfig?.bundle
+          ?? bundleFilenameConfig?.template
 
         let templateFilename: string
         // `lazyBundleFilename` is only set when `bundle` is a function.


### PR DESCRIPTION
Stacked on #3569.

`applyEntry` resolves the Lynx template filename from the Rspeedy config, reached through `api.useExposed(Symbol.for('rspeedy.api'))`. That is one of the reasons the template pipeline only runs under Rspeedy. The same value already travels through the Rsbuild config as `output.filename.bundle` / `template`, so it can be read from there instead.

One gap had to be closed first: `toRsbuildConfig` dropped the string form of `output.filename`, because only the object form was forwarded. The string form carries the same `bundle`/`template` meaning, so it is now resolved with the existing `getFilename` helper rather than dropped. Only the string case changes; `undefined` stays `undefined` and the object form is still forwarded as-is.

No behaviour change under Rspeedy: for every input shape the resolved template filename is the same as before.

| `output.filename` | resolved bundle name |
| --- | --- |
| unset | `[name].[platform].bundle` |
| `'x.bundle'` | `x.bundle` |
| `{ bundle: 'y.bundle' }` | `y.bundle` |

Verified: `@lynx-js/rspeedy`, `@lynx-js/rsbuild-plugin` and `@lynx-js/react-rsbuild-plugin` test suites pass, both packages type-check, and `@examples/react` `main.lynx.bundle` is byte-identical to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bundle and template filenames are now correctly read from the Rsbuild output configuration.
  * String-based filename settings are applied consistently to generated bundle and template files.
  * Existing object-based filename configurations continue to work unchanged.

* **Documentation**
  * Added release notes describing the updated filename configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->