### PR TITLE
feat(transform): lower authored page for Element Template

### DIFF
--- a/packages/react/runtime/__test__/element-template/fixtures/page-compiled/authored-page/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/page-compiled/authored-page/index.tsx
@@ -1,0 +1,54 @@
+interface AppProps {
+  onTap?: () => void;
+  pageId?: string;
+  pageKey?: string;
+  pageRef?: unknown;
+  refMode?: 'direct' | 'spread';
+  withPage?: boolean;
+}
+
+export function App({
+  onTap,
+  pageId = 'screen',
+  pageKey = 'page',
+  pageRef,
+  refMode = 'spread',
+  withPage = true,
+}: AppProps) {
+  const child = (
+    <view id='child'>
+      <text>child</text>
+    </view>
+  );
+  if (!withPage) {
+    return (
+      <view id='without-page'>
+        <text>without page</text>
+      </view>
+    );
+  }
+  const pageProps = {
+    id: pageId,
+    className: 'screen',
+    bindtap: onTap,
+    ref: pageRef,
+  };
+  if (refMode === 'direct') {
+    return (
+      <page
+        key={pageKey}
+        id={pageId}
+        className='screen'
+        bindtap={onTap}
+        ref={pageRef}
+      >
+        {child}
+      </page>
+    );
+  }
+  return (
+    <page key={pageKey} {...pageProps}>
+      {child}
+    </page>
+  );
+}

