### PR TITLE
feat(react): compile element template main thread refs

### DIFF
--- a/packages/react/runtime/__test__/core/main-thread-function.test.ts
+++ b/packages/react/runtime/__test__/core/main-thread-function.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMainThreadFunction } from '../../src/core/main-thread-function.js';
+
+describe('core/main-thread-function primitive', () => {
+  it('identifies transformed main-thread functions', () => {
+    expect(isMainThreadFunction({ _wkltId: 'callback' })).toBe(true);
+    expect(isMainThreadFunction({ _wkltId: 1 })).toBe(false);
+    expect(isMainThreadFunction({ _wvid: 1 })).toBe(false);
+    expect(isMainThreadFunction(Object.assign([], { _wkltId: 'callback' }))).toBe(false);
+    expect(isMainThreadFunction(null)).toBe(false);
+  });
+});

--- a/packages/react/runtime/__test__/core/main-thread-ref.test.ts
+++ b/packages/react/runtime/__test__/core/main-thread-ref.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  MainThreadRef,
-  clearMainThreadRefLastIdForTesting,
-  isMainThreadRef,
-  isMainThreadRefCallback,
-} from '../../src/core/main-thread-ref.js';
+import { MainThreadRef, clearMainThreadRefLastIdForTesting, isMainThreadRef } from '../../src/core/main-thread-ref.js';
 import { takeMainThreadRefInitValuePatch } from '../../src/core/main-thread-ref-init-value.js';
 import { clearMtsConfigCacheForTesting } from '../../src/core/mts-capability.js';
 
@@ -99,12 +94,9 @@ describe('core/main-thread-ref primitive', () => {
     );
   });
 
-  it('identifies object refs and main-thread callback worklets', () => {
+  it('identifies object refs', () => {
     expect(isMainThreadRef({ _wvid: 1 })).toBe(true);
     expect(isMainThreadRef({ _wvid: '1' })).toBe(false);
     expect(isMainThreadRef(null)).toBe(false);
-    expect(isMainThreadRefCallback({ _wkltId: 'callback' })).toBe(true);
-    expect(isMainThreadRefCallback({ _wkltId: 1 })).toBe(false);
-    expect(isMainThreadRefCallback({ _wvid: 1 })).toBe(false);
   });
 });

