### PR TITLE
build(web-core): make ./encode artifacts usable from both Node and the browser

### DIFF
--- a/.changeset/encode-bundler-target-universal.md
+++ b/.changeset/encode-bundler-target-universal.md
@@ -1,0 +1,22 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Build `binary/encode` with `wasm-bindgen --target bundler` and publish `@lynx-js/web-core/encode` as an rslib bundle, so one set of artifacts serves both Node and the browser.
+
+**Why**
+
+`binary/encode` used to be generated with `--target experimental-nodejs-module`, whose glue calls `readFileSync('node:fs')` at module scope. That made `@lynx-js/web-core/encode` importable from Node only. The `bundler` target instead emits an "async wasm module" glue (`import * as wasm from './encode_bg.wasm'`), which a bundler can resolve for either platform.
+
+**What changed in the published package**
+
+- `./encode` now resolves to `dist/encode_prod/index.js` (bundled by rslib, like `./server` already was) instead of the unbundled `dist/encode/index.js` emitted by `tsc`. The wasm is emitted as a build asset under `dist/encode_prod/static/wasm/`.
+- Bundling is what keeps the import clean: consuming the `bundler` glue directly from Node would work only on Node 22 or newer, and would print `ExperimentalWarning: Importing WebAssembly module instances` on every build. Letting rslib resolve the wasm at web-core build time avoids both.
+- `encode_bg.wasm` is byte-for-byte unchanged; only the JavaScript glue differs. The `binary/encode/*.d.ts` type declarations are identical under both targets.
+
+**Compatibility**
+
+- No API change. `encode()` and `encodeCSS(cssMap): Uint8Array` keep their synchronous signatures. The wasm initialization becomes a single module-level `await` inside the bundle, which is already accommodated by the `await import('@lynx-js/web-core/encode')` that consumers use. Encoded output is byte-identical to the previous release.
+- `@lynx-js/css-serializer` stays an external dependency of the bundle and is not inlined.
+- Note on Node versions: `@lynx-js/web-core/encode` does not work on Node 20 and did not work there before this change either. The `encode` wasm is optimized with `wasm-opt --all-features`, and Node 20's engine rejects it with `CompileError: Unknown heap type -14` regardless of which glue is used. This is a pre-existing limitation that this change neither introduces nor fixes; the effective floor for this entry point is Node 22.
+- The tarball grows by roughly the size of the encode wasm, because `binary/encode/encode_bg.wasm` is still shipped alongside the copy that rslib emits into `dist/encode_prod/`.

--- a/packages/web-platform/web-core/package.json
+++ b/packages/web-platform/web-core/package.json
@@ -13,8 +13,8 @@
   "exports": {
     "./encode": {
       "types": "./dist/encode/index.d.ts",
-      "import": "./dist/encode/index.js",
-      "default": "./dist/encode/index.js"
+      "import": "./dist/encode_prod/index.js",
+      "default": "./dist/encode_prod/index.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",

--- a/packages/web-platform/web-core/rslib.config.ts
+++ b/packages/web-platform/web-core/rslib.config.ts
@@ -6,21 +6,47 @@ export default defineConfig({
       format: 'esm',
       syntax: 'esnext',
       dts: false,
+      source: {
+        entry: {
+          index: './ts/server/index.ts',
+        },
+      },
+      output: {
+        externals: [
+          /\.wasm$/,
+          /binary\/server\/.*\.js$/,
+        ],
+        distPath: {
+          root: './dist/server_prod',
+        },
+      },
+    },
+    {
+      // `./encode` is bundled rather than published as-is so that the
+      // `--target bundler` wasm glue is resolved here, at web-core build time,
+      // instead of by the consumer's Node runtime. Importing `encode_bg.wasm`
+      // as an ES module works only on Node >= 22 and emits
+      // `ExperimentalWarning: Importing WebAssembly module instances` on every
+      // build; letting rslib emit the wasm as an asset avoids both.
+      // Note: `output.externals` is intentionally NOT inherited here -- the
+      // `/\.wasm$/` external used by the server entry would keep the glue's
+      // wasm import unresolved.
+      format: 'esm',
+      syntax: 'esnext',
+      dts: false,
+      source: {
+        entry: {
+          index: './ts/encode/index.ts',
+        },
+      },
+      output: {
+        distPath: {
+          root: './dist/encode_prod',
+        },
+      },
     },
   ],
-  source: {
-    entry: {
-      index: './ts/server/index.ts',
-    },
-  },
   output: {
     target: 'node',
-    externals: [
-      /\.wasm$/,
-      /binary\/server\/.*\.js$/,
-    ],
-    distPath: {
-      root: './dist/server_prod',
-    },
   },
 });