--- a/packages/react/runtime/__test__/element-template/runtime/page/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/page/compiled-fixtures.test.tsx
@@ -390,6 +390,7 @@ describe('Compiled authored ET page fixtures', () => {
     expect(patchedPage.attributes?.id).toBe('background-replacement');
     expect(patchedPage.elementSlots?.[0]).toHaveLength(1);
     const patchedRootUid = patchedPage.elementSlots?.[0]?.[0]?.uid;
+    expect(patchedRootUid).toBeDefined();
     expect(serializeToJSX(pageModule.__page)).toContain('child');
 
     envManager.switchToBackground();

--- a/packages/react/runtime/__test__/element-template/runtime/page/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/page/compiled-fixtures.test.tsx
@@ -1,0 +1,487 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  installElementTemplateCommitHook,
+  isElementTemplateHydrated,
+  resetElementTemplateCommitState,
+} from '../../../../src/element-template/background/commit-hook.js';
+import {
+  installElementTemplateHydrationListener,
+  resetElementTemplateHydrationListener,
+} from '../../../../src/element-template/background/hydration-listener.js';
+import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
+import { installElementTemplateRenderScopeHooks } from '../../../../src/element-template/background/render-scope.js';
+import { formatElementTemplateUpdateCommands } from '../../../../src/element-template/debug/alog.js';
+import { callDestroyLifetimeFun } from '../../../../src/element-template/native/callDestroyLifetimeFun.js';
+import {
+  installElementTemplatePatchListener,
+  resetElementTemplatePatchListener,
+} from '../../../../src/element-template/native/patch-listener.js';
+import { reloadBackground } from '../../../../src/element-template/native/reload-background.js';
+import { reloadMainThread } from '../../../../src/element-template/native/reload-main-thread.js';
+import { clearEventState } from '../../../../src/element-template/prop-adapters/event.js';
+import { clearRefState } from '../../../../src/element-template/prop-adapters/ref.js';
+import { ElementTemplateLifecycleConstant } from '../../../../src/element-template/protocol/lifecycle-constant.js';
+import { ElementTemplateUpdateOps } from '../../../../src/element-template/protocol/opcodes.js';
+import type { ElementTemplateUpdateCommitContext } from '../../../../src/element-template/protocol/types.js';
+import { parseElementTemplateUpdateEventPayload } from '../../../../src/element-template/protocol/update-event.js';
+import * as pageModule from '../../../../src/element-template/runtime/page/page.js';
+import * as rootModule from '../../../../src/element-template/runtime/page/root-instance.js';
+import { clearEtAttrPlanMap } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
+import {
+  loadCompiledFixturePair,
+  type CompiledFixtureModuleExports,
+} from '../../test-utils/debug/compiledFixtureModule.js';
+import {
+  renderCompiledFixtureOnBackground,
+  renderCompiledFixtureOnMainThread,
+} from '../../test-utils/debug/compiledThreadRunner.js';
+import { ElementTemplateEnvManager } from '../../test-utils/debug/envManager.js';
+import { serializeToJSX } from '../../test-utils/debug/serializer.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const AUTHORED_PAGE_FIXTURE = path.resolve(__dirname, '../../fixtures/page-compiled/authored-page/index.tsx');
+
+interface AuthoredPageProps {
+  onTap?: () => void;
+  pageId?: string;
+  pageKey?: string;
+  pageRef?: unknown;
+  refMode?: 'direct' | 'spread';
+  withPage?: boolean;
+}
+
+interface CompiledAuthoredPageModule extends CompiledFixtureModuleExports {
+  App: (props: AuthoredPageProps) => JSX.Element;
+}
+
+describe('Compiled authored ET page fixtures', () => {
+  const envManager = new ElementTemplateEnvManager();
+  let updateEvents: ElementTemplateUpdateCommitContext[] = [];
+  const onUpdate = (event: { data: unknown }) => {
+    updateEvents.push(parseElementTemplateUpdateEventPayload(event.data));
+  };
+
+  function renderOnBackground(
+    moduleExports: CompiledAuthoredPageModule,
+    props: AuthoredPageProps,
+  ): void {
+    const child = renderCompiledFixtureOnBackground(moduleExports, envManager, props);
+    if (!child) {
+      throw new Error('Missing rendered page child.');
+    }
+  }
+
+  async function renderHydratedPair(
+    backgroundProps: AuthoredPageProps,
+    mainThreadProps: AuthoredPageProps = backgroundProps,
+  ): Promise<CompiledAuthoredPageModule> {
+    const modules = await loadCompiledFixturePair<CompiledAuthoredPageModule>(AUTHORED_PAGE_FIXTURE);
+    renderOnBackground(modules.backgroundModule, backgroundProps);
+    renderCompiledFixtureOnMainThread(modules.mainModule, envManager, mainThreadProps);
+    expect(isElementTemplateHydrated()).toBe(true);
+    envManager.switchToMainThread();
+    envManager.switchToBackground();
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        setTimeout(resolve);
+      });
+    });
+    return modules.backgroundModule;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetElementTemplateCommitState();
+    resetElementTemplateHydrationListener();
+    clearEtAttrPlanMap();
+    clearEventState();
+    clearRefState();
+    updateEvents = [];
+    envManager.resetEnv('background');
+    envManager.setUseElementTemplate(true);
+    installElementTemplateRenderScopeHooks();
+    installElementTemplateCommitHook();
+    installElementTemplateHydrationListener();
+
+    envManager.switchToMainThread();
+    installElementTemplatePatchListener();
+    lynx.getJSContext().addEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+    envManager.switchToBackground();
+  });
+
+  it('preserves authored page key as compiled VNode reconciliation metadata', async () => {
+    const { backgroundModule } = await loadCompiledFixturePair<CompiledAuthoredPageModule>(AUTHORED_PAGE_FIXTURE);
+
+    const vnode = backgroundModule.App({ pageKey: 'stable-page' }) as unknown as {
+      key?: unknown;
+      props: Record<string, unknown>;
+    };
+
+    expect(vnode.key).toBe('stable-page');
+    expect(vnode.props).not.toHaveProperty('key');
+  });
+
+  it('reconciles background page attrs when main-thread first screen differs', async () => {
+    await renderHydratedPair(
+      { pageId: 'background', withPage: true },
+      { pageId: 'main-thread', withPage: true },
+    );
+
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)).toMatchObject({
+      isHydration: true,
+      ops: [
+        ElementTemplateUpdateOps.setAttribute,
+        0,
+        0,
+        {
+          id: 'background',
+          class: 'screen',
+          bindtap: null,
+        },
+      ],
+    });
+    expect(pageModule.__page).toMatchObject({
+      attributes: expect.objectContaining({ id: 'background' }),
+    });
+    envManager.switchToBackground();
+  });
+
+  afterEach(() => {
+    envManager.switchToMainThread();
+    lynx.getJSContext().removeEventListener(ElementTemplateLifecycleConstant.update, onUpdate);
+    resetElementTemplatePatchListener();
+    envManager.switchToBackground();
+    resetElementTemplateHydrationListener();
+    clearEventState();
+    clearRefState();
+    envManager.setUseElementTemplate(false);
+  });
+
+  it('updates, clears, and remounts compiled authored page state on reserved target 0', async () => {
+    const onTap = vi.fn();
+    const pageRef = vi.fn();
+    const pageProps = { onTap, pageId: 'screen', pageRef, withPage: true };
+    const backgroundModule = await renderHydratedPair(pageProps);
+
+    expect(backgroundElementTemplateInstanceManager.get(0)).toBe(rootModule.__root);
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0:bindtap')).toBe(onTap);
+    expect(pageRef).toHaveBeenCalledWith(expect.objectContaining({
+      selector: '[ref=0-0]',
+    }));
+
+    expect(__SerializeElementTemplate).toHaveBeenCalledTimes(1);
+    expect(__SerializeElementTemplate).toHaveBeenCalledWith(pageModule.__page);
+
+    envManager.switchToMainThread();
+    expect(pageModule.__page).toMatchObject({
+      type: 'page',
+      attributes: expect.objectContaining({
+        id: 'screen',
+        class: 'screen',
+      }),
+    });
+    expect(updateEvents.at(-1)?.isHydration).toBe(true);
+    expect(updateEvents.at(-1)?.ops).toEqual([]);
+    envManager.switchToBackground();
+
+    pageRef.mockClear();
+    updateEvents = [];
+    const nextOnTap = vi.fn();
+    renderOnBackground(backgroundModule, { ...pageProps, onTap: nextOnTap });
+
+    envManager.switchToMainThread();
+    expect(updateEvents).toEqual([]);
+    envManager.switchToBackground();
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0:bindtap')).toBe(nextOnTap);
+    expect(pageRef).not.toHaveBeenCalled();
+
+    renderOnBackground(backgroundModule, { ...pageProps, onTap: nextOnTap, pageId: 'next' });
+
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      0,
+      0,
+      {
+        id: 'next',
+        class: 'screen',
+        bindtap: '0:0:bindtap',
+        ref: '0-0',
+      },
+    ]);
+    expect(pageModule.__page).toMatchObject({
+      attributes: expect.objectContaining({ id: 'next' }),
+    });
+    envManager.switchToBackground();
+
+    updateEvents = [];
+    renderOnBackground(backgroundModule, { ...pageProps, onTap: nextOnTap, withPage: false });
+
+    envManager.switchToMainThread();
+    expect(formatElementTemplateUpdateCommands(updateEvents.at(-1)?.ops)).toEqual([
+      {
+        op: 'setAttribute',
+        targetId: 0,
+        attrSlotIndex: 0,
+        value: null,
+      },
+      {
+        op: 'removeNode',
+        targetId: 0,
+        elementSlotIndex: 0,
+        childId: -1,
+        removedSubtreeHandleIds: [-1],
+      },
+      {
+        op: 'createTemplate',
+        handleId: 3,
+        templateKey: expect.any(String),
+        bundleUrl: null,
+        attributeSlots: [],
+        elementSlots: [],
+      },
+      {
+        op: 'insertNode',
+        targetId: 0,
+        elementSlotIndex: 0,
+        childId: 3,
+        referenceId: 0,
+      },
+    ]);
+    expect(serializeToJSX(pageModule.__page)).toContain('without page');
+    expect(serializeToJSX(pageModule.__page)).not.toContain('child');
+    envManager.switchToBackground();
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0:bindtap')).toBeUndefined();
+    expect(pageRef).toHaveBeenCalledWith(null);
+
+    const remountOnTap = vi.fn();
+    const remountRef = vi.fn();
+    updateEvents = [];
+    renderOnBackground(backgroundModule, {
+      onTap: remountOnTap,
+      pageId: 'remounted',
+      pageRef: remountRef,
+      withPage: true,
+    });
+
+    envManager.switchToMainThread();
+    expect(formatElementTemplateUpdateCommands(updateEvents.at(-1)?.ops)).toEqual([
+      {
+        op: 'removeNode',
+        targetId: 0,
+        elementSlotIndex: 0,
+        childId: 3,
+        removedSubtreeHandleIds: [3],
+      },
+      {
+        op: 'setAttribute',
+        targetId: 0,
+        attrSlotIndex: 0,
+        value: {
+          id: 'remounted',
+          class: 'screen',
+          bindtap: '0:0:bindtap',
+          ref: '0-0',
+        },
+      },
+      {
+        op: 'createTemplate',
+        handleId: 4,
+        templateKey: expect.any(String),
+        bundleUrl: null,
+        attributeSlots: [],
+        elementSlots: [],
+      },
+      {
+        op: 'insertNode',
+        targetId: 0,
+        elementSlotIndex: 0,
+        childId: 4,
+        referenceId: 0,
+      },
+    ]);
+    expect(serializeToJSX(pageModule.__page)).toContain('child');
+    expect(serializeToJSX(pageModule.__page)).not.toContain('without page');
+    envManager.switchToBackground();
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0:bindtap')).toBe(remountOnTap);
+    expect(remountRef).toHaveBeenCalledWith(expect.objectContaining({ selector: '[ref=0-0]' }));
+  });
+
+  it.each(['direct', 'spread'] as const)(
+    'delivers compiled %s page refs through typed attributes',
+    async refMode => {
+      const backgroundPageRef = vi.fn();
+      const mainThreadPageRef = vi.fn();
+
+      await renderHydratedPair(
+        { pageRef: backgroundPageRef, refMode, withPage: true },
+        { pageRef: mainThreadPageRef, refMode, withPage: true },
+      );
+
+      expect(backgroundPageRef).toHaveBeenCalledWith(expect.objectContaining({
+        selector: '[ref=0-0]',
+      }));
+      expect(mainThreadPageRef).not.toHaveBeenCalled();
+      envManager.switchToMainThread();
+      expect(pageModule.__page).toMatchObject({
+        attributes: expect.objectContaining({ ref: '0-0' }),
+      });
+      envManager.switchToBackground();
+    },
+  );
+
+  it.each(['direct', 'spread'] as const)(
+    'detaches the old compiled %s page ref before attaching its replacement',
+    async refMode => {
+      const firstRef = vi.fn();
+      const mainThreadRef = vi.fn();
+      const replacementRef = vi.fn();
+      const backgroundModule = await renderHydratedPair(
+        {
+          pageRef: firstRef,
+          refMode,
+          withPage: true,
+        },
+        {
+          pageRef: mainThreadRef,
+          refMode,
+          withPage: true,
+        },
+      );
+
+      renderOnBackground(backgroundModule, {
+        pageRef: replacementRef,
+        refMode,
+        withPage: true,
+      });
+
+      expect(firstRef).toHaveBeenLastCalledWith(null);
+      expect(replacementRef).toHaveBeenCalledWith(expect.objectContaining({
+        selector: '[ref=0-0]',
+      }));
+      expect(mainThreadRef).not.toHaveBeenCalled();
+      expect(firstRef.mock.invocationCallOrder.at(-1)).toBeLessThan(
+        replacementRef.mock.invocationCallOrder[0]!,
+      );
+    },
+  );
+
+  it('reloads from current physical page state after a target-0 replacement', async () => {
+    const pageProps = { pageId: 'before-replacement', withPage: true };
+    const backgroundModule = await renderHydratedPair(pageProps);
+
+    renderOnBackground(backgroundModule, { ...pageProps, withPage: false });
+    renderOnBackground(backgroundModule, {
+      ...pageProps,
+      pageId: 'background-replacement',
+    });
+
+    envManager.switchToMainThread();
+    const patchedPage = __SerializeElementTemplate(pageModule.__page) as {
+      attributes?: { id?: string } | null;
+      elementSlots?: Array<Array<{ uid: number | string }> | null | undefined>;
+    };
+    expect(patchedPage.attributes?.id).toBe('background-replacement');
+    expect(patchedPage.elementSlots?.[0]).toHaveLength(1);
+    const patchedRootUid = patchedPage.elementSlots?.[0]?.[0]?.uid;
+    expect(serializeToJSX(pageModule.__page)).toContain('child');
+
+    envManager.switchToBackground();
+    (rootModule.__root as unknown as { __jsx: unknown }).__jsx = backgroundModule.App(pageProps);
+    reloadBackground({});
+    expect(isElementTemplateHydrated()).toBe(false);
+
+    envManager.switchToMainThread();
+    updateEvents = [];
+    vi.mocked(__SerializeElementTemplate).mockClear();
+    reloadMainThread({}, { reloadTemplate: true });
+    expect(__SerializeElementTemplate).toHaveBeenCalledTimes(2);
+    const cleanupSnapshot = vi.mocked(__SerializeElementTemplate).mock.results[0]?.value as {
+      attributes?: { id?: string } | null;
+      elementSlots?: Array<Array<{ uid: number | string }> | null | undefined>;
+    };
+    expect(cleanupSnapshot.attributes?.id).toBe('background-replacement');
+    expect(cleanupSnapshot.elementSlots?.[0]?.map(root => root.uid)).toContain(patchedRootUid);
+    const reloadEnvelope = vi.mocked(__SerializeElementTemplate).mock.results[1]?.value as {
+      attributes?: { id?: string } | null;
+      elementSlots?: Array<Array<{ uid: number | string }> | null | undefined>;
+    };
+    expect(reloadEnvelope.attributes?.id).toBe('before-replacement');
+    expect(reloadEnvelope.elementSlots?.[0]).toHaveLength(1);
+    expect(reloadEnvelope.elementSlots?.[0]?.map(root => root.uid)).not.toContain(patchedRootUid);
+    envManager.switchToBackground();
+    expect(isElementTemplateHydrated()).toBe(true);
+
+    envManager.switchToMainThread();
+    const reloadedPage = __SerializeElementTemplate(pageModule.__page) as {
+      attributes?: { id?: string } | null;
+      elementSlots?: Array<Array<{ uid: number | string }> | null | undefined>;
+    };
+    expect(reloadedPage.attributes?.id).toBe('before-replacement');
+    expect(reloadedPage.elementSlots?.[0]).toHaveLength(1);
+    expect(reloadedPage.elementSlots?.[0]?.map(root => root.uid)).not.toContain(patchedRootUid);
+    expect(serializeToJSX(pageModule.__page)).toContain('child');
+    expect(updateEvents.at(-1)).toMatchObject({
+      isHydration: true,
+      ops: [],
+    });
+    envManager.switchToBackground();
+  });
+
+  it('clears compiled page event and ref state on background destroy', async () => {
+    const onTap = vi.fn();
+    const pageRef = vi.fn();
+    await renderHydratedPair({ onTap, pageId: 'screen', pageRef, withPage: true });
+
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0:bindtap')).toBe(onTap);
+    pageRef.mockClear();
+
+    callDestroyLifetimeFun();
+
+    expect(isElementTemplateHydrated()).toBe(false);
+    expect(backgroundElementTemplateInstanceManager.getRawAttributeValueByEventValue('0:0:bindtap')).toBeNull();
+    expect(pageRef).toHaveBeenCalledWith(null);
+  });
+
+  it('rebinds compiled page state after reload and accepts later updates', async () => {
+    const pageProps = { pageId: 'before-reload', withPage: true };
+    const backgroundModule = await renderHydratedPair(pageProps);
+    const oldBackgroundRoot = rootModule.__root;
+
+    reloadBackground({});
+    expect(rootModule.__root).not.toBe(oldBackgroundRoot);
+
+    envManager.switchToMainThread();
+    reloadMainThread({}, { reloadTemplate: true });
+    envManager.switchToBackground();
+    expect(isElementTemplateHydrated()).toBe(true);
+    envManager.switchToMainThread();
+    envManager.switchToBackground();
+
+    updateEvents = [];
+    renderOnBackground(backgroundModule, { ...pageProps, pageId: 'after-reload' });
+
+    envManager.switchToMainThread();
+    expect(updateEvents.at(-1)?.ops).toEqual([
+      ElementTemplateUpdateOps.setAttribute,
+      0,
+      0,
+      {
+        id: 'after-reload',
+        class: 'screen',
+        bindtap: null,
+        ref: null,
+      },
+    ]);
+    expect(pageModule.__page).toMatchObject({
+      attributes: expect.objectContaining({ id: 'after-reload' }),
+    });
+    envManager.switchToBackground();
+  });
+});