--- a/packages/react/runtime/__test__/element-template/fixtures/background/ref/unsupported-ref/index.tsx
+++ b/packages/react/runtime/__test__/element-template/fixtures/background/ref/unsupported-ref/index.tsx
@@ -6,7 +6,7 @@ interface AppProps {
 export function App({ mainThreadRef, workletRef }: AppProps) {
   return (
     <view main-thread:ref={mainThreadRef} worklet:ref={workletRef}>
-      unsupported
+      namespaced refs
     </view>
   );
 }

--- a/packages/react/runtime/__test__/element-template/imports/main-thread-ref-api.test.ts
+++ b/packages/react/runtime/__test__/element-template/imports/main-thread-ref-api.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { MainThreadRef, useMainThreadRef } from '@lynx-js/react/element-template';
+
+describe('element-template MainThreadRef entry', () => {
+  it('exposes MainThreadRef APIs from the public ET alias', () => {
+    expect(MainThreadRef).toBeTypeOf('function');
+    expect(useMainThreadRef).toBeTypeOf('function');
+  });
+});

--- a/packages/react/runtime/__test__/element-template/internal/legacy-internal-guardrail.test.ts
+++ b/packages/react/runtime/__test__/element-template/internal/legacy-internal-guardrail.test.ts
@@ -14,6 +14,8 @@ describe('legacy internal guardrail', () => {
   it('keeps ref attr slot adapter on the ET internal surface only', () => {
     expect(ElementTemplateInternal.adaptRefAttrSlot).toBeTypeOf('function');
     expect('adaptRefAttrSlot' in ElementTemplateRuntime).toBe(false);
+    expect(ElementTemplateInternal.adaptMTRefAttrSlot).toBeTypeOf('function');
+    expect('adaptMTRefAttrSlot' in ElementTemplateRuntime).toBe(false);
   });
 
   it('keeps the ET main-thread event loader surface minimal', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/ref/compiled-fixtures.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/ref/compiled-fixtures.test.tsx
@@ -34,7 +34,7 @@ const __dirname = path.dirname(__filename);
 const DIRECT_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/direct-ref/index.tsx');
 const SPREAD_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/spread-ref/index.tsx');
 const MULTI_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/multi-ref/index.tsx');
-const UNSUPPORTED_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/unsupported-ref/index.tsx');
+const NAMESPACED_REF_FIXTURE = path.resolve(__dirname, '../../../fixtures/background/ref/unsupported-ref/index.tsx');
 
 interface DirectFixtureProps {
   hostRef?: unknown;
@@ -303,21 +303,20 @@ describe('Compiled ordinary ref background updates', () => {
     }));
   });
 
-  it('drops compiled unsupported namespaced refs before native payloads', async () => {
+  it('hydrates compiled direct MTRefs while dropping unsupported worklet refs', async () => {
     const { backgroundModule, mainModule } = await loadCompiledFixture<CompiledAppModule<UnsupportedFixtureProps>>(
-      UNSUPPORTED_REF_FIXTURE,
+      NAMESPACED_REF_FIXTURE,
     );
-    const mainThreadRef = vi.fn();
+    const mainThreadRef = { _wvid: 7 };
     const workletRef = vi.fn();
 
     const props = { mainThreadRef, workletRef };
     const host = renderOnBackground(backgroundModule, props);
-    expect(host.attributeSlots).toEqual([null, null]);
+    expect(host.attributeSlots).toEqual([{ type: 'main-thread-ref', value: mainThreadRef }, null]);
 
     hydrateFromMainThread(mainModule, props);
 
-    expect(host.attributeSlots).toEqual([null, null]);
-    expect(mainThreadRef).not.toHaveBeenCalled();
+    expect(host.attributeSlots).toEqual([{ type: 'main-thread-ref', value: mainThreadRef }, null]);
     expect(workletRef).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/template/element-template-attr-slot-plan.test.ts
@@ -8,12 +8,14 @@ import { resetElementTemplateBackgroundFunctionRuntime } from '../../../../src/e
 import {
   __etAttrPlanMap,
   adaptMTEventAttrSlot,
+  adaptMTRefAttrSlot,
   adaptRefAttrSlot,
   adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
   type EtAttrAdapter,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
 import { isMTEventNativeWrapper } from '../../../../src/element-template/runtime/template/main-thread-event-ctx.js';
+import type { MTRefNativeWrapper } from '../../../../src/element-template/runtime/template/main-thread-ref-ctx.js';
 import { clearRefState, flushPendingRefs } from '../../../../src/element-template/prop-adapters/ref.js';
 
 function expectMTEventPreparedWrapper(value: unknown): {
@@ -35,6 +37,11 @@ function expectMTEventPreparedWrapper(value: unknown): {
       _wkltId: string;
     };
   };
+}
+
+function expectMTRefPreparedWrapper(value: unknown): MTRefNativeWrapper {
+  expect(value).toEqual(expect.objectContaining({ type: 'main-thread-ref' }));
+  return value as MTRefNativeWrapper;
 }
 
 describe('ElementTemplate attr slot plan registry', () => {
@@ -220,6 +227,72 @@ describe('ElementTemplate attr slot plan registry', () => {
         previousRawSlots: [ctx],
       })[0],
     ).toBe(preparedSlots[0]);
+  });
+
+  it('wraps direct main-thread ref object values for ET runtime state', () => {
+    const ref = { _wvid: 7, _type: 'main-thread' };
+
+    const wrapper = expectMTRefPreparedWrapper(adaptMTRefAttrSlot(-2, 0, ref));
+
+    expect(wrapper.type).toBe('main-thread-ref');
+    expect(wrapper.value).toBe(ref);
+  });
+
+  it('wraps direct main-thread callback refs without mutating the raw callback', () => {
+    const rawCallback = { _wkltId: 'main-thread-ref-callback', _c: { label: 'first' } };
+
+    const wrapper = expectMTRefPreparedWrapper(adaptMTRefAttrSlot(-2, 0, rawCallback));
+
+    expect(wrapper.value).toEqual(expect.objectContaining({
+      _c: { label: 'first' },
+      _wkltId: 'main-thread-ref-callback',
+    }));
+    expect(wrapper.value).not.toBe(rawCallback);
+    expect(wrapper.value._c).toBe(rawCallback._c);
+    expect(rawCallback).not.toHaveProperty('_execId');
+  });
+
+  it('normalizes empty direct main-thread ref slots to null', () => {
+    expect(adaptMTRefAttrSlot(-2, 0, null)).toBeNull();
+    expect(adaptMTRefAttrSlot(-2, 0, undefined)).toBeNull();
+  });
+
+  it('throws for invalid direct main-thread ref values', () => {
+    for (const value of [false, true, 1, 'ref', {}, { _lepusWorkletHash: 'legacy' }, { _wkltId: 1 }]) {
+      expect(() => adaptMTRefAttrSlot(-2, 0, value)).toThrow(
+        'ElementTemplate main-thread:ref expects a MainThreadRef object or a main-thread function.',
+      );
+    }
+  });
+
+  it('rejects false before it can replace an existing direct main-thread ref', () => {
+    const ref = { _wvid: 7 };
+    const previousWrapper = adaptMTRefAttrSlot(-2, 0, ref);
+
+    expect(() =>
+      adaptMTRefAttrSlot(-2, 0, false, {
+        previousPreparedSlots: [previousWrapper],
+        previousRawSlots: [ref],
+      })
+    ).toThrow(
+      'ElementTemplate main-thread:ref expects a MainThreadRef object or a main-thread function.',
+    );
+    expect(expectMTRefPreparedWrapper(previousWrapper).value).toBe(ref);
+  });
+
+  it('reuses the previous prepared direct main-thread ref wrapper for the same raw value', () => {
+    const ref = { _wvid: 7 };
+    const firstWrapper = adaptMTRefAttrSlot(-2, 0, ref);
+
+    expect(adaptMTRefAttrSlot(-2, 0, ref, {
+      previousPreparedSlots: [firstWrapper],
+      previousRawSlots: [ref],
+    })).toBe(firstWrapper);
+
+    expect(adaptMTRefAttrSlot(-2, 0, { _wvid: 7 }, {
+      previousPreparedSlots: [firstWrapper],
+      previousRawSlots: [ref],
+    })).not.toBe(firstWrapper);
   });
 
   it('skips queued ref effects for templates without attr plans', () => {

--- a/packages/react/runtime/__test__/snapshot/worklet/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/worklet/workletRef.test.jsx
@@ -12,12 +12,8 @@ import { __root } from '../../../src/root';
 import { setupPage } from '../../../src/snapshot';
 import { destroyWorklet } from '../../../src/snapshot/worklet/destroy';
 import { clearConfigCacheForTesting } from '../../../src/snapshot/worklet/functionality';
-import {
-  MainThreadRef,
-  isMainThreadRef,
-  isMainThreadRefCallback,
-  useMainThreadRef,
-} from '../../../src/core/main-thread-ref';
+import { MainThreadRef, isMainThreadRef, useMainThreadRef } from '../../../src/core/main-thread-ref';
+import { isMainThreadFunction } from '../../../src/core/main-thread-function';
 import { takeMainThreadRefInitValuePatch } from '../../../src/core/main-thread-ref-init-value';
 import { globalEnvManager } from '../utils/envManager';
 import { injectUpdateMTRefInitValue } from '../../../src/snapshot/worklet/ref/updateInitValue';
@@ -97,8 +93,8 @@ describe('WorkletRef in js', () => {
   it('should identify main-thread ref values', () => {
     expect(isMainThreadRef({ _wvid: 1 })).toBe(true);
     expect(isMainThreadRef({ _wkltId: 'callback' })).toBe(false);
-    expect(isMainThreadRefCallback({ _wkltId: 'callback' })).toBe(true);
-    expect(isMainThreadRefCallback({ _wvid: 1 })).toBe(false);
+    expect(isMainThreadFunction({ _wkltId: 'callback' })).toBe(true);
+    expect(isMainThreadFunction({ _wvid: 1 })).toBe(false);
   });
 
   it('should send init value to the main thread', () => {

--- a/packages/react/runtime/src/core/main-thread-function.ts
+++ b/packages/react/runtime/src/core/main-thread-function.ts
@@ -1,0 +1,12 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { Worklet } from '../worklet-runtime/bindings/types.js';
+
+export function isMainThreadFunction(value: unknown): value is Worklet {
+  return value != null
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && typeof (value as { _wkltId?: unknown })._wkltId === 'string';
+}

--- a/packages/react/runtime/src/core/main-thread-ref.ts
+++ b/packages/react/runtime/src/core/main-thread-ref.ts
@@ -6,7 +6,7 @@ import type { RefObject } from 'react';
 import { useMemo } from './hooks/react.js';
 import { addMainThreadRefInitValue } from './main-thread-ref-init-value.js';
 import { WorkletEvents } from '../worklet-runtime/bindings/events.js';
-import type { Worklet, WorkletRefImpl } from '../worklet-runtime/bindings/types.js';
+import type { WorkletRefImpl } from '../worklet-runtime/bindings/types.js';
 
 // Split into two variables for testing purposes.
 let lastIdBG = 0;
@@ -20,12 +20,6 @@ export function isMainThreadRef(value: unknown): value is WorkletRefImpl<unknown
   return typeof value === 'object'
     && value !== null
     && typeof (value as { _wvid?: unknown })._wvid === 'number';
-}
-
-export function isMainThreadRefCallback(value: unknown): value is Worklet {
-  return typeof value === 'object'
-    && value !== null
-    && typeof (value as { _wkltId?: unknown })._wkltId === 'string';
 }
 
 /**

--- a/packages/react/runtime/src/core/thread-function-call/main-thread.ts
+++ b/packages/react/runtime/src/core/thread-function-call/main-thread.ts
@@ -8,6 +8,7 @@ import { WorkletEvents } from '../../worklet-runtime/bindings/events.js';
 import type { RunWorkletCtxData } from '../../worklet-runtime/bindings/events.js';
 import type { Worklet } from '../../worklet-runtime/bindings/types.js';
 import { registerBackgroundFunctionCtx } from '../background-function/run-on-background.js';
+import { isMainThreadFunction } from '../main-thread-function.js';
 import { isMtsEnabled } from '../mts-capability.js';
 
 interface RunOnMainThreadOptions {
@@ -66,15 +67,8 @@ function isRunOnBackgroundSupported(): boolean {
   return isSdkVersionGt(2, 15);
 }
 
-function isMainThreadFunctionCtx(value: unknown): value is Worklet {
-  return value != null
-    && typeof value === 'object'
-    && !Array.isArray(value)
-    && typeof (value as { _wkltId?: unknown })._wkltId === 'string';
-}
-
 function prepareMainThreadFunctionCtx(worklet: unknown): void {
-  if (isMainThreadFunctionCtx(worklet) && isRunOnBackgroundSupported()) {
+  if (isMainThreadFunction(worklet) && isRunOnBackgroundSupported()) {
     registerBackgroundFunctionCtx(worklet);
   }
 }

--- a/packages/react/runtime/src/element-template/index.ts
+++ b/packages/react/runtime/src/element-template/index.ts
@@ -132,6 +132,7 @@ export { useLynxGlobalEventListener };
 export * from './client/root.js';
 export { runOnBackground } from './runtime/template/main-thread-background-function.js';
 export { runOnMainThread } from './runtime/template/main-thread-function.js';
+export { MainThreadRef, useMainThreadRef } from '../core/main-thread-ref.js';
 
 export type { GlobalProps } from '../core/globalProps.js';
 export type { DataProcessorDefinition, DataProcessors, InitData, InitDataRaw } from '../lynx-api.js';

--- a/packages/react/runtime/src/element-template/internal.ts
+++ b/packages/react/runtime/src/element-template/internal.ts
@@ -49,7 +49,6 @@ export { wrapWithLynxComponent } from '../core/compat/lynxComponent.js';
 
 export { loadLazyBundle } from '../core/lynx/lazy-bundle.js';
 
-// TODO(ET MTS): add MTRef hydrate semantics in follow-up tracks.
 export { transformToWorklet } from './runtime/template/main-thread-background-function.js';
 export { loadWorkletRuntime } from '@lynx-js/react/worklet-runtime/bindings';
 
@@ -63,6 +62,7 @@ export {
   __etAttrPlanMap,
   adaptEventAttrSlot,
   adaptMTEventAttrSlot,
+  adaptMTRefAttrSlot,
   adaptRefAttrSlot,
   adaptSpreadAttrSlot,
 } from './runtime/template/attr-slot-plan.js';

--- a/packages/react/runtime/src/element-template/runtime/template/attr-slot-plan.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/attr-slot-plan.ts
@@ -2,7 +2,9 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { isMTEventCtx, prepareMTEventCtxForNative } from './main-thread-event-ctx.js';
+import { prepareMTEventCtxForNative } from './main-thread-event-ctx.js';
+import { prepareMTRefForNative } from './main-thread-ref-ctx.js';
+import { isMainThreadFunction } from '../../../core/main-thread-function.js';
 import { getEventValue } from '../../prop-adapters/event-value.js';
 import { prepareRefAttrSlot } from '../../prop-adapters/ref.js';
 import { prepareSpreadAttrSlot } from '../../prop-adapters/spread.js';
@@ -49,7 +51,7 @@ export function adaptMTEventAttrSlot(
   if (value === null || value === undefined || value === false) {
     return null;
   }
-  if (!isMTEventCtx(value)) {
+  if (!isMainThreadFunction(value)) {
     if (__DEV__) {
       lynx.reportError(
         new Error(`ElementTemplate main-thread event slot ${handleId}:${attrSlotIndex} expects a worklet ctx object.`),
@@ -70,6 +72,19 @@ export function adaptRefAttrSlot(
   value: unknown,
 ): SerializableValue | null {
   return prepareRefAttrSlot(handleId, attrSlotIndex, value);
+}
+
+export function adaptMTRefAttrSlot(
+  _handleId: number,
+  attrSlotIndex: number,
+  value: unknown,
+  context?: EtAttrAdapterContext,
+): SerializableValue | null {
+  return prepareMTRefForNative(
+    value,
+    context?.previousPreparedSlots?.[attrSlotIndex],
+    context?.previousRawSlots?.[attrSlotIndex],
+  );
 }
 
 export function adaptSpreadAttrSlot(

--- a/packages/react/runtime/src/element-template/runtime/template/main-thread-background-function.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/main-thread-background-function.ts
@@ -16,7 +16,7 @@ import { isRunOnBackgroundEnabled } from '../../../worklet-runtime/jsFunctionLif
 type BackgroundFunctionCtx = Parameters<typeof registerBackgroundFunctionCtx>[0];
 type RetainableMainThreadCtx = Parameters<typeof retainWorkletCtx>[0];
 
-interface MTEventBackgroundFunctionCtx {
+interface MainThreadBackgroundFunctionCtx {
   _wkltId: string;
   [key: string]: unknown;
 }
@@ -27,13 +27,13 @@ interface MTEventBackgroundFunctionCtx {
 export const transformToWorklet = createBackgroundFunctionHandle;
 export { runOnBackground };
 
-export function registerMTEventBackgroundFunctionCtx(ctx: MTEventBackgroundFunctionCtx): void {
+export function registerMainThreadBackgroundFunctionCtx(ctx: MainThreadBackgroundFunctionCtx): void {
   if (__JS__ && isRunOnBackgroundEnabled()) {
     registerBackgroundFunctionCtx(ctx as BackgroundFunctionCtx);
   }
 }
 
-export function retainMTEventBackgroundFunctionCtx(ctx: MTEventBackgroundFunctionCtx): void {
+export function retainMainThreadBackgroundFunctionCtx(ctx: MainThreadBackgroundFunctionCtx): void {
   retainWorkletCtx(ctx as RetainableMainThreadCtx);
 }
 

--- a/packages/react/runtime/src/element-template/runtime/template/main-thread-dynamic-attr-state.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/main-thread-dynamic-attr-state.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { __etAttrPlanMap, adaptMTEventAttrSlot } from './attr-slot-plan.js';
-import { retainMTEventBackgroundFunctionCtx } from './main-thread-background-function.js';
+import { retainMainThreadBackgroundFunctionCtx } from './main-thread-background-function.js';
 import { isMTEventNativeWrapper } from './main-thread-event-ctx.js';
 import type { MTEventCtx } from './main-thread-event-ctx.js';
 
@@ -33,7 +33,7 @@ function deleteSlotState(handleId: number, attrSlotIndex: number): void {
 }
 
 function setSlotState(handleId: number, attrSlotIndex: number, nativeHeldValue: MTEventCtx): void {
-  retainMTEventBackgroundFunctionCtx(nativeHeldValue);
+  retainMainThreadBackgroundFunctionCtx(nativeHeldValue);
   let handleState = dynamicAttrState.get(handleId);
   if (!handleState) {
     handleState = new Map();

--- a/packages/react/runtime/src/element-template/runtime/template/main-thread-event-ctx.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/main-thread-event-ctx.ts
@@ -2,7 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { registerMTEventBackgroundFunctionCtx } from './main-thread-background-function.js';
+import { registerMainThreadBackgroundFunctionCtx } from './main-thread-background-function.js';
+import { isMainThreadFunction } from '../../../core/main-thread-function.js';
 import type { SerializableValue } from '../../protocol/types.js';
 
 export interface MTEventCtx {
@@ -18,19 +19,12 @@ export interface MTEventNativeWrapper {
   value: MTEventCtx;
 }
 
-export function isMTEventCtx(value: unknown): value is MTEventCtx {
-  return value != null
-    && typeof value === 'object'
-    && !Array.isArray(value)
-    && typeof (value as { _wkltId?: unknown })._wkltId === 'string';
-}
-
 export function isMTEventNativeWrapper(value: unknown): value is MTEventNativeWrapper {
   return value != null
     && typeof value === 'object'
     && !Array.isArray(value)
     && (value as { type?: unknown }).type === 'worklet'
-    && isMTEventCtx((value as { value?: unknown }).value);
+    && isMainThreadFunction((value as { value?: unknown }).value);
 }
 
 export function prepareMTEventCtxForNative(
@@ -43,7 +37,7 @@ export function prepareMTEventCtxForNative(
   }
 
   const preparedCtx = { ...rawCtx };
-  registerMTEventBackgroundFunctionCtx(preparedCtx);
+  registerMainThreadBackgroundFunctionCtx(preparedCtx);
 
   return {
     type: 'worklet',

--- a/packages/react/runtime/src/element-template/runtime/template/main-thread-ref-ctx.ts
+++ b/packages/react/runtime/src/element-template/runtime/template/main-thread-ref-ctx.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { Element, Worklet, WorkletRefImpl } from '@lynx-js/react/worklet-runtime/bindings';
+
+import { registerMainThreadBackgroundFunctionCtx } from './main-thread-background-function.js';
+import { isMainThreadFunction } from '../../../core/main-thread-function.js';
+import { isMainThreadRef } from '../../../core/main-thread-ref.js';
+import type { SerializableValue } from '../../protocol/types.js';
+
+export type MTRefValue = WorkletRefImpl<Element> | Worklet;
+
+export interface MTRefNativeWrapper {
+  type: 'main-thread-ref';
+  value: MTRefValue;
+}
+
+export function isMTRefValue(value: unknown): value is MTRefValue {
+  return isMainThreadRef(value) || isMainThreadFunction(value);
+}
+
+export function prepareMTRefForNative(
+  rawValue: unknown,
+  previousPreparedValue?: unknown,
+  previousRawValue?: unknown,
+): SerializableValue | null {
+  if (rawValue === null || rawValue === undefined) {
+    return null;
+  }
+  if (!isMTRefValue(rawValue)) {
+    throw new Error('ElementTemplate main-thread:ref expects a MainThreadRef object or a main-thread function.');
+  }
+  if (previousRawValue === rawValue) {
+    return previousPreparedValue as SerializableValue;
+  }
+
+  let value: MTRefValue;
+  if (isMainThreadFunction(rawValue)) {
+    value = { ...rawValue };
+    registerMainThreadBackgroundFunctionCtx(value);
+  } else {
+    value = rawValue;
+  }
+
+  return {
+    type: 'main-thread-ref',
+    value,
+  } as unknown as SerializableValue;
+}

--- a/packages/react/transform/crates/swc_plugin_element_template/attr_name.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/attr_name.rs
@@ -12,7 +12,8 @@ pub enum AttrName {
   ID,
   Ref,
   TimingFlag,
-  WorkletRef,
+  UnsupportedNamespacedRef,
+  MTRef,
   Gesture,
 }
 
@@ -56,8 +57,11 @@ impl AttrName {
   pub fn from_ns(ns: Ident, name: Ident) -> Self {
     let ns_str = ns.sym.as_ref();
     let name_str = name.sym.as_ref();
+    if ns_str == "main-thread" && name_str == "ref" {
+      return AttrName::MTRef;
+    }
     if name_str == "ref" {
-      return AttrName::WorkletRef;
+      return AttrName::UnsupportedNamespacedRef;
     }
 
     if ns_str != "main-thread" {

--- a/packages/react/transform/crates/swc_plugin_element_template/extractor.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/extractor.rs
@@ -31,6 +31,7 @@ static NO_FLATTEN_ATTRIBUTES: Lazy<HashSet<String>> = Lazy::new(|| {
     "overlap".to_string(),
     "exposure-scene".to_string(),
     "exposure-id".to_string(),
+    "main-thread:ref".to_string(),
   ])
 });
 
@@ -210,7 +211,10 @@ where
           key,
         );
       }
-      AttrName::WorkletEvent | AttrName::WorkletRef | AttrName::Gesture => {
+      AttrName::WorkletEvent
+      | AttrName::UnsupportedNamespacedRef
+      | AttrName::MTRef
+      | AttrName::Gesture => {
         self.push_dynamic_attr(*jsx_attr_value((*value).clone()), attr_name, key);
       }
     }
@@ -265,7 +269,10 @@ where
         let attr_name = AttrName::from_ns(ns.clone().into(), name.clone().into());
         let preserve_literal_expr = !matches!(
           attr_name,
-          AttrName::WorkletEvent | AttrName::WorkletRef | AttrName::Gesture
+          AttrName::WorkletEvent
+            | AttrName::UnsupportedNamespacedRef
+            | AttrName::MTRef
+            | AttrName::Gesture
         );
         self.push_dynamic_jsx_attr(attr_name, &key, value, preserve_literal_expr);
       }

--- a/packages/react/transform/crates/swc_plugin_element_template/lib.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lib.rs
@@ -414,6 +414,7 @@ where
       Event,
       MTEvent,
       Ref,
+      MTRef,
       Spread,
     }
 
@@ -435,6 +436,11 @@ where
           slot_index,
           ..
         } => Some((*slot_index, AttrPlanAdapter::Ref)),
+        DynamicAttributePart::Attr {
+          attr_name: AttrName::MTRef,
+          slot_index,
+          ..
+        } => Some((*slot_index, AttrPlanAdapter::MTRef)),
         DynamicAttributePart::Spread { slot_index, .. } => {
           Some((*slot_index, AttrPlanAdapter::Spread))
         }
@@ -448,6 +454,7 @@ where
           AttrPlanAdapter::Event => "event",
           AttrPlanAdapter::MTEvent => "mt-event",
           AttrPlanAdapter::Ref => "ref",
+          AttrPlanAdapter::MTRef => "mt-ref",
           AttrPlanAdapter::Spread => "spread",
         };
         format!("{slot_index}:{adapter}")
@@ -568,6 +575,10 @@ where
             ),
             AttrPlanAdapter::Ref => quote!(
               "$internal_runtime_id.adaptRefAttrSlot" as Expr,
+              internal_runtime_id: Expr = internal_runtime_id.clone(),
+            ),
+            AttrPlanAdapter::MTRef => quote!(
+              "$internal_runtime_id.adaptMTRefAttrSlot" as Expr,
               internal_runtime_id: Expr = internal_runtime_id.clone(),
             ),
             AttrPlanAdapter::Spread => quote!(

--- a/packages/react/transform/crates/swc_plugin_element_template/lowering.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/lowering.rs
@@ -58,7 +58,7 @@ where
             } else {
               value
             }
-          } else if let AttrName::WorkletRef = attr_name {
+          } else if let AttrName::UnsupportedNamespacedRef = attr_name {
             quote!("null" as Expr)
           } else {
             value

--- a/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
+++ b/packages/react/transform/crates/swc_plugin_element_template/tests/element_template_contract.rs
@@ -262,6 +262,73 @@ fn should_emit_spread_attr_plan_with_ref_adapter() {
 }
 
 #[test]
+fn should_emit_direct_main_thread_ref_attr_plan_for_js_target() {
+  let (code, _) = first_user_template_json_with_code(
+    r#"
+      <view main-thread:ref={mainThreadRef} />
+    "#,
+    JSXTransformerConfig {
+      target: swc_plugins_shared::target::TransformTarget::JS,
+      ..element_template_config()
+    },
+  );
+  let code = without_whitespace(&code);
+
+  assert_attr_plan_assignment(
+    &code,
+    "0,ReactLynxInternal.adaptMTRefAttrSlot",
+    "direct main-thread ref slots should register an ET MTRef attr plan",
+  );
+  assert!(
+    code.contains("attributeSlots={[mainThreadRef]}"),
+    "JS target should keep raw main-thread refs in attributeSlots before runtime preparation, got: {code}"
+  );
+}
+
+#[test]
+fn should_emit_direct_main_thread_ref_attr_plan_for_lepus_target() {
+  let (code, _) = first_user_template_json_with_code(
+    r#"
+      <view main-thread:ref={mainThreadRef} />
+    "#,
+    JSXTransformerConfig {
+      target: swc_plugins_shared::target::TransformTarget::LEPUS,
+      ..element_template_config()
+    },
+  );
+  let code = without_whitespace(&code);
+
+  assert_attr_plan_assignment(
+    &code,
+    "0,ReactLynxInternal.adaptMTRefAttrSlot",
+    "direct main-thread ref slots should register an ET MTRef attr plan",
+  );
+  assert!(
+    code.contains("attributeSlots={[mainThreadRef]}"),
+    "LEPUS target should keep raw main-thread refs in attributeSlots before runtime preparation, got: {code}"
+  );
+}
+
+#[test]
+fn should_disable_flatten_for_direct_main_thread_ref_targets() {
+  let template = first_user_template_json(
+    r#"
+      <view main-thread:ref={mainThreadRef} />
+    "#,
+  );
+
+  let attrs = template["attributesArray"]
+    .as_array()
+    .expect("attributesArray");
+  assert!(
+    attrs.iter().any(|attr| {
+      attr["kind"] == "static" && attr["key"] == "flatten" && attr["value"] == false
+    }),
+    "main-thread:ref target should carry create-time flatten=false descriptor, got: {template:?}",
+  );
+}
+
+#[test]
 fn should_inject_css_scope_attr_for_element_template_subtree() {
   let (code, template) = first_user_template_json_with_code(
     r#"
@@ -664,7 +731,7 @@ fn should_keep_slot_descriptor_order_for_dynamic_attr_spread_event_and_ref() {
 }
 
 #[test]
-fn should_keep_worklet_attr_descriptor_keys_for_namespaced_attrs() {
+fn should_keep_main_thread_attr_descriptor_keys_for_namespaced_attrs() {
   let (code, template) = first_user_template_json_with_code(
     r#"
       <view main-thread:bindtap={handleTap} main-thread:ref={viewRef} />
@@ -685,14 +752,18 @@ fn should_keep_worklet_attr_descriptor_keys_for_namespaced_attrs() {
     "main-thread:ref must not be lowered as an ordinary ET ref adapter, got: {code}"
   );
   assert!(
-    !code.contains("viewRef"),
-    "unsupported namespaced ref must not leak the raw ref value, got: {code}"
+    code.contains("adaptMTRefAttrSlot"),
+    "main-thread:ref must use the ET MTRef adapter, got: {code}"
+  );
+  assert!(
+    code.contains("attributeSlots={[handleTap,viewRef]}"),
+    "default LEPUS target should keep raw main-thread refs in attributeSlots before runtime preparation, got: {code}"
   );
 
   let attrs = template["attributesArray"]
     .as_array()
     .expect("attributesArray");
-  assert_eq!(attrs.len(), 2);
+  assert_eq!(attrs.len(), 3);
 
   assert_eq!(attrs[0]["kind"], "slot");
   assert_eq!(attrs[0]["key"], "main-thread:bindtap");
@@ -701,6 +772,10 @@ fn should_keep_worklet_attr_descriptor_keys_for_namespaced_attrs() {
   assert_eq!(attrs[1]["kind"], "slot");
   assert_eq!(attrs[1]["key"], "main-thread:ref");
   assert_eq!(attrs[1]["attrSlotIndex"].as_f64(), Some(1.0));
+
+  assert_eq!(attrs[2]["kind"], "static");
+  assert_eq!(attrs[2]["key"], "flatten");
+  assert_eq!(attrs[2]["value"], false);
 }
 
 #[test]


### PR DESCRIPTION
This is 2/6 of the Element Template MainThreadRef stack and follows the merged #3608.

## Why this change

Element Template already kept `main-thread:ref` as an attribute-slot descriptor in the Template Definition, but the transform classified every namespaced `*:ref` as the legacy `WorkletRef` kind. That classification had two consequences:

1. lowering replaced the runtime value with `null`; and
2. no entry was emitted into the ET attribute-slot plan, so the runtime had no adapter that could prepare a MainThreadRef value.

For example, this source:

```tsx
const nodeRef = useMainThreadRef<MainThread.Element>(null);

return <view main-thread:ref={nodeRef} />;
```

previously produced output equivalent to the following. The template hash is abbreviated in these examples.

```tsx
const _et_x = `${globDynamicComponentEntry}:_et_x`;

// There was no __etAttrPlanMap[_et_x] entry for this slot.
<_et_x attributeSlots={[null]} />;
```

The Template Definition still described the slot:

```ts
attributesArray: [
  {
    kind: 'slot',
    key: 'main-thread:ref',
    attrSlotIndex: 0,
  },
]
```

The descriptor and runtime value therefore disagreed: slot 0 was named `main-thread:ref`, but the value needed to create the ref relationship had already been discarded. The compiled fixture observed the same result at runtime: both `main-thread:ref` and the still-unsupported `worklet:ref` became `null` slots.

## Transform output after this PR

The transform now recognizes exactly `main-thread:ref` as a dedicated `MTRef` attribute kind. Both JS and LEPUS targets retain the raw value and emit a sparse ET attribute-slot plan:

```tsx
const _et_x = `${globDynamicComponentEntry}:_et_x`;

ReactLynxInternal.__etAttrPlanMap[_et_x] = [
  0,
  ReactLynxInternal.adaptMTRefAttrSlot,
];

<_et_x attributeSlots={[nodeRef]} />;
```

All other namespaced `*:ref` attributes are classified as `UnsupportedNamespacedRef`. This is not another supported ref path: those slots continue to lower to `null` and emit no attr-plan adapter. The name makes that existing drop behavior explicit instead of presenting it as a second worklet-based ref implementation.

The plan is stored as `[slotIndex, adapter]` pairs. It lets the shared ET slot preparation path handle slot 0 as a MainThreadRef without adding another metadata prop or special cases to the generic materializer.

The generated Template Definition now also prevents the referenced element from being flattened:

```ts
attributesArray: [
  {
    kind: 'slot',
    key: 'main-thread:ref',
    attrSlotIndex: 0,
  },
  {
    kind: 'static',
    key: 'flatten',
    value: false,
  },
]
```

A main-thread ref must eventually resolve to a real element. Allowing this target to be flattened would remove that stable element boundary before the later attach phase. The transform also records the `0:mt-ref` plan signature when interning templates, so the same canonical Template Definition cannot silently be reused with a different adapter layout.

## Runtime representation

`adaptMTRefAttrSlot` converts the raw slot into the ET-owned representation consumed by the later MainThreadRef protocol:

```ts
[nodeRef]
// attribute-slot plan
//   -> adaptMTRefAttrSlot(handleId, 0, nodeRef)
[
  {
    type: 'main-thread-ref',
    value: nodeRef,
  },
]
```

The adapter accepts the two public MainThreadRef forms:

- A `MainThreadRef` object is kept as the wrapper value.
- A main-thread callback ref is shallow-cloned before background-function registration, so registration metadata is not written back to the raw React slot value.

`null` and `undefined` become `null`. Any other value fails immediately with an error explaining that `main-thread:ref` expects a MainThreadRef object or a main-thread function. When a render reuses the same raw value, the adapter reuses the previous prepared wrapper instead of registering or allocating it again.

This is intentionally a dedicated adapter rather than `adaptRefAttrSlot`: ordinary React refs are converted to selector markers and resolved through the BTS ref-effect path, while `main-thread:ref` must preserve an MTS value for main-thread hydration and later native-element attachment.

The ET public entry also exports `MainThreadRef` and `useMainThreadRef`, while `adaptMTRefAttrSlot` remains internal compiler/runtime protocol surface. The background-function registration helper is renamed from the MT-event-specific name because both main-thread events and callback refs now use it.

`isMainThreadFunction` is the shared core identity check for transformed main-thread functions. Callback refs, direct main-thread events, and `runOnMainThread` reuse it instead of maintaining ref- or event-specific predicates.

## Scope and follow-ups

This PR establishes the compile-time and prepared-slot representation for direct `main-thread:ref`. It does not yet:

- transport initial MainThreadRef values;
- resolve the real native `FiberElement` and attach or clean up the ref;
- align attachment and cleanup with typed-list holder lifecycle;
- support `main-thread:ref` through spread attributes; or
- enable legacy `worklet:ref`.

Those behaviors remain in the following PRs in the stack. In particular, this PR does not claim that the prepared wrapper alone completes native attachment.

A changeset is not required because Element Template remains unreleased.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).









