### PR TITLE
fix(react/transform): stop sharing parsed `defineDCE` values across transforms

### DIFF
--- a/.changeset/stable-define-source-maps.md
+++ b/.changeset/stable-define-source-maps.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Build the `defineDCE` value map without swc's process-wide cache, so the source map of a module no longer depends on which module was transformed before it. It made production builds non-reproducible: the source map is part of the module hash in Rspack, so an unchanged source could produce a different chunk hash, and with minification on, different mangled names.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,6 @@ dependencies = [
  "convert_case 0.11.0",
  "getrandom 0.4.3",
  "hex",
- "indexmap",
  "napi",
  "napi-build",
  "napi-derive",

--- a/packages/react/transform/Cargo.toml
+++ b/packages/react/transform/Cargo.toml
@@ -10,14 +10,13 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 convert_case = { workspace = true }
 hex = { workspace = true }
-indexmap = { workspace = true }
 napi = { workspace = true, features = ["serde-json"] }
 napi-derive = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 sha-1 = { workspace = true }
-swc_core = { workspace = true, features = ["base", "ecma_codegen", "ecma_parser", "ecma_transforms_typescript", "ecma_quote", "ecma_transforms_react", "ecma_transforms_optimization", "ecma_visit", "testing_transform"] }
+swc_core = { workspace = true, features = ["base", "ecma_codegen", "ecma_parser", "ecma_transforms_typescript", "ecma_quote", "ecma_transforms_react", "ecma_transforms_optimization", "ecma_utils", "ecma_visit", "testing_transform"] }
 swc_plugin_compat = { path = "./crates/swc_plugin_compat", features = ["napi"] }
 swc_plugin_css_scope = { path = "./crates/swc_plugin_css_scope", features = ["napi"] }
 swc_plugin_define_dce = { path = "./crates/swc_plugin_define_dce", features = ["napi"] }

--- a/packages/react/transform/__test__/sourcemap.spec.js
+++ b/packages/react/transform/__test__/sourcemap.spec.js
@@ -1,0 +1,51 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, it } from 'vitest';
+
+import { transformReactLynxSync } from '../main.js';
+
+// Values of `defineDCE.define` are parsed once per distinct define set and
+// then memoized for the rest of the process, so this name is not shared with
+// any other test: another test using it would warm the cache up first.
+const DEFINE = '__SOURCEMAP_STABILITY__';
+
+function options() {
+  return {
+    mode: 'test',
+    pluginName: '',
+    filename: 'test.jsx',
+    sourceFileName: 'test.jsx',
+    sourcemap: true,
+    cssScope: false,
+    shake: false,
+    compat: false,
+    refresh: false,
+    directiveDCE: false,
+    snapshot: false,
+    defineDCE: {
+      define: {
+        [DEFINE]: 'true',
+      },
+    },
+    worklet: {
+      target: 'JS',
+      filename: 'test.jsx',
+      runtimePkg: '@lynx-js/react/internal',
+    },
+    isModule: 'unknown',
+  };
+}
+
+const source = `export const flag = ${DEFINE}\nconsole.log(flag)\n`;
+
+describe('source map', () => {
+  it('does not change when the same input is transformed twice', () => {
+    const first = transformReactLynxSync(source, options());
+    const second = transformReactLynxSync(source, options());
+
+    expect(second.code).toBe(first.code);
+    expect(second.map).toBe(first.map);
+  });
+});

--- a/packages/react/transform/src/lib.rs
+++ b/packages/react/transform/src/lib.rs
@@ -15,12 +15,12 @@ use std::{cell::RefCell, rc::Rc, vec};
 
 use napi::{bindgen_prelude::AsyncTask, Either, Env, Task};
 
