### PR TITLE
example(react): cover element template ref lifecycles

### DIFF
--- a/examples/react-et-mtf/src/App.css
+++ b/examples/react-et-mtf/src/App.css
@@ -3,7 +3,7 @@
 }
 
 .Page {
-  min-height: 100vh;
+  height: 100vh;
   background-color: #f5f7fb;
   display: flex;
   flex-direction: column;
@@ -73,6 +73,12 @@
 }
 
 .CheckList {
+  flex: 1;
+  min-height: 0;
+}
+
+.CheckListContent {
+  display: flex;
   flex-direction: column;
 }
 
@@ -145,4 +151,92 @@
 
 .CheckActual--small {
   font-size: 12px;
+}
+
+.RefTarget {
+  align-items: center;
+  background-color: #f7e6cc;
+  border-color: #d08b2c;
+  border-radius: 6px;
+  border-width: 1px;
+  height: 46px;
+  justify-content: center;
+  margin-bottom: 7px;
+}
+
+.RefTarget--callback {
+  background-color: #e9f7f8;
+  border-color: #27838b;
+}
+
+.RefTargetText {
+  color: #1f2937;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.RefPlaceholder {
+  align-items: center;
+  background-color: #f3f4f6;
+  border-color: #cbd5e1;
+  border-radius: 6px;
+  border-width: 1px;
+  height: 46px;
+  justify-content: center;
+  margin-bottom: 7px;
+}
+
+.RefPlaceholderText {
+  color: #64748b;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.ListScrollAction {
+  align-items: center;
+  background-color: #e2e8f0;
+  border-radius: 6px;
+  height: 40px;
+  justify-content: center;
+  margin-top: 8px;
+}
+
+.ListScrollActionText {
+  color: #334155;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.ListScrollAction--disabled {
+  opacity: 0.6;
+}
+
+.SmokeList {
+  background-color: #f8fafc;
+  border-color: #cbd5e1;
+  border-radius: 6px;
+  border-width: 1px;
+  height: 188px;
+  margin-top: 8px;
+}
+
+.SmokeListItem {
+  background-color: #ffffff;
+  border-bottom-color: #e2e8f0;
+  border-bottom-width: 1px;
+  height: 64px;
+  justify-content: center;
+  padding: 0 12px;
+}
+
+.SmokeListItemTitle {
+  color: #111827;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.SmokeListItemMeta {
+  color: #64748b;
+  font-size: 11px;
+  margin-top: 3px;
 }

--- a/examples/react-et-mtf/src/App.tsx
+++ b/examples/react-et-mtf/src/App.tsx
@@ -3,15 +3,82 @@ import {
   runOnMainThread,
   useCallback,
   useEffect,
+  useMainThreadRef,
   useState,
 } from '@lynx-js/react';
+import type { MainThreadRef } from '@lynx-js/react';
 import type { MainThread } from '@lynx-js/types';
 
 import './App.css';
 
 const NOT_RUN = 'Not run';
+const TOTAL_CHECKS = 9;
+const LIST_ITEMS = Array.from({ length: 18 }, (_, index) => ({
+  id: `row-${index}`,
+  title: `Row ${index}`,
+}));
+
+type ListItem = typeof LIST_ITEMS[number];
+type CallbackRefName = 'A' | 'B';
+type CallbackLifecyclePhase = 'idle' | 'replace' | 'unmount';
+type CallbackLifecycleStep =
+  | 'ready'
+  | 'marking-replace'
+  | 'replacing'
+  | 'unmount-ready'
+  | 'marking-unmount'
+  | 'unmounting'
+  | 'complete';
+type ListLifecycleStep =
+  | 'idle'
+  | 'marking-start'
+  | 'ready'
+  | 'marking-forward'
+  | 'forward-pending'
+  | 'forward'
+  | 'return-ready'
+  | 'marking-return'
+  | 'return-pending'
+  | 'return'
+  | 'error'
+  | 'complete';
+type ListLifecyclePhase =
+  | 'idle'
+  | 'ready'
+  | 'forward-pending'
+  | 'forward'
+  | 'return-pending'
+  | 'return'
+  | 'complete';
+
+interface ListLifecycleTracker {
+  phase: ListLifecyclePhase;
+  attachedItemIds: Record<string, boolean>;
+  forwardBaselineItemIds: Record<string, boolean>;
+  forwardDetachedItemIds: Record<string, boolean>;
+  returnTargetItemId: string | null;
+}
+
+interface ListRefReport {
+  itemId: string;
+  mounted: boolean;
+  phase: ListLifecyclePhase;
+  returnTargetItemId: string | null;
+  verified: boolean;
+}
+
+interface ListReturnConfirmation {
+  targetItemId: string | null;
+  verified: boolean;
+}
 
 let backgroundSequence = 0;
+let callbackLifecycleStep: CallbackLifecycleStep = 'ready';
+let callbackReplacementACleaned = false;
+let callbackReplacementBMounted = false;
+let listLifecycleStep: ListLifecycleStep = 'idle';
+const attachedListItemIds = new Set<string>();
+const forwardScrollDetachedItemIds = new Set<string>();
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -29,6 +96,101 @@ function checkBadgeText(passed: boolean): string {
   return passed ? 'PASS' : 'RUN';
 }
 
