### PR TITLE
build: upgrade pnpm to 11.22

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -19,30 +19,35 @@ runs:
         node-version: ${{ inputs.node-version }}
         package-manager-cache: false
 
-    - name: Get pnpm store directory
-      id: pnpm-store
+    - name: Get pnpm cache directories
+      id: pnpm-cache
       shell: bash
       run: | # zizmor: ignore[adhoc-packages] corepack must be installed globally outside of a lockfile
-        npm install -g corepack@latest
+        npm install -g corepack@0.35.0
         corepack enable
-        echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+        {
+          echo "paths<<EOF"
+          pnpm store path
+          pnpm cache path
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
 
-    - name: Restore pnpm store cache
+    - name: Restore pnpm caches
       id: restore
       uses: lynx-infra/cache/restore@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
       with:
-        path: ${{ steps.pnpm-store.outputs.path }}
-        key: pnpm-store-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        path: ${{ steps.pnpm-cache.outputs.paths }}
+        key: pnpm-cache-v2-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-pnpm-11-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
         restore-keys: |
-          pnpm-store-v1-${{ runner.os }}-
+          pnpm-cache-v2-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-pnpm-11-
 
     - name: Install
       shell: bash
       run: pnpm install --frozen-lockfile
 
-    - name: Save pnpm store cache
+    - name: Save pnpm caches
       if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       uses: lynx-infra/cache/save@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
       with:
-        path: ${{ steps.pnpm-store.outputs.path }}
-        key: pnpm-store-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        path: ${{ steps.pnpm-cache.outputs.paths }}
+        key: pnpm-cache-v2-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-pnpm-11-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}

--- a/.github/pnpm-11-ci.instructions.md
+++ b/.github/pnpm-11-ci.instructions.md
@@ -1,5 +1,11 @@
 ---
-applyTo: ".github/workflows/**/*.yml"
+applyTo: "{.github/actions/**/*.yml,.github/workflows/**/*.yml}"
 ---
 
 When a workflow needs pnpm 11, prefer installing and enabling Corepack after `actions/setup-node` rather than using `pnpm/action-setup@v4`; that action still executes on the GitHub Actions Node 20 runtime and cannot self-install pnpm 11, which requires Node >=22.13.
+
+Pin the Corepack version in CI instead of installing `corepack@latest`; upgrade it deliberately alongside the repository's package-manager pin.
+
+Cache both `pnpm store path` and `pnpm cache path`. Include OS, architecture, Node version, package-manager declaration, and lockfile content in the cache key so native packages and pnpm metadata are not shared across incompatible toolchains.
+
+Run `pnpm dedupe --check --lockfile-only` and `pnpm peers check --lockfile-only` together as lockfile quality gates; the checks should not depend on or modify `node_modules`.

