### PR TITLE
ci: install pnpr before starting publish registry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,7 +218,8 @@ jobs:
         export no_proxy="${no_proxy:+$no_proxy,}localhost,127.0.0.1"
         pnpr_config="$RUNNER_TEMP/pnpr-config.json"
         node packages/tools/canary-release/pnpr-config.js "$pnpr_config" "$RUNNER_TEMP/pnpr-storage"
-        pnpm --config.minimum-release-age=0 dlx @pnpm/pnpr@0.1.0-alpha.7 \
+        npm install --global @pnpm/pnpr@0.1.0-alpha.7
+        pnpr \
           --config "$pnpr_config" \
           --listen 127.0.0.1:4873 \
           --public-url http://localhost:4873 &


### PR DESCRIPTION
## Summary

- install the pinned pnpr release before starting the local publish registry
- keep the readiness retry window focused on server startup

## Why

The previous background pnpm dlx command downloaded pnpr while the readiness probe was already retrying. On a cold runner, that download consumed the retry window and curl exited with code 7 before pnpr listened on port 4873.

Installing pnpr synchronously with npm removes the download from the startup window while keeping the package version pinned.

## Validation

- pnpm install --frozen-lockfile
- pnpm biome check
- pnpm dprint check .github/workflows/test.yml
- parsed the workflow YAML and checked its embedded shell with bash -n
- installed pnpr into a temporary global prefix and verified pnpr --version

## Checklist

- [x] Tests updated (not required; this changes CI orchestration only).
- [x] Documentation updated (not required; no user-facing behavior changed).
- [x] Changeset added (not required; no package behavior changed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test publishing workflow to use a globally installed publishing utility.
  * Simplified the command used to run the publishing step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->