+function CallbackRefTarget({
+  callbackName,
+  lifecyclePhaseRef,
+  onReport,
+}: {
+  callbackName: CallbackRefName;
+  lifecyclePhaseRef: MainThreadRef<CallbackLifecyclePhase>;
+  onReport: (
+    callbackName: CallbackRefName,
+    mounted: boolean,
+    phase: CallbackLifecyclePhase,
+  ) => void;
+}) {
+  const targetRef = useCallback((element: MainThread.Element | null) => {
+    'main thread';
+    const phase = lifecyclePhaseRef.current;
+    void runOnBackground((
+      name: CallbackRefName,
+      mounted: boolean,
+      callbackPhase: CallbackLifecyclePhase,
+    ) => {
+      onReport(name, mounted, callbackPhase);
+    })(callbackName, element !== null, phase);
+  }, [callbackName, lifecyclePhaseRef, onReport]);
+
+  return (
+    <view
+      className='RefTarget RefTarget--callback'
+      main-thread:ref={targetRef}
+    >
+      <text className='RefTargetText'>callback {callbackName} target</text>
+    </view>
+  );
+}
+
+function SmokeListRow({
+  item,
+  lifecycleRef,
+  onReport,
+}: {
+  item: ListItem;
+  lifecycleRef: MainThreadRef<ListLifecycleTracker>;
+  onReport: (report: ListRefReport) => void;
+}) {
+  const reportRef = useCallback((element: MainThread.Element | null) => {
+    'main thread';
+    const tracker = lifecycleRef.current;
+    const mounted = element !== null;
+    const phase = tracker.phase;
+    let verified = false;
+    if (mounted) {
+      tracker.attachedItemIds[item.id] = true;
+      if (phase === 'forward-pending' || phase === 'forward') {
+        delete tracker.forwardDetachedItemIds[item.id];
+      } else if (
+        phase === 'return'
+        && tracker.returnTargetItemId === item.id
+      ) {
+        tracker.phase = 'complete';
+        verified = true;
+      }
+    } else {
+      delete tracker.attachedItemIds[item.id];
+      if (
+        (phase === 'forward-pending' || phase === 'forward')
+        && tracker.forwardBaselineItemIds[item.id]
+      ) {
+        tracker.forwardDetachedItemIds[item.id] = true;
+      }
+    }
+    const report: ListRefReport = {
+      itemId: item.id,
+      mounted,
+      phase,
+      returnTargetItemId: tracker.returnTargetItemId,
+      verified,
+    };
+    void runOnBackground((value: ListRefReport) => {
+      onReport(value);
+    })(report);
+  }, [item.id, lifecycleRef, onReport]);
+
+  return (
+    <list-item item-key={item.id}>
+      <view
+        className='SmokeListItem'
+        main-thread:ref={reportRef}
+      >
+        <text className='SmokeListItemTitle'>{item.title}</text>
+        <text className='SmokeListItemMeta'>{item.id}</text>
+      </view>
+    </list-item>
+  );
+}
+
 export function App() {
   const [status, setStatus] = useState('Ready');
   const [directResult, setDirectResult] = useState(NOT_RUN);
@@ -37,7 +199,36 @@ export function App() {
   const [payloadResult, setPayloadResult] = useState(NOT_RUN);
   const [mainDirectResult, setMainDirectResult] = useState(NOT_RUN);
   const [mainRoundTripResult, setMainRoundTripResult] = useState(NOT_RUN);
+  const [objectRefResult, setObjectRefResult] = useState(NOT_RUN);
+  const [callbackRefResult, setCallbackRefResult] = useState(NOT_RUN);
+  const [callbackVersion, setCallbackVersion] = useState<CallbackRefName>('A');
+  const [callbackStep, setCallbackStep] = useState<CallbackLifecycleStep>(
+    'ready',
+  );
+  const [callbackACleanupCount, setCallbackACleanupCount] = useState(0);
+  const [callbackBMountCount, setCallbackBMountCount] = useState(0);
+  const [callbackBCleanupCount, setCallbackBCleanupCount] = useState(0);
+  const [showCallbackTarget, setShowCallbackTarget] = useState(true);
+  const [listRefResult, setListRefResult] = useState(NOT_RUN);
+  const [listAttachedCount, setListAttachedCount] = useState(0);
+  const [listForwardDetachedCount, setListForwardDetachedCount] = useState(0);
+  const [listVerifiedItemId, setListVerifiedItemId] = useState<string | null>(
+    null,
+  );
+  const [listStep, setListStep] = useState<ListLifecycleStep>('idle');
+  const [showListTest, setShowListTest] = useState(false);
   const [completedUpdates, setCompletedUpdates] = useState(0);
+  const objectTargetRef = useMainThreadRef<MainThread.Element>(null);
+  const callbackLifecyclePhaseRef = useMainThreadRef<CallbackLifecyclePhase>(
+    'idle',
+  );
+  const listLifecycleRef = useMainThreadRef<ListLifecycleTracker>({
+    phase: 'idle',
+    attachedItemIds: {},
+    forwardBaselineItemIds: {},
+    forwardDetachedItemIds: {},
+    returnTargetItemId: null,
+  });
 
   useEffect(() => {
     console.info('Hello, ReactLynx ET MTF');
@@ -173,6 +364,496 @@ export function App() {
     })('round trip');
   }, [echoOnMainThread, pulse]);
 
+  const onObjectRefTap = useCallback((e: MainThread.TouchEvent) => {
+    'main thread';
+    pulse(e);
+    const target = objectTargetRef.current;
+    if (target) {
+      target.animate([
+        { opacity: 1 },
+        { opacity: 0.55 },
+        { opacity: 1 },
+      ], {
+        duration: 220,
+        iterations: 1,
+      });
+    }
+    void runOnBackground((hasTarget: boolean) => {
+      backgroundSequence += 1;
+      setStatus(
+        hasTarget ? 'Object ref check passed' : 'Object ref check failed',
+      );
+      setObjectRefResult(
+        hasTarget
+          ? `object ref reached native element #${backgroundSequence}`
+          : 'object ref current is null',
+      );
+      if (hasTarget) {
+        setCompletedUpdates((count) => count + 1);
+      }
+    })(target !== null);
+  }, [objectTargetRef, pulse]);
+
+  const setCallbackLifecyclePhase = useCallback(
+    (phase: CallbackLifecyclePhase) => {
+      'main thread';
+      callbackLifecyclePhaseRef.current = phase;
+    },
+    [callbackLifecyclePhaseRef],
+  );
+
+  const reportCallbackRef = useCallback((
+    callbackName: CallbackRefName,
+    mounted: boolean,
+    phase: CallbackLifecyclePhase,
+  ) => {
+    backgroundSequence += 1;
+    if (callbackName === 'A' && !mounted) {
+      setCallbackACleanupCount((count) => count + 1);
+    } else if (callbackName === 'B' && mounted) {
+      setCallbackBMountCount((count) => count + 1);
+    } else if (callbackName === 'B' && !mounted) {
+      setCallbackBCleanupCount((count) => count + 1);
+    }
+
+    if (phase === 'replace') {
+      if (callbackName === 'A' && !mounted) {
+        callbackReplacementACleaned = true;
+      } else if (callbackName === 'B' && mounted) {
+        callbackReplacementBMounted = true;
+      }
+      if (
+        callbackLifecycleStep === 'replacing'
+        && callbackReplacementACleaned
+        && callbackReplacementBMounted
+      ) {
+        callbackLifecycleStep = 'unmount-ready';
+        setCallbackStep('unmount-ready');
+        setStatus('Callback replacement passed');
+        setCallbackRefResult(
+          'callback A cleaned and callback B mounted on the same target',
+        );
+      }
+    } else if (
+      phase === 'unmount'
+      && callbackName === 'B'
+      && !mounted
+      && callbackLifecycleStep === 'unmounting'
+    ) {
+      callbackLifecycleStep = 'complete';
+      setCallbackStep('complete');
+      setStatus('Callback replacement and unmount passed');
+      setCallbackRefResult(
+        'callback A cleaned on replacement; callback B cleaned on unmount',
+      );
+    } else if (phase === 'idle' && callbackName === 'A' && mounted) {
+      setStatus('Callback A mounted');
+      setCallbackRefResult(`callback A mounted #${backgroundSequence}`);
+    }
+    setCompletedUpdates((count) => count + 1);
+  }, []);
+
+  const onAdvanceCallbackRef = useCallback(() => {
+    if (callbackLifecycleStep === 'ready') {
+      callbackLifecycleStep = 'marking-replace';
+      callbackReplacementACleaned = false;
+      callbackReplacementBMounted = false;
+      setCallbackStep('marking-replace');
+      setStatus('Preparing callback replacement');
+      void runOnMainThread(setCallbackLifecyclePhase)('replace')
+        .then(() => {
+          callbackLifecycleStep = 'replacing';
+          setCallbackStep('replacing');
+          setCallbackRefResult('Replacing callback A with callback B');
+          setCallbackVersion('B');
+        })
+        .catch((error: unknown) => {
+          callbackLifecycleStep = 'ready';
+          setCallbackStep('ready');
+          setStatus('Callback replacement setup failed');
+          setCallbackRefResult(`Error: ${formatError(error)}`);
+        });
+    } else if (callbackLifecycleStep === 'unmount-ready') {
+      callbackLifecycleStep = 'marking-unmount';
+      setCallbackStep('marking-unmount');
+      setStatus('Preparing callback unmount');
+      void runOnMainThread(setCallbackLifecyclePhase)('unmount')
+        .then(() => {
+          callbackLifecycleStep = 'unmounting';
+          setCallbackStep('unmounting');
+          setCallbackRefResult('Removing the callback B target');
+          setShowCallbackTarget(false);
+        })
+        .catch((error: unknown) => {
+          callbackLifecycleStep = 'unmount-ready';
+          setCallbackStep('unmount-ready');
+          setStatus('Callback unmount setup failed');
+          setCallbackRefResult(`Error: ${formatError(error)}`);
+        });
+    }
+  }, [setCallbackLifecyclePhase]);
+
+  const resetListLifecycle = useCallback(() => {
+    'main thread';
+    listLifecycleRef.current = {
+      phase: 'ready',
+      attachedItemIds: {},
+      forwardBaselineItemIds: {},
+      forwardDetachedItemIds: {},
+      returnTargetItemId: null,
+    };
+  }, [listLifecycleRef]);
+
+  const beginListForward = useCallback(() => {
+    'main thread';
+    const tracker = listLifecycleRef.current;
+    const baselineItemIds: Record<string, boolean> = {};
+    let attachedCount = 0;
+    for (const itemId in tracker.attachedItemIds) {
+      baselineItemIds[itemId] = true;
+      attachedCount += 1;
+    }
+    if (attachedCount === 0) {
+      return 0;
+    }
+    tracker.phase = 'forward-pending';
+    tracker.forwardBaselineItemIds = baselineItemIds;
+    tracker.forwardDetachedItemIds = {};
+    tracker.returnTargetItemId = null;
+    return attachedCount;
+  }, [listLifecycleRef]);
+
+  const confirmListForward = useCallback((): number => {
+    'main thread';
+    const tracker = listLifecycleRef.current;
+    if (tracker.phase !== 'forward-pending') {
+      return -1;
+    }
+    tracker.phase = 'forward';
+    let detachedCount = 0;
+    for (const itemId in tracker.forwardDetachedItemIds) {
+      if (!tracker.attachedItemIds[itemId]) {
+        detachedCount += 1;
+      }
+    }
+    return detachedCount;
+  }, [listLifecycleRef]);
+
+  const cancelListForward = useCallback(() => {
+    'main thread';
+    const tracker = listLifecycleRef.current;
+    if (tracker.phase === 'forward-pending') {
+      tracker.phase = 'ready';
+      tracker.forwardBaselineItemIds = {};
+      tracker.forwardDetachedItemIds = {};
+      tracker.returnTargetItemId = null;
+    }
+  }, [listLifecycleRef]);
+
+  const beginListReturn = useCallback((): string | null => {
+    'main thread';
+    const tracker = listLifecycleRef.current;
+    for (const itemId in tracker.forwardDetachedItemIds) {
+      if (!tracker.attachedItemIds[itemId]) {
+        tracker.phase = 'return-pending';
+        tracker.returnTargetItemId = itemId;
+        return itemId;
+      }
+    }
+    return null;
+  }, [listLifecycleRef]);
+
+  const confirmListReturn = useCallback((): ListReturnConfirmation => {
+    'main thread';
+    const tracker = listLifecycleRef.current;
+    const targetItemId = tracker.returnTargetItemId;
+    if (tracker.phase !== 'return-pending' || targetItemId === null) {
+      return { targetItemId: null, verified: false };
+    }
+    if (tracker.attachedItemIds[targetItemId]) {
+      tracker.phase = 'complete';
+      return { targetItemId, verified: true };
+    }
+    tracker.phase = 'return';
+    return { targetItemId, verified: false };
+  }, [listLifecycleRef]);
+
+  const cancelListReturn = useCallback(() => {
+    'main thread';
+    const tracker = listLifecycleRef.current;
+    if (tracker.phase === 'return-pending') {
+      tracker.phase = 'forward';
+      tracker.returnTargetItemId = null;
+    }
+  }, [listLifecycleRef]);
+
+  const reportListItemRef = useCallback((report: ListRefReport) => {
+    backgroundSequence += 1;
+    if (report.mounted) {
+      attachedListItemIds.add(report.itemId);
+    } else {
+      attachedListItemIds.delete(report.itemId);
+    }
+
+    if (
+      report.verified
+      && listLifecycleStep !== 'complete'
+      && listLifecycleStep !== 'error'
+    ) {
+      listLifecycleStep = 'complete';
+      setListStep('complete');
+      setListVerifiedItemId(report.itemId);
+      setStatus('List holder cleanup and reattach passed');
+      setListRefResult(
+        `${report.itemId} cleaned after forward scroll and reattached after return`,
+      );
+    } else if (
+      listLifecycleStep !== 'complete'
+      && listLifecycleStep !== 'error'
+    ) {
+      if (
+        report.phase === 'forward-pending'
+        || report.phase === 'forward'
+      ) {
+        if (report.mounted) {
+          forwardScrollDetachedItemIds.delete(report.itemId);
+        } else {
+          forwardScrollDetachedItemIds.add(report.itemId);
+        }
+        setListForwardDetachedCount(forwardScrollDetachedItemIds.size);
+        if (
+          !report.mounted
+          && report.phase === 'forward'
+          && listLifecycleStep === 'forward'
+        ) {
+          listLifecycleStep = 'return-ready';
+          setListStep('return-ready');
+          setStatus('List holder cleanup observed; return to row 0');
+          setListRefResult(
+            `${report.itemId} holder cleaned after forward scroll`,
+          );
+        }
+      } else if (report.phase === 'ready') {
+        setStatus(
+          report.mounted
+            ? 'List item holder attached'
+            : 'List item holder cleaned',
+        );
+        setListRefResult(
+          `${report.itemId} holder ${
+            report.mounted ? 'attached' : 'cleaned'
+          } #${backgroundSequence}`,
+        );
+      } else if (report.phase === 'return' && report.returnTargetItemId) {
+        setListRefResult(
+          `Waiting for ${report.returnTargetItemId} to reattach`,
+        );
+      }
+    }
+    setListAttachedCount(attachedListItemIds.size);
+    setCompletedUpdates((count) => count + 1);
+  }, []);
+
+  const onStartListTest = useCallback(() => {
+    if (listLifecycleStep !== 'idle') {
+      return;
+    }
+    attachedListItemIds.clear();
+    forwardScrollDetachedItemIds.clear();
+    listLifecycleStep = 'marking-start';
+    setListAttachedCount(0);
+    setListForwardDetachedCount(0);
+    setListVerifiedItemId(null);
+    setListRefResult('Preparing native holder tracking');
+    setListStep('marking-start');
+    setStatus('Preparing list holder lifecycle check');
+    void runOnMainThread(resetListLifecycle)()
+      .then(() => {
+        listLifecycleStep = 'ready';
+        setListRefResult('Waiting for native holder attachments');
+        setListStep('ready');
+        setShowListTest(true);
+      })
+      .catch((error: unknown) => {
+        listLifecycleStep = 'idle';
+        setListStep('idle');
+        setStatus('List holder tracking setup failed');
+        setListRefResult(`Error: ${formatError(error)}`);
+      });
+  }, [resetListLifecycle]);
+
+  const onScrollList = useCallback(() => {
+    if (listLifecycleStep !== 'ready') {
+      return;
+    }
+    listLifecycleStep = 'marking-forward';
+    setListStep('marking-forward');
+    setStatus('Preparing forward list scroll');
+    void runOnMainThread(beginListForward)()
+      .then((attachedCount) => {
+        if (attachedCount === 0) {
+          listLifecycleStep = 'ready';
+          setListStep('ready');
+          setStatus('Waiting for list holders to attach');
+          return;
+        }
+        forwardScrollDetachedItemIds.clear();
+        listLifecycleStep = 'forward-pending';
+        setListForwardDetachedCount(0);
+        setListVerifiedItemId(null);
+        setListRefResult('Requesting scroll to row 12');
+        setListStep('forward-pending');
+        lynx.createSelectorQuery()
+          .select('.SmokeList')
+          .invoke({
+            method: 'scrollToPosition',
+            params: { position: 12 },
+            success: () => {
+              void runOnMainThread(confirmListForward)().then(
+                (value) => {
+                  const detachedCount = value as number;
+                  if (detachedCount < 0 || listLifecycleStep === 'complete') {
+                    return;
+                  }
+                  if (detachedCount > 0) {
+                    listLifecycleStep = 'return-ready';
+                    setListStep('return-ready');
+                    setStatus('List holder cleanup observed; return to row 0');
+                  } else {
+                    listLifecycleStep = 'forward';
+                    setListStep('forward');
+                    setStatus(
+                      'Forward scroll accepted; waiting for holder cleanup',
+                    );
+                  }
+                  setListRefResult(
+                    'Scrolled to row 12; waiting for holder cleanup',
+                  );
+                },
+              ).catch((error: unknown) => {
+                listLifecycleStep = 'error';
+                setListStep('error');
+                setStatus('List forward confirmation failed');
+                setListRefResult(`Error: ${formatError(error)}`);
+              });
+            },
+            fail: ({ code }) => {
+              void runOnMainThread(cancelListForward)().then(() => {
+                listLifecycleStep = 'ready';
+                setListStep('ready');
+                setStatus('List forward scroll failed; ready to retry');
+                setListRefResult(
+                  `scrollToPosition(12) failed with code ${code}`,
+                );
+              }).catch((error: unknown) => {
+                listLifecycleStep = 'error';
+                setListStep('error');
+                setStatus('List forward cancellation failed');
+                setListRefResult(
+                  `scrollToPosition(12) failed with code ${code}; cancel error: ${
+                    formatError(error)
+                  }`,
+                );
+              });
+            },
+          })
+          .exec();
+      })
+      .catch((error: unknown) => {
+        listLifecycleStep = 'error';
+        setListStep('error');
+        setStatus('List forward phase setup failed');
+        setListRefResult(`Error: ${formatError(error)}`);
+      });
+  }, [beginListForward, cancelListForward, confirmListForward]);
+
+  const onReturnList = useCallback(() => {
+    if (listLifecycleStep !== 'return-ready') {
+      return;
+    }
+    listLifecycleStep = 'marking-return';
+    setListStep('marking-return');
+    setStatus('Locking the cleaned holder for return');
+    void runOnMainThread(beginListReturn)()
+      .then((targetItemId) => {
+        if (typeof targetItemId !== 'string') {
+          listLifecycleStep = 'forward';
+          setListStep('forward');
+          setStatus('No cleaned holder is currently detached');
+          setListRefResult(
+            'Waiting for another holder cleanup before returning',
+          );
+          return;
+        }
+        listLifecycleStep = 'return-pending';
+        setListRefResult(`Requesting return to row 0 for ${targetItemId}`);
+        setListStep('return-pending');
+        lynx.createSelectorQuery()
+          .select('.SmokeList')
+          .invoke({
+            method: 'scrollToPosition',
+            params: { position: 0 },
+            success: () => {
+              void runOnMainThread(confirmListReturn)().then((value) => {
+                const confirmation = value as ListReturnConfirmation;
+                if (
+                  confirmation.targetItemId === null
+                  || listLifecycleStep === 'complete'
+                ) {
+                  return;
+                }
+                if (confirmation.verified) {
+                  listLifecycleStep = 'complete';
+                  setListStep('complete');
+                  setListVerifiedItemId(confirmation.targetItemId);
+                  setStatus('List holder cleanup and reattach passed');
+                  setListRefResult(
+                    `${confirmation.targetItemId} cleaned after forward scroll and reattached after return`,
+                  );
+                } else {
+                  listLifecycleStep = 'return';
+                  setListStep('return');
+                  setListRefResult(
+                    `Returned to row 0; waiting for ${confirmation.targetItemId}`,
+                  );
+                }
+              }).catch((error: unknown) => {
+                listLifecycleStep = 'error';
+                setListStep('error');
+                setStatus('List return confirmation failed');
+                setListRefResult(`Error: ${formatError(error)}`);
+              });
+            },
+            fail: ({ code }) => {
+              void runOnMainThread(cancelListReturn)().then(() => {
+                listLifecycleStep = 'return-ready';
+                setListStep('return-ready');
+                setStatus('List return scroll failed; ready to retry');
+                setListRefResult(
+                  `scrollToPosition(0) failed with code ${code}`,
+                );
+              }).catch((error: unknown) => {
+                listLifecycleStep = 'error';
+                setListStep('error');
+                setStatus('List return cancellation failed');
+                setListRefResult(
+                  `scrollToPosition(0) failed with code ${code}; cancel error: ${
+                    formatError(error)
+                  }`,
+                );
+              });
+            },
+          })
+          .exec();
+      })
+      .catch((error: unknown) => {
+        listLifecycleStep = 'error';
+        setListStep('error');
+        setStatus('List return phase setup failed');
+        setListRefResult(`Error: ${formatError(error)}`);
+      });
+  }, [beginListReturn, cancelListReturn, confirmListReturn]);
+
   const directPassed = directResult.startsWith(
     'tap event reached background #',
   );
@@ -187,27 +868,100 @@ export function App() {
   );
   const mainDirectPassed = mainDirectResult.startsWith('background to main #');
   const mainRoundTripPassed = mainRoundTripResult.startsWith('round trip #');
+  const objectRefPassed = objectRefResult.startsWith(
+    'object ref reached native element #',
+  );
+  const callbackRefPassed = callbackStep === 'complete';
+  const listRefPassed = listVerifiedItemId !== null;
   const passedCount = Number(directPassed)
     + Number(nestedPassed)
     + Number(burstPassed)
     + Number(payloadPassed)
     + Number(mainDirectPassed)
-    + Number(mainRoundTripPassed);
-  const allPassed = passedCount === 6;
+    + Number(mainRoundTripPassed)
+    + Number(objectRefPassed)
+    + Number(callbackRefPassed)
+    + Number(listRefPassed);
+  const allPassed = passedCount === TOTAL_CHECKS;
+  let callbackExpected =
+    'Tap once to replace callback A with B on the same element.';
+  let callbackActionHandler: (() => void) | undefined = onAdvanceCallbackRef;
+  if (callbackStep === 'marking-replace' || callbackStep === 'replacing') {
+    callbackExpected = 'Waiting for callback A cleanup and callback B mount.';
+    callbackActionHandler = undefined;
+  } else if (callbackStep === 'unmount-ready') {
+    callbackExpected =
+      'Replacement passed: tap again to remove the callback B target.';
+  } else if (
+    callbackStep === 'marking-unmount'
+    || callbackStep === 'unmounting'
+  ) {
+    callbackExpected = 'Waiting for callback B cleanup after target removal.';
+    callbackActionHandler = undefined;
+  } else if (callbackStep === 'complete') {
+    callbackExpected =
+      'Passed: callback A cleaned on replacement and callback B cleaned on unmount.';
+    callbackActionHandler = undefined;
+  }
+  let listExpected =
+    'Tap this card to mount the list and start the holder lifecycle check.';
+  let listActionText = 'Waiting for holder cleanup';
+  let listActionHandler: (() => void) | undefined;
+  if (showListTest) {
+    listExpected =
+      'Scroll to row 12 and wait for a currently attached holder to clean up.';
+  }
+  if (listStep === 'ready') {
+    listActionText = 'Scroll to row 12';
+    listActionHandler = onScrollList;
+  } else if (
+    listStep === 'marking-forward'
+    || listStep === 'forward-pending'
+  ) {
+    listActionText = 'Starting forward scroll';
+  } else if (listStep === 'return-ready') {
+    listExpected =
+      'Return to row 0 and verify that a cleaned holder attaches again.';
+    listActionText = 'Return to row 0';
+    listActionHandler = onReturnList;
+  } else if (
+    listStep === 'marking-return'
+    || listStep === 'return-pending'
+  ) {
+    listExpected =
+      'Return to row 0 and verify that a cleaned holder attaches again.';
+    listActionText = 'Starting return scroll';
+  } else if (listStep === 'return') {
+    listExpected =
+      'Return to row 0 and verify that a cleaned holder attaches again.';
+    listActionText = 'Waiting for holder reattach';
+  } else if (listStep === 'error') {
+    listExpected = 'The holder lifecycle result is indeterminate.';
+    listActionText = 'Reload the page to retry';
+  } else if (listStep === 'complete') {
+    listExpected =
+      'Passed: one holder cleaned up after the forward scroll and reattached after returning.';
+    listActionText = `Verified ${listVerifiedItemId}`;
+  }
+  const listActionClass = listActionHandler
+    ? 'ListScrollAction'
+    : 'ListScrollAction ListScrollAction--disabled';
 
   return (
     <view className='Page'>
       <view className='Header'>
         <text className='Title'>ET main-thread smoke</text>
         <text className='Subtitle'>
-          Event, background, and main-thread function checks
+          Event, background, main-thread function, and ref checks
         </text>
       </view>
 
       <view className={allPassed ? 'Summary Summary--pass' : 'Summary'}>
         <view className='SummaryColumn'>
           <text className='SummaryLabel'>Overall</text>
-          <text className='SummaryValue'>{`${passedCount} / 6 passed`}</text>
+          <text className='SummaryValue'>
+            {`${passedCount} / ${TOTAL_CHECKS} passed`}
+          </text>
         </view>
         <view className='SummaryColumn'>
           <text className='SummaryLabel'>Last result</text>
@@ -219,109 +973,222 @@ export function App() {
         </view>
       </view>
 
-      <view className='CheckList'>
-        <view
-          className={checkCardClass(directPassed)}
-          main-thread:bindtap={onDirectTap}
-        >
-          <view className='CheckHeader'>
-            <text className='CheckTitle'>Main-thread event to background</text>
-            <text className={checkBadgeClass(directPassed)}>
-              {checkBadgeText(directPassed)}
+      <scroll-view className='CheckList' scroll-orientation='vertical'>
+        <view className='CheckListContent'>
+          <view
+            className={checkCardClass(directPassed)}
+            main-thread:bindtap={onDirectTap}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>
+                Main-thread event to background
+              </text>
+              <text className={checkBadgeClass(directPassed)}>
+                {checkBadgeText(directPassed)}
+              </text>
+            </view>
+            <text className='CheckExpected'>
+              Expected: a tap handled on the main thread updates from
+              background.
             </text>
+            <text className='CheckActual'>Actual: {directResult}</text>
           </view>
-          <text className='CheckExpected'>
-            Expected: a tap handled on the main thread updates from background.
-          </text>
-          <text className='CheckActual'>Actual: {directResult}</text>
-        </view>
 
-        <view
-          className={checkCardClass(nestedPassed)}
-          main-thread:bindtap={onNestedTap}
-        >
-          <view className='CheckHeader'>
-            <text className='CheckTitle'>Nested background call</text>
-            <text className={checkBadgeClass(nestedPassed)}>
-              {checkBadgeText(nestedPassed)}
+          <view
+            className={checkCardClass(nestedPassed)}
+            main-thread:bindtap={onNestedTap}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>Nested background call</text>
+              <text className={checkBadgeClass(nestedPassed)}>
+                {checkBadgeText(nestedPassed)}
+              </text>
+            </view>
+            <text className='CheckExpected'>
+              Expected: a main-thread function can start another background
+              call.
             </text>
+            <text className='CheckActual'>Actual: {nestedResult}</text>
           </view>
-          <text className='CheckExpected'>
-            Expected: a main-thread function can start another background call.
-          </text>
-          <text className='CheckActual'>Actual: {nestedResult}</text>
-        </view>
 
-        <view
-          className={checkCardClass(burstPassed)}
-          main-thread:bindtap={onBurstTap}
-        >
-          <view className='CheckHeader'>
-            <text className='CheckTitle'>Three background calls</text>
-            <text className={checkBadgeClass(burstPassed)}>
-              {checkBadgeText(burstPassed)}
+          <view
+            className={checkCardClass(burstPassed)}
+            main-thread:bindtap={onBurstTap}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>Three background calls</text>
+              <text className={checkBadgeClass(burstPassed)}>
+                {checkBadgeText(burstPassed)}
+              </text>
+            </view>
+            <text className='CheckExpected'>
+              Expected: one event delivers background calls a, b, and c.
+            </text>
+            <text className='CheckActual CheckActual--small'>
+              Actual: {burstResult}
             </text>
           </view>
-          <text className='CheckExpected'>
-            Expected: one event delivers background calls a, b, and c.
-          </text>
-          <text className='CheckActual CheckActual--small'>
-            Actual: {burstResult}
-          </text>
-        </view>
 
-        <view
-          className={checkCardClass(payloadPassed)}
-          main-thread:bindtap={onPayloadTap}
-        >
-          <view className='CheckHeader'>
-            <text className='CheckTitle'>Object payload to background</text>
-            <text className={checkBadgeClass(payloadPassed)}>
-              {checkBadgeText(payloadPassed)}
+          <view
+            className={checkCardClass(payloadPassed)}
+            main-thread:bindtap={onPayloadTap}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>Object payload to background</text>
+              <text className={checkBadgeClass(payloadPassed)}>
+                {checkBadgeText(payloadPassed)}
+              </text>
+            </view>
+            <text className='CheckExpected'>
+              Expected: source=payload and value=42 survive transport.
             </text>
+            <text className='CheckActual'>Actual: {payloadResult}</text>
           </view>
-          <text className='CheckExpected'>
-            Expected: source=payload and value=42 survive transport.
-          </text>
-          <text className='CheckActual'>Actual: {payloadResult}</text>
-        </view>
 
-        <view
-          className={checkCardClass(mainDirectPassed)}
-          bindtap={onMainDirectTap}
-        >
-          <view className='CheckHeader'>
-            <text className='CheckTitle'>Background to main thread</text>
-            <text className={checkBadgeClass(mainDirectPassed)}>
-              {checkBadgeText(mainDirectPassed)}
+          <view
+            className={checkCardClass(mainDirectPassed)}
+            bindtap={onMainDirectTap}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>Background to main thread</text>
+              <text className={checkBadgeClass(mainDirectPassed)}>
+                {checkBadgeText(mainDirectPassed)}
+              </text>
+            </view>
+            <text className='CheckExpected'>
+              Expected: background waits for a main-thread echo.
+            </text>
+            <text className='CheckActual CheckActual--small'>
+              Actual: {mainDirectResult}
             </text>
           </view>
-          <text className='CheckExpected'>
-            Expected: background waits for a main-thread echo.
-          </text>
-          <text className='CheckActual CheckActual--small'>
-            Actual: {mainDirectResult}
-          </text>
-        </view>
 
-        <view
-          className={checkCardClass(mainRoundTripPassed)}
-          main-thread:bindtap={onMainRoundTripTap}
-        >
-          <view className='CheckHeader'>
-            <text className='CheckTitle'>Main to background to main</text>
-            <text className={checkBadgeClass(mainRoundTripPassed)}>
-              {checkBadgeText(mainRoundTripPassed)}
+          <view
+            className={checkCardClass(mainRoundTripPassed)}
+            main-thread:bindtap={onMainRoundTripTap}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>Main to background to main</text>
+              <text className={checkBadgeClass(mainRoundTripPassed)}>
+                {checkBadgeText(mainRoundTripPassed)}
+              </text>
+            </view>
+            <text className='CheckExpected'>
+              Expected: main event enters background, then calls main thread.
+            </text>
+            <text className='CheckActual CheckActual--small'>
+              Actual: {mainRoundTripResult}
             </text>
           </view>
-          <text className='CheckExpected'>
-            Expected: main event enters background, then calls main thread.
-          </text>
-          <text className='CheckActual CheckActual--small'>
-            Actual: {mainRoundTripResult}
-          </text>
+
+          <view
+            className={checkCardClass(objectRefPassed)}
+            main-thread:bindtap={onObjectRefTap}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>Object main-thread ref</text>
+              <text className={checkBadgeClass(objectRefPassed)}>
+                {checkBadgeText(objectRefPassed)}
+              </text>
+            </view>
+            <view className='RefTarget' main-thread:ref={objectTargetRef}>
+              <text className='RefTargetText'>object ref target</text>
+            </view>
+            <text className='CheckExpected'>
+              Tap this card: the target should animate and report a real
+              element.
+            </text>
+            <text className='CheckActual'>Actual: {objectRefResult}</text>
+          </view>
+
+          <view
+            className={checkCardClass(callbackRefPassed)}
+            bindtap={callbackActionHandler}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>Callback ref cleanup</text>
+              <text className={checkBadgeClass(callbackRefPassed)}>
+                {checkBadgeText(callbackRefPassed)}
+              </text>
+            </view>
+            {showCallbackTarget
+              ? (
+                <CallbackRefTarget
+                  callbackName={callbackVersion}
+                  lifecyclePhaseRef={callbackLifecyclePhaseRef}
+                  onReport={reportCallbackRef}
+                />
+              )
+              : (
+                <view className='RefPlaceholder'>
+                  <text className='RefPlaceholderText'>
+                    callback B target removed
+                  </text>
+                </view>
+              )}
+            <text className='CheckExpected'>
+              {callbackExpected}
+            </text>
+            <text className='CheckActual CheckActual--small'>
+              Actual: {callbackRefResult} | A cleanup{' '}
+              {String(callbackACleanupCount)} | B mount{' '}
+              {String(callbackBMountCount)} | B cleanup{' '}
+              {String(callbackBCleanupCount)}
+            </text>
+          </view>
+
+          <view
+            className={checkCardClass(listRefPassed)}
+            bindtap={showListTest ? undefined : onStartListTest}
+          >
+            <view className='CheckHeader'>
+              <text className='CheckTitle'>List item ref lifecycle</text>
+              <text className={checkBadgeClass(listRefPassed)}>
+                {checkBadgeText(listRefPassed)}
+              </text>
+            </view>
+            <text className='CheckExpected'>
+              {listExpected}
+            </text>
+            <text className='CheckActual CheckActual--small'>
+              Actual: {listRefResult} | attached {String(listAttachedCount)}
+              {' '}
+              | forward cleanup {String(listForwardDetachedCount)}
+            </text>
+            {showListTest
+              ? (
+                <>
+                  <view
+                    className={listActionClass}
+                    bindtap={listActionHandler}
+                  >
+                    <text className='ListScrollActionText'>
+                      {listActionText}
+                    </text>
+                  </view>
+                  <list
+                    className='SmokeList'
+                    list-type='single'
+                  >
+                    {LIST_ITEMS.map((item) => (
+                      <SmokeListRow
+                        item={item}
+                        key={item.id}
+                        lifecycleRef={listLifecycleRef}
+                        onReport={reportListItemRef}
+                      />
+                    ))}
+                  </list>
+                </>
+              )
+              : (
+                <view className='RefPlaceholder'>
+                  <text className='RefPlaceholderText'>tap card to start</text>
+                </view>
+              )}
+          </view>
         </view>
-      </view>
+      </scroll-view>
     </view>
   );
 }

--- a/packages/react/runtime/__test__/element-template/native/mts-destroy.test.ts
+++ b/packages/react/runtime/__test__/element-template/native/mts-destroy.test.ts
@@ -4,9 +4,10 @@ import { installOnMtsDestruction, onMtsDestruction } from '../../../src/element-
 import {
   composeElementTemplateListAttributes,
   createElementTemplateListState,
-  registerElementTemplateListItem,
+  registerElementTemplateListItem as registerElementTemplateListItemInternal,
   registerElementTemplateListState,
 } from '../../../src/element-template/runtime/list/list.js';
+import type { ETListItemMeta } from '../../../src/element-template/runtime/list/list.js';
 import {
   attachMainThreadDynamicAttrRefsForSubtree,
   clearMainThreadDynamicAttrState,
@@ -29,6 +30,17 @@ type LynxWithNative = typeof globalThis & {
     };
   };
 };
