### PR TITLE
fix(react-signals): ship CHANGELOG.md

### DIFF
--- a/.changeset/react-signals-ship-changelog.md
+++ b/.changeset/react-signals-ship-changelog.md
@@ -1,0 +1,4 @@
+---
+---
+
+Ship `CHANGELOG.md` in the published package, like every other package here.

--- a/packages/react-signals/package.json
+++ b/packages/react-signals/package.json
@@ -29,6 +29,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
+    "CHANGELOG.md",
     "dist",
     "README.md"
   ],


### PR DESCRIPTION
`packages/react-signals` was added without `CHANGELOG.md` in `files`, unlike every other published package here. Once the first changelog was generated by the 2026-08-21 release, `meta-updater --test` started reporting the manifest as out of date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * The package’s changelog is now included in published package contents, making release history available to consumers.
  * Added a release entry documenting this packaging update.
  * No changes were made to the package’s public API or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->