### PR TITLE
feat: expose a name that marks pluginLynx as applied

### DIFF
--- a/.changeset/plugin-lynx-marker.md
+++ b/.changeset/plugin-lynx-marker.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Add `PLUGIN_LYNX_NAME` so plugins can tell whether `pluginLynx` is applied.

--- a/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
@@ -6,6 +6,9 @@
 
 import type { RsbuildPlugin } from '@rsbuild/core';
 
+// @public
+export const PLUGIN_LYNX_NAME = "lynx:rsbuild";
+
 // @public (undocumented)
 export function pluginLynx(): RsbuildPlugin[];
 

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -16,10 +16,24 @@ import { pluginSwc } from './plugins/swc.plugin.js'
 import { pluginTarget } from './plugins/target.plugin.js'
 
 /**
+ * The name of the plugin that marks `pluginLynx` as applied. Use it with
+ * `api.isPluginExists` to tell whether the Lynx build engine is already there.
+ *
+ * @public
+ */
+export const PLUGIN_LYNX_NAME = 'lynx:rsbuild'
+
+/**
  * @public
  */
 export function pluginLynx(): RsbuildPlugin[] {
   return [
+    {
+      name: PLUGIN_LYNX_NAME,
+      setup() {
+        // A marker, so its presence can be detected. It has no behavior.
+      },
+    },
     pluginChunkLoading(),
     pluginCssMinimizer(),
     pluginDev(),

--- a/packages/rspeedy/plugin-lynx/test/marker.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/marker.test.ts
@@ -1,0 +1,16 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core'
+
+import { createStubRsbuild } from './createStubRsbuild.js'
+import { PLUGIN_LYNX_NAME } from '../src/index.js'
+
+describe('PLUGIN_LYNX_NAME', () => {
+  test('marks pluginLynx as applied', async () => {
+    const rsbuild = await createStubRsbuild()
+    await rsbuild.unwrapConfig()
+
+    expect(rsbuild.isPluginExists(PLUGIN_LYNX_NAME)).toBe(true)
+  })
+})


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `lynx:rsbuild` marker to identify when the Lynx Rsbuild plugin is active.
  * The marker is available for presence detection without affecting build behavior.

* **Documentation**
  * Documented the new public marker in the API reference.

* **Tests**
  * Added coverage confirming the marker is registered correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).