### PR TITLE
feat(react): bind main thread refs to list holders

### DIFF
--- a/packages/react/runtime/__test__/element-template/native/mts-destroy.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/mts-destroy.test.ts
@@ -4,9 +4,10 @@ import { installOnMtsDestruction, onMtsDestruction } from '../../../src/element-
 import {
   composeElementTemplateListAttributes,
   createElementTemplateListState,
-  registerElementTemplateListItem,
+  registerElementTemplateListItem as registerElementTemplateListItemInternal,
   registerElementTemplateListState,
 } from '../../../src/element-template/runtime/list/list.js';
+import type { ETListItemMeta } from '../../../src/element-template/runtime/list/list.js';
 import {
   attachMainThreadDynamicAttrRefsForSubtree,
   clearMainThreadDynamicAttrState,
@@ -29,6 +30,17 @@ type LynxWithNative = typeof globalThis & {
     };
   };
 };
+
+function registerElementTemplateListItem(
+  uid: number,
+  ref: ElementRef,
+  meta: Omit<ETListItemMeta, 'subtreeHandles'> & Partial<Pick<ETListItemMeta, 'subtreeHandles'>>,
+): void {
+  registerElementTemplateListItemInternal(uid, ref, {
+    ...meta,
+    subtreeHandles: meta.subtreeHandles ?? [],
+  });
+}
 
 describe('mts-destroy', () => {
   afterEach(() => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -17,6 +17,7 @@ import {
   BackgroundPageRootInstance,
   BackgroundTypedElementTemplateInstance,
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
+  collectMainThreadRefSubtreeHandleIds,
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { clearEventState, getEventHandlerForEventValue } from '../../../../src/element-template/prop-adapters/event.js';
@@ -336,7 +337,7 @@ describe('BackgroundElementTemplateInstance', () => {
     ]);
   });
 
-  it('emits logical list insertions as incremental typed list item patches', () => {
+  it('emits logical list appends as incremental typed list item patches', () => {
     const list = new BackgroundListElementTemplateInstance();
     const oldListId = list.instanceId;
     backgroundElementTemplateInstanceManager.updateId(oldListId, -10);
@@ -352,7 +353,7 @@ describe('BackgroundElementTemplateInstance', () => {
     markElementTemplateHydrated();
     globalCommitContext.ops = [];
 
-    list.insertBefore(second, first);
+    list.appendChild(second);
 
     expect(globalCommitContext.ops).toEqual([
       ElementTemplateUpdateOps.createTemplate,
@@ -369,7 +370,7 @@ describe('BackgroundElementTemplateInstance', () => {
         platformInfo: { 'item-key': 'b' },
         subtreeHandleIds: [],
       },
-      -11,
+      0,
     ]);
   });
 
@@ -496,40 +497,6 @@ describe('BackgroundElementTemplateInstance', () => {
     expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
   });
 
-  it('emits logical updates for both lists when an item moves across typed lists', () => {
-    const oldList = new BackgroundListElementTemplateInstance();
-    const newList = new BackgroundListElementTemplateInstance();
-    backgroundElementTemplateInstanceManager.updateId(oldList.instanceId, -10);
-    backgroundElementTemplateInstanceManager.updateId(newList.instanceId, -20);
-    oldList.markMaterializedByHydration();
-    newList.markMaterializedByHydration();
-    const item = new BackgroundElementTemplateInstance('_et_item_a');
-    item.setAttribute('__listItemPlatformInfo', { 'item-key': 'a' });
-    oldList.appendChild(item);
-    backgroundElementTemplateInstanceManager.updateId(item.instanceId, -11);
-    item.markMaterializedByHydration();
-    markElementTemplateHydrated();
-    globalCommitContext.ops = [];
-
-    newList.appendChild(item);
-
-    expect(globalCommitContext.ops).toEqual([
-      ElementTemplateUpdateOps.removeTypedListItem,
-      -10,
-      -11,
-      [],
-      ElementTemplateUpdateOps.insertTypedListItem,
-      -20,
-      {
-        __etHandleRef: -11,
-        type: '_et_item_a',
-        platformInfo: { 'item-key': 'a' },
-        subtreeHandleIds: [],
-      },
-      0,
-    ]);
-  });
-
   it('refreshes list item subtree membership when Suspense restores a descendant', () => {
     __etAttrPlanMap._et_child = [0, adaptMTRefAttrSlot];
     const list = new BackgroundListElementTemplateInstance();
@@ -563,6 +530,29 @@ describe('BackgroundElementTemplateInstance', () => {
         platformInfo: {},
         subtreeHandleIds: [child.instanceId],
       },
+    ]);
+  });
+
+  it('stops MainThreadRef subtree membership at nested typed list holders', () => {
+    __etAttrPlanMap._et_outer_ref = [0, adaptMTRefAttrSlot];
+    __etAttrPlanMap.list = [0, adaptMTRefAttrSlot];
+    __etAttrPlanMap._et_nested_ref = [0, adaptMTRefAttrSlot];
+    const outerItem = new BackgroundElementTemplateInstance('_et_outer_item');
+    const outerRef = new BackgroundElementTemplateInstance('_et_outer_ref');
+    const nestedList = new BackgroundListElementTemplateInstance();
+    const nestedItem = new BackgroundElementTemplateInstance('_et_nested_item');
+    const nestedRef = new BackgroundElementTemplateInstance('_et_nested_ref');
+    outerItem.appendChild(outerRef);
+    outerItem.appendChild(nestedList);
+    nestedList.appendChild(nestedItem);
+    nestedItem.appendChild(nestedRef);
+
+    expect(collectMainThreadRefSubtreeHandleIds(outerItem)).toEqual([
+      outerRef.instanceId,
+      nestedList.instanceId,
+    ]);
+    expect(collectMainThreadRefSubtreeHandleIds(nestedItem)).toEqual([
+      nestedRef.instanceId,
     ]);
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -17,6 +17,7 @@ import {
   BackgroundPageRootInstance,
   BackgroundTypedElementTemplateInstance,
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
+  collectMainThreadRefSubtreeHandleIds,
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { clearEventState, getEventHandlerForEventValue } from '../../../../src/element-template/prop-adapters/event.js';
@@ -538,6 +539,29 @@ describe('BackgroundElementTemplateInstance', () => {
         platformInfo: {},
         subtreeHandleIds: [child.instanceId],
       },
+    ]);
+  });
+
+  it('stops MainThreadRef subtree membership at nested typed list holders', () => {
+    __etAttrPlanMap._et_outer_ref = [0, adaptMTRefAttrSlot];
+    __etAttrPlanMap.list = [0, adaptMTRefAttrSlot];
+    __etAttrPlanMap._et_nested_ref = [0, adaptMTRefAttrSlot];
+    const outerItem = new BackgroundElementTemplateInstance('_et_outer_item');
+    const outerRef = new BackgroundElementTemplateInstance('_et_outer_ref');
+    const nestedList = new BackgroundListElementTemplateInstance();
+    const nestedItem = new BackgroundElementTemplateInstance('_et_nested_item');
+    const nestedRef = new BackgroundElementTemplateInstance('_et_nested_ref');
+    outerItem.appendChild(outerRef);
+    outerItem.appendChild(nestedList);
+    nestedList.appendChild(nestedItem);
+    nestedItem.appendChild(nestedRef);
+
+    expect(collectMainThreadRefSubtreeHandleIds(outerItem)).toEqual([
+      outerRef.instanceId,
+      nestedList.instanceId,
+    ]);
+    expect(collectMainThreadRefSubtreeHandleIds(nestedItem)).toEqual([
+      nestedRef.instanceId,
     ]);
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/background/suspense.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/suspense.test.tsx
@@ -7,7 +7,10 @@ import {
   markElementTemplateHydrated,
   resetElementTemplateCommitState,
 } from '../../../../src/element-template/background/commit-hook.js';
-import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import {
+  BackgroundElementTemplateInstance,
+  BackgroundListElementTemplateInstance,
+} from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { root, Suspense, lazy } from '../../../../src/element-template/index.js';
 import { loadLazyBundle } from '../../../../src/core/lynx/lazy-bundle.js';
@@ -18,6 +21,7 @@ import type {
   ElementTemplateUpdateCommandStream,
   ElementTemplateUpdateCommitContext,
   SerializableValue,
+  UpdateTypedListItemCommand,
 } from '../../../../src/element-template/protocol/types.js';
 import { parseElementTemplateUpdateEventPayload } from '../../../../src/element-template/protocol/update-event.js';
 import { __root } from '../../../../src/element-template/runtime/page/root-instance.js';
@@ -61,10 +65,26 @@ interface ParsedRemoveNodeOp {
   removedSubtreeHandleIds: number[];
 }
 
+interface ParsedInsertTypedListItemOp {
+  op: 'insertTypedListItem';
+  targetId: number;
+  item: UpdateTypedListItemCommand;
+  referenceId: number;
+}
+
+interface ParsedRemoveTypedListItemOp {
+  op: 'removeTypedListItem';
+  targetId: number;
+  childId: number;
+  removedSubtreeHandleIds: number[];
+}
+
 type ParsedOp =
   | ParsedCreateTemplateOp
   | ParsedInsertNodeOp
   | ParsedRemoveNodeOp
+  | ParsedInsertTypedListItemOp
+  | ParsedRemoveTypedListItemOp
   | {
     op: 'setAttribute';
     targetId: number;
@@ -255,6 +275,22 @@ function parseUpdateOps(stream: ElementTemplateUpdateCommandStream): ParsedOp[] 
           removedSubtreeHandleIds: stream[i++] as number[],
         });
         break;
+      case ElementTemplateUpdateOps.insertTypedListItem:
+        parsed.push({
+          op: 'insertTypedListItem',
+          targetId: stream[i++] as number,
+          item: stream[i++] as UpdateTypedListItemCommand,
+          referenceId: stream[i++] as number,
+        });
+        break;
+      case ElementTemplateUpdateOps.removeTypedListItem:
+        parsed.push({
+          op: 'removeTypedListItem',
+          targetId: stream[i++] as number,
+          childId: stream[i++] as number,
+          removedSubtreeHandleIds: stream[i++] as number[],
+        });
+        break;
       default:
         throw new Error(`Unsupported test opcode: ${String(op)}`);
     }
@@ -379,6 +415,109 @@ describe('ElementTemplate Suspense background lifecycle', () => {
       attachedSubtreeHandleIds: null,
     });
     expect(ops.filter(op => op.op === 'removeNode')).toEqual([]);
+    envManager.switchToBackground();
+  });
+
+  it('restores one typed list item identity from the Suspense detached parent', async () => {
+    const deferred = createDeferred<void>();
+    let shouldSuspend = false;
+
+    function Suspender({ children }: { children?: ComponentChildren }): ComponentChildren {
+      if (shouldSuspend) {
+        throw deferred.promise;
+      }
+      return children ?? null;
+    }
+
+    function App(): JSX.Element {
+      return (
+        <list>
+          <Suspense fallback={null}>
+            <Suspender>
+              <Marker value='item' />
+            </Suspender>
+          </Suspense>
+        </list>
+      );
+    }
+
+    root.render(<App />);
+    await flushSuspenseRenders(scheduledRenders);
+
+    const list = getRenderedHost();
+    expect(list).toBeInstanceOf(BackgroundListElementTemplateInstance);
+    const item = getMarkerElementByValue(list, 'item');
+    markRenderedTreeHydrated();
+    updateEvents = [];
+
+    shouldSuspend = true;
+    root.render(<App />);
+    await flushSuspenseRenders(scheduledRenders);
+
+    expect(findMarkerElementByValue(list, 'item')).toBeNull();
+    envManager.switchToMainThread();
+    expect(parseUpdateOps(updateEvents.flatMap(event => event.ops))).toEqual([{
+      op: 'removeTypedListItem',
+      targetId: list.instanceId,
+      childId: item.instanceId,
+      removedSubtreeHandleIds: [item.instanceId],
+    }]);
+    envManager.switchToBackground();
+    updateEvents = [];
+
+    shouldSuspend = false;
+    deferred.resolve();
+    await flushSuspenseRenders(scheduledRenders);
+
+    expect(getMarkerElementByValue(list, 'item')).toBe(item);
+    envManager.switchToMainThread();
+    const ops = parseUpdateOps(updateEvents.flatMap(event => event.ops));
+    const createIndex = ops.findIndex(op => op.op === 'createTemplate' && op.handleId === item.instanceId);
+    const firstInsertIndex = ops.findIndex(op => op.op === 'insertTypedListItem');
+    expect(ops[createIndex]).toEqual({
+      op: 'createTemplate',
+      handleId: item.instanceId,
+      templateKey: MARKER_TYPE,
+      bundleUrl: null,
+      attributeSlots: ['item'],
+      elementSlots: [],
+    });
+    expect(createIndex).toBeLessThan(firstInsertIndex);
+    const inserts = ops.filter(op => op.op === 'insertTypedListItem');
+    const removes = ops.filter(op => op.op === 'removeTypedListItem');
+    expect(inserts.length).toBeGreaterThan(0);
+    for (const insert of inserts) {
+      expect(insert).toEqual({
+        op: 'insertTypedListItem',
+        targetId: list.instanceId,
+        item: {
+          __etHandleRef: item.instanceId,
+          type: MARKER_TYPE,
+          platformInfo: {},
+          subtreeHandleIds: [],
+        },
+        referenceId: 0,
+      });
+    }
+    for (const remove of removes) {
+      expect(remove).toEqual({
+        op: 'removeTypedListItem',
+        targetId: list.instanceId,
+        childId: item.instanceId,
+        removedSubtreeHandleIds: [],
+      });
+    }
+    let logicalItemCount = 0;
+    for (const op of ops) {
+      if (op.op === 'insertTypedListItem') {
+        logicalItemCount += 1;
+      } else if (op.op === 'removeTypedListItem') {
+        logicalItemCount -= 1;
+        expect(logicalItemCount).toBeGreaterThanOrEqual(0);
+      }
+    }
+    expect(logicalItemCount).toBe(1);
+    expect(ops.at(-1)?.op).toBe('insertTypedListItem');
     envManager.switchToBackground();
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -28,9 +28,10 @@ import {
   composeElementTemplateListAttributes,
   createElementTemplateListState,
   markElementTemplateListDestroyed,
-  registerElementTemplateListItem,
+  registerElementTemplateListItem as registerElementTemplateListItemInternal,
   registerElementTemplateListState,
 } from '../../../../src/element-template/runtime/list/list.js';
+import type { ETListItemMeta } from '../../../../src/element-template/runtime/list/list.js';
 import {
   attachMainThreadDynamicAttrRefsForSubtree,
   clearMainThreadDynamicAttrState,
@@ -68,6 +69,17 @@ interface PageWithChildren {
 
 type HydrateEvent = { data: ElementTemplateHydrateCommitContext };
 type HydrateInstances = SerializedEtNode[];
+
+function registerElementTemplateListItem(
+  uid: number,
+  ref: ElementRef,
+  meta: Omit<ETListItemMeta, 'subtreeHandles'> & Partial<Pick<ETListItemMeta, 'subtreeHandles'>>,
+): void {
+  registerElementTemplateListItemInternal(uid, ref, {
+    ...meta,
+    subtreeHandles: meta.subtreeHandles ?? [],
+  });
+}
 
 function createRawTextOps(id: number, text: string) {
   return [
@@ -126,16 +138,24 @@ function seedMTEventState(
   initializeMainThreadDynamicAttrSlots(handleId, MT_EVENT_TEMPLATE, attributeSlots);
 }
 
+function seedDetachedMTRefState(
+  handleId: number,
+  attrSlotIndex: number,
+  value: Record<string, unknown>,
+): void {
+  registerMTRefSlots(attrSlotIndex);
+  const attributeSlots: unknown[] = [];
+  attributeSlots[attrSlotIndex] = { type: 'main-thread-ref', value };
+  initializeMainThreadDynamicAttrSlots(handleId, MT_REF_TEMPLATE, attributeSlots);
+}
+
 function seedMTRefState(
   handleId: number,
   attrSlotIndex: number,
   value: Record<string, unknown>,
   nativeRef: ElementRef,
 ): void {
-  registerMTRefSlots(attrSlotIndex);
-  const attributeSlots: unknown[] = [];
-  attributeSlots[attrSlotIndex] = { type: 'main-thread-ref', value };
-  initializeMainThreadDynamicAttrSlots(handleId, MT_REF_TEMPLATE, attributeSlots);
+  seedDetachedMTRefState(handleId, attrSlotIndex, value);
   attachMainThreadDynamicAttrRefsForSubtree([{ uid: handleId, ref: nativeRef }]);
 }
 
@@ -1948,7 +1968,12 @@ describe('ElementTemplate patch stream (apply)', () => {
       { id: 'typed-list' },
       [],
       {
-        listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: { 'item-key': 'a' } }],
+        listChildren: [{
+          __etHandleRef: 12,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [12],
+        }],
         estimatedHeight: 80,
       },
     ]);
@@ -1999,6 +2024,377 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, itemRef, null]]);
   });
 
+  it('attaches and cleans list item subtree MTRef on component-at-index and enqueue-component', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 210 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 211 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 212 } as unknown as ElementRef;
+    const ref = { _wvid: 71 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(210, listRef);
+    elementTemplateRegistry.set(211, itemRef);
+    elementTemplateRegistry.set(212, childRef);
+    seedDetachedMTRefState(212, 0, ref);
+    registerElementTemplateListItem(211, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 211, ref: itemRef },
+        { uid: 212, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([211]);
+    registerElementTemplateListState(210, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      const sign = componentAtIndex(listRef, 7, 0, 91, false);
+
+      expect(sign).toBe(211);
+      expect(mockInsertNodeToElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef, null]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(212, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      updateWorkletRef.mockClear();
+      enqueueComponent(listRef, 7, sign);
+
+      expect(mockRemoveNodeFromElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(212, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps nested list item MTRef detached until its own holder insert', () => {
+    envManager.switchToMainThread();
+    const outerListRef = { __isNativeRef: true, id: 'outer-list', __mockNativeId: 290 } as unknown as ElementRef;
+    const outerItemRef = { __isNativeRef: true, id: 'outer-item', __mockNativeId: 291 } as unknown as ElementRef;
+    const nestedListRef = { __isNativeRef: true, id: 'nested-list', __mockNativeId: 292 } as unknown as ElementRef;
+    const nestedItemRef = { __isNativeRef: true, id: 'nested-item', __mockNativeId: 293 } as unknown as ElementRef;
+    const nestedChildRef = { __isNativeRef: true, id: 'nested-child', __mockNativeId: 294 } as unknown as ElementRef;
+    const ref = { _wvid: 79 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(290, outerListRef);
+    elementTemplateRegistry.set(291, outerItemRef);
+    elementTemplateRegistry.set(292, nestedListRef);
+    elementTemplateRegistry.set(293, nestedItemRef);
+    elementTemplateRegistry.set(294, nestedChildRef);
+    seedDetachedMTRefState(294, 0, ref);
+    registerElementTemplateListItem(291, outerItemRef, {
+      templateKey: '_et_outer_item',
+      platformInfo: { 'item-key': 'outer' },
+      subtreeHandles: [
+        { uid: 291, ref: outerItemRef },
+        { uid: 292, ref: nestedListRef },
+      ],
+    });
+    registerElementTemplateListItem(293, nestedItemRef, {
+      templateKey: '_et_nested_item',
+      platformInfo: { 'item-key': 'nested' },
+      subtreeHandles: [
+        { uid: 293, ref: nestedItemRef },
+        { uid: 294, ref: nestedChildRef },
+      ],
+    });
+    const outerState = createElementTemplateListState([291]);
+    const nestedState = createElementTemplateListState([293]);
+    registerElementTemplateListState(290, outerState, false, outerListRef);
+    registerElementTemplateListState(292, nestedState, false, nestedListRef);
+    const outerComponentAtIndex = composeElementTemplateListAttributes(null, outerState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+    const nestedComponentAtIndex = composeElementTemplateListAttributes(null, nestedState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+
+    try {
+      expect(outerComponentAtIndex(outerListRef, 7, 0, 91, false)).toBe(291);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(294, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      expect(nestedComponentAtIndex(nestedListRef, 8, 0, 92, false)).toBe(293);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, nestedChildRef);
+      expect(getMainThreadDynamicAttrState(294, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it.each(
+    [
+      ['component-at-index', 'insert'],
+      ['component-at-indexes', 'insert'],
+      ['component-at-index', 'unique-id'],
+      ['component-at-indexes', 'unique-id'],
+    ] as const,
+  )(
+    'does not attach list item MTRef when %s %s fails',
+    (callbackName, failure) => {
+      envManager.switchToMainThread();
+      const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 280 } as unknown as ElementRef;
+      const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 281 } as unknown as ElementRef;
+      const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 282 } as unknown as ElementRef;
+      const ref = { _wvid: 78 };
+      const { updateWorkletRef, restore } = installWorkletRefRuntime();
+      elementTemplateRegistry.set(280, listRef);
+      elementTemplateRegistry.set(281, itemRef);
+      elementTemplateRegistry.set(282, childRef);
+      seedDetachedMTRefState(282, 0, ref);
+      registerElementTemplateListItem(281, itemRef, {
+        templateKey: '_et_item',
+        platformInfo: { 'item-key': 'a' },
+        subtreeHandles: [
+          { uid: 281, ref: itemRef },
+          { uid: 282, ref: childRef },
+        ],
+      });
+      const state = createElementTemplateListState([281]);
+      registerElementTemplateListState(280, state, false, listRef);
+      const attrs = composeElementTemplateListAttributes(null, state);
+      const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+      const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+
+      try {
+        if (failure === 'insert') {
+          mockInsertNodeToElementTemplate.mockImplementationOnce(() => {
+            throw new Error('list insert failed');
+          });
+        } else {
+          vi.mocked(__GetElementUniqueID).mockImplementationOnce(() => {
+            throw new Error('list unique-id failed');
+          });
+        }
+
+        expect(() => {
+          if (callbackName === 'component-at-index') {
+            componentAtIndex(listRef, 7, 0, 91, false);
+          } else {
+            componentAtIndexes(listRef, 7, [0], [91], false, false);
+          }
+        }).toThrow(`list ${failure} failed`);
+        expect(updateWorkletRef).not.toHaveBeenCalled();
+        expect(getMainThreadDynamicAttrState(282, 0)).toEqual({
+          kind: 'mt-ref',
+          value: ref,
+        });
+
+        if (callbackName === 'component-at-index') {
+          expect(componentAtIndex(listRef, 7, 0, 92, false)).toBe(281);
+        } else {
+          componentAtIndexes(listRef, 7, [0], [92], false, false);
+        }
+        expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  it('keeps dynamically added detached list item MTRef blocked until component-at-index', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 250 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 251 } as unknown as ElementRef;
+    const ref = { _wvid: 75 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(250, listRef);
+    elementTemplateRegistry.set(251, itemRef);
+    registerElementTemplateListItem(251, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [{ uid: 251, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([251]);
+    registerElementTemplateListState(250, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    registerTemplates([{
+      templateId: '_et_ref_child',
+      compiledTemplate: {
+        kind: 'element',
+        type: 'view',
+        attributesArray: [{
+          kind: 'slot',
+          key: 'main-thread:ref',
+          attrSlotIndex: 0,
+        }],
+        children: [],
+      },
+    }]);
+
+    try {
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.createTemplate,
+        252,
+        '_et_ref_child',
+        null,
+        [{ type: 'main-thread-ref', value: ref }],
+        [],
+        ElementTemplateUpdateOps.insertNode,
+        251,
+        0,
+        252,
+        0,
+        [],
+        ElementTemplateUpdateOps.updateTypedListItem,
+        250,
+        {
+          __etHandleRef: 251,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [251, 252],
+        },
+      ]);
+
+      const childRef = elementTemplateRegistry.get(252)!;
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(252, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      componentAtIndex(listRef, 7, 0, 94, false);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(252, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans dynamically added attached list item MTRef on enqueue-component', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 260 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 261 } as unknown as ElementRef;
+    const ref = { _wvid: 76 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(260, listRef);
+    elementTemplateRegistry.set(261, itemRef);
+    registerElementTemplateListItem(261, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [{ uid: 261, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([261]);
+    registerElementTemplateListState(260, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    registerTemplates([{
+      templateId: '_et_ref_child',
+      compiledTemplate: {
+        kind: 'element',
+        type: 'view',
+        attributesArray: [{
+          kind: 'slot',
+          key: 'main-thread:ref',
+          attrSlotIndex: 0,
+        }],
+        children: [],
+      },
+    }]);
+
+    try {
+      const sign = componentAtIndex(listRef, 7, 0, 95, false);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.createTemplate,
+        262,
+        '_et_ref_child',
+        null,
+        [{ type: 'main-thread-ref', value: ref }],
+        [],
+        ElementTemplateUpdateOps.insertNode,
+        261,
+        0,
+        262,
+        0,
+        [],
+        ElementTemplateUpdateOps.updateTypedListItem,
+        260,
+        {
+          __etHandleRef: 261,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [261, 262],
+        },
+      ]);
+
+      const childRef = elementTemplateRegistry.get(262)!;
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+
+      enqueueComponent(listRef, 7, sign);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(262, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('attaches list item subtree MTRef from component-at-indexes', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 220 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 221 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 222 } as unknown as ElementRef;
+    const ref = { _wvid: 72 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(220, listRef);
+    elementTemplateRegistry.set(221, itemRef);
+    elementTemplateRegistry.set(222, childRef);
+    seedDetachedMTRefState(222, 0, ref);
+    registerElementTemplateListItem(221, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 221, ref: itemRef },
+        { uid: 222, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([221]);
+    registerElementTemplateListState(220, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+
+    try {
+      componentAtIndexes(listRef, 7, [0], [92], false, true);
+
+      expect(mockInsertNodeToElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef, null]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(222, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it('creates exact typed lists outside development using the internal listChildren contract', () => {
     const originalDev = globalThis.__DEV__;
     globalThis.__DEV__ = false;
@@ -2016,7 +2412,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         null,
         [],
         {
-          listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {} }],
+          listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {}, subtreeHandleIds: [12] }],
           estimatedHeight: 80,
         },
       ]);
@@ -2092,7 +2488,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       'list',
       null,
       [[11]],
-      { listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {} }] },
+      { listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {}, subtreeHandleIds: [12] }] },
     ]);
 
     expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(0);
@@ -2241,7 +2637,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       'list',
       null,
       [],
-      { listChildren: [{ __etHandleRef: 404, type: '_et_item', platformInfo: {} }] },
+      { listChildren: [{ __etHandleRef: 404, type: '_et_item', platformInfo: {}, subtreeHandleIds: [404] }] },
     ]);
 
     expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(0);
@@ -2264,11 +2660,11 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       41,
-      { __etHandleRef: 404, type: '_et_item', platformInfo: {} },
+      { __etHandleRef: 404, type: '_et_item', platformInfo: {}, subtreeHandleIds: [404] },
       0,
       ElementTemplateUpdateOps.updateTypedListItem,
       41,
-      { __etHandleRef: 405, type: '_et_item', platformInfo: {} },
+      { __etHandleRef: 405, type: '_et_item', platformInfo: {}, subtreeHandleIds: [405] },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(0);
@@ -2409,6 +2805,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 33,
         type: '_et_item_b',
         platformInfo: { 'item-key': 'b' },
+        subtreeHandleIds: [33],
       },
       0,
     ]);
@@ -2459,6 +2856,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 37,
         type: '_et_item_b',
         platformInfo: { 'item-key': 'b' },
+        subtreeHandleIds: [37],
       },
       0,
       ElementTemplateUpdateOps.setAttribute,
@@ -2512,11 +2910,11 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 204, type: '_et_item_204', platformInfo: { 'item-key': '204' } },
+      { __etHandleRef: 204, type: '_et_item_204', platformInfo: { 'item-key': '204' }, subtreeHandleIds: [204] },
       202,
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 205, type: '_et_item_205', platformInfo: { 'item-key': '205' } },
+      { __etHandleRef: 205, type: '_et_item_205', platformInfo: { 'item-key': '205' }, subtreeHandleIds: [205] },
       204,
       ElementTemplateUpdateOps.removeTypedListItem,
       200,
@@ -2528,7 +2926,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 203, type: '_et_item_203', platformInfo: { 'item-key': '203' } },
+      { __etHandleRef: 203, type: '_et_item_203', platformInfo: { 'item-key': '203' }, subtreeHandleIds: [203] },
       0,
     ]);
 
@@ -2579,14 +2977,24 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       210,
-      { __etHandleRef: 213, type: '_et_item_d', platformInfo: { 'item-key': 'd' } },
+      { __etHandleRef: 213, type: '_et_item_d', platformInfo: { 'item-key': 'd' }, subtreeHandleIds: [213] },
       212,
       ElementTemplateUpdateOps.updateTypedListItem,
       210,
-      { __etHandleRef: 211, type: '_et_item_a', platformInfo: { 'item-key': 'a', 'full-span': true } },
+      {
+        __etHandleRef: 211,
+        type: '_et_item_a',
+        platformInfo: { 'item-key': 'a', 'full-span': true },
+        subtreeHandleIds: [211],
+      },
       ElementTemplateUpdateOps.updateTypedListItem,
       210,
-      { __etHandleRef: 212, type: '_et_item_b', platformInfo: { 'item-key': 'b', 'estimated-height': 42 } },
+      {
+        __etHandleRef: 212,
+        type: '_et_item_b',
+        platformInfo: { 'item-key': 'b', 'estimated-height': 42 },
+        subtreeHandleIds: [212],
+      },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(1);
@@ -2617,7 +3025,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.updateTypedListItem,
       214,
-      { __etHandleRef: 2141, type: '_et_item_a', platformInfo: { 'item-key': 'a' } },
+      { __etHandleRef: 2141, type: '_et_item_a', platformInfo: { 'item-key': 'a' }, subtreeHandleIds: [2141] },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(0);
@@ -2648,11 +3056,16 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       215,
-      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [217] },
       216,
       ElementTemplateUpdateOps.updateTypedListItem,
       215,
-      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b', 'full-span': true } },
+      {
+        __etHandleRef: 217,
+        type: '_et_item_b',
+        platformInfo: { 'item-key': 'b', 'full-span': true },
+        subtreeHandleIds: [217],
+      },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(1);
@@ -2702,11 +3115,16 @@ describe('ElementTemplate patch stream (apply)', () => {
       [2183],
       ElementTemplateUpdateOps.insertTypedListItem,
       218,
-      { __etHandleRef: 2181, type: '_et_item_a', platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' } },
+      {
+        __etHandleRef: 2181,
+        type: '_et_item_a',
+        platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' },
+        subtreeHandleIds: [2181],
+      },
       0,
       ElementTemplateUpdateOps.insertTypedListItem,
       218,
-      { __etHandleRef: 2184, type: '_et_item_x', platformInfo: { 'item-key': 'x' } },
+      { __etHandleRef: 2184, type: '_et_item_x', platformInfo: { 'item-key': 'x' }, subtreeHandleIds: [2184] },
       2181,
     ]);
 
@@ -2744,7 +3162,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       { id: 'intermediate' },
       ElementTemplateUpdateOps.insertTypedListItem,
       220,
-      { __etHandleRef: 222, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 222, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [222] },
       0,
       ElementTemplateUpdateOps.setAttribute,
       220,
@@ -2767,7 +3185,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     }));
   });
 
-  it('moves already attached same-list items when native requests the moved index first', () => {
+  it('moves an attached same-list item after native enqueues its rebind', () => {
     envManager.switchToMainThread();
     const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 225 } as unknown as ElementRef;
     const aRef = { __isNativeRef: true, id: 'a', __mockNativeId: 226 } as unknown as ElementRef;
@@ -2800,20 +3218,79 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       225,
-      { __etHandleRef: 227, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 227, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [227] },
       226,
     ]);
     mockInsertNodeToElementTemplate.mockClear();
     mockRemoveNodeFromElementTemplate.mockClear();
 
-    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(227);
+    enqueueComponent(listRef, 7, 227);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
 
+    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(227);
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, bRef, aRef]]);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     enqueueComponent(listRef, 7, 227);
-    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
-    enqueueComponent(listRef, 7, 227);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, bRef]]);
+  });
+
+  it('keeps a moved item MTRef attached when native enqueues the old holder after rebind', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 2250 } as unknown as ElementRef;
+    const aRef = { __isNativeRef: true, id: 'a', __mockNativeId: 2260 } as unknown as ElementRef;
+    const bRef = { __isNativeRef: true, id: 'b', __mockNativeId: 2270 } as unknown as ElementRef;
+    const ref = { _wvid: 79 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(2250, listRef);
+    elementTemplateRegistry.set(2260, aRef);
+    elementTemplateRegistry.set(2270, bRef);
+    seedDetachedMTRefState(2270, 0, ref);
+    registerElementTemplateListItem(2260, aRef, {
+      templateKey: '_et_item_a',
+      platformInfo: { 'item-key': 'a' },
+    });
+    registerElementTemplateListItem(2270, bRef, {
+      templateKey: '_et_item_b',
+      platformInfo: { 'item-key': 'b' },
+      subtreeHandles: [{ uid: 2270, ref: bRef }],
+    });
+    const state = createElementTemplateListState([2260, 2270]);
+    registerElementTemplateListState(2250, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      expect(componentAtIndex(listRef, 7, 0, 88, false)).toBe(2260);
+      expect(componentAtIndex(listRef, 7, 1, 89, false)).toBe(2270);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      mockRemoveNodeFromElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        2250,
+        2270,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        2250,
+        { __etHandleRef: 2270, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [2270] },
+        2260,
+      ]);
+      mockInsertNodeToElementTemplate.mockClear();
+
+      expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(2270);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, bRef, aRef]]);
+      enqueueComponent(listRef, 7, 2270);
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+
+      enqueueComponent(listRef, 7, 2270);
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, bRef]]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+    } finally {
+      restore();
+    }
   });
 
   it('places multiple attached same-list moves in final order on the first native request', () => {
@@ -2856,7 +3333,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       240,
-      { __etHandleRef: 243, type: '_et_item_c', platformInfo: { 'item-key': 'c' } },
+      { __etHandleRef: 243, type: '_et_item_c', platformInfo: { 'item-key': 'c' }, subtreeHandleIds: [243] },
       241,
       ElementTemplateUpdateOps.removeTypedListItem,
       240,
@@ -2864,20 +3341,21 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       240,
-      { __etHandleRef: 241, type: '_et_item_a', platformInfo: { 'item-key': 'a' } },
+      { __etHandleRef: 241, type: '_et_item_a', platformInfo: { 'item-key': 'a' }, subtreeHandleIds: [241] },
       0,
     ]);
     mockInsertNodeToElementTemplate.mockClear();
     mockRemoveNodeFromElementTemplate.mockClear();
 
