### PR TITLE
test: cover Rsbuild and Rspeedy bundle parity

### DIFF
--- a/.changeset/rsbuild-rspeedy-parity.md
+++ b/.changeset/rsbuild-rspeedy-parity.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+---
+
+Cover that an Rsbuild build and an Rspeedy build produce the same bundle.

--- a/.changeset/rsbuild-rspeedy-parity.md
+++ b/.changeset/rsbuild-rspeedy-parity.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/react-rsbuild-plugin": patch
----
-
-Cover that an Rsbuild build and an Rspeedy build produce the same bundle.

--- a/packages/rspeedy/plugin-react/test/parity.test.ts
+++ b/packages/rspeedy/plugin-react/test/parity.test.ts
@@ -1,0 +1,57 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { execFileSync } from 'node:child_process'
+import { readFileSync, rmSync } from 'node:fs'
+import path from 'node:path'
+
+import { afterAll, describe, expect, test } from '@rstest/core'
+
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+const cwd = import.meta.dirname
+const roots: string[] = []
+
+// Each build runs in its own process: a second build in the same process
+// produces a different chunk content hash, so builds sharing a process cannot
+// be compared.
+function build(tool: 'rspeedy' | 'rsbuild', mode: string): Buffer {
+  const root = `dist-parity-${mode}-${tool}`
+  roots.push(root)
+  execFileSync(
+    process.execPath,
+    [path.join(cwd, 'parity', 'build.mjs'), tool, mode, root],
+    { cwd, stdio: 'ignore' },
+  )
+  return readFileSync(path.join(cwd, root, 'main.lynx.bundle'))
+}
+
+// Identifiers minted per build rather than derived from the source: the
+// development timestamp and hot-update hashes, and the debug metadata release,
+// which is keyed on `chunk.hash`.
+const stripPerBuildIds = (bundle: Buffer) =>
+  bundle
+    .toString('latin1')
+    .replaceAll(/\/\/ \d{10,}/g, '// <timestamp>')
+    .replaceAll(/__webpack_require__\.h = \(\) => \("[0-9a-f]+"\)/g, '<hmr>')
+    .replaceAll(/debugmetadata:[0-9a-f]+/g, 'debugmetadata:<release>')
+    .replaceAll(/\.hot-update\.js [0-9a-f]+/g, '.hot-update.js <hash>')
+
+afterAll(() => {
+  for (const root of roots) {
+    rmSync(path.join(cwd, root), { recursive: true, force: true })
+  }
+})
+
+describe('Rspeedy and Rsbuild parity', () => {
+  test('production bundles match apart from per-build identifiers', () => {
+    expect(stripPerBuildIds(build('rsbuild', 'production'))).toBe(
+      stripPerBuildIds(build('rspeedy', 'production')),
+    )
+  })
+
+  test('development bundles match apart from per-build identifiers', () => {
+    expect(stripPerBuildIds(build('rsbuild', 'development'))).toBe(
+      stripPerBuildIds(build('rspeedy', 'development')),
+    )
+  })
+})

--- a/packages/rspeedy/plugin-react/test/parity/build.mjs
+++ b/packages/rspeedy/plugin-react/test/parity/build.mjs
@@ -16,11 +16,7 @@ const config = {
   mode,
   environments: { lynx: {} },
   source: { entry: { main: './fixtures/basic.tsx' } },
-  // `chunk.hash` is not reproducible across builds, and both the content hash
-  // in a filename and the debug metadata release are keyed on it. The filename
-  // hash is turned off and the release is stripped before comparing; minifying
-  // is turned off as well, because a release that differs by one string still
-  // permutes every mangled name.
+  // TODO: restore the defaults once swc-project/swc#12129 lands.
   output: { distPath: { root }, filenameHash: false, minify: false },
   plugins: [pluginReactLynx()],
 }

--- a/packages/rspeedy/plugin-react/test/parity/build.mjs
+++ b/packages/rspeedy/plugin-react/test/parity/build.mjs
@@ -27,8 +27,10 @@ const config = {
 
 if (tool === 'rspeedy') {
   const rspeedy = await createRspeedy({ cwd, rspeedyConfig: config })
-  await rspeedy.build()
+  const { close } = await rspeedy.build()
+  await close()
 } else {
   const rsbuild = await createRsbuild({ cwd, rsbuildConfig: config })
-  await rsbuild.build()
+  const { close } = await rsbuild.build()
+  await close()
 }

--- a/packages/rspeedy/plugin-react/test/parity/build.mjs
+++ b/packages/rspeedy/plugin-react/test/parity/build.mjs
@@ -1,0 +1,34 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createRsbuild } from '@rsbuild/core'
+
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
+import { createRspeedy } from '@lynx-js/rspeedy'
+
+const [tool, mode, root] = process.argv.slice(2)
+const cwd = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const config = {
+  mode,
+  environments: { lynx: {} },
+  source: { entry: { main: './fixtures/basic.tsx' } },
+  // `chunk.hash` is not reproducible across builds, and both the content hash
+  // in a filename and the debug metadata release are keyed on it. The filename
+  // hash is turned off and the release is stripped before comparing; minifying
+  // is turned off as well, because a release that differs by one string still
+  // permutes every mangled name.
+  output: { distPath: { root }, filenameHash: false, minify: false },
+  plugins: [pluginReactLynx()],
+}
+
+if (tool === 'rspeedy') {
+  const rspeedy = await createRspeedy({ cwd, rspeedyConfig: config })
+  await rspeedy.build()
+} else {
+  const rsbuild = await createRsbuild({ cwd, rsbuildConfig: config })
+  await rsbuild.build()
+}


### PR DESCRIPTION
Part of the series that moves the Lynx build engine out of `@lynx-js/rspeedy` and into `pluginLynx`.

The point of the series is that an Rsbuild build with only `pluginReactLynx()` produces the same bundle as an Rspeedy build. This locks that in: the same fixture is built both ways, each in its own process, in production and in development, and the two bundles are compared.

The comparison ignores identifiers minted per build rather than derived from the source. `chunk.hash` is not reproducible across builds, and both the content hash in a filename and the debug metadata release are keyed on it, so the filename hash is turned off and the release is stripped.

That reproducibility problem is not ours: swc's `inline_globals` keeps the span of the value it substitutes for a define, and those values come from a process-wide cache, so their spans belong to a `SourceMap` from an earlier call. The module's source map therefore moves between builds, which moves `build_info.hash`, `chunk.hash` and the content hash. Fix proposed upstream in swc-project/swc#12129; with it, 40 Rspeedy builds of the same source produce one bundle instead of ten. Once that lands the two allowances in this test can go away.

Stacked on #3596.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that development and production bundles generated by Rsbuild and Rspeedy remain equivalent.
  * Normalized build-specific metadata during comparisons for reliable results.
  * Isolated builds and cleaned up temporary output after testing.

* **Chores**
  * Added a parity build utility using consistent React, environment, output, and deterministic build settings.
  * Documented the parity coverage in the upcoming patch release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->