### PR TITLE
test(react): reach the app object through lynx.getApp() in commitHook test

### DIFF
--- a/packages/react/runtime/__test__/snapshot/lifecycle/commitHook.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/commitHook.test.jsx
@@ -35,7 +35,7 @@ function mountAndHydrate(jsx) {
   globalEnvManager.switchToBackground();
   render(jsx, __root);
 
-  lynxCoreInject.tt.OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
+  lynx.getApp().OnLifecycleEvent(...globalThis.__OnLifecycleEvent.mock.calls[0]);
 
   globalEnvManager.switchToMainThread();
   const rLynxChange = lynx.getNativeApp().callLepusMethod.mock.calls.at(-1);


### PR DESCRIPTION
The react/runtime test harness stopped defining `lynxCoreInject` when the runtime moved to `lynx.getApp()` (#3553). A test added in parallel (#3620) still reads `lynxCoreInject.tt`, so `main` now fails with `lynxCoreInject is not defined`. The two PRs touched different files, so neither conflicted and both landed.

```
FAIL react/runtime __test__/snapshot/lifecycle/commitHook.test.jsx > replaceCommitHook > sends a single patch per commit when installed repeatedly
ReferenceError: lynxCoreInject is not defined
```

`lynx.getApp()` returns the same object, so the assertion is unchanged.

Verified: `pnpm run test:snapshot` in `packages/react/runtime` — 97 files, 777 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated lifecycle test coverage to invoke lifecycle events through the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->