### PR TITLE
refactor: emit the Lynx template for non-Rspeedy callers

### DIFF
--- a/.changeset/ungate-template-pipeline.md
+++ b/.changeset/ungate-template-pipeline.md
@@ -2,4 +2,4 @@
 "@lynx-js/react-rsbuild-plugin": patch
 ---
 
-Emit the Lynx template for callers other than Rspeedy.
+Emit the Lynx template for callers other than `rslib` and `rstest`.

--- a/.changeset/ungate-template-pipeline.md
+++ b/.changeset/ungate-template-pipeline.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Emit the Lynx template for callers other than Rspeedy.

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -80,8 +80,11 @@ export function applyEntry(
     const bundleFilenameConfig = api.getRsbuildConfig('original').output
       ?.filename as Filename | undefined
 
-    const isRspeedy = api.context.callerName === 'rspeedy'
-    if (isRspeedy) {
+    // `rslib` builds libraries and `rstest` runs tests, neither of which emits
+    // a Lynx template.
+    const emitTemplate = api.context.callerName !== 'rslib'
+      && api.context.callerName !== 'rstest'
+    if (emitTemplate) {
       const entries = chain.entryPoints.entries() ?? {}
       const isLynx = environment.name === 'lynx'
         || environment.name.startsWith('lynx-')


### PR DESCRIPTION
Stacked on #3570.

`applyEntry` sets up the whole Lynx template pipeline (`LynxTemplatePlugin`, the runtime wrapper, `LynxEncodePlugin`, the web plugin) inside a block gated on `callerName === 'rspeedy'`. That is why building with plain Rsbuild and `pluginReactLynx` produces JavaScript chunks but no `.bundle`.

Nothing inside the block needs Rspeedy any more: its last Rspeedy read, the bundle filename, moved to the Rsbuild config in #3570. Only the gate was left, so it is inverted from "opt in for Rspeedy" to "opt out for the callers that must not emit a template". `rslib` builds libraries and `rstest` runs tests; both already have dedicated branches in `pluginReactLynx` and neither should produce a Lynx template. The only caller newly included is plain `rsbuild`.

Measured on `@examples/react`, built once through Rspeedy and once through plain Rsbuild with `pluginLynx()` + `pluginReactLynx()` over the same source:

| | `main.lynx.bundle` |
| --- | --- |
| Rspeedy | 94824 bytes |
| Rsbuild, before this change | not emitted |
| Rsbuild, after this change | 94875 bytes |

The remaining 51 bytes are a `/*! LICENSE: ... */` banner, because `output.legalComments: 'none'` is still applied by `toRsbuildConfig` rather than by the engine. That is the next step.

Verified: `@lynx-js/react-rsbuild-plugin` tests pass, `@lynx-js/react-umd` (the `rslib` caller) still builds, and `@examples/react` `main.lynx.bundle` under Rspeedy is byte-identical to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lynx templates are now generated for supported callers beyond Rspeedy.
  - Template generation remains disabled for Rslib and Rstest workflows.
  - This provides more consistent template availability across supported build workflows.

- **Documentation**
  - Added release notes describing the expanded template generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->