### PR TITLE
style: format the react-signals changeset

### DIFF
--- a/.changeset/react-signals-ship-changelog.md
+++ b/.changeset/react-signals-ship-changelog.md
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 Ship `CHANGELOG.md` in the published package, like every other package here.


### PR DESCRIPTION
`.changeset/react-signals-ship-changelog.md` (from #3625) is not dprint-formatted, so `code-style-check` fails on every open PR against current `main`.

`pnpm dprint fmt` on that one file; `changeset status` still resolves it to no package bumps, as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved formatting in the release changeset metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->