-    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(243);
+    enqueueComponent(listRef, 7, 243);
+    enqueueComponent(listRef, 7, 241);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
 
+    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(243);
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
       [listRef, 0, aRef, null],
       [listRef, 0, cRef, bRef],
     ]);
-    enqueueComponent(listRef, 7, 243);
-    enqueueComponent(listRef, 7, 241);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     expect(componentAtIndex(listRef, 7, 1, 91, false)).toBe(242);
   });
@@ -2914,7 +3392,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       230,
-      { __etHandleRef: 232, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 232, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [232] },
       231,
       ElementTemplateUpdateOps.removeTypedListItem,
       230,
@@ -2931,7 +3409,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         updateAction: [],
       },
     }));
-    expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, secondRef]]);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([]);
     expect(elementTemplateRegistry.get(231)).toBeUndefined();
     expect(elementTemplateRegistry.get(232)).toBe(secondRef);
   });
@@ -3116,6 +3594,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 52,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'old' },
+        subtreeHandleIds: [52],
       },
       0,
       ElementTemplateUpdateOps.updateTypedListItem,
@@ -3124,6 +3603,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 52,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'new' },
+        subtreeHandleIds: [52],
       },
     ]);
 
@@ -3164,6 +3644,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 82,
         type: '_et_item',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' },
+        subtreeHandleIds: [82],
       },
     ]);
 
@@ -3227,6 +3708,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 72,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a' },
+        subtreeHandleIds: [72],
       },
       0,
     ]);
