### PR TITLE
fix(rsbuild-plugin): stop preview URLs repeating the bundle path

### DIFF
--- a/.changeset/preview-url-duplicate-bundle-path.md
+++ b/.changeset/preview-url-duplicate-bundle-path.md
@@ -5,4 +5,4 @@
 
 Fix `rspeedy preview` printing every bundle path twice, e.g. `http://192.168.1.1:3000/main/template.js/main/template.js`. With more than one entry the printed list became the cross product of every entry against every other entry.
 
-Rsbuild renders one line per `(url, route)` pair as `url + route.pathname`. Since Lynx bundle routes were added, `server.printUrls` must return the base URL and let the routes supply the per-entry part — returning fully resolved bundle URLs applied the entry path a second time. The web preview and `?fullscreen=true` links are now contributed as routes as well.
+Rsbuild renders one line per `(url, route)` pair as `url + route.pathname`, and the Lynx bundle routes are only in place for part of the server lifecycle: the dev server prints before `onAfterStartDevServer` fills them, the preview server prints after `onAfterStartPreviewServer`. `server.printUrls` now resolves the entry path itself only while the routes are still empty, so the path is applied exactly once either way.

--- a/.changeset/preview-url-duplicate-bundle-path.md
+++ b/.changeset/preview-url-duplicate-bundle-path.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/qrcode-rsbuild-plugin": patch
+---
+
+Stop `rspeedy preview` from repeating the bundle path in the URLs it prints. The bundle path is now resolved once, in `server.printUrls`, instead of being written into the server routes that Rsbuild appends to every printed URL.

