### PR TITLE
fix(react): make commit hook installation idempotent and restorable

### DIFF
--- a/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
+++ b/packages/react/runtime/__test__/element-template/runtime/background/commit-hook.test.ts
@@ -11,6 +11,7 @@ import {
   markElementTemplateHydrated,
   resetElementTemplateCommitState,
   scheduleElementTemplateRemovedSubtreeCleanup,
+  uninstallElementTemplateCommitHookForTesting,
 } from '../../../../src/element-template/background/commit-hook.js';
 import { destroyElementTemplateBackgroundRuntime } from '../../../../src/element-template/background/destroy.js';
 import {
@@ -759,7 +760,47 @@ describe('ElementTemplate commit hook', () => {
 
   it('is idempotent', () => {
     installElementTemplateCommitHook();
+    const wrapped = options.__c;
     installElementTemplateCommitHook();
-    expect(true).toBe(true);
+    expect(options.__c).toBe(wrapped);
+  });
+
+  it('can be uninstalled and reinstalled', () => {
+    installElementTemplateCommitHook();
+    const wrapped = options.__c;
+    uninstallElementTemplateCommitHookForTesting();
+    const original = options.__c;
+    expect(original).not.toBe(wrapped);
+
+    uninstallElementTemplateCommitHookForTesting();
+    expect(options.__c).toBe(original);
+
+    installElementTemplateCommitHook();
+    expect(options.__c).not.toBe(original);
+    uninstallElementTemplateCommitHookForTesting();
+    expect(options.__c).toBe(original);
+    installElementTemplateCommitHook();
+  });
+
+  it('deletes the commit option when none existed before install', () => {
+    uninstallElementTemplateCommitHookForTesting();
+    const hadCommit = '__c' in options;
+    const original = options.__c;
+    try {
+      delete options.__c;
+
+      installElementTemplateCommitHook();
+      expect(typeof options.__c).toBe('function');
+      uninstallElementTemplateCommitHookForTesting();
+      expect('__c' in options).toBe(false);
+    } finally {
+      uninstallElementTemplateCommitHookForTesting();
+      if (hadCommit && original) {
+        options.__c = original;
+      } else {
+        delete options.__c;
+      }
+      installElementTemplateCommitHook();
+    }
   });
 });

--- a/packages/react/runtime/__test__/snapshot/delayed-lifecycle-events.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/delayed-lifecycle-events.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { delayedLifecycleEvents } from '../../src/snapshot/lifecycle/event/delayLifecycleEvents';
 import { flushDelayedLifecycleEvents } from '../../src/snapshot/lynx/tt';
 import { __root } from '../../src/root';
@@ -7,8 +7,11 @@ import { expect } from 'vitest';
 import { render } from 'preact';
 import { replaceCommitHook } from '../../src/snapshot/lifecycle/patch/commit';
 
-beforeEach(() => {
+beforeAll(() => {
   replaceCommitHook();
+});
+
+beforeEach(() => {
   globalEnvManager.resetEnv();
 });
 afterEach(() => {

--- a/packages/react/runtime/__test__/snapshot/lifecycle/commitHook.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/commitHook.test.jsx
@@ -1,0 +1,81 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { render } from 'preact';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useState } from '../../../src/index';
+import { __root } from '../../../src/root';
+import { setupPage } from '../../../src/snapshot';
+import { replaceCommitHook } from '../../../src/snapshot/lifecycle/patch/commit';
+import { injectUpdateMainThread } from '../../../src/snapshot/lifecycle/patch/updateMainThread';
+import { globalEnvManager } from '../utils/envManager';
+import { elementTree, waitSchedule } from '../utils/nativeMethod';
+
+beforeAll(() => {
+  setupPage(__CreatePage('0', 0));
+  injectUpdateMainThread();
+});
+
+beforeEach(() => {
+  globalEnvManager.resetEnv();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  elementTree.clear();
+});
+
+function mountAndHydrate(jsx) {
+  __root.__jsx = jsx;
+  renderPage();
+
+  globalEnvManager.switchToBackground();
+  render(jsx, __root);
+
+  lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+
+  globalEnvManager.switchToMainThread();
+  const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls.at(-1);
+  globalThis[rLynxChange[0]](rLynxChange[1]);
+
+  globalEnvManager.switchToBackground();
+  rLynxChange[2]?.();
+}
+
+describe('replaceCommitHook', () => {
+  // Repeated installation (as test files do in `beforeEach`) stacks one
+  // commit-hook wrapper per call onto Preact's global `options`. On every
+  // commit the outermost wrapper takes the real snapshot patch and each
+  // inner copy re-fires with an already-drained queue, sending a spurious
+  // empty patch per extra install.
+  it('stacks wrappers and sends duplicate empty patches when installed repeatedly', async () => {
+    replaceCommitHook();
+    replaceCommitHook();
+    replaceCommitHook();
+
+    let setText;
+    function App() {
+      const [text, setState] = useState('a');
+      setText = setState;
+      return <text>{text}</text>;
+    }
+
+    mountAndHydrate(<App />);
+
+    const callsBeforeUpdate = lynx.getNativeApp().callLepusMethod.mock.calls.length;
+    setText('b');
+    await waitSchedule();
+
+    const newCalls = lynx.getNativeApp().callLepusMethod.mock.calls.slice(callsBeforeUpdate);
+    expect(newCalls.length).toBe(3);
+
+    const patches = newCalls.map(call => JSON.parse(call[1].data));
+    expect(patches[0].patchList[0].snapshotPatch).not.toHaveLength(0);
+    expect(patches[1].patchList[0].snapshotPatch).toBeUndefined();
+    expect(patches[1].flushOptions).toMatchObject({ emptyPatch: true });
+    expect(patches[2].patchList[0].snapshotPatch).toBeUndefined();
+    expect(patches[2].flushOptions).toMatchObject({ emptyPatch: true });
+  });
+});

--- a/packages/react/runtime/__test__/snapshot/lifecycle/commitHook.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/commitHook.test.jsx
@@ -2,13 +2,13 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { render } from 'preact';
+import { options, render } from 'preact';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useState } from '../../../src/index';
 import { __root } from '../../../src/root';
 import { setupPage } from '../../../src/snapshot';
-import { replaceCommitHook } from '../../../src/snapshot/lifecycle/patch/commit';
+import { removeCommitHookForTesting, replaceCommitHook } from '../../../src/snapshot/lifecycle/patch/commit';
 import { injectUpdateMainThread } from '../../../src/snapshot/lifecycle/patch/updateMainThread';
 import { globalEnvManager } from '../utils/envManager';
 import { elementTree, waitSchedule } from '../utils/nativeMethod';
@@ -23,6 +23,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  removeCommitHookForTesting();
   vi.restoreAllMocks();
   elementTree.clear();
 });
@@ -45,12 +46,14 @@ function mountAndHydrate(jsx) {
 }
 
 describe('replaceCommitHook', () => {
-  // Repeated installation (as test files do in `beforeEach`) stacks one
-  // commit-hook wrapper per call onto Preact's global `options`. On every
-  // commit the outermost wrapper takes the real snapshot patch and each
-  // inner copy re-fires with an already-drained queue, sending a spurious
-  // empty patch per extra install.
-  it('stacks wrappers and sends duplicate empty patches when installed repeatedly', async () => {
+  it('is idempotent', () => {
+    replaceCommitHook();
+    const wrapped = options.__c;
+    replaceCommitHook();
+    expect(options.__c).toBe(wrapped);
+  });
+
+  it('sends a single patch per commit when installed repeatedly', async () => {
     replaceCommitHook();
     replaceCommitHook();
     replaceCommitHook();
@@ -68,14 +71,42 @@ describe('replaceCommitHook', () => {
     setText('b');
     await waitSchedule();
 
-    const newCalls = lynx.getNativeApp().callLepusMethod.mock.calls.slice(callsBeforeUpdate);
-    expect(newCalls.length).toBe(3);
+    expect(lynx.getNativeApp().callLepusMethod.mock.calls.length).toBe(callsBeforeUpdate + 1);
+  });
 
-    const patches = newCalls.map(call => JSON.parse(call[1].data));
-    expect(patches[0].patchList[0].snapshotPatch).not.toHaveLength(0);
-    expect(patches[1].patchList[0].snapshotPatch).toBeUndefined();
-    expect(patches[1].flushOptions).toMatchObject({ emptyPatch: true });
-    expect(patches[2].patchList[0].snapshotPatch).toBeUndefined();
-    expect(patches[2].flushOptions).toMatchObject({ emptyPatch: true });
+  it('can be removed and reinstalled', () => {
+    replaceCommitHook();
+    const wrapped = options.__c;
+    removeCommitHookForTesting();
+    const original = options.__c;
+    expect(original).not.toBe(wrapped);
+
+    removeCommitHookForTesting();
+    expect(options.__c).toBe(original);
+
+    replaceCommitHook();
+    expect(options.__c).not.toBe(original);
+    removeCommitHookForTesting();
+    expect(options.__c).toBe(original);
+  });
+
+  it('deletes the commit option when none existed before install', () => {
+    const hadCommit = '__c' in options;
+    const original = options.__c;
+    try {
+      delete options.__c;
+
+      replaceCommitHook();
+      expect(typeof options.__c).toBe('function');
+      removeCommitHookForTesting();
+      expect('__c' in options).toBe(false);
+    } finally {
+      removeCommitHookForTesting();
+      if (hadCommit) {
+        options.__c = original;
+      } else {
+        delete options.__c;
+      }
+    }
   });
 });

--- a/packages/react/runtime/__test__/snapshot/page.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/page.test.jsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { __page } from '../../src/snapshot';
 import { globalEnvManager } from './utils/envManager';
@@ -9,8 +9,11 @@ import { render } from 'preact';
 import { replaceCommitHook } from '../../src/snapshot/lifecycle/patch/commit';
 import { deinitGlobalSnapshotPatch } from '../../src/snapshot/lifecycle/patch/snapshotPatch';
 
-beforeEach(() => {
+beforeAll(() => {
   replaceCommitHook();
+});
+
+beforeEach(() => {
   globalEnvManager.resetEnv();
   elementTree.clear();
 });

--- a/packages/react/runtime/__test__/snapshot/worklet/runOnMainThread.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/worklet/runOnMainThread.test.jsx
@@ -62,13 +62,13 @@ beforeAll(() => {
       MTFQueue.push({ api: '__FlushElementTree' });
     }),
   );
+  replaceCommitHook();
 });
 
 beforeEach(() => {
   globalThis.SystemInfo.lynxSdkVersion = '2.14';
   clearConfigCacheForTesting();
   globalEnvManager.resetEnv();
-  replaceCommitHook();
 });
 
 afterEach(() => {

--- a/packages/react/runtime/src/element-template/background/commit-hook.ts
+++ b/packages/react/runtime/src/element-template/background/commit-hook.ts
@@ -26,6 +26,7 @@ import { clearPendingRefs, flushPendingRefs, hasPendingRefs } from '../prop-adap
 import { createElementTemplateUpdateEvent } from '../protocol/update-event.js';
 
 let installed = false;
+let previousCommit: typeof options[typeof COMMIT];
 let hasHydrated = false;
 const scheduledRemovedSubtreeCleanupTimers = /*#__PURE__*/ new Set<ReturnType<typeof setTimeout>>();
 
@@ -152,6 +153,7 @@ export function installElementTemplateCommitHook(): void {
     return;
   }
   installed = true;
+  previousCommit = options[COMMIT];
 
   hook(options, COMMIT, (originalCommit, vnode, commitQueue) => {
     if (__BACKGROUND__) {
@@ -176,4 +178,25 @@ export function installElementTemplateCommitHook(): void {
 
     originalCommit?.(vnode, commitQueue);
   });
+}
+
+/**
+ * Restores the commit option replaced by
+ * {@link installElementTemplateCommitHook} so tests can clean up the global
+ * Preact `options` object. Assumes the matching install was the most recent
+ * commit-option replacement; the snapshot and ElementTemplate runtimes are
+ * separate entrypoints and never install their commit hooks in the same
+ * context.
+ */
+export function uninstallElementTemplateCommitHookForTesting(): void {
+  if (!installed) {
+    return;
+  }
+  installed = false;
+  if (previousCommit) {
+    options[COMMIT] = previousCommit;
+    previousCommit = undefined;
+  } else {
+    delete options[COMMIT];
+  }
 }

--- a/packages/react/runtime/src/snapshot/lifecycle/patch/commit.ts
+++ b/packages/react/runtime/src/snapshot/lifecycle/patch/commit.ts
@@ -88,10 +88,20 @@ function takeGlobalPatchOptions(): GlobalPatchOptions {
   return res;
 }
 
+let commitHookInstalled = false;
+let previousCommit: typeof options[typeof COMMIT];
+
 /**
- * Replaces Preact's default commit hook with our custom implementation
+ * Replaces Preact's default commit hook with our custom implementation.
+ * Calling it again is a no-op until {@link removeCommitHookForTesting} is called.
  */
 function replaceCommitHook(): void {
+  if (commitHookInstalled) {
+    return;
+  }
+  commitHookInstalled = true;
+  previousCommit = options[COMMIT];
+
   hook(
     options,
     COMMIT,
@@ -179,6 +189,26 @@ function replaceCommitHook(): void {
 }
 
 /**
+ * Restores the commit option replaced by {@link replaceCommitHook} so tests
+ * can clean up the global Preact `options` object. Assumes the matching
+ * install was the most recent commit-option replacement; the snapshot and
+ * ElementTemplate runtimes are separate entrypoints and never install their
+ * commit hooks in the same context.
+ */
+function removeCommitHookForTesting(): void {
+  if (!commitHookInstalled) {
+    return;
+  }
+  commitHookInstalled = false;
+  if (previousCommit) {
+    options[COMMIT] = previousCommit;
+    previousCommit = undefined;
+  } else {
+    delete options[COMMIT];
+  }
+}
+
+/**
  * Prepares the patch update for transmission to the native layer
  */
 function commitPatchUpdate(patchList: PatchList, patchOptions: GlobalPatchOptions): {
@@ -240,6 +270,7 @@ export {
   genCommitTaskId,
   globalBackgroundSnapshotInstancesToRemove,
   globalCommitTaskMap,
+  removeCommitHookForTesting,
   replaceCommitHook,
   type PatchList,
   type PatchOptions,


### PR DESCRIPTION
## What

Two commits:

1. `test(react)`: lock the current behavior in a regression test — installing `replaceCommitHook` three times makes one commit send 3 patches: the real one plus one spurious `emptyPatch` per extra install.
2. `fix(react)`: guard `replaceCommitHook` with an installed flag (mirroring the existing guard in `installElementTemplateCommitHook`) and flip the test to assert a single patch per commit. Move the three per-test installs (`page`, `delayed-lifecycle-events`, `runOnMainThread`) from `beforeEach` to `beforeAll` like every other snapshot test file. Add `removeCommitHookForTesting` / `uninstallElementTemplateCommitHookForTesting` (`ForTesting` suffix per the existing `clearConfigCacheForTesting` convention) so tests can restore the original `options.__c`.

## Why

Installing the commit hook in `beforeEach` stacked one wrapper per test onto Preact's module-global `options`. Every commit then re-fired each stacked copy: the outermost takes the real snapshot patch and each inner copy sends a spurious empty `rLynxChange` patch. Existing assertions never observed the trailing empties (they index early calls only), which is why no snapshots change. The ElementTemplate runtime is already guarded; `testing-library` installs once per file and is unaffected.

## Validation

- Commit 1 passes on the unfixed code; its assertions flip in commit 2.
- `test:snapshot` 777 passed, `test:et` 730 passed, `test:core` 55 passed, coverage stays 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented repeated commit-hook installation from stacking duplicate hooks.
  - Preserved and restored previously configured commit behavior when hooks are removed.
  - Ensured cleanup removes temporary commit settings when no prior configuration exists.
  - Improved hook uninstall and reinstall behavior across lifecycle and element-template flows.
- **Tests**
  - Added coverage for idempotent installation, restoration, removal, and reinstallation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->