@@ -3234,6 +3716,342 @@ describe('ElementTemplate patch stream (apply)', () => {
 
     expect(componentAtIndex(listRef, 7, 1, 92, false)).toBe(136);
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+  });
+
+  it('preserves MTRef during same-list rebind and cleans the later holder release', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 230 } as unknown as ElementRef;
+    const firstRef = { __isNativeRef: true, id: 'first', __mockNativeId: 231 } as unknown as ElementRef;
+    const secondRef = { __isNativeRef: true, id: 'second', __mockNativeId: 232 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 233 } as unknown as ElementRef;
+    const ref = { _wvid: 73 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(230, listRef);
+    elementTemplateRegistry.set(231, firstRef);
+    elementTemplateRegistry.set(232, secondRef);
+    elementTemplateRegistry.set(233, childRef);
+    seedDetachedMTRefState(233, 0, ref);
+    registerElementTemplateListItem(231, firstRef, {
+      templateKey: '_et_item_a',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 231, ref: firstRef },
+        { uid: 233, ref: childRef },
+      ],
+    });
+    registerElementTemplateListItem(232, secondRef, {
+      templateKey: '_et_item_b',
+      platformInfo: { 'item-key': 'b' },
+      subtreeHandles: [{ uid: 232, ref: secondRef }],
+    });
+    const state = createElementTemplateListState([231, 232]);
+    registerElementTemplateListState(230, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      const oldSign = componentAtIndex(listRef, 7, 0, 91, false);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        230,
+        231,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        230,
+        {
+          __etHandleRef: 231,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [231, 233],
+        },
+        0,
+      ]);
+      mockInsertNodeToElementTemplate.mockClear();
+
+      enqueueComponent(listRef, 7, oldSign);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(233, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      expect(componentAtIndex(listRef, 7, 1, 92, false)).toBe(oldSign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+
+      mockRemoveNodeFromElementTemplate.mockClear();
+      enqueueComponent(listRef, 7, oldSign);
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef]]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(233, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      expect(componentAtIndex(listRef, 7, 1, 93, false)).toBe(oldSign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans a released same-list holder when its rebind insert fails', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 290 } as unknown as ElementRef;
+    const firstRef = { __isNativeRef: true, id: 'first', __mockNativeId: 291 } as unknown as ElementRef;
+    const secondRef = { __isNativeRef: true, id: 'second', __mockNativeId: 292 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 293 } as unknown as ElementRef;
+    const ref = { _wvid: 79 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(290, listRef);
+    elementTemplateRegistry.set(291, firstRef);
+    elementTemplateRegistry.set(292, secondRef);
+    elementTemplateRegistry.set(293, childRef);
+    seedDetachedMTRefState(293, 0, ref);
+    registerElementTemplateListItem(291, firstRef, {
+      templateKey: '_et_item_a',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 291, ref: firstRef },
+        { uid: 293, ref: childRef },
+      ],
+    });
+    registerElementTemplateListItem(292, secondRef, {
+      templateKey: '_et_item_b',
+      platformInfo: { 'item-key': 'b' },
+      subtreeHandles: [{ uid: 292, ref: secondRef }],
+    });
+    const state = createElementTemplateListState([291, 292]);
+    registerElementTemplateListState(290, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      const sign = componentAtIndex(listRef, 7, 0, 91, false);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      mockRemoveNodeFromElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        290,
+        291,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        290,
+        {
+          __etHandleRef: 291,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [291, 293],
+        },
+        0,
+      ]);
+      enqueueComponent(listRef, 7, sign);
+      mockInsertNodeToElementTemplate.mockImplementationOnce(() => {
+        throw new Error('list move insert failed');
+      });
+
+      expect(() => componentAtIndex(listRef, 7, 1, 92, false)).toThrow(
+        'list move insert failed',
+      );
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([
+        [listRef, 0, firstRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([[ref, null]]);
+      expect(getMainThreadDynamicAttrState(293, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      expect(componentAtIndex(listRef, 7, 1, 93, false)).toBe(sign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, firstRef, null],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([[ref, childRef]]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps successful batch moves attached and cleans remaining released moves after insert failure', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 300 } as unknown as ElementRef;
+    const aRef = { __isNativeRef: true, id: 'a', __mockNativeId: 301 } as unknown as ElementRef;
+    const bRef = { __isNativeRef: true, id: 'b', __mockNativeId: 302 } as unknown as ElementRef;
+    const cRef = { __isNativeRef: true, id: 'c', __mockNativeId: 303 } as unknown as ElementRef;
+    const dRef = { __isNativeRef: true, id: 'd', __mockNativeId: 304 } as unknown as ElementRef;
+    const mtRefs = {
+      a: { _wvid: 80 },
+      b: { _wvid: 81 },
+      c: { _wvid: 82 },
+      d: { _wvid: 83 },
+    };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(300, listRef);
+    for (
+      const [uid, itemRef, itemKey, mtRef] of [
+        [301, aRef, 'a', mtRefs.a],
+        [302, bRef, 'b', mtRefs.b],
+        [303, cRef, 'c', mtRefs.c],
+        [304, dRef, 'd', mtRefs.d],
+      ] as const
+    ) {
+      elementTemplateRegistry.set(uid, itemRef);
+      seedDetachedMTRefState(uid, 0, mtRef);
+      registerElementTemplateListItem(uid, itemRef, {
+        templateKey: `_et_item_${itemKey}`,
+        platformInfo: { 'item-key': itemKey },
+        subtreeHandles: [{ uid, ref: itemRef }],
+      });
+    }
+    const state = createElementTemplateListState([301, 302, 303, 304]);
+    registerElementTemplateListState(300, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      componentAtIndexes(listRef, 7, [0, 1, 2, 3], [90, 91, 92, 93], false, false);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      mockRemoveNodeFromElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        304,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 304,
+          type: '_et_item_d',
+          platformInfo: { 'item-key': 'd' },
+          subtreeHandleIds: [304],
+        },
+        301,
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        303,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 303,
+          type: '_et_item_c',
+          platformInfo: { 'item-key': 'c' },
+          subtreeHandleIds: [303],
+        },
+        301,
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        301,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 301,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [301],
+        },
+        0,
+      ]);
+      enqueueComponent(listRef, 7, 304);
+      enqueueComponent(listRef, 7, 303);
+      enqueueComponent(listRef, 7, 301);
+      mockInsertNodeToElementTemplate
+        .mockImplementationOnce(() => {})
+        .mockImplementationOnce(() => {
+          throw new Error('batch list move insert failed');
+        });
+
+      expect(() => {
+        componentAtIndexes(listRef, 7, [0, 1, 2, 3], [94, 95, 96, 97], false, false);
+      }).toThrow('batch list move insert failed');
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, aRef, null],
+        [listRef, 0, cRef, bRef],
+      ]);
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([
+        [listRef, 0, dRef],
+        [listRef, 0, cRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([
+        [mtRefs.d, null],
+        [mtRefs.c, null],
+      ]);
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      componentAtIndexes(listRef, 7, [0, 1], [98, 99], false, false);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, dRef, bRef],
+        [listRef, 0, cRef, bRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([
+        [mtRefs.d, dRef],
+        [mtRefs.c, cRef],
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans live list subtree MTRef on logical item removal after update-list-info', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 240 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 241 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 242 } as unknown as ElementRef;
+    const ref = { _wvid: 74 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(240, listRef);
+    elementTemplateRegistry.set(241, itemRef);
+    elementTemplateRegistry.set(242, childRef);
+    seedDetachedMTRefState(242, 0, ref);
+    registerElementTemplateListItem(241, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 241, ref: itemRef },
+        { uid: 242, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([241]);
+    registerElementTemplateListState(240, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+
+    try {
+      componentAtIndex(listRef, 7, 0, 93, false);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        240,
+        241,
+        [241, 242],
+      ]);
+
+      expect(mockSetAttributeOfElementTemplate.mock.calls.at(-1)?.[0]).toBe(listRef);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(242, 0)).toBeUndefined();
+    } finally {
+      restore();
+    }
   });
 
   it('treats same-key list item replacement with a new ref as remove and insert', () => {
@@ -3262,6 +4080,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 63,
         type: '_et_item',
         platformInfo: { 'item-key': 'same' },
+        subtreeHandleIds: [63],
       },
       0,
     ]);
@@ -3278,8 +4097,8 @@ describe('ElementTemplate patch stream (apply)', () => {
 
   it('keeps destroyed typed list callbacks Snapshot-safe', () => {
     envManager.switchToMainThread();
-    const listRef = 120 as unknown as ElementRef;
-    const itemRef = 121 as unknown as ElementRef;
+    const listRef = { __isNativeRef: true, __mockNativeId: 120 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, __mockNativeId: 121 } as unknown as ElementRef;
     registerElementTemplateListItem(121, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'a' },
@@ -3291,6 +4110,9 @@ describe('ElementTemplate patch stream (apply)', () => {
     const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
     const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
 
+    expect(componentAtIndex(listRef, 7, 0, 99, false)).toBe(121);
+    mockInsertNodeToElementTemplate.mockClear();
+    mockFlushElementTree.mockClear();
     markElementTemplateListDestroyed(120);
 
     expect(componentAtIndex(listRef, 7, 0, 99, false)).toBe(-1);
@@ -3300,6 +4122,39 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(mockInsertNodeToElementTemplate.mock.calls).toHaveLength(0);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     expect(mockFlushElementTree.mock.calls).toHaveLength(0);
+  });
+
+  it('keeps the physical owner aligned when an attached list item record is replaced', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, __mockNativeId: 130 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, __mockNativeId: 131 } as unknown as ElementRef;
+    elementTemplateRegistry.set(130, listRef);
+    elementTemplateRegistry.set(131, itemRef);
+    registerElementTemplateListItem(131, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+    });
+    const state = createElementTemplateListState([131]);
+    registerElementTemplateListState(130, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+    const sign = componentAtIndex(listRef, 7, 0, 99, false);
+    mockRemoveNodeFromElementTemplate.mockClear();
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      130,
+      {
+        __etHandleRef: 131,
+        type: '_et_item',
+        platformInfo: { 'item-key': 'a', 'full-span': true },
+        subtreeHandleIds: [],
+      },
+    ]);
+    enqueueComponent(listRef, 7, sign);
+
+    expect(mockRemoveNodeFromElementTemplate).toHaveBeenCalledWith(listRef, 0, itemRef);
   });
 
   it('skips typed slot 0 attributes when the target handle is unresolved', () => {
@@ -3380,6 +4235,77 @@ describe('ElementTemplate patch stream (apply)', () => {
     const reportError = (globalThis.lynx as unknown as LynxWithReportErrorMock).reportError;
     expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain('insert subtree handle 999 not found');
     resetReportedErrors();
+  });
+
+  it('reports a missing typed list item subtree handle', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'list' } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item' } as unknown as ElementRef;
+    elementTemplateRegistry.set(500, listRef);
+    elementTemplateRegistry.set(501, itemRef);
+    registerElementTemplateListItem(501, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: {},
+      subtreeHandles: [{ uid: 501, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([501]);
+    registerElementTemplateListState(500, state, false, listRef);
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      500,
+      {
+        __etHandleRef: 501,
+        type: '_et_item',
+        platformInfo: {},
+        subtreeHandleIds: [501, 999],
+      },
+    ]);
+
+    expect(state.items[0]?.subtreeHandles).toEqual([{ uid: 501, ref: itemRef }]);
+    const reportError = (globalThis.lynx as unknown as LynxWithReportErrorMock).reportError;
+    expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain(
+      'typed list update item subtree handle 999 not found',
+    );
+    resetReportedErrors();
+  });
+
+  it('updates typed list subtree membership when its size stays the same', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'list' } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item' } as unknown as ElementRef;
+    const previousChildRef = { __isNativeRef: true, id: 'previous-child' } as unknown as ElementRef;
+    const nextChildRef = { __isNativeRef: true, id: 'next-child' } as unknown as ElementRef;
+    elementTemplateRegistry.set(510, listRef);
+    elementTemplateRegistry.set(511, itemRef);
+    elementTemplateRegistry.set(512, previousChildRef);
+    elementTemplateRegistry.set(513, nextChildRef);
+    registerElementTemplateListItem(511, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: {},
+      subtreeHandles: [
+        { uid: 511, ref: itemRef },
+        { uid: 512, ref: previousChildRef },
+      ],
+    });
+    const state = createElementTemplateListState([511]);
+    registerElementTemplateListState(510, state, false, listRef);
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      510,
+      {
+        __etHandleRef: 511,
+        type: '_et_item',
+        platformInfo: {},
+        subtreeHandleIds: [511, 513],
+      },
+    ]);
+
+    expect(state.items[0]?.subtreeHandles).toEqual([
+      { uid: 511, ref: itemRef },
+      { uid: 513, ref: nextChildRef },
+    ]);
   });
 
   it('reports missing child handle on removeNode', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -28,9 +28,10 @@ import {
   composeElementTemplateListAttributes,
   createElementTemplateListState,
   markElementTemplateListDestroyed,
-  registerElementTemplateListItem,
+  registerElementTemplateListItem as registerElementTemplateListItemInternal,
   registerElementTemplateListState,
 } from '../../../../src/element-template/runtime/list/list.js';
+import type { ETListItemMeta } from '../../../../src/element-template/runtime/list/list.js';
 import {
   attachMainThreadDynamicAttrRefsForSubtree,
   clearMainThreadDynamicAttrState,
@@ -68,6 +69,17 @@ interface PageWithChildren {
 
 type HydrateEvent = { data: ElementTemplateHydrateCommitContext };
 type HydrateInstances = SerializedEtNode[];
+
+function registerElementTemplateListItem(
+  uid: number,
+  ref: ElementRef,
+  meta: Omit<ETListItemMeta, 'subtreeHandles'> & Partial<Pick<ETListItemMeta, 'subtreeHandles'>>,
+): void {
+  registerElementTemplateListItemInternal(uid, ref, {
+    ...meta,
+    subtreeHandles: meta.subtreeHandles ?? [],
+  });
+}
 
 function createRawTextOps(id: number, text: string) {
   return [
@@ -1958,7 +1970,12 @@ describe('ElementTemplate patch stream (apply)', () => {
       { id: 'typed-list' },
       [],
       {
-        listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: { 'item-key': 'a' } }],
+        listChildren: [{
+          __etHandleRef: 12,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [12],
+        }],
         estimatedHeight: 80,
       },
     ]);
@@ -2009,6 +2026,356 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, itemRef, null]]);
   });
 
