### PR TITLE
fix(rspeedy): declare middleware project reference

### DIFF
--- a/packages/rspeedy/core/tsconfig.build.json
+++ b/packages/rspeedy/core/tsconfig.build.json
@@ -26,6 +26,5 @@
     { "path": "../../webpack/css-extract-webpack-plugin/tsconfig.build.json" },
     { "path": "../plugin-debug-metadata/tsconfig.build.json" },
     { "path": "../plugin-lynx/tsconfig.build.json" },
-    { "path": "../../web-platform/web-rsbuild-server-middleware/tsconfig.json" },
   ],
 }

--- a/packages/rspeedy/plugin-lynx/tsconfig.build.json
+++ b/packages/rspeedy/plugin-lynx/tsconfig.build.json
@@ -8,6 +8,7 @@
   "references": [
     { "path": "../../webpack/cache-events-webpack-plugin/tsconfig.build.json" },
     { "path": "../../webpack/chunk-loading-webpack-plugin/tsconfig.build.json" },
+    { "path": "../../web-platform/web-rsbuild-server-middleware/tsconfig.json" },
   ],
   "include": ["src"],
 }


### PR DESCRIPTION
## Summary

- Move the web Rsbuild server middleware TypeScript project reference from `@lynx-js/rspeedy` to `@lynx-js/rsbuild-plugin`, which now owns the dependency.
- Ensure a clean build of the plugin project emits the middleware declarations before compiling `dev.plugin.ts`.

Before this change, building `packages/rspeedy/plugin-lynx/tsconfig.build.json` from a clean checkout failed with TS2307 for `@lynx-js/web-rsbuild-server-middleware`. The standalone repository build could mask the missing edge because another root project reached the middleware first.

## Verification

- `pnpm exec tsc6 --build packages/rspeedy/plugin-lynx/tsconfig.build.json --clean --pretty false`
- `pnpm exec tsc6 --build packages/rspeedy/plugin-lynx/tsconfig.build.json --pretty false`
- `pnpm turbo build --summarize` — 71/71 tasks passed
- `pnpm exec rstest run --project rsbuild-plugin` — 12 files, 113 tests passed
- `pnpm dprint fmt`
- `pnpm biome check`
- `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint .` — 0 errors

## Checklist

- [x] Tests updated (not required; this fixes build graph metadata).
- [x] Documentation updated (not required).
- [x] Changeset added (not required; no published runtime or API behavior changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration for the Lynx plugin.
  * Prevented unnecessary middleware project processing during the core build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->