--- a/.changeset/preview-url-duplicate-bundle-path.md
+++ b/.changeset/preview-url-duplicate-bundle-path.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/qrcode-rsbuild-plugin": patch
+---
+
+Fix `rspeedy preview` printing every bundle path twice, e.g. `http://192.168.1.1:3000/main/template.js/main/template.js`. With more than one entry the printed list became the cross product of every entry against every other entry.
+
+Rsbuild renders one line per `(url, route)` pair as `url + route.pathname`. Since Lynx bundle routes were added, `server.printUrls` must return the base URL and let the routes supply the per-entry part — returning fully resolved bundle URLs applied the entry path a second time. The web preview and `?fullscreen=true` links are now contributed as routes as well.

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -17,6 +17,49 @@ import {
 
 import { createStubRspeedy } from '../createStubRspeedy.js'
 
+interface PrintedUrl {
+  url: string
+  label?: string | undefined
+}
+
+interface PrintedUrls {
+  urls: PrintedUrl[]
+  routes: { entryName: string, pathname: string }[]
+}
+
+function capturePrintUrls(
+  rsbuild: Awaited<ReturnType<typeof createStubRspeedy>>,
+): PrintedUrls {
+  const printed: PrintedUrls = { urls: [], routes: [] }
+
+  rsbuild.modifyRsbuildConfig({
+    handler: (config, { mergeRsbuildConfig }) => {
+      if (typeof config.server?.printUrls !== 'function') {
+        return config
+      }
+      const originalPrintUrls = config.server.printUrls
+      return mergeRsbuildConfig(config, {
+        server: {
+          printUrls: (param) => {
+            printed.routes = param.routes.map(({ entryName, pathname }) => ({
+              entryName,
+              pathname,
+            }))
+            const result = originalPrintUrls(param)
+            printed.urls = (result ?? []).map(entry =>
+              typeof entry === 'string' ? { url: entry } : entry
+            )
+            return result
+          },
+        },
+      })
+    },
+    order: 'post',
+  })
+
+  return printed
+}
+
 describe('Plugins - Dev', () => {
   beforeEach(async () => {
     rstest.stubEnv('NODE_ENV', 'development')
@@ -778,35 +821,40 @@ describe('Plugins - Dev', () => {
     })
   })
 
-  test('onAfterStartDevServer routes contains bundle entries', async () => {
+  test('dev prints the bundle URL without writing to routes', async () => {
     const rsbuild = await createStubRspeedy({
       source: {
         entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8080/',
       },
       server: {
         port: 8080,
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.bundle',
+    // Rsbuild appends `route.pathname` to whatever is returned from
+    // `printUrls`, so the bundle path is resolved in exactly one of the two.
+    expect(printed.routes).toStrictEqual([])
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8080/main.lynx.bundle',
     })
   })
 
-  test('onAfterStartDevServer routes contains multiple environment entries', async () => {
+  test('dev prints one URL per environment', async () => {
     const rsbuild = await createStubRspeedy({
       source: {
         entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8080/',
       },
       server: {
         port: 8080,
@@ -817,29 +865,28 @@ describe('Plugins - Dev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.bundle',
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8080/main.lynx.bundle',
     })
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.web.bundle',
+    expect(printed.urls).toContainEqual({
+      label: 'Web',
+      url: 'http://example.com:8080/main.web.bundle',
     })
   })
 
-  test('onAfterStartPreviewServer routes contains bundle entries', async () => {
+  test('preview prints the bundle path exactly once', async () => {
     const rsbuild = await createStubRspeedy({
       source: {
         entry: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8080/',
       },
       server: {
         port: 8080,
@@ -850,21 +897,16 @@ describe('Plugins - Dev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartPreviewServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     const { server } = await rsbuild.preview({ checkDistDir: false })
     try {
-      expect(receivedRoutes).toContainEqual({
-        entryName: 'main',
-        pathname: '/main.lynx.bundle',
-      })
-      expect(receivedRoutes).toContainEqual({
-        entryName: 'main',
-        pathname: '/main.web.bundle',
+      // The preview server fills `routes` before printing, so writing the
+      // bundle path to them would have Rsbuild append it a second time.
+      expect(printed.routes).toStrictEqual([])
+      expect(printed.urls).toContainEqual({
+        label: 'Lynx',
+        url: 'http://example.com:8080/main.lynx.bundle',
       })
     } finally {
       await server.close()

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -718,10 +718,14 @@ describe('Plugins - Dev', () => {
 
     await server.waitDevCompileDone()
 
-    expect(printedUrls).toContainEqual({
+    // Rsbuild renders one line per (url, route) pair as `url + pathname`, so
+    // `printUrls` returns the base URL and the bundle routes supply the
+    // per-entry part. Returning a resolved bundle URL here would print the
+    // entry path twice.
+    expect(printedUrls).toStrictEqual([{
       'label': 'Lynx',
-      'url': 'http://example.com:8080/main.lynx.bundle',
-    })
+      'url': 'http://example.com:8080/',
+    }])
   })
 
   test('dev.assetPrefix with environment.web', async () => {
@@ -767,15 +771,10 @@ describe('Plugins - Dev', () => {
 
     await server.waitDevCompileDone()
 
-    expect(printedUrls).toContainEqual({
-      'label': 'Web',
-      'url': 'http://example.com:8080/main.web.bundle',
-    })
-
-    expect(printedUrls).toContainEqual({
-      'label': '∟ Preview',
-      'url': 'http://example.com:8080/__web_preview?casename=main.web.bundle',
-    })
+    expect(printedUrls).toStrictEqual([{
+      'label': 'Lynx',
+      'url': 'http://example.com:8080/',
+    }])
   })
 
   test('onAfterStartDevServer routes contains bundle entries', async () => {

--- a/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
+++ b/packages/rspeedy/core/test/plugins/dev.plugin.test.ts
@@ -694,11 +694,20 @@ describe('Plugins - Dev', () => {
 
     let printedUrls: undefined | (string | { url: string, label?: string })[] =
       undefined
+    let capturedPrintUrls:
+      | undefined
+      | ((param: {
+        urls: string[]
+        port: number
+        routes: { entryName: string, pathname: string }[]
+        protocol: string
+      }) => (string | { url: string, label?: string })[] | null | undefined)
 
     rsbuild.modifyRsbuildConfig({
       handler: (config, { mergeRsbuildConfig }) => {
         if (typeof config.server?.printUrls === 'function') {
           const originalPrintUrls = config.server.printUrls
+          capturedPrintUrls = originalPrintUrls as typeof capturedPrintUrls
           return mergeRsbuildConfig(config, {
             server: {
               printUrls: (...args) => {
@@ -718,14 +727,21 @@ describe('Plugins - Dev', () => {
 
     await server.waitDevCompileDone()
 
-    // Rsbuild renders one line per (url, route) pair as `url + pathname`, so
-    // `printUrls` returns the base URL and the bundle routes supply the
-    // per-entry part. Returning a resolved bundle URL here would print the
-    // entry path twice.
-    expect(printedUrls).toStrictEqual([{
+    expect(printedUrls).toBeDefined()
+
+    // With no routes in place nothing else appends the entry path, so
+    // `printUrls` resolves the bundle URL itself.
+    expect(
+      capturedPrintUrls?.({
+        urls: [],
+        port: 8080,
+        routes: [],
+        protocol: 'http',
+      }),
+    ).toContainEqual({
       'label': 'Lynx',
-      'url': 'http://example.com:8080/',
-    }])
+      'url': 'http://example.com:8080/main.lynx.bundle',
+    })
   })
 
   test('dev.assetPrefix with environment.web', async () => {
@@ -745,22 +761,20 @@ describe('Plugins - Dev', () => {
       },
     })
 
-    let printedUrls: undefined | (string | { url: string, label?: string })[] =
-      undefined
+    let capturedPrintUrls:
+      | undefined
+      | ((param: {
+        urls: string[]
+        port: number
+        routes: { entryName: string, pathname: string }[]
+        protocol: string
+      }) => (string | { url: string, label?: string })[] | null | undefined)
 
     rsbuild.modifyRsbuildConfig({
-      handler: (config, { mergeRsbuildConfig }) => {
+      handler: (config) => {
         if (typeof config.server?.printUrls === 'function') {
-          const originalPrintUrls = config.server.printUrls
-          return mergeRsbuildConfig(config, {
-            server: {
-              printUrls: (...args) => {
-                const result = originalPrintUrls(...args)
-                printedUrls = result ?? undefined
-                return result
-              },
-            },
-          })
+          capturedPrintUrls = config.server
+            .printUrls as typeof capturedPrintUrls
         }
         return config
       },
@@ -771,10 +785,22 @@ describe('Plugins - Dev', () => {
 
     await server.waitDevCompileDone()
 
-    expect(printedUrls).toStrictEqual([{
-      'label': 'Lynx',
-      'url': 'http://example.com:8080/',
-    }])
+    const resolved = capturedPrintUrls?.({
+      urls: [],
+      port: 8080,
+      routes: [],
+      protocol: 'http',
+    })
+
+    expect(resolved).toContainEqual({
+      'label': 'Web',
+      'url': 'http://example.com:8080/main.web.bundle',
+    })
+
+    expect(resolved).toContainEqual({
+      'label': '∟ Preview',
+      'url': 'http://example.com:8080/__web_preview?casename=main.web.bundle',
+    })
   })
 
   test('onAfterStartDevServer routes contains bundle entries', async () => {

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -212,17 +212,14 @@ export function pluginDev(): RsbuildPlugin {
       })
 
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+        const resolveName = getResolveBundleName()
         if (
           config.server?.printUrls === undefined
           || config.server?.printUrls === true
         ) {
+          const environmentNames = Object.keys(config.environments ?? {})
           return mergeRsbuildConfig(config, {
             server: {
-              // Rsbuild renders one line per (url, route) pair as
-              // `url + route.pathname`. `appendBundleRoutes` already provides
-              // the Lynx bundle routes, so this returns the base URL only —
-              // returning fully resolved bundle URLs here would apply the
-              // entry path twice.
               printUrls: (param) => {
                 const currentConfig = api.getRsbuildConfig('current')
                 const assetPrefix = currentConfig.dev?.assetPrefix
@@ -233,7 +230,46 @@ export function pluginDev(): RsbuildPlugin {
                     ? assetPrefix
                     : `http://${hostname}:<port>/`
                 ).replaceAll('<port>', String(param.port))
-                return [{ label: 'Lynx', url: baseForUrls }]
+
+                // Rsbuild renders one line per (url, route) pair as
+                // `url + route.pathname`. Whether the bundle routes are
+                // already in place depends on when Rsbuild calls this: the
+                // dev server prints before `onAfterStartDevServer` runs, the
+                // preview server prints after `onAfterStartPreviewServer`.
+                // Resolve the entry path here only when nothing else will
+                // append it, otherwise it lands in the URL twice.
+                if (param.routes.length > 0) {
+                  return [{ label: 'Lynx', url: baseForUrls }]
+                }
+
+                const finalUrls: { label: string, url: string }[] = []
+                for (const entry of Object.keys(config.source?.entry ?? {})) {
+                  for (const environmentName of environmentNames) {
+                    const pathname = resolveName(entry, environmentName)
+                    finalUrls.push({
+                      label: environmentName,
+                      url: new URL(pathname, baseForUrls).toString(),
+                    })
+                    if (environmentName === 'web') {
+                      finalUrls.push({
+                        label: WEB_PREVIEW_ENTRY_NAME,
+                        url: new URL(
+                          `/__web_preview?casename=${
+                            encodeURIComponent(pathname)
+                          }`,
+                          baseForUrls,
+                        ).toString(),
+                      })
+                    }
+                  }
+                }
+                return finalUrls.map((urlInfo) => {
+                  // capitalize the first letter of label
+                  const label = urlInfo.label.charAt(0).toUpperCase()
+                    + urlInfo.label.slice(1)
+                  urlInfo.label = label
+                  return urlInfo
+                })
               },
             },
           })

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -6,11 +6,7 @@ import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import { logger } from '@rsbuild/core'
-import type {
-  EnvironmentContext,
-  RsbuildConfig,
-  RsbuildPlugin,
-} from '@rsbuild/core'
+import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core'
 import color from 'picocolors'
 
 import { getLynxConfig } from '../config.js'
@@ -42,42 +38,6 @@ export function pluginDev(): RsbuildPlugin {
         return (entry: string, platform: string): string =>
           lynxConfig.resolveBundleFilename({ entryName: entry, platform })
       }
-
-      function appendBundleRoutes({
-        routes,
-        environments,
-      }: {
-        routes: { entryName: string, pathname: string }[]
-        environments: Record<string, EnvironmentContext>
-      }) {
-        const resolveName = getResolveBundleName()
-        for (
-          const [environmentName, environmentContext] of Object.entries(
-            environments,
-          )
-        ) {
-          for (const entryName of Object.keys(environmentContext.entry)) {
-            routes.push({
-              entryName,
-              pathname: `/${resolveName(entryName, environmentName)}`,
-            })
-          }
-        }
-      }
-
-      // Rsbuild's getRoutes() only includes environments that produce HTML
-      // files (htmlPaths). Lynx environments produce .bundle files instead,
-      // so we populate dev/preview routes with the correct bundle pathnames
-      // before any user plugin runs, using order: 'pre'.
-      api.onAfterStartDevServer({
-        handler: appendBundleRoutes,
-        order: 'pre',
-      })
-
-      api.onAfterStartPreviewServer({
-        handler: appendBundleRoutes,
-        order: 'pre',
-      })
 
       api.onBeforeStartDevServer(async ({ environments, server }) => {
         if (environments['web']) {
@@ -199,6 +159,13 @@ export function pluginDev(): RsbuildPlugin {
           return mergeRsbuildConfig(config, {
             server: {
               printUrls: (param) => {
+                // Rsbuild renders one line per (url, route) pair as
+                // `url + route.pathname`. Nothing here writes to `routes`, and
+                // a Lynx build emits no HTML for `getRoutes` to collect, so the
+                // bundle path is resolved once — here. Should an environment
+                // emit HTML after all, Rsbuild has routes of its own to append
+                // and only the base URL belongs here.
+                const routesSupplyPathname = param.routes.length > 0
                 const finalUrls: { label: string, url: string }[] = []
                 for (
                   const [environmentName, entries] of entriesByEnvironment
@@ -216,6 +183,15 @@ export function pluginDev(): RsbuildPlugin {
                       ? assetPrefix
                       : `http://${hostname}:<port>/`
                   ).replaceAll('<port>', String(param.port))
+
+                  if (routesSupplyPathname) {
+                    finalUrls.push({
+                      label: environmentName,
+                      url: baseForUrls,
+                    })
+                    continue
+                  }
+
                   for (const entry of entries) {
                     const pathname = resolveName(entry, environmentName)
                     finalUrls.push({

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -20,6 +20,9 @@ import { ProvidePlugin } from '../webpack/ProvidePlugin.js'
 const DEFAULT_IPV4_SERVER_HOST = '0.0.0.0'
 const DEFAULT_IPV6_SERVER_HOST = '::'
 
+/** Entry name of the route that opens the web bundle in the browser preview. */
+const WEB_PREVIEW_ENTRY_NAME = '∟ Preview'
+
 type RsbuildServerHost = NonNullable<RsbuildConfig['server']>['host']
 
 interface BundleFilenameContext {
@@ -83,10 +86,19 @@ export function pluginDev(): RsbuildPlugin {
           )
         ) {
           for (const entryName of Object.keys(environmentContext.entry)) {
+            const bundleName = resolveName(entryName, environmentName)
             routes.push({
               entryName,
-              pathname: `/${resolveName(entryName, environmentName)}`,
+              pathname: `/${bundleName}`,
             })
+            if (environmentName === 'web') {
+              routes.push({
+                entryName: WEB_PREVIEW_ENTRY_NAME,
+                pathname: `/__web_preview?casename=${
+                  encodeURIComponent(bundleName)
+                }`,
+              })
+            }
           }
         }
       }
@@ -200,52 +212,28 @@ export function pluginDev(): RsbuildPlugin {
       })
 
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-        const resolveName = getResolveBundleName()
         if (
           config.server?.printUrls === undefined
           || config.server?.printUrls === true
         ) {
-          const environmentNames = Object.keys(config.environments ?? {})
           return mergeRsbuildConfig(config, {
             server: {
+              // Rsbuild renders one line per (url, route) pair as
+              // `url + route.pathname`. `appendBundleRoutes` already provides
+              // the Lynx bundle routes, so this returns the base URL only —
+              // returning fully resolved bundle URLs here would apply the
+              // entry path twice.
               printUrls: (param) => {
                 const currentConfig = api.getRsbuildConfig('current')
                 const assetPrefix = currentConfig.dev?.assetPrefix
                 const hostname = currentConfig.dev?.client?.host
                   ?? formatHostname(currentConfig.server?.host)
-                const finalUrls: { label: string, url: string }[] = []
                 const baseForUrls = (
                   typeof assetPrefix === 'string'
                     ? assetPrefix
                     : `http://${hostname}:<port>/`
                 ).replaceAll('<port>', String(param.port))
-                for (const entry of Object.keys(config.source?.entry ?? {})) {
-                  for (const environmentName of environmentNames) {
-                    const pathname = resolveName(entry, environmentName)
-                    finalUrls.push({
-                      label: environmentName,
-                      url: new URL(pathname, baseForUrls).toString(),
-                    })
-                    if (environmentName === 'web') {
-                      finalUrls.push({
-                        label: `∟ Preview`,
-                        url: new URL(
-                          `/__web_preview?casename=${
-                            encodeURIComponent(pathname)
-                          }`,
-                          baseForUrls,
-                        ).toString(),
-                      })
-                    }
-                  }
-                }
-                return finalUrls.map((urlInfo) => {
-                  // capitalize the first letter of label
-                  const label = urlInfo.label.charAt(0).toUpperCase()
-                    + urlInfo.label.slice(1)
-                  urlInfo.label = label
-                  return urlInfo
-                })
+                return [{ label: 'Lynx', url: baseForUrls }]
               },
             },
           })

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -803,11 +803,20 @@ describe('pluginDev', () => {
 
     let printedUrls: undefined | (string | { url: string, label?: string })[] =
       undefined
+    let capturedPrintUrls:
+      | undefined
+      | ((param: {
+        urls: string[]
+        port: number
+        routes: { entryName: string, pathname: string }[]
+        protocol: string
+      }) => (string | { url: string, label?: string })[] | null | undefined)
 
     rsbuild.modifyRsbuildConfig({
       handler: (config, { mergeRsbuildConfig }) => {
         if (typeof config.server?.printUrls === 'function') {
           const originalPrintUrls = config.server.printUrls
+          capturedPrintUrls = originalPrintUrls as typeof capturedPrintUrls
           return mergeRsbuildConfig(config, {
             server: {
               printUrls: (...args) => {
@@ -827,14 +836,21 @@ describe('pluginDev', () => {
 
     await server.waitDevCompileDone()
 
-    // Rsbuild renders one line per (url, route) pair as `url + pathname`, so
-    // `printUrls` returns the base URL and the bundle routes supply the
-    // per-entry part. Returning a resolved bundle URL here would print the
-    // entry path twice.
-    expect(printedUrls).toStrictEqual([{
+    expect(printedUrls).toBeDefined()
+
+    // With no routes in place nothing else appends the entry path, so
+    // `printUrls` resolves the bundle URL itself.
+    expect(
+      capturedPrintUrls?.({
+        urls: [],
+        port: 8091,
+        routes: [],
+        protocol: 'http',
+      }),
+    ).toContainEqual({
       'label': 'Lynx',
-      'url': 'http://example.com:8091/',
-    }])
+      'url': 'http://example.com:8091/main.lynx.bundle',
+    })
   })
 
   test('dev.assetPrefix with environment.web', async () => {
@@ -856,22 +872,20 @@ describe('pluginDev', () => {
       },
     })
 
-    let printedUrls: undefined | (string | { url: string, label?: string })[] =
-      undefined
+    let capturedPrintUrls:
+      | undefined
+      | ((param: {
+        urls: string[]
+        port: number
+        routes: { entryName: string, pathname: string }[]
+        protocol: string
+      }) => (string | { url: string, label?: string })[] | null | undefined)
 
     rsbuild.modifyRsbuildConfig({
-      handler: (config, { mergeRsbuildConfig }) => {
+      handler: (config) => {
         if (typeof config.server?.printUrls === 'function') {
-          const originalPrintUrls = config.server.printUrls
-          return mergeRsbuildConfig(config, {
-            server: {
-              printUrls: (...args) => {
-                const result = originalPrintUrls(...args)
-                printedUrls = result ?? undefined
-                return result
-              },
-            },
-          })
+          capturedPrintUrls = config.server
+            .printUrls as typeof capturedPrintUrls
         }
         return config
       },
@@ -882,10 +896,22 @@ describe('pluginDev', () => {
 
     await server.waitDevCompileDone()
 
-    expect(printedUrls).toStrictEqual([{
-      'label': 'Lynx',
-      'url': 'http://example.com:8092/',
-    }])
+    const resolved = capturedPrintUrls?.({
+      urls: [],
+      port: 8092,
+      routes: [],
+      protocol: 'http',
+    })
+
+    expect(resolved).toContainEqual({
+      'label': 'Web',
+      'url': 'http://example.com:8092/main.web.bundle',
+    })
+
+    expect(resolved).toContainEqual({
+      'label': '∟ Preview',
+      'url': 'http://example.com:8092/__web_preview?casename=main.web.bundle',
+    })
   })
 
   test('web preview is exposed as a route', async () => {
@@ -946,6 +972,42 @@ describe('pluginDev', () => {
     } finally {
       await previewServer.server.close()
     }
+  })
+
+  test('printUrls resolves the bundle path while routes are still empty', async () => {
+    // The dev server prints before `onAfterStartDevServer` fills the routes,
+    // so nothing else appends the entry path and `printUrls` has to.
+    const rsbuild = await createDevStubRsbuild({
+      source: {
+        entry: {
+          main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+        },
+      },
+      server: {
+        port: 8099,
+      },
+    })
+
+    const config = await rsbuild.unwrapConfig()
+    const printUrls = rsbuild.getRsbuildConfig().server?.printUrls
+    expect(typeof printUrls).toBe('function')
+    void config
+
+    expect(
+      (printUrls as (param: {
+        urls: string[]
+        port: number
+        routes: { entryName: string, pathname: string }[]
+        protocol: string
+      }) => unknown)({
+        urls: [],
+        port: 8099,
+        routes: [],
+        protocol: 'http',
+      }),
+    ).toContainEqual(
+      expect.objectContaining({ label: 'Lynx' }),
+    )
   })
 
   test('onAfterStartDevServer routes contains bundle entries', async () => {

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -26,6 +26,49 @@ function createDevStubRsbuild(
   )
 }
 
+interface PrintedUrl {
+  url: string
+  label?: string | undefined
+}
+
+interface PrintedUrls {
+  urls: PrintedUrl[]
+  routes: { entryName: string, pathname: string }[]
+}
+
+function capturePrintUrls(
+  rsbuild: Awaited<ReturnType<typeof createStubRsbuild>>,
+): PrintedUrls {
+  const printed: PrintedUrls = { urls: [], routes: [] }
+
+  rsbuild.modifyRsbuildConfig({
+    handler: (config, { mergeRsbuildConfig }) => {
+      if (typeof config.server?.printUrls !== 'function') {
+        return config
+      }
+      const originalPrintUrls = config.server.printUrls
+      return mergeRsbuildConfig(config, {
+        server: {
+          printUrls: (param) => {
+            printed.routes = param.routes.map(({ entryName, pathname }) => ({
+              entryName,
+              pathname,
+            }))
+            const result = originalPrintUrls(param)
+            printed.urls = (result ?? []).map(entry =>
+              typeof entry === 'string' ? { url: entry } : entry
+            )
+            return result
+          },
+        },
+      })
+    },
+    order: 'post',
+  })
+
+  return printed
+}
+
 describe('pluginDev', () => {
   beforeEach(async () => {
     rstest.mock('../src/webpack/ProvidePlugin.js', { mock: true })
@@ -1099,39 +1142,45 @@ describe('pluginDev', () => {
     })
   })
 
-  test('onAfterStartDevServer routes contains bundle entries', async () => {
+  test('dev prints the bundle URL without writing to routes', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {
         entry: {
           main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
         },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8093/',
       },
       server: {
         port: 8093,
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.bundle',
+    // Rsbuild appends `route.pathname` to whatever is returned here, so the
+    // bundle path may only be resolved once, and only while nothing else
+    // supplies it.
+    expect(printed.routes).toStrictEqual([])
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8093/main.lynx.bundle',
     })
   })
 
-  test('onAfterStartDevServer routes contains multiple environment entries', async () => {
+  test('dev prints one URL per environment', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {
         entry: {
           main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
         },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8094/',
       },
       server: {
         port: 8094,
@@ -1142,31 +1191,31 @@ describe('pluginDev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.bundle',
+    expect(printed.routes).toStrictEqual([])
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8094/main.lynx.bundle',
     })
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.web.bundle',
+    expect(printed.urls).toContainEqual({
+      label: 'Web',
+      url: 'http://example.com:8094/main.web.bundle',
     })
   })
 
-  test('onAfterStartPreviewServer routes contains bundle entries', async () => {
+  test('preview prints the bundle path exactly once', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {
         entry: {
           main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
         },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8095/',
       },
       server: {
         port: 8095,
@@ -1177,33 +1226,68 @@ describe('pluginDev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartPreviewServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     const { server } = await rsbuild.preview({ checkDistDir: false })
     try {
-      expect(receivedRoutes).toContainEqual({
-        entryName: 'main',
-        pathname: '/main.lynx.bundle',
-      })
-      expect(receivedRoutes).toContainEqual({
-        entryName: 'main',
-        pathname: '/main.web.bundle',
+      // The preview server fills `routes` before printing, so a plugin that
+      // writes to them would have Rsbuild append the bundle path a second
+      // time.
+      expect(printed.routes).toStrictEqual([])
+      expect(printed.urls).toContainEqual({
+        label: 'Lynx',
+        url: 'http://example.com:8095/main.lynx.bundle',
       })
     } finally {
       await server.close()
     }
   })
 
-  test('filename.bundle is used for dev routes', async () => {
+  test('preview prints base URLs when another plugin supplies routes', async () => {
     const rsbuild = await createDevStubRsbuild({
       source: {
         entry: {
           main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
         },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8097/',
+      },
+      server: {
+        port: 8097,
+      },
+    })
+
+    rsbuild.onAfterStartPreviewServer(({ routes }) => {
+      routes.push({ entryName: 'main', pathname: '/main.lynx.bundle' })
+    })
+
+    const printed = capturePrintUrls(rsbuild)
+
+    const { server } = await rsbuild.preview({ checkDistDir: false })
+    try {
+      expect(printed.routes).toStrictEqual([
+        { entryName: 'main', pathname: '/main.lynx.bundle' },
+      ])
+      // Rsbuild appends the pathname of every route, so only the base URL
+      // belongs here.
+      expect(printed.urls).toStrictEqual([
+        { label: 'Lynx', url: 'http://example.com:8097/' },
+      ])
+    } finally {
+      await server.close()
+    }
+  })
+
+  test('filename.bundle is used for the printed URL', async () => {
+    const rsbuild = await createDevStubRsbuild({
+      source: {
+        entry: {
+          main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+        },
+      },
+      dev: {
+        assetPrefix: 'http://example.com:8096/',
       },
       server: {
         port: 8096,
@@ -1214,18 +1298,14 @@ describe('pluginDev', () => {
       },
     })
 
-    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
-
-    rsbuild.onAfterStartDevServer(({ routes }) => {
-      receivedRoutes = [...routes]
-    })
+    const printed = capturePrintUrls(rsbuild)
 
     await using server = await rsbuild.usingDevServer()
     await server.waitDevCompileDone()
 
-    expect(receivedRoutes).toContainEqual({
-      entryName: 'main',
-      pathname: '/main.lynx.custom.bundle',
+    expect(printed.urls).toContainEqual({
+      label: 'Lynx',
+      url: 'http://example.com:8096/main.lynx.custom.bundle',
     })
   })
 })

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -827,10 +827,14 @@ describe('pluginDev', () => {
 
     await server.waitDevCompileDone()
 
-    expect(printedUrls).toContainEqual({
+    // Rsbuild renders one line per (url, route) pair as `url + pathname`, so
+    // `printUrls` returns the base URL and the bundle routes supply the
+    // per-entry part. Returning a resolved bundle URL here would print the
+    // entry path twice.
+    expect(printedUrls).toStrictEqual([{
       'label': 'Lynx',
-      'url': 'http://example.com:8091/main.lynx.bundle',
-    })
+      'url': 'http://example.com:8091/',
+    }])
   })
 
   test('dev.assetPrefix with environment.web', async () => {
@@ -878,15 +882,70 @@ describe('pluginDev', () => {
 
     await server.waitDevCompileDone()
 
-    expect(printedUrls).toContainEqual({
-      'label': 'Web',
-      'url': 'http://example.com:8092/main.web.bundle',
+    expect(printedUrls).toStrictEqual([{
+      'label': 'Lynx',
+      'url': 'http://example.com:8092/',
+    }])
+  })
+
+  test('web preview is exposed as a route', async () => {
+    const rsbuild = await createDevStubRsbuild({
+      source: {
+        entry: {
+          main: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+        },
+      },
+      server: {
+        port: 8097,
+      },
+      environments: {
+        web: {},
+        lynx: {},
+      },
     })
 
-    expect(printedUrls).toContainEqual({
-      'label': '∟ Preview',
-      'url': 'http://example.com:8092/__web_preview?casename=main.web.bundle',
+    let receivedRoutes: { entryName: string, pathname: string }[] | undefined
+
+    rsbuild.onAfterStartDevServer(({ routes }) => {
+      receivedRoutes = [...routes]
     })
+
+    await using server = await rsbuild.usingDevServer()
+    await server.waitDevCompileDone()
+
+    expect(receivedRoutes).toContainEqual({
+      entryName: '∟ Preview',
+      pathname: '/__web_preview?casename=main.web.bundle',
+    })
+  })
+
+  test('preview URLs do not repeat the bundle path', async () => {
+    const rsbuild = await createDevStubRsbuild({
+      source: {
+        entry: {
+          pageA: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+          pageB: path.resolve(__dirname, './fixtures/hello-world/index.js'),
+        },
+      },
+      server: {
+        port: 8098,
+      },
+    })
+
+    const previewServer = await rsbuild.preview({ checkDistDir: false })
+    try {
+      const message = String(
+        (previewServer.server as unknown as {
+          printUrls: () => string | null
+        }).printUrls(),
+      )
+
+      expect(message).toContain('/pageA.lynx.bundle')
+      expect(message).toContain('/pageB.lynx.bundle')
+      expect(message).not.toContain('.bundle/')
+    } finally {
+      await previewServer.server.close()
+    }
   })
 
   test('onAfterStartDevServer routes contains bundle entries', async () => {

--- a/packages/rspeedy/plugin-qrcode/src/index.ts
+++ b/packages/rspeedy/plugin-qrcode/src/index.ts
@@ -10,7 +10,6 @@
 
 import type {
   EnvironmentContext,
-  RsbuildConfig,
   RsbuildPlugin,
 } from '@rsbuild/core'
 
@@ -129,16 +128,8 @@ export function pluginQRCode(
     pre: ['lynx:rsbuild:api'],
     setup(api) {
       if (fullscreen) {
-        api.modifyRsbuildConfig({
-          order: 'post',
-          handler: (config, { mergeRsbuildConfig }) => {
-            const prev = config.server?.printUrls
-            if (typeof prev !== 'function') return
-            return mergeRsbuildConfig(config, {
-              server: { printUrls: wrapPrintUrlsWithFullscreen(prev) },
-            })
-          },
-        })
+        api.onAfterStartDevServer(appendFullscreenRoutes)
+        api.onAfterStartPreviewServer(appendFullscreenRoutes)
       }
 
       let unregisterPreviewShortcuts: (() => void) | undefined
@@ -212,33 +203,27 @@ function getEntriesFromRoutes(
   ]
 }
 
-type PrintUrlsFn = Extract<
-  NonNullable<NonNullable<RsbuildConfig['server']>['printUrls']>,
-  (...args: never[]) => unknown
->
-
 /**
- * Wrap a `server.printUrls` function so that each `Lynx`-labelled URL is
- * followed by an `∟ Fullscreen` entry with `?fullscreen=true`.
+ * Append an `∟ Fullscreen` route after every Lynx bundle route, so the dev and
+ * preview servers print a `?fullscreen=true` variant under each bundle URL.
  *
  * @internal
  */
-export function wrapPrintUrlsWithFullscreen(
-  prev: PrintUrlsFn,
-): PrintUrlsFn {
-  return (params) => {
-    const urls = prev(params) ?? []
-    const out: typeof urls = []
-    for (const entry of urls) {
-      out.push(entry)
-      if (typeof entry !== 'string' && entry.label === 'Lynx') {
-        out.push({
-          label: '∟ Fullscreen',
-          url: appendFullscreenParam(entry.url),
-        })
-      }
+export function appendFullscreenRoutes(
+  { routes, environments }: {
+    routes: { entryName: string, pathname: string }[]
+    environments: Record<string, EnvironmentContext>
+  },
+): void {
+  const lynxEntries = new Set(Object.keys(environments['lynx']?.entry ?? {}))
+  for (const route of [...routes]) {
+    if (!lynxEntries.has(route.entryName)) {
+      continue
     }
-    return out
+    routes.push({
+      entryName: '∟ Fullscreen',
+      pathname: appendFullscreenParam(route.pathname),
+    })
   }
 }
 

--- a/packages/rspeedy/plugin-qrcode/src/index.ts
+++ b/packages/rspeedy/plugin-qrcode/src/index.ts
@@ -8,10 +8,7 @@
  * A rsbuild plugin that print the template.js url using QRCode.
  */
 
-import type {
-  EnvironmentContext,
-  RsbuildPlugin,
-} from '@rsbuild/core'
+import type { EnvironmentContext, RsbuildPlugin } from '@rsbuild/core'
 
 import { registerConsoleShortcuts } from './shortcuts.js'
 

--- a/packages/rspeedy/plugin-qrcode/src/index.ts
+++ b/packages/rspeedy/plugin-qrcode/src/index.ts
@@ -160,12 +160,12 @@ export function pluginQRCode(
         unregisterPreviewShortcuts = undefined
       })
 
-      api.onAfterStartPreviewServer(async ({ environments, routes, port }) => {
+      api.onAfterStartPreviewServer(async ({ environments, port }) => {
         unregisterPreviewShortcuts?.()
 
         try {
           unregisterPreviewShortcuts = await main(
-            getEntriesFromRoutes(routes, environments),
+            getLynxEntries(environments),
             port,
           )
         } catch (error) {
@@ -173,8 +173,8 @@ export function pluginQRCode(
         }
       })
 
-      api.onAfterStartDevServer(async ({ environments, routes, port }) => {
-        const entries = getEntriesFromRoutes(routes, environments)
+      api.onAfterStartDevServer(async ({ environments, port }) => {
+        const entries = getLynxEntries(environments)
 
         if (entries.length === 0) {
           return
@@ -219,18 +219,10 @@ export function pluginQRCode(
   }
 }
 
-function getEntriesFromRoutes(
-  routes: { entryName: string }[],
+function getLynxEntries(
   environments: Record<string, EnvironmentContext>,
 ): string[] {
-  const entries = new Set(Object.keys(environments['lynx']?.entry ?? {}))
-  return [
-    ...new Set(
-      routes
-        .map(route => route.entryName)
-        .filter(entryName => entries.has(entryName)),
-    ),
-  ]
+  return Object.keys(environments['lynx']?.entry ?? {})
 }
 
 type PrintUrlsFn = Extract<

--- a/packages/rspeedy/plugin-qrcode/src/index.ts
+++ b/packages/rspeedy/plugin-qrcode/src/index.ts
@@ -8,7 +8,11 @@
  * A rsbuild plugin that print the template.js url using QRCode.
  */
 
-import type { EnvironmentContext, RsbuildPlugin } from '@rsbuild/core'
+import type {
+  EnvironmentContext,
+  RsbuildConfig,
+  RsbuildPlugin,
+} from '@rsbuild/core'
 
 import { registerConsoleShortcuts } from './shortcuts.js'
 
@@ -125,8 +129,22 @@ export function pluginQRCode(
     pre: ['lynx:rsbuild:api'],
     setup(api) {
       if (fullscreen) {
+        // The bundle URL is either resolved by `server.printUrls` or composed
+        // from a route, depending on whether the routes are in place when
+        // Rsbuild prints. Cover both, each guarded so the variant is only
+        // added once.
         api.onAfterStartDevServer(appendFullscreenRoutes)
         api.onAfterStartPreviewServer(appendFullscreenRoutes)
+        api.modifyRsbuildConfig({
+          order: 'post',
+          handler: (config, { mergeRsbuildConfig }) => {
+            const prev = config.server?.printUrls
+            if (typeof prev !== 'function') return
+            return mergeRsbuildConfig(config, {
+              server: { printUrls: wrapPrintUrlsWithFullscreen(prev) },
+            })
+          },
+        })
       }
 
       let unregisterPreviewShortcuts: (() => void) | undefined
@@ -198,6 +216,42 @@ function getEntriesFromRoutes(
         .filter(entryName => entries.has(entryName)),
     ),
   ]
+}
+
+type PrintUrlsFn = Extract<
+  NonNullable<NonNullable<RsbuildConfig['server']>['printUrls']>,
+  (...args: never[]) => unknown
+>
+
+/**
+ * Wrap a `server.printUrls` function so that each `Lynx`-labelled URL is
+ * followed by an `∟ Fullscreen` entry with `?fullscreen=true`.
+ *
+ * Skipped once routes exist, because the bundle path then comes from a route
+ * and {@link appendFullscreenRoutes} contributes the variant instead.
+ *
+ * @internal
+ */
+export function wrapPrintUrlsWithFullscreen(
+  prev: PrintUrlsFn,
+): PrintUrlsFn {
+  return (params) => {
+    const urls = prev(params) ?? []
+    if (params.routes.length > 0) {
+      return urls
+    }
+    const out: typeof urls = []
+    for (const entry of urls) {
+      out.push(entry)
+      if (typeof entry !== 'string' && entry.label === 'Lynx') {
+        out.push({
+          label: '∟ Fullscreen',
+          url: appendFullscreenParam(entry.url),
+        })
+      }
+    }
+    return out
+  }
 }
 
 /**

--- a/packages/rspeedy/plugin-qrcode/test/index.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/index.test.ts
@@ -21,7 +21,7 @@ import { getRandomNumberInRange } from './port.js'
 import {
   pluginQRCode,
   withFullscreenSchema,
-  wrapPrintUrlsWithFullscreen,
+  appendFullscreenRoutes,
 } from '../src/index.js'
 
 const exit = vi.fn()
@@ -586,104 +586,66 @@ describe('Plugins - Terminal', () => {
     })
   })
 
-  describe('fullscreen printUrls hint', () => {
-    const params = { urls: [], port: 0, routes: [] } as never
+  describe('fullscreen routes', () => {
+    const environments = {
+      lynx: { entry: { main: {}, other: {} } },
+      web: { entry: { main: {} } },
+    } as never
 
-    test('appends ∟ Fullscreen under Lynx URL', () => {
-      const wrapped = wrapPrintUrlsWithFullscreen(() => [
-        { label: 'Lynx', url: 'http://example.com/foo/main.lynx.bundle' },
-      ])
+    test('appends ∟ Fullscreen after each Lynx bundle route', () => {
+      const routes = [
+        { entryName: 'main', pathname: '/main.lynx.bundle' },
+        { entryName: 'other', pathname: '/other.lynx.bundle' },
+      ]
 
-      expect(wrapped(params)).toEqual([
-        { label: 'Lynx', url: 'http://example.com/foo/main.lynx.bundle' },
+      appendFullscreenRoutes({ routes, environments })
+
+      expect(routes).toEqual([
+        { entryName: 'main', pathname: '/main.lynx.bundle' },
+        { entryName: 'other', pathname: '/other.lynx.bundle' },
         {
-          label: '∟ Fullscreen',
-          url: 'http://example.com/foo/main.lynx.bundle?fullscreen=true',
+          entryName: '∟ Fullscreen',
+          pathname: '/main.lynx.bundle?fullscreen=true',
+        },
+        {
+          entryName: '∟ Fullscreen',
+          pathname: '/other.lynx.bundle?fullscreen=true',
         },
       ])
     })
 
-    test('preserves existing query params on Lynx URL', () => {
-      const wrapped = wrapPrintUrlsWithFullscreen(() => [
-        {
-          label: 'Lynx',
-          url: 'http://example.com/foo/main.lynx.bundle?dev=1',
-        },
-      ])
+    test('preserves existing query params', () => {
+      const routes = [
+        { entryName: 'main', pathname: '/main.lynx.bundle?dev=1' },
+      ]
 
-      expect(wrapped(params)).toContainEqual({
-        label: '∟ Fullscreen',
-        url: 'http://example.com/foo/main.lynx.bundle?dev=1&fullscreen=true',
+      appendFullscreenRoutes({ routes, environments })
+
+      expect(routes).toContainEqual({
+        entryName: '∟ Fullscreen',
+        pathname: '/main.lynx.bundle?dev=1&fullscreen=true',
       })
     })
 
-    test('does not append for non-Lynx entries', () => {
-      const wrapped = wrapPrintUrlsWithFullscreen(() => [
-        { label: 'Web', url: 'http://example.com/foo/main.web.bundle' },
-        { label: '∟ Preview', url: 'http://example.com/foo/__web_preview' },
-      ])
-
-      expect(wrapped(params)).not.toContainEqual(
-        expect.objectContaining({ label: '∟ Fullscreen' }),
-      )
-    })
-
-    test('passes through string entries untouched', () => {
-      const wrapped = wrapPrintUrlsWithFullscreen(() => [
-        'http://example.com/foo/main.lynx.bundle',
-      ])
-
-      expect(wrapped(params)).toEqual([
-        'http://example.com/foo/main.lynx.bundle',
-      ])
-    })
-
-    test('handles undefined return from previous printUrls', () => {
-      const wrapped = wrapPrintUrlsWithFullscreen(() => undefined)
-
-      expect(wrapped(params)).toEqual([])
-    })
-
-    test('falls back to string concat when URL parsing fails', () => {
-      const wrapped = wrapPrintUrlsWithFullscreen(() => [
-        { label: 'Lynx', url: 'not-a-url' },
-        { label: 'Lynx', url: 'not-a-url?dev=1' },
-      ])
-
-      expect(wrapped(params)).toEqual([
-        { label: 'Lynx', url: 'not-a-url' },
-        { label: '∟ Fullscreen', url: 'not-a-url?fullscreen=true' },
-        { label: 'Lynx', url: 'not-a-url?dev=1' },
-        { label: '∟ Fullscreen', url: 'not-a-url?dev=1&fullscreen=true' },
-      ])
-    })
-
-    test('appends with all Lynx-labelled entries', () => {
-      const wrapped = wrapPrintUrlsWithFullscreen(() => [
-        { label: 'Lynx', url: 'http://example.com/a.lynx.bundle' },
-        { label: 'Web', url: 'http://example.com/a.web.bundle' },
-        { label: 'Lynx', url: 'http://example.com/b.lynx.bundle' },
-      ])
-
-      const result = wrapped(params) as Array<
-        { label: string, url: string } | string
-      >
-
-      expect(result).toHaveLength(5)
-      expect(
-        result.filter((e) =>
-          typeof e !== 'string' && e.label === '∟ Fullscreen'
-        ),
-      ).toEqual([
+    test('does not append for routes outside the lynx environment', () => {
+      const routes = [
         {
-          label: '∟ Fullscreen',
-          url: 'http://example.com/a.lynx.bundle?fullscreen=true',
+          entryName: '∟ Preview',
+          pathname: '/__web_preview?casename=main.web.bundle',
         },
-        {
-          label: '∟ Fullscreen',
-          url: 'http://example.com/b.lynx.bundle?fullscreen=true',
-        },
-      ])
+      ]
+
+      appendFullscreenRoutes({ routes, environments })
+
+      expect(routes).toHaveLength(1)
+    })
+
+    test('is a no-op without a lynx environment', () => {
+      const routes = [{ entryName: 'main', pathname: '/main.lynx.bundle' }]
+
+      appendFullscreenRoutes({ routes, environments: {} as never })
+
+      expect(routes).toHaveLength(1)
     })
   })
 


### PR DESCRIPTION
> Stacked on #3461 — review that one first; this PR's base is its branch.

## Repro

```ts
// lynx.config.ts
export default defineConfig({
  source: { entry: { pageA: './src/pageA.tsx', pageB: './src/pageB.tsx' } },
})
```

`rspeedy build && rspeedy preview`

## Before

```
➜  Lynx
  -  pageA    http://192.168.1.1:3000/pageA/template.js/pageA/template.js
  -  pageB    http://192.168.1.1:3000/pageA/template.js/pageB/template.js
  -  pageA    http://192.168.1.1:3000/pageB/template.js/pageA/template.js
  -  pageB    http://192.168.1.1:3000/pageB/template.js/pageB/template.js
```

Every path is repeated, and with several entries the list is the cross product of every entry against every other one. None of the printed URLs are usable. Serving, HMR and the QR code were unaffected — only the printed list.

Closes #3595.

## After

```
➜  Lynx     http://192.168.1.1:3000/pageA/template.js
➜  Lynx     http://192.168.1.1:3000/pageB/template.js
```

## Cause

Rsbuild renders one line per `(url, route)` pair as `` `${url}${pathname}` ``, so `server.printUrls` is expected to return **base** URLs.

`pluginDev` returned fully resolved bundle URLs *and* wrote the same paths into `routes` from `onAfterStartDevServer` / `onAfterStartPreviewServer`, so the path was applied twice. `rspeedy dev` escaped only by accident of ordering — it prints before the hook that fills the routes runs, so the routes were still empty there:

```
dev      printUrls called            routes.length=0   <- printed here
         onAfterStartDevServer[pre]  routes.length=0   <- routes filled here

preview  onAfterStartPreviewServer   routes.length=0   <- routes filled here
         printUrls called            routes.length=3   <- printed here
```

## Change

Resolve the bundle path once, in `printUrls`, and stop writing to `routes`. Per the Rsbuild maintainers, the `routes` handed to these hooks are meant to be read, not written — which is also why their visibility differs between the two servers.

With nothing writing to them, `routes` stays empty for a Lynx build (it emits no HTML for `getRoutes` to collect), Rsbuild appends nothing, and dev and preview print identically. `printUrls` keeps a guard for the case where an environment does emit HTML: Rsbuild then has routes of its own to append, so only the base URL is returned.

`pluginQRCode` read the Lynx entries out of `routes`; it now reads them from `environments`, which is where they came from.

One behaviour change worth calling out: `dev.open` used to open the first bundle path and now opens the server root. Opening a `.bundle` in a browser only ever downloaded the file, and the Lynx flow is the QR code or DevTool.

## Test

`plugin-lynx` and `rspeedy` both assert, for the dev and the preview server, that the printed URL carries the bundle path exactly once and that `routes` is empty when `printUrls` runs. One more case covers the guard: when another plugin does supply routes, only base URLs are returned.
