### PR TITLE
refactor: move the debug metadata plugin into @lynx-js/rsbuild-plugin

### DIFF
--- a/.changeset/engine-debug-metadata.md
+++ b/.changeset/engine-debug-metadata.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Move the debug metadata plugin from `@lynx-js/rspeedy` into `pluginLynx`.

--- a/packages/rspeedy/core/package.json
+++ b/packages/rspeedy/core/package.json
@@ -53,7 +53,6 @@
     "test:type": "tsc6 --noEmit"
   },
   "dependencies": {
-    "@lynx-js/debug-metadata-rsbuild-plugin": "workspace:^",
     "@lynx-js/rsbuild-plugin": "workspace:*",
     "@rsbuild/core": "catalog:rsbuild",
     "@rsdoctor/rspack-plugin": "~1.6.1"

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -30,10 +30,6 @@ export async function applyDefaultPlugins(
   const defaultPlugins = Object.freeze<Promise<RsbuildPlugin>[]>([
     import('./api.plugin.js').then(({ pluginAPI }) => pluginAPI(config)),
 
-    import('@lynx-js/debug-metadata-rsbuild-plugin').then(
-      ({ pluginLynxDebugMetadata }) => pluginLynxDebugMetadata(),
-    ),
-
     import('./rsdoctor.plugin.js').then(({ pluginRsdoctor }) =>
       pluginRsdoctor(config.tools?.rsdoctor)
     ),

--- a/packages/rspeedy/plugin-lynx/package.json
+++ b/packages/rspeedy/plugin-lynx/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@lynx-js/cache-events-webpack-plugin": "workspace:^",
     "@lynx-js/chunk-loading-webpack-plugin": "workspace:^",
+    "@lynx-js/debug-metadata-rsbuild-plugin": "workspace:^",
     "@lynx-js/web-rsbuild-server-middleware": "workspace:*",
     "@lynx-js/webpack-dev-transport": "workspace:^",
     "@lynx-js/websocket": "workspace:^",

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 import type { RsbuildPlugin } from '@rsbuild/core'
 
+import { pluginLynxDebugMetadata } from '@lynx-js/debug-metadata-rsbuild-plugin'
+
 import { pluginChunkLoading } from './plugins/chunkLoading.plugin.js'
 import { pluginCssMinimizer } from './plugins/cssMinimizer.plugin.js'
 import { pluginDev } from './plugins/dev.plugin.js'
@@ -37,6 +39,7 @@ export function pluginLynx(): RsbuildPlugin[] {
     pluginChunkLoading(),
     pluginCssMinimizer(),
     pluginDev(),
+    pluginLynxDebugMetadata(),
     pluginMinify(),
     pluginOptimization(),
     pluginOutput(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1538,9 +1538,6 @@ importers:
 
   packages/rspeedy/core:
     dependencies:
-      '@lynx-js/debug-metadata-rsbuild-plugin':
-        specifier: workspace:^
-        version: link:../plugin-debug-metadata
       '@lynx-js/rsbuild-plugin':
         specifier: workspace:*
         version: link:../plugin-lynx
@@ -1763,6 +1760,9 @@ importers:
       '@lynx-js/chunk-loading-webpack-plugin':
         specifier: workspace:^
         version: link:../../webpack/chunk-loading-webpack-plugin
+      '@lynx-js/debug-metadata-rsbuild-plugin':
+        specifier: workspace:^
+        version: link:../plugin-debug-metadata
       '@lynx-js/web-rsbuild-server-middleware':
         specifier: workspace:*
         version: link:../../web-platform/web-rsbuild-server-middleware


### PR DESCRIPTION
Part of the series that moves the Lynx build engine out of `@lynx-js/rspeedy` and into `pluginLynx`.

`pluginLynxDebugMetadata` was the last engine plugin still applied from Rspeedy's own default plugin list. Applying it from `pluginLynx` gives an Rsbuild build the same debug metadata as an Rspeedy build.

Stacked on #3578.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Debug metadata support is now included through the Lynx plugin.
  - Existing Rspeedy configurations continue to receive debug metadata without requiring separate setup.

- **Chores**
  - Updated package release metadata to reflect the change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->