### PR TITLE
fix(rsbuild-plugin): alias the @rspack/core/hot subpaths the dev client imports

### DIFF
--- a/.changeset/rspack-hot-subpath-alias.md
+++ b/.changeset/rspack-hot-subpath-alias.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Alias `@rspack/core/hot/log.js` and `@rspack/core/hot/log-apply-result.js`, which `@lynx-js/webpack-dev-transport` imports without declaring `@rspack/core`. Development builds failed to resolve them on any package manager that does not hoist `@rspack/core`, such as npm and Yarn.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,32 +220,70 @@ jobs:
         fi
         node packages/tools/canary-release/snapshot.js
         pnpm --recursive publish --no-git-checks --access public --registry=http://localhost:4873
-        cd `mktemp -d`
-        npx --registry http://localhost:4873 create-rspeedy-canary@latest --template react --dir create-rspeedy-regression --tools eslint --skill lynx-devtool
-        cd create-rspeedy-regression
-        npx --registry http://localhost:4873 upgrade-rspeedy-canary@latest
-        pnpm install --registry=http://localhost:4873
-        pnpm run build
-        pnpm run build --mode development
-        pnpm run lint
-        cd `mktemp -d`
-        npx --registry http://localhost:4873 create-rspeedy-canary@latest --template react --dir create-rspeedy-regression-vitest-rltl --tools eslint,vitest-rltl
-        cd create-rspeedy-regression-vitest-rltl
-        npx --registry http://localhost:4873 upgrade-rspeedy-canary@latest
-        pnpm install --registry=http://localhost:4873
-        pnpm run build
-        pnpm run build --mode development
-        pnpm run lint
-        pnpm run test
-        cd `mktemp -d`
-        npx --registry http://localhost:4873 create-rspeedy-canary@latest --template react --dir create-rspeedy-regression-rstest-rltl --tools eslint,rstest-rltl
-        cd create-rspeedy-regression-rstest-rltl
-        npx --registry http://localhost:4873 upgrade-rspeedy-canary@latest
-        pnpm install --registry=http://localhost:4873
-        pnpm run build
-        pnpm run build --mode development
-        pnpm run lint
-        pnpm run test
+
+        # `npm run <script> <args>` swallows the args unless they follow `--`,
+        # while Yarn 4 would forward the `--` itself to the script.
+        run_script() {
+          local pm=$1 script=$2
+          shift 2
+          if [ "$pm" = npm ] && [ $# -gt 0 ]; then
+            npm run "$script" -- "$@"
+          else
+            "$pm" run "$script" "$@"
+          fi
+        }
+
+        install_with() {
+          case $1 in
+            pnpm) pnpm install --registry=http://localhost:4873 ;;
+            npm) npm install --registry=http://localhost:4873 ;;
+            yarn)
+              corepack prepare yarn@4.18.0 --activate
+              # Marks the generated app as a standalone project so Yarn does not
+              # try to attach it to any package.json above the temp directory.
+              touch yarn.lock
+              yarn config set nodeLinker node-modules
+              yarn config set npmRegistryServer http://localhost:4873
+              yarn config set unsafeHttpWhitelist --json '["localhost"]'
+              # The projects are generated fresh, so there is no lockfile to be
+              # immutable about -- but Yarn turns that on whenever CI is set.
+              yarn config set enableImmutableInstalls false
+              # Yarn quarantines any version published less than `1d` ago, but
+              # the canary versions reached the mock registry seconds earlier.
+              yarn config set npmMinimalAgeGate 0
+              # Hardened mode turns itself on for public pull requests and
+              # validates resolutions against the registry, which the throwaway
+              # project generated here has nothing to gain from.
+              yarn config set enableHardenedMode false
+              yarn install
+              ;;
+          esac
+        }
+
+        # Each package manager lays `node_modules` out differently, so they do
+        # not agree on which undeclared transitive dependency a package can
+        # still resolve. Smoke-test all of them to catch phantom dependencies.
+        smoke_test() {
+          local pm=$1 tools=$2 dir=$3
+          shift 3
+          cd `mktemp -d`
+          npx --registry http://localhost:4873 create-rspeedy-canary@latest --template react --dir "$dir" --tools "$tools" "$@"
+          cd "$dir"
+          npx --registry http://localhost:4873 upgrade-rspeedy-canary@latest
+          install_with "$pm"
+          local bin=${pm%%-*}
+          run_script "$bin" build
+          run_script "$bin" build --mode development
+          run_script "$bin" lint
+        }
+
+        smoke_test pnpm eslint create-rspeedy-regression --skill lynx-devtool
+        smoke_test pnpm eslint,vitest-rltl create-rspeedy-regression-vitest-rltl
+        run_script pnpm test
+        smoke_test pnpm eslint,rstest-rltl create-rspeedy-regression-rstest-rltl
+        run_script pnpm test
+        smoke_test npm eslint create-rspeedy-regression-npm --skill lynx-devtool
+        smoke_test yarn eslint create-rspeedy-regression-yarn --skill lynx-devtool
   test-react:
     needs: build
     uses: ./.github/workflows/workflow-test.yml

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -312,6 +312,18 @@ export function pluginDev(): RsbuildPlugin {
                   paths: [rsbuildPath],
                 })
               )
