### PR TITLE
refactor: move the legalComments default into @lynx-js/rsbuild-plugin

### DIFF
--- a/.changeset/move-legal-comments.md
+++ b/.changeset/move-legal-comments.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Move the `output.legalComments` default into `pluginLynx()`.

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -60,9 +60,7 @@ export function toRsbuildConfig(
 
       inlineScripts: config.output?.inlineScripts,
 
-      // TODO(OSS): change the default value to `linked`(or `undefined`) when OSS.
-      // We expect to use different default legalComments with Rsbuild
-      legalComments: config.output?.legalComments ?? 'none',
+      legalComments: config.output?.legalComments,
 
       minify: config.output?.minify,
 

--- a/packages/rspeedy/core/test/config/rsbuild.test.ts
+++ b/packages/rspeedy/core/test/config/rsbuild.test.ts
@@ -469,7 +469,7 @@ describe('Config - toRsBuildConfig', () => {
           "filename": undefined,
           "filenameHash": undefined,
           "inlineScripts": undefined,
-          "legalComments": "none",
+          "legalComments": undefined,
           "minify": undefined,
           "polyfill": "off",
           "sourceMap": undefined,

--- a/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
@@ -44,6 +44,8 @@ export function pluginOutput(): RsbuildPlugin {
               filename: {
                 css: originalFilename?.css ?? '[name]/[name].css',
               },
+              // A Lynx bundle has nowhere to link a separate license file to.
+              legalComments: original.output?.legalComments ?? 'none',
             },
           },
         )


### PR DESCRIPTION
Stacked on #3572.

Lynx encodes everything into a single template, so a linked license file has nowhere to point at. `output.legalComments` is therefore forced to `none`, but that default lives in `toRsbuildConfig`, which means a raw Rsbuild build keeps Rsbuild's own `linked` default and emits a `/*! LICENSE: ... */` banner. It is a Lynx platform fact, so it moves into `pluginLynx()`.

The user value still flows through, because `output.legalComments` is a native Rsbuild option: the engine reads `getRsbuildConfig('original')` and only supplies the default when the user did not set one, the same pattern the plugin already uses for `distPath.css` and `filename.css`.

Measured on `@examples/react`, same source built through Rspeedy and through plain Rsbuild with `pluginLynx()` + `pluginReactLynx()`:

| | `main.lynx.bundle` |
| --- | --- |
| Rspeedy | 94824 bytes |
| Rsbuild, before this change | 94875 bytes |
| Rsbuild, after this change | 94824 bytes |

The two files are now the same size, and the only remaining difference is 64 bytes of `background.<contenthash>.js` naming. The embedded JavaScript is identical, so the hash is fed by a config value that has not moved yet; the normalized configs still differ on `output.sourceMap.css`, `output.inlineScripts`, `output.dataUriLimit`, `output.cssModules.localIdentName` and the `output.filename.bundle` default. Those are the next steps.

Verified: `@lynx-js/rspeedy` and `@lynx-js/rsbuild-plugin` tests pass, and `@examples/react` `main.lynx.bundle` under Rspeedy is byte-identical to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the default handling of legal comments during builds.
  * Legal comments are now omitted by default while preserving any explicitly configured setting.
* **Chores**
  * Updated release metadata for the affected build packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->