### PR TITLE
fix: drop the redundant scoped @rspack/core overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,6 @@ catalogs:
 overrides:
   '@lynx-js/react': workspace:*
   '@rspack/core': 2.1.7
-  '@rsbuild/core>@rspack/core': 2.1.7
-  '@rsdoctor/rspack-plugin>@rspack/core': 2.1.7
-  '@rsdoctor/types>@rspack/core': 2.1.7
 
 packageExtensionsChecksum: sha256-Y9ZLHWMP51V1VaeUicx/UxFRX96fq7QFLXtege8aEOA=
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -149,9 +149,6 @@ overrides:
   # found"). Force every @lynx-js/react to the single workspace copy.
   "@lynx-js/react": "workspace:*"
   "@rspack/core": "catalog:rspack"
-  "@rsbuild/core>@rspack/core": "catalog:rspack"
-  "@rsdoctor/rspack-plugin>@rspack/core": "catalog:rspack"
-  "@rsdoctor/types>@rspack/core": "catalog:rspack"
 
 packageExtensions:
   # Typia's internal packages import TypeScript without declaring it. Keep


### PR DESCRIPTION
## Why

`pnpm-workspace.yaml` pins `@rspack/core` four times:

```yaml
"@rspack/core": "catalog:rspack"
"@rsbuild/core>@rspack/core": "catalog:rspack"
"@rsdoctor/rspack-plugin>@rspack/core": "catalog:rspack"
"@rsdoctor/types>@rspack/core": "catalog:rspack"
```

The scoped entries date back to #2497, when rsbuild2 needed a different rspack
than the rest of the workspace. Since #2603 moved everything to rspack v2 they
all resolve to the same catalog version, and a bare override already applies at
every depth, so the three scoped ones no longer do anything.

## What they do break

[rstack-ecosystem-ci](https://github.com/rstackjs/rstack-ecosystem-ci) builds
rspack from source and swaps it into this repo by merging its overrides into
`pnpm-workspace.yaml` key by key (`utils.ts`):

```js
wsContent.overrides = { ...wsContent.overrides, ...normalizedOverrides }
```

`@rspack/core` and `@rspack/binding` are replaced because the keys match. A
scoped key is a *different* key, so it survives the merge — anything resolving
`@rspack/core` through `@rsbuild/core` keeps the catalog version while the
binding moves to the locally built one:

```
error   Unmatched version @rspack/core@2.1.7 and @rspack/binding@2.2.0-rc.0.
	The expected version of @rspack/core to the current binding is 2.2.0-rc.0.
```

That fails every `rslib build` in the suite, since rslib goes through
`@rsbuild/core`:
https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/32465342299/job/96724567475

## Verified

Removing them changes no resolution. The whole lockfile diff is the three
override records:

```
-  '@rsbuild/core>@rspack/core': 2.1.7
-  '@rsdoctor/rspack-plugin>@rspack/core': 2.1.7
-  '@rsdoctor/types>@rspack/core': 2.1.7
```

`@rspack/core` still resolves to `2.1.7` and nothing else, before and after.
`pnpm dedupe --check --lockfile-only` and `pnpm peers check --lockfile-only`
both pass.

No changeset: `pnpm-workspace.yaml` is not a published manifest, and
`check-dep-changes-have-changeset.cjs` only inspects `package.json` files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified dependency configuration by removing redundant transitive package overrides.
  * Retained the direct package version override to maintain consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->