--- a/.github/pnpm-11.instructions.md
+++ b/.github/pnpm-11.instructions.md
@@ -10,6 +10,12 @@ When enabling `strictPeerDependencies`, keep known compatibility exceptions in `
 
 When bumping the `packageManager` pnpm version in package.json files, keep the `+sha512.<hex>` suffix aligned with the npm package tarball integrity; convert the `npm view pnpm@<version> dist.integrity` base64 payload to hex for Corepack's strict package-manager pin.
 
+Do not use pnpm's deprecated `$` version references in overrides. Define the shared version in a catalog and reference it with `catalog:` or `catalog:<name>` from both dependency declarations and overrides.
+
+Do not add `ignorePatchFailures`; pnpm 11 removed the setting and always fails when a configured patch cannot be applied.
+
+Keep `minimumReleaseAgeStrict` enabled when the repository configures `minimumReleaseAge`. Use `minimumReleaseAgeIgnoreMissingTime` to handle registries that omit publish times; disabling strict mode instead permits packages younger than the configured age when no mature version matches.
+
 When adding Renovate npm minimum-release-age presets, mirror the delay in pnpm with `minimumReleaseAge` in `pnpm-workspace.yaml`; Renovate delegates lockfile maintenance to the package manager and does not enforce its own minimum release age for those updates.
 
 Do not add broad React or React DOM overrides in `pnpm-workspace.yaml`. Keep workspace React consumers on exact `react` and `react-dom` patch versions, and use scoped package metadata fixes when a tool package such as Rspress needs its internal React dependencies pinned to the same patch; Rspress SSG fails when pnpm resolves `react` and `react-dom` to different patch versions.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,7 +35,7 @@ jobs:
           cache-key: test-ubuntu-copilot-setup-steps
       - name: Install
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0
           corepack enable
           pnpm install --frozen-lockfile
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,16 @@ jobs:
         with:
           node-version: "24"
           package-manager-cache: false
-      - run: |
-          npm install -g corepack@latest
+      - name: Enable Corepack
+        run: | # zizmor: ignore[adhoc-packages] corepack must be installed globally outside of a lockfile
+          npm install -g corepack@0.35.0
           corepack enable
-          pnpm dedupe --check
+      - name: Lockfile Check
+        run: |
+          pnpm dedupe --check --lockfile-only
+          pnpm peers check --lockfile-only
+      - name: Sherif Check
+        run: |
           pnpm dlx sherif@latest -i tailwindcss
 
   lighthouse:

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "vitest": "^3.2.7",
     "yaml": "^2.9.0"
   },
-  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "engines": {
     "node": "^22.11 || ^24"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1395,10 +1395,10 @@ importers:
     devDependencies:
       '@emnapi/core':
         specifier: ^1.7.1
-        version: 1.11.2
+        version: 1.11.1
       '@emnapi/runtime':
         specifier: ^1.7.1
-        version: 1.11.2
+        version: 1.11.1
       '@napi-rs/cli':
         specifier: 2.18.4
         version: 2.18.4(patch_hash=ba947eb1c48b2a85834e99f92cbbae896722ce61fd5ae67507a3be9041959ebd)
@@ -2346,10 +2346,10 @@ importers:
     devDependencies:
       '@emnapi/core':
         specifier: ^1.7.1
-        version: 1.11.2
+        version: 1.11.1
       '@emnapi/runtime':
         specifier: ^1.7.1
-        version: 1.11.2
+        version: 1.11.1
       '@lynx-js/lynx-core':
         specifier: 0.1.4
         version: 0.1.4
@@ -2364,7 +2364,7 @@ importers:
         version: 2.1.10(core-js@3.50.0)
       '@rsdoctor/rspack-plugin':
         specifier: ~1.6.1
-        version: 1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -13224,21 +13224,21 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/core@1.11.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
+    optional: true
 
   '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
@@ -15491,6 +15491,30 @@ snapshots:
 
   '@rsdoctor/client@1.6.1': {}
 
+  '@rsdoctor/core@1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+    dependencies:
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.10(core-js@3.50.0))
+      '@rsdoctor/graph': 1.6.1(@rspack/core@2.1.7(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/sdk': 1.6.1(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.7(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.7(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      browserslist-load-config: 1.0.3
+      es-toolkit: 1.49.0
+      filesize: 11.0.22
+      fs-extra: 11.4.0
+      semver: 7.8.5
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rsbuild/core'
+      - '@rspack/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
   '@rsdoctor/core@1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.10(core-js@3.50.0))
@@ -15524,6 +15548,24 @@ snapshots:
       source-map: 0.7.6
     transitivePeerDependencies:
       - '@rspack/core'
+      - webpack
+
+  '@rsdoctor/rspack-plugin@1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+    dependencies:
+      '@rsdoctor/core': 1.6.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/graph': 1.6.1(@rspack/core@2.1.7(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/sdk': 1.6.1(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/types': 1.6.1(@rspack/core@2.1.7(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@rsdoctor/utils': 1.6.1(@rspack/core@2.1.7(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+    optionalDependencies:
+      '@rspack/core': 2.1.7(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rsbuild/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
       - webpack
 
   '@rsdoctor/rspack-plugin@1.6.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.10(core-js@3.50.0))(@rspack/core@2.1.7(@swc/helpers@0.5.23))(supports-color@10.2.2)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(cssnano@7.1.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
@@ -15690,6 +15732,14 @@ snapshots:
   '@rspack/resolver-binding-linux-x64-musl@0.2.8':
     optional: true
 
+  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
@@ -15706,6 +15756,22 @@ snapshots:
 
   '@rspack/resolver-binding-win32-x64-msvc@0.2.8':
     optional: true
+
+  '@rspack/resolver@0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    optionalDependencies:
+      '@rspack/resolver-binding-darwin-arm64': 0.2.8
+      '@rspack/resolver-binding-darwin-x64': 0.2.8
+      '@rspack/resolver-binding-linux-arm64-gnu': 0.2.8
+      '@rspack/resolver-binding-linux-arm64-musl': 0.2.8
+      '@rspack/resolver-binding-linux-x64-gnu': 0.2.8
+      '@rspack/resolver-binding-linux-x64-musl': 0.2.8
+      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@rspack/resolver-binding-win32-arm64-msvc': 0.2.8
+      '@rspack/resolver-binding-win32-ia32-msvc': 0.2.8
+      '@rspack/resolver-binding-win32-x64-msvc': 0.2.8
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   '@rspack/resolver@0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,11 +33,14 @@ packages:
 enablePrePostScripts: false
 engineStrict: true
 hoistWorkspacePackages: true
-ignorePatchFailures: false
 optimisticRepeatInstall: true
 publicHoistPattern: []
 resolutionMode: "lowest-direct"
 strictPeerDependencies: true
+
+# Treat workspace topology and filter mistakes as hard errors.
+disallowWorkspaceCycles: true
+failIfNoMatch: true
 
 # Match Renovate's npm minimum release age; pnpm also guards lockfile maintenance.
 minimumReleaseAge: 4320
@@ -53,17 +56,13 @@ minimumReleaseAgeExclude:
   - "@rsbuild/*"
   - "@rstest/*"
   - "@rstackjs/create-toolkit"
-  # Renovate security update: turbo@2.9.14
-  - turbo@2.9.14
-  # Renovate security update: dompurify@3.4.0
-  - dompurify@3.4.0
   # Changesets v3 packages were released as one coordinated set.
   - "@changesets/*"
-# npm's abbreviated metadata omits the `time` field, so a strict check hard-fails
-# (`ERR_PNPM_MISSING_TIME`) on packages it cannot date — e.g. during
-# `pnpm dedupe --check`. Run non-strict so the age check is enforced when `time`
-# is available and skipped (with a warning) when it is not.
-minimumReleaseAgeStrict: false
+minimumReleaseAgeExcludePrune: true
+# Some registry metadata omits the `time` field. Skip only those packages;
+# otherwise fail rather than falling back to a release younger than three days.
+minimumReleaseAgeIgnoreMissingTime: true
+minimumReleaseAgeStrict: true
 
 peerDependencyRules:
   allowedVersions:
@@ -149,10 +148,10 @@ overrides:
   # singletons, which breaks ReactLynx snapshot registration ("BackgroundSnapshot not
   # found"). Force every @lynx-js/react to the single workspace copy.
   "@lynx-js/react": "workspace:*"
-  "@rspack/core": "$@rspack/core"
-  "@rsbuild/core>@rspack/core": "$@rspack/core"
-  "@rsdoctor/rspack-plugin>@rspack/core": "$@rspack/core"
-  "@rsdoctor/types>@rspack/core": "$@rspack/core"
+  "@rspack/core": "catalog:rspack"
+  "@rsbuild/core>@rspack/core": "catalog:rspack"
+  "@rsdoctor/rspack-plugin>@rspack/core": "catalog:rspack"
+  "@rsdoctor/types>@rspack/core": "catalog:rspack"
 
 packageExtensions:
   # Typia's internal packages import TypeScript without declaring it. Keep


### PR DESCRIPTION
## Summary

- upgrade the repository package manager from pnpm 11.20.0 to 11.22.0 with a verified Corepack integrity hash
- harden workspace configuration with strict release-age enforcement, stale-exception pruning, catalog-based overrides, cycle detection, and unmatched-filter failures
- pin Corepack in CI, cache both pnpm's store and metadata cache, and add lockfile-only dedupe and peer dependency checks
- regenerate the lockfile with pnpm 11.22 and document the new maintenance rules

## Test plan

- `pnpm install --frozen-lockfile`
- `pnpm dedupe --check --lockfile-only`
- `pnpm peers check --lockfile-only`
- `pnpm dprint check`
- `pnpm biome check`
- `pnpm turbo build` (71/71 tasks successful)

## Checklist

- [x] Tests updated (not required; configuration-only change with existing checks extended).
- [x] Documentation updated.
- [x] Changeset added (not required; no publishable package API or behavior changed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the project to pnpm 11.22.0 with stricter workspace validation.
  * Improved dependency caching for faster, more consistent CI runs.
  * Added lockfile checks for duplicate dependencies and peer-dependency issues.
  * Pinned Corepack to a stable version across automated workflows.
* **Documentation**
  * Expanded pnpm 11 guidance, including catalog-based overrides and dependency age policies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->