+              .set(
+                '@rspack/core/hot/log.js',
+                require.resolve('@rspack/core/hot/log', {
+                  paths: [rsbuildPath],
+                })
+              )
+              .set(
+                '@rspack/core/hot/log-apply-result.js',
+                require.resolve('@rspack/core/hot/log-apply-result', {
+                  paths: [rsbuildPath],
+                })
+              )
               .set('@rspack/core/hot/dev-server', hotDevServerPath)
             .end()
           .end()

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -216,6 +216,47 @@ describe('pluginDev', () => {
     )
   })
 
+  test('alias every @rspack/core/hot subpath the client imports', async () => {
+    // `@rspack/core` is not a dependency of `@lynx-js/webpack-dev-transport`,
+    // so every subpath its client imports has to be aliased here or the app
+    // build breaks wherever the package manager does not hoist it.
+    const rsbuild = await createDevStubRsbuild()
+
+    const config = await rsbuild.unwrapConfig()
+
+    const { createRequire } = await import('node:module')
+    const { readdir, readFile } = await import('node:fs/promises')
+    const clientDir = path.resolve(
+      path.dirname(
+        createRequire(import.meta.url).resolve(
+          '@lynx-js/webpack-dev-transport/client',
+        ),
+      ),
+      '../../client',
+    )
+    const entries = await readdir(clientDir, { recursive: true })
+    const sources = await Promise.all(
+      entries
+        .filter(name => /\.[cm]?tsx?$/.test(name))
+        .map(name => readFile(path.join(clientDir, name), 'utf-8')),
+    )
+    // Covers `from '…'`, bare side-effect `import '…'` and `import('…')`,
+    // under either quote style. `declare module '…'` is deliberately not a
+    // match -- a type shim needs no alias.
+    const importRE =
+      /(?:from|import)\s*(?:\(\s*)?(['"])(@rspack\/core\/hot\/[^'"]+)\1/g
+    const imported = new Set(
+      sources.flatMap(source =>
+        [...source.matchAll(importRE)].map(([, , specifier]) => specifier!)
+      ),
+    )
+
+    expect(imported.size).toBeGreaterThan(0)
+    for (const specifier of imported) {
+      expect(config.resolve?.alias).toHaveProperty(specifier)
+    }
+  })
+
   test('no Websocket class injected for web', async () => {
     const rsbuild = await createDevStubRsbuild({
       environments: {


### PR DESCRIPTION
## The bug

`@lynx-js/webpack-dev-transport` imports `@rspack/core/hot/log.js` and
`@rspack/core/hot/log-apply-result.js` (added in #3434), but `@rspack/core` is
only a `devDependency` of that package. `pluginDev` compensates by aliasing the
`@rspack/core/hot/*` subpaths it knows about, and those two were never added, so
a **development-mode** build fails with `Module not found`. Production builds
are unaffected.

It passed on pnpm only because pnpm's hidden hoisted store
(`node_modules/.pnpm/node_modules`) is on the resolution path of anything inside
`.pnpm/`, so the phantom dependency resolved by accident. `test-publish` only
ever installed with pnpm, so CI never saw it.

Verified with the same generated project on each package manager:

| install | dev build |
| --- | --- |
| npm | fails |
| yarn 4, `nodeLinker: node-modules` | fails |
| pnpm | passes |

## Changes

- **`@lynx-js/rsbuild-plugin`** -- alias both missing subpaths in `pluginDev`.
- **`@lynx-js/rsbuild-plugin`** tests -- the alias assertion no longer hardcodes
  a list. It reads the dev-transport client sources and asserts every
  `@rspack/core/hot/*` specifier they import is aliased, so the next added
  import cannot regress silently. Confirmed it fails without the fix.
- **`test-publish`** -- the repeated smoke-test blocks are now one function with
  a package-manager dimension, adding npm and yarn 4 next to the existing pnpm
  runs. The npm variant reproduces this bug and passes with the fix.

Two Yarn settings are needed for the mock registry: `enableImmutableInstalls`
(Yarn enables it whenever `CI` is set, but the projects are generated with no
lockfile) and `npmMinimalAgeGate` (Yarn quarantines any version published less
than `1d` ago, and the canary versions reach the registry seconds earlier).

## Not included

Running the same smoke test under pnpm with `hoist: false` surfaces several
pre-existing packaging problems unrelated to this fix. That is kept separate in
#3581 rather than bundled here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development-build resolution issues for Rspack hot-log modules when dependencies are not hoisted.
  * Added aliases to ensure required hot-module imports resolve correctly.

* **Tests**
  * Expanded publish smoke tests to cover npm, pnpm, and Yarn workflows.
  * Added validation that Rspack hot-module imports have corresponding aliases.

* **Chores**
  * Simplified dependency installation and script argument handling in publish workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->