+
+function registerElementTemplateListItem(
+  uid: number,
+  ref: ElementRef,
+  meta: Omit<ETListItemMeta, 'subtreeHandles'> & Partial<Pick<ETListItemMeta, 'subtreeHandles'>>,
+): void {
+  registerElementTemplateListItemInternal(uid, ref, {
+    ...meta,
+    subtreeHandles: meta.subtreeHandles ?? [],
+  });
+}
 
 describe('mts-destroy', () => {
   afterEach(() => {

--- a/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/instance.test.ts
@@ -17,6 +17,7 @@ import {
   BackgroundPageRootInstance,
   BackgroundTypedElementTemplateInstance,
   BUILTIN_RAW_TEXT_TEMPLATE_KEY,
+  collectMainThreadRefSubtreeHandleIds,
 } from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { clearEventState, getEventHandlerForEventValue } from '../../../../src/element-template/prop-adapters/event.js';
@@ -336,7 +337,7 @@ describe('BackgroundElementTemplateInstance', () => {
     ]);
   });
 
-  it('emits logical list insertions as incremental typed list item patches', () => {
+  it('emits logical list appends as incremental typed list item patches', () => {
     const list = new BackgroundListElementTemplateInstance();
     const oldListId = list.instanceId;
     backgroundElementTemplateInstanceManager.updateId(oldListId, -10);
@@ -352,7 +353,7 @@ describe('BackgroundElementTemplateInstance', () => {
     markElementTemplateHydrated();
     globalCommitContext.ops = [];
 
-    list.insertBefore(second, first);
+    list.appendChild(second);
 
     expect(globalCommitContext.ops).toEqual([
       ElementTemplateUpdateOps.createTemplate,
@@ -369,7 +370,7 @@ describe('BackgroundElementTemplateInstance', () => {
         platformInfo: { 'item-key': 'b' },
         subtreeHandleIds: [],
       },
-      -11,
+      0,
     ]);
   });
 
@@ -496,40 +497,6 @@ describe('BackgroundElementTemplateInstance', () => {
     expect(globalCommitContext.nonPayload.removedSubtreesAwaitingTeardown).toEqual([]);
   });
 
-  it('emits logical updates for both lists when an item moves across typed lists', () => {
-    const oldList = new BackgroundListElementTemplateInstance();
-    const newList = new BackgroundListElementTemplateInstance();
-    backgroundElementTemplateInstanceManager.updateId(oldList.instanceId, -10);
-    backgroundElementTemplateInstanceManager.updateId(newList.instanceId, -20);
-    oldList.markMaterializedByHydration();
-    newList.markMaterializedByHydration();
-    const item = new BackgroundElementTemplateInstance('_et_item_a');
-    item.setAttribute('__listItemPlatformInfo', { 'item-key': 'a' });
-    oldList.appendChild(item);
-    backgroundElementTemplateInstanceManager.updateId(item.instanceId, -11);
-    item.markMaterializedByHydration();
-    markElementTemplateHydrated();
-    globalCommitContext.ops = [];
-
-    newList.appendChild(item);
-
-    expect(globalCommitContext.ops).toEqual([
-      ElementTemplateUpdateOps.removeTypedListItem,
-      -10,
-      -11,
-      [],
-      ElementTemplateUpdateOps.insertTypedListItem,
-      -20,
-      {
-        __etHandleRef: -11,
-        type: '_et_item_a',
-        platformInfo: { 'item-key': 'a' },
-        subtreeHandleIds: [],
-      },
-      0,
-    ]);
-  });
-
   it('refreshes list item subtree membership when Suspense restores a descendant', () => {
     __etAttrPlanMap._et_child = [0, adaptMTRefAttrSlot];
     const list = new BackgroundListElementTemplateInstance();
@@ -563,6 +530,29 @@ describe('BackgroundElementTemplateInstance', () => {
         platformInfo: {},
         subtreeHandleIds: [child.instanceId],
       },
+    ]);
+  });
+
+  it('stops MainThreadRef subtree membership at nested typed list holders', () => {
+    __etAttrPlanMap._et_outer_ref = [0, adaptMTRefAttrSlot];
+    __etAttrPlanMap.list = [0, adaptMTRefAttrSlot];
+    __etAttrPlanMap._et_nested_ref = [0, adaptMTRefAttrSlot];
+    const outerItem = new BackgroundElementTemplateInstance('_et_outer_item');
+    const outerRef = new BackgroundElementTemplateInstance('_et_outer_ref');
+    const nestedList = new BackgroundListElementTemplateInstance();
+    const nestedItem = new BackgroundElementTemplateInstance('_et_nested_item');
+    const nestedRef = new BackgroundElementTemplateInstance('_et_nested_ref');
+    outerItem.appendChild(outerRef);
+    outerItem.appendChild(nestedList);
+    nestedList.appendChild(nestedItem);
+    nestedItem.appendChild(nestedRef);
+
+    expect(collectMainThreadRefSubtreeHandleIds(outerItem)).toEqual([
+      outerRef.instanceId,
+      nestedList.instanceId,
+    ]);
+    expect(collectMainThreadRefSubtreeHandleIds(nestedItem)).toEqual([
+      nestedRef.instanceId,
     ]);
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/background/suspense.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/background/suspense.test.tsx
@@ -7,7 +7,10 @@ import {
   markElementTemplateHydrated,
   resetElementTemplateCommitState,
 } from '../../../../src/element-template/background/commit-hook.js';
-import { BackgroundElementTemplateInstance } from '../../../../src/element-template/background/instance.js';
+import {
+  BackgroundElementTemplateInstance,
+  BackgroundListElementTemplateInstance,
+} from '../../../../src/element-template/background/instance.js';
 import { backgroundElementTemplateInstanceManager } from '../../../../src/element-template/background/manager.js';
 import { root, Suspense, lazy } from '../../../../src/element-template/index.js';
 import { loadLazyBundle } from '../../../../src/core/lynx/lazy-bundle.js';
@@ -18,6 +21,7 @@ import type {
   ElementTemplateUpdateCommandStream,
   ElementTemplateUpdateCommitContext,
   SerializableValue,
+  UpdateTypedListItemCommand,
 } from '../../../../src/element-template/protocol/types.js';
 import { parseElementTemplateUpdateEventPayload } from '../../../../src/element-template/protocol/update-event.js';
 import { __root } from '../../../../src/element-template/runtime/page/root-instance.js';
@@ -61,10 +65,26 @@ interface ParsedRemoveNodeOp {
   removedSubtreeHandleIds: number[];
 }
 
+interface ParsedInsertTypedListItemOp {
+  op: 'insertTypedListItem';
+  targetId: number;
+  item: UpdateTypedListItemCommand;
+  referenceId: number;
+}
+
+interface ParsedRemoveTypedListItemOp {
+  op: 'removeTypedListItem';
+  targetId: number;
+  childId: number;
+  removedSubtreeHandleIds: number[];
+}
+
 type ParsedOp =
   | ParsedCreateTemplateOp
   | ParsedInsertNodeOp
   | ParsedRemoveNodeOp
+  | ParsedInsertTypedListItemOp
+  | ParsedRemoveTypedListItemOp
   | {
     op: 'setAttribute';
     targetId: number;
@@ -255,6 +275,22 @@ function parseUpdateOps(stream: ElementTemplateUpdateCommandStream): ParsedOp[] 
           removedSubtreeHandleIds: stream[i++] as number[],
         });
         break;
+      case ElementTemplateUpdateOps.insertTypedListItem:
+        parsed.push({
+          op: 'insertTypedListItem',
+          targetId: stream[i++] as number,
+          item: stream[i++] as UpdateTypedListItemCommand,
+          referenceId: stream[i++] as number,
+        });
+        break;
+      case ElementTemplateUpdateOps.removeTypedListItem:
+        parsed.push({
+          op: 'removeTypedListItem',
+          targetId: stream[i++] as number,
+          childId: stream[i++] as number,
+          removedSubtreeHandleIds: stream[i++] as number[],
+        });
+        break;
       default:
         throw new Error(`Unsupported test opcode: ${String(op)}`);
     }
@@ -379,6 +415,109 @@ describe('ElementTemplate Suspense background lifecycle', () => {
       attachedSubtreeHandleIds: null,
     });
     expect(ops.filter(op => op.op === 'removeNode')).toEqual([]);
+    envManager.switchToBackground();
+  });
+
+  it('restores one typed list item identity from the Suspense detached parent', async () => {
+    const deferred = createDeferred<void>();
+    let shouldSuspend = false;
+
+    function Suspender({ children }: { children?: ComponentChildren }): ComponentChildren {
+      if (shouldSuspend) {
+        throw deferred.promise;
+      }
+      return children ?? null;
+    }
+
+    function App(): JSX.Element {
+      return (
+        <list>
+          <Suspense fallback={null}>
+            <Suspender>
+              <Marker value='item' />
+            </Suspender>
+          </Suspense>
+        </list>
+      );
+    }
+
+    root.render(<App />);
+    await flushSuspenseRenders(scheduledRenders);
+
+    const list = getRenderedHost();
+    expect(list).toBeInstanceOf(BackgroundListElementTemplateInstance);
+    const item = getMarkerElementByValue(list, 'item');
+    markRenderedTreeHydrated();
+    updateEvents = [];
+
+    shouldSuspend = true;
+    root.render(<App />);
+    await flushSuspenseRenders(scheduledRenders);
+
+    expect(findMarkerElementByValue(list, 'item')).toBeNull();
+    envManager.switchToMainThread();
+    expect(parseUpdateOps(updateEvents.flatMap(event => event.ops))).toEqual([{
+      op: 'removeTypedListItem',
+      targetId: list.instanceId,
+      childId: item.instanceId,
+      removedSubtreeHandleIds: [item.instanceId],
+    }]);
+    envManager.switchToBackground();
+    updateEvents = [];
+
+    shouldSuspend = false;
+    deferred.resolve();
+    await flushSuspenseRenders(scheduledRenders);
+
+    expect(getMarkerElementByValue(list, 'item')).toBe(item);
+    envManager.switchToMainThread();
+    const ops = parseUpdateOps(updateEvents.flatMap(event => event.ops));
+    const createIndex = ops.findIndex(op => op.op === 'createTemplate' && op.handleId === item.instanceId);
+    const firstInsertIndex = ops.findIndex(op => op.op === 'insertTypedListItem');
+    expect(ops[createIndex]).toEqual({
+      op: 'createTemplate',
+      handleId: item.instanceId,
+      templateKey: MARKER_TYPE,
+      bundleUrl: null,
+      attributeSlots: ['item'],
+      elementSlots: [],
+    });
+    expect(createIndex).toBeLessThan(firstInsertIndex);
+    const inserts = ops.filter(op => op.op === 'insertTypedListItem');
+    const removes = ops.filter(op => op.op === 'removeTypedListItem');
+    expect(inserts.length).toBeGreaterThan(0);
+    for (const insert of inserts) {
+      expect(insert).toEqual({
+        op: 'insertTypedListItem',
+        targetId: list.instanceId,
+        item: {
+          __etHandleRef: item.instanceId,
+          type: MARKER_TYPE,
+          platformInfo: {},
+          subtreeHandleIds: [],
+        },
+        referenceId: 0,
+      });
+    }
+    for (const remove of removes) {
+      expect(remove).toEqual({
+        op: 'removeTypedListItem',
+        targetId: list.instanceId,
+        childId: item.instanceId,
+        removedSubtreeHandleIds: [],
+      });
+    }
+    let logicalItemCount = 0;
+    for (const op of ops) {
+      if (op.op === 'insertTypedListItem') {
+        logicalItemCount += 1;
+      } else if (op.op === 'removeTypedListItem') {
+        logicalItemCount -= 1;
+        expect(logicalItemCount).toBeGreaterThanOrEqual(0);
+      }
+    }
+    expect(logicalItemCount).toBe(1);
+    expect(ops.at(-1)?.op).toBe('insertTypedListItem');
     envManager.switchToBackground();
   });
 

--- a/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/patch/element-template-patch.test.tsx
@@ -28,9 +28,10 @@ import {
   composeElementTemplateListAttributes,
   createElementTemplateListState,
   markElementTemplateListDestroyed,
-  registerElementTemplateListItem,
+  registerElementTemplateListItem as registerElementTemplateListItemInternal,
   registerElementTemplateListState,
 } from '../../../../src/element-template/runtime/list/list.js';
+import type { ETListItemMeta } from '../../../../src/element-template/runtime/list/list.js';
 import {
   attachMainThreadDynamicAttrRefsForSubtree,
   clearMainThreadDynamicAttrState,
@@ -68,6 +69,17 @@ interface PageWithChildren {
 
 type HydrateEvent = { data: ElementTemplateHydrateCommitContext };
 type HydrateInstances = SerializedEtNode[];
+
+function registerElementTemplateListItem(
+  uid: number,
+  ref: ElementRef,
+  meta: Omit<ETListItemMeta, 'subtreeHandles'> & Partial<Pick<ETListItemMeta, 'subtreeHandles'>>,
+): void {
+  registerElementTemplateListItemInternal(uid, ref, {
+    ...meta,
+    subtreeHandles: meta.subtreeHandles ?? [],
+  });
+}
 
 function createRawTextOps(id: number, text: string) {
   return [
@@ -126,16 +138,24 @@ function seedMTEventState(
   initializeMainThreadDynamicAttrSlots(handleId, MT_EVENT_TEMPLATE, attributeSlots);
 }
 
+function seedDetachedMTRefState(
+  handleId: number,
+  attrSlotIndex: number,
+  value: Record<string, unknown>,
+): void {
+  registerMTRefSlots(attrSlotIndex);
+  const attributeSlots: unknown[] = [];
+  attributeSlots[attrSlotIndex] = { type: 'main-thread-ref', value };
+  initializeMainThreadDynamicAttrSlots(handleId, MT_REF_TEMPLATE, attributeSlots);
+}
+
 function seedMTRefState(
   handleId: number,
   attrSlotIndex: number,
   value: Record<string, unknown>,
   nativeRef: ElementRef,
 ): void {
-  registerMTRefSlots(attrSlotIndex);
-  const attributeSlots: unknown[] = [];
-  attributeSlots[attrSlotIndex] = { type: 'main-thread-ref', value };
-  initializeMainThreadDynamicAttrSlots(handleId, MT_REF_TEMPLATE, attributeSlots);
+  seedDetachedMTRefState(handleId, attrSlotIndex, value);
   attachMainThreadDynamicAttrRefsForSubtree([{ uid: handleId, ref: nativeRef }]);
 }
 
@@ -1948,7 +1968,12 @@ describe('ElementTemplate patch stream (apply)', () => {
       { id: 'typed-list' },
       [],
       {
-        listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: { 'item-key': 'a' } }],
+        listChildren: [{
+          __etHandleRef: 12,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [12],
+        }],
         estimatedHeight: 80,
       },
     ]);
@@ -1999,6 +2024,364 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, itemRef, null]]);
   });
 
+  it('attaches and cleans list item subtree MTRef on component-at-index and enqueue-component', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 210 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 211 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 212 } as unknown as ElementRef;
+    const ref = { _wvid: 71 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(210, listRef);
+    elementTemplateRegistry.set(211, itemRef);
+    elementTemplateRegistry.set(212, childRef);
+    seedDetachedMTRefState(212, 0, ref);
+    registerElementTemplateListItem(211, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 211, ref: itemRef },
+        { uid: 212, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([211]);
+    registerElementTemplateListState(210, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      const sign = componentAtIndex(listRef, 7, 0, 91, false);
+
+      expect(sign).toBe(211);
+      expect(mockInsertNodeToElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef, null]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(212, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      updateWorkletRef.mockClear();
+      enqueueComponent(listRef, 7, sign);
+
+      expect(mockRemoveNodeFromElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(212, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps nested list item MTRef detached until its own holder insert', () => {
+    envManager.switchToMainThread();
+    const outerListRef = { __isNativeRef: true, id: 'outer-list', __mockNativeId: 290 } as unknown as ElementRef;
+    const outerItemRef = { __isNativeRef: true, id: 'outer-item', __mockNativeId: 291 } as unknown as ElementRef;
+    const nestedListRef = { __isNativeRef: true, id: 'nested-list', __mockNativeId: 292 } as unknown as ElementRef;
+    const nestedItemRef = { __isNativeRef: true, id: 'nested-item', __mockNativeId: 293 } as unknown as ElementRef;
+    const nestedChildRef = { __isNativeRef: true, id: 'nested-child', __mockNativeId: 294 } as unknown as ElementRef;
+    const ref = { _wvid: 79 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(290, outerListRef);
+    elementTemplateRegistry.set(291, outerItemRef);
+    elementTemplateRegistry.set(292, nestedListRef);
+    elementTemplateRegistry.set(293, nestedItemRef);
+    elementTemplateRegistry.set(294, nestedChildRef);
+    seedDetachedMTRefState(294, 0, ref);
+    registerElementTemplateListItem(291, outerItemRef, {
+      templateKey: '_et_outer_item',
+      platformInfo: { 'item-key': 'outer' },
+      subtreeHandles: [
+        { uid: 291, ref: outerItemRef },
+        { uid: 292, ref: nestedListRef },
+      ],
+    });
+    registerElementTemplateListItem(293, nestedItemRef, {
+      templateKey: '_et_nested_item',
+      platformInfo: { 'item-key': 'nested' },
+      subtreeHandles: [
+        { uid: 293, ref: nestedItemRef },
+        { uid: 294, ref: nestedChildRef },
+      ],
+    });
+    const outerState = createElementTemplateListState([291]);
+    const nestedState = createElementTemplateListState([293]);
+    registerElementTemplateListState(290, outerState, false, outerListRef);
+    registerElementTemplateListState(292, nestedState, false, nestedListRef);
+    const outerComponentAtIndex = composeElementTemplateListAttributes(null, outerState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+    const nestedComponentAtIndex = composeElementTemplateListAttributes(null, nestedState)[
+      'component-at-index'
+    ] as ComponentAtIndexCallback;
+
+    try {
+      expect(outerComponentAtIndex(outerListRef, 7, 0, 91, false)).toBe(291);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(294, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      expect(nestedComponentAtIndex(nestedListRef, 8, 0, 92, false)).toBe(293);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, nestedChildRef);
+      expect(getMainThreadDynamicAttrState(294, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it.each(['component-at-index', 'component-at-indexes'] as const)(
+    'does not attach list item MTRef when %s insert fails',
+    (callbackName) => {
+      envManager.switchToMainThread();
+      const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 280 } as unknown as ElementRef;
+      const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 281 } as unknown as ElementRef;
+      const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 282 } as unknown as ElementRef;
+      const ref = { _wvid: 78 };
+      const { updateWorkletRef, restore } = installWorkletRefRuntime();
+      elementTemplateRegistry.set(280, listRef);
+      elementTemplateRegistry.set(281, itemRef);
+      elementTemplateRegistry.set(282, childRef);
+      seedDetachedMTRefState(282, 0, ref);
+      registerElementTemplateListItem(281, itemRef, {
+        templateKey: '_et_item',
+        platformInfo: { 'item-key': 'a' },
+        subtreeHandles: [
+          { uid: 281, ref: itemRef },
+          { uid: 282, ref: childRef },
+        ],
+      });
+      const state = createElementTemplateListState([281]);
+      registerElementTemplateListState(280, state, false, listRef);
+      const attrs = composeElementTemplateListAttributes(null, state);
+      const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+      const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+
+      try {
+        mockInsertNodeToElementTemplate.mockImplementationOnce(() => {
+          throw new Error('list insert failed');
+        });
+
+        expect(() => {
+          if (callbackName === 'component-at-index') {
+            componentAtIndex(listRef, 7, 0, 91, false);
+          } else {
+            componentAtIndexes(listRef, 7, [0], [91], false, false);
+          }
+        }).toThrow('list insert failed');
+        expect(updateWorkletRef).not.toHaveBeenCalled();
+        expect(getMainThreadDynamicAttrState(282, 0)).toEqual({
+          kind: 'mt-ref',
+          value: ref,
+        });
+
+        if (callbackName === 'component-at-index') {
+          expect(componentAtIndex(listRef, 7, 0, 92, false)).toBe(281);
+        } else {
+          componentAtIndexes(listRef, 7, [0], [92], false, false);
+        }
+        expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  it('keeps dynamically added detached list item MTRef blocked until component-at-index', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 250 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 251 } as unknown as ElementRef;
+    const ref = { _wvid: 75 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(250, listRef);
+    elementTemplateRegistry.set(251, itemRef);
+    registerElementTemplateListItem(251, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [{ uid: 251, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([251]);
+    registerElementTemplateListState(250, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    registerTemplates([{
+      templateId: '_et_ref_child',
+      compiledTemplate: {
+        kind: 'element',
+        type: 'view',
+        attributesArray: [{
+          kind: 'slot',
+          key: 'main-thread:ref',
+          attrSlotIndex: 0,
+        }],
+        children: [],
+      },
+    }]);
+
+    try {
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.createTemplate,
+        252,
+        '_et_ref_child',
+        null,
+        [{ type: 'main-thread-ref', value: ref }],
+        [],
+        ElementTemplateUpdateOps.insertNode,
+        251,
+        0,
+        252,
+        0,
+        [],
+        ElementTemplateUpdateOps.updateTypedListItem,
+        250,
+        {
+          __etHandleRef: 251,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [251, 252],
+        },
+      ]);
+
+      const childRef = elementTemplateRegistry.get(252)!;
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(252, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      componentAtIndex(listRef, 7, 0, 94, false);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(252, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans dynamically added attached list item MTRef on enqueue-component', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 260 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 261 } as unknown as ElementRef;
+    const ref = { _wvid: 76 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(260, listRef);
+    elementTemplateRegistry.set(261, itemRef);
+    registerElementTemplateListItem(261, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [{ uid: 261, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([261]);
+    registerElementTemplateListState(260, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    registerTemplates([{
+      templateId: '_et_ref_child',
+      compiledTemplate: {
+        kind: 'element',
+        type: 'view',
+        attributesArray: [{
+          kind: 'slot',
+          key: 'main-thread:ref',
+          attrSlotIndex: 0,
+        }],
+        children: [],
+      },
+    }]);
+
+    try {
+      const sign = componentAtIndex(listRef, 7, 0, 95, false);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.createTemplate,
+        262,
+        '_et_ref_child',
+        null,
+        [{ type: 'main-thread-ref', value: ref }],
+        [],
+        ElementTemplateUpdateOps.insertNode,
+        261,
+        0,
+        262,
+        0,
+        [],
+        ElementTemplateUpdateOps.updateTypedListItem,
+        260,
+        {
+          __etHandleRef: 261,
+          type: '_et_item',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [261, 262],
+        },
+      ]);
+
+      const childRef = elementTemplateRegistry.get(262)!;
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+
+      enqueueComponent(listRef, 7, sign);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(262, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('attaches list item subtree MTRef from component-at-indexes', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 220 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 221 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 222 } as unknown as ElementRef;
+    const ref = { _wvid: 72 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(220, listRef);
+    elementTemplateRegistry.set(221, itemRef);
+    elementTemplateRegistry.set(222, childRef);
+    seedDetachedMTRefState(222, 0, ref);
+    registerElementTemplateListItem(221, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 221, ref: itemRef },
+        { uid: 222, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([221]);
+    registerElementTemplateListState(220, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+
+    try {
+      componentAtIndexes(listRef, 7, [0], [92], false, true);
+
+      expect(mockInsertNodeToElementTemplate.mock.calls.at(-1)).toEqual([listRef, 0, itemRef, null]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(222, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it('creates exact typed lists outside development using the internal listChildren contract', () => {
     const originalDev = globalThis.__DEV__;
     globalThis.__DEV__ = false;
@@ -2016,7 +2399,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         null,
         [],
         {
-          listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {} }],
+          listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {}, subtreeHandleIds: [12] }],
           estimatedHeight: 80,
         },
       ]);
@@ -2092,7 +2475,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       'list',
       null,
       [[11]],
-      { listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {} }] },
+      { listChildren: [{ __etHandleRef: 12, type: '_et_item', platformInfo: {}, subtreeHandleIds: [12] }] },
     ]);
 
     expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(0);
@@ -2241,7 +2624,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       'list',
       null,
       [],
-      { listChildren: [{ __etHandleRef: 404, type: '_et_item', platformInfo: {} }] },
+      { listChildren: [{ __etHandleRef: 404, type: '_et_item', platformInfo: {}, subtreeHandleIds: [404] }] },
     ]);
 
     expect(mockCreateTypedElementTemplate.mock.calls).toHaveLength(0);
@@ -2264,11 +2647,11 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       41,
-      { __etHandleRef: 404, type: '_et_item', platformInfo: {} },
+      { __etHandleRef: 404, type: '_et_item', platformInfo: {}, subtreeHandleIds: [404] },
       0,
       ElementTemplateUpdateOps.updateTypedListItem,
       41,
-      { __etHandleRef: 405, type: '_et_item', platformInfo: {} },
+      { __etHandleRef: 405, type: '_et_item', platformInfo: {}, subtreeHandleIds: [405] },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(0);
@@ -2409,6 +2792,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 33,
         type: '_et_item_b',
         platformInfo: { 'item-key': 'b' },
+        subtreeHandleIds: [33],
       },
       0,
     ]);
@@ -2459,6 +2843,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 37,
         type: '_et_item_b',
         platformInfo: { 'item-key': 'b' },
+        subtreeHandleIds: [37],
       },
       0,
       ElementTemplateUpdateOps.setAttribute,
@@ -2512,11 +2897,11 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 204, type: '_et_item_204', platformInfo: { 'item-key': '204' } },
+      { __etHandleRef: 204, type: '_et_item_204', platformInfo: { 'item-key': '204' }, subtreeHandleIds: [204] },
       202,
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 205, type: '_et_item_205', platformInfo: { 'item-key': '205' } },
+      { __etHandleRef: 205, type: '_et_item_205', platformInfo: { 'item-key': '205' }, subtreeHandleIds: [205] },
       204,
       ElementTemplateUpdateOps.removeTypedListItem,
       200,
@@ -2528,7 +2913,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       200,
-      { __etHandleRef: 203, type: '_et_item_203', platformInfo: { 'item-key': '203' } },
+      { __etHandleRef: 203, type: '_et_item_203', platformInfo: { 'item-key': '203' }, subtreeHandleIds: [203] },
       0,
     ]);
 
@@ -2579,14 +2964,24 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.insertTypedListItem,
       210,
-      { __etHandleRef: 213, type: '_et_item_d', platformInfo: { 'item-key': 'd' } },
+      { __etHandleRef: 213, type: '_et_item_d', platformInfo: { 'item-key': 'd' }, subtreeHandleIds: [213] },
       212,
       ElementTemplateUpdateOps.updateTypedListItem,
       210,
-      { __etHandleRef: 211, type: '_et_item_a', platformInfo: { 'item-key': 'a', 'full-span': true } },
+      {
+        __etHandleRef: 211,
+        type: '_et_item_a',
+        platformInfo: { 'item-key': 'a', 'full-span': true },
+        subtreeHandleIds: [211],
+      },
       ElementTemplateUpdateOps.updateTypedListItem,
       210,
-      { __etHandleRef: 212, type: '_et_item_b', platformInfo: { 'item-key': 'b', 'estimated-height': 42 } },
+      {
+        __etHandleRef: 212,
+        type: '_et_item_b',
+        platformInfo: { 'item-key': 'b', 'estimated-height': 42 },
+        subtreeHandleIds: [212],
+      },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(1);
@@ -2617,7 +3012,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     applyElementTemplateUpdateCommands([
       ElementTemplateUpdateOps.updateTypedListItem,
       214,
-      { __etHandleRef: 2141, type: '_et_item_a', platformInfo: { 'item-key': 'a' } },
+      { __etHandleRef: 2141, type: '_et_item_a', platformInfo: { 'item-key': 'a' }, subtreeHandleIds: [2141] },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(0);
@@ -2648,11 +3043,16 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       215,
-      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [217] },
       216,
       ElementTemplateUpdateOps.updateTypedListItem,
       215,
-      { __etHandleRef: 217, type: '_et_item_b', platformInfo: { 'item-key': 'b', 'full-span': true } },
+      {
+        __etHandleRef: 217,
+        type: '_et_item_b',
+        platformInfo: { 'item-key': 'b', 'full-span': true },
+        subtreeHandleIds: [217],
+      },
     ]);
 
     expect(mockSetAttributeOfElementTemplate.mock.calls).toHaveLength(1);
@@ -2702,11 +3102,16 @@ describe('ElementTemplate patch stream (apply)', () => {
       [2183],
       ElementTemplateUpdateOps.insertTypedListItem,
       218,
-      { __etHandleRef: 2181, type: '_et_item_a', platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' } },
+      {
+        __etHandleRef: 2181,
+        type: '_et_item_a',
+        platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' },
+        subtreeHandleIds: [2181],
+      },
       0,
       ElementTemplateUpdateOps.insertTypedListItem,
       218,
-      { __etHandleRef: 2184, type: '_et_item_x', platformInfo: { 'item-key': 'x' } },
+      { __etHandleRef: 2184, type: '_et_item_x', platformInfo: { 'item-key': 'x' }, subtreeHandleIds: [2184] },
       2181,
     ]);
 
@@ -2744,7 +3149,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       { id: 'intermediate' },
       ElementTemplateUpdateOps.insertTypedListItem,
       220,
-      { __etHandleRef: 222, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 222, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [222] },
       0,
       ElementTemplateUpdateOps.setAttribute,
       220,
@@ -2767,7 +3172,7 @@ describe('ElementTemplate patch stream (apply)', () => {
     }));
   });
 
-  it('moves already attached same-list items when native requests the moved index first', () => {
+  it('moves an attached same-list item after native enqueues its rebind', () => {
     envManager.switchToMainThread();
     const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 225 } as unknown as ElementRef;
     const aRef = { __isNativeRef: true, id: 'a', __mockNativeId: 226 } as unknown as ElementRef;
@@ -2800,17 +3205,17 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       225,
-      { __etHandleRef: 227, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 227, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [227] },
       226,
     ]);
     mockInsertNodeToElementTemplate.mockClear();
     mockRemoveNodeFromElementTemplate.mockClear();
 
-    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(227);
-
-    expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, bRef, aRef]]);
-    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     enqueueComponent(listRef, 7, 227);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
+
+    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(227);
+    expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, bRef, aRef]]);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     enqueueComponent(listRef, 7, 227);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, bRef]]);
@@ -2856,7 +3261,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       240,
-      { __etHandleRef: 243, type: '_et_item_c', platformInfo: { 'item-key': 'c' } },
+      { __etHandleRef: 243, type: '_et_item_c', platformInfo: { 'item-key': 'c' }, subtreeHandleIds: [243] },
       241,
       ElementTemplateUpdateOps.removeTypedListItem,
       240,
