### PR TITLE
refactor(react): unify typed Element Template attributes

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/hydrate.test.ts
@@ -11,6 +11,7 @@ import {
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
+import { clearRefState, flushPendingRefs } from '../../../../src/element-template/prop-adapters/ref.js';
 import { ElementTemplateUpdateOps } from '../../../../src/element-template/protocol/opcodes.js';
 import type {
   SerializedElementTemplate,
@@ -68,6 +69,7 @@ describe('hydrate', () => {
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
     clearEtAttrPlanMap();
+    clearRefState();
     resetElementTemplateCommitState();
     vi.clearAllMocks();
     (globalThis as { __LYNX_REPORT_ERROR_CALLS?: Error[] }).__LYNX_REPORT_ERROR_CALLS = [];
@@ -1249,6 +1251,52 @@ describe('hydrate', () => {
     expect(backgroundElementTemplateInstanceManager.get(oldItemId)).toBeUndefined();
     expect(backgroundElementTemplateInstanceManager.get(-10)).toBe(list);
     expect(backgroundElementTemplateInstanceManager.get(-11)).toBe(item);
+  });
+
+  it('re-prepares typed list event and ref attributes after hydration handle binding', () => {
+    const handler = vi.fn();
+    const ref = vi.fn();
+    const list = new BackgroundListElementTemplateInstance();
+    const oldListId = list.instanceId;
+    list.setAttribute('attributes', {
+      bindtap: handler,
+      ref,
+    });
+    flushPendingRefs();
+    const refProxy = ref.mock.calls[0]![0];
+
+    const stream = hydrate(
+      {
+        tag: 'list',
+        attributes: {
+          bindtap: '-10:0:bindtap',
+          ref: '-10-0',
+          'component-at-index': null,
+          'component-at-indexes': null,
+          'enqueue-component': null,
+        },
+        elementSlots: null,
+        uid: -10,
+        options: {
+          listChildren: [],
+        },
+      } satisfies SerializedTypedNode,
+      list,
+    );
+    flushPendingRefs();
+
+    expect(stream).toEqual([]);
+    expect(list.attributeSlots).toEqual([{
+      bindtap: '-10:0:bindtap',
+      ref: '-10-0',
+    }]);
+    expect(backgroundElementTemplateInstanceManager.get(oldListId)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(-10)).toBe(list);
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(
+      '-10:0:bindtap',
+    )).toBe(handler);
+    expect(ref).toHaveBeenCalledTimes(1);
+    expect(refProxy).toMatchObject({ selector: '[ref=-10-0]' });
   });
 
   it('hydrates typed lists outside development while dropping transient native list attributes', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -100,10 +100,11 @@ describe('BackgroundElementTemplateInstance', () => {
     ]);
   });
 
-  it('emits generic typed element create with standard attribute slots and no runtime options', () => {
+  it('owns empty attributes in the generic typed attribute slot', () => {
     const typed = new BackgroundTypedElementTemplateInstance('x-host');
-    typed.setAttribute('attributeSlots', ['title']);
     globalCommitContext.ops = [];
+
+    expect(typed.attributeSlots).toEqual([null]);
 
     typed.emitCreate();
 
@@ -115,11 +116,58 @@ describe('BackgroundElementTemplateInstance', () => {
       null,
       null,
     ]);
+  });
+
+  it('prepares generic typed attributes through the slot-0 spread plan', () => {
+    const handler = vi.fn();
+    const ref = vi.fn();
+    const typed = new BackgroundTypedElementTemplateInstance('x-host');
+    typed.setAttribute('attributes', {
+      bindtap: handler,
+      className: 'card',
+      ref,
+    });
+    flushPendingRefs();
+    globalCommitContext.ops = [];
+
+    typed.emitCreate();
+
+    expect(typed.attributeSlots).toEqual([{
+      bindtap: `${typed.instanceId}:0:bindtap`,
+      class: 'card',
+      ref: `${typed.instanceId}-0`,
+    }]);
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(
+      `${typed.instanceId}:0:bindtap`,
+    )).toBe(handler);
+    expect(ref).toHaveBeenCalledWith(expect.objectContaining({
+      selector: `[ref=${typed.instanceId}-0]`,
+    }));
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.createTypedElement,
+      typed.instanceId,
+      'x-host',
+      {
+        bindtap: `${typed.instanceId}:0:bindtap`,
+        class: 'card',
+        ref: `${typed.instanceId}-0`,
+      },
+      null,
+      null,
+    ]);
 
     globalCommitContext.ops = [];
     typed.emitCreate();
 
     expect(globalCommitContext.ops).toEqual([]);
+  });
+
+  it('retains inherited instance metadata on typed hosts', () => {
+    const typed = new BackgroundTypedElementTemplateInstance('x-host');
+
+    typed.setAttribute('__listItemPlatformInfo', { 'item-key': 'typed' });
+
+    expect(typed.getListItemPlatformInfo()).toEqual({ 'item-key': 'typed' });
   });
 
   it('reports illegal typed element handle ids on create', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
@@ -91,7 +91,12 @@ describe('renderOpcodesIntoElementTemplate', () => {
   it('creates exact list through typed native create with slot-0 refs as listChildren', () => {
     const itemRef = { kind: 'item-ref' };
     const listRef = { kind: 'list-ref' };
-    const attributes = { id: 'typed-list' };
+    const handler = vi.fn();
+    const attributes = {
+      bindtap: handler,
+      className: 'feed',
+      id: 'typed-list',
+    };
     createElementTemplate.mockReturnValueOnce(itemRef);
     createTypedElementTemplate.mockReturnValueOnce(listRef);
 
@@ -123,6 +128,8 @@ describe('renderOpcodesIntoElementTemplate', () => {
     const typedCreateCall = createTypedElementTemplate.mock.calls[0]!;
     expect(typedCreateCall[0]).toBe('list');
     expect(typedCreateCall[1]).toEqual({
+      bindtap: '-2:0:bindtap',
+      class: 'feed',
       id: 'typed-list',
       'component-at-index': expect.any(Function),
       'component-at-indexes': expect.any(Function),
@@ -134,6 +141,8 @@ describe('renderOpcodesIntoElementTemplate', () => {
     expect(flushInitialElementTemplateListUpdates()).toEqual([{
       uid: -2,
       attributes: {
+        bindtap: '-2:0:bindtap',
+        class: 'feed',
         id: 'typed-list',
         'component-at-index': expect.any(Function),
         'component-at-indexes': expect.any(Function),

--- a/packages/react/runtime/src/element-template/background/attr-slots.ts
+++ b/packages/react/runtime/src/element-template/background/attr-slots.ts
@@ -5,11 +5,12 @@
 import { getSpreadRefFromValue, queueRefAttrUpdate } from '../prop-adapters/ref.js';
 import type { SerializableValue } from '../protocol/types.js';
 import { __etAttrPlanMap, adaptRefAttrSlot, adaptSpreadAttrSlot } from '../runtime/template/attr-slot-plan.js';
-import type { EtAttrAdapter, EtAttrAdapterContext } from '../runtime/template/attr-slot-plan.js';
+import type { EtAttrAdapter, EtAttrAdapterContext, EtAttrPlan } from '../runtime/template/attr-slot-plan.js';
 
 export interface PrepareAttributeSlotsOptions {
   previousPreparedSlots?: readonly unknown[];
   previousRawSlots?: readonly unknown[];
+  attributePlan?: EtAttrPlan | undefined;
 }
 
 function normalizeAttributeSlots(rawSlots: readonly unknown[]): SerializableValue[] {
@@ -67,7 +68,7 @@ export function prepareAttributeSlots(
   rawSlots: readonly unknown[],
   options?: PrepareAttributeSlotsOptions,
 ): SerializableValue[] {
-  const attrPlan = __etAttrPlanMap[templateKey];
+  const attrPlan = options?.attributePlan ?? __etAttrPlanMap[templateKey];
   if (!attrPlan || attrPlan.length === 0) {
     return normalizeAttributeSlots(rawSlots);
   }
@@ -99,8 +100,9 @@ export function queueRefAttributeSlotUpdates(
   handleId: number,
   previousRawSlots?: readonly unknown[],
   nextRawSlots?: readonly unknown[],
+  attributePlan?: EtAttrPlan,
 ): void {
-  const attrPlan = __etAttrPlanMap[templateKey];
+  const attrPlan = attributePlan ?? __etAttrPlanMap[templateKey];
   if (!attrPlan || attrPlan.length === 0) {
     return;
   }

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -17,6 +17,8 @@ import type {
   TypedElementAttributesCommand,
   UpdateTypedListItemCommand,
 } from '../protocol/types.js';
+import type { EtAttrPlan } from '../runtime/template/attr-slot-plan.js';
+import { TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX, TYPED_ELEMENT_ATTR_PLAN } from '../runtime/template/typed-attributes.js';
 
 function pushOp(...items: ElementTemplateUpdateCommandStream): void {
   globalCommitContext.ops.push(...items);
@@ -137,6 +139,10 @@ export class BackgroundElementTemplateInstance {
 
   private needsMainThreadCreate(): boolean {
     return this.instanceId !== 0 && !this.isMaterializedOnMainThread;
+  }
+
+  protected getAttributeSlotPlan(): EtAttrPlan | undefined {
+    return undefined;
   }
 
   private markSubtreeDetachedFromMainThread(): void {
@@ -356,7 +362,13 @@ export class BackgroundElementTemplateInstance {
 
   queueRefCleanupForSubtree(): void {
     if (this.rawAttributeSlots) {
-      queueRefAttributeSlotUpdates(this.type, this.instanceId, this.rawAttributeSlots);
+      queueRefAttributeSlotUpdates(
+        this.type,
+        this.instanceId,
+        this.rawAttributeSlots,
+        undefined,
+        this.getAttributeSlotPlan(),
+      );
     }
 
     let child = this.firstChild;
@@ -388,10 +400,17 @@ export class BackgroundElementTemplateInstance {
       {
         previousPreparedSlots: this.attributeSlots,
         previousRawSlots: this.rawAttributeSlots,
+        attributePlan: this.getAttributeSlotPlan(),
       },
     );
     if (options?.publishRefEffects ?? true) {
-      queueRefAttributeSlotUpdates(this.type, this.instanceId, undefined, this.rawAttributeSlots);
+      queueRefAttributeSlotUpdates(
+        this.type,
+        this.instanceId,
+        undefined,
+        this.rawAttributeSlots,
+        this.getAttributeSlotPlan(),
+      );
     }
   }
 
@@ -428,10 +447,17 @@ export class BackgroundElementTemplateInstance {
         {
           previousPreparedSlots: previousSlots,
           previousRawSlots,
+          attributePlan: this.getAttributeSlotPlan(),
         },
       );
       if (shouldQueueRefEffects) {
-        queueRefAttributeSlotUpdates(this.type, this.instanceId, previousRawSlots, value);
+        queueRefAttributeSlotUpdates(
+          this.type,
+          this.instanceId,
+          previousRawSlots,
+          value,
+          this.getAttributeSlotPlan(),
+        );
       }
       this.rawAttributeSlots = nextSlots === value ? undefined : value;
       const maxLength = Math.max(previousSlots.length, nextSlots.length);
@@ -492,16 +518,10 @@ export class BackgroundElementTemplateInstance {
   }
 }
 
-function toTypedAttributesCommand(value: unknown): TypedElementAttributesCommand | null {
-  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
-    return null;
-  }
-  return value as TypedElementAttributesCommand;
-}
-
 export class BackgroundTypedElementTemplateInstance extends BackgroundElementTemplateInstance {
   constructor(type: string) {
     super(type);
+    this.attributeSlots = [null];
   }
 
   override emitCreate(): void {
@@ -529,25 +549,15 @@ export class BackgroundTypedElementTemplateInstance extends BackgroundElementTem
       super.setAttribute(key, value);
       return;
     }
-    const previousValue = this.attributeSlots[0];
-    const nextValue = toTypedAttributesCommand(value);
-    this.attributeSlots = [nextValue];
-    if (
-      isElementTemplateHydrated()
-      && this.isMaterializedOnMainThread
-      && !isDirectOrDeepEqual(previousValue, nextValue)
-    ) {
-      pushOp(
-        ElementTemplateUpdateOps.setAttribute,
-        this.instanceId,
-        0,
-        nextValue,
-      );
-    }
+    super.setAttribute('attributeSlots', [value]);
   }
 
   protected getTypedAttributesForCreate(): TypedElementAttributesCommand | null {
-    return toTypedAttributesCommand(this.attributeSlots[0]);
+    return this.attributeSlots[TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX] as TypedElementAttributesCommand | null;
+  }
+
+  protected override getAttributeSlotPlan(): EtAttrPlan {
+    return TYPED_ELEMENT_ATTR_PLAN;
   }
 
   protected getElementSlotsForCreate(): ElementTemplateHandleSlotsCommand | null {

--- a/packages/react/runtime/src/element-template/runtime/patch.ts
+++ b/packages/react/runtime/src/element-template/runtime/patch.ts
@@ -19,6 +19,7 @@ import {
 } from './list/list.js';
 import type { ETListFlushResult, ETListUpdateItem } from './list/list.js';
 import { elementTemplateRegistry } from './template/registry.js';
+import { TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX } from './template/typed-attributes.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
 import type { ElementTemplateUpdateOp } from '../protocol/opcodes.js';
 import {
@@ -107,7 +108,7 @@ export function applyElementTemplateUpdateCommands(
         if (!nativeRef) {
           continue;
         }
-        if (attrSlotIndex === 0) {
+        if (attrSlotIndex === TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX) {
           const listAttributes = updateElementTemplateListAttributes(
             targetId,
             value as RuntimeTypedElementAttributes | null,
@@ -301,7 +302,7 @@ function applyListFlushResults(results: ETListFlushResult[]): void {
     }
     __SetAttributeOfElementTemplate(
       listRef,
-      0,
+      TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX,
       result.attributes,
       null,
     );

--- a/packages/react/runtime/src/element-template/runtime/render/render-main-thread.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-main-thread.ts
@@ -16,6 +16,7 @@ import { flushInitialElementTemplateListUpdates } from '../list/list.js';
 import { insertRootIntoPage, removeRootFromPage } from '../page/page.js';
 import { __root } from '../page/root-instance.js';
 import { getElementTemplateNativeRef } from '../template/registry.js';
+import { TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX } from '../template/typed-attributes.js';
 
 // ET reload reuses the native page, so the main-thread render path owns the
 // root refs it appended and can remove only those roots before rebuilding.
@@ -83,7 +84,7 @@ function flushInitialListUpdates(): void {
     const result = results[index]!;
     const listRef = getElementTemplateNativeRef(result.uid);
     if (listRef) {
-      __SetAttributeOfElementTemplate(listRef, 0, result.attributes, null);
+      __SetAttributeOfElementTemplate(listRef, TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX, result.attributes, null);
     }
   }
 }

--- a/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
@@ -19,6 +19,7 @@ import {
   createTypedElementTemplateWithReservedHandle,
   reserveElementTemplateId,
 } from '../template/handle.js';
+import { prepareTypedElementAttributes } from '../template/typed-attributes.js';
 
 const BUILTIN_RAW_TEXT_TEMPLATE_KEY = '_et_builtin_raw_text';
 const TYPED_LIST_HOST_TYPE = 'list';
@@ -105,15 +106,19 @@ export function renderOpcodesIntoElementTemplate(
 
         if (concreteType === TYPED_LIST_HOST_TYPE) {
           const listChildren = elementSlots?.[0] ?? [];
+          const handleId = reserveElementTemplateId();
+          const preparedTypedAttributes = prepareTypedElementAttributes(
+            handleId,
+            typedAttributes,
+          );
           const listState = createElementTemplateListState(
             listItemUids ?? EMPTY_LIST_ITEM_UIDS,
-            typedAttributes ?? null,
+            preparedTypedAttributes,
           );
           const attrsWithCallbacks = composeElementTemplateListAttributes(
             undefined,
             listState,
           );
-          const handleId = reserveElementTemplateId();
           const elementRef = createTypedElementTemplateWithReservedHandle(
             handleId,
             TYPED_LIST_HOST_TYPE,

--- a/packages/react/runtime/src/element-template/runtime/template/typed-attributes.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/typed-attributes.ts
@@ -1,0 +1,25 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { adaptSpreadAttrSlot } from './attr-slot-plan.js';
+import type { EtAttrPlan } from './attr-slot-plan.js';
+import type { RuntimeTypedElementAttributes, TypedElementAttributesCommand } from '../../protocol/types.js';
+
+export const TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX = 0;
+
+export const TYPED_ELEMENT_ATTR_PLAN: EtAttrPlan = [
+  TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX,
+  adaptSpreadAttrSlot,
+];
+
+export function prepareTypedElementAttributes(
+  handleId: number,
+  attributes: RuntimeTypedElementAttributes | null | undefined,
+): TypedElementAttributesCommand | null {
+  return adaptSpreadAttrSlot(
+    handleId,
+    TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX,
+    attributes,
+  ) as TypedElementAttributesCommand | null;
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typed list elements now preserve and apply classes, event handlers, and refs during rendering.
  * Generic typed elements now retain list metadata and serialize attributes correctly.
  * Attribute updates remain consistent when hydration handles are rebound.

* **Bug Fixes**
  * Improved ref callback behavior and event-handler mapping after hydration.
  * Ensured typed-list attributes are available during initial creation and subsequent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Overview

Typed Element Template attributes currently take different preparation paths depending on where an instance is materialized. In particular, background typed instances prepare slot-0 attributes before insertion, while the main-thread typed list path can forward raw attributes. This makes attribute, event, and ref behavior depend on the rendering layer.

This PR establishes one shared typed-attribute path before adding authored `<page />` support in later stacked changes:

- defines the fixed slot-0 spread plan and attribute preparation in `runtime/template/typed-attributes.ts`;
- makes `BackgroundTypedElementTemplateInstance` own the slot-0 invariant, raw/prepared attributes, and their event/ref lifecycle;
- reserves the main-thread handle before preparing attributes, then composes list-owned callbacks after preparation so internal callbacks are not filtered as user spread values;
- makes main-thread insertion and patching address typed attributes through the same shared slot constant instead of local literals;
- covers empty and populated slots, initial materialization, updates, hydration handle rebinding, event replacement, and ref attachment.

This layer does not add `<page />` behavior, change the public API or native schema, or introduce compatibility fallbacks. The subsequent PRs in the stack build page support on this common typed-instance contract.

## Review order

1. `runtime/template/typed-attributes.ts`
2. `background/attr-slots.ts` and `background/instance.ts`
3. `runtime/render/render-opcodes.ts` and `runtime/render/render-main-thread.ts`
4. `runtime/patch.ts`
5. Focused background and render tests

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

Documentation and a changeset are not required for this internal, unreleased Element Template refactor.