-use rustc_hash::FxBuildHasher;
+use rustc_hash::FxHashMap;
 
 use swc_core::{
   atoms::Atom,
   base::{
-    config::{GlobalPassOption, IsModule, SourceMapsConfig},
+    config::{IsModule, SourceMapsConfig},
     Compiler, PrintArgs,
   },
   common::{
@@ -33,7 +33,7 @@ use swc_core::{
   ecma::{
     ast::*,
     codegen,
-    parser::{Syntax, TsSyntax},
+    parser::{parse_file_as_expr, Syntax, TsSyntax},
     transforms::{
       base::{
         fixer::fixer,
@@ -41,9 +41,10 @@ use swc_core::{
         hygiene::{hygiene_with_config, Config},
         resolver,
       },
-      optimization::{simplifier, simplify},
+      optimization::{inline_globals, simplifier, simplify},
       react, typescript,
     },
+    utils::{drop_span, NodeIgnoringSpan},
     visit::visit_mut_pass,
   },
 };
@@ -508,23 +509,50 @@ fn transform_react_lynx_inner(
     };
 
     let define_dce_plugin = {
-      let opts = GlobalPassOption {
-        vars: match &options.define_dce {
-          Either::A(_) => Default::default(),
-          Either::B(config) => {
-            let mut map = indexmap::IndexMap::<_, _, FxBuildHasher>::default();
-            for (key, value) in &config.define {
-              map.insert(key.as_str().into(), value.as_str().into());
-            }
-            map
-          }
-        },
-        envs: Default::default(),
-        typeofs: Default::default(),
+      // Not `GlobalPassOption::build`: its process-wide cache hands back
+      // spans of a `SourceMap` that is already gone. See swc-project/swc#12129.
+      let parse = |src: &str| -> Expr {
+        let fm = cm.new_source_file(FileName::Anon.into(), src.to_string());
+
+        let mut errors = vec![];
+        let expr = parse_file_as_expr(
+          &fm,
+          Syntax::Es(Default::default()),
+          Default::default(),
+          None,
+          &mut errors,
+        );
+
+        for e in errors {
+          e.into_diagnostic(&handler).emit()
+        }
+
+        match expr {
+          Ok(v) => *drop_span(v),
+          _ => panic!("{} is not a valid expression", fm.src),
+        }
       };
 
+      let mut globals = FxHashMap::default();
+      let mut global_exprs = FxHashMap::default();
+
+      if let Either::B(config) = &options.define_dce {
+        for (key, value) in &config.define {
+          if key.contains('.') {
+            global_exprs.insert(NodeIgnoringSpan::owned(parse(key)), parse(value));
+          } else {
+            globals.insert(Atom::from(key.as_str()), parse(value));
+          }
+        }
+      }
+
       Optional::new(
-        opts.build(&cm, &handler),
+        inline_globals(
+          Default::default(),
+          Lrc::new(globals),
+          Lrc::new(global_exprs),
+          Default::default(),
+        ),
         matches!(options.define_dce, Either::B(_)),
       )
     };


### PR DESCRIPTION
Production builds of unchanged sources are not reproducible: the same module can come out with a different chunk hash between two builds, and with minification on, every mangled name in the chunk moves with it.

## Cause

`defineDCE.define` values go to swc's `GlobalPassOption::build`, which parses each value into an anonymous file of the `SourceMap` it is handed and memoizes the parsed expression in a **process-wide** cache. A span only means anything to the `SourceMap` that produced it, so every later transform in the process substitutes values carrying positions of a `SourceMap` that is already gone.

What comes out depends on where that stale position lands in the file currently being compiled:

- the transform that parses the value emits mappings into the anonymous file (the define text itself is reported as a source);
- a transform that hits the cache emits nothing for it, or a mapping to an unrelated line if the file it is compiling is long enough.

The generated code is identical either way — only the mappings move. But `SourceMapDevToolPlugin` puts the map on the module, the map is part of the module's build hash in Rspack, so the chunk hash moves, and the minifier orders its short names by character frequency over the whole chunk, so one changed string permutes every mangled name.

Which of those happens is not stable across builds: the cache key is order sensitive and `define` is a `HashMap`, and the cached position is derived from the size of whichever module the process transformed first.

Full write-up and the measurements behind it: https://github.com/swc-project/swc/pull/12129

## Fix

Build the `globals` / `global_exprs` maps in `transform_react_lynx_inner` and drop the spans of the parsed values, instead of going through `GlobalPassOption::build`. Nothing is shared between transforms, and a substituted value can no longer carry a position into the source map of the file being compiled. Values are still parsed against the caller's `SourceMap`, so a syntax error in a define value keeps its position.

Parsing per transform instead of once per process costs a handful of tiny parses per file, next to nothing against a full transform.

The upstream fix (swc-project/swc#12129) does the same thing inside `GlobalPassOption::build`, but this does not need to wait for it, and stays correct after it lands.

## Tests

The first commit adds `__test__/sourcemap.spec.js`, which transforms the same input twice and compares the maps. It fails there — same code, different mappings:

```
- "mappings":"AAAA,OAAO,MAAM,OAAb,KAA2C;AAC3C,QAAQ,GAAG,CAAC"
+ "mappings":"AAAA,OAAO,MAAM,YAA8B;AAC3C,QAAQ,GAAG,CAAC"
```

The define name in that test is deliberately not shared with any other test: the cache is per process, so another test using the same define set would warm it up first and the test would pass for the wrong reason.

Verified locally on both backends — `pnpm vitest run` (wasm) and `USE_NAPI=1 pnpm vitest run`: 89 passed, plus `cargo test` for the crates.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source map stability when transforming identical React Lynx input repeatedly.
  * Production builds now produce more reproducible output by avoiding cross-build cache interference.
  * Invalid define values are now reported consistently during transformation.

* **Tests**
  * Added regression coverage to verify identical generated code and source maps across repeated transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->