+  it('attaches and cleans list item subtree MTRef on component-at-index and enqueue-component', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 210 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 211 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 212 } as unknown as ElementRef;
+    const ref = { _wvid: 71 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(210, listRef);
+    elementTemplateRegistry.set(211, itemRef);
+    elementTemplateRegistry.set(212, childRef);
+    seedDetachedMTRefState(212, 0, ref, childRef);
+    registerElementTemplateListItem(211, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 211, ref: itemRef },
+        { uid: 212, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([211]);
+    registerElementTemplateListState(210, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      const sign = componentAtIndex(listRef, 7, 0, 91, false);
+
+      expect(sign).toBe(211);
+      expect(mockInsertNodeToElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef, null]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(212, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: true,
+      });
+
+      updateWorkletRef.mockClear();
+      enqueueComponent(listRef, 7, sign);
+
+      expect(mockRemoveNodeFromElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(212, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: false,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it.each(['component-at-index', 'component-at-indexes'] as const)(
+    'does not attach list item MTRef when %s insert fails',
+    (callbackName) => {
+      envManager.switchToMainThread();
+      const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 280 } as unknown as ElementRef;
+      const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 281 } as unknown as ElementRef;
+      const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 282 } as unknown as ElementRef;
+      const ref = { _wvid: 78 };
+      const { updateWorkletRef, restore } = installWorkletRefRuntime();
+      elementTemplateRegistry.set(280, listRef);
+      elementTemplateRegistry.set(281, itemRef);
+      elementTemplateRegistry.set(282, childRef);
+      seedDetachedMTRefState(282, 0, ref, childRef);
+      registerElementTemplateListItem(281, itemRef, {
+        templateKey: '_et_item',
+        platformInfo: { 'item-key': 'a' },
+        subtreeHandles: [
+          { uid: 281, ref: itemRef },
+          { uid: 282, ref: childRef },
+        ],
+      });
+      const state = createElementTemplateListState([281]);
+      registerElementTemplateListState(280, state, false, listRef);
+      const attrs = composeElementTemplateListAttributes(null, state);
+      const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+      const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+
+      try {
+        mockInsertNodeToElementTemplate.mockImplementationOnce(() => {
+          throw new Error('list insert failed');
+        });
+
+        expect(() => {
+          if (callbackName === 'component-at-index') {
+            componentAtIndex(listRef, 7, 0, 91, false);
+          } else {
+            componentAtIndexes(listRef, 7, [0], [91], false, false);
+          }
+        }).toThrow('list insert failed');
+        expect(updateWorkletRef).not.toHaveBeenCalled();
+        expect(getMainThreadDynamicAttrState(282, 0)).toEqual({
+          kind: 'mt-ref',
+          value: ref,
+          attached: false,
+        });
+
+        if (callbackName === 'component-at-index') {
+          expect(componentAtIndex(listRef, 7, 0, 92, false)).toBe(281);
+        } else {
+          componentAtIndexes(listRef, 7, [0], [92], false, false);
+        }
+        expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  it('does not attach list item MTRef when unique-id lookup fails', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 283 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 284 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 285 } as unknown as ElementRef;
+    const ref = { _wvid: 79 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(283, listRef);
+    elementTemplateRegistry.set(284, itemRef);
+    elementTemplateRegistry.set(285, childRef);
+    seedDetachedMTRefState(285, 0, ref, childRef);
+    registerElementTemplateListItem(284, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 284, ref: itemRef },
+        { uid: 285, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([284]);
+    registerElementTemplateListState(283, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+
+    try {
+      vi.mocked(__GetElementUniqueID).mockImplementationOnce(() => {
+        throw new Error('unique id failed');
+      });
+
+      expect(() => componentAtIndex(listRef, 7, 0, 91, false)).toThrow('unique id failed');
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(285, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: false,
+      });
+
+      expect(componentAtIndex(listRef, 7, 0, 92, false)).toBe(284);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps dynamically added detached list item MTRef blocked until component-at-index', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 250 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 251 } as unknown as ElementRef;
+    const ref = { _wvid: 75 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(250, listRef);
+    elementTemplateRegistry.set(251, itemRef);
+    registerElementTemplateListItem(251, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [{ uid: 251, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([251]);
+    registerElementTemplateListState(250, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    registerTemplates([{
+      templateId: '_et_ref_child',
+      compiledTemplate: {
+        kind: 'element',
+        type: 'view',
+        attributesArray: [{
+          kind: 'slot',
+          key: 'main-thread:ref',
+          attrSlotIndex: 0,
+        }],
+        children: [],
+      },
+    }]);
+
+    try {
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.createTemplate,
+        252,
+        '_et_ref_child',
+        null,
+        [{ type: 'main-thread-ref', value: ref }],
+        [],
+        true,
+        ElementTemplateUpdateOps.insertNode,
+        251,
+        0,
+        252,
+        0,
+        [],
+        ElementTemplateUpdateOps.updateTypedListItem,
+        250,
+        {
+          __etHandleRef: 251,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [251, 252],
+        },
+      ]);
+
+      const childRef = elementTemplateRegistry.get(252)!;
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(252, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: false,
+      });
+
+      componentAtIndex(listRef, 7, 0, 94, false);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(252, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: true,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans dynamically added attached list item MTRef on enqueue-component', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 260 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 261 } as unknown as ElementRef;
+    const ref = { _wvid: 76 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(260, listRef);
+    elementTemplateRegistry.set(261, itemRef);
+    registerElementTemplateListItem(261, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [{ uid: 261, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([261]);
+    registerElementTemplateListState(260, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    registerTemplates([{
+      templateId: '_et_ref_child',
+      compiledTemplate: {
+        kind: 'element',
+        type: 'view',
+        attributesArray: [{
+          kind: 'slot',
+          key: 'main-thread:ref',
+          attrSlotIndex: 0,
+        }],
+        children: [],
+      },
+    }]);
+
+    try {
+      const sign = componentAtIndex(listRef, 7, 0, 95, false);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.createTemplate,
+        262,
+        '_et_ref_child',
+        null,
+        [{ type: 'main-thread-ref', value: ref }],
+        [],
+        true,
+        ElementTemplateUpdateOps.insertNode,
+        261,
+        0,
+        262,
+        0,
+        [],
+        ElementTemplateUpdateOps.updateTypedListItem,
+        260,
+        {
+          __etHandleRef: 261,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [261, 262],
+        },
+      ]);
+
+      const childRef = elementTemplateRegistry.get(262)!;
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+
+      enqueueComponent(listRef, 7, sign);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(262, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: false,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('attaches list item subtree MTRef from component-at-indexes', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 220 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 221 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 222 } as unknown as ElementRef;
+    const ref = { _wvid: 72 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(220, listRef);
+    elementTemplateRegistry.set(221, itemRef);
+    elementTemplateRegistry.set(222, childRef);
+    seedDetachedMTRefState(222, 0, ref, childRef);
+    registerElementTemplateListItem(221, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 221, ref: itemRef },
+        { uid: 222, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([221]);
+    registerElementTemplateListState(220, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+
+    try {
+      componentAtIndexes(listRef, 7, [0], [92], false, true);
+
+      expect(mockInsertNodeToElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef, null]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(222, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: true,
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it('creates exact typed lists outside development using the internal listChildren contract', () => {
     const originalDev = globalThis.__DEV__;
     globalThis.__DEV__ = false;
@@ -2026,7 +2393,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         null,
         [],
         {
-          listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {} }],
+          listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {}, subtreeHandleIds: [12] }],
           estimatedHeight: 80,
         },
       ]);
@@ -2102,7 +2469,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       'list',
       null,
       [[11]],
-      { listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {} }] },
+      { listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {}, subtreeHandleIds: [12] }] },
     ]);
 
     expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(0);
@@ -2251,7 +2618,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       'list',
       null,
       [],
-      { listChildren: [{ __etHandleRef: 404, type: '_et_item', platformInfo: {} }] },
+      { listChildren: [{ __etHandleRef: 404, type: '_et_item', platformInfo: {}, subtreeHandleIds: [404] }] },
     ]);
 
     expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(0);
@@ -2274,11 +2641,11 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       41,
-      { __etHandleRef: 404, type: '_et_item', platformInfo: {} },
+      { __etHandleRef: 404, type: '_et_item', platformInfo: {}, subtreeHandleIds: [404] },
       0,
       ElementTemplateUpdateOps.updateTypedListItem,
       41,
-      { __etHandleRef: 405, type: '_et_item', platformInfo: {} },
+      { __etHandleRef: 405, type: '_et_item', platformInfo: {}, subtreeHandleIds: [405] },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(0);
@@ -2419,6 +2786,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 33,
         type: '_et_item_b',
         platformInfo: { 'item-key': 'b' },
+        subtreeHandleIds: [33],
       },
       0,
     ]);
@@ -2469,6 +2837,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 37,
         type: '_et_item_b',
         platformInfo: { 'item-key': 'b' },
+        subtreeHandleIds: [37],
       },
       0,
       ElementTemplateUpdateOps.setAttribute,
@@ -2522,11 +2891,11 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 204, type: '_et_item_204', platformInfo: { 'item-key': '204' } },
+      { __etHandleRef: 204, type: '_et_item_204', platformInfo: { 'item-key': '204' }, subtreeHandleIds: [204] },
       202,
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 205, type: '_et_item_205', platformInfo: { 'item-key': '205' } },
+      { __etHandleRef: 205, type: '_et_item_205', platformInfo: { 'item-key': '205' }, subtreeHandleIds: [205] },
       204,
       ElementTemplateUpdateOps.removeTypedListItem,
       200,
@@ -2538,7 +2907,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 203, type: '_et_item_203', platformInfo: { 'item-key': '203' } },
+      { __etHandleRef: 203, type: '_et_item_203', platformInfo: { 'item-key': '203' }, subtreeHandleIds: [203] },
       0,
     ]);
 
@@ -2589,14 +2958,24 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       210,
-      { __etHandleRef: 213, type: '_et_item_d', platformInfo: { 'item-key': 'd' } },
+      { __etHandleRef: 213, type: '_et_item_d', platformInfo: { 'item-key': 'd' }, subtreeHandleIds: [213] },
       212,
       ElementTemplateUpdateOps.updateTypedListItem,
       210,
-      { __etHandleRef: 211, type: '_et_item_a', platformInfo: { 'item-key': 'a', 'full-span': true } },
+      {
+        __etHandleRef: 211,
+        type: '_et_item_a',
+        platformInfo: { 'item-key': 'a', 'full-span': true },
+        subtreeHandleIds: [211],
+      },
       ElementTemplateUpdateOps.updateTypedListItem,
       210,
-      { __etHandleRef: 212, type: '_et_item_b', platformInfo: { 'item-key': 'b', 'estimated-height': 42 } },
+      {
+        __etHandleRef: 212,
+        type: '_et_item_b',
+        platformInfo: { 'item-key': 'b', 'estimated-height': 42 },
+        subtreeHandleIds: [212],
+      },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(1);
@@ -2627,7 +3006,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.updateTypedListItem,
       214,
-      { __etHandleRef: 2141, type: '_et_item_a', platformInfo: { 'item-key': 'a' } },
+      { __etHandleRef: 2141, type: '_et_item_a', platformInfo: { 'item-key': 'a' }, subtreeHandleIds: [2141] },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(0);
@@ -2658,11 +3037,16 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       215,
-      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [217] },
       216,
       ElementTemplateUpdateOps.updateTypedListItem,
       215,
-      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b', 'full-span': true } },
+      {
+        __etHandleRef: 217,
+        type: '_et_item_b',
+        platformInfo: { 'item-key': 'b', 'full-span': true },
+        subtreeHandleIds: [217],
+      },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(1);
@@ -2712,11 +3096,16 @@ describe('ElementTemplate patch stream (apply)', () => {
       [2183],
       ElementTemplateUpdateOps.insertTypedListItem,
       218,
-      { __etHandleRef: 2181, type: '_et_item_a', platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' } },
+      {
+        __etHandleRef: 2181,
+        type: '_et_item_a',
+        platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' },
+        subtreeHandleIds: [2181],
+      },
       0,
       ElementTemplateUpdateOps.insertTypedListItem,
       218,
-      { __etHandleRef: 2184, type: '_et_item_x', platformInfo: { 'item-key': 'x' } },
+      { __etHandleRef: 2184, type: '_et_item_x', platformInfo: { 'item-key': 'x' }, subtreeHandleIds: [2184] },
       2181,
     ]);
 
@@ -2754,7 +3143,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       { id: 'intermediate' },
       ElementTemplateUpdateOps.insertTypedListItem,
       220,
-      { __etHandleRef: 222, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 222, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [222] },
       0,
       ElementTemplateUpdateOps.setAttribute,
       220,
@@ -2777,7 +3166,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     }));
   });
 
-  it('moves already attached same-list items when native requests the moved index first', () => {
+  it('moves an attached same-list item after native enqueues its rebind', () => {
     envManager.switchToMainThread();
     const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 225 } as unknown as ElementRef;
     const aRef = { __isNativeRef: true, id: 'a', __mockNativeId: 226 } as unknown as ElementRef;
@@ -2810,17 +3199,17 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       225,
-      { __etHandleRef: 227, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 227, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [227] },
       226,
     ]);
     mockInsertNodeToElementTemplate.mockClear();
     mockRemoveNodeFromElementTemplate.mockClear();
 
-    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(227);
-
-    expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, bRef, aRef]]);
-    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     enqueueComponent(listRef, 7, 227);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
+
+    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(227);
+    expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, bRef, aRef]]);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     enqueueComponent(listRef, 7, 227);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, bRef]]);
@@ -2866,7 +3255,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       240,
-      { __etHandleRef: 243, type: '_et_item_c', platformInfo: { 'item-key': 'c' } },
+      { __etHandleRef: 243, type: '_et_item_c', platformInfo: { 'item-key': 'c' }, subtreeHandleIds: [243] },
       241,
       ElementTemplateUpdateOps.removeTypedListItem,
       240,
@@ -2874,20 +3263,21 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       240,
-      { __etHandleRef: 241, type: '_et_item_a', platformInfo: { 'item-key': 'a' } },
+      { __etHandleRef: 241, type: '_et_item_a', platformInfo: { 'item-key': 'a' }, subtreeHandleIds: [241] },
       0,
     ]);
     mockInsertNodeToElementTemplate.mockClear();
     mockRemoveNodeFromElementTemplate.mockClear();
 
-    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(243);
+    enqueueComponent(listRef, 7, 243);
+    enqueueComponent(listRef, 7, 241);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
 
+    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(243);
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
       [listRef, 0, aRef, null],
       [listRef, 0, cRef, bRef],
     ]);
-    enqueueComponent(listRef, 7, 243);
-    enqueueComponent(listRef, 7, 241);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     expect(componentAtIndex(listRef, 7, 1, 91, false)).toBe(242);
   });
@@ -2924,7 +3314,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       230,
-      { __etHandleRef: 232, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 232, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [232] },
       231,
       ElementTemplateUpdateOps.removeTypedListItem,
       230,
@@ -2941,7 +3331,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         updateAction: [],
       },
     }));
-    expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, secondRef]]);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([]);
     expect(elementTemplateRegistry.get(231)).toBeUndefined();
     expect(elementTemplateRegistry.get(232)).toBe(secondRef);
   });
@@ -3126,6 +3516,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 52,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'old' },
+        subtreeHandleIds: [52],
       },
       0,
       ElementTemplateUpdateOps.updateTypedListItem,
@@ -3134,6 +3525,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 52,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'new' },
+        subtreeHandleIds: [52],
       },
     ]);
 
@@ -3174,6 +3566,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 82,
         type: '_et_item',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' },
+        subtreeHandleIds: [82],
       },
     ]);
 
@@ -3237,6 +3630,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 72,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a' },
+        subtreeHandleIds: [72],
       },
       0,
     ]);