--- a/packages/react/runtime/src/element-template/internal.ts
+++ b/packages/react/runtime/src/element-template/internal.ts
@@ -66,3 +66,4 @@ export {
   adaptRefAttrSlot,
   adaptSpreadAttrSlot,
 } from './runtime/template/attr-slot-plan.js';
+export { __ElementTemplatePage } from './runtime/page/authored-page.js';

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -374,7 +374,7 @@ where
     rendered_attrs.push(jsx_expr_attr("$0", page_children));
     let page_helper_name = JSXElementName::JSXMemberExpr(JSXMemberExpr {
       obj: JSXObject::Ident(internal_runtime_ident),
-      prop: private_ident!("__ElementTemplatePage").into(),
+      prop: IdentName::new("__ElementTemplatePage".into(), DUMMY_SP),
       span: node.opening.span,
     });
     node.opening.name = page_helper_name.clone();
@@ -382,7 +382,6 @@ where
     if let Some(closing) = &mut node.closing {
       closing.name = page_helper_name;
     }
-    node.children.clear();
   }
 }
 

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -98,7 +98,7 @@ fn empty_object_expr() -> Expr {
   })
 }
 
-fn typed_list_attributes_expr(attrs: Vec<JSXAttrOrSpread>) -> (Vec<JSXAttrOrSpread>, Expr) {
+fn typed_host_attributes_expr(attrs: Vec<JSXAttrOrSpread>) -> (Vec<JSXAttrOrSpread>, Expr) {
   let mut passthrough_attrs = vec![];
   let mut object_props = vec![];
 
@@ -328,7 +328,7 @@ where
 
     let span = node.span();
     let opening_span = node.opening.span;
-    let (mut rendered_attrs, attributes) = typed_list_attributes_expr(node.opening.attrs.take());
+    let (mut rendered_attrs, attributes) = typed_host_attributes_expr(node.opening.attrs.take());
     let list_children = if node.children.is_empty() {
       empty_array_expr()
     } else {
@@ -356,6 +356,34 @@ where
       closing: None,
     };
   }
+
+  fn lower_authored_page_runtime_jsx(&mut self, node: &mut JSXElement) {
+    node.visit_mut_children_with(self);
+
+    let internal_runtime_ident = match self.internal_runtime_id.clone() {
+      Expr::Ident(ident) => ident,
+      _ => unreachable!("ET internal runtime must be bound through a namespace import"),
+    };
+    let (mut rendered_attrs, attributes) = typed_host_attributes_expr(node.opening.attrs.take());
+    let page_children = if node.children.is_empty() {
+      empty_array_expr()
+    } else {
+      jsx_children_to_expr(node.children.take())
+    };
+    rendered_attrs.push(jsx_expr_attr("attributes", attributes));
+    rendered_attrs.push(jsx_expr_attr("$0", page_children));
+    let page_helper_name = JSXElementName::JSXMemberExpr(JSXMemberExpr {
+      obj: JSXObject::Ident(internal_runtime_ident),
+      prop: private_ident!("__ElementTemplatePage").into(),
+      span: node.opening.span,
+    });
+    node.opening.name = page_helper_name.clone();
+    node.opening.attrs = rendered_attrs;
+    if let Some(closing) = &mut node.closing {
+      closing.name = page_helper_name;
+    }
+    node.children.clear();
+  }
 }
 
 impl<C> VisitMut for JSXTransformer<C>
