### PR TITLE
feat(react): add ET authored page background runtime

### DIFF
--- a/packages/react/runtime/__test__/element-template/lynx/performance.test.ts
+++ b/packages/react/runtime/__test__/element-template/lynx/performance.test.ts
@@ -110,7 +110,7 @@ describe('ElementTemplate performance timing (current api)', () => {
     markTimingLegacy('updateSetStateTrigger', 'flag');
     globalCommitContext.ops = createRawTextOps(1, 'payload');
 
-    options.__?.({} as unknown as object, null);
+    options.__?.({} as unknown as object, {} as unknown as object);
 
     expect(nativeMarkTiming.mock.calls).toEqual([
       ['flag', 'updateSetStateTrigger'],

--- a/packages/react/runtime/__test__/element-template/native/callDestroyLifetimeFun.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/callDestroyLifetimeFun.test.ts
@@ -68,14 +68,19 @@ describe('callDestroyLifetimeFun', () => {
     lynx.getJSContext().dispatchEvent({
       type: ElementTemplateLifecycleConstant.hydrate,
       data: {
-        instances: [
-          {
-            templateKey: '_et_test',
-            attributeSlots: [],
-            elementSlots: [],
-            uid: -1,
-          } satisfies SerializedElementTemplate,
-        ],
+        page: {
+          tag: 'page',
+          attributes: null,
+          elementSlots: [[
+            {
+              templateKey: '_et_test',
+              attributeSlots: [],
+              elementSlots: [],
+              uid: -1,
+            } satisfies SerializedElementTemplate,
+          ]],
+          uid: 0,
+        },
         reloadVersion: getReloadVersion(),
       },
     });

--- a/packages/react/runtime/__test__/element-template/native/index.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/index.test.ts
@@ -88,6 +88,7 @@ describe('element-template native index wiring', () => {
     }));
     vi.doMock('../../../src/element-template/background/instance.js', () => ({
       BackgroundElementTemplateInstance: class BackgroundElementTemplateInstance {},
+      BackgroundPageRootInstance: class BackgroundPageRootInstance {},
     }));
     vi.doMock('../../../src/element-template/native/reload-background.js', () => ({
       reloadBackground,
@@ -131,6 +132,14 @@ describe('element-template native index wiring', () => {
     const updateCardData = vi.fn();
     const updateGlobalProps = vi.fn();
     const reloadBackground = vi.fn();
+    class MockBackgroundElementTemplateInstance {
+      constructor(public type: string) {}
+    }
+    class MockBackgroundPageRootInstance extends MockBackgroundElementTemplateInstance {
+      constructor() {
+        super('root');
+      }
+    }
 
     vi.doMock('../../../src/element-template/native/main-thread-api.js', () => ({
       injectCalledByNative,
@@ -177,9 +186,8 @@ describe('element-template native index wiring', () => {
       resetEventStateForRuntime,
     }));
     vi.doMock('../../../src/element-template/background/instance.js', () => ({
-      BackgroundElementTemplateInstance: class BackgroundElementTemplateInstance {
-        constructor(public type: string) {}
-      },
+      BackgroundElementTemplateInstance: MockBackgroundElementTemplateInstance,
+      BackgroundPageRootInstance: MockBackgroundPageRootInstance,
     }));
     vi.doMock('../../../src/element-template/native/reload-background.js', () => ({
       reloadBackground,
@@ -188,6 +196,7 @@ describe('element-template native index wiring', () => {
     await import('../../../src/element-template/native/index.js');
 
     expect(setRoot).toHaveBeenCalledTimes(1);
+    expect(setRoot).toHaveBeenCalledWith(expect.any(MockBackgroundPageRootInstance));
     expect(setupBackgroundElementTemplateDocument).toHaveBeenCalledTimes(1);
     expect(installElementTemplateHydrationListener).toHaveBeenCalledTimes(1);
     expect(installElementTemplateCommitHook).toHaveBeenCalledTimes(1);

--- a/packages/react/runtime/__test__/element-template/native/reload.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/reload.test.ts
@@ -4,7 +4,7 @@ import { increaseReloadVersion } from '../../../src/core/reload-version.js';
 import { setupBackgroundElementTemplateDocument } from '../../../src/element-template/background/document.js';
 import { destroyElementTemplateBackgroundRuntime } from '../../../src/element-template/background/destroy.js';
 import { installElementTemplateHydrationListener } from '../../../src/element-template/background/hydration-listener.js';
-import { BackgroundElementTemplateInstance } from '../../../src/element-template/background/instance.js';
+import { BackgroundPageRootInstance } from '../../../src/element-template/background/instance.js';
 import { profileEnd, profileStart } from '../../../src/element-template/debug/profile.js';
 import { reloadBackground } from '../../../src/element-template/native/reload-background.js';
 import { reloadMainThread } from '../../../src/element-template/native/reload-main-thread.js';
@@ -106,11 +106,19 @@ vi.mock('../../../src/element-template/prop-adapters/event.js', () => ({
   resetEventStateForRuntime: vi.fn(),
 }));
 
-vi.mock('../../../src/element-template/background/instance.js', () => ({
-  BackgroundElementTemplateInstance: class BackgroundElementTemplateInstance {
+vi.mock('../../../src/element-template/background/instance.js', () => {
+  class BackgroundElementTemplateInstance {
     constructor(public type: string) {}
-  },
-}));
+  }
+  return {
+    BackgroundElementTemplateInstance,
+    BackgroundPageRootInstance: class BackgroundPageRootInstance extends BackgroundElementTemplateInstance {
+      constructor() {
+        super('root');
+      }
+    },
+  };
+});
 
 vi.mock('../../../src/element-template/debug/profile.js', () => ({
   profileEnd: vi.fn(),
@@ -339,8 +347,8 @@ describe('ElementTemplate reloadBackground', () => {
     expect(increaseReloadVersion).toHaveBeenCalledTimes(1);
     expect(lynx.__initData).not.toBe(initData);
     expect(lynx.__initData).toEqual({ msg: 'reload', stable: true });
-    expect(vi.mocked(setRoot)).toHaveBeenCalledWith(expect.any(BackgroundElementTemplateInstance));
-    expect(__root).toBeInstanceOf(BackgroundElementTemplateInstance);
+    expect(vi.mocked(setRoot)).toHaveBeenCalledWith(expect.any(BackgroundPageRootInstance));
+    expect(__root).toBeInstanceOf(BackgroundPageRootInstance);
     expect(__root).not.toBe(oldRoot);
     expect(__root.__jsx).toBe(jsx);
     expect(__root).not.toHaveProperty('stale');

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -14,6 +14,7 @@ import { setupBackgroundElementTemplateDocument } from '../../../../src/element-
 import {
   BackgroundElementTemplateInstance,
   BackgroundListElementTemplateInstance,
+  BackgroundPageRootInstance,
   BackgroundTypedElementTemplateInstance,
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
 } from '../../../../src/element-template/background/instance.js';
@@ -64,6 +65,97 @@ describe('BackgroundElementTemplateInstance', () => {
     new BackgroundElementTemplateInstance('image', ['logo.png']);
 
     expect(globalCommitContext.ops).toEqual([]);
+  });
+
+  it('routes hydrated logical root child patches through the native page handle', () => {
+    const root = new BackgroundPageRootInstance();
+    expect(root).toBeInstanceOf(BackgroundTypedElementTemplateInstance);
+    expect(root.type).toBe('page');
+    expect(root.instanceId).toBe(0);
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBe(root);
+    const child = new BackgroundElementTemplateInstance('_et_child');
+    markElementTemplateHydrated();
+    globalCommitContext.ops = [];
+
+    root.appendChild(child);
+
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.createTemplate,
+      child.instanceId,
+      '_et_child',
+      null,
+      [],
+      [],
+      ElementTemplateUpdateOps.insertNode,
+      0,
+      0,
+      child.instanceId,
+      0,
+    ]);
+
+    globalCommitContext.ops = [];
+    root.removeChild(child);
+
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.removeNode,
+      0,
+      0,
+      child.instanceId,
+      [child.instanceId],
+    ]);
+  });
+
+  it('keeps authored page attrs on the root and ignores stale helper cleanup', () => {
+    const root = new BackgroundPageRootInstance();
+    const firstLifetime = {};
+    const replacementLifetime = {};
+
+    root.setAuthoredPageAttributes(firstLifetime, { id: 'first' });
+    root.setAuthoredPageAttributes(replacementLifetime, { id: 'replacement' });
+    root.clearAuthoredPageAttributes(firstLifetime);
+
+    expect(root.getRawAttributeSlot(0)).toEqual({ id: 'replacement' });
+    expect(root.getRawAttributeSlot(1)).toBeUndefined();
+
+    markElementTemplateHydrated();
+    globalCommitContext.ops = [];
+    root.clearAuthoredPageAttributes(replacementLifetime);
+
+    expect(root.getRawAttributeSlot(0)).toBeNull();
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      0,
+      0,
+      null,
+    ]);
+  });
+
+  it('reconciles authored page attrs after hydration', () => {
+    const root = new BackgroundPageRootInstance();
+    root.setAuthoredPageAttributes({}, { id: 'background' });
+    globalCommitContext.ops = [];
+
+    root.reconcileAuthoredPageAttributesOnHydration({ id: 'main-thread' });
+
+    expect(globalCommitContext.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      0,
+      0,
+      { id: 'background' },
+    ]);
+
+    globalCommitContext.ops = [];
+    root.reconcileAuthoredPageAttributesOnHydration({ id: 'background' });
+
+    expect(globalCommitContext.ops).toEqual([]);
+  });
+
+  it('removes the reserved page root registration on teardown', () => {
+    const root = new BackgroundPageRootInstance();
+
+    root.tearDown();
+
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBeUndefined();
   });
 
   it('creates exact list hosts through the list-specific background instance', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/manager.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/manager.test.ts
@@ -3,7 +3,10 @@
 // LICENSE file in the root directory of this source tree.
 
 import { beforeEach, describe, expect, it } from 'vitest';
-import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import {
+  BackgroundElementTemplateInstance,
+  BackgroundPageRootInstance,
+} from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 
 describe('BackgroundElementTemplateInstanceManager', () => {
@@ -23,6 +26,27 @@ describe('BackgroundElementTemplateInstanceManager', () => {
     expect(backgroundElementTemplateInstanceManager.get(instance2.instanceId)).toBe(instance2);
   });
 
+  it('registers the pre-existing page root at reserved handleId 0', () => {
+    const root = new BackgroundPageRootInstance();
+    const ordinary = new BackgroundElementTemplateInstance('view');
+
+    expect(root.instanceId).toBe(0);
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBe(root);
+    expect(ordinary.instanceId).toBeGreaterThan(0);
+  });
+
+  it('transfers the reserved handleId 0 entry to a fresh page root', () => {
+    const oldRoot = new BackgroundPageRootInstance();
+    const newRoot = new BackgroundPageRootInstance();
+
+    expect(oldRoot.instanceId).toBe(0);
+    expect(newRoot.instanceId).toBe(0);
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBe(newRoot);
+
+    oldRoot.tearDown();
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBe(newRoot);
+  });
+
   it('should update ID correctly', () => {
     const instance = new BackgroundElementTemplateInstance('view');
     const oldId = instance.instanceId;
@@ -36,10 +60,13 @@ describe('BackgroundElementTemplateInstanceManager', () => {
   });
 
   it('rejects illegal handleId 0', () => {
+    const root = new BackgroundPageRootInstance();
     const instance = new BackgroundElementTemplateInstance('view');
 
     expect(() => backgroundElementTemplateInstanceManager.updateId(instance.instanceId, 0))
       .toThrow('ElementTemplate handleId must be a non-zero integer');
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBe(root);
+    expect(backgroundElementTemplateInstanceManager.get(instance.instanceId)).toBe(instance);
   });
 
   it('rejects duplicate handleId rebinding', () => {
@@ -74,6 +101,23 @@ describe('BackgroundElementTemplateInstanceManager', () => {
       .toBe(handler);
     expect(
       backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(`${instance.instanceId}:0:missing`),
+    )
+      .toBeUndefined();
+  });
+
+  it('resolves page events through the registered root attribute slot', () => {
+    const handler = () => {};
+    const root = new BackgroundPageRootInstance();
+    root.setAuthoredPageAttributes({}, { bindtap: handler });
+
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0:bindtap')).toBe(handler);
+  });
+
+  it('preserves undefined for a missing slot on a registered ordinary instance', () => {
+    const instance = new BackgroundElementTemplateInstance('view', []);
+
+    expect(
+      backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue(`${instance.instanceId}:0`),
     )
       .toBeUndefined();
   });

--- a/packages/react/runtime/__test__/element-template/runtime/background/reload.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/reload.test.ts
@@ -6,7 +6,10 @@ import {
   installElementTemplateHydrationListener,
   resetElementTemplateHydrationListener,
 } from '../../../../src/element-template/background/hydration-listener.js';
-import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import {
+  BackgroundElementTemplateInstance,
+  BackgroundPageRootInstance,
+} from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { reloadBackground } from '../../../../src/element-template/native/reload-background.js';
 import { ElementTemplateLifecycleConstant } from '../../../../src/element-template/protocol/lifecycle-constant.js';
@@ -31,7 +34,7 @@ describe('ElementTemplate background reload', () => {
     envManager.resetEnv('background');
     resetElementTemplateHydrationListener();
     backgroundElementTemplateInstanceManager.clear();
-    setRoot(new BackgroundElementTemplateInstance('root'));
+    setRoot(new BackgroundPageRootInstance());
     setupBackgroundElementTemplateDocument();
     installElementTemplateHydrationListener();
   });
@@ -49,6 +52,8 @@ describe('ElementTemplate background reload', () => {
 
     const reloadedRoot = __root as BackgroundElementTemplateInstance;
     expect(reloadedRoot).not.toBe(oldRoot);
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBe(reloadedRoot);
+    expect(backgroundElementTemplateInstanceManager.get(0)).not.toBe(oldRoot);
     const after = new BackgroundElementTemplateInstance('_et_test');
     reloadedRoot.appendChild(after);
     const oldId = after.instanceId;

--- a/packages/react/runtime/__test__/element-template/runtime/background/root-render.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/root-render.test.tsx
@@ -1,18 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resetElementTemplateCommitState } from '../../../../src/element-template/background/commit-hook.js';
-import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import { globalCommitContext } from '../../../../src/element-template/background/commit-context.js';
+import {
+  BackgroundElementTemplateInstance,
+  BackgroundPageRootInstance,
+} from '../../../../src/element-template/background/instance.js';
+import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { installElementTemplateRenderScopeHooks } from '../../../../src/element-template/background/render-scope.js';
 import { callDestroyLifetimeFun } from '../../../../src/element-template/native/callDestroyLifetimeFun.js';
-import { root } from '../../../../src/element-template/index.js';
+import { root, useState } from '../../../../src/element-template/index.js';
 import { clearRefState, flushPendingRefs } from '../../../../src/element-template/prop-adapters/ref.js';
 import { __root } from '../../../../src/element-template/runtime/page/root-instance.js';
+import { __ElementTemplatePage } from '../../../../src/element-template/runtime/page/authored-page.js';
 import {
   __etAttrPlanMap,
   adaptRefAttrSlot,
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 import { ElementTemplateEnvManager } from '../../test-utils/debug/envManager.js';
+
+function waitSchedule(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      setTimeout(resolve);
+    });
+  });
+}
 
 describe('ElementTemplate root render timing', () => {
   const envManager = new ElementTemplateEnvManager();
@@ -49,6 +63,120 @@ describe('ElementTemplate root render timing', () => {
       installElementTemplateRenderScopeHooks();
       installElementTemplateRenderScopeHooks();
     }).not.toThrow();
+  });
+
+  it('does not emit a page attr update for an initial page without attrs', () => {
+    root.render(
+      <__ElementTemplatePage $0={<view />} />,
+    );
+
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toBeNull();
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:1')).toBeUndefined();
+    expect((__root as BackgroundPageRootInstance).getRawAttributeSlot(1)).toBeUndefined();
+    expect(globalCommitContext.ops).toEqual([]);
+  });
+
+  it('keeps the keyed replacement attrs when the old helper cleanup runs', async () => {
+    let replacePage: (() => void) | undefined;
+    function App() {
+      const [pageId, setPageId] = useState('first');
+      replacePage = () => setPageId('second');
+      return <__ElementTemplatePage key={pageId} attributes={{ id: pageId }} $0={<view />} />;
+    }
+
+    root.render(<App />);
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toEqual({
+      id: 'first',
+    });
+
+    await waitSchedule();
+    replacePage?.();
+    await waitSchedule();
+
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toEqual({
+      id: 'second',
+    });
+  });
+
+  it('updates authored page attrs through real background renders', async () => {
+    let setPageId: ((value: string) => void) | undefined;
+
+    function App() {
+      const [pageId, setId] = useState('first');
+      setPageId = setId;
+      return <__ElementTemplatePage attributes={{ id: pageId }} $0={<view />} />;
+    }
+
+    root.render(<App />);
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toEqual({
+      id: 'first',
+    });
+
+    setPageId?.('second');
+    await waitSchedule();
+
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toEqual({
+      id: 'second',
+    });
+  });
+
+  it('preserves authored page attrs through descendant-only updates', async () => {
+    let updateChild: (() => void) | undefined;
+
+    function Child() {
+      const [count, setCount] = useState(0);
+      updateChild = () => setCount(value => value + 1);
+      return <view data-count={count} />;
+    }
+
+    function App() {
+      return <__ElementTemplatePage attributes={{ id: 'stable' }} $0={<Child />} />;
+    }
+
+    root.render(<App />);
+    const pageAttributes = backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0');
+
+    updateChild?.();
+    await waitSchedule();
+
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toBe(pageAttributes);
+  });
+
+  it('clears authored page attrs after the page is removed', async () => {
+    let hidePage: (() => void) | undefined;
+
+    function App() {
+      const [withPage, setWithPage] = useState(true);
+      hidePage = () => setWithPage(false);
+      return withPage
+        ? <__ElementTemplatePage attributes={{ id: 'temporary' }} $0={<view />} />
+        : <view />;
+    }
+
+    root.render(<App />);
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toEqual({
+      id: 'temporary',
+    });
+
+    await waitSchedule();
+    hidePage?.();
+    await waitSchedule();
+
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toBeNull();
+  });
+
+  it('clears authored page state on background destroy', async () => {
+    root.render(
+      <__ElementTemplatePage attributes={{ id: 'destroyed' }} $0={<view />} />,
+    );
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toEqual({
+      id: 'destroyed',
+    });
+
+    await waitSchedule();
+    callDestroyLifetimeFun();
+
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0')).toBeNull();
   });
 
   it('cleans direct refs through root unmount on background destroy', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
@@ -1072,7 +1072,7 @@ describe('ElementTemplate hydration listener', () => {
     expect(reportErrorSpy).toHaveBeenCalledTimes(1);
     expect(String(reportErrorSpy.mock.calls[0]?.[0]?.message ?? '')).toContain('invalid uid 0');
     expect(backgroundElementTemplateInstanceManager.get(oldId)).toBe(after);
-    expect(backgroundElementTemplateInstanceManager.get(0)).toBeUndefined();
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBe(backgroundRoot);
 
     lynxObj.reportError = oldReportError;
   });

--- a/packages/react/runtime/__test__/element-template/runtime/page/authored-page.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/page/authored-page.test.ts
@@ -1,0 +1,35 @@
+import { h } from 'preact';
+import { describe, expect, it, vi } from 'vitest';
+
+import { __ElementTemplatePage } from '../../../../src/element-template/runtime/page/authored-page.js';
+
+describe('authored ET page projection', () => {
+  it('keeps typed attributes and logical children on ordinary props', () => {
+    const ref = vi.fn();
+    const child = h('view', {});
+    const attributes = {
+      id: 'page',
+      ref,
+    };
+    const vnode = h(__ElementTemplatePage, {
+      $0: child,
+      attributes,
+    });
+
+    expect(vnode.ref).toBeUndefined();
+    expect(vnode.props).toEqual({
+      $0: child,
+      attributes,
+    });
+  });
+
+  it('does not promote a ref inside typed attributes to the VNode ref channel', () => {
+    const ref = vi.fn();
+    const vnode = h(__ElementTemplatePage, {
+      attributes: { ref },
+    });
+
+    expect(vnode.ref).toBeUndefined();
+    expect(vnode.props.attributes).toEqual({ ref });
+  });
+});

--- a/packages/react/runtime/__test__/element-template/test-utils/debug/envManager.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/debug/envManager.ts
@@ -5,7 +5,7 @@
 import { flushCoreContextEvents, flushJSContextEvents } from '../mock/mockNativePapi/context.js';
 import { installMainThreadHooks } from '../../../../src/core/hooks/mainThreadImpl.js';
 import { setupBackgroundElementTemplateDocument } from '../../../../src/element-template/background/document.js';
-import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import { BackgroundPageRootInstance } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { __root, setRoot } from '../../../../src/element-template/runtime/page/root-instance.js';
 import { resetTemplateId } from '../../../../src/element-template/runtime/template/handle.js';
@@ -28,13 +28,13 @@ type RootWithTemplates = RootRef & {
 
 export class ElementTemplateEnvManager {
   private mainRoot: RootRef | undefined;
-  private backgroundRoot: BackgroundElementTemplateInstance | undefined;
+  private backgroundRoot: BackgroundPageRootInstance | undefined;
 
   constructor(private target: EnvTarget = globalThis as unknown as EnvTarget) {}
 
   switchToMainThread(fn?: () => void): void {
     if (this.target.__BACKGROUND__) {
-      this.backgroundRoot = __root as BackgroundElementTemplateInstance;
+      this.backgroundRoot = __root as BackgroundPageRootInstance;
     }
 
     this.mainRoot ??= {};
@@ -56,8 +56,8 @@ export class ElementTemplateEnvManager {
       this.mainRoot = __root;
     }
 
-    if (!(this.backgroundRoot instanceof BackgroundElementTemplateInstance)) {
-      this.backgroundRoot = new BackgroundElementTemplateInstance('root');
+    if (!(this.backgroundRoot instanceof BackgroundPageRootInstance)) {
+      this.backgroundRoot = new BackgroundPageRootInstance();
     }
 
     setRoot(this.backgroundRoot);

--- a/packages/react/runtime/src/element-template/background/hydrate.ts
+++ b/packages/react/runtime/src/element-template/background/hydrate.ts
@@ -13,6 +13,7 @@ import { backgroundElementTemplateInstanceManager } from './manager.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
 import { hydrationMap } from '../hydration-map.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
+import { ELEMENT_TEMPLATE_PAGE_HANDLE_ID, ELEMENT_TEMPLATE_PAGE_ROOT_SLOT_INDEX } from '../protocol/page.js';
 import { elementTemplateIdentityKey, parseElementTemplateType } from '../protocol/template-type.js';
 import type {
   SerializableValue,
@@ -24,8 +25,6 @@ import { __etAttrPlanMap, adaptMTEventAttrSlot } from '../runtime/template/attr-
 import { isMTEventNativeWrapper } from '../runtime/template/main-thread-event-ctx.js';
 
 const MAIN_BUNDLE_URL_SENTINEL = '__Card__';
-const PAGE_ROOT_TARGET_HANDLE_ID = 0;
-const PAGE_ROOT_SLOT_ID = 0;
 const COMPONENT_AT_INDEX_ATTR = 'component-at-index';
 const COMPONENT_AT_INDEXES_ATTR = 'component-at-indexes';
 const ENQUEUE_COMPONENT_ATTR = 'enqueue-component';
@@ -38,8 +37,8 @@ export function hydrateRootChildrenIntoContext(
   root: BackgroundElementTemplateInstance,
 ): boolean {
   return hydrateChildListIntoContext(
-    PAGE_ROOT_TARGET_HANDLE_ID,
-    PAGE_ROOT_SLOT_ID,
+    ELEMENT_TEMPLATE_PAGE_HANDLE_ID,
+    ELEMENT_TEMPLATE_PAGE_ROOT_SLOT_INDEX,
     serializedChildren,
     root.childNodes,
   );
@@ -435,7 +434,12 @@ function collectRemovableSerializedSubtreeHandleIdsInto(
 
 function getRemovableSerializedHandleId(serialized: SerializedEtNode): number | null {
   const handleId = serialized.uid as number;
-  if (__DEV__ && (typeof handleId !== 'number' || !Number.isInteger(handleId) || handleId === 0)) {
+  if (
+    __DEV__
+    && (typeof handleId !== 'number'
+      || !Number.isInteger(handleId)
+      || handleId === ELEMENT_TEMPLATE_PAGE_HANDLE_ID)
+  ) {
     lynx.reportError(
       new Error(`ElementTemplate hydrate remove received invalid uid ${String(handleId)}.`),
     );

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -8,6 +8,7 @@ import { isElementTemplateHydrated } from './commit-hook.js';
 import { backgroundElementTemplateInstanceManager } from './manager.js';
 import { isDirectOrDeepEqual } from '../../utils.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
+import { ELEMENT_TEMPLATE_PAGE_HANDLE_ID, ELEMENT_TEMPLATE_PAGE_TYPE } from '../protocol/page.js';
 import { parseElementTemplateType } from '../protocol/template-type.js';
 import type {
   ElementTemplateHandleSlotsCommand,
@@ -17,6 +18,7 @@ import type {
   TypedElementAttributesCommand,
   UpdateTypedListItemCommand,
 } from '../protocol/types.js';
+import type { AuthoredPageAttributes } from '../runtime/page/authored-page.js';
 import type { EtAttrPlan } from '../runtime/template/attr-slot-plan.js';
 import { TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX, TYPED_ELEMENT_ATTR_PLAN } from '../runtime/template/typed-attributes.js';
 
@@ -109,7 +111,7 @@ export class BackgroundElementTemplateInstance {
     if (this.isMaterializedOnMainThread) {
       return;
     }
-    if (__DEV__ && this.instanceId === 0) {
+    if (__DEV__ && this.instanceId === ELEMENT_TEMPLATE_PAGE_HANDLE_ID) {
       lynx.reportError(new Error('ElementTemplate patch has illegal handleId 0.'));
       return;
     }
@@ -138,7 +140,7 @@ export class BackgroundElementTemplateInstance {
   }
 
   private needsMainThreadCreate(): boolean {
-    return this.instanceId !== 0 && !this.isMaterializedOnMainThread;
+    return this.instanceId !== ELEMENT_TEMPLATE_PAGE_HANDLE_ID && !this.isMaterializedOnMainThread;
   }
 
   protected getAttributeSlotPlan(): EtAttrPlan | undefined {
@@ -146,7 +148,7 @@ export class BackgroundElementTemplateInstance {
   }
 
   private markSubtreeDetachedFromMainThread(): void {
-    if (this.instanceId !== 0) {
+    if (this.instanceId !== ELEMENT_TEMPLATE_PAGE_HANDLE_ID) {
       this.isMaterializedOnMainThread = false;
     }
     let child = this.firstChild;
@@ -164,7 +166,7 @@ export class BackgroundElementTemplateInstance {
   }
 
   private restoreManagerRegistration(): void {
-    if (this.instanceId === 0) {
+    if (this.instanceId === ELEMENT_TEMPLATE_PAGE_HANDLE_ID) {
       return;
     }
     const instances = backgroundElementTemplateInstanceManager.values;
@@ -201,8 +203,6 @@ export class BackgroundElementTemplateInstance {
   }
 
   protected canEmitUpdatePatch(): boolean {
-    // Background tree construction is local until hydrate binds it to main-thread
-    // instances. Only hydrated and materialized owners can emit update ops.
     return isElementTemplateHydrated() && !this.needsMainThreadCreate();
   }
 
@@ -355,7 +355,7 @@ export class BackgroundElementTemplateInstance {
     this.rawAttributeSlots = undefined;
 
     // Remove from manager
-    if (this.instanceId) {
+    if (backgroundElementTemplateInstanceManager.values.get(this.instanceId) === this) {
       backgroundElementTemplateInstanceManager.values.delete(this.instanceId);
     }
   }
@@ -436,7 +436,7 @@ export class BackgroundElementTemplateInstance {
       const previousSlots = this.attributeSlots;
       const previousRawSlots = this.rawAttributeSlots ?? previousSlots;
       const isHydrated = isElementTemplateHydrated();
-      const canEmitUpdatePatch = isHydrated && !this.needsMainThreadCreate();
+      const canEmitUpdatePatch = this.canEmitUpdatePatch();
       // Pre-hydration commits must expose refs to effects, while post-hydration
       // unmaterialized nodes defer ref attach to create emission to avoid dupes.
       const shouldQueueRefEffects = !isHydrated || canEmitUpdatePatch;
@@ -528,7 +528,7 @@ export class BackgroundTypedElementTemplateInstance extends BackgroundElementTem
     if (this.isMaterializedOnMainThread) {
       return;
     }
-    if (__DEV__ && this.instanceId === 0) {
+    if (__DEV__ && this.instanceId === ELEMENT_TEMPLATE_PAGE_HANDLE_ID) {
       lynx.reportError(new Error('ElementTemplate patch has illegal handleId 0.'));
       return;
     }
@@ -566,6 +566,51 @@ export class BackgroundTypedElementTemplateInstance extends BackgroundElementTem
 
   protected getRuntimeOptionsForCreate(): RuntimeOptionsCommand | null {
     return null;
+  }
+}
+
+export class BackgroundPageRootInstance extends BackgroundTypedElementTemplateInstance {
+  // Preact may render a keyed replacement before running the old Page's passive cleanup.
+  // Only the current helper lifetime may clear the shared root attributes.
+  private authoredPageLifetime: object | undefined;
+
+  constructor() {
+    super(ELEMENT_TEMPLATE_PAGE_TYPE);
+    backgroundElementTemplateInstanceManager.registerPageRoot(this);
+    this.isMaterializedOnMainThread = true;
+  }
+
+  setAuthoredPageAttributes(
+    lifetime: object,
+    attributes: AuthoredPageAttributes,
+  ): void {
+    this.authoredPageLifetime = lifetime;
+    this.setAttribute('attributes', attributes);
+  }
+
+  clearAuthoredPageAttributes(lifetime: object): void {
+    if (this.authoredPageLifetime !== lifetime) {
+      return;
+    }
+    this.authoredPageLifetime = undefined;
+    this.setAttribute('attributes', null);
+  }
+
+  reconcileAuthoredPageAttributesOnHydration(
+    mainThreadAttributes: TypedElementAttributesCommand | null,
+  ): void {
+    const backgroundAttributes = this.attributeSlots[TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX] as
+      | TypedElementAttributesCommand
+      | null;
+    if (isDirectOrDeepEqual(mainThreadAttributes, backgroundAttributes)) {
+      return;
+    }
+    pushOp(
+      ElementTemplateUpdateOps.setAttribute,
+      this.instanceId,
+      TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX,
+      backgroundAttributes,
+    );
   }
 }
 
@@ -685,7 +730,7 @@ function collectElementTemplateSubtreeHandleIdsImpl(
   instance: BackgroundElementTemplateInstance,
   handles: number[],
 ): void {
-  if (instance.instanceId !== 0) {
+  if (instance.instanceId !== ELEMENT_TEMPLATE_PAGE_HANDLE_ID) {
     handles.push(instance.instanceId);
   }
   let child = instance.firstChild;
@@ -698,7 +743,7 @@ function collectElementTemplateSubtreeHandleIdsImpl(
 function emitMainThreadCreateRecursive(instance: BackgroundElementTemplateInstance): void {
   if (
     !isElementTemplateHydrated()
-    || instance.instanceId === 0
+    || instance.instanceId === ELEMENT_TEMPLATE_PAGE_HANDLE_ID
   ) {
     return;
   }

--- a/packages/react/runtime/src/element-template/background/manager.ts
+++ b/packages/react/runtime/src/element-template/background/manager.ts
@@ -3,17 +3,19 @@
 // LICENSE file in the root directory of this source tree.
 
 import type { BackgroundElementTemplateInstance } from './instance.js';
+import { ELEMENT_TEMPLATE_PAGE_HANDLE_ID } from '../protocol/page.js';
 
 export const backgroundElementTemplateInstanceManager: {
   nextId: number;
   values: Map<number, BackgroundElementTemplateInstance>;
   register(instance: BackgroundElementTemplateInstance): void;
+  registerPageRoot(instance: BackgroundElementTemplateInstance): void;
   updateId(oldId: number, newId: number): void;
   get(id: number): BackgroundElementTemplateInstance | undefined;
   getRawAttributeValueByEventValue(eventValue: string): unknown;
   clear(): void;
 } = {
-  nextId: 0,
+  nextId: ELEMENT_TEMPLATE_PAGE_HANDLE_ID,
   values: new Map<number, BackgroundElementTemplateInstance>(),
 
   register(instance: BackgroundElementTemplateInstance): void {
@@ -21,8 +23,14 @@ export const backgroundElementTemplateInstanceManager: {
     this.values.set(instance.instanceId, instance);
   },
 
+  registerPageRoot(instance: BackgroundElementTemplateInstance): void {
+    this.values.delete(instance.instanceId);
+    instance.instanceId = ELEMENT_TEMPLATE_PAGE_HANDLE_ID;
+    this.values.set(ELEMENT_TEMPLATE_PAGE_HANDLE_ID, instance);
+  },
+
   updateId(oldId: number, newId: number): void {
-    if (!Number.isInteger(newId) || newId === 0) {
+    if (!Number.isInteger(newId) || newId === ELEMENT_TEMPLATE_PAGE_HANDLE_ID) {
       throw new Error(`ElementTemplate handleId must be a non-zero integer, got ${String(newId)}.`);
     }
 
@@ -62,7 +70,6 @@ export const backgroundElementTemplateInstanceManager: {
     if (!instance) {
       return null;
     }
-
     const value = instance.getRawAttributeSlot(Number(parts[1]));
     const spreadKey = parts[2];
     if (!spreadKey) {

--- a/packages/react/runtime/src/element-template/native/index.ts
+++ b/packages/react/runtime/src/element-template/native/index.ts
@@ -17,7 +17,7 @@ import { updateCardData } from '../../core/lynx-update-data.js';
 import { installElementTemplateCommitHook } from '../background/commit-hook.js';
 import { setupBackgroundElementTemplateDocument } from '../background/document.js';
 import { installElementTemplateHydrationListener } from '../background/hydration-listener.js';
-import { BackgroundElementTemplateInstance } from '../background/instance.js';
+import { BackgroundPageRootInstance } from '../background/instance.js';
 import { installElementTemplateRenderScopeHooks } from '../background/render-scope.js';
 import { initElementTemplatePAPICallAlog } from '../debug/elementPAPICall.js';
 import { initProfileHook } from '../debug/profile.js';
@@ -64,7 +64,7 @@ function init(): void {
 
   if (__BACKGROUND__) {
     console.log('experimental_useElementTemplate:', __USE_ELEMENT_TEMPLATE__);
-    setRoot(new BackgroundElementTemplateInstance('root'));
+    setRoot(new BackgroundPageRootInstance());
     setupBackgroundElementTemplateDocument();
     installElementTemplateHydrationListener();
     resetEventStateForRuntime();

--- a/packages/react/runtime/src/element-template/native/reload-background.ts
+++ b/packages/react/runtime/src/element-template/native/reload-background.ts
@@ -10,7 +10,7 @@ import { increaseReloadVersion } from '../../core/reload-version.js';
 import { destroyElementTemplateBackgroundRuntime } from '../background/destroy.js';
 import { setupBackgroundElementTemplateDocument } from '../background/document.js';
 import { installElementTemplateHydrationListener } from '../background/hydration-listener.js';
-import { BackgroundElementTemplateInstance } from '../background/instance.js';
+import { BackgroundPageRootInstance } from '../background/instance.js';
 import { profileEnd, profileStart } from '../debug/profile.js';
 import { resetEventStateForRuntime } from '../prop-adapters/event.js';
 import { __root, setRoot } from '../runtime/page/root-instance.js';
@@ -29,7 +29,7 @@ export function reloadBackground(updateData: unknown): void {
     lynx.__initData = Object.assign({}, lynx.__initData);
     applyUpdatePageData(updateData);
 
-    setRoot(new BackgroundElementTemplateInstance('root'));
+    setRoot(new BackgroundPageRootInstance());
     __root.__jsx = jsx;
     setupBackgroundElementTemplateDocument();
     installElementTemplateHydrationListener();

--- a/packages/react/runtime/src/element-template/protocol/page.ts
+++ b/packages/react/runtime/src/element-template/protocol/page.ts
@@ -1,0 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export const ELEMENT_TEMPLATE_PAGE_TYPE = 'page';
+export const ELEMENT_TEMPLATE_PAGE_HANDLE_ID = 0;
+export const ELEMENT_TEMPLATE_PAGE_ROOT_SLOT_INDEX = 0;

--- a/packages/react/runtime/src/element-template/runtime/page/authored-page.ts
+++ b/packages/react/runtime/src/element-template/runtime/page/authored-page.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { ComponentChild, FunctionalComponent } from 'preact';
+
+import { useEffect, useRef } from '@lynx-js/react/hooks';
+
+import { __root } from './root-instance.js';
+
+export type AuthoredPageAttributes = Record<string, unknown> | null;
+
+export interface ElementTemplatePageProps {
+  $0?: ComponentChild;
+  attributes?: AuthoredPageAttributes;
+  key?: unknown;
+}
+
+interface BackgroundAuthoredPageRoot {
+  clearAuthoredPageAttributes(lifetime: object): void;
+  setAuthoredPageAttributes(lifetime: object, attributes: AuthoredPageAttributes): void;
+}
+
+export const __ElementTemplatePage: FunctionalComponent<ElementTemplatePageProps> = function ElementTemplatePage(
+  props,
+): ComponentChild {
+  const lifetime = useRef<object>({});
+  const root = __root as unknown as BackgroundAuthoredPageRoot;
+
+  if (__BACKGROUND__) {
+    root.setAuthoredPageAttributes(lifetime.current, props.attributes ?? null);
+    useEffect(() => () => root.clearAuthoredPageAttributes(lifetime.current), []);
+  }
+
+  return props.$0;
+};

--- a/packages/react/runtime/src/element-template/runtime/page/page.ts
+++ b/packages/react/runtime/src/element-template/runtime/page/page.ts
@@ -2,14 +2,22 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import {
+  ELEMENT_TEMPLATE_PAGE_HANDLE_ID,
+  ELEMENT_TEMPLATE_PAGE_ROOT_SLOT_INDEX,
+  ELEMENT_TEMPLATE_PAGE_TYPE,
+} from '../../protocol/page.js';
+
 export let __page: ElementRef;
 
-const ELEMENT_TEMPLATE_PAGE_TYPE = 'page';
-const ELEMENT_TEMPLATE_PAGE_UID = '0';
-const ELEMENT_TEMPLATE_PAGE_ROOT_SLOT = 0;
-
 export function createElementTemplatePage(): ElementRef {
-  return __CreateTypedElementTemplate(ELEMENT_TEMPLATE_PAGE_TYPE, null, null, ELEMENT_TEMPLATE_PAGE_UID, null);
+  return __CreateTypedElementTemplate(
+    ELEMENT_TEMPLATE_PAGE_TYPE,
+    null,
+    null,
+    String(ELEMENT_TEMPLATE_PAGE_HANDLE_ID),
+    null,
+  );
 }
 
 export function setupPage(page: ElementRef): void {
@@ -17,9 +25,9 @@ export function setupPage(page: ElementRef): void {
 }
 
 export function insertRootIntoPage(rootRef: ElementRef): void {
-  __InsertNodeToElementTemplate(__page, ELEMENT_TEMPLATE_PAGE_ROOT_SLOT, rootRef, null);
+  __InsertNodeToElementTemplate(__page, ELEMENT_TEMPLATE_PAGE_ROOT_SLOT_INDEX, rootRef, null);
 }
 
 export function removeRootFromPage(rootRef: ElementRef): void {
-  __RemoveNodeFromElementTemplate(__page, ELEMENT_TEMPLATE_PAGE_ROOT_SLOT, rootRef);
+  __RemoveNodeFromElementTemplate(__page, ELEMENT_TEMPLATE_PAGE_ROOT_SLOT_INDEX, rootRef);
 }

--- a/packages/react/runtime/src/element-template/runtime/patch.ts
+++ b/packages/react/runtime/src/element-template/runtime/patch.ts
@@ -22,6 +22,7 @@ import { elementTemplateRegistry } from './template/registry.js';
 import { TYPED_ELEMENT_ATTRIBUTES_SLOT_INDEX } from './template/typed-attributes.js';
 import { ElementTemplateUpdateOps } from '../protocol/opcodes.js';
 import type { ElementTemplateUpdateOp } from '../protocol/opcodes.js';
+import { ELEMENT_TEMPLATE_PAGE_HANDLE_ID } from '../protocol/page.js';
 import {
   elementTemplateIdentityKey,
   elementTemplateTypeTag,
@@ -442,7 +443,7 @@ function resolveTargetHandle(id: number, role: string): ElementRef | null {
 }
 
 function isValidHandleId(handleId: number): boolean {
-  return Number.isInteger(handleId) && handleId !== 0;
+  return Number.isInteger(handleId) && handleId !== ELEMENT_TEMPLATE_PAGE_HANDLE_ID;
 }
 
 function validateCreateHandleId(handleId: number): Error | null {

--- a/packages/react/runtime/src/element-template/runtime/template/registry.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/registry.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { ELEMENT_TEMPLATE_PAGE_HANDLE_ID } from '../../protocol/page.js';
 import { __page } from '../page/page.js';
 
 // Registry for mapping element-template handle IDs to native refs.
@@ -30,7 +31,7 @@ export function getElementTemplateNativeRef(id: number): ElementRef | undefined 
 }
 
 export function getElementTemplateTargetNativeRef(id: number): ElementRef | undefined {
-  return id === 0 ? __page : getElementTemplateNativeRef(id);
+  return id === ELEMENT_TEMPLATE_PAGE_HANDLE_ID ? __page : getElementTemplateNativeRef(id);
 }
 
 export function hasElementTemplateNativeRef(id: number): boolean {


### PR DESCRIPTION
## Overview

This PR adds the background-runtime layer for authored Element Template `<page />` support on top of the shared typed-attribute foundation.

- registers the existing logical page root in the background instance manager at reserved handle `0`;
- routes page attributes, events, and refs through the ordinary typed attribute-slot pipeline;
- adds the transparent internal Page helper that writes `attributes`, returns `$0`, and clears attributes on unmount;
- retains one narrow lifetime token so a keyed replacement stale passive cleanup cannot clear its successor;
- preserves page-root ownership across init, destroy, reload, and hydration setup.

This layer does not add main-thread page instructions, the serialized page-root hydrate envelope, or authored JSX lowering. Those are separate later PRs in the stack.

## Review order

1. `background/manager.ts` and the reserved page-root registration
2. `background/instance.ts` and the thin `BackgroundPageRootInstance`
3. `runtime/page/authored-page.ts`
4. init/reload integration
5. focused manager, instance, root-render, and authored-page tests

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).

Documentation is maintained in the parent project Track. A changeset is not required for this internal, unreleased Element Template layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authored page support with configurable attributes, children, and keys.
  * Added consistent page-root handling across rendering, hydration, reloads, and native integration.
  * Preserved page attributes across updates and hydration while safely removing outdated attributes.

* **Bug Fixes**
  * Improved page-root protection during cleanup and invalid-handle handling.
  * Fixed page-root registration and replacement during reloads and hydration.

* **Tests**
  * Expanded coverage for page rendering, attribute updates, hydration, reloads, teardown, and authored-page behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->