@@ -2864,20 +3269,21 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       240,
-      { __etHandleRef: 241, type: '_et_item_a', platformInfo: { 'item-key': 'a' } },
+      { __etHandleRef: 241, type: '_et_item_a', platformInfo: { 'item-key': 'a' }, subtreeHandleIds: [241] },
       0,
     ]);
     mockInsertNodeToElementTemplate.mockClear();
     mockRemoveNodeFromElementTemplate.mockClear();
 
-    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(243);
+    enqueueComponent(listRef, 7, 243);
+    enqueueComponent(listRef, 7, 241);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
 
+    expect(componentAtIndex(listRef, 7, 0, 90, false)).toBe(243);
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
       [listRef, 0, aRef, null],
       [listRef, 0, cRef, bRef],
     ]);
-    enqueueComponent(listRef, 7, 243);
-    enqueueComponent(listRef, 7, 241);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     expect(componentAtIndex(listRef, 7, 1, 91, false)).toBe(242);
   });
@@ -2914,7 +3320,7 @@ describe('ElementTemplate patch stream (apply)', () => {
       [],
       ElementTemplateUpdateOps.insertTypedListItem,
       230,
-      { __etHandleRef: 232, type: '_et_item_b', platformInfo: { 'item-key': 'b' } },
+      { __etHandleRef: 232, type: '_et_item_b', platformInfo: { 'item-key': 'b' }, subtreeHandleIds: [232] },
       231,
       ElementTemplateUpdateOps.removeTypedListItem,
       230,
@@ -2931,7 +3337,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         updateAction: [],
       },
     }));
