### PR TITLE
fix(web-elements): stabilize lazy text layout details

### DIFF
--- a/.changeset/stable-text-layout-detail.md
+++ b/.changeset/stable-text-layout-detail.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/web-elements': patch
+---
+
+Keep repeated text layout-detail reads stable and expose lazy `lines.length`.

--- a/.github/web-elements-x-text.instructions.md
+++ b/.github/web-elements-x-text.instructions.md
@@ -3,3 +3,4 @@ applyTo: "packages/web-platform/web-elements/src/elements/XText/**"
 ---
 
 When updating `x-text` truncation measurement, keep text-like inline containers such as `x-text`, `inline-text`, `raw-text`, and `lynx-wrapper` transparent so their descendants are measured with DFS. Treat `x-view` as one atomic inline box; measuring both the `x-view` and its child boxes can double-count inline views and make one visual line look like multiple lines.
+Keep text `layout` detail lazy so main-thread consumers only pay for the fields they read. Repeated reads must reuse the cached measurement, and array-like metadata such as `lines.length` must not force eager event materialization. Use the content `#inner-box` rectangle as the measurement boundary; the host rectangle includes padding and borders and produces incorrect line boundaries.

--- a/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
+++ b/packages/web-platform/web-elements/src/elements/XText/XTextTruncation.ts
@@ -371,32 +371,32 @@ export class XTextTruncation
     this.#enableLayoutEvent = status;
   }
 
