### PR TITLE
ci: smoke-test create-rspeedy output under pnpm with hoist: false

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,17 @@ jobs:
         pnpm run build --mode development
         pnpm run lint
         cd `mktemp -d`
+        npx --registry http://localhost:4873 create-rspeedy-canary@latest --template react --dir create-rspeedy-regression-pnpm-strict --tools eslint --skill lynx-devtool
+        cd create-rspeedy-regression-pnpm-strict
+        npx --registry http://localhost:4873 upgrade-rspeedy-canary@latest
+        # Drops pnpm's hidden hoisted store, so an undeclared transitive
+        # dependency fails here rather than in a user's npm project.
+        printf 'hoist: false\n' > pnpm-workspace.yaml
+        pnpm install --registry=http://localhost:4873
+        pnpm run build
+        pnpm run build --mode development
+        pnpm run lint
+        cd `mktemp -d`
         npx --registry http://localhost:4873 create-rspeedy-canary@latest --template react --dir create-rspeedy-regression-vitest-rltl --tools eslint,vitest-rltl
         cd create-rspeedy-regression-vitest-rltl
         npx --registry http://localhost:4873 upgrade-rspeedy-canary@latest


### PR DESCRIPTION
Exploratory, **expected to fail** -- opened to see what CI reports, not to merge.

Adds one `test-publish` variant that installs the generated project with pnpm's
hidden hoisted store disabled (`pnpm-workspace.yaml` with `hoist: false`), so an
undeclared transitive dependency fails in CI rather than in a user's npm project.

Based on `main` and contains only the workflow change, so it does not overlap
with #3577.

## What CI actually reports

The production build passes. The **development** build fails at config time:

```
error   Cannot find module '@lynx-js/rsbuild-plugin/package.json'
Require stack:
- .../node_modules/@lynx-js/rsbuild-plugin-canary/dist/index.js
    at Object.handler (.../@lynx-js/rsbuild-plugin-canary/dist/index.js:263:61)
    at async modifyBundlerChain (...)
```

`dev.plugin.ts` resolves its own package by name via
`require.resolve('@lynx-js/rsbuild-plugin/package.json')`. Canary publishing
renames the package to `@lynx-js/rsbuild-plugin-canary`, so that self-reference
only resolves through a hoisted alias directory. Introduced in #3364.

Note this throws inside `modifyBundlerChain`, i.e. **before** the
`resolve.alias` chain is built and long before any module is bundled. So it
masks the `@rspack/core/hot` bug that #3577 fixes: this variant reports the same
error with or without #3577, and rebasing on top of it changes nothing until the
self-reference is fixed first.

## Known to be behind it

Found while investigating #3577, all pre-existing and independent of it. Each
was reproduced locally by resolving the one before it:

1. The self-reference above -- what CI hits here.
2. `@lynx-js/react/testing-library` imports `@lynx-js/rspeedy`, `@rsbuild/core`,
   `@rstest/core` and `vitest` -- the externals in its `rslib.config.ts` -- but
   declares none of them.
3. The rstest path then fails on `preact/hooks`. `preact` is an aliased fork
   (`npm:@lynx-js/internal-preact`), so declaring a dependency cannot fix it; the
   testing-library would have to stop externalizing it.

Each needs its own change, which is why none of them are bundled here.