-    expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, secondRef]]);
+    expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([]);
     expect(elementTemplateRegistry.get(231)).toBeUndefined();
     expect(elementTemplateRegistry.get(232)).toBe(secondRef);
   });
@@ -3116,6 +3522,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 52,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'old' },
+        subtreeHandleIds: [52],
       },
       0,
       ElementTemplateUpdateOps.updateTypedListItem,
@@ -3124,6 +3531,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 52,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'new' },
+        subtreeHandleIds: [52],
       },
     ]);
 
@@ -3164,6 +3572,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 82,
         type: '_et_item',
         platformInfo: { 'item-key': 'a', 'reuse-identifier': 'next' },
+        subtreeHandleIds: [82],
       },
     ]);
 
@@ -3227,6 +3636,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 72,
         type: '_et_item_a',
         platformInfo: { 'item-key': 'a' },
+        subtreeHandleIds: [72],
       },
       0,
     ]);
@@ -3234,6 +3644,342 @@ describe('ElementTemplate patch stream (apply)', () => {
 
     expect(componentAtIndex(listRef, 7, 1, 92, false)).toBe(136);
     expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+  });
+
+  it('preserves MTRef during same-list rebind and cleans the later holder release', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 230 } as unknown as ElementRef;
+    const firstRef = { __isNativeRef: true, id: 'first', __mockNativeId: 231 } as unknown as ElementRef;
+    const secondRef = { __isNativeRef: true, id: 'second', __mockNativeId: 232 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 233 } as unknown as ElementRef;
+    const ref = { _wvid: 73 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(230, listRef);
+    elementTemplateRegistry.set(231, firstRef);
+    elementTemplateRegistry.set(232, secondRef);
+    elementTemplateRegistry.set(233, childRef);
+    seedDetachedMTRefState(233, 0, ref);
+    registerElementTemplateListItem(231, firstRef, {
+      templateKey: '_et_item_a',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 231, ref: firstRef },
+        { uid: 233, ref: childRef },
+      ],
+    });
+    registerElementTemplateListItem(232, secondRef, {
+      templateKey: '_et_item_b',
+      platformInfo: { 'item-key': 'b' },
+      subtreeHandles: [{ uid: 232, ref: secondRef }],
+    });
+    const state = createElementTemplateListState([231, 232]);
+    registerElementTemplateListState(230, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      const oldSign = componentAtIndex(listRef, 7, 0, 91, false);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        230,
+        231,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        230,
+        {
+          __etHandleRef: 231,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [231, 233],
+        },
+        0,
+      ]);
+      mockInsertNodeToElementTemplate.mockClear();
+
+      enqueueComponent(listRef, 7, oldSign);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(233, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      expect(componentAtIndex(listRef, 7, 1, 92, false)).toBe(oldSign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+
+      mockRemoveNodeFromElementTemplate.mockClear();
+      enqueueComponent(listRef, 7, oldSign);
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef]]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(233, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      expect(componentAtIndex(listRef, 7, 1, 93, false)).toBe(oldSign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([[listRef, 0, firstRef, null]]);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans a released same-list holder when its rebind insert fails', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 290 } as unknown as ElementRef;
+    const firstRef = { __isNativeRef: true, id: 'first', __mockNativeId: 291 } as unknown as ElementRef;
+    const secondRef = { __isNativeRef: true, id: 'second', __mockNativeId: 292 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 293 } as unknown as ElementRef;
+    const ref = { _wvid: 79 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(290, listRef);
+    elementTemplateRegistry.set(291, firstRef);
+    elementTemplateRegistry.set(292, secondRef);
+    elementTemplateRegistry.set(293, childRef);
+    seedDetachedMTRefState(293, 0, ref);
+    registerElementTemplateListItem(291, firstRef, {
+      templateKey: '_et_item_a',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 291, ref: firstRef },
+        { uid: 293, ref: childRef },
+      ],
+    });
+    registerElementTemplateListItem(292, secondRef, {
+      templateKey: '_et_item_b',
+      platformInfo: { 'item-key': 'b' },
+      subtreeHandles: [{ uid: 292, ref: secondRef }],
+    });
+    const state = createElementTemplateListState([291, 292]);
+    registerElementTemplateListState(290, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      const sign = componentAtIndex(listRef, 7, 0, 91, false);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      mockRemoveNodeFromElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        290,
+        291,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        290,
+        {
+          __etHandleRef: 291,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [291, 293],
+        },
+        0,
+      ]);
+      enqueueComponent(listRef, 7, sign);
+      mockInsertNodeToElementTemplate.mockImplementationOnce(() => {
+        throw new Error('list move insert failed');
+      });
+
+      expect(() => componentAtIndex(listRef, 7, 1, 92, false)).toThrow(
+        'list move insert failed',
+      );
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([
+        [listRef, 0, firstRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([[ref, null]]);
+      expect(getMainThreadDynamicAttrState(293, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      expect(componentAtIndex(listRef, 7, 1, 93, false)).toBe(sign);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, firstRef, null],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([[ref, childRef]]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps successful batch moves attached and cleans remaining released moves after insert failure', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 300 } as unknown as ElementRef;
+    const aRef = { __isNativeRef: true, id: 'a', __mockNativeId: 301 } as unknown as ElementRef;
+    const bRef = { __isNativeRef: true, id: 'b', __mockNativeId: 302 } as unknown as ElementRef;
+    const cRef = { __isNativeRef: true, id: 'c', __mockNativeId: 303 } as unknown as ElementRef;
+    const dRef = { __isNativeRef: true, id: 'd', __mockNativeId: 304 } as unknown as ElementRef;
+    const mtRefs = {
+      a: { _wvid: 80 },
+      b: { _wvid: 81 },
+      c: { _wvid: 82 },
+      d: { _wvid: 83 },
+    };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(300, listRef);
+    for (
+      const [uid, itemRef, itemKey, mtRef] of [
+        [301, aRef, 'a', mtRefs.a],
+        [302, bRef, 'b', mtRefs.b],
+        [303, cRef, 'c', mtRefs.c],
+        [304, dRef, 'd', mtRefs.d],
+      ] as const
+    ) {
+      elementTemplateRegistry.set(uid, itemRef);
+      seedDetachedMTRefState(uid, 0, mtRef);
+      registerElementTemplateListItem(uid, itemRef, {
+        templateKey: `_et_item_${itemKey}`,
+        platformInfo: { 'item-key': itemKey },
+        subtreeHandles: [{ uid, ref: itemRef }],
+      });
+    }
+    const state = createElementTemplateListState([301, 302, 303, 304]);
+    registerElementTemplateListState(300, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+
+    try {
+      componentAtIndexes(listRef, 7, [0, 1, 2, 3], [90, 91, 92, 93], false, false);
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      mockRemoveNodeFromElementTemplate.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        304,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 304,
+          type: '_et_item_d',
+          platformInfo: { 'item-key': 'd' },
+          subtreeHandleIds: [304],
+        },
+        301,
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        303,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 303,
+          type: '_et_item_c',
+          platformInfo: { 'item-key': 'c' },
+          subtreeHandleIds: [303],
+        },
+        301,
+        ElementTemplateUpdateOps.removeTypedListItem,
+        300,
+        301,
+        [],
+        ElementTemplateUpdateOps.insertTypedListItem,
+        300,
+        {
+          __etHandleRef: 301,
+          type: '_et_item_a',
+          platformInfo: { 'item-key': 'a' },
+          subtreeHandleIds: [301],
+        },
+        0,
+      ]);
+      enqueueComponent(listRef, 7, 304);
+      enqueueComponent(listRef, 7, 303);
+      enqueueComponent(listRef, 7, 301);
+      mockInsertNodeToElementTemplate
+        .mockImplementationOnce(() => {})
+        .mockImplementationOnce(() => {
+          throw new Error('batch list move insert failed');
+        });
+
+      expect(() => {
+        componentAtIndexes(listRef, 7, [0, 1, 2, 3], [94, 95, 96, 97], false, false);
+      }).toThrow('batch list move insert failed');
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, aRef, null],
+        [listRef, 0, cRef, bRef],
+      ]);
+      expect(mockRemoveNodeFromElementTemplate.mock.calls).toEqual([
+        [listRef, 0, dRef],
+        [listRef, 0, cRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([
+        [mtRefs.d, null],
+        [mtRefs.c, null],
+      ]);
+
+      updateWorkletRef.mockClear();
+      mockInsertNodeToElementTemplate.mockClear();
+      componentAtIndexes(listRef, 7, [0, 1], [98, 99], false, false);
+      expect(mockInsertNodeToElementTemplate.mock.calls).toEqual([
+        [listRef, 0, dRef, bRef],
+        [listRef, 0, cRef, bRef],
+      ]);
+      expect(updateWorkletRef.mock.calls).toEqual([
+        [mtRefs.d, dRef],
+        [mtRefs.c, cRef],
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('cleans live list subtree MTRef on logical item removal after update-list-info', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'typed-list', __mockNativeId: 240 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item', __mockNativeId: 241 } as unknown as ElementRef;
+    const childRef = { __isNativeRef: true, id: 'child', __mockNativeId: 242 } as unknown as ElementRef;
+    const ref = { _wvid: 74 };
+    const { updateWorkletRef, restore } = installWorkletRefRuntime();
+    elementTemplateRegistry.set(240, listRef);
+    elementTemplateRegistry.set(241, itemRef);
+    elementTemplateRegistry.set(242, childRef);
+    seedDetachedMTRefState(242, 0, ref);
+    registerElementTemplateListItem(241, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+      subtreeHandles: [
+        { uid: 241, ref: itemRef },
+        { uid: 242, ref: childRef },
+      ],
+    });
+    const state = createElementTemplateListState([241]);
+    registerElementTemplateListState(240, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+
+    try {
+      componentAtIndex(listRef, 7, 0, 93, false);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      updateWorkletRef.mockClear();
+
+      applyElementTemplateUpdateCommands([
+        ElementTemplateUpdateOps.removeTypedListItem,
+        240,
+        241,
+        [241, 242],
+      ]);
+
+      expect(mockSetAttributeOfElementTemplate.mock.calls.at(-1)?.[0]).toBe(listRef);
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, null);
+      expect(getMainThreadDynamicAttrState(242, 0)).toBeUndefined();
+    } finally {
+      restore();
+    }
   });
 
   it('treats same-key list item replacement with a new ref as remove and insert', () => {
@@ -3262,6 +4008,7 @@ describe('ElementTemplate patch stream (apply)', () => {
         __etHandleRef: 63,
         type: '_et_item',
         platformInfo: { 'item-key': 'same' },
+        subtreeHandleIds: [63],
       },
       0,
     ]);
@@ -3278,8 +4025,8 @@ describe('ElementTemplate patch stream (apply)', () => {
 
   it('keeps destroyed typed list callbacks Snapshot-safe', () => {
     envManager.switchToMainThread();
-    const listRef = 120 as unknown as ElementRef;
-    const itemRef = 121 as unknown as ElementRef;
+    const listRef = { __isNativeRef: true, __mockNativeId: 120 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, __mockNativeId: 121 } as unknown as ElementRef;
     registerElementTemplateListItem(121, itemRef, {
       templateKey: '_et_item',
       platformInfo: { 'item-key': 'a' },
@@ -3291,6 +4038,9 @@ describe('ElementTemplate patch stream (apply)', () => {
     const componentAtIndexes = attrs['component-at-indexes'] as ComponentAtIndexesCallback;
     const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
 
+    expect(componentAtIndex(listRef, 7, 0, 99, false)).toBe(121);
+    mockInsertNodeToElementTemplate.mockClear();
+    mockFlushElementTree.mockClear();
     markElementTemplateListDestroyed(120);
 
     expect(componentAtIndex(listRef, 7, 0, 99, false)).toBe(-1);
@@ -3300,6 +4050,39 @@ describe('ElementTemplate patch stream (apply)', () => {
     expect(mockInsertNodeToElementTemplate.mock.calls).toHaveLength(0);
     expect(mockRemoveNodeFromElementTemplate.mock.calls).toHaveLength(0);
     expect(mockFlushElementTree.mock.calls).toHaveLength(0);
+  });
+
+  it('keeps the physical owner aligned when an attached list item record is replaced', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, __mockNativeId: 130 } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, __mockNativeId: 131 } as unknown as ElementRef;
+    elementTemplateRegistry.set(130, listRef);
+    elementTemplateRegistry.set(131, itemRef);
+    registerElementTemplateListItem(131, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: { 'item-key': 'a' },
+    });
+    const state = createElementTemplateListState([131]);
+    registerElementTemplateListState(130, state, false, listRef);
+    const attrs = composeElementTemplateListAttributes(null, state);
+    const componentAtIndex = attrs['component-at-index'] as ComponentAtIndexCallback;
+    const enqueueComponent = attrs['enqueue-component'] as EnqueueComponentCallback;
+    const sign = componentAtIndex(listRef, 7, 0, 99, false);
+    mockRemoveNodeFromElementTemplate.mockClear();
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      130,
+      {
+        __etHandleRef: 131,
+        type: '_et_item',
+        platformInfo: { 'item-key': 'a', 'full-span': true },
+        subtreeHandleIds: [],
+      },
+    ]);
+    enqueueComponent(listRef, 7, sign);
+
+    expect(mockRemoveNodeFromElementTemplate).toHaveBeenCalledWith(listRef, 0, itemRef);
   });
 
   it('skips typed slot 0 attributes when the target handle is unresolved', () => {
@@ -3380,6 +4163,77 @@ describe('ElementTemplate patch stream (apply)', () => {
     const reportError = (globalThis.lynx as unknown as LynxWithReportErrorMock).reportError;
     expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain('insert subtree handle 999 not found');
     resetReportedErrors();
+  });
+
+  it('reports a missing typed list item subtree handle', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'list' } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item' } as unknown as ElementRef;
+    elementTemplateRegistry.set(500, listRef);
+    elementTemplateRegistry.set(501, itemRef);
+    registerElementTemplateListItem(501, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: {},
+      subtreeHandles: [{ uid: 501, ref: itemRef }],
+    });
+    const state = createElementTemplateListState([501]);
+    registerElementTemplateListState(500, state, false, listRef);
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      500,
+      {
+        __etHandleRef: 501,
+        type: '_et_item',
+        platformInfo: {},
+        subtreeHandleIds: [501, 999],
+      },
+    ]);
+
+    expect(state.items[0]?.subtreeHandles).toEqual([{ uid: 501, ref: itemRef }]);
+    const reportError = (globalThis.lynx as unknown as LynxWithReportErrorMock).reportError;
+    expect(String(reportError.mock.calls[0]?.[0]?.message ?? '')).toContain(
+      'typed list update item subtree handle 999 not found',
+    );
+    resetReportedErrors();
+  });
+
+  it('updates typed list subtree membership when its size stays the same', () => {
+    envManager.switchToMainThread();
+    const listRef = { __isNativeRef: true, id: 'list' } as unknown as ElementRef;
+    const itemRef = { __isNativeRef: true, id: 'item' } as unknown as ElementRef;
+    const previousChildRef = { __isNativeRef: true, id: 'previous-child' } as unknown as ElementRef;
+    const nextChildRef = { __isNativeRef: true, id: 'next-child' } as unknown as ElementRef;
+    elementTemplateRegistry.set(510, listRef);
+    elementTemplateRegistry.set(511, itemRef);
+    elementTemplateRegistry.set(512, previousChildRef);
+    elementTemplateRegistry.set(513, nextChildRef);
+    registerElementTemplateListItem(511, itemRef, {
+      templateKey: '_et_item',
+      platformInfo: {},
+      subtreeHandles: [
+        { uid: 511, ref: itemRef },
+        { uid: 512, ref: previousChildRef },
+      ],
+    });
+    const state = createElementTemplateListState([511]);
+    registerElementTemplateListState(510, state, false, listRef);
+
+    applyElementTemplateUpdateCommands([
+      ElementTemplateUpdateOps.updateTypedListItem,
+      510,
+      {
+        __etHandleRef: 511,
+        type: '_et_item',
+        platformInfo: {},
+        subtreeHandleIds: [511, 513],
+      },
+    ]);
+
+    expect(state.items[0]?.subtreeHandles).toEqual([
+      { uid: 511, ref: itemRef },
+      { uid: 513, ref: nextChildRef },
+    ]);
   });
 
   it('reports missing child handle on removeNode', () => {

--- a/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
+++ b/packages/react/runtime/__test__/element-template/runtime/render/render-opcodes-into-element-template.et.test.tsx
@@ -14,10 +14,15 @@ import { elementTemplateRegistry } from '../../../../src/element-template/runtim
 import {
   __etAttrPlanMap,
   adaptEventAttrSlot,
+  adaptMTRefAttrSlot,
   adaptRefAttrSlot,
   adaptSpreadAttrSlot,
   clearEtAttrPlanMap,
 } from '../../../../src/element-template/runtime/template/attr-slot-plan.js';
+import {
+  clearMainThreadDynamicAttrState,
+  getMainThreadDynamicAttrState,
+} from '../../../../src/element-template/runtime/template/main-thread-dynamic-attr-state.js';
 import {
   __OpAttr,
   __OpBegin,
@@ -58,12 +63,14 @@ describe('renderOpcodesIntoElementTemplate', () => {
     vi.stubGlobal('__OnLifecycleEvent', onLifecycleEvent);
     elementTemplateRegistry.clear();
     destroyAllElementTemplateListStates();
+    clearMainThreadDynamicAttrState();
     clearEtAttrPlanMap();
     resetTemplateId();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    clearMainThreadDynamicAttrState();
     clearEtAttrPlanMap();
   });
 
@@ -398,6 +405,73 @@ describe('renderOpcodesIntoElementTemplate', () => {
         listID: 9,
       }],
     ]);
+  });
+
+  it('defers first-screen list item subtree MTRef attach until native requests the item', () => {
+    const previousWorkletImpl = globalThis.lynxWorkletImpl;
+    const updateWorkletRef = vi.fn();
+    globalThis.lynxWorkletImpl = {
+      ...previousWorkletImpl,
+      _refImpl: {
+        updateWorkletRef,
+      },
+    };
+    const listRef = { kind: 'list-ref', __mockNativeId: 400 };
+    const itemRef = { kind: 'item-ref', __mockNativeId: 401 };
+    const childRef = { kind: 'child-ref', __mockNativeId: 402 };
+    const ref = { _wvid: 77 };
+    __etAttrPlanMap['__Card__:_et_ref_child'] = [0, adaptMTRefAttrSlot];
+    createElementTemplate
+      .mockReturnValueOnce(childRef)
+      .mockReturnValueOnce(itemRef);
+    createTypedElementTemplate.mockReturnValueOnce(listRef);
+
+    try {
+      renderOpcodesIntoElementTemplate([
+        __OpBegin,
+        { type: 'list' },
+        __OpSlot,
+        0,
+        __OpBegin,
+        { type: '_et_item', props: { __listItemPlatformInfo: { 'item-key': 'a' } } },
+        __OpSlot,
+        0,
+        __OpBegin,
+        { type: '__Card__:_et_ref_child' },
+        __OpAttr,
+        'attributeSlots',
+        [ref],
+        __OpEnd,
+        __OpEnd,
+        __OpEnd,
+      ]);
+
+      expect(createElementTemplate.mock.calls[0]).toEqual([
+        '_et_ref_child',
+        null,
+        [null],
+        null,
+        -1,
+      ]);
+      expect(updateWorkletRef).not.toHaveBeenCalled();
+      expect(getMainThreadDynamicAttrState(-1, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+
+      const attrs = createTypedElementTemplate.mock.calls[0]![1] as Record<string, (...args: unknown[]) => unknown>;
+      const componentAtIndex = attrs['component-at-index']!;
+
+      expect(componentAtIndex(listRef, 9, 0, 72, true)).toBe(401);
+
+      expect(updateWorkletRef).toHaveBeenCalledWith(ref, childRef);
+      expect(getMainThreadDynamicAttrState(-1, 0)).toEqual({
+        kind: 'mt-ref',
+        value: ref,
+      });
+    } finally {
+      globalThis.lynxWorkletImpl = previousWorkletImpl;
+    }
   });
 
   it('rejects non-list-item roots in typed list logical children', () => {

--- a/packages/react/runtime/src/element-template/background/instance.ts
+++ b/packages/react/runtime/src/element-template/background/instance.ts
@@ -684,11 +684,11 @@ export class BackgroundListElementTemplateInstance extends BackgroundTypedElemen
     beforeChild: BackgroundElementTemplateInstance | null,
     silent?: boolean,
   ): void {
-    const previousParent = child.parent;
+    const isSameListMove = child.parent === this;
     super.insertBefore(child, beforeChild, true);
     if (!silent) {
-      if (previousParent instanceof BackgroundListElementTemplateInstance) {
-        previousParent.emitTypedListItemRemove(child, EMPTY_REMOVED_SUBTREE_HANDLE_IDS);
+      if (isSameListMove) {
+        this.emitTypedListItemRemove(child, EMPTY_REMOVED_SUBTREE_HANDLE_IDS);
       }
       this.emitTypedListItemInsert(child, beforeChild);
     }
@@ -788,6 +788,11 @@ function collectMainThreadRefSubtreeHandleIdsImpl(
   if (hasMainThreadRefAttrSlot(instance.type)) {
     handles ??= [];
     handles.push(instance.instanceId);
+  }
+  // The nested list holder belongs to this subtree, while its logical children
+  // are materialized and owned by that list's own holder callbacks.
+  if (instance instanceof BackgroundListElementTemplateInstance) {
+    return handles;
   }
   let child = instance.firstChild;
   while (child) {

--- a/packages/react/runtime/src/element-template/runtime/list/list.ts
+++ b/packages/react/runtime/src/element-template/runtime/list/list.ts
@@ -8,6 +8,12 @@ import type {
   RuntimeTypedElementAttributes,
   SerializableValue,
 } from '../../protocol/types.js';
+import { insertElementTemplateSubtree } from '../template/handle.js';
+import {
+  attachMainThreadDynamicAttrRefsForSubtree,
+  detachMainThreadDynamicAttrRefsForSubtree,
+} from '../template/main-thread-dynamic-attr-state.js';
+import type { MainThreadDynamicAttrSubtreeHandle } from '../template/main-thread-dynamic-attr-state.js';
 
 const LIST_ELEMENT_SLOT_INDEX = 0;
 const COMPONENT_AT_INDEX_ATTR = 'component-at-index';
@@ -19,6 +25,7 @@ export type ETListItemPlatformInfo = Record<string, SerializableValue>;
 export interface ETListItemMeta {
   templateKey: string;
   platformInfo: ETListItemPlatformInfo;
+  subtreeHandles: readonly MainThreadDynamicAttrSubtreeHandle[];
 }
 
 interface ETListItemRecord extends ETListItemMeta {
@@ -27,21 +34,26 @@ interface ETListItemRecord extends ETListItemMeta {
   uid: number;
   // Native item root ref. The root can exist detached until native requests it.
   ref: ElementRef;
+  // All ET handles in this item subtree. Direct MTRefs can live below the item
+  // root, but their lifecycle still follows native holder ownership.
+  subtreeHandles: MainThreadDynamicAttrSubtreeHandle[];
   // True after `component-at-index(es)` has inserted this item root into the
   // list's native slot.
   attached: boolean;
   // Same-list reorder keeps the item attached, but the next callback must still
   // call insert so native moves the existing child to the new sibling position.
   needsAttachMove: boolean;
-  // Native may enqueue the old cell after an attached item has already moved to
-  // the new position. Skipping that one detach preserves Snapshot move ordering.
-  skipNextEnqueue: boolean;
 }
 
 interface ETListCallbacks {
   componentAtIndex: ComponentAtIndexCallback;
   componentAtIndexes: ComponentAtIndexesCallback;
   enqueueComponent: EnqueueComponentCallback;
+}
+
+interface AttachedETListItem {
+  item: ETListItemRecord;
+  sign: number;
 }
 
 export interface ETListState {
@@ -56,7 +68,7 @@ export interface ETListState {
   // callbacks observe the latest committed-by-JS list shape.
   items: ETListItemRecord[];
   // Native sign -> item lookup for list callbacks. This is not the attached
-  // item set: removed visible items stay addressable until native enqueues the
+  // item set: removed materialized items stay addressable until native enqueues the
   // old sign while applying the final `update-list-info`.
   callbackItemBySign: Map<number, ETListItemRecord>;
   // Holder teardown keeps callbacks Snapshot-safe for late native calls.
@@ -64,6 +76,10 @@ export interface ETListState {
   // True while one or more currently attached items need same-list placement.
   // The next list callback reorders attached refs once, from right to left.
   hasAttachedMoves: boolean;
+  // Native releases a moved holder before requesting its replacement. Keep its
+  // MTRefs attached across that pair, but remember which failed inserts need
+  // holder cleanup.
+  releasedMoveItemUids: Set<number>;
   // Latest typed slot 0 attrs excluding list callbacks and transient
   // `update-list-info`; final list flush composes these with stable callbacks.
   attributes: RuntimeTypedElementAttributes;
@@ -75,6 +91,7 @@ export interface ETListState {
 export interface ETListUpdateItem extends ETListItemMeta {
   uid: number;
   ref: ElementRef;
+  subtreeHandles: MainThreadDynamicAttrSubtreeHandle[];
 }
 
 export interface ETListUpdateInfo {
@@ -110,6 +127,7 @@ interface PendingETListUpdate {
 
 const listItemByUid = /* @__PURE__ */ new Map<number, ETListItemRecord>();
 const listStateByUid = /* @__PURE__ */ new Map<number, ETListState>();
+const attachedListItemByUid = /* @__PURE__ */ new Map<number, AttachedETListItem>();
 const pendingInitialListUpdateUids = /* @__PURE__ */ new Set<number>();
 const pendingListUpdates = /* @__PURE__ */ new Map<number, PendingETListUpdate>();
 
@@ -123,9 +141,9 @@ export function registerElementTemplateListItem(
     ref,
     templateKey: meta.templateKey,
     platformInfo: meta.platformInfo,
+    subtreeHandles: Array.from(meta.subtreeHandles),
     attached: false,
     needsAttachMove: false,
-    skipNextEnqueue: false,
   });
 }
 
@@ -171,9 +189,9 @@ export function createElementTemplateListStateFromItems(
       ref: item.ref,
       templateKey: item.templateKey,
       platformInfo: item.platformInfo,
+      subtreeHandles: item.subtreeHandles,
       attached: false,
       needsAttachMove: false,
-      skipNextEnqueue: false,
     });
   }
 
@@ -191,6 +209,7 @@ function createElementTemplateListStateWithRecords(
     callbackItemBySign: new Map(),
     destroyed: false,
     hasAttachedMoves: false,
+    releasedMoveItemUids: new Set(),
     attributes: attributes ?? {},
     callbacks: null as unknown as ETListCallbacks,
   };
@@ -222,7 +241,17 @@ export function markElementTemplateListDestroyed(uid: number): number[] | undefi
     return undefined;
   }
   state.destroyed = true;
+  for (const item of state.callbackItemBySign.values()) {
+    if (item.attached) {
+      const attachedItem = attachedListItemByUid.get(item.uid)!;
+      detachMainThreadDynamicAttrRefsForSubtree(attachedItem.item.subtreeHandles);
+      attachedListItemByUid.delete(item.uid);
+      attachedItem.item.attached = false;
+      attachedItem.item.needsAttachMove = false;
+    }
+  }
   state.callbackItemBySign.clear();
+  state.releasedMoveItemUids.clear();
   listStateByUid.delete(uid);
   pendingInitialListUpdateUids.delete(uid);
   const pendingUpdate = pendingListUpdates.get(uid);
@@ -237,6 +266,7 @@ export function destroyAllElementTemplateListStates(): void {
   }
   listStateByUid.clear();
   listItemByUid.clear();
+  attachedListItemByUid.clear();
   pendingInitialListUpdateUids.clear();
   pendingListUpdates.clear();
 }
@@ -269,9 +299,9 @@ export function insertElementTemplateListItem(
     ref: item.ref,
     templateKey: item.templateKey,
     platformInfo: item.platformInfo,
+    subtreeHandles: item.subtreeHandles,
     attached: previousRecord?.attached ?? false,
     needsAttachMove,
-    skipNextEnqueue: previousRecord?.skipNextEnqueue ?? false,
   };
   if (needsAttachMove) {
     state.hasAttachedMoves = true;
@@ -307,23 +337,63 @@ export function updateElementTemplateListItem(
   const previous = state.items[index]!;
   const hasCurrentChange = previous.templateKey !== item.templateKey
     || !isDirectOrDeepEqual(previous.platformInfo, item.platformInfo);
-  if (!hasCurrentChange) {
+  let hasSubtreeHandlesChange = previous.subtreeHandles.length !== item.subtreeHandles.length;
+  for (
+    let handleIndex = 0;
+    !hasSubtreeHandlesChange && handleIndex < previous.subtreeHandles.length;
+    handleIndex += 1
+  ) {
+    hasSubtreeHandlesChange = previous.subtreeHandles[handleIndex]!.uid !== item.subtreeHandles[handleIndex]!.uid;
+  }
+  if (!hasCurrentChange && !hasSubtreeHandlesChange) {
     // Hydrate emits retained item refreshes without serialized platformInfo, so
     // unchanged items must not dirty the list or trigger an empty final flush.
+    return;
+  }
+  if (hasSubtreeHandlesChange) {
+    const attachedItem = attachedListItemByUid.get(item.uid)?.item;
+    const lifecycleItem = attachedItem ?? previous;
+    const previousHandleUids = new Set<number>();
+    for (let handleIndex = 0; handleIndex < lifecycleItem.subtreeHandles.length; handleIndex += 1) {
+      previousHandleUids.add(lifecycleItem.subtreeHandles[handleIndex]!.uid);
+    }
+    const addedHandles: MainThreadDynamicAttrSubtreeHandle[] = [];
+    for (let handleIndex = 0; handleIndex < item.subtreeHandles.length; handleIndex += 1) {
+      const handle = item.subtreeHandles[handleIndex]!;
+      if (!previousHandleUids.has(handle.uid)) {
+        addedHandles.push(handle);
+      }
+    }
+    if (addedHandles.length > 0) {
+      if (lifecycleItem.attached) {
+        attachMainThreadDynamicAttrRefsForSubtree(addedHandles);
+      } else {
+        detachMainThreadDynamicAttrRefsForSubtree(addedHandles);
+      }
+    }
+    lifecycleItem.subtreeHandles = item.subtreeHandles;
+  }
+  if (!hasCurrentChange) {
+    previous.subtreeHandles = item.subtreeHandles;
     return;
   }
   if (!pendingListUpdates.has(uid)) {
     markPendingListUpdate(uid, state);
   }
-  state.items[index] = {
+  const next: ETListItemRecord = {
     uid: item.uid,
     ref: item.ref,
     templateKey: item.templateKey,
     platformInfo: item.platformInfo,
+    subtreeHandles: item.subtreeHandles,
     attached: previous.attached,
     needsAttachMove: previous.needsAttachMove,
-    skipNextEnqueue: previous.skipNextEnqueue,
   };
+  state.items[index] = next;
+  const attachedItem = attachedListItemByUid.get(item.uid);
+  if (attachedItem?.item === previous) {
+    attachedItem.item = next;
+  }
 }
 
 export function flushPendingElementTemplateListUpdates(): ETListFlushResult[] {
@@ -549,24 +619,22 @@ function createEnqueueComponentCallback(state: ETListState): EnqueueComponentCal
       }
       return;
     }
-    if (item.skipNextEnqueue) {
-      item.skipNextEnqueue = false;
+    if (item.needsAttachMove) {
+      state.releasedMoveItemUids.add(item.uid);
       if (shouldLog) {
         logListCallbackAlog('enqueue-component returned', {
           listHandleId: state.listHandleId,
           listID,
           sign,
           itemHandleId: item.uid,
-          reason: 'skip-next-enqueue',
+          reason: 'same-list-move-rebind',
         });
       }
       return;
     }
 
-    __RemoveNodeFromElementTemplate(state.holderRef!, LIST_ELEMENT_SLOT_INDEX, item.ref);
-    item.attached = false;
-    item.needsAttachMove = false;
-    state.callbackItemBySign.delete(sign);
+    const attachedItem = attachedListItemByUid.get(item.uid)!;
+    detachListItemFromHolder(state, item, attachedItem);
     if (shouldLog) {
       logListCallbackAlog('enqueue-component detached', {
         listHandleId: state.listHandleId,
@@ -609,12 +677,27 @@ function attachListItemAtIndex(
     });
   }
   moveAttachedListItemsIntoFinalOrder(state, list);
-  if (!item.attached) {
+  let sign: number;
+  if (item.attached) {
+    const attachedItem = attachedListItemByUid.get(item.uid)!;
+    attachedItem.item = item;
+    sign = attachedItem.sign;
+    state.callbackItemBySign.set(sign, item);
+  } else {
     const referenceItem = findNextAttachedItem(state, cellIndex);
     const referenceRef = referenceItem?.ref ?? null;
-    __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
+    insertElementTemplateSubtree(
+      list,
+      LIST_ELEMENT_SLOT_INDEX,
+      item.ref,
+      referenceRef,
+      item.subtreeHandles,
+    );
     item.attached = true;
     item.needsAttachMove = false;
+    sign = __GetElementUniqueID(item.ref);
+    attachedListItemByUid.set(item.uid, { item, sign });
+    state.callbackItemBySign.set(sign, item);
     if (shouldLog) {
       logListCallbackAlog('attach-list-item inserted', {
         listHandleId: state.listHandleId,
@@ -625,9 +708,6 @@ function attachListItemAtIndex(
       });
     }
   }
-
-  const sign = __GetElementUniqueID(item.ref);
-  state.callbackItemBySign.set(sign, item);
   if (shouldLog) {
     logListCallbackAlog('attach-list-item sign', {
       listHandleId: state.listHandleId,
@@ -691,21 +771,51 @@ function moveAttachedListItemsIntoFinalOrder(
     return;
   }
 
-  let referenceRef: ElementRef | null = null;
-  for (let index = state.items.length - 1; index >= 0; index -= 1) {
-    const item = state.items[index]!;
-    if (!item.attached) {
-      item.needsAttachMove = false;
-      continue;
+  try {
+    let referenceRef: ElementRef | null = null;
+    for (let index = state.items.length - 1; index >= 0; index -= 1) {
+      const item = state.items[index]!;
+      if (!item.attached) {
+        item.needsAttachMove = false;
+        continue;
+      }
+      if (item.needsAttachMove) {
+        __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
+        item.needsAttachMove = false;
+        state.releasedMoveItemUids.delete(item.uid);
+      }
+      referenceRef = item.ref;
     }
-    if (item.needsAttachMove) {
-      __InsertNodeToElementTemplate(list, LIST_ELEMENT_SLOT_INDEX, item.ref, referenceRef);
-      item.needsAttachMove = false;
-      item.skipNextEnqueue = true;
+    state.hasAttachedMoves = false;
+  } catch (error) {
+    for (const item of state.items) {
+      if (item.needsAttachMove && state.releasedMoveItemUids.has(item.uid)) {
+        detachListItemFromHolder(
+          state,
+          item,
+          attachedListItemByUid.get(item.uid)!,
+        );
+      }
     }
-    referenceRef = item.ref;
+    state.hasAttachedMoves = state.items.some((item) => item.needsAttachMove);
+    throw error;
   }
-  state.hasAttachedMoves = false;
+}
+
+function detachListItemFromHolder(
+  state: ETListState,
+  item: ETListItemRecord,
+  attachedItem: AttachedETListItem,
+): void {
+  __RemoveNodeFromElementTemplate(state.holderRef!, LIST_ELEMENT_SLOT_INDEX, item.ref);
+  detachMainThreadDynamicAttrRefsForSubtree(attachedItem.item.subtreeHandles);
+  attachedListItemByUid.delete(item.uid);
+  attachedItem.item.attached = false;
+  attachedItem.item.needsAttachMove = false;
+  item.attached = false;
+  item.needsAttachMove = false;
+  state.releasedMoveItemUids.delete(item.uid);
+  state.callbackItemBySign.delete(attachedItem.sign);
 }
 
 function findNextAttachedItem(

--- a/packages/react/runtime/src/element-template/runtime/patch.ts
+++ b/packages/react/runtime/src/element-template/runtime/patch.ts
@@ -443,11 +443,16 @@ function resolveTypedListItem(
   // native list identifies items by the same identity key the templates were
   // registered under (see the `createTemplate` op above), so normalize it.
   const nativeTemplate = parseElementTemplateType(item.type);
+  const subtreeHandles = resolveSubtreeHandles(item.subtreeHandleIds, `${role} subtree`);
+  if (subtreeHandles === null) {
+    return null;
+  }
   return {
     uid: item.__etHandleRef,
     ref,
     templateKey: elementTemplateIdentityKey(nativeTemplate.templateKey, nativeTemplate.bundleUrl),
     platformInfo: item.platformInfo,
+    subtreeHandles,
   };
 }
 

--- a/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
+++ b/packages/react/runtime/src/element-template/runtime/render/render-opcodes.ts
@@ -210,6 +210,7 @@ export function renderOpcodesIntoElementTemplate(
             // update path (`resolveTypedListItem`) stays consistent with it.
             templateKey: elementTemplateIdentityKey(nativeTemplate.templateKey, nativeTemplate.bundleUrl),
             platformInfo: listItemPlatformInfo,
+            subtreeHandles: materializationHandles,
           });
         }
         appendChildToParent(


### PR DESCRIPTION
This is 6/6 of the Element Template MainThreadRef stack and depends on #3612.

## Scope

- Turn the ET main-thread-function example into a focused MainThreadRef smoke page.
- Show direct attachment, updates, cleanup, and typed-list holder reuse as visible pass or fail states.
- Keep the example suitable for simulator and device acceptance checks.

## Review boundary

This layer contains no runtime implementation. It is the manual smoke surface for the preceding five PRs.

A changeset is not required because this is an unreleased ET example.

@coderabbitai summary

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).