--- a/packages/web-platform/web-core/scripts/build.js
+++ b/packages/web-platform/web-core/scripts/build.js
@@ -30,7 +30,7 @@ function build(
   rustFlags,
   wasmBindgenArgs,
   optimizeArgs,
-  isNode = false,
+  wasmTarget = 'web',
   overrideOutDir = undefined,
 ) {
   const outDir = path.join(
@@ -53,9 +53,7 @@ function build(
     },
   );
   execSync(
-    `pnpm exec dotslash ./scripts/wasm-bindgen ${wasmBindgenArgs} --out-dir ${outDir} --target ${
-      isNode ? 'experimental-nodejs-module' : 'web'
-    } --out-name ${outputWasmName} ${cargoOutput}`,
+    `pnpm exec dotslash ./scripts/wasm-bindgen ${wasmBindgenArgs} --out-dir ${outDir} --target ${wasmTarget} --out-name ${outputWasmName} ${cargoOutput}`,
     { cwd: packageRoot, stdio: 'inherit' },
   );
   execSync(
@@ -73,9 +71,7 @@ function build(
     },
   );
   execSync(
-    `pnpm exec dotslash ./scripts/wasm-bindgen ${wasmBindgenArgs} --keep-debug --out-dir ${outDir} --target ${
-      isNode ? 'experimental-nodejs-module' : 'web'
-    } --out-name ${outputWasmDebugName} ${cargoOutputDebug}`,
+    `pnpm exec dotslash ./scripts/wasm-bindgen ${wasmBindgenArgs} --keep-debug --out-dir ${outDir} --target ${wasmTarget} --out-name ${outputWasmDebugName} ${cargoOutputDebug}`,
     { cwd: packageRoot, stdio: 'inherit' },
   );
 }