@@ -375,7 +403,11 @@ where
             self.lower_typed_list_runtime_jsx(node);
             return;
           }
-          if tag_str == "page" || tag_str == "component" {
+          if tag_str == "page" {
+            self.lower_authored_page_runtime_jsx(node);
+            return;
+          }
+          if tag_str == "component" {
             HANDLER.with(|handler| {
               handler
                 .struct_span_err(

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template.rs
@@ -857,10 +857,10 @@ fn should_keep_dynamic_component_asset_id_content_addressed_without_entry_prefix
 }
 
 #[test]
-fn should_report_page_element_as_unsupported() {
-  let (_, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
+fn should_lower_page_element_to_internal_page_helper() {
+  let (code, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
     r#"
-      <page>
+      <page key={pageKey} id="root-page" bindtap={onTap} ref={pageRef}>
         <view>Page Element Test</view>
       </page>
     "#,
@@ -868,14 +868,195 @@ fn should_report_page_element_as_unsupported() {
   );
 
   assert!(
-    diagnostics
+    !diagnostics
       .iter()
       .any(|message| message == "<page /> is not supported"),
-    "expected <page /> unsupported diagnostic, got: {diagnostics:?}"
+    "valid <page /> should not emit unsupported diagnostic, got: {diagnostics:?}"
+  );
+  assert!(
+    code.contains("__ElementTemplatePage"),
+    "authored <page /> should lower to ET internal page helper:\n{code}"
+  );
+  assert!(
+    code.contains("key={pageKey}") && code.contains("attributes={{"),
+    "authored <page /> should use explicit key plus typed attributes:\n{code}"
+  );
+  assert!(
+    code.contains("\"bindtap\": onTap")
+      && code.contains("\"ref\": pageRef")
+      && !code.contains("__ELEMENT_TEMPLATE_DIRECT_REF_MARKER"),
+    "page event/ref values should remain in typed attributes:\n{code}"
+  );
+
+  let user_templates = user_templates(&templates);
+  assert_eq!(
+    user_templates.len(),
+    1,
+    "only the child view should produce a compiled ET template: {templates:?}"
+  );
+  let template =
+    serde_json::to_value(&user_templates[0].compiled_template).expect("compiled template json");
+  assert_eq!(template["type"], "view");
+  assert!(
+    user_templates
+      .iter()
+      .all(|template| template.compiled_template["type"].as_str() != Some("page")),
+    "authored <page /> must not emit a page compiled template: {templates:?}"
+  );
+}
+
+#[test]
+fn should_lower_page_element_in_development_mode() {
+  let (code, templates, diagnostics) = transform_to_code_templates_and_diagnostics_with_mode(
+    r#"
+      <page id="root-page">
+        <view>Page Element Test</view>
+      </page>
+    "#,
+    JSXTransformerConfig {
+      runtime_pkg: "@custom/react".into(),
+      ..element_template_config()
+    },
+    TransformMode::Development,
+  );
+
+  assert!(
+    diagnostics.is_empty(),
+    "valid <page /> should not emit diagnostics in development mode, got: {diagnostics:?}"
+  );
+  assert!(
+    code.contains(r#"import * as ReactLynxInternal from "@custom/react/internal""#),
+    "development mode should use the current internal runtime namespace import:\n{code}"
+  );
+  assert!(
+    !code.contains("require("),
+    "development mode should not restore the obsolete runtime require alias:\n{code}"
+  );
+  assert!(
+    code.contains("__ElementTemplatePage"),
+    "authored <page /> should lower to ET internal page helper:\n{code}"
+  );
+  assert_eq!(user_templates(&templates).len(), 1);
+}
+
+#[test]
+fn should_follow_typed_list_carrier_for_explicit_page_children() {
+  let (code, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"<page id="root-page" children={explicitChild} />"#,
+    element_template_config(),
+  );
+
+  assert!(
+    diagnostics.is_empty(),
+    "unexpected diagnostics: {diagnostics:?}"
+  );
+  assert!(
+    code.contains("attributes={{")
+      && code.contains("\"id\": \"root-page\"")
+      && code.contains("\"children\": explicitChild")
+      && code.contains("$0={[]}"),
+    "page should inherit the current typed-list carrier contract:\n{code}"
+  );
+  assert!(
+    user_templates(&templates).is_empty(),
+    "a childless authored page should not emit a user page template: {templates:?}"
+  );
+}
+
+#[test]
+fn should_follow_typed_list_key_partition_order() {
+  let (code, _, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"<page id={before()} key={pageKey()} ref={pageRef()} title={after()} />"#,
+    element_template_config_for_target(TransformTarget::JS),
+  );
+
+  assert!(
+    diagnostics.is_empty(),
+    "unexpected diagnostics: {diagnostics:?}"
+  );
+  let before_position = code.find("before()").expect("before attr");
+  let key_position = code.find("pageKey()").expect("page key");
+  let ref_position = code.find("pageRef()").expect("page ref");
+  let after_position = code.find("after()").expect("after attr");
+  assert!(
+    key_position < before_position
+      && before_position < ref_position
+      && ref_position < after_position,
+    "page should inherit the current typed-list key partition order:\n{code}"
+  );
+}
+
+#[test]
+fn should_lower_spread_page_with_typed_list_carrier() {
+  let (code, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"
+      <page key={beforeKey} id="before" {...first()} children={explicitChild} {...second()} bindtap={onTap} ref={pageRef}>
+        {jsxChild}
+      </page>
+    "#,
+    element_template_config(),
+  );
+
+  assert!(
+    diagnostics.is_empty(),
+    "unexpected diagnostics: {diagnostics:?}"
+  );
+  assert_eq!(
+    code.matches("first()").count(),
+    1,
+    "each page spread expression must be evaluated once:\n{code}"
+  );
+  assert_eq!(
+    code.matches("second()").count(),
+    1,
+    "each page spread expression must be evaluated once:\n{code}"
+  );
+  assert!(
+    code.contains("key={beforeKey}")
+      && code.contains("attributes={{")
+      && code.contains("\"children\": explicitChild")
+      && code.contains("...first()")
+      && code.contains("...second()")
+      && !code.contains("__ElementTemplatePageSpread")
+      && !code.contains("__ELEMENT_TEMPLATE_DIRECT_REF_MARKER"),
+    "page should collect non-key opening attrs with the typed-list carrier:\n{code}"
+  );
+  assert!(
+    code.contains("\"bindtap\": onTap") && code.contains("\"ref\": pageRef"),
+    "page event/ref values should remain in typed attributes:\n{code}"
+  );
+  assert!(
+    code.contains("$0={jsxChild}"),
+    "JSX children should use the typed logical carrier:\n{code}"
+  );
+  assert!(
+    user_templates(&templates)
+      .iter()
+      .all(|template| template.compiled_template["type"].as_str() != Some("page")),
+    "spread-authored <page /> must not emit a page compiled template: {templates:?}"
+  );
+}
+
+#[test]
+fn should_still_report_component_element_as_unsupported() {
+  let (_, templates, diagnostics) = transform_to_code_templates_and_diagnostics(
+    r#"
+      <component is="dynamic-view">
+        <view>Component Element Test</view>
+      </component>
+    "#,
+    element_template_config(),
+  );
+
+  assert!(
+    diagnostics
+      .iter()
+      .any(|message| message == "<component /> is not supported"),
+    "expected <component /> unsupported diagnostic, got: {diagnostics:?}"
   );
   assert!(
     templates.is_empty(),
-    "unsupported <page /> should not emit poisoned templates: {templates:?}"
+    "unsupported <component /> should not emit poisoned templates: {templates:?}"
   );
 }
 


### PR DESCRIPTION
## Context

The preceding Element Template Page work, now present on `main`, provides the typed Page root and its runtime lifecycle. However, the ET SWC transform still reports authored `<page />` as unsupported, so compiled application source cannot enter that existing runtime path.

This PR adds that missing transform integration. It does not introduce or change the Page runtime protocol, hydration algorithm, or patch lifecycle.

## Change

Authored JSX such as:

```tsx
<page key={pageKey} id='screen' {...pageProps}>
  <view>Content</view>
</page>
```

is lowered to the existing private Page helper using the same carrier shape as Typed List. Conceptually:

```tsx
<ReactLynxInternal.__ElementTemplatePage
  key={pageKey}
  attributes={{ id: 'screen', ...pageProps }}
  $0={<view>Content</view>}
/>
```

The transform contract is:

- explicit `key` remains reconciliation metadata on the helper;
- other opening attributes and spreads are collected into `attributes`;
- JSX children are carried by `$0`;
- no compiled Page template is emitted; child ET nodes continue to compile normally.

To share that contract without adding Page-specific attribute handling, the transform's Typed List attribute collector is generalized to a typed-host collector and reused by both List and Page. The runtime package only exposes `__ElementTemplatePage` through its private internal namespace so the generated JSX can resolve the existing helper.

Transform contract tests cover direct attributes, spreads, key partitioning, development-mode imports, and the unchanged unsupported `<component />` path. A compiled authored-page fixture verifies that this lowering reaches the existing main/background Page runtime, including its attribute, event, ref, replacement, reload, and hydration paths; those runtime behaviors are not implemented by this PR.

## Limits

This PR intentionally inherits the current Typed List carrier limitations for spread-provided `key`, explicit or spread-provided `children`, strict opening-attribute evaluation order, and complete shared MTS ref normalization. Those semantics remain part of the joint List/Page follow-up.

Snapshot, Typed List behavior, and the unsupported `<component />` transform are unchanged. No migration or changeset is required because Element Template is still internal and unreleased.

## Review Focus

1. Check that Page lowering reuses the Typed List carrier without changing List output.
2. Check the `key` / `attributes` / `$0` partition and the internal helper import in both production and development transforms.
3. Check that the compiled fixture proves the transform/runtime connection without adding a second Page protocol.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