@@ -3244,6 +3638,705 @@ describe('ElementTemplate patch stream (apply)', () => {
 
     expect(componentAtIndex(listRef, 7, 1, 92, false)).toBe(136);
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+  });
+
+  it('preserves MTRef during same-list rebind and cleans the later holder release', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 230 } as unknown as ElementRef;
+    const firstRef = { __isNativeRef: true, id: 'first', __mockNativeId: 231 } as unknown as ElementRef;
+    const secondRef = { __isNativeRef: true, id: 'second', __mockNativeId: 232 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 233 } as unknown as ElementRef;
+    const ref = { _wvid: 73 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(230, listRef);
+    elementTemplateRegistry.set(231, firstRef);
+    elementTemplateRegistry.set(232, secondRef);
+    elementTemplateRegistry.set(233, childRef);
+    seedDetachedMTRefState(233, 0, ref, childRef);
+    registerElementTemplateListItem(231, firstRef, {
+      templateKey: '_et_item_a',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 231, ref: firstRef },
+        { uid: 233, ref: childRef },
+      ],
+    });
+    registerElementTemplateListItem(232, secondRef, {
+      templateKey: '_et_item_b',
+      platformInfo: { 'item-key': 'b' },
+      subtreeHandles: [{ uid: 232, ref: secondRef }],
+    });
+    const state = createElementTemplateListState([231, 232]);
+    registerElementTemplateListState(230, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      const oldSign = componentAtIndex(listRef, 7, 0, 91, false);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        230,
+        231,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        230,
+        {
+          __etHandleRef: 231,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [231, 233],
+        },
+        0,
+      ]);
+      mockInsertNodeToElementTemplate.mockClear();
+
+      enqueueComponent(listRef, 7, oldSign);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(233, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: true,
+      });
+
+      expect(componentAtIndex(listRef, 7, 1, 92, false)).toBe(oldSign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+
+      mockRemoveNodeFromElementTemplate.mockClear();
+      enqueueComponent(listRef, 7, oldSign);
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef]]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(233, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: false,
+      });
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      expect(componentAtIndex(listRef, 7, 1, 93, false)).toBe(oldSign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans a released same-list holder when its rebind insert fails', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 290 } as unknown as ElementRef;
+    const firstRef = { __isNativeRef: true, id: 'first', __mockNativeId: 291 } as unknown as ElementRef;
+    const secondRef = { __isNativeRef: true, id: 'second', __mockNativeId: 292 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 293 } as unknown as ElementRef;
+    const ref = { _wvid: 79 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(290, listRef);
+    elementTemplateRegistry.set(291, firstRef);
+    elementTemplateRegistry.set(292, secondRef);
+    elementTemplateRegistry.set(293, childRef);
+    seedDetachedMTRefState(293, 0, ref, childRef);
+    registerElementTemplateListItem(291, firstRef, {
+      templateKey: '_et_item_a',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 291, ref: firstRef },
+        { uid: 293, ref: childRef },
+      ],
+    });
+    registerElementTemplateListItem(292, secondRef, {
+      templateKey: '_et_item_b',
+      platformInfo: { 'item-key': 'b' },
+      subtreeHandles: [{ uid: 292, ref: secondRef }],
+    });
+    const state = createElementTemplateListState([291, 292]);
+    registerElementTemplateListState(290, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      const sign = componentAtIndex(listRef, 7, 0, 91, false);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      mockRemoveNodeFromElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        290,
+        291,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        290,
+        {
+          __etHandleRef: 291,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [291, 293],
+        },
+        0,
+      ]);
+      enqueueComponent(listRef, 7, sign);
+      mockInsertNodeToElementTemplate.mockImplementationOnce(() => {
+        throw new Error('list move insert failed');
+      });
+
+      expect(() => componentAtIndex(listRef, 7, 1, 92, false)).toThrow(
+        'list move insert failed',
+      );
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([
+        [listRef, 0, firstRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([[ref, null]]);
+      expect(getMainThreadDynamicAttrState(293, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: false,
+      });
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      expect(componentAtIndex(listRef, 7, 1, 93, false)).toBe(sign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, firstRef, null],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([[ref, childRef]]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps successful batch moves attached and cleans remaining released moves after insert failure', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 300 } as unknown as ElementRef;
+    const aRef = { __isNativeRef: true, id: 'a', __mockNativeId: 301 } as unknown as ElementRef;
+    const bRef = { __isNativeRef: true, id: 'b', __mockNativeId: 302 } as unknown as ElementRef;
+    const cRef = { __isNativeRef: true, id: 'c', __mockNativeId: 303 } as unknown as ElementRef;
+    const dRef = { __isNativeRef: true, id: 'd', __mockNativeId: 304 } as unknown as ElementRef;
+    const mtRefs = {
+      a: { _wvid: 80 },
+      b: { _wvid: 81 },
+      c: { _wvid: 82 },
+      d: { _wvid: 83 },
+    };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(300, listRef);
+    for (
+      const [uid, itemRef, itemKey, mtRef] of [
+        [301, aRef, 'a', mtRefs.a],
+        [302, bRef, 'b', mtRefs.b],
+        [303, cRef, 'c', mtRefs.c],
+        [304, dRef, 'd', mtRefs.d],
+      ] as const
+    ) {
+      elementTemplateRegistry.set(uid, itemRef);
+      seedDetachedMTRefState(uid, 0, mtRef, itemRef);
+      registerElementTemplateListItem(uid, itemRef, {
+        templateKey: `_et_item_${itemKey}`,
+        platformInfo: { 'item-key': itemKey },
+        subtreeHandles: [{ uid, ref: itemRef }],
+      });
+    }
+    const state = createElementTemplateListState([301, 302, 303, 304]);
+    registerElementTemplateListState(300, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      componentAtIndexes(listRef, 7, [0, 1, 2, 3], [90, 91, 92, 93], false, false);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      mockRemoveNodeFromElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        304,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 304,
+          type: '_et_item_d',
+          platformInfo: { 'item-key': 'd' },
+          subtreeHandleIds: [304],
+        },
+        301,
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        303,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 303,
+          type: '_et_item_c',
+          platformInfo: { 'item-key': 'c' },
+          subtreeHandleIds: [303],
+        },
+        301,
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        301,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 301,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [301],
+        },
+        0,
+      ]);
+      enqueueComponent(listRef, 7, 304);
+      enqueueComponent(listRef, 7, 303);
+      enqueueComponent(listRef, 7, 301);
+      mockInsertNodeToElementTemplate
+        .mockImplementationOnce(() => {})
+        .mockImplementationOnce(() => {
+          throw new Error('batch list move insert failed');
+        });
+
+      expect(() => {
+        componentAtIndexes(listRef, 7, [0, 1, 2, 3], [94, 95, 96, 97], false, false);
+      }).toThrow('batch list move insert failed');
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, aRef, null],
+        [listRef, 0, cRef, bRef],
+      ]);
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([
+        [listRef, 0, dRef],
+        [listRef, 0, cRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([
+        [mtRefs.d, null],
+        [mtRefs.c, null],
+      ]);
+      expect(getMainThreadDynamicAttrState(301, 0)?.attached).toBe(true);
+      expect(getMainThreadDynamicAttrState(303, 0)?.attached).toBe(false);
+      expect(getMainThreadDynamicAttrState(304, 0)?.attached).toBe(false);
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      componentAtIndexes(listRef, 7, [0, 1], [98, 99], false, false);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, dRef, bRef],
+        [listRef, 0, cRef, bRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([
+        [mtRefs.d, dRef],
+        [mtRefs.c, cRef],
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('ignores an old-list enqueue after an object MTRef item attaches to a new list', () => {
+    envManager.switchToMainThread();
+    const oldListRef = { __isNativeRef: true, id: 'old-list', __mockNativeId: 271 } as unknown as ElementRef;
+    const newListRef = { __isNativeRef: true, id: 'new-list', __mockNativeId: 272 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 273 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 274 } as unknown as ElementRef;
+    const ref = { _wvid: 76 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(271, oldListRef);
+    elementTemplateRegistry.set(272, newListRef);
+    elementTemplateRegistry.set(273, itemRef);
+    elementTemplateRegistry.set(274, childRef);
+    seedDetachedMTRefState(274, 0, ref, childRef);
+    registerElementTemplateListItem(273, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'item' },
+      subtreeHandles: [{ uid: 274, ref: childRef }],
+    });
+    const oldState = createElementTemplateListState([273]);
+    const newState = createElementTemplateListState([]);
+    registerElementTemplateListState(271, oldState, false, oldListRef);
+    registerElementTemplateListState(272, newState, false, newListRef);
+    const oldAttrs = composeElementTemplateListAttributes(null, oldState);
+    const newAttrs = composeElementTemplateListAttributes(null, newState);
+    const oldComponentAtIndex = oldAttrs['component-at-index'] as ComponentAtIndexCallback;
+    const oldEnqueue = oldAttrs['enqueue-component'] as EnqueueComponentCallback;
+    const newComponentAtIndex = newAttrs['component-at-index'] as ComponentAtIndexCallback;
+    const newEnqueue = newAttrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      const sign = oldComponentAtIndex(oldListRef, 7, 0, 91, false);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        271,
+        273,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        272,
+        {
+          __etHandleRef: 273,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'item' },
+          subtreeHandleIds: [274],
+        },
+        0,
+      ]);
+
+      expect(newComponentAtIndex(newListRef, 8, 0, 92, false)).toBe(sign);
+      oldEnqueue(oldListRef, 7, sign);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(274, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: true,
+      });
+
+      newEnqueue(newListRef, 8, sign);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+    } finally {
+      restore();
+    }
+  });
+
+  it('reattaches a callback MTRef when the old list enqueues before the new list attaches', () => {
+    envManager.switchToMainThread();
+    const oldListRef = { __isNativeRef: true, id: 'old-list', __mockNativeId: 281 } as unknown as ElementRef;
+    const newListRef = { __isNativeRef: true, id: 'new-list', __mockNativeId: 282 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 283 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 284 } as unknown as ElementRef;
+    const callback = { _wkltId: 'cross-list-ref' };
+    const cleanup = vi.fn();
+    const previousRunWorklet = globalThis.runWorklet;
+    globalThis.runWorklet = vi.fn(() => cleanup);
+    elementTemplateRegistry.set(281, oldListRef);
+    elementTemplateRegistry.set(282, newListRef);
+    elementTemplateRegistry.set(283, itemRef);
+    elementTemplateRegistry.set(284, childRef);
+    seedDetachedMTRefState(284, 0, callback, childRef);
+    registerElementTemplateListItem(283, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'item' },
+      subtreeHandles: [{ uid: 284, ref: childRef }],
+    });
+    const oldState = createElementTemplateListState([283]);
+    const newState = createElementTemplateListState([]);
+    registerElementTemplateListState(281, oldState, false, oldListRef);
+    registerElementTemplateListState(282, newState, false, newListRef);
+    const oldAttrs = composeElementTemplateListAttributes(null, oldState);
+    const newAttrs = composeElementTemplateListAttributes(null, newState);
+    const oldComponentAtIndex = oldAttrs['component-at-index'] as ComponentAtIndexCallback;
+    const oldEnqueue = oldAttrs['enqueue-component'] as EnqueueComponentCallback;
+    const newComponentAtIndex = newAttrs['component-at-index'] as ComponentAtIndexCallback;
+
+    try {
+      const sign = oldComponentAtIndex(oldListRef, 7, 0, 91, false);
+      (globalThis.runWorklet as ReturnType<typeof vi.fn>).mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        281,
+        283,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        282,
+        {
+          __etHandleRef: 283,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'item' },
+          subtreeHandleIds: [284],
+        },
+        0,
+      ]);
+
+      oldEnqueue(oldListRef, 7, sign);
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(newComponentAtIndex(newListRef, 8, 0, 92, false)).toBe(sign);
+      expect(globalThis.runWorklet).toHaveBeenCalledWith(callback, [{ elementRefptr: childRef }]);
+      expect(getMainThreadDynamicAttrState(284, 0)).toEqual({
+        kind: 'mt-ref',
+        value: callback,
+        attached: true,
+      });
+    } finally {
+      globalThis.runWorklet = previousRunWorklet;
+    }
+  });
+
+  it('reattaches a callback MTRef when the old list is destroyed before the new list attaches', () => {
+    envManager.switchToMainThread();
+    const oldListRef = { __isNativeRef: true, id: 'old-list', __mockNativeId: 291 } as unknown as ElementRef;
+    const newListRef = { __isNativeRef: true, id: 'new-list', __mockNativeId: 292 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 293 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 294 } as unknown as ElementRef;
+    const callback = { _wkltId: 'destroyed-old-list-ref' };
+    const cleanup = vi.fn();
+    const previousRunWorklet = globalThis.runWorklet;
+    globalThis.runWorklet = vi.fn(() => cleanup);
+    elementTemplateRegistry.set(291, oldListRef);
+    elementTemplateRegistry.set(292, newListRef);
+    elementTemplateRegistry.set(293, itemRef);
+    elementTemplateRegistry.set(294, childRef);
+    seedDetachedMTRefState(294, 0, callback, childRef);
+    registerElementTemplateListItem(293, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'item' },
+      subtreeHandles: [{ uid: 294, ref: childRef }],
+    });
+    const oldState = createElementTemplateListState([293]);
+    const newState = createElementTemplateListState([]);
+    registerElementTemplateListState(291, oldState, false, oldListRef);
+    registerElementTemplateListState(292, newState, false, newListRef);
+    const oldComponentAtIndex = composeElementTemplateListAttributes(null, oldState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+    const newComponentAtIndex = composeElementTemplateListAttributes(null, newState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+
+    try {
+      const sign = oldComponentAtIndex(oldListRef, 7, 0, 91, false);
+      (globalThis.runWorklet as ReturnType<typeof vi.fn>).mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        291,
+        293,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        292,
+        {
+          __etHandleRef: 293,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'item' },
+          subtreeHandleIds: [294],
+        },
+        0,
+      ]);
+
+      markElementTemplateListDestroyed(291);
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(getMainThreadDynamicAttrState(294, 0)).toEqual({
+        kind: 'mt-ref',
+        value: callback,
+        attached: false,
+      });
+
+      expect(newComponentAtIndex(newListRef, 8, 0, 92, false)).toBe(sign);
+      expect(globalThis.runWorklet).toHaveBeenCalledWith(callback, [{ elementRefptr: childRef }]);
+      expect(getMainThreadDynamicAttrState(294, 0)).toEqual({
+        kind: 'mt-ref',
+        value: callback,
+        attached: true,
+      });
+    } finally {
+      globalThis.runWorklet = previousRunWorklet;
+    }
+  });
+
+  it('uses current item membership when the physical old-list owner is destroyed', () => {
+    envManager.switchToMainThread();
+    const oldListRef = { __isNativeRef: true, id: 'old-list', __mockNativeId: 301 } as unknown as ElementRef;
+    const newListRef = { __isNativeRef: true, id: 'new-list', __mockNativeId: 302 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 303 } as unknown as ElementRef;
+    const movedOutRef = { __isNativeRef: true, id: 'moved-out', __mockNativeId: 304 } as unknown as ElementRef;
+    const addedRef = { __isNativeRef: true, id: 'added', __mockNativeId: 305 } as unknown as ElementRef;
+    const movedOutMTRef = { _wvid: 77 };
+    const addedMTRef = { _wvid: 78 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(301, oldListRef);
+    elementTemplateRegistry.set(302, newListRef);
+    elementTemplateRegistry.set(303, itemRef);
+    elementTemplateRegistry.set(304, movedOutRef);
+    elementTemplateRegistry.set(305, addedRef);
+    seedDetachedMTRefState(304, 0, movedOutMTRef, movedOutRef);
+    seedDetachedMTRefState(305, 0, addedMTRef, addedRef);
+    registerElementTemplateListItem(303, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'item' },
+      subtreeHandles: [{ uid: 304, ref: movedOutRef }],
+    });
+    const oldState = createElementTemplateListState([303]);
+    const newState = createElementTemplateListState([]);
+    registerElementTemplateListState(301, oldState, false, oldListRef);
+    registerElementTemplateListState(302, newState, false, newListRef);
+    const oldComponentAtIndex = composeElementTemplateListAttributes(null, oldState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+
+    try {
+      oldComponentAtIndex(oldListRef, 7, 0, 91, false);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        301,
+        303,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        302,
+        {
+          __etHandleRef: 303,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'item' },
+          subtreeHandleIds: [304],
+        },
+        0,
+        ElementTemplateUpdateOps.updateTypedListItem,
+        302,
+        {
+          __etHandleRef: 303,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'item' },
+          subtreeHandleIds: [304, 305],
+        },
+      ]);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(addedMTRef, addedRef);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.updateTypedListItem,
+        302,
+        {
+          __etHandleRef: 303,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'item' },
+          subtreeHandleIds: [305],
+        },
+      ]);
+      markElementTemplateListDestroyed(301);
+
+      expect(updateWorkletRef).toHaveBeenCalledTimes(1);
+      expect(updateWorkletRef).toHaveBeenCalledWith(addedMTRef, null);
+      expect(getMainThreadDynamicAttrState(304, 0)).toEqual({
+        kind: 'mt-ref',
+        value: movedOutMTRef,
+        attached: true,
+      });
+      expect(getMainThreadDynamicAttrState(305, 0)).toEqual({
+        kind: 'mt-ref',
+        value: addedMTRef,
+        attached: false,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not cleanup a descendant after its list item membership moves to another attached item', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 250 } as unknown as ElementRef;
+    const itemARef = { __isNativeRef: true, id: 'item-a', __mockNativeId: 251 } as unknown as ElementRef;
+    const itemBRef = { __isNativeRef: true, id: 'item-b', __mockNativeId: 252 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 253 } as unknown as ElementRef;
+    const ref = { _wvid: 75 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(250, listRef);
+    elementTemplateRegistry.set(251, itemARef);
+    elementTemplateRegistry.set(252, itemBRef);
+    elementTemplateRegistry.set(253, childRef);
+    seedDetachedMTRefState(253, 0, ref, childRef);
+    registerElementTemplateListItem(251, itemARef, {
+      templateKey: '_et_item_a',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [{ uid: 251, ref: itemARef }, { uid: 253, ref: childRef }],
+    });
+    registerElementTemplateListItem(252, itemBRef, {
+      templateKey: '_et_item_b',
+      platformInfo: { 'item-key': 'b' },
+      subtreeHandles: [{ uid: 252, ref: itemBRef }],
+    });
+    const state = createElementTemplateListState([251, 252]);
+    registerElementTemplateListState(250, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      const itemASign = componentAtIndex(listRef, 7, 0, 91, false);
+      componentAtIndex(listRef, 7, 1, 92, false);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.updateTypedListItem,
+        250,
+        {
+          __etHandleRef: 251,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [251],
+        },
+        ElementTemplateUpdateOps.updateTypedListItem,
+        250,
+        {
+          __etHandleRef: 252,
+          type: '_et_item_b',
+          platformInfo: { 'item-key': 'b' },
+          subtreeHandleIds: [252, 253],
+        },
+      ]);
+
+      enqueueComponent(listRef, 7, itemASign);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(253, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: true,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans live list subtree MTRef on logical item removal after update-list-info', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 240 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 241 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 242 } as unknown as ElementRef;
+    const ref = { _wvid: 74 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(240, listRef);
+    elementTemplateRegistry.set(241, itemRef);
+    elementTemplateRegistry.set(242, childRef);
+    seedDetachedMTRefState(242, 0, ref, childRef);
+    registerElementTemplateListItem(241, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 241, ref: itemRef },
+        { uid: 242, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([241]);
+    registerElementTemplateListState(240, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+
+    try {
+      componentAtIndex(listRef, 7, 0, 93, false);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        240,
+        241,
+        [241, 242],
+      ]);
+
+      expect(mockSetAttributeOfElementTemplate.mock.calls.at(-1)?.[0]).toBe(listRef);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(242, 0)).toBeUndefined();
+    } finally {
+      restore();
+    }
   });
 
   it('treats same-key list item replacement with a new ref as remove and insert', () => {
@@ -3272,6 +4365,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 63,
         type: '_et_item',
         platformInfo: { 'item-key': 'same' },
+        subtreeHandleIds: [63],
       },
       0,
     ]);
@@ -3288,8 +4382,8 @@ describe('ElementTemplate patch stream (apply)', () => {
 
   it('keeps destroyed typed list callbacks Snapshot-safe', () => {
     envManager.switchToMainThread();
-    const listRef = 120 as unknown as ElementRef;
-    const itemRef = 121 as unknown as ElementRef;
+    const listRef = { __isNativeRef: true, __mockNativeId: 120 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, __mockNativeId: 121 } as unknown as ElementRef;
     registerElementTemplateListItem(121, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'a' },
@@ -3301,6 +4395,9 @@ describe('ElementTemplate patch stream (apply)', () => {
     const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
     const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
 
+    expect(componentAtIndex(listRef, 7, 0, 99, false)).toBe(121);
+    mockInsertNodeToElementTemplate.mockClear();
+    mockFlushElementTree.mockClear();
     markElementTemplateListDestroyed(120);
 
     expect(componentAtIndex(listRef, 7, 0, 99, false)).toBe(-1);
@@ -3310,6 +4407,39 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(mockInsertNodeToElementTemplate.mock.calls).toHaveLength(0);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     expect(mockFlushElementTree.mock.calls).toHaveLength(0);
+  });
+
+  it('keeps the physical owner aligned when an attached list item record is replaced', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, __mockNativeId: 130 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, __mockNativeId: 131 } as unknown as ElementRef;
+    elementTemplateRegistry.set(130, listRef);
+    elementTemplateRegistry.set(131, itemRef);
+    registerElementTemplateListItem(131, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+    });
+    const state = createElementTemplateListState([131]);
+    registerElementTemplateListState(130, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+    const sign = componentAtIndex(listRef, 7, 0, 99, false);
+    mockRemoveNodeFromElementTemplate.mockClear();
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      130,
+      {
+        __etHandleRef: 131,
+        type: '_et_item',
+        platformInfo: { 'item-key': 'a', 'full-span': true },
+        subtreeHandleIds: [],
+      },
+    ]);
+    enqueueComponent(listRef, 7, sign);
+
+    expect(mockRemoveNodeFromElementTemplate).toHaveBeenCalledWith(listRef, 0, itemRef);
   });
 
   it('skips typed slot 0 attributes when the target handle is unresolved', () => {
@@ -3390,6 +4520,77 @@ describe('ElementTemplate patch stream (apply)', () => {
     const reportError = (globalThis.lynx as unknown as LynxWithReportErrorMock).reportError;
     expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain('insert subtree handle 999 not found');
     resetReportedErrors();
+  });
+
+  it('reports a missing typed list item subtree handle', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'list' } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item' } as unknown as ElementRef;
+    elementTemplateRegistry.set(500, listRef);
+    elementTemplateRegistry.set(501, itemRef);
+    registerElementTemplateListItem(501, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: {},
+      subtreeHandles: [{ uid: 501, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([501]);
+    registerElementTemplateListState(500, state, false, listRef);
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      500,
+      {
+        __etHandleRef: 501,
+        type: '_et_item',
+        platformInfo: {},
+        subtreeHandleIds: [501, 999],
+      },
+    ]);
+
+    expect(state.items[0]?.subtreeHandles).toEqual([{ uid: 501, ref: itemRef }]);
+    const reportError = (globalThis.lynx as unknown as LynxWithReportErrorMock).reportError;
+    expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain(
+      'typed list update item subtree handle 999 not found',
+    );
+    resetReportedErrors();
+  });
+
+  it('updates typed list subtree membership when its size stays the same', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'list' } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item' } as unknown as ElementRef;
+    const previousChildRef = { __isNativeRef: true, id: 'previous-child' } as unknown as ElementRef;
+    const nextChildRef = { __isNativeRef: true, id: 'next-child' } as unknown as ElementRef;
+    elementTemplateRegistry.set(510, listRef);
+    elementTemplateRegistry.set(511, itemRef);
+    elementTemplateRegistry.set(512, previousChildRef);
+    elementTemplateRegistry.set(513, nextChildRef);
+    registerElementTemplateListItem(511, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: {},
+      subtreeHandles: [
+        { uid: 511, ref: itemRef },
+        { uid: 512, ref: previousChildRef },
+      ],
+    });
+    const state = createElementTemplateListState([511]);
+    registerElementTemplateListState(510, state, false, listRef);
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      510,
+      {
+        __etHandleRef: 511,
+        type: '_et_item',
+        platformInfo: {},
+        subtreeHandleIds: [511, 513],
+      },
+    ]);
+
+    expect(state.items[0]?.subtreeHandles).toEqual([
+      { uid: 511, ref: itemRef },
+      { uid: 513, ref: nextChildRef },
+    ]);
   });
 
   it('reports missing child handle on removeNode', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -2087,6 +2087,69 @@ describe('ElementTemplate patch stream (apply)', () => {
     }
   });
 