+  #getTextMeasure() {
+    return this.#textMeasure ??= new TextRenderingMeasureTool(
+      this.#dom,
+      this.#getInnerBox().getBoundingClientRect(),
+    );
+  }
+
   #sendLayoutEvent(truncateAt?: number) {
     if (!this.#enableLayoutEvent) return;
     const detail = new Proxy(this, {
       get(that, property): any {
         if (property === 'lineCount') {
-          if (!that.#textMeasure) {
-            that.#textMeasure = new TextRenderingMeasureTool(
-              that.#dom,
-              that.#dom.getBoundingClientRect(),
-            );
-          }
-          return that.#textMeasure.getLineCount();
+          return that.#getTextMeasure().getLineCount();
         } else if (property === 'lines') {
           // event.detail.lines
           return new Proxy(that, {
             get(that, lineIndex): any {
+              if (lineIndex === 'length') {
+                return that.#getTextMeasure().getLineCount();
+              }
               // event.detail.lines[num]
               const lineIndexNum = parseFloat(lineIndex.toString());
               if (!isNaN(lineIndexNum)) {
-                if (!that.#textMeasure) {
-                  that.#textMeasure = new TextRenderingMeasureTool(
-                    that.#dom,
-                    that.#dom.getBoundingClientRect(),
-                  );
-                }
-                const lineInfo = that.#textMeasure.getLineInfo(lineIndexNum);
+                const lineInfo = that.#getTextMeasure().getLineInfo(
+                  lineIndexNum,
+                );
                 if (lineInfo) {
                   return new Proxy(lineInfo, {
                     get(lineInfo, property): any {
@@ -480,9 +480,7 @@ class TextRenderingMeasureTool {
     const { left: containerLeft } = this.#domRect;
     const lastLineInfo = this.#lazyLinesInfo[this.#lazyLinesInfo.length - 1];
     const lastNodeInfo = lastLineInfo?.[lastLineInfo.length - 1];
-    const nextNodeIndex = lastNodeInfo?.nodeIndex
-      ? lastNodeInfo?.nodeIndex + 1
-      : 0;
+    const nextNodeIndex = lastNodeInfo ? lastNodeInfo.nodeIndex + 1 : 0;
     for (
       let nodeIndex: number = nextNodeIndex,
         currentNodeInfo: NodeInfo | undefined;

--- a/packages/web-platform/web-elements/tests/fixtures/x-text/layout-detail-lazy.html
+++ b/packages/web-platform/web-elements/tests/fixtures/x-text/layout-detail-lazy.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<!-- Copyright 2026 The Lynx Authors. All rights reserved.
+ Licensed under the Apache License Version 2.0 that can be found in the
+ LICENSE file in the root directory of this source tree. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+      name="viewport"
+    >
+    <link href="/main.css" rel="stylesheet">
+  </head>
+  <body>
+    <script src="/main.js" defer></script>
+  </body>
+</html>

--- a/packages/web-platform/web-elements/tests/web-elements.spec.ts
+++ b/packages/web-platform/web-elements/tests/web-elements.spec.ts
@@ -122,6 +122,91 @@ test.describe('web-elements test suite', () => {
     });
   });
   test.describe('x-text', () => {
+    test('layout-detail-lazy', async ({ page }, { titlePath }) => {
+      const title = getTitle(titlePath);
+      await gotoWebComponentPage(page, title);
+      const details = await page.evaluate(async () => {
+        const readDetail = (firstProperty: 'lineCount' | 'linesLength') =>
+          new Promise<{
+            firstValue: number;
+            repeatedValue: number;
+            counterpartValue: number;
+            rangeReadCounts: number[];
+          }>((resolve, reject) => {
+            const originalGetClientRects = Range.prototype.getClientRects;
+            let rangeReadCount = 0;
+            Range.prototype.getClientRects = function() {
+              rangeReadCount++;
+              return originalGetClientRects.call(this);
+            };
+
+            try {
+              const element = document.createElement('x-text');
+              element.style.width = '140px';
+              element.style.padding = '20px';
+              element.style.wordBreak = 'break-all';
+              element.setAttribute('text-maxline', '2');
+              element.textContent =
+                'A topic title long enough to wrap across several lines';
+              element.addEventListener(
+                'layout',
+                (event) => {
+                  try {
+                    const eventDetail = (event as CustomEvent).detail;
+                    const rangeReadsBeforeDetail = rangeReadCount;
+                    const readFirstProperty = () =>
+                      firstProperty === 'lineCount'
+                        ? eventDetail.lineCount
+                        : eventDetail.lines.length;
+                    const firstValue = readFirstProperty();
+                    const rangeReadsAfterFirstValue = rangeReadCount;
+                    const repeatedValue = readFirstProperty();
+                    const rangeReadsAfterRepeatedValue = rangeReadCount;
+                    const counterpartValue = firstProperty === 'lineCount'
+                      ? eventDetail.lines.length
+                      : eventDetail.lineCount;
+                    resolve({
+                      firstValue,
+                      repeatedValue,
+                      counterpartValue,
+                      rangeReadCounts: [
+                        rangeReadsBeforeDetail,
+                        rangeReadsAfterFirstValue,
+                        rangeReadsAfterRepeatedValue,
+                        rangeReadCount,
+                      ],
+                    });
+                  } catch (error) {
+                    reject(error);
+                  } finally {
+                    Range.prototype.getClientRects = originalGetClientRects;
+                  }
+                },
+                { once: true },
+              );
+              document.body.append(element);
+            } catch (error) {
+              Range.prototype.getClientRects = originalGetClientRects;
+              reject(error);
+            }
+          });
+
+        return {
+          lineCountFirst: await readDetail('lineCount'),
+          linesLengthFirst: await readDetail('linesLength'),
+        };
+      });
+
+      for (const detail of Object.values(details)) {
+        expect(detail.firstValue).toBeGreaterThan(1);
+        expect(detail.repeatedValue).toBe(detail.firstValue);
+        expect(detail.counterpartValue).toBe(detail.firstValue);
+        expect(detail.rangeReadCounts[0]).toBe(0);
+        expect(detail.rangeReadCounts[1]).toBeGreaterThan(0);
+        expect(detail.rangeReadCounts[2]).toBe(detail.rangeReadCounts[1]);
+        expect(detail.rangeReadCounts[3]).toBe(detail.rangeReadCounts[2]);
+      }
+    });
     test('raw-text-no-js', async ({ page }, { titlePath }) => {
       const title = getTitle(titlePath);
       await gotoWebComponentPage(page, title);


### PR DESCRIPTION
## Summary

- keep repeated `event.detail.lineCount` reads stable instead of appending the same measured lines again
- expose `event.detail.lines.length` through the existing lazy measurement path
- reuse the inner text box as the measurement boundary, including for padded text

## Design

This intentionally preserves the existing MTS-only lazy-read contract. The `layout` detail remains proxy-backed and is not materialized during event dispatch, so listening to the event does not perform text measurement by itself. Measurement starts only when a main-thread consumer reads `lineCount`, `lines.length`, or an indexed line.

This is separate from #3624, which reports event-dispatch failures. It does not add background-thread support for text layout detail.

## Regression coverage

The new Playwright case verifies that:

- no `Range#getClientRects` call happens before the detail is read
- a padded text element is measured against its inner content box
- reading `lineCount` twice returns the same value without remeasuring
- `lines.length` equals `lineCount` without remeasuring

The same test fails on the previous implementation because the second read changes from `5` to `10`.

## Testing

- `pnpm turbo build` (72/72 tasks)
- `pnpm dprint check` for the changed files
- `pnpm --filter @lynx-js/web-elements test --grep 'layout-detail-lazy'` (Chromium, Firefox, WebKit)

## Checklist

- [x] Tests added
- [x] Changeset added
- [x] Repository guidance updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized repeated text layout-detail reads for `x-text`.
  * Improved multiline truncation measurement, including correct handling of single-node content.
  * Ensured measurements use the content area rather than padded or bordered regions.

* **New Features**
  * Exposed `lines.length` lazily while preserving cached repeated reads for consistent results.

* **Tests**
  * Added coverage for lazy layout metadata access, multiline content, and repeated layout-detail reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->