### PR TITLE
fix(web-core): report event dispatch failures

### DIFF
--- a/.changeset/report-event-dispatch-errors.md
+++ b/.changeset/report-event-dispatch-errors.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/web-core": patch
+---
+
+Report cross-thread event and main-thread worklet failures instead of silently dropping them.

--- a/.github/web-core-wasm-boundary.instructions.md
+++ b/.github/web-core-wasm-boundary.instructions.md
@@ -3,3 +3,4 @@ applyTo: "packages/web-platform/web-core/{src,ts,tests}/**/*,packages/web-platfo
 ---
 
 Treat potentially throwing Rust-to-JavaScript event dispatch imports made while a `MainThreadWasmContext` export is active as WebAssembly exception boundaries: declare them with `wasm-bindgen(catch)` and consume their `Result` so an exception cannot escape through the wasm frame and leave the context's borrow guard active. Keep this boundary independent of element event-listener registration and callback invocation. Add regression tests that throw from the real JavaScript binding and invoke another wasm context method afterward.
+Do not silently discard cross-thread event or main-thread worklet failures at that boundary. Catch them in the JavaScript binding, defer reporting until the active WebAssembly frame has unwound, then route them through the main-thread `_ReportError` hook so hosts receive the existing `error` event.

--- a/packages/web-platform/web-core/tests/element-apis.spec.ts
+++ b/packages/web-platform/web-core/tests/element-apis.spec.ts
@@ -1676,11 +1676,13 @@ describe('Element APIs', () => {
     );
   });
 
-  test('cross-thread event errors do not escape the wasm boundary', () => {
+  test('cross-thread event errors are reported after leaving the wasm boundary', async () => {
     const publishError = new DOMException(
       'The object could not be cloned.',
       'DataCloneError',
     );
+    const reportError = rstest.fn();
+    mtsBinding.lynxViewInstance.mainThreadGlobalThis._ReportError = reportError;
     mtsBinding.lynxViewInstance.backgroundThread.publishEvent = rstest.fn(
       () => {
         throw publishError;
@@ -1699,29 +1701,24 @@ describe('Element APIs', () => {
         new window.Event('click'),
       );
     }).not.toThrow();
+    expect(reportError).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(publishError, undefined);
     expect(() => mtsGlobalThis.__CreateView(0)).not.toThrow();
   });
 
-  test('worklet errors do not escape the wasm boundary', () => {
+  test('worklet errors are reported after leaving the wasm boundary', async () => {
     const workletError = {
       name: 'TypeError',
       message: 'worklet failed',
       stack: 'TypeError: worklet failed\n    at worklet.js:1:1',
     };
-    mtsBinding = new WASMJSBinding(
-      createTestLynxViewInstance(rootDom, {
-        runWorklet: () => {
-          throw workletError;
-        },
-      } as any),
-    );
-    mtsGlobalThis = createElementAPI(
-      rootDom,
-      mtsBinding,
-      true,
-      true,
-      true,
-    );
+    const reportError = rstest.fn();
+    mtsBinding.lynxViewInstance.mainThreadGlobalThis.runWorklet = () => {
+      throw workletError;
+    };
+    mtsBinding.lynxViewInstance.mainThreadGlobalThis._ReportError = reportError;
 
     const page = mtsGlobalThis.__CreatePage('0', 0);
     const target = mtsGlobalThis.__CreateView(0);
@@ -1740,6 +1737,10 @@ describe('Element APIs', () => {
         new window.Event('click'),
       );
     }).not.toThrow();
+    expect(reportError).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(workletError, undefined);
     expect(() => mtsGlobalThis.__CreateView(0)).not.toThrow();
   });
 

--- a/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/elementAPIs/WASMJSBinding.ts
@@ -96,6 +96,15 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     return undefined;
   }
 
+  #reportErrorAfterWasmUnwinds(error: unknown): void {
+    queueMicrotask(() => {
+      this.lynxViewInstance.mainThreadGlobalThis._ReportError(
+        error as Error,
+        undefined,
+      );
+    });
+  }
+
   runWorklet(
     handler: { value: unknown },
     eventObject: LynxCrossThreadEvent,
@@ -125,9 +134,14 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
     eventObject.target.elementRefptr = resolvedTarget;
     // @ts-expect-error
     eventObject.currentTarget.elementRefptr = currentTarget;
-    this.lynxViewInstance.mainThreadGlobalThis.runWorklet?.(handler.value, [
-      eventObject,
-    ]);
+    try {
+      this.lynxViewInstance.mainThreadGlobalThis.runWorklet?.(handler.value, [
+        eventObject,
+      ]);
+    } catch (error) {
+      this.#reportErrorAfterWasmUnwinds(error);
+      throw error;
+    }
   }
 
   /**
@@ -197,17 +211,22 @@ export class WASMJSBinding implements RustMainthreadContextBinding {
       currentTarget as DecoratedHTMLElement,
       currentTargetDataset,
     );
-    if (parentComponentId) {
-      this.lynxViewInstance?.backgroundThread.publicComponentEvent(
-        parentComponentId,
-        handlerName,
-        eventObject,
-      );
-    } else {
-      this.lynxViewInstance.backgroundThread.publishEvent(
-        handlerName,
-        eventObject,
-      );
+    try {
+      if (parentComponentId) {
+        this.lynxViewInstance?.backgroundThread.publicComponentEvent(
+          parentComponentId,
+          handlerName,
+          eventObject,
+        );
+      } else {
+        this.lynxViewInstance.backgroundThread.publishEvent(
+          handlerName,
+          eventObject,
+        );
+      }
+    } catch (error) {
+      this.#reportErrorAfterWasmUnwinds(error);
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

- report cross-thread event publication failures through the existing `<lynx-view>` error channel
- report main-thread worklet failures through the same channel
- defer reporting until the active WASM frame has unwound, preserving the safety guarantee from #3356
- keep `x-text` layout detail and its MTS-only lazy-read behavior unchanged

This completes the error-reporting half of #3356. That change catches JavaScript exceptions at the WASM boundary so the runtime remains usable, but the returned error is discarded. A failed event therefore becomes invisible.

## Minimal reproduction

```jsx
<text text-maxline="2" bindlayout={onLayout}>
  A title long enough to wrap
</text>
```

`x-text` layout detail is intentionally lazy and intended for main-thread handlers. If it is bound to a background-thread handler, posting the event throws `DataCloneError`. Before this change, #3356 catches that exception at the WASM boundary and then silently discards it: `onLayout` does not run and the host receives no error.

After this change, the runtime still catches the exception and remains usable, but the same error is asynchronously delivered through the existing `<lynx-view>` `error` event. The same behavior applies when a main-thread worklet throws.

This PR deliberately does not make layout detail cloneable or move its measurement to the background-thread path; the existing MTS on-demand contract is preserved.
Consumers that only need a layout-ready signal should use the common `layoutchange` event. Consumers that need text line metadata should use `main-thread:bindlayout`. Follow-up #3626 fixes repeated reads within that lazy MTS detail without changing its thread contract.

## Testing

- `pnpm turbo build` (72/72 tasks)
- `pnpm dprint check`
- `pnpm eslint .` with the repository-recommended 32 GB Node heap (0 errors)
- `pnpm --filter @lynx-js/web-core test -- element-apis.spec.ts -t 'reported after leaving the wasm boundary'` (402/402)
- `cargo test --all-features` in `packages/web-platform/web-core` (120/120)

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
- [x] Changeset added.
