### PR TITLE
feat(react): transport element template ref init values

### DIFF
--- a/packages/react/runtime/__test__/element-template/native/callDestroyLifetimeFun.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/callDestroyLifetimeFun.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getReloadVersion } from '../../../src/core/reload-version.js';
+import { MainThreadRef, clearMainThreadRefLastIdForTesting } from '../../../src/core/main-thread-ref.js';
+import { takeMainThreadRefInitValuePatch } from '../../../src/core/main-thread-ref-init-value.js';
+import { clearMtsConfigCacheForTesting } from '../../../src/core/mts-capability.js';
 import {
   globalCommitContext,
   markRemovedSubtreeForPostDispatchTeardown,
@@ -26,12 +29,16 @@ describe('callDestroyLifetimeFun', () => {
     vi.clearAllMocks();
     resetElementTemplateHydrationListener();
     resetElementTemplateCommitState();
+    clearMainThreadRefLastIdForTesting();
+    clearMtsConfigCacheForTesting();
+    takeMainThreadRefInitValuePatch();
     envManager.resetEnv('background');
   });
 
   afterEach(() => {
     resetElementTemplateHydrationListener();
     resetElementTemplateCommitState();
+    takeMainThreadRefInitValuePatch();
   });
 
   it('destroys background runtime state', () => {
@@ -53,6 +60,14 @@ describe('callDestroyLifetimeFun', () => {
     expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
     expect(globalCommitContext.ops).toEqual([]);
     expect(backgroundElementTemplateInstanceManager.values.size).toBe(0);
+  });
+
+  it('discards pending MainThreadRef init values on full-lifetime destroy', () => {
+    new MainThreadRef('stale');
+
+    callDestroyLifetimeFun();
+
+    expect(takeMainThreadRefInitValuePatch()).toEqual([]);
   });
 
   it('removes the hydration listener without processing later hydrate payloads', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
@@ -4,6 +4,9 @@ import { WorkletEvents } from '@lynx-js/react/worklet-runtime/bindings';
 import { options } from 'preact';
 import { Component, createElement } from 'preact/compat';
 
+import { MainThreadRef, clearMainThreadRefLastIdForTesting } from '../../../../src/core/main-thread-ref.js';
+import { takeMainThreadRefInitValuePatch } from '../../../../src/core/main-thread-ref-init-value.js';
+import { clearMtsConfigCacheForTesting } from '../../../../src/core/mts-capability.js';
 import { getReloadVersion } from '../../../../src/core/reload-version.js';
 import * as elementTemplateAlog from '../../../../src/element-template/debug/alog.js';
 import {
@@ -109,16 +112,22 @@ function installDataChangeHarness() {
 describe('ElementTemplate commit hook', () => {
   const envManager = new ElementTemplateEnvManager();
   let updateEvents: unknown[] = [];
+  let originalLynxSdkVersion: string | undefined;
 
   const onUpdate = (event: { data: unknown }) => {
     updateEvents.push(parseElementTemplateUpdateEventPayload(event.data));
   };
 
   beforeEach(() => {
+    originalLynxSdkVersion = SystemInfo.lynxSdkVersion;
     resetElementTemplateCommitState();
     backgroundElementTemplateInstanceManager.clear();
     backgroundElementTemplateInstanceManager.nextId = 0;
     clearRefState();
+    SystemInfo.lynxSdkVersion = '4.0';
+    clearMainThreadRefLastIdForTesting();
+    clearMtsConfigCacheForTesting();
+    takeMainThreadRefInitValuePatch();
     updateEvents = [];
     envManager.resetEnv('background');
     installElementTemplateCommitHook();
@@ -136,7 +145,10 @@ describe('ElementTemplate commit hook', () => {
     resetElementTemplateHydrationListener();
     resetElementTemplateCommitState();
     clearRefState();
+    takeMainThreadRefInitValuePatch();
     takeDelayedRunOnMainThreadData();
+    SystemInfo.lynxSdkVersion = originalLynxSdkVersion;
+    clearMtsConfigCacheForTesting();
   });
 
   it('dispatches update after commit when hydrated', () => {
@@ -205,6 +217,26 @@ describe('ElementTemplate commit hook', () => {
     ]);
     envManager.switchToBackground();
     expect(takeDelayedRunOnMainThreadData()).toEqual([]);
+  });
+
+  it('dispatches MainThreadRef init-value patch after commit when hydrated', () => {
+    markElementTemplateHydrated();
+    new MainThreadRef('commit-init');
+
+    options.__c?.({} as unknown as object, []);
+
+    envManager.switchToMainThread();
+    expect(updateEvents).toEqual([
+      {
+        ops: [],
+        flushOptions: { emptyPatch: true },
+        flowIds: undefined,
+        reloadVersion: getReloadVersion(),
+        mainThreadRefInitValuePatch: [[1, 'commit-init']],
+      },
+    ]);
+    envManager.switchToBackground();
+    expect(takeMainThreadRefInitValuePatch()).toEqual([]);
   });
 
   it('drops only the failed delayed runOnMainThread return when update dispatch throws', async () => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
@@ -36,7 +36,10 @@ import {
   enqueueDelayedRunOnMainThreadData,
   takeDelayedRunOnMainThreadData,
 } from '../../../../src/core/thread-function-call/main-thread.js';
-import { onFunctionCall } from '../../../../src/core/thread-function-call/return-value.js';
+import {
+  onFunctionCall,
+  resetFunctionCallReturnListener,
+} from '../../../../src/core/thread-function-call/return-value.js';
 import {
   InitDataConsumer,
   InitDataProvider,
@@ -47,7 +50,6 @@ import {
 } from '../../../../src/element-template/index.js';
 import { ElementTemplateEnvManager } from '../../test-utils/debug/envManager.js';
 import { clearRefState, queueRefAttrUpdate } from '../../../../src/element-template/prop-adapters/ref.js';
-import { flushCoreContextEvents } from '../../test-utils/mock/mockNativePapi/context.js';
 
 function createRawTextOps(id: number, text: string) {
   return [
@@ -147,6 +149,7 @@ describe('ElementTemplate commit hook', () => {
     clearRefState();
     takeMainThreadRefInitValuePatch();
     takeDelayedRunOnMainThreadData();
+    resetFunctionCallReturnListener();
     SystemInfo.lynxSdkVersion = originalLynxSdkVersion;
     clearMtsConfigCacheForTesting();
   });
@@ -239,38 +242,44 @@ describe('ElementTemplate commit hook', () => {
     expect(takeMainThreadRefInitValuePatch()).toEqual([]);
   });
 
-  it('drops only the failed delayed runOnMainThread return when update dispatch throws', async () => {
-    markElementTemplateHydrated();
-    const dispatchError = new Error('update dispatch failed');
-    const coreContext = lynx.getCoreContext();
-    const removeEventListener = vi.spyOn(coreContext, 'removeEventListener');
-    vi.spyOn(coreContext, 'dispatchEvent').mockImplementationOnce(() => {
-      throw dispatchError;
-    });
-    const worklet = { _wkltId: 'failed-commit-main-thread-function' };
-    let keptResolveId = 0;
-    const keptPromise = new Promise(resolve => {
-      keptResolveId = onFunctionCall(resolve);
-    });
+  it('cleans commit state when update serialization throws', () => {
+    vi.useFakeTimers();
+    globalThis.__ALOG__ = false;
+    const serializeError = new Error('update serialization failed');
+    const throwingValue = {
+      toJSON() {
+        throw serializeError;
+      },
+    } as unknown as string;
+    const ref = vi.fn();
+    const removedRoot = new BackgroundElementTemplateInstance('removed');
+    const removeEventListener = vi.spyOn(lynx.getCoreContext(), 'removeEventListener');
 
-    enqueueDelayedRunOnMainThreadData({
-      worklet,
-      params: [],
-      resolveId: onFunctionCall(vi.fn()),
-    });
+    try {
+      markElementTemplateHydrated();
+      queueRefAttrUpdate(null, ref, -2, 0);
+      markRemovedSubtreeForPostDispatchTeardown(removedRoot);
+      globalCommitContext.ops = createRawTextOps(1, throwingValue);
+      enqueueDelayedRunOnMainThreadData({
+        worklet: { _wkltId: 'failed-serialize-main-thread-function' },
+        params: [],
+        resolveId: onFunctionCall(vi.fn()),
+      });
 
-    expect(() => options.__c?.({} as unknown as object, [])).toThrow(dispatchError);
-    expect(takeDelayedRunOnMainThreadData()).toEqual([]);
-    expect(removeEventListener).not.toHaveBeenCalled();
+      expect(() => options.__c?.({} as unknown as object, [])).toThrow(serializeError);
+      expect(takeDelayedRunOnMainThreadData()).toEqual([]);
+      expect(removeEventListener).toHaveBeenCalledWith(WorkletEvents.FunctionCallRet, expect.any(Function));
+      expect(globalCommitContext.ops).toEqual([]);
+      expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
 
-    envManager.switchToMainThread();
-    lynx.getJSContext().dispatchEvent({
-      type: WorkletEvents.FunctionCallRet,
-      data: JSON.stringify({ resolveId: keptResolveId, returnValue: 'kept' }),
-    });
-    flushCoreContextEvents();
-    envManager.switchToBackground();
-    await expect(keptPromise).resolves.toBe('kept');
+      options.__c?.({} as unknown as object, []);
+      expect(ref).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(10000);
+      expect(backgroundElementTemplateInstanceManager.get(removedRoot.instanceId)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('dispatches triggerDataUpdated when useInitData observes a data change', () => {
@@ -739,54 +748,6 @@ describe('ElementTemplate commit hook', () => {
       expect(backgroundElementTemplateInstanceManager.get(root.instanceId)).toBeUndefined();
     } finally {
       vi.useRealTimers();
-    }
-  });
-
-  it('resets commit state when update dispatch throws', () => {
-    vi.useFakeTimers();
-    const dispatchError = new Error('update dispatch failed');
-    const dispatchSpy = vi.spyOn(lynx.getCoreContext(), 'dispatchEvent').mockImplementationOnce(() => {
-      throw dispatchError;
-    });
-
-    try {
-      markElementTemplateHydrated();
-      const root = new BackgroundElementTemplateInstance('root');
-      markRemovedSubtreeForPostDispatchTeardown(root);
-      globalCommitContext.ops = createRawTextOps(1, 'flush');
-
-      expect(() => options.__c?.({} as unknown as object, [])).toThrow(dispatchError);
-      expect(globalCommitContext.ops).toEqual([]);
-      expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
-
-      vi.advanceTimersByTime(10000);
-      expect(backgroundElementTemplateInstanceManager.get(root.instanceId)).toBeUndefined();
-    } finally {
-      dispatchSpy.mockRestore();
-      vi.useRealTimers();
-    }
-  });
-
-  it('clears pending refs when update dispatch throws', () => {
-    const ref = vi.fn();
-    const dispatchError = new Error('update dispatch failed');
-    const dispatchSpy = vi.spyOn(lynx.getCoreContext(), 'dispatchEvent').mockImplementationOnce(() => {
-      throw dispatchError;
-    });
-
-    try {
-      markElementTemplateHydrated();
-      queueRefAttrUpdate(null, ref, -2, 0);
-      globalCommitContext.ops = createRawTextOps(1, 'flush');
-
-      expect(() => options.__c?.({} as unknown as object, [])).toThrow(dispatchError);
-      expect(ref).not.toHaveBeenCalled();
-
-      globalCommitContext.ops = [];
-      options.__c?.({} as unknown as object, []);
-      expect(ref).not.toHaveBeenCalled();
-    } finally {
-      dispatchSpy.mockRestore();
     }
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
@@ -13,6 +13,10 @@ import {
   resetElementTemplateHydrationListener,
 } from '../../../../src/element-template/background/hydration-listener.js';
 import {
+  installElementTemplatePatchListener,
+  resetElementTemplatePatchListener,
+} from '../../../../src/element-template/native/patch-listener.js';
+import {
   BackgroundElementTemplateInstance,
   BackgroundListElementTemplateInstance,
 } from '../../../../src/element-template/background/instance.js';
@@ -260,6 +264,46 @@ describe('ElementTemplate hydration listener', () => {
       mainThreadRefInitValuePatch: [[1, 'hydrate-init']],
     });
     expect(takeMainThreadRefInitValuePatch()).toEqual([]);
+  });
+
+  it('applies MainThreadRef init values when reload makes the hydration update stale', () => {
+    const updateWorkletRefInitValueChanges = vi.fn();
+    const previousWorkletImpl = globalThis.lynxWorkletImpl;
+    globalThis.lynxWorkletImpl = {
+      ...previousWorkletImpl,
+      _refImpl: {
+        updateWorkletRefInitValueChanges,
+      },
+    };
+
+    try {
+      envManager.switchToBackground();
+      installElementTemplateHydrationListener();
+
+      const backgroundRoot = __root as BackgroundElementTemplateInstance;
+      const after = new BackgroundElementTemplateInstance('_et_test');
+      backgroundRoot.appendChild(after);
+      new MainThreadRef('reload-init');
+
+      envManager.switchToMainThread();
+      installElementTemplatePatchListener();
+      dispatchHydrate([createSerializedTemplate(after.instanceId, '_et_test')]);
+
+      envManager.switchToBackground();
+      // This harness shares module state across both simulated threads. Advance
+      // the version after BTS dispatch so the queued update is stale on MTS.
+      increaseReloadVersion();
+      vi.mocked(__FlushElementTree).mockClear();
+      envManager.switchToMainThread();
+
+      expect(updateWorkletRefInitValueChanges).toHaveBeenCalledWith([[1, 'reload-init']]);
+      expect(__FlushElementTree).not.toHaveBeenCalled();
+    } finally {
+      envManager.switchToMainThread();
+      resetElementTemplatePatchListener();
+      globalThis.lynxWorkletImpl = previousWorkletImpl;
+      envManager.switchToBackground();
+    }
   });
 
   it('clears delayed runOnMainThread state when hydrate matching fails', () => {
@@ -625,56 +669,6 @@ describe('ElementTemplate hydration listener', () => {
       lynx.reportError = oldReportError;
       lynx.createSelectorQuery = oldCreateSelectorQuery;
       printTreeSpy.mockRestore();
-    }
-  });
-
-  it('clears init-value and delayed call state when hydrate update dispatch throws', () => {
-    const dispatchError = new Error('hydrate update dispatch failed');
-    const oldCreateSelectorQuery = lynx.createSelectorQuery;
-    const eventHandler = vi.fn();
-    const ref = vi.fn();
-    const exec = vi.fn();
-    const select = vi.fn(() => ({ setNativeProps: vi.fn(() => ({ exec })) }));
-    lynx.createSelectorQuery = vi.fn(() => ({ select })) as typeof lynx.createSelectorQuery;
-
-    try {
-      __etAttrPlanMap._et_dispatch_failure = [0, adaptEventAttrSlot, 1, adaptRefAttrSlot];
-      resetEventStateForRuntime();
-      envManager.switchToBackground();
-      installElementTemplateHydrationListener();
-      const removeEventListener = vi.spyOn(lynx.getCoreContext(), 'removeEventListener');
-
-      const backgroundRoot = __root as BackgroundElementTemplateInstance;
-      const after = new BackgroundElementTemplateInstance('_et_dispatch_failure', [eventHandler, ref]);
-      backgroundRoot.appendChild(after);
-      publishEvent('-1:0:', { type: 'tap' });
-      new ElementTemplateRefProxy(after.instanceId, 1).setNativeProps({ opacity: 1 }).exec();
-      new MainThreadRef('failed-dispatch-init');
-      void runOnMainThread({ _wkltId: 'failed-dispatch-main-thread-function' } as unknown as () => void)();
-
-      envManager.switchToMainThread();
-      dispatchHydrate([{
-        ...createSerializedTemplate(after.instanceId, '_et_dispatch_failure'),
-        attributeSlots: ['-1:0:', '-1-1'],
-      }]);
-      vi.spyOn(lynx.getCoreContext(), 'dispatchEvent').mockImplementationOnce(() => {
-        throw dispatchError;
-      });
-
-      expect(() => envManager.switchToBackground()).toThrow(dispatchError);
-      expect(takeMainThreadRefInitValuePatch()).toEqual([]);
-      expect(takeDelayedRunOnMainThreadData()).toEqual([]);
-      expect(removeEventListener).toHaveBeenCalledWith(WorkletEvents.FunctionCallRet, expect.any(Function));
-      expect(globalPipelineOptions).toBeUndefined();
-      flushPendingEvents();
-      flushPendingRefs();
-      flushDelayedRefUiOps();
-      expect(eventHandler).not.toHaveBeenCalled();
-      expect(ref).not.toHaveBeenCalled();
-      expect(select).not.toHaveBeenCalled();
-      expect(exec).not.toHaveBeenCalled();
-    } finally {
-      lynx.createSelectorQuery = oldCreateSelectorQuery;
     }
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/hydration/hydration-listener.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WorkletEvents } from '@lynx-js/react/worklet-runtime/bindings';
 
+import { MainThreadRef, clearMainThreadRefLastIdForTesting } from '../../../../src/core/main-thread-ref.js';
+import { takeMainThreadRefInitValuePatch } from '../../../../src/core/main-thread-ref-init-value.js';
+import { clearMtsConfigCacheForTesting } from '../../../../src/core/mts-capability.js';
 import { getReloadVersion, increaseReloadVersion } from '../../../../src/core/reload-version.js';
 import * as elementTemplateAlog from '../../../../src/element-template/debug/alog.js';
 import { globalCommitContext } from '../../../../src/element-template/background/commit-context.js';
@@ -17,10 +20,12 @@ import { backgroundElementTemplateInstanceManager } from '../../../../src/elemen
 import { PerformanceTimingFlags, PipelineOrigins, globalPipelineOptions } from '../../../../src/core/performance.js';
 import {
   clearEventState,
+  flushPendingEvents,
   publishEvent,
   resetEventStateForRuntime,
 } from '../../../../src/element-template/prop-adapters/event.js';
 import {
+  ElementTemplateRefProxy,
   clearRefState,
   flushDelayedRefUiOps,
   flushPendingRefs,
@@ -100,6 +105,10 @@ describe('ElementTemplate hydration listener', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     originalLynxSdkVersion = SystemInfo.lynxSdkVersion;
+    SystemInfo.lynxSdkVersion = '4.0';
+    clearMainThreadRefLastIdForTesting();
+    clearMtsConfigCacheForTesting();
+    takeMainThreadRefInitValuePatch();
     clearEtAttrPlanMap();
     clearEventState();
     clearRefState();
@@ -111,9 +120,11 @@ describe('ElementTemplate hydration listener', () => {
     globalThis.__ALOG__ = true;
     resetElementTemplateHydrationListener();
     clearRefState();
+    takeMainThreadRefInitValuePatch();
     takeDelayedRunOnMainThreadData();
     resetFunctionCallReturnListener();
     SystemInfo.lynxSdkVersion = originalLynxSdkVersion;
+    clearMtsConfigCacheForTesting();
   });
 
   it('hydrates instances sent from main thread', () => {
@@ -216,6 +227,41 @@ describe('ElementTemplate hydration listener', () => {
     expect(takeDelayedRunOnMainThreadData()).toEqual([]);
   });
 
+  it('dispatches MainThreadRef init-value patch after clean hydrate', () => {
+    envManager.switchToBackground();
+    installElementTemplateHydrationListener();
+    const dispatchSpy = vi.spyOn(lynx.getCoreContext(), 'dispatchEvent');
+
+    const backgroundRoot = __root as BackgroundElementTemplateInstance;
+    const after = new BackgroundElementTemplateInstance('_et_test');
+    backgroundRoot.appendChild(after);
+    new MainThreadRef('hydrate-init');
+
+    envManager.switchToMainThread();
+    dispatchHydrate([createSerializedTemplate(after.instanceId, '_et_test')]);
+
+    envManager.switchToBackground();
+    const updatePayload = parseUpdateEventData(dispatchSpy.mock.calls.at(-1)?.[0]?.data);
+    expect(updatePayload).toEqual({
+      ops: [],
+      flushOptions: {
+        pipelineOptions: {
+          pipelineID: 'pipelineID',
+          needTimestamps: true,
+          pipelineOrigin: PipelineOrigins.reactLynxHydrate,
+          dsl: 'reactLynx',
+          stage: 'hydrate',
+        },
+      },
+      flowIds: undefined,
+      isHydration: true,
+      reloadVersion: getReloadVersion(),
+      delayedRunOnMainThreadData: undefined,
+      mainThreadRefInitValuePatch: [[1, 'hydrate-init']],
+    });
+    expect(takeMainThreadRefInitValuePatch()).toEqual([]);
+  });
+
   it('clears delayed runOnMainThread state when hydrate matching fails', () => {
     SystemInfo.lynxSdkVersion = '4.0';
     envManager.switchToBackground();
@@ -252,6 +298,32 @@ describe('ElementTemplate hydration listener', () => {
       expect(takeDelayedRunOnMainThreadData()).toEqual([]);
       expect(removeEventListener).toHaveBeenCalledWith(WorkletEvents.FunctionCallRet, expect.any(Function));
       expect(globalPipelineOptions).toBeUndefined();
+    } finally {
+      lynx.reportError = oldReportError;
+    }
+  });
+
+  it('clears MainThreadRef init-value patch when hydrate matching fails', () => {
+    SystemInfo.lynxSdkVersion = '4.0';
+    const oldReportError = lynx.reportError;
+    const reportError = vi.fn();
+    lynx.reportError = reportError;
+
+    try {
+      envManager.switchToBackground();
+      installElementTemplateHydrationListener();
+
+      const backgroundRoot = __root as BackgroundElementTemplateInstance;
+      const after = new BackgroundElementTemplateInstance('_et_test');
+      backgroundRoot.appendChild(after);
+      new MainThreadRef('failed-hydrate-init');
+
+      envManager.switchToMainThread();
+      dispatchHydrate([createSerializedTemplate(0, '_et_test')]);
+
+      envManager.switchToBackground();
+      expect(takeMainThreadRefInitValuePatch()).toEqual([]);
+      expect(reportError).toHaveBeenCalledTimes(1);
     } finally {
       lynx.reportError = oldReportError;
     }
@@ -486,13 +558,21 @@ describe('ElementTemplate hydration listener', () => {
 
   it('resets commit state when hydrate update serialization throws', () => {
     SystemInfo.lynxSdkVersion = '4.0';
-    globalThis.__ALOG__ = false;
     const serializeError = new Error('hydrate update serialization failed');
     const oldReportError = lynx.reportError;
+    const oldCreateSelectorQuery = lynx.createSelectorQuery;
     const reportError = vi.fn();
+    const eventHandler = vi.fn();
+    const ref = vi.fn();
+    const exec = vi.fn();
+    const select = vi.fn(() => ({ setNativeProps: vi.fn(() => ({ exec })) }));
+    const printTreeSpy = vi.spyOn(elementTemplateAlog, 'printElementTemplateTreeToString').mockReturnValue('<tree>');
     lynx.reportError = reportError;
+    lynx.createSelectorQuery = vi.fn(() => ({ select })) as typeof lynx.createSelectorQuery;
 
     try {
+      __etAttrPlanMap._et_serialize_failure = [1, adaptEventAttrSlot, 2, adaptRefAttrSlot];
+      resetEventStateForRuntime();
       envManager.switchToBackground();
       installElementTemplateHydrationListener();
       const removeEventListener = vi.spyOn(lynx.getCoreContext(), 'removeEventListener');
@@ -503,15 +583,18 @@ describe('ElementTemplate hydration listener', () => {
           throw serializeError;
         },
       } as unknown as SerializableValue;
-      const after = new BackgroundElementTemplateInstance('_et_test', [throwingValue]);
+      const after = new BackgroundElementTemplateInstance('_et_serialize_failure', [throwingValue, eventHandler, ref]);
       backgroundRoot.appendChild(after);
+      publishEvent('-1:1:', { type: 'tap' });
+      new ElementTemplateRefProxy(after.instanceId, 2).setNativeProps({ opacity: 1 }).exec();
+      new MainThreadRef('failed-serialize-init');
       void runOnMainThread({ _wkltId: 'failed-serialize-main-thread-function' } as unknown as () => void)();
 
       envManager.switchToMainThread();
       dispatchHydrate([
         {
-          ...createSerializedTemplate(-1, '_et_test'),
-          attributeSlots: ['before'],
+          ...createSerializedTemplate(-1, '_et_serialize_failure'),
+          attributeSlots: ['before', '-1:1:', '-1-2'],
         } satisfies SerializedElementTemplate,
       ]);
 
@@ -519,9 +602,17 @@ describe('ElementTemplate hydration listener', () => {
       expect(reportError).toHaveBeenCalledWith(serializeError);
       expect(globalCommitContext.ops).toEqual([]);
       expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
+      expect(takeMainThreadRefInitValuePatch()).toEqual([]);
       expect(takeDelayedRunOnMainThreadData()).toEqual([]);
       expect(removeEventListener).toHaveBeenCalledWith(WorkletEvents.FunctionCallRet, expect.any(Function));
       expect(globalPipelineOptions).toBeUndefined();
+      flushPendingEvents();
+      flushPendingRefs();
+      flushDelayedRefUiOps();
+      expect(eventHandler).not.toHaveBeenCalled();
+      expect(ref).not.toHaveBeenCalled();
+      expect(select).not.toHaveBeenCalled();
+      expect(exec).not.toHaveBeenCalled();
       expect(lynx.performance._markTiming.mock.calls).toEqual([
         ['pipelineID', 'hydrateParseSnapshotStart'],
         ['pipelineID', 'hydrateParseSnapshotEnd'],
@@ -532,6 +623,58 @@ describe('ElementTemplate hydration listener', () => {
       ]);
     } finally {
       lynx.reportError = oldReportError;
+      lynx.createSelectorQuery = oldCreateSelectorQuery;
+      printTreeSpy.mockRestore();
+    }
+  });
+
+  it('clears init-value and delayed call state when hydrate update dispatch throws', () => {
+    const dispatchError = new Error('hydrate update dispatch failed');
+    const oldCreateSelectorQuery = lynx.createSelectorQuery;
+    const eventHandler = vi.fn();
+    const ref = vi.fn();
+    const exec = vi.fn();
+    const select = vi.fn(() => ({ setNativeProps: vi.fn(() => ({ exec })) }));
+    lynx.createSelectorQuery = vi.fn(() => ({ select })) as typeof lynx.createSelectorQuery;
+
+    try {
+      __etAttrPlanMap._et_dispatch_failure = [0, adaptEventAttrSlot, 1, adaptRefAttrSlot];
+      resetEventStateForRuntime();
+      envManager.switchToBackground();
+      installElementTemplateHydrationListener();
+      const removeEventListener = vi.spyOn(lynx.getCoreContext(), 'removeEventListener');
+
+      const backgroundRoot = __root as BackgroundElementTemplateInstance;
+      const after = new BackgroundElementTemplateInstance('_et_dispatch_failure', [eventHandler, ref]);
+      backgroundRoot.appendChild(after);
+      publishEvent('-1:0:', { type: 'tap' });
+      new ElementTemplateRefProxy(after.instanceId, 1).setNativeProps({ opacity: 1 }).exec();
+      new MainThreadRef('failed-dispatch-init');
+      void runOnMainThread({ _wkltId: 'failed-dispatch-main-thread-function' } as unknown as () => void)();
+
+      envManager.switchToMainThread();
+      dispatchHydrate([{
+        ...createSerializedTemplate(after.instanceId, '_et_dispatch_failure'),
+        attributeSlots: ['-1:0:', '-1-1'],
+      }]);
+      vi.spyOn(lynx.getCoreContext(), 'dispatchEvent').mockImplementationOnce(() => {
+        throw dispatchError;
+      });
+
+      expect(() => envManager.switchToBackground()).toThrow(dispatchError);
+      expect(takeMainThreadRefInitValuePatch()).toEqual([]);
+      expect(takeDelayedRunOnMainThreadData()).toEqual([]);
+      expect(removeEventListener).toHaveBeenCalledWith(WorkletEvents.FunctionCallRet, expect.any(Function));
+      expect(globalPipelineOptions).toBeUndefined();
+      flushPendingEvents();
+      flushPendingRefs();
+      flushDelayedRefUiOps();
+      expect(eventHandler).not.toHaveBeenCalled();
+      expect(ref).not.toHaveBeenCalled();
+      expect(select).not.toHaveBeenCalled();
+      expect(exec).not.toHaveBeenCalled();
+    } finally {
+      lynx.createSelectorQuery = oldCreateSelectorQuery;
     }
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -116,6 +116,10 @@ function seedMTEventState(
   initializeMainThreadDynamicAttrSlots(handleId, MT_EVENT_TEMPLATE, attributeSlots);
 }
 
+function createMainThreadRefImplMock(clearFirstScreenWorkletRefMap = vi.fn()) {
+  return { clearFirstScreenWorkletRefMap };
+}
+
 describe('ElementTemplate patch stream (apply)', () => {
   const envManager = new ElementTemplateEnvManager();
   let hydrationData: HydrateInstances = [];
@@ -298,6 +302,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
       _hydrateCtx: hydrateCtx,
+      _refImpl: createMainThreadRefImplMock(),
     };
     elementTemplateRegistry.set(targetId, {} as ElementRef);
 
@@ -454,6 +459,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
       _hydrateCtx: hydrateCtx,
+      _refImpl: createMainThreadRefImplMock(),
     };
     elementTemplateRegistry.set(targetId, {} as ElementRef);
     seedMTEventState(targetId, 0, oldCtx);
@@ -489,10 +495,14 @@ describe('ElementTemplate patch stream (apply)', () => {
     const runDelayedBackgroundFunctions = vi.fn(() => {
       callOrder.push('runOnBackground');
     });
+    const clearFirstScreenWorkletRefMap = vi.fn(() => {
+      callOrder.push('clearFirstScreenRefs');
+    });
     const previousWorkletImpl = globalThis.lynxWorkletImpl;
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
       _hydrateCtx: hydrateCtx,
+      _refImpl: createMainThreadRefImplMock(clearFirstScreenWorkletRefMap),
       _runOnBackgroundDelayImpl: {
         runDelayedBackgroundFunctions,
       },
@@ -520,6 +530,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       expect(callOrder).toEqual([
         'hydrate',
         'runOnBackground',
+        'clearFirstScreenRefs',
         'flushElementTree',
       ]);
     } finally {
@@ -539,10 +550,14 @@ describe('ElementTemplate patch stream (apply)', () => {
     const runDelayedBackgroundFunctions = vi.fn(() => {
       callOrder.push('runOnBackground');
     });
+    const clearFirstScreenWorkletRefMap = vi.fn(() => {
+      callOrder.push('clearFirstScreenRefs');
+    });
     const previousWorkletImpl = globalThis.lynxWorkletImpl;
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
       _hydrateCtx: hydrateCtx,
+      _refImpl: createMainThreadRefImplMock(clearFirstScreenWorkletRefMap),
       _runOnBackgroundDelayImpl: {
         runDelayedBackgroundFunctions,
       },
@@ -590,6 +605,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       expect(callOrder).toEqual([
         'hydrate',
         'runOnBackground',
+        'clearFirstScreenRefs',
         'eom:false',
         'runOnMainThread',
         'eom:true',
@@ -658,9 +674,13 @@ describe('ElementTemplate patch stream (apply)', () => {
     const runDelayedBackgroundFunctions = vi.fn(() => {
       callOrder.push('runOnBackground');
     });
+    const clearFirstScreenWorkletRefMap = vi.fn(() => {
+      callOrder.push('clearFirstScreenRefs');
+    });
     const previousWorkletImpl = globalThis.lynxWorkletImpl;
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
+      _refImpl: createMainThreadRefImplMock(clearFirstScreenWorkletRefMap),
       _runOnBackgroundDelayImpl: {
         runDelayedBackgroundFunctions,
       },
@@ -684,6 +704,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       expect(runDelayedBackgroundFunctions).toHaveBeenCalledTimes(1);
       expect(callOrder).toEqual([
         'runOnBackground',
+        'clearFirstScreenRefs',
         'flushElementTree',
       ]);
     } finally {
@@ -765,6 +786,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
       _hydrateCtx: hydrateCtx,
+      _refImpl: createMainThreadRefImplMock(),
     };
     elementTemplateRegistry.set(targetId, {} as ElementRef);
     seedMTEventState(targetId, 0, oldCtx);
@@ -839,6 +861,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     const previousWorkletImpl = globalThis.lynxWorkletImpl;
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
+      _refImpl: createMainThreadRefImplMock(),
       _runOnBackgroundDelayImpl: {
         runDelayedBackgroundFunctions,
       },
@@ -875,6 +898,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       }).toThrow('setAttribute failed');
 
       expect(runDelayedBackgroundFunctions).toHaveBeenCalledTimes(1);
+      expect(globalThis.lynxWorkletImpl._refImpl.clearFirstScreenWorkletRefMap).toHaveBeenCalledTimes(1);
       expect(setShouldFlush).not.toHaveBeenCalled();
       expect(runRunOnMainThreadTask).not.toHaveBeenCalled();
       expect(getMainThreadDynamicAttrState(targetId, 0)).toBeUndefined();
@@ -891,6 +915,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     const previousWorkletImpl = globalThis.lynxWorkletImpl;
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
+      _refImpl: createMainThreadRefImplMock(),
       _runOnBackgroundDelayImpl: {
         runDelayedBackgroundFunctions,
       },
@@ -933,12 +958,70 @@ describe('ElementTemplate patch stream (apply)', () => {
     }
   });
 
-  it('does not run delayed main-thread tasks for stale reload payloads', () => {
-    const staleReloadVersion = getReloadVersion();
-    const runRunOnMainThreadTask = vi.fn();
+  it('applies MainThreadRef init patches before same-payload delayed main-thread tasks', () => {
+    const callOrder: string[] = [];
+    const updateWorkletRefInitValueChanges = vi.fn(() => {
+      callOrder.push('init-patch');
+    });
+    const runRunOnMainThreadTask = vi.fn(() => {
+      callOrder.push('runOnMainThread');
+    });
     const previousWorkletImpl = globalThis.lynxWorkletImpl;
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
+      _refImpl: {
+        updateWorkletRefInitValueChanges,
+      },
+      _eomImpl: {
+        setShouldFlush: vi.fn(),
+      },
+      _runRunOnMainThreadTask: runRunOnMainThreadTask,
+    };
+
+    try {
+      envManager.switchToMainThread();
+      installElementTemplatePatchListener();
+      mockFlushElementTree.mockImplementationOnce(() => {
+        callOrder.push('flushElementTree');
+      });
+
+      envManager.switchToBackground();
+      dispatchElementTemplateUpdate({
+        ops: [],
+        flushOptions: {},
+        delayedRunOnMainThreadData: [
+          {
+            worklet: { _wkltId: 'same-payload-main-thread-function' },
+            params: [],
+            resolveId: 10,
+          },
+        ],
+        mainThreadRefInitValuePatch: [[1, 'same-payload-init']],
+      });
+      envManager.switchToMainThread();
+
+      expect(updateWorkletRefInitValueChanges).toHaveBeenCalledWith([[1, 'same-payload-init']]);
+      expect(runRunOnMainThreadTask).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual([
+        'init-patch',
+        'runOnMainThread',
+        'flushElementTree',
+      ]);
+    } finally {
+      globalThis.lynxWorkletImpl = previousWorkletImpl;
+    }
+  });
+
+  it('does not run delayed main-thread tasks for stale reload payloads', () => {
+    const staleReloadVersion = getReloadVersion();
+    const runRunOnMainThreadTask = vi.fn();
+    const updateWorkletRefInitValueChanges = vi.fn();
+    const previousWorkletImpl = globalThis.lynxWorkletImpl;
+    globalThis.lynxWorkletImpl = {
+      ...previousWorkletImpl,
+      _refImpl: {
+        updateWorkletRefInitValueChanges,
+      },
       _eomImpl: {
         setShouldFlush: vi.fn(),
       },
@@ -963,9 +1046,11 @@ describe('ElementTemplate patch stream (apply)', () => {
             resolveId: 10,
           },
         ],
+        mainThreadRefInitValuePatch: [[1, 'stale-init']],
       });
       envManager.switchToMainThread();
 
+      expect(updateWorkletRefInitValueChanges).toHaveBeenCalledWith([[1, 'stale-init']]);
       expect(runRunOnMainThreadTask).not.toHaveBeenCalled();
       expect(mockFlushElementTree).not.toHaveBeenCalled();
     } finally {
@@ -1003,6 +1088,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
       _hydrateCtx: hydrateCtx,
+      _refImpl: createMainThreadRefImplMock(),
     };
     elementTemplateRegistry.set(targetId, {} as ElementRef);
     seedMTEventState(targetId, 0, oldCtx);
@@ -1054,6 +1140,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     globalThis.lynxWorkletImpl = {
       ...previousWorkletImpl,
       _hydrateCtx: hydrateCtx,
+      _refImpl: createMainThreadRefImplMock(),
     };
     elementTemplateRegistry.set(targetId, {} as ElementRef);
     elementTemplateRegistry.set(childId, {} as ElementRef);

--- a/packages/react/runtime/__test__/element-template/runtime/patch/update-timing.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/update-timing.test.ts
@@ -129,6 +129,7 @@ describe('ElementTemplate update timing (main thread patch)', () => {
     const payload = {
       ops: createRawTextOps(1, 'stale'),
       flushOptions: { pipelineOptions },
+      flowIds: [101, 202],
       reloadVersion: staleReloadVersion,
     };
 
@@ -140,7 +141,17 @@ describe('ElementTemplate update timing (main thread patch)', () => {
     const flushCalls = (__FlushElementTree as unknown as { mock: { calls: unknown[][] } }).mock
       .calls;
     expect(flushCalls).toHaveLength(0);
-    expect(lynx.performance._markTiming.mock.calls).toEqual([]);
+    expect(lynx.performance.profileStart).toHaveBeenCalledWith('ReactLynx::patch', {
+      flowId: 101,
+      flowIds: [101, 202],
+    });
+    expect(lynx.performance.profileEnd).toHaveBeenCalledTimes(1);
+    expect(lynx.performance._markTiming.mock.calls).toEqual([
+      ['pipelineID', 'mtsRenderStart'],
+      ['pipelineID', 'parseChangesStart'],
+      ['pipelineID', 'parseChangesEnd'],
+      ['pipelineID', 'mtsRenderEnd'],
+    ]);
   });
 
   it('marks parse timing for empty update envelopes with pipeline options', () => {

--- a/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi.ts
+++ b/packages/react/runtime/__test__/element-template/test-utils/mock/mockNativePapi.ts
@@ -174,6 +174,7 @@ export function installMockNativePapi(
     g.__LYNX_REPORT_ERROR_CALLS.push(error);
     nativeLog.push(['lynx.reportError', error]);
   });
+  const mockCreateJSObjectDestructionObserver = vi.fn().mockImplementation(() => ({}));
 
   const mockSetAttribute = vi.fn().mockImplementation((element: unknown, name: string, value: unknown) => {
     nativeLog.push(['__SetAttribute', formatNode(element), name, value]);
@@ -354,8 +355,15 @@ export function installMockNativePapi(
   vi.stubGlobal('__FlushElementTree', mockFlushElementTree);
   const currentLynx = (globalThis as unknown as { lynx?: any }).lynx;
   const baseLynx = (currentLynx && typeof currentLynx === 'object') ? currentLynx : {};
+  const baseGetNativeApp = typeof baseLynx.getNativeApp === 'function'
+    ? baseLynx.getNativeApp
+    : undefined;
   vi.stubGlobal('lynx', {
     ...baseLynx,
+    getNativeApp: () => ({
+      ...baseGetNativeApp?.call(baseLynx),
+      createJSObjectDestructionObserver: mockCreateJSObjectDestructionObserver,
+    }),
     reportError: mockReportError,
   });
 

--- a/packages/react/runtime/__test__/snapshot/worklet/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/worklet/workletRef.test.jsx
@@ -175,14 +175,6 @@ describe('WorkletRef in js', () => {
     );
   });
 
-  it('should throw when native capabilities not fulfilled', () => {
-    globalEnvManager.switchToBackground();
-    lynx.getCoreContext = undefined;
-    expect(() => {
-      new MainThreadRef(1);
-    }).not.toThrow();
-  });
-
   it('should not send init value to the main thread when native capabilities not fulfilled', () => {
     SystemInfo.lynxSdkVersion = '2.13';
     const Comp = () => {

--- a/packages/react/runtime/__test__/worklet-runtime/observers.test.js
+++ b/packages/react/runtime/__test__/worklet-runtime/observers.test.js
@@ -3,7 +3,10 @@
 // LICENSE file in the root directory of this source tree.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { hydrateWorkletCtx as hydrateWorkletCtxFromBindings } from '../../src/worklet-runtime/bindings';
+import {
+  clearFirstScreenMainThreadRefs,
+  hydrateWorkletCtx as hydrateWorkletCtxFromBindings,
+} from '../../src/worklet-runtime/bindings';
 import { hydrateWorkletCtx, onWorkletCtxUpdate, retainWorkletCtx } from '../../src/worklet-runtime/bindings/observers';
 import { initWorklet } from '../../src/worklet-runtime/workletRuntime';
 
@@ -71,6 +74,18 @@ describe('MTFObservers', () => {
   it('exports element-free ctx hydration from the bindings entry', () => {
     expect(typeof hydrateWorkletCtxFromBindings).toBe('function');
     expect(hydrateWorkletCtxFromBindings).toBe(hydrateWorkletCtx);
+  });
+
+  it('clears only temporary first-screen MainThreadRefs', () => {
+    const firstScreenRef = { _wvid: -1, current: 'first-screen' };
+    const hydratedRef = { _wvid: 1, current: 'hydrated' };
+    globalThis.lynxWorkletImpl._refImpl._firstScreenWorkletRefMap[-1] = firstScreenRef;
+    globalThis.lynxWorkletImpl._refImpl._workletRefMap[1] = hydratedRef;
+
+    clearFirstScreenMainThreadRefs();
+
+    expect(globalThis.lynxWorkletImpl._refImpl._firstScreenWorkletRefMap).toEqual({});
+    expect(globalThis.lynxWorkletImpl._refImpl._workletRefMap[1]).toBe(hydratedRef);
   });
 
   it('hydrates worklet ctx without replaying delayed worklet events', () => {

--- a/packages/react/runtime/src/core/main-thread-ref.ts
+++ b/packages/react/runtime/src/core/main-thread-ref.ts
@@ -55,7 +55,7 @@ export class MainThreadRef<T> {
       addMainThreadRefInitValue(this._wvid, initValue);
       const id = this._wvid;
       this._lifecycleObserver = lynx.getNativeApp().createJSObjectDestructionObserver?.(() => {
-        lynx.getCoreContext?.().dispatchEvent({
+        lynx.getCoreContext().dispatchEvent({
           type: WorkletEvents.releaseWorkletRef,
           data: {
             id,

--- a/packages/react/runtime/src/element-template/background/commit-hook.ts
+++ b/packages/react/runtime/src/element-template/background/commit-hook.ts
@@ -11,6 +11,8 @@ import {
 } from './commit-context.js';
 import type { BackgroundElementTemplateInstance } from './instance.js';
 import { clearElementTemplateRenderScope, resetElementTemplateRenderScope } from './render-scope.js';
+import type { MainThreadRefInitValuePatch } from '../../core/main-thread-ref-init-value.js';
+import { takeMainThreadRefInitValuePatch } from '../../core/main-thread-ref-init-value.js';
 import { globalPipelineOptions, markTiming, markTimingLegacy, setPipeline } from '../../core/performance.js';
 import { getReloadVersion } from '../../core/reload-version.js';
 import {
@@ -66,12 +68,14 @@ export function cancelElementTemplateRemovedSubtreeCleanup(): void {
   scheduledRemovedSubtreeCleanupTimers.clear();
 }
 
-function flushElementTemplateCommitChanges(): void {
+function flushElementTemplateCommitChanges(mainThreadRefInitValuePatch: MainThreadRefInitValuePatch): void {
   const hasNativeOps = globalCommitContext.ops.length > 0;
   const hasDelayedRunOnMainThread = delayedRunOnMainThreadData.length > 0;
+  const hasMainThreadRefInitValuePatch = mainThreadRefInitValuePatch.length > 0;
   const hasUpdatePayload = hasNativeOps
     || !isEmptyObject(globalCommitContext.flushOptions)
-    || hasDelayedRunOnMainThread;
+    || hasDelayedRunOnMainThread
+    || hasMainThreadRefInitValuePatch;
   const removedSubtreesAwaitingTeardown = hasNativeOps ? takeRemovedSubtreesForPostDispatchTeardown() : [];
   let didFlushRefs = false;
   let didDispatchUpdatePayload = false;
@@ -113,6 +117,7 @@ function flushElementTemplateCommitChanges(): void {
                 flushOptions: globalCommitContext.flushOptions,
                 flowIds: globalCommitContext.flowIds,
                 delayedRunOnMainThreadDataCount: delayedRunOnMainThreadPayload?.length,
+                mainThreadRefInitValuePatchCount: mainThreadRefInitValuePatch.length,
               },
               null,
               2,
@@ -126,6 +131,9 @@ function flushElementTemplateCommitChanges(): void {
         reloadVersion: getReloadVersion(),
         flowIds: globalCommitContext.flowIds,
         delayedRunOnMainThreadData: delayedRunOnMainThreadPayload,
+        mainThreadRefInitValuePatch: hasMainThreadRefInitValuePatch
+          ? mainThreadRefInitValuePatch
+          : undefined,
       }));
       didDispatchUpdatePayload = true;
     }
@@ -164,16 +172,17 @@ export function installElementTemplateCommitHook(): void {
       // User effects can run before ET hydrate arrives, so ordinary refs must be
       // attached on the background commit even though native UI ops are delayed.
       flushPendingRefs();
-    } else if (
-      __BACKGROUND__ && hasHydrated
-      && (
+    } else if (__BACKGROUND__ && hasHydrated) {
+      const mainThreadRefInitValuePatch = takeMainThreadRefInitValuePatch();
+      if (
         globalCommitContext.ops.length > 0
         || !isEmptyObject(globalCommitContext.flushOptions)
         || hasPendingRefs()
         || delayedRunOnMainThreadData.length > 0
-      )
-    ) {
-      flushElementTemplateCommitChanges();
+        || mainThreadRefInitValuePatch.length > 0
+      ) {
+        flushElementTemplateCommitChanges(mainThreadRefInitValuePatch);
+      }
     }
 
     originalCommit?.(vnode, commitQueue);

--- a/packages/react/runtime/src/element-template/background/commit-hook.ts
+++ b/packages/react/runtime/src/element-template/background/commit-hook.ts
@@ -77,37 +77,35 @@ function flushElementTemplateCommitChanges(mainThreadRefInitValuePatch: MainThre
     || hasDelayedRunOnMainThread
     || hasMainThreadRefInitValuePatch;
   const removedSubtreesAwaitingTeardown = hasNativeOps ? takeRemovedSubtreesForPostDispatchTeardown() : [];
-  let didFlushRefs = false;
-  let didDispatchUpdatePayload = false;
-  let delayedRunOnMainThreadPayload: typeof delayedRunOnMainThreadData | undefined;
-  try {
-    if (hasUpdatePayload) {
-      markTimingLegacy('updateDiffVdomEnd');
-      markTiming('diffVdomEnd');
+  if (hasUpdatePayload) {
+    markTimingLegacy('updateDiffVdomEnd');
+    markTiming('diffVdomEnd');
 
-      if (__PROFILE__) {
-        profileStart('ReactLynx::commitChanges');
-      }
-      markTiming('packChangesStart');
-      if (globalPipelineOptions) {
-        globalCommitContext.flushOptions.pipelineOptions = globalPipelineOptions;
-      }
-      markTiming('packChangesEnd');
-      if (globalPipelineOptions) {
-        setPipeline(undefined);
-      }
-      if (__PROFILE__) {
-        profileEnd();
-      }
+    if (__PROFILE__) {
+      profileStart('ReactLynx::commitChanges');
+    }
+    markTiming('packChangesStart');
+    if (globalPipelineOptions) {
+      globalCommitContext.flushOptions.pipelineOptions = globalPipelineOptions;
+    }
+    markTiming('packChangesEnd');
+    if (globalPipelineOptions) {
+      setPipeline(undefined);
+    }
+    if (__PROFILE__) {
+      profileEnd();
+    }
 
-      if (!hasNativeOps && !hasDelayedRunOnMainThread) {
-        globalCommitContext.flushOptions.emptyPatch = true;
-      }
+    if (!hasNativeOps && !hasDelayedRunOnMainThread) {
+      globalCommitContext.flushOptions.emptyPatch = true;
+    }
 
-      delayedRunOnMainThreadPayload = hasDelayedRunOnMainThread
-        ? takeDelayedRunOnMainThreadData()
-        : undefined;
+    const delayedRunOnMainThreadPayload = hasDelayedRunOnMainThread
+      ? takeDelayedRunOnMainThreadData()
+      : undefined;
 
+    let updateEvent: ReturnType<typeof createElementTemplateUpdateEvent>;
+    try {
       if (typeof __ALOG__ !== 'undefined' && __ALOG__) {
         console.alog?.(
           '[ReactLynxDebug] ElementTemplate BTS -> MTS update:\n'
@@ -125,7 +123,7 @@ function flushElementTemplateCommitChanges(mainThreadRefInitValuePatch: MainThre
         );
       }
 
-      lynx.getCoreContext().dispatchEvent(createElementTemplateUpdateEvent({
+      updateEvent = createElementTemplateUpdateEvent({
         ops: globalCommitContext.ops,
         flushOptions: globalCommitContext.flushOptions,
         reloadVersion: getReloadVersion(),
@@ -134,26 +132,27 @@ function flushElementTemplateCommitChanges(mainThreadRefInitValuePatch: MainThre
         mainThreadRefInitValuePatch: hasMainThreadRefInitValuePatch
           ? mainThreadRefInitValuePatch
           : undefined,
-      }));
-      didDispatchUpdatePayload = true;
-    }
-    // When native ops exist, patch first so a newly attached ref observes the
-    // committed native state. Ref-only commits still flush through this path.
-    flushPendingRefs();
-    didFlushRefs = true;
-  } finally {
-    if (delayedRunOnMainThreadPayload && !didDispatchUpdatePayload) {
-      dropFunctionCallReturnIds(delayedRunOnMainThreadPayload.map(data => data.resolveId));
-    }
-    if (!didFlushRefs) {
+      });
+    } catch (error) {
+      if (delayedRunOnMainThreadPayload) {
+        dropFunctionCallReturnIds(delayedRunOnMainThreadPayload.map(data => data.resolveId));
+      }
       clearPendingRefs();
+      resetGlobalCommitContext();
+      scheduleElementTemplateRemovedSubtreeCleanup(removedSubtreesAwaitingTeardown);
+      throw error;
     }
-    resetGlobalCommitContext();
-    // Match Snapshot's cleanup boundary: start the delayed teardown only
-    // after the bridge dispatch attempt, so background JS objects are not
-    // torn down before main-thread detach observes the same commit.
-    scheduleElementTemplateRemovedSubtreeCleanup(removedSubtreesAwaitingTeardown);
+
+    lynx.getCoreContext().dispatchEvent(updateEvent);
   }
+  // When native ops exist, patch first so a newly attached ref observes the
+  // committed native state. Ref-only commits still flush through this path.
+  flushPendingRefs();
+  resetGlobalCommitContext();
+  // Match Snapshot's cleanup boundary: start the delayed teardown only
+  // after the bridge dispatch, so background JS objects are not torn down
+  // before main-thread detach observes the same commit.
+  scheduleElementTemplateRemovedSubtreeCleanup(removedSubtreesAwaitingTeardown);
 }
 
 export function installElementTemplateCommitHook(): void {

--- a/packages/react/runtime/src/element-template/background/hydration-listener.ts
+++ b/packages/react/runtime/src/element-template/background/hydration-listener.ts
@@ -13,6 +13,7 @@ import {
 } from './commit-hook.js';
 import type { BackgroundPageRootInstance } from './instance.js';
 import { hydratePageRootIntoContext } from './page-root-hydrate.js';
+import { takeMainThreadRefInitValuePatch } from '../../core/main-thread-ref-init-value.js';
 import {
   PerformanceTimingFlags,
   PipelineOrigins,
@@ -97,6 +98,7 @@ export function installElementTemplateHydrationListener(): void {
         clearPendingRefs();
         clearDelayedRefUiOps();
         resetElementTemplateMainThreadFunctionRuntime();
+        takeMainThreadRefInitValuePatch();
         resetGlobalCommitContext();
       }
 
@@ -105,25 +107,11 @@ export function installElementTemplateHydrationListener(): void {
         const delayedRunOnMainThreadPayload = hasDelayedRunOnMainThread
           ? takeDelayedRunOnMainThreadData()
           : undefined;
+        const mainThreadRefInitValuePatch = takeMainThreadRefInitValuePatch();
+        const hasMainThreadRefInitValuePatch = mainThreadRefInitValuePatch.length > 0;
         const pipelineOptions = globalPipelineOptions;
         if (pipelineOptions) {
           globalCommitContext.flushOptions.pipelineOptions = pipelineOptions;
-        }
-        if (typeof __ALOG__ !== 'undefined' && __ALOG__) {
-          console.alog?.(
-            '[ReactLynxDebug] ElementTemplate hydrate update commands:\n'
-              + JSON.stringify(
-                {
-                  ops: formatElementTemplateUpdateCommands(globalCommitContext.ops),
-                  flushOptions: globalCommitContext.flushOptions,
-                  flowIds: globalCommitContext.flowIds,
-                  isHydration: true,
-                  delayedRunOnMainThreadDataCount: delayedRunOnMainThreadPayload?.length,
-                },
-                null,
-                2,
-              ),
-          );
         }
         const removedSubtreesAwaitingTeardown = globalCommitContext.ops.length > 0
           ? takeRemovedSubtreesForPostDispatchTeardown()
@@ -134,6 +122,23 @@ export function installElementTemplateHydrationListener(): void {
         }
         markTiming('packChangesStart');
         try {
+          if (typeof __ALOG__ !== 'undefined' && __ALOG__) {
+            console.alog?.(
+              '[ReactLynxDebug] ElementTemplate hydrate update commands:\n'
+                + JSON.stringify(
+                  {
+                    ops: formatElementTemplateUpdateCommands(globalCommitContext.ops),
+                    flushOptions: globalCommitContext.flushOptions,
+                    flowIds: globalCommitContext.flowIds,
+                    isHydration: true,
+                    delayedRunOnMainThreadDataCount: delayedRunOnMainThreadPayload?.length,
+                    mainThreadRefInitValuePatchCount: mainThreadRefInitValuePatch.length,
+                  },
+                  null,
+                  2,
+                ),
+            );
+          }
           hydrateUpdateEvent = createElementTemplateUpdateEvent({
             ops: globalCommitContext.ops,
             flushOptions: globalCommitContext.flushOptions,
@@ -141,6 +146,9 @@ export function installElementTemplateHydrationListener(): void {
             reloadVersion: getReloadVersion(),
             flowIds: globalCommitContext.flowIds,
             delayedRunOnMainThreadData: delayedRunOnMainThreadPayload,
+            mainThreadRefInitValuePatch: hasMainThreadRefInitValuePatch
+              ? mainThreadRefInitValuePatch
+              : undefined,
           });
         } catch (error) {
           if (delayedRunOnMainThreadPayload) {
@@ -167,7 +175,21 @@ export function installElementTemplateHydrationListener(): void {
         if (!hydrateUpdateEvent) {
           return;
         }
-        lynx.getCoreContext().dispatchEvent(hydrateUpdateEvent);
+
+        let didDispatchHydrateUpdate = false;
+        try {
+          lynx.getCoreContext().dispatchEvent(hydrateUpdateEvent);
+          didDispatchHydrateUpdate = true;
+        } finally {
+          if (!didDispatchHydrateUpdate) {
+            if (delayedRunOnMainThreadPayload) {
+              dropFunctionCallReturnIds(delayedRunOnMainThreadPayload.map(data => data.resolveId));
+            }
+            clearPendingEvents();
+            clearPendingRefs();
+            clearDelayedRefUiOps();
+          }
+        }
         flushPendingEvents();
         // Ordinary refs attach on Preact commit boundaries; hydration only releases
         // delayed selector ops after ids have been rebound to stable native handles.

--- a/packages/react/runtime/src/element-template/background/hydration-listener.ts
+++ b/packages/react/runtime/src/element-template/background/hydration-listener.ts
@@ -176,20 +176,7 @@ export function installElementTemplateHydrationListener(): void {
           return;
         }
 
-        let didDispatchHydrateUpdate = false;
-        try {
-          lynx.getCoreContext().dispatchEvent(hydrateUpdateEvent);
-          didDispatchHydrateUpdate = true;
-        } finally {
-          if (!didDispatchHydrateUpdate) {
-            if (delayedRunOnMainThreadPayload) {
-              dropFunctionCallReturnIds(delayedRunOnMainThreadPayload.map(data => data.resolveId));
-            }
-            clearPendingEvents();
-            clearPendingRefs();
-            clearDelayedRefUiOps();
-          }
-        }
+        lynx.getCoreContext().dispatchEvent(hydrateUpdateEvent);
         flushPendingEvents();
         // Ordinary refs attach on Preact commit boundaries; hydration only releases
         // delayed selector ops after ids have been rebound to stable native handles.

--- a/packages/react/runtime/src/element-template/native/callDestroyLifetimeFun.ts
+++ b/packages/react/runtime/src/element-template/native/callDestroyLifetimeFun.ts
@@ -1,8 +1,10 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { takeMainThreadRefInitValuePatch } from '../../core/main-thread-ref-init-value.js';
 import { destroyElementTemplateBackgroundRuntime } from '../background/destroy.js';
 
 export function callDestroyLifetimeFun(): void {
+  takeMainThreadRefInitValuePatch();
   destroyElementTemplateBackgroundRuntime();
 }

--- a/packages/react/runtime/src/element-template/native/patch-listener.ts
+++ b/packages/react/runtime/src/element-template/native/patch-listener.ts
@@ -4,9 +4,11 @@
 
 import type { ClosureValueType } from '@lynx-js/react/worklet-runtime/bindings';
 import {
+  clearFirstScreenMainThreadRefs,
   flushDelayedRunOnBackgroundFunctions,
   runRunOnMainThreadTask,
   setEomShouldFlushElementTree,
+  updateWorkletRefInitValueChanges,
 } from '@lynx-js/react/worklet-runtime/bindings';
 
 import { markTiming, setPipeline } from '../../core/performance.js';
@@ -27,13 +29,6 @@ export function installElementTemplatePatchListener(): void {
 
   listener = (event: Pick<ElementTemplateUpdateEvent, 'data'>) => {
     const { patchOptions } = event.data;
-    if (
-      typeof patchOptions.reloadVersion === 'number'
-      && patchOptions.reloadVersion < getReloadVersion()
-    ) {
-      return;
-    }
-
     const { flowIds, pipelineOptions } = patchOptions;
     const shouldProfilePatch = !!flowIds
       && typeof lynx.performance?.profileStart === 'function'
@@ -50,6 +45,21 @@ export function installElementTemplatePatchListener(): void {
 
     const payload = JSON.parse(event.data.payload) as ElementTemplateUpdateCommitContext;
     markTiming('parseChangesEnd');
+
+    if (payload.mainThreadRefInitValuePatch?.length) {
+      updateWorkletRefInitValueChanges(payload.mainThreadRefInitValuePatch);
+    }
+
+    if (
+      typeof patchOptions.reloadVersion === 'number'
+      && patchOptions.reloadVersion < getReloadVersion()
+    ) {
+      markTiming('mtsRenderEnd');
+      if (shouldProfilePatch) {
+        lynx.performance.profileEnd();
+      }
+      return;
+    }
 
     const hasOps = payload.ops.length > 0;
     const flushOptions = payload.flushOptions;
@@ -78,12 +88,14 @@ export function installElementTemplatePatchListener(): void {
         markTiming('mtsRenderEnd');
         if (isHydration) {
           flushDelayedRunOnBackgroundFunctions();
+          clearFirstScreenMainThreadRefs();
         }
       }
     } else {
       markTiming('mtsRenderEnd');
       if (isHydration) {
         flushDelayedRunOnBackgroundFunctions();
+        clearFirstScreenMainThreadRefs();
       }
     }
     if (delayedRunOnMainThreadData?.length) {

--- a/packages/react/runtime/src/element-template/protocol/types.ts
+++ b/packages/react/runtime/src/element-template/protocol/types.ts
@@ -6,6 +6,7 @@ import type { RunWorkletCtxData } from '@lynx-js/react/worklet-runtime/bindings'
 
 import { ElementTemplateUpdateOps } from './opcodes.js';
 import { ELEMENT_TEMPLATE_PAGE_HANDLE_ID, ELEMENT_TEMPLATE_PAGE_TYPE } from './page.js';
+import type { MainThreadRefInitValuePatch } from '../../core/main-thread-ref-init-value.js';
 
 export type SerializableValue =
   | string
@@ -200,4 +201,5 @@ export interface ElementTemplateUpdateCommitContext {
   isHydration?: boolean | undefined;
   reloadVersion?: number | undefined;
   delayedRunOnMainThreadData?: RunWorkletCtxData[] | undefined;
+  mainThreadRefInitValuePatch?: MainThreadRefInitValuePatch | undefined;
 }

--- a/packages/react/runtime/src/worklet-runtime/bindings/bindings.ts
+++ b/packages/react/runtime/src/worklet-runtime/bindings/bindings.ts
@@ -37,6 +37,13 @@ function updateWorkletRefInitValueChanges(patch?: [number, unknown][]): void {
 }
 
 /**
+ * Releases the temporary negative-ID MainThreadRefs after hydration handoff.
+ */
+function clearFirstScreenMainThreadRefs(): void {
+  globalThis.lynxWorkletImpl?._refImpl.clearFirstScreenWorkletRefMap();
+}
+
+/**
  * Register a worklet.
  *
  * @internal
@@ -76,6 +83,7 @@ export {
   runWorkletCtx,
   updateWorkletRef,
   updateWorkletRefInitValueChanges,
+  clearFirstScreenMainThreadRefs,
   registerWorklet,
   delayRunOnBackground,
   setEomShouldFlushElementTree,

--- a/packages/react/runtime/src/worklet-runtime/bindings/observers.ts
+++ b/packages/react/runtime/src/worklet-runtime/bindings/observers.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { clearFirstScreenMainThreadRefs } from './bindings.js';
 import type { Worklet } from './types.js';
 
 /**
@@ -54,7 +55,7 @@ export function clearDelayedRunOnBackgroundFunctions(): void {
  */
 export function onHydrationFinished(): void {
   globalThis.lynxWorkletImpl?._runOnBackgroundDelayImpl.runDelayedBackgroundFunctions();
-  globalThis.lynxWorkletImpl?._refImpl.clearFirstScreenWorkletRefMap();
+  clearFirstScreenMainThreadRefs();
   // For old version dynamic component compatibility.
   globalThis.lynxWorkletImpl?._eventDelayImpl.clearDelayedWorklets();
 }


### PR DESCRIPTION
This is 3/6 of the Element Template MainThreadRef stack and follows the merged #3609.

## Why this change

#3609 preserves `main-thread:ref` values through the Element Template transform and prepares them as ET-owned MainThreadRef wrappers. A MainThreadRef still has two pieces of state that cross threads separately:

```ts
const ref = new MainThreadRef('idle');

// Serialized with a callback or attribute slot.
ref.toJSON(); // { _wvid: 1 }

// Required to create the corresponding main-thread ref entry.
[1, 'idle'];
```

The `_wvid` identifies the ref, but it intentionally does not carry `current`. The background runtime records the initial value in the shared MainThreadRef init-value queue. Snapshot already drains that queue and sends it to the main-thread ref runtime; Element Template previously did not. As a result, ET could transport a ref handle while the main-thread `_workletRefMap` still had no entry for that id.

## Protocol and data flow

This PR adds the optional field below to the existing JSON-encoded ET update payload:

```ts
interface ElementTemplateUpdateCommitContext {
  ops: ElementTemplateUpdateCommandStream;
  flushOptions: ElementTemplateFlushOptions;
  mainThreadRefInitValuePatch?: [id: number, value: unknown][];
}
```

For example, creating two refs on the background thread now contributes this data to the next ET update envelope:

```ts
new MainThreadRef('idle');
new MainThreadRef({ count: 1 });

// JSON payload sent by createElementTemplateUpdateEvent(...)
{
  "ops": [],
  "flushOptions": { "emptyPatch": true },
  "mainThreadRefInitValuePatch": [
    [1, "idle"],
    [2, { "count": 1 }]
  ]
}
```

There are two background send boundaries:

- During initial hydration, ET first matches the serialized typed page to the background tree. A successful match drains the init-value queue and includes it in the hydration update envelope.
- After hydration, each Preact commit drains the queue together with native ops, flush options, refs, and delayed `runOnMainThread` calls. A ref-only commit emits an `emptyPatch` update so the values are not left waiting for an unrelated native operation.

The queue uses take semantics: once an envelope owns a patch, the global queue is empty. This matches Snapshot and prevents the same id/value pair from being replayed by a later commit.

On the main thread, the patch listener now processes an envelope in this order:

```ts
const payload = JSON.parse(event.data.payload);

updateWorkletRefInitValueChanges(payload.mainThreadRefInitValuePatch);
checkReloadVersion();
applyElementTemplateUpdateCommands(payload.ops);
runDelayedBackgroundFunctions();
clearFirstScreenMainThreadRefs();
runDelayedMainThreadFunctions(payload.delayedRunOnMainThreadData);
__FlushElementTree(...);
```

Applying init values before delayed main-thread functions is required because a function in the same envelope may read the newly created ref. Init values are also applied before the stale-reload early return. This deliberately follows Snapshot: native ET operations and delayed function calls from an old reload are discarded, while MainThreadRefs created before `reloadTemplate` may still be referenced afterward and therefore keep their initial-value update.

At a successful hydration boundary, ET also follows Snapshot's ref ownership order. Worklet-context hydration first copies any accessed negative-ID first-screen ref value into its positive background ID. ET then replays delayed `runOnBackground` calls and clears the temporary negative-ID map before delayed `runOnMainThread` tasks and native flush. The positive hydrated entries remain available; only the first-screen aliases are released.

## Ownership and failure behavior

MainThreadRef init values are one-shot synchronization data, not a transactional native patch:

- A failed hydration match discards the queued values because the incomplete tree must not publish externally observable work.
- Serialization failure does not put an already-taken patch back into the queue. The commit path cleans up delayed return ids, pending refs, and detached subtree state before rethrowing the original serialization error. RuntimeProxy `getXxxContext()` and `dispatchEvent()` are internal native contracts and are called directly rather than modeled as recoverable failures.
- Full-lifetime destroy drains any values that were never assigned to an update envelope, preventing an old runtime from leaking them into a later lifetime.
- Existing delayed-function return-id cleanup and pending event/ref cleanup remain responsible for their own queues; this PR does not combine those ownership models with MainThreadRef storage.

The payload keeps the existing JSON boundary rather than adding a second bridge method. Initial values are required to satisfy the same JSON-serializable value contract as other ET protocol data. This PR intentionally adds no ET-only codec or runtime validation; unsupported values retain the existing Snapshot/native transport behavior instead of defining a second value model.

## Scope and follow-ups

This PR establishes initial-value transport and ownership only. It does not yet:

- resolve a prepared `main-thread:ref` to a native `FiberElement`;
- attach or clean up direct MainThreadRefs with element lifecycle;
- align attachment and cleanup with typed-list holder materialization and recycling; or
- add the final smoke example that exercises the complete feature.

Those behaviors remain in the following PRs in the stack. A changeset is not required because Element Template remains unreleased.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hydration reliability by correctly applying and cleaning up reference initialization updates.
  * Prevented stale, failed, or partially applied updates from leaving temporary references, delayed callbacks, or pending events.
  * Ensured references are initialized before related delayed tasks and cleaned up when elements are destroyed or hydration fails.
  * Improved commit recovery and update timing/profiling behavior for stale reloads.
* **New Features**
  * Added automatic cleanup of temporary first-screen references after hydration completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
