### PR TITLE
fix(react): release worklet refs when list items are removed

### DIFF
--- a/.changeset/release-list-worklet-refs.md
+++ b/.changeset/release-list-worklet-refs.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Release worklet refs when list items are logically removed while preserving native element recycling.

--- a/packages/react/runtime/__test__/snapshot/list.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/list.test.jsx
@@ -4916,3 +4916,41 @@ describe('destroy list after element transfer', () => {
     expect(gRecycleMap[listID]).toBeUndefined();
   });
 });
+
+describe('list worklet ref lifecycle', () => {
+  it('unrefs worklet refs when a list child is logically removed', () => {
+    const listSnapshot = __SNAPSHOT__(<list>{HOLE}</list>);
+    const itemSnapshot = __SNAPSHOT__(<list-item />);
+    const list = new SnapshotInstance(listSnapshot);
+    const item = new SnapshotInstance(itemSnapshot);
+    const replacement = new SnapshotInstance(itemSnapshot);
+    const workletRef = { _wvid: 1 };
+    const updateWorkletRef = vi.fn();
+    const previousWorkletImpl = globalThis.lynxWorkletImpl;
+
+    globalThis.lynxWorkletImpl = {
+      ...previousWorkletImpl,
+      _refImpl: {
+        ...previousWorkletImpl?._refImpl,
+        updateWorkletRef,
+      },
+    };
+
+    try {
+      item.__worklet_ref_set = new Set([workletRef]);
+      __pendingListUpdates.runWithoutUpdates(() => {
+        list.insertBefore(item);
+        list.removeChild(item);
+      });
+
+      expect(updateWorkletRef).toHaveBeenCalledTimes(1);
+      expect(updateWorkletRef).toHaveBeenCalledWith(workletRef, null);
+
+      // A recycled native element may still be hydrated later.
+      hydrate(item, replacement);
+      expect(updateWorkletRef).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.lynxWorkletImpl = previousWorkletImpl;
+    }
+  });
+});

--- a/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
+++ b/packages/react/runtime/src/snapshot/snapshot/snapshot.ts
@@ -500,6 +500,9 @@ export class SnapshotInstance {
         )).onRemoveChild(child);
       }
 
+      // Native elements may be recycled later, but React-owned worklet refs end
+      // at the logical removal boundary.
+      unref(child, true);
       this.__removeChild(child);
       traverseSnapshotInstance(child, v => {
         clearTransientChildPropRefs(v, removedSnapshots);

--- a/packages/web-platform/web-core/tsconfig.json
+++ b/packages/web-platform/web-core/tsconfig.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "rootDir": "./ts",
     "outDir": "./dist",
-    "lib": ["DOM", "ESNext", "WebWorker"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext", "WebWorker"],
   },
   "include": ["ts"],
   "references": [


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed cleanup of worklet references when list items are logically removed.
  - Prevented stale references and duplicate cleanup when removed list items are replaced.
  - Preserved native element recycling during list updates.
  - Improved compatibility for iterable DOM APIs in web platform integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

List items keep their native elements alive for recycling after logical removal. However, the removed Snapshot subtree also retained its worklet refs until a later hydration pass. This allowed the background-side ref wrapper to be destroyed before the main thread sent the delayed removal.

Release worklet refs at the List logical-removal boundary while leaving native element recycling unchanged. Because unref clears the recorded ref set, a later recycle hydration remains idempotent.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; this is an internal lifecycle correction).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).