@@ -104,7 +100,7 @@ build(
   '-C opt-level=z -C target_feature=+bulk-memory -C strip=symbols',
   '',
   '-Oz --enable-nontrapping-float-to-int',
-  false,
+  'web',
   'client_legacy',
 );
 build(
@@ -112,6 +108,10 @@ build(
   '-C opt-level=3 -C target_feature=+bulk-memory,+sign-ext,+simd128,+reference-types,+nontrapping-fptoint,+mutable-globals',
   '',
   '-O4 --enable-bulk-memory-opt --enable-sign-ext --enable-simd --enable-reference-types --enable-nontrapping-float-to-int --enable-mutable-globals',
-  true,
+  'experimental-nodejs-module',
 );
-build('encode', '', '', '--all-features', true);
+// `bundler` emits an "async wasm module" glue (`import * as wasm from
+// './encode_bg.wasm'`). It is consumed by a bundler on both platforms: rslib
+// bundles it into `dist/encode_prod` for Node, and rspack/rsbuild handles it for
+// the browser. Keeping a single glue is what lets `./encode` serve both.
+build('encode', '', '', '--all-features', 'bundler');


### PR DESCRIPTION
## Why

`binary/encode` is generated with `wasm-bindgen --target experimental-nodejs-module`, whose glue reads the wasm via `readFileSync` from `node:fs` at module scope:

```js
import { readFileSync } from 'node:fs';
// ...
const wasmBytes = readFileSync(new URL('encode_bg.wasm', import.meta.url));
```

That pins `@lynx-js/web-core/encode` to Node. There is no way to reuse the encoder inside a browser bundle, even though the wasm itself is platform-neutral.

This PR makes one set of `encode` artifacts serve both platforms.

## What changed

Three files, web-core only:

| File | Change |
|---|---|
| `scripts/build.js` | `+10 / −8` — the `isNode` boolean becomes an explicit `wasmTarget` string; `encode` switches to `--target bundler` |
| `rslib.config.ts` | server-specific `output` moves into its own `lib[]` entry so a second entry can bundle `./encode` |
| `package.json` | `exports["./encode"]` → `dist/encode_prod/index.js` |

`--target bundler` emits an *async wasm module* glue (`import * as wasm from './encode_bg.wasm'`) that a bundler resolves on either platform. rslib then bundles `./encode` into `dist/encode_prod`, exactly the way `./server` already is.

**Bundling is the load-bearing half, not a nicety.** See the trade-off table below.

`output.externals` is deliberately *not* shared between the two rslib entries — the `/\.wasm$/` external the server entry relies on would leave the encode glue's wasm import unresolved.

## The two shapes considered

The maintainer asked to try the async-wasm-module route. It admits two shapes; measured, not assumed:

| | Diff | Node 22/24 | Browser |
|---|---|---|---|
| ① target switch only | `build.js` only, ~5 lines | works, but prints `ExperimentalWarning: Importing WebAssembly module instances` **on every build** | works |
| ② **this PR** (switch + rslib bundle) | 3 files | works, **no warning** | works |

Actual output, same payload, same machine:

```
(A) shape ① — unbundled dist/encode + bundler glue
  node 22.23.2: OK 207 bytes sha256=5410c8256e9aced6
                (node:…) ExperimentalWarning: Importing WebAssembly module instances is an
                experimental feature and might change at any time
  node 24.18.1: OK 207 bytes sha256=5410c8256e9aced6
                (node:…) ExperimentalWarning: Importing WebAssembly module instances is an
                experimental feature and might change at any time

(B) shape ② — this PR, rslib-bundled dist/encode_prod
  node 22.23.2: OK 207 bytes sha256=5410c8256e9aced6
  node 24.18.1: OK 207 bytes sha256=5410c8256e9aced6
```

Shape ① was rejected because that warning would surface in every ReactLynx web build.

A third option — a second, browser-only glue alongside the Node one — was dropped: it needs a `browser`-field remap of a relative path to reach `ts/encode/encodeCSS.ts`, which I could not confirm rspack honours.

## No API change

`encodeCSS(cssMap: Record<string, CSS.LynxStyleNode[]>): Uint8Array` and `encode()` keep their **synchronous** signatures; `ts/` is untouched (`git diff --stat -- ts/` is empty).

The wasm await is hoisted by the bundler into a single module-level `await` inside the bundle (one `await __webpack_require__(…)`), which is already absorbed by the `await import('@lynx-js/web-core/encode')` both consumers use today:

- `packages/webpack/template-webpack-plugin/src/WebEncodePlugin.ts:159`
- `packages/rspeedy/lynx-bundle-rslib-config/src/webpack/webEncode.ts:75`

A CJS `require()` consumer would break, but there is none.

## Verification

Byte-level invariants:

- `binary/encode/encode_bg.wasm` — **byte-identical** to `origin/main` (`sha256 18261ca4…`). Only the JS glue differs.
- tracked `binary/encode/*.d.ts` — **zero drift**; `encode.d.ts` and `encode_bg.wasm.d.ts` are identical under both targets.
- `dist/server_prod/index.js` — **byte-identical** (`sha256 d3e6c261…`), so splitting the rslib config did not perturb the server entry.
- Encoder output — **byte-identical across `origin/main`, this PR, and a real browser bundle**: `207 bytes / sha256 5410c8256e9aced6`. The browser figure comes from the real `ts/encode/index.ts` bundled by rsbuild for `target: web` and executed in headless Chromium.

Real consumers actually exercised (not just typechecked):

- `getWebEncodeMode()` driven end-to-end → `285 bytes sha256=0be11695a3213bcc`, magic header `SDRAWROF`; identical on `origin/main`.
- `@lynx-js/template-webpack-plugin` rstest **101/101**, including `test/cases/web/*`, which run real rspack compilations through `WebEncodePlugin`.

Suites and gates:

- web-core rstest **363/363** (unchanged from `origin/main` at `7b45cad5b`); template-webpack-plugin **101/101**
- `pnpm turbo build` **71/71** (14 cached / 71 → 57 executed, not a cache replay)
- `npx tsc6 --build --force` → **0 errors**; package-level `tsc --noEmit` → 0
- `dprint check`, `biome check packages/`, `sherif -i tailwindcss`, `meta-updater --test`, all four changeset scripts, `node --test .github/scripts/*.test.cjs` (15/15), `typos --hidden .changeset/` → all clean

Mutation probes (to show the suites really traverse the new path, rather than passing vacuously):

- `throw` appended to `binary/encode/encode_bg.js` (new bundler glue) → web-core 363 → **200 passed, 4 files failed**; restored → 363
- `throw` appended to `dist/encode_prod/index.js` (new bundled artifact) → template-webpack-plugin 101 → **97 passed, 4 failed**; restored → 101

Also run on **Node 22.23.2** (CI only provides Node 24): web-core 363/363, template-webpack-plugin 101/101.

## Node version boundary

`@lynx-js/web-core/encode` **does not work on Node 20, and did not before this change either.** The encode wasm is optimized with `wasm-opt --all-features`, and Node 20 rejects it independently of the glue:

```
node 20.20.2, origin/main (experimental-nodejs-module glue):
  CompileError: WebAssembly.Module(): Compiling function #132 failed: Unknown heap type -14
node 20.20.2, this PR:
  CompileError: … Unknown heap type -14   (same failure, same place)
```

This is a **pre-existing** limitation that this PR neither introduces nor fixes. The effective floor for this entry point is Node 22. Worth flagging separately: `@lynx-js/template-webpack-plugin` declares `engines.node: "^18.14 || >=19.4"` and `@lynx-js/lynx-bundle-rslib-config` declares `"^20.19.0 || >=22.12.0"`, both of which already overstate support for the web-encode path. CI runs Node 24 only (`.nvmrc` = `v24`), so CI cannot observe this either way.

## Cost, measured

`npm pack --dry-run` on this branch:

```
+ dist/encode_prod/index.js                            43,240 B
+ dist/encode_prod/static/wasm/951da2df4d.module.wasm  167,689 B
=> +210,929 B (+206.0 kB) unpacked
```

The wasm is now present twice: once in `binary/encode/` and once as the asset rslib emits. Note this already happens for the client entry on `main` (`binary/client/client_bg.wasm` and `dist/client_prod/static/wasm/a8ce68e7e9.module.wasm` are the same 227,536 bytes), so the pattern is pre-existing rather than new here.

If reviewers prefer to reclaim it, two follow-ups are available and both are one-liners — excluding `binary/encode/**` from `files`, and dropping the now-unreferenced `dist/encode/**` tsc output (8 files, 26,044 B). I left `files` untouched to keep this PR's diff minimal and avoid changing what deep-importers can reach in the same change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the `@lynx-js/web-core/encode` package to use a production-ready bundled build.
  - Improved WebAssembly packaging for reliable use across supported bundlers and runtime environments.
  - Existing synchronous `encode` and `encodeCSS` APIs remain unchanged.
  - Published package contents now include the required WebAssembly asset, increasing package size accordingly.
  - Node.js 22 or later is required; Node.js 20 remains unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Known red check: `codecov/patch`

`codecov/patch` reports `0.00% of diff hit`, attributed entirely to **10 lines in `packages/web-platform/web-core/scripts/build.js`**. Codecov's own comment says `All tests successful. No failed tests found.`

This is structural, not a gap in this PR's testing. `scripts/build.js` is the wasm build driver: it shells out to `cargo`, `wasm-bindgen` and `wasm-opt`, and only ever runs under `npm run build:wasm`. No unit test can execute it, and web-core's rstest coverage is scoped to `coverage.include: ['ts/**', 'src/**']`, so those lines can never be hit. Root `codecov.yml` ignores `**/rstest.config.ts` but has no entry for package build scripts.

The lines are nevertheless covered by *behavioural* evidence rather than line coverage: the target switch is what produces the `bundler` glue, and appending a `throw` to that glue turns 4 web-core test files red (363 → 200), while appending a `throw` to the resulting bundle turns 4 template-webpack-plugin tests red (101 → 97).

Silencing the check would mean editing root `codecov.yml`, which is outside `packages/web-platform/web-core`. I left it alone deliberately to keep this PR scoped to web-core — happy to add the ignore entry here, or in a separate PR, if maintainers prefer.