+  it('keeps nested list item MTRef detached until its own holder insert', () => {
+    envManager.switchToMainThread();
+    const outerListRef = { __isNativeRef: true, id: 'outer-list', __mockNativeId: 290 } as unknown as ElementRef;
+    const outerItemRef = { __isNativeRef: true, id: 'outer-item', __mockNativeId: 291 } as unknown as ElementRef;
+    const nestedListRef = { __isNativeRef: true, id: 'nested-list', __mockNativeId: 292 } as unknown as ElementRef;
+    const nestedItemRef = { __isNativeRef: true, id: 'nested-item', __mockNativeId: 293 } as unknown as ElementRef;
+    const nestedChildRef = { __isNativeRef: true, id: 'nested-child', __mockNativeId: 294 } as unknown as ElementRef;
+    const ref = { _wvid: 79 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(290, outerListRef);
+    elementTemplateRegistry.set(291, outerItemRef);
+    elementTemplateRegistry.set(292, nestedListRef);
+    elementTemplateRegistry.set(293, nestedItemRef);
+    elementTemplateRegistry.set(294, nestedChildRef);
+    seedDetachedMTRefState(294, 0, ref);
+    registerElementTemplateListItem(291, outerItemRef, {
+      templateKey: '_et_outer_item',
+      platformInfo: { 'item-key': 'outer' },
+      subtreeHandles: [
+        { uid: 291, ref: outerItemRef },
+        { uid: 292, ref: nestedListRef },
+      ],
+    });
+    registerElementTemplateListItem(293, nestedItemRef, {
+      templateKey: '_et_nested_item',
+      platformInfo: { 'item-key': 'nested' },
+      subtreeHandles: [
+        { uid: 293, ref: nestedItemRef },
+        { uid: 294, ref: nestedChildRef },
+      ],
+    });
+    const outerState = createElementTemplateListState([291]);
+    const nestedState = createElementTemplateListState([293]);
+    registerElementTemplateListState(290, outerState, false, outerListRef);
+    registerElementTemplateListState(292, nestedState, false, nestedListRef);
+    const outerComponentAtIndex = composeElementTemplateListAttributes(null, outerState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+    const nestedComponentAtIndex = composeElementTemplateListAttributes(null, nestedState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+
+    try {
+      expect(outerComponentAtIndex(outerListRef, 7, 0, 91, false)).toBe(291);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(294, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: false,
+      });
+
+      expect(nestedComponentAtIndex(nestedListRef, 8, 0, 92, false)).toBe(293);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, nestedChildRef);
+      expect(getMainThreadDynamicAttrState(294, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: true,
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it.each(['component-at-index', 'component-at-indexes'] as const)(
     'does not attach list item MTRef when %s insert fails',
     (callbackName) => {

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -148,16 +148,24 @@ function seedMTEventState(
   initializeMainThreadDynamicAttrSlots(handleId, MT_EVENT_TEMPLATE, attributeSlots);
 }
 
+function seedDetachedMTRefState(
+  handleId: number,
+  attrSlotIndex: number,
+  value: Record<string, unknown>,
+): void {
+  registerMTRefHandle(handleId, attrSlotIndex);
+  const attributeSlots: unknown[] = [];
+  attributeSlots[attrSlotIndex] = { type: 'main-thread-ref', value };
+  initializeMainThreadDynamicAttrSlots(handleId, MT_REF_TEMPLATE, attributeSlots);
+}
+
 function seedMTRefState(
   handleId: number,
   attrSlotIndex: number,
   value: Record<string, unknown>,
   nativeRef: ElementRef,
 ): void {
-  registerMTRefHandle(handleId, attrSlotIndex);
-  const attributeSlots: unknown[] = [];
-  attributeSlots[attrSlotIndex] = { type: 'main-thread-ref', value };
-  initializeMainThreadDynamicAttrSlots(handleId, MT_REF_TEMPLATE, attributeSlots);
+  seedDetachedMTRefState(handleId, attrSlotIndex, value);
   attachMainThreadDynamicAttrRefsForSubtree([{ uid: handleId, ref: nativeRef }]);
 }
 
@@ -2036,7 +2044,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(210, listRef);
     elementTemplateRegistry.set(211, itemRef);
     elementTemplateRegistry.set(212, childRef);
-    seedDetachedMTRefState(212, 0, ref, childRef);
+    seedDetachedMTRefState(212, 0, ref);
     registerElementTemplateListItem(211, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'a' },
@@ -2091,7 +2099,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       elementTemplateRegistry.set(280, listRef);
       elementTemplateRegistry.set(281, itemRef);
       elementTemplateRegistry.set(282, childRef);
-      seedDetachedMTRefState(282, 0, ref, childRef);
+      seedDetachedMTRefState(282, 0, ref);
       registerElementTemplateListItem(281, itemRef, {
         templateKey: '_et_item',
         platformInfo: { 'item-key': 'a' },
@@ -2137,50 +2145,6 @@ describe('ElementTemplate patch stream (apply)', () => {
     },
   );
 
-  it('does not attach list item MTRef when unique-id lookup fails', () => {
-    envManager.switchToMainThread();
-    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 283 } as unknown as ElementRef;
-    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 284 } as unknown as ElementRef;
-    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 285 } as unknown as ElementRef;
-    const ref = { _wvid: 79 };
-    const { updateWorkletRef, restore } = installWorkletRefRuntime();
-    elementTemplateRegistry.set(283, listRef);
-    elementTemplateRegistry.set(284, itemRef);
-    elementTemplateRegistry.set(285, childRef);
-    seedDetachedMTRefState(285, 0, ref, childRef);
-    registerElementTemplateListItem(284, itemRef, {
-      templateKey: '_et_item',
-      platformInfo: { 'item-key': 'a' },
-      subtreeHandles: [
-        { uid: 284, ref: itemRef },
-        { uid: 285, ref: childRef },
-      ],
-    });
-    const state = createElementTemplateListState([284]);
-    registerElementTemplateListState(283, state, false, listRef);
-    const attrs = composeElementTemplateListAttributes(null, state);
-    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
-
-    try {
-      vi.mocked(__GetElementUniqueID).mockImplementationOnce(() => {
-        throw new Error('unique id failed');
-      });
-
-      expect(() => componentAtIndex(listRef, 7, 0, 91, false)).toThrow('unique id failed');
-      expect(updateWorkletRef).not.toHaveBeenCalled();
-      expect(getMainThreadDynamicAttrState(285, 0)).toEqual({
-        kind: 'mt-ref',
-        value: ref,
-        attached: false,
-      });
-
-      expect(componentAtIndex(listRef, 7, 0, 92, false)).toBe(284);
-      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
-    } finally {
-      restore();
-    }
-  });
-
   it('keeps dynamically added detached list item MTRef blocked until component-at-index', () => {
     envManager.switchToMainThread();
     const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 250 } as unknown as ElementRef;
@@ -2221,7 +2185,6 @@ describe('ElementTemplate patch stream (apply)', () => {
         null,
         [{ type: 'main-thread-ref', value: ref }],
         [],
-        true,
         ElementTemplateUpdateOps.insertNode,
         251,
         0,
@@ -2303,7 +2266,6 @@ describe('ElementTemplate patch stream (apply)', () => {
         null,
         [{ type: 'main-thread-ref', value: ref }],
         [],
-        true,
         ElementTemplateUpdateOps.insertNode,
         261,
         0,
@@ -2347,7 +2309,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(220, listRef);
     elementTemplateRegistry.set(221, itemRef);
     elementTemplateRegistry.set(222, childRef);
-    seedDetachedMTRefState(222, 0, ref, childRef);
+    seedDetachedMTRefState(222, 0, ref);
     registerElementTemplateListItem(221, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'a' },
@@ -3652,7 +3614,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(231, firstRef);
     elementTemplateRegistry.set(232, secondRef);
     elementTemplateRegistry.set(233, childRef);
-    seedDetachedMTRefState(233, 0, ref, childRef);
+    seedDetachedMTRefState(233, 0, ref);
     registerElementTemplateListItem(231, firstRef, {
       templateKey: '_et_item_a',
       platformInfo: { 'item-key': 'a' },
@@ -3739,7 +3701,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(291, firstRef);
     elementTemplateRegistry.set(292, secondRef);
     elementTemplateRegistry.set(293, childRef);
-    seedDetachedMTRefState(293, 0, ref, childRef);
+    seedDetachedMTRefState(293, 0, ref);
     registerElementTemplateListItem(291, firstRef, {
       templateKey: '_et_item_a',
       platformInfo: { 'item-key': 'a' },
@@ -3834,7 +3796,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       ] as const
     ) {
       elementTemplateRegistry.set(uid, itemRef);
-      seedDetachedMTRefState(uid, 0, mtRef, itemRef);
+      seedDetachedMTRefState(uid, 0, mtRef);
       registerElementTemplateListItem(uid, itemRef, {
         templateKey: `_et_item_${itemKey}`,
         platformInfo: { 'item-key': itemKey },
@@ -3950,7 +3912,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(272, newListRef);
     elementTemplateRegistry.set(273, itemRef);
     elementTemplateRegistry.set(274, childRef);
-    seedDetachedMTRefState(274, 0, ref, childRef);
+    seedDetachedMTRefState(274, 0, ref);
     registerElementTemplateListItem(273, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'item' },
@@ -4018,7 +3980,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(282, newListRef);
     elementTemplateRegistry.set(283, itemRef);
     elementTemplateRegistry.set(284, childRef);
-    seedDetachedMTRefState(284, 0, callback, childRef);
+    seedDetachedMTRefState(284, 0, callback);
     registerElementTemplateListItem(283, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'item' },
@@ -4082,7 +4044,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(292, newListRef);
     elementTemplateRegistry.set(293, itemRef);
     elementTemplateRegistry.set(294, childRef);
-    seedDetachedMTRefState(294, 0, callback, childRef);
+    seedDetachedMTRefState(294, 0, callback);
     registerElementTemplateListItem(293, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'item' },
@@ -4154,8 +4116,8 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(303, itemRef);
     elementTemplateRegistry.set(304, movedOutRef);
     elementTemplateRegistry.set(305, addedRef);
-    seedDetachedMTRefState(304, 0, movedOutMTRef, movedOutRef);
-    seedDetachedMTRefState(305, 0, addedMTRef, addedRef);
+    seedDetachedMTRefState(304, 0, movedOutMTRef);
+    seedDetachedMTRefState(305, 0, addedMTRef);
     registerElementTemplateListItem(303, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'item' },
@@ -4241,7 +4203,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(251, itemARef);
     elementTemplateRegistry.set(252, itemBRef);
     elementTemplateRegistry.set(253, childRef);
-    seedDetachedMTRefState(253, 0, ref, childRef);
+    seedDetachedMTRefState(253, 0, ref);
     registerElementTemplateListItem(251, itemARef, {
       templateKey: '_et_item_a',
       platformInfo: { 'item-key': 'a' },
@@ -4305,7 +4267,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     elementTemplateRegistry.set(240, listRef);
     elementTemplateRegistry.set(241, itemRef);
     elementTemplateRegistry.set(242, childRef);
-    seedDetachedMTRefState(242, 0, ref, childRef);
+    seedDetachedMTRefState(242, 0, ref);
     registerElementTemplateListItem(241, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'a' },

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
@@ -14,10 +14,15 @@ import { elementTemplateRegistry } from '../../../../src/element-template/runtim
 import {
   __etAttrPlanMap,
   adaptEventAttrSlot,
+  adaptMTRefAttrSlot,
   adaptRefAttrSlot,
   adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
+import {
+  clearMainThreadDynamicAttrState,
+  getMainThreadDynamicAttrState,
+} from '../../../../src/element-template/runtime/template/main-thread-dynamic-attr-state.js';
 import {
   __OpAttr,
   __OpBegin,
@@ -58,12 +63,14 @@ describe('renderOpcodesIntoElementTemplate', () => {
     vi.stubGlobal('__OnLifecycleEvent', onLifecycleEvent);
     elementTemplateRegistry.clear();
     destroyAllElementTemplateListStates();
+    clearMainThreadDynamicAttrState();
     clearEtAttrPlanMap();
     resetTemplateId();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    clearMainThreadDynamicAttrState();
     clearEtAttrPlanMap();
   });
 
@@ -398,6 +405,73 @@ describe('renderOpcodesIntoElementTemplate', () => {
         listID: 9,
       }],
     ]);
+  });
+
+  it('defers first-screen list item subtree MTRef attach until native requests the item', () => {
+    const previousWorkletImpl = globalThis.lynxWorkletImpl;
+    const updateWorkletRef = vi.fn();
+    globalThis.lynxWorkletImpl = {
+      ...previousWorkletImpl,
+      _refImpl: {
+        updateWorkletRef,
+      },
+    };
+    const listRef = { kind: 'list-ref', __mockNativeId: 400 };
+    const itemRef = { kind: 'item-ref', __mockNativeId: 401 };
+    const childRef = { kind: 'child-ref', __mockNativeId: 402 };
+    const ref = { _wvid: 77 };
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    createElementTemplate
+      .mockReturnValueOnce(childRef)
+      .mockReturnValueOnce(itemRef);
+    createTypedElementTemplate.mockReturnValueOnce(listRef);
+
+    try {
+      renderOpcodesIntoElementTemplate([
+        __OpBegin,
+        { type: 'list' },
+        __OpSlot,
+        0,
+        __OpBegin,
+        { type: '_et_item', props: { __listItemPlatformInfo: { 'item-key': 'a' } } },
+        __OpSlot,
+        0,
+        __OpBegin,
+        { type: '__Card__:_et_ref_child' },
+        __OpAttr,
+        'attributeSlots',
+        [ref],
+        __OpEnd,
+        __OpEnd,
+        __OpEnd,
+      ]);
+
+      expect(createElementTemplate.mock.calls[0]).toEqual([
+        '_et_ref_child',
+        null,
+        [null],
+        null,
+        -1,
+      ]);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(-1, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      const attrs = createTypedElementTemplate.mock.calls[0]![1] as Record<string, (...args: unknown[]) => unknown>;
+      const componentAtIndex = attrs['component-at-index']!;
+
+      expect(componentAtIndex(listRef, 9, 0, 72, true)).toBe(401);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(-1, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      globalThis.lynxWorkletImpl = previousWorkletImpl;
+    }
   });
 
   it('rejects non-list-item roots in typed list logical children', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
@@ -14,10 +14,15 @@ import { elementTemplateRegistry } from '../../../../src/element-template/runtim
 import {
   __etAttrPlanMap,
   adaptEventAttrSlot,
+  adaptMTRefAttrSlot,
   adaptRefAttrSlot,
   adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
+import {
+  clearMainThreadDynamicAttrState,
+  getMainThreadDynamicAttrState,
+} from '../../../../src/element-template/runtime/template/main-thread-dynamic-attr-state.js';
 import {
   __OpAttr,
   __OpBegin,
@@ -58,12 +63,14 @@ describe('renderOpcodesIntoElementTemplate', () => {
     vi.stubGlobal('__OnLifecycleEvent', onLifecycleEvent);
     elementTemplateRegistry.clear();
     destroyAllElementTemplateListStates();
+    clearMainThreadDynamicAttrState();
     clearEtAttrPlanMap();
     resetTemplateId();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    clearMainThreadDynamicAttrState();
     clearEtAttrPlanMap();
   });
 
@@ -398,6 +405,75 @@ describe('renderOpcodesIntoElementTemplate', () => {
         listID: 9,
       }],
     ]);
+  });
+
+  it('defers first-screen list item subtree MTRef attach until native requests the item', () => {
+    const previousWorkletImpl = globalThis.lynxWorkletImpl;
+    const updateWorkletRef = vi.fn();
+    globalThis.lynxWorkletImpl = {
+      ...previousWorkletImpl,
+      _refImpl: {
+        updateWorkletRef,
+      },
+    };
+    const listRef = { kind: 'list-ref', __mockNativeId: 400 };
+    const itemRef = { kind: 'item-ref', __mockNativeId: 401 };
+    const childRef = { kind: 'child-ref', __mockNativeId: 402 };
+    const ref = { _wvid: 77 };
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    createElementTemplate
+      .mockReturnValueOnce(childRef)
+      .mockReturnValueOnce(itemRef);
+    createTypedElementTemplate.mockReturnValueOnce(listRef);
+
+    try {
+      renderOpcodesIntoElementTemplate([
+        __OpBegin,
+        { type: 'list' },
+        __OpSlot,
+        0,
+        __OpBegin,
+        { type: '_et_item', props: { __listItemPlatformInfo: { 'item-key': 'a' } } },
+        __OpSlot,
+        0,
+        __OpBegin,
+        { type: '__Card__:_et_ref_child' },
+        __OpAttr,
+        'attributeSlots',
+        [ref],
+        __OpEnd,
+        __OpEnd,
+        __OpEnd,
+      ]);
+
+      expect(createElementTemplate.mock.calls[0]).toEqual([
+        '_et_ref_child',
+        null,
+        [null],
+        null,
+        -1,
+      ]);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(-1, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: false,
+      });
+
+      const attrs = createTypedElementTemplate.mock.calls[0]![1] as Record<string, (...args: unknown[]) => unknown>;
+      const componentAtIndex = attrs['component-at-index']!;
+
+      expect(componentAtIndex(listRef, 9, 0, 72, true)).toBe(401);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(-1, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+        attached: true,
+      });
+    } finally {
+      globalThis.lynxWorkletImpl = previousWorkletImpl;
+    }
   });
 
   it('rejects non-list-item roots in typed list logical children', () => {

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -684,11 +684,11 @@ export class BackgroundListElementTemplateInstance extends BackgroundTypedElemen
     beforeChild: BackgroundElementTemplateInstance | null,
     silent?: boolean,
   ): void {
-    const previousParent = child.parent;
+    const isSameListMove = child.parent === this;
     super.insertBefore(child, beforeChild, true);
     if (!silent) {
-      if (previousParent instanceof BackgroundListElementTemplateInstance) {
-        previousParent.emitTypedListItemRemove(child, EMPTY_REMOVED_SUBTREE_HANDLE_IDS);
+      if (isSameListMove) {
+        this.emitTypedListItemRemove(child, EMPTY_REMOVED_SUBTREE_HANDLE_IDS);
       }
       this.emitTypedListItemInsert(child, beforeChild);
     }
@@ -788,6 +788,11 @@ function collectMainThreadRefSubtreeHandleIdsImpl(
   if (hasMainThreadRefAttrSlot(instance.type)) {
     handles ??= [];
     handles.push(instance.instanceId);
+  }
+  // The nested list holder belongs to this subtree, while its logical children
+  // are materialized and owned by that list's own holder callbacks.
+  if (instance instanceof BackgroundListElementTemplateInstance) {
+    return handles;
   }
   let child = instance.firstChild;
   while (child) {

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -783,6 +783,11 @@ function collectMainThreadRefSubtreeHandleIdsImpl(
   if (hasMainThreadRefAttrSlot(instance.type)) {
     handles.push(instance.instanceId);
   }
+  // The nested list holder belongs to this subtree, while its logical children
+  // are materialized and owned by that list's own holder callbacks.
+  if (instance instanceof BackgroundListElementTemplateInstance) {
+    return;
+  }
   let child = instance.firstChild;
   while (child) {
     collectMainThreadRefSubtreeHandleIdsImpl(child, handles);

--- a/packages/react/runtime/src/element-template/runtime/list/list.ts
+++ b/packages/react/runtime/src/element-template/runtime/list/list.ts
@@ -8,6 +8,11 @@ import type {
   RuntimeTypedElementAttributes,
   SerializableValue,
 } from '../../protocol/types.js';
+import {
+  attachMainThreadDynamicAttrRefsForSubtree,
+  detachMainThreadDynamicAttrRefsForSubtree,
+} from '../template/main-thread-dynamic-attr-state.js';
+import type { MainThreadDynamicAttrSubtreeHandle } from '../template/main-thread-dynamic-attr-state.js';
 
 const LIST_ELEMENT_SLOT_INDEX = 0;
 const COMPONENT_AT_INDEX_ATTR = 'component-at-index';
@@ -19,6 +24,7 @@ export type ETListItemPlatformInfo = Record<string, SerializableValue>;
 export interface ETListItemMeta {
   templateKey: string;
   platformInfo: ETListItemPlatformInfo;
+  subtreeHandles: readonly MainThreadDynamicAttrSubtreeHandle[];
 }
 
 interface ETListItemRecord extends ETListItemMeta {
@@ -27,21 +33,27 @@ interface ETListItemRecord extends ETListItemMeta {
   uid: number;
   // Native item root ref. The root can exist detached until native requests it.
   ref: ElementRef;
+  // All ET handles in this item subtree. Direct MTRefs can live below the item
+  // root, but their lifecycle still follows native holder ownership.
+  subtreeHandles: MainThreadDynamicAttrSubtreeHandle[];
   // True after `component-at-index(es)` has inserted this item root into the
   // list's native slot.
   attached: boolean;
   // Same-list reorder keeps the item attached, but the next callback must still
   // call insert so native moves the existing child to the new sibling position.
   needsAttachMove: boolean;
-  // Native may enqueue the old cell after an attached item has already moved to
-  // the new position. Skipping that one detach preserves Snapshot move ordering.
-  skipNextEnqueue: boolean;
 }
 
 interface ETListCallbacks {
   componentAtIndex: ComponentAtIndexCallback;
   componentAtIndexes: ComponentAtIndexesCallback;
   enqueueComponent: EnqueueComponentCallback;
+}
+
+interface AttachedETListItem {
+  state: ETListState;
+  item: ETListItemRecord;
+  sign: number;
 }
 
 export interface ETListState {
@@ -56,7 +68,7 @@ export interface ETListState {
   // callbacks observe the latest committed-by-JS list shape.
   items: ETListItemRecord[];
   // Native sign -> item lookup for list callbacks. This is not the attached
-  // item set: removed visible items stay addressable until native enqueues the
+  // item set: removed materialized items stay addressable until native enqueues the
   // old sign while applying the final `update-list-info`.
   callbackItemBySign: Map<number, ETListItemRecord>;
   // Holder teardown keeps callbacks Snapshot-safe for late native calls.
@@ -64,6 +76,10 @@ export interface ETListState {
   // True while one or more currently attached items need same-list placement.
   // The next list callback reorders attached refs once, from right to left.
   hasAttachedMoves: boolean;
+  // Native releases a moved holder before requesting its replacement. Keep its
+  // MTRefs attached across that pair, but remember which failed inserts need
+  // holder cleanup.
+  releasedMoveItemUids: Set<number>;
   // Latest typed slot 0 attrs excluding list callbacks and transient
   // `update-list-info`; final list flush composes these with stable callbacks.
   attributes: RuntimeTypedElementAttributes;
@@ -75,6 +91,7 @@ export interface ETListState {
 export interface ETListUpdateItem extends ETListItemMeta {
   uid: number;
   ref: ElementRef;
+  subtreeHandles: MainThreadDynamicAttrSubtreeHandle[];
 }
 
 export interface ETListUpdateInfo {
@@ -110,6 +127,7 @@ interface PendingETListUpdate {
 
 const listItemByUid = /* @__PURE__ */ new Map<number, ETListItemRecord>();
 const listStateByUid = /* @__PURE__ */ new Map<number, ETListState>();
+const attachedListItemByUid = /* @__PURE__ */ new Map<number, AttachedETListItem>();
 const pendingInitialListUpdateUids = /* @__PURE__ */ new Set<number>();
 const pendingListUpdates = /* @__PURE__ */ new Map<number, PendingETListUpdate>();
 
@@ -123,9 +141,9 @@ export function registerElementTemplateListItem(
     ref,
     templateKey: meta.templateKey,
     platformInfo: meta.platformInfo,
+    subtreeHandles: Array.from(meta.subtreeHandles),
     attached: false,
     needsAttachMove: false,
-    skipNextEnqueue: false,
   });
 }
 
@@ -171,9 +189,9 @@ export function createElementTemplateListStateFromItems(
       ref: item.ref,
       templateKey: item.templateKey,
       platformInfo: item.platformInfo,
+      subtreeHandles: item.subtreeHandles,
       attached: false,
       needsAttachMove: false,
-      skipNextEnqueue: false,
     });
   }
 
@@ -191,6 +209,7 @@ function createElementTemplateListStateWithRecords(
     callbackItemBySign: new Map(),
     destroyed: false,
     hasAttachedMoves: false,
+    releasedMoveItemUids: new Set(),
     attributes: attributes ?? {},
     callbacks: null as unknown as ETListCallbacks,
   };
@@ -222,7 +241,17 @@ export function markElementTemplateListDestroyed(uid: number): number[] | undefi
     return undefined;
   }
   state.destroyed = true;
+  for (const item of state.callbackItemBySign.values()) {
+    const attachedItem = attachedListItemByUid.get(item.uid);
+    if (attachedItem?.state === state) {
+      detachMainThreadDynamicAttrRefsForSubtree(attachedItem.item.subtreeHandles);
+      attachedListItemByUid.delete(item.uid);
+      attachedItem.item.attached = false;
+      attachedItem.item.needsAttachMove = false;
+    }
+  }
   state.callbackItemBySign.clear();
+  state.releasedMoveItemUids.clear();
   listStateByUid.delete(uid);
   pendingInitialListUpdateUids.delete(uid);
   const pendingUpdate = pendingListUpdates.get(uid);
@@ -237,6 +266,7 @@ export function destroyAllElementTemplateListStates(): void {
   }
   listStateByUid.clear();
   listItemByUid.clear();
+  attachedListItemByUid.clear();
   pendingInitialListUpdateUids.clear();
   pendingListUpdates.clear();
 }
@@ -269,9 +299,9 @@ export function insertElementTemplateListItem(
     ref: item.ref,
     templateKey: item.templateKey,
     platformInfo: item.platformInfo,
+    subtreeHandles: item.subtreeHandles,
     attached: previousRecord?.attached ?? false,
     needsAttachMove,
-    skipNextEnqueue: previousRecord?.skipNextEnqueue ?? false,
   };
   if (needsAttachMove) {
     state.hasAttachedMoves = true;
@@ -307,23 +337,63 @@ export function updateElementTemplateListItem(
   const previous = state.items[index]!;
   const hasCurrentChange = previous.templateKey !== item.templateKey
     || !isDirectOrDeepEqual(previous.platformInfo, item.platformInfo);
-  if (!hasCurrentChange) {
+  let hasSubtreeHandlesChange = previous.subtreeHandles.length !== item.subtreeHandles.length;
+  for (
+    let handleIndex = 0;
+    !hasSubtreeHandlesChange && handleIndex < previous.subtreeHandles.length;
+    handleIndex += 1
+  ) {
+    hasSubtreeHandlesChange = previous.subtreeHandles[handleIndex]!.uid !== item.subtreeHandles[handleIndex]!.uid;
+  }
+  if (!hasCurrentChange && !hasSubtreeHandlesChange) {
     // Hydrate emits retained item refreshes without serialized platformInfo, so
     // unchanged items must not dirty the list or trigger an empty final flush.
+    return;
+  }
+  if (hasSubtreeHandlesChange) {
+    const attachedItem = attachedListItemByUid.get(item.uid)?.item;
+    const lifecycleItem = attachedItem ?? previous;
+    const previousHandleUids = new Set<number>();
+    for (let handleIndex = 0; handleIndex < lifecycleItem.subtreeHandles.length; handleIndex += 1) {
+      previousHandleUids.add(lifecycleItem.subtreeHandles[handleIndex]!.uid);
+    }
+    const addedHandles: MainThreadDynamicAttrSubtreeHandle[] = [];
+    for (let handleIndex = 0; handleIndex < item.subtreeHandles.length; handleIndex += 1) {
+      const handle = item.subtreeHandles[handleIndex]!;
+      if (!previousHandleUids.has(handle.uid)) {
+        addedHandles.push(handle);
+      }
+    }
+    if (addedHandles.length > 0) {
+      if (lifecycleItem.attached) {
+        attachMainThreadDynamicAttrRefsForSubtree(addedHandles);
+      } else {
+        detachMainThreadDynamicAttrRefsForSubtree(addedHandles);
+      }
+    }
+    lifecycleItem.subtreeHandles = item.subtreeHandles;
+  }
+  if (!hasCurrentChange) {
+    previous.subtreeHandles = item.subtreeHandles;
     return;
   }
   if (!pendingListUpdates.has(uid)) {
     markPendingListUpdate(uid, state);
   }
-  state.items[index] = {
+  const next: ETListItemRecord = {
     uid: item.uid,
     ref: item.ref,
     templateKey: item.templateKey,
     platformInfo: item.platformInfo,
+    subtreeHandles: item.subtreeHandles,
     attached: previous.attached,
     needsAttachMove: previous.needsAttachMove,
-    skipNextEnqueue: previous.skipNextEnqueue,
   };
+  state.items[index] = next;
+  const attachedItem = attachedListItemByUid.get(item.uid);
+  if (attachedItem?.item === previous) {
+    attachedItem.item = next;
+  }
 }
 
 export function flushPendingElementTemplateListUpdates(): ETListFlushResult[] {
@@ -549,24 +619,36 @@ function createEnqueueComponentCallback(state: ETListState): EnqueueComponentCal
       }
       return;
     }
-    if (item.skipNextEnqueue) {
-      item.skipNextEnqueue = false;
+    if (item.needsAttachMove) {
+      state.releasedMoveItemUids.add(item.uid);
       if (shouldLog) {
         logListCallbackAlog('enqueue-component returned', {
           listHandleId: state.listHandleId,
           listID,
           sign,
           itemHandleId: item.uid,
-          reason: 'skip-next-enqueue',
+          reason: 'same-list-move-rebind',
         });
       }
       return;
     }
 
-    __RemoveNodeFromElementTemplate(state.holderRef!, LIST_ELEMENT_SLOT_INDEX, item.ref);
-    item.attached = false;
-    item.needsAttachMove = false;
-    state.callbackItemBySign.delete(sign);
+    const attachedItem = attachedListItemByUid.get(item.uid);
+    if (attachedItem?.state !== state) {
+      state.callbackItemBySign.delete(sign);
+      if (shouldLog) {
+        logListCallbackAlog('enqueue-component returned', {
+          listHandleId: state.listHandleId,
+          listID,
+          sign,
+          itemHandleId: item.uid,
+          reason: 'attachment-owned-by-another-list',
+        });
+      }
+      return;
+    }
+
+    detachListItemFromHolder(state, item, attachedItem);
     if (shouldLog) {
       logListCallbackAlog('enqueue-component detached', {
         listHandleId: state.listHandleId,
@@ -609,12 +691,22 @@ function attachListItemAtIndex(
     });
   }
   moveAttachedListItemsIntoFinalOrder(state, list);
-  if (!item.attached) {
+  let sign: number;
+  if (item.attached) {
+    const attachedItem = attachedListItemByUid.get(item.uid)!;
+    attachedItem.item = item;
+    sign = attachedItem.sign;
+    state.callbackItemBySign.set(sign, item);
+  } else {
     const referenceItem = findNextAttachedItem(state, cellIndex);
     const referenceRef = referenceItem?.ref ?? null;
     __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
+    sign = __GetElementUniqueID(item.ref);
     item.attached = true;
     item.needsAttachMove = false;
+    attachMainThreadDynamicAttrRefsForSubtree(item.subtreeHandles);
+    attachedListItemByUid.set(item.uid, { state, item, sign });
+    state.callbackItemBySign.set(sign, item);
     if (shouldLog) {
       logListCallbackAlog('attach-list-item inserted', {
         listHandleId: state.listHandleId,
@@ -625,9 +717,6 @@ function attachListItemAtIndex(
       });
     }
   }
-
-  const sign = __GetElementUniqueID(item.ref);
-  state.callbackItemBySign.set(sign, item);
   if (shouldLog) {
     logListCallbackAlog('attach-list-item sign', {
       listHandleId: state.listHandleId,
@@ -691,21 +780,51 @@ function moveAttachedListItemsIntoFinalOrder(
     return;
   }
 
-  let referenceRef: ElementRef | null = null;
-  for (let index = state.items.length - 1; index >= 0; index -= 1) {
-    const item = state.items[index]!;
-    if (!item.attached) {
-      item.needsAttachMove = false;
-      continue;
+  try {
+    let referenceRef: ElementRef | null = null;
+    for (let index = state.items.length - 1; index >= 0; index -= 1) {
+      const item = state.items[index]!;
+      if (!item.attached) {
+        item.needsAttachMove = false;
+        continue;
+      }
+      if (item.needsAttachMove) {
+        __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
+        item.needsAttachMove = false;
+        state.releasedMoveItemUids.delete(item.uid);
+      }
+      referenceRef = item.ref;
     }
-    if (item.needsAttachMove) {
-      __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
-      item.needsAttachMove = false;
-      item.skipNextEnqueue = true;
+    state.hasAttachedMoves = false;
+  } catch (error) {
+    for (const item of state.items) {
+      if (item.needsAttachMove && state.releasedMoveItemUids.has(item.uid)) {
+        detachListItemFromHolder(
+          state,
+          item,
+          attachedListItemByUid.get(item.uid)!,
+        );
+      }
     }
-    referenceRef = item.ref;
+    state.hasAttachedMoves = state.items.some((item) => item.needsAttachMove);
+    throw error;
   }
-  state.hasAttachedMoves = false;
+}
+
+function detachListItemFromHolder(
+  state: ETListState,
+  item: ETListItemRecord,
+  attachedItem: AttachedETListItem,
+): void {
+  __RemoveNodeFromElementTemplate(state.holderRef!, LIST_ELEMENT_SLOT_INDEX, item.ref);
+  detachMainThreadDynamicAttrRefsForSubtree(attachedItem.item.subtreeHandles);
+  attachedListItemByUid.delete(item.uid);
+  attachedItem.item.attached = false;
+  attachedItem.item.needsAttachMove = false;
+  item.attached = false;
+  item.needsAttachMove = false;
+  state.releasedMoveItemUids.delete(item.uid);
+  state.callbackItemBySign.delete(attachedItem.sign);
 }
 
 function findNextAttachedItem(

--- a/packages/react/runtime/src/element-template/runtime/list/list.ts
+++ b/packages/react/runtime/src/element-template/runtime/list/list.ts
@@ -8,6 +8,11 @@ import type {
   RuntimeTypedElementAttributes,
   SerializableValue,
 } from '../../protocol/types.js';
+import {
+  attachMainThreadDynamicAttrRefsForSubtree,
+  detachMainThreadDynamicAttrRefsForSubtree,
+} from '../template/main-thread-dynamic-attr-state.js';
+import type { MainThreadDynamicAttrSubtreeHandle } from '../template/main-thread-dynamic-attr-state.js';
 
 const LIST_ELEMENT_SLOT_INDEX = 0;
 const COMPONENT_AT_INDEX_ATTR = 'component-at-index';
@@ -19,6 +24,7 @@ export type ETListItemPlatformInfo = Record<string, SerializableValue>;
 export interface ETListItemMeta {
   templateKey: string;
   platformInfo: ETListItemPlatformInfo;
+  subtreeHandles: readonly MainThreadDynamicAttrSubtreeHandle[];
 }
 
 interface ETListItemRecord extends ETListItemMeta {
@@ -27,21 +33,26 @@ interface ETListItemRecord extends ETListItemMeta {
   uid: number;
   // Native item root ref. The root can exist detached until native requests it.
   ref: ElementRef;
+  // All ET handles in this item subtree. Direct MTRefs can live below the item
+  // root, but their lifecycle still follows native holder ownership.
+  subtreeHandles: MainThreadDynamicAttrSubtreeHandle[];
   // True after `component-at-index(es)` has inserted this item root into the
   // list's native slot.
   attached: boolean;
   // Same-list reorder keeps the item attached, but the next callback must still
   // call insert so native moves the existing child to the new sibling position.
   needsAttachMove: boolean;
-  // Native may enqueue the old cell after an attached item has already moved to
-  // the new position. Skipping that one detach preserves Snapshot move ordering.
-  skipNextEnqueue: boolean;
 }
 
 interface ETListCallbacks {
   componentAtIndex: ComponentAtIndexCallback;
   componentAtIndexes: ComponentAtIndexesCallback;
   enqueueComponent: EnqueueComponentCallback;
+}
+
+interface AttachedETListItem {
+  item: ETListItemRecord;
+  sign: number;
 }
 
 export interface ETListState {
@@ -56,7 +67,7 @@ export interface ETListState {
   // callbacks observe the latest committed-by-JS list shape.
   items: ETListItemRecord[];
   // Native sign -> item lookup for list callbacks. This is not the attached
-  // item set: removed visible items stay addressable until native enqueues the
+  // item set: removed materialized items stay addressable until native enqueues the
   // old sign while applying the final `update-list-info`.
   callbackItemBySign: Map<number, ETListItemRecord>;
   // Holder teardown keeps callbacks Snapshot-safe for late native calls.
@@ -64,6 +75,9 @@ export interface ETListState {
   // True while one or more currently attached items need same-list placement.
   // The next list callback reorders attached refs once, from right to left.
   hasAttachedMoves: boolean;
+  // Native may release the old holder before or after requesting its replacement.
+  // One side of that callback pair waits here for the other side.
+  pendingMoveCallbackItemUids: Set<number>;
   // Latest typed slot 0 attrs excluding list callbacks and transient
   // `update-list-info`; final list flush composes these with stable callbacks.
   attributes: RuntimeTypedElementAttributes;
@@ -75,6 +89,7 @@ export interface ETListState {
 export interface ETListUpdateItem extends ETListItemMeta {
   uid: number;
   ref: ElementRef;
+  subtreeHandles: MainThreadDynamicAttrSubtreeHandle[];
 }
 
 export interface ETListUpdateInfo {
@@ -110,6 +125,7 @@ interface PendingETListUpdate {
 
 const listItemByUid = /* @__PURE__ */ new Map<number, ETListItemRecord>();
 const listStateByUid = /* @__PURE__ */ new Map<number, ETListState>();
+const attachedListItemByUid = /* @__PURE__ */ new Map<number, AttachedETListItem>();
 const pendingInitialListUpdateUids = /* @__PURE__ */ new Set<number>();
 const pendingListUpdates = /* @__PURE__ */ new Map<number, PendingETListUpdate>();
 
@@ -123,9 +139,9 @@ export function registerElementTemplateListItem(
     ref,
     templateKey: meta.templateKey,
     platformInfo: meta.platformInfo,
+    subtreeHandles: Array.from(meta.subtreeHandles),
     attached: false,
     needsAttachMove: false,
-    skipNextEnqueue: false,
   });
 }
 
@@ -171,9 +187,9 @@ export function createElementTemplateListStateFromItems(
       ref: item.ref,
       templateKey: item.templateKey,
       platformInfo: item.platformInfo,
+      subtreeHandles: item.subtreeHandles,
       attached: false,
       needsAttachMove: false,
-      skipNextEnqueue: false,
     });
   }
 
@@ -191,6 +207,7 @@ function createElementTemplateListStateWithRecords(
     callbackItemBySign: new Map(),
     destroyed: false,
     hasAttachedMoves: false,
+    pendingMoveCallbackItemUids: new Set(),
     attributes: attributes ?? {},
     callbacks: null as unknown as ETListCallbacks,
   };
@@ -222,7 +239,17 @@ export function markElementTemplateListDestroyed(uid: number): number[] | undefi
     return undefined;
   }
   state.destroyed = true;
+  for (const item of state.callbackItemBySign.values()) {
+    if (item.attached) {
+      const attachedItem = attachedListItemByUid.get(item.uid)!;
+      detachMainThreadDynamicAttrRefsForSubtree(attachedItem.item.subtreeHandles);
+      attachedListItemByUid.delete(item.uid);
+      attachedItem.item.attached = false;
+      attachedItem.item.needsAttachMove = false;
+    }
+  }
   state.callbackItemBySign.clear();
+  state.pendingMoveCallbackItemUids.clear();
   listStateByUid.delete(uid);
   pendingInitialListUpdateUids.delete(uid);
   const pendingUpdate = pendingListUpdates.get(uid);
@@ -237,6 +264,7 @@ export function destroyAllElementTemplateListStates(): void {
   }
   listStateByUid.clear();
   listItemByUid.clear();
+  attachedListItemByUid.clear();
   pendingInitialListUpdateUids.clear();
   pendingListUpdates.clear();
 }
@@ -269,9 +297,9 @@ export function insertElementTemplateListItem(
     ref: item.ref,
     templateKey: item.templateKey,
     platformInfo: item.platformInfo,
+    subtreeHandles: item.subtreeHandles,
     attached: previousRecord?.attached ?? false,
     needsAttachMove,
-    skipNextEnqueue: previousRecord?.skipNextEnqueue ?? false,
   };
   if (needsAttachMove) {
     state.hasAttachedMoves = true;
@@ -307,23 +335,63 @@ export function updateElementTemplateListItem(
   const previous = state.items[index]!;
   const hasCurrentChange = previous.templateKey !== item.templateKey
     || !isDirectOrDeepEqual(previous.platformInfo, item.platformInfo);
-  if (!hasCurrentChange) {
+  let hasSubtreeHandlesChange = previous.subtreeHandles.length !== item.subtreeHandles.length;
+  for (
+    let handleIndex = 0;
+    !hasSubtreeHandlesChange && handleIndex < previous.subtreeHandles.length;
+    handleIndex += 1
+  ) {
+    hasSubtreeHandlesChange = previous.subtreeHandles[handleIndex]!.uid !== item.subtreeHandles[handleIndex]!.uid;
+  }
+  if (!hasCurrentChange && !hasSubtreeHandlesChange) {
     // Hydrate emits retained item refreshes without serialized platformInfo, so
     // unchanged items must not dirty the list or trigger an empty final flush.
+    return;
+  }
+  if (hasSubtreeHandlesChange) {
+    const attachedItem = attachedListItemByUid.get(item.uid)?.item;
+    const lifecycleItem = attachedItem ?? previous;
+    const previousHandleUids = new Set<number>();
+    for (let handleIndex = 0; handleIndex < lifecycleItem.subtreeHandles.length; handleIndex += 1) {
+      previousHandleUids.add(lifecycleItem.subtreeHandles[handleIndex]!.uid);
+    }
+    const addedHandles: MainThreadDynamicAttrSubtreeHandle[] = [];
+    for (let handleIndex = 0; handleIndex < item.subtreeHandles.length; handleIndex += 1) {
+      const handle = item.subtreeHandles[handleIndex]!;
+      if (!previousHandleUids.has(handle.uid)) {
+        addedHandles.push(handle);
+      }
+    }
+    if (addedHandles.length > 0) {
+      if (lifecycleItem.attached) {
+        attachMainThreadDynamicAttrRefsForSubtree(addedHandles);
+      } else {
+        detachMainThreadDynamicAttrRefsForSubtree(addedHandles);
+      }
+    }
+    lifecycleItem.subtreeHandles = item.subtreeHandles;
+  }
+  if (!hasCurrentChange) {
+    previous.subtreeHandles = item.subtreeHandles;
     return;
   }
   if (!pendingListUpdates.has(uid)) {
     markPendingListUpdate(uid, state);
   }
-  state.items[index] = {
+  const next: ETListItemRecord = {
     uid: item.uid,
     ref: item.ref,
     templateKey: item.templateKey,
     platformInfo: item.platformInfo,
+    subtreeHandles: item.subtreeHandles,
     attached: previous.attached,
     needsAttachMove: previous.needsAttachMove,
-    skipNextEnqueue: previous.skipNextEnqueue,
   };
+  state.items[index] = next;
+  const attachedItem = attachedListItemByUid.get(item.uid);
+  if (attachedItem?.item === previous) {
+    attachedItem.item = next;
+  }
 }
 
 export function flushPendingElementTemplateListUpdates(): ETListFlushResult[] {
@@ -549,24 +617,34 @@ function createEnqueueComponentCallback(state: ETListState): EnqueueComponentCal
       }
       return;
     }
-    if (item.skipNextEnqueue) {
-      item.skipNextEnqueue = false;
+    if (item.needsAttachMove) {
+      state.pendingMoveCallbackItemUids.add(item.uid);
       if (shouldLog) {
         logListCallbackAlog('enqueue-component returned', {
           listHandleId: state.listHandleId,
           listID,
           sign,
           itemHandleId: item.uid,
-          reason: 'skip-next-enqueue',
+          reason: 'same-list-move-rebind',
+        });
+      }
+      return;
+    }
+    if (state.pendingMoveCallbackItemUids.delete(item.uid)) {
+      if (shouldLog) {
+        logListCallbackAlog('enqueue-component returned', {
+          listHandleId: state.listHandleId,
+          listID,
+          sign,
+          itemHandleId: item.uid,
+          reason: 'same-list-move-old-holder',
         });
       }
       return;
     }
 
-    __RemoveNodeFromElementTemplate(state.holderRef!, LIST_ELEMENT_SLOT_INDEX, item.ref);
-    item.attached = false;
-    item.needsAttachMove = false;
-    state.callbackItemBySign.delete(sign);
+    const attachedItem = attachedListItemByUid.get(item.uid)!;
+    detachListItemFromHolder(state, item, attachedItem);
     if (shouldLog) {
       logListCallbackAlog('enqueue-component detached', {
         listHandleId: state.listHandleId,
@@ -609,12 +687,22 @@ function attachListItemAtIndex(
     });
   }
   moveAttachedListItemsIntoFinalOrder(state, list);
-  if (!item.attached) {
+  let sign: number;
+  if (item.attached) {
+    const attachedItem = attachedListItemByUid.get(item.uid)!;
+    attachedItem.item = item;
+    sign = attachedItem.sign;
+    state.callbackItemBySign.set(sign, item);
+  } else {
     const referenceItem = findNextAttachedItem(state, cellIndex);
     const referenceRef = referenceItem?.ref ?? null;
     __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
+    sign = __GetElementUniqueID(item.ref);
     item.attached = true;
     item.needsAttachMove = false;
+    attachedListItemByUid.set(item.uid, { item, sign });
+    state.callbackItemBySign.set(sign, item);
+    attachMainThreadDynamicAttrRefsForSubtree(item.subtreeHandles);
     if (shouldLog) {
       logListCallbackAlog('attach-list-item inserted', {
         listHandleId: state.listHandleId,
@@ -625,9 +713,6 @@ function attachListItemAtIndex(
       });
     }
   }
-
-  const sign = __GetElementUniqueID(item.ref);
-  state.callbackItemBySign.set(sign, item);
   if (shouldLog) {
     logListCallbackAlog('attach-list-item sign', {
       listHandleId: state.listHandleId,
@@ -691,21 +776,53 @@ function moveAttachedListItemsIntoFinalOrder(
     return;
   }
 
-  let referenceRef: ElementRef | null = null;
-  for (let index = state.items.length - 1; index >= 0; index -= 1) {
-    const item = state.items[index]!;
-    if (!item.attached) {
-      item.needsAttachMove = false;
-      continue;
+  try {
+    let referenceRef: ElementRef | null = null;
+    for (let index = state.items.length - 1; index >= 0; index -= 1) {
+      const item = state.items[index]!;
+      if (!item.attached) {
+        item.needsAttachMove = false;
+        continue;
+      }
+      if (item.needsAttachMove) {
+        __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
+        item.needsAttachMove = false;
+        if (!state.pendingMoveCallbackItemUids.delete(item.uid)) {
+          state.pendingMoveCallbackItemUids.add(item.uid);
+        }
+      }
+      referenceRef = item.ref;
     }
-    if (item.needsAttachMove) {
-      __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
-      item.needsAttachMove = false;
-      item.skipNextEnqueue = true;
+    state.hasAttachedMoves = false;
+  } catch (error) {
+    for (const item of state.items) {
+      if (item.needsAttachMove && state.pendingMoveCallbackItemUids.has(item.uid)) {
+        detachListItemFromHolder(
+          state,
+          item,
+          attachedListItemByUid.get(item.uid)!,
+        );
+      }
     }
-    referenceRef = item.ref;
+    state.hasAttachedMoves = state.items.some((item) => item.needsAttachMove);
+    throw error;
   }
-  state.hasAttachedMoves = false;
+}
+
+function detachListItemFromHolder(
+  state: ETListState,
+  item: ETListItemRecord,
+  attachedItem: AttachedETListItem,
+): void {
+  __RemoveNodeFromElementTemplate(state.holderRef!, LIST_ELEMENT_SLOT_INDEX, item.ref);
+  detachMainThreadDynamicAttrRefsForSubtree(attachedItem.item.subtreeHandles);
+  attachedListItemByUid.delete(item.uid);
+  attachedItem.item.attached = false;
+  attachedItem.item.needsAttachMove = false;
+  item.attached = false;
+  item.needsAttachMove = false;
+  state.pendingMoveCallbackItemUids.delete(item.uid);
+  state.callbackItemBySign.delete(attachedItem.sign);
 }
 
 function findNextAttachedItem(

--- a/packages/react/runtime/src/element-template/runtime/list/list.ts
+++ b/packages/react/runtime/src/element-template/runtime/list/list.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeTypedElementAttributes,
   SerializableValue,
 } from '../../protocol/types.js';
+import { insertElementTemplateSubtree } from '../template/handle.js';
 import {
   attachMainThreadDynamicAttrRefsForSubtree,
   detachMainThreadDynamicAttrRefsForSubtree,
@@ -700,11 +701,16 @@ function attachListItemAtIndex(
   } else {
     const referenceItem = findNextAttachedItem(state, cellIndex);
     const referenceRef = referenceItem?.ref ?? null;
-    __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
-    sign = __GetElementUniqueID(item.ref);
+    insertElementTemplateSubtree(
+      list,
+      LIST_ELEMENT_SLOT_INDEX,
+      item.ref,
+      referenceRef,
+      item.subtreeHandles,
+    );
     item.attached = true;
     item.needsAttachMove = false;
-    attachMainThreadDynamicAttrRefsForSubtree(item.subtreeHandles);
+    sign = __GetElementUniqueID(item.ref);
     attachedListItemByUid.set(item.uid, { state, item, sign });
     state.callbackItemBySign.set(sign, item);
     if (shouldLog) {

--- a/packages/react/runtime/src/element-template/runtime/patch.ts
+++ b/packages/react/runtime/src/element-template/runtime/patch.ts
@@ -443,11 +443,16 @@ function resolveTypedListItem(
   // native list identifies items by the same identity key the templates were
   // registered under (see the `createTemplate` op above), so normalize it.
   const nativeTemplate = parseElementTemplateType(item.type);
+  const subtreeHandles = resolveSubtreeHandles(item.subtreeHandleIds, `${role} subtree`);
+  if (subtreeHandles === null) {
+    return null;
+  }
   return {
     uid: item.__etHandleRef,
     ref,
     templateKey: elementTemplateIdentityKey(nativeTemplate.templateKey, nativeTemplate.bundleUrl),
     platformInfo: item.platformInfo,
+    subtreeHandles,
   };
 }
 

--- a/packages/react/runtime/src/element-template/runtime/patch.ts
+++ b/packages/react/runtime/src/element-template/runtime/patch.ts
@@ -442,11 +442,16 @@ function resolveTypedListItem(
   // native list identifies items by the same identity key the templates were
   // registered under (see the `createTemplate` op above), so normalize it.
   const nativeTemplate = parseElementTemplateType(item.type);
+  const subtreeHandles = resolveSubtreeHandles(item.subtreeHandleIds, `${role} subtree`);
+  if (subtreeHandles === null) {
+    return null;
+  }
   return {
     uid: item.__etHandleRef,
     ref,
     templateKey: elementTemplateIdentityKey(nativeTemplate.templateKey, nativeTemplate.bundleUrl),
     platformInfo: item.platformInfo,
+    subtreeHandles,
   };
 }
 

--- a/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
@@ -210,6 +210,7 @@ export function renderOpcodesIntoElementTemplate(
             // update path (`resolveTypedListItem`) stays consistent with it.
             templateKey: elementTemplateIdentityKey(nativeTemplate.templateKey, nativeTemplate.bundleUrl),
             platformInfo: listItemPlatformInfo,
+            subtreeHandles: materializationHandles,
           });
         }
         appendChildToParent(


### PR DESCRIPTION
This is 5/6 of the Element Template MainThreadRef stack and follows the merged #3611.

## Problem

Typed-list item subtrees are created before native assigns them to a holder. Their MainThreadRefs must therefore follow physical holder ownership, rather than logical list membership or pixel visibility:

- `component-at-index` and `component-at-indexes` attach after the item root is inserted into the holder and native identity is available.
- `enqueue-component` cleans refs after the holder releases the item.
- Same-list reordering moves an already attached item without firing the ref again.

Before this PR, the ET list callback inserted the item root into its holder without advancing MainThreadRef lifecycle state. Detached items therefore never received their element, and released holders did not clean their refs.

## Holder materialization transaction

#3611 makes ordinary ET creation initialize MainThreadRefs as detached and provides shared attach/detach primitives. A typed list has one extra requirement: native identity must be obtained before user ref callbacks run. The list callback therefore owns this transaction explicitly:

```ts
__InsertNodeToElementTemplate(list, slot, item.ref, referenceRef)
const sign = __GetElementUniqueID(item.ref)
attachedListItemByUid.set(item.uid, { item, sign })
state.callbackItemBySign.set(sign, item)
attachMainThreadDynamicAttrRefsForSubtree(item.subtreeHandles)
```

This order gives each stage a clear boundary:

1. Native insertion must succeed before any lifecycle state advances.
2. Native identity and holder ownership are published before a callback ref runs.
3. MainThreadRefs attach only after the item can be addressed and later enqueued safely.

If native insertion or identity lookup throws, the ref remains detached and the next list callback can retry. If a user ref callback throws, holder ownership is already complete, so a later enqueue can still find and clean the item.

## List lifecycle

Typed-list item metadata carries the ET handles in the item's physical subtree up to nested typed-list ownership boundaries. A nested list holder belongs to the outer item, while its logical item children are carried by that nested list's own records. The runtime uses this metadata to:

1. Attach a newly materialized item subtree after the holder transaction succeeds.
2. Keep refs attached during same-list reorder, where the raw insert PAPI only changes sibling placement.
3. Detach after `__RemoveNodeFromElementTemplate` succeeds in `enqueue-component`.
4. Reconcile dynamically added or removed subtree handles against the item's current attachment state.
5. Clean attached item subtrees during list destruction and MTS teardown.

Same-list moves preserve the original native sign. Native may enqueue the old holder before or after requesting its replacement, so the runtime treats release and rebind as a callback pair: whichever arrives first waits for the other without detaching the ref. If an insert fails after an early release, only released items that were not successfully rebound are cleaned.

## Preact producer scope

The implementation follows the operations Preact 11 currently emits:

- A same-list reorder removes and reinserts the same logical item without changing holder ownership.
- Suspense descendant restoration inserts from its detached parent into the target item, so only that item's subtree membership is refreshed.
- Suspense around a direct typed-list item emits a normal `removeTypedListItem` with subtree cleanup while showing the fallback. Restoration recreates the same ET handle before the next `insertTypedListItem`.

There is no cross-list owner table for arbitrary direct item transfer because the current producer does not emit that path. A future producer would need an explicit protocol and regression test instead of speculative ownership state.

Preload may materialize and attach an item before it is pixel-visible. The contract follows holder ownership and does not promise viewport visibility timing.

## Failure behavior

- A failed initial holder insert leaves the item detached.
- A failed native identity lookup leaves ref lifecycle and ownership unpublished; retrying the callback completes the transaction.
- A failed holder removal leaves the current attachment state intact.
- A failed same-list rebind cleans only released holders that could not be reinserted; already successful moves stay attached.
- Native errors and user callback errors propagate; there are no silent fallbacks.

## Review boundary

This PR does not copy the Snapshot recycle pool, model unsupported cross-list item transfer, or add visibility-observer responsibilities to refs. It integrates MainThreadRef with the existing ET list-holder lifecycle and reuses the shared lifecycle primitives introduced by #3611.

The user-facing smoke example remains in #3613. A changeset is not required because Element Template remains unreleased.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
