### PR TITLE
ci: run the test workflow for pull requests to any branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - "**/*.md"
   merge_group:


### PR DESCRIPTION
The `Test` workflow only triggers on pull requests whose base is `main`, so a pull request stacked on another branch runs none of it. `Done` lives in this workflow and is a required check on `main`, which means a stacked pull request has no way to be validated until the one below it lands and its base becomes `main`.

This is not specific to one stack: `220` pull requests are currently open and `47` of them target a branch other than `main`.

Dropping the `branches` filter makes the workflow run for every pull request regardless of base. Gating it any more precisely is not possible here, because a trigger can only filter on static branch name patterns, while whether a pull request belongs to a stack is only known through the API. Skipping the jobs instead of not triggering them is also not an option, since `Done` fails when any needed job is skipped.

The trade-off is CI time for those `47` pull requests, which currently run no tests at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated checks now run for pull requests targeting any branch, while existing Markdown path exclusions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->