### PR TITLE
fix(react): report multiple authored ET pages

### DIFF
--- a/packages/react/runtime/__test__/element-template/fixtures/page-compiled/authored-page/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/page-compiled/authored-page/index.tsx
@@ -2,6 +2,7 @@ interface AppProps {
   onTap?: () => void;
   pageId?: string;
   pageKey?: string;
+  pageKeys?: string[];
   pageRef?: unknown;
   refMode?: 'direct' | 'spread';
   withPage?: boolean;
@@ -11,6 +12,7 @@ export function App({
   onTap,
   pageId = 'screen',
   pageKey = 'page',
+  pageKeys,
   pageRef,
   refMode = 'spread',
   withPage = true,
@@ -25,6 +27,17 @@ export function App({
       <view id='without-page'>
         <text>without page</text>
       </view>
+    );
+  }
+  if (pageKeys) {
+    return (
+      <>
+        {pageKeys.map(pageKey => (
+          <page key={pageKey}>
+            <view id={`${pageKey}-child`} />
+          </page>
+        ))}
+      </>
     );
   }
   const pageProps = {

--- a/packages/react/runtime/__test__/element-template/runtime/page/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/page/compiled-fixtures.test.tsx
@@ -50,6 +50,7 @@ interface AuthoredPageProps {
   onTap?: () => void;
   pageId?: string;
   pageKey?: string;
+  pageKeys?: string[];
   pageRef?: unknown;
   refMode?: 'direct' | 'spread';
   withPage?: boolean;
@@ -76,6 +77,14 @@ describe('Compiled authored ET page fixtures', () => {
     }
   }
 
+  function waitForPassiveEffects(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        setTimeout(resolve);
+      });
+    });
+  }
+
   async function renderHydratedPair(
     backgroundProps: AuthoredPageProps,
     mainThreadProps: AuthoredPageProps = backgroundProps,
@@ -86,11 +95,7 @@ describe('Compiled authored ET page fixtures', () => {
     expect(isElementTemplateHydrated()).toBe(true);
     envManager.switchToMainThread();
     envManager.switchToBackground();
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => {
-        setTimeout(resolve);
-      });
-    });
+    await waitForPassiveEffects();
     return modules.backgroundModule;
   }
 
@@ -124,6 +129,71 @@ describe('Compiled authored ET page fixtures', () => {
 
     expect(vnode.key).toBe('stable-page');
     expect(vnode.props).not.toHaveProperty('key');
+  });
+
+  it('reports multiple authored pages mounted concurrently on background', async () => {
+    const { backgroundModule } = await loadCompiledFixturePair<CompiledAuthoredPageModule>(AUTHORED_PAGE_FIXTURE);
+    const originalReportError = lynx.reportError;
+    const reportError = vi.fn();
+    lynx.reportError = reportError;
+
+    try {
+      renderOnBackground(backgroundModule, { pageKeys: ['first-page', 'second-page'], withPage: true });
+      await waitForPassiveEffects();
+
+      expect(reportError).toHaveBeenCalledTimes(1);
+      expect(reportError).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Attempt to render more than one `<page />`, which is not supported.',
+      }));
+    } finally {
+      lynx.reportError = originalReportError;
+    }
+  });
+
+  it('keeps tracking a duplicate after the first authored page unmounts', async () => {
+    const { backgroundModule } = await loadCompiledFixturePair<CompiledAuthoredPageModule>(AUTHORED_PAGE_FIXTURE);
+    const originalReportError = lynx.reportError;
+    const reportError = vi.fn();
+    lynx.reportError = reportError;
+
+    try {
+      renderOnBackground(backgroundModule, { pageKeys: ['first-page', 'second-page'], withPage: true });
+      await waitForPassiveEffects();
+      expect(reportError).toHaveBeenCalledTimes(1);
+      reportError.mockClear();
+
+      renderOnBackground(backgroundModule, { pageKeys: ['second-page'], withPage: true });
+      await waitForPassiveEffects();
+      renderOnBackground(backgroundModule, { pageKeys: ['second-page', 'third-page'], withPage: true });
+      await waitForPassiveEffects();
+
+      expect(reportError).toHaveBeenCalledTimes(1);
+      expect(reportError).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Attempt to render more than one `<page />`, which is not supported.',
+      }));
+    } finally {
+      lynx.reportError = originalReportError;
+    }
+  });
+
+  it('does not report a keyed authored page replacement as multiple pages', async () => {
+    const { backgroundModule } = await loadCompiledFixturePair<CompiledAuthoredPageModule>(AUTHORED_PAGE_FIXTURE);
+    const originalReportError = lynx.reportError;
+    const reportError = vi.fn();
+    lynx.reportError = reportError;
+
+    try {
+      renderOnBackground(backgroundModule, { pageKey: 'first-page', withPage: true });
+      await waitForPassiveEffects();
+      reportError.mockClear();
+
+      renderOnBackground(backgroundModule, { pageKey: 'replacement-page', withPage: true });
+      await waitForPassiveEffects();
+
+      expect(reportError).not.toHaveBeenCalled();
+    } finally {
+      lynx.reportError = originalReportError;
+    }
   });
 
   it('reconciles background page attrs when main-thread first screen differs', async () => {

--- a/packages/react/runtime/src/element-template/runtime/page/authored-page.ts
+++ b/packages/react/runtime/src/element-template/runtime/page/authored-page.ts
@@ -11,6 +11,8 @@ import { __root } from './root-instance.js';
 
 export type AuthoredPageAttributes = Record<string, unknown> | null;
 
+const mountedAuthoredPageLifetimes = new Set<object>();
+
 export interface ElementTemplatePageProps {
   $0?: ComponentChild;
   attributes?: AuthoredPageAttributes;
@@ -30,7 +32,21 @@ export const __ElementTemplatePage: FunctionalComponent<ElementTemplatePageProps
 
   if (__BACKGROUND__) {
     root.setAuthoredPageAttributes(lifetime.current, props.attributes ?? null);
-    useLayoutEffect(() => () => root.clearAuthoredPageAttributes(lifetime.current), []);
+    useLayoutEffect(() => {
+      if (__DEV__) {
+        if (mountedAuthoredPageLifetimes.size > 0) {
+          lynx.reportError(new Error('Attempt to render more than one `<page />`, which is not supported.'));
+        }
+        mountedAuthoredPageLifetimes.add(lifetime.current);
+      }
+
+      return () => {
+        if (__DEV__) {
+          mountedAuthoredPageLifetimes.delete(lifetime.current);
+        }
+        root.clearAuthoredPageAttributes(lifetime.current);
+      };
+    }, []);
   }
 
   return props.$0;


### PR DESCRIPTION
Report a Snapshot-compatible development error when more than one authored ET `<page />` is mounted concurrently on the background thread. The check runs in the helper passive effect, so a keyed replacement cleans up the old Page before the new Page is counted and does not require page-root or protocol state.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authored page lifecycle handling during rendering.
  * Added clear development-time feedback when multiple authored pages are displayed concurrently.
  * Ensured keyed page replacement works correctly without triggering duplicate-page warnings.
  * Improved cleanup of page state when pages are removed or replaced.

* **Tests**
  * Added coverage for multiple-page rendering, concurrent page detection, duplicate tracking after unmount, and keyed page replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->