### PR TITLE
fix(template-webpack-plugin): skip lazy bundles whose chunk group lost its chunks

### DIFF
--- a/.changeset/skip-degenerate-lazy-bundle.md
+++ b/.changeset/skip-degenerate-lazy-bundle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/template-webpack-plugin": patch
+---
+
+Stop emitting a lazy bundle for a dynamic import whose module is also imported statically. Rspack puts such a module in the initial chunk and drops the now-empty async chunk, but keeps the chunk group, so the template was still emitted with an empty payload that nothing loads -- and the web target crashed encoding it.

--- a/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
+++ b/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts
@@ -790,7 +790,12 @@ class LynxTemplatePluginImpl {
     const context = compilation.compiler.context;
 
     asyncChunkGroups = groupBy(
-      compilation.chunkGroups.filter(cg => !cg.isInitial()),
+      // A statically imported module goes to the initial chunk, leaving its
+      // async chunk empty; `RemoveEmptyChunksPlugin` drops that chunk but
+      // keeps the group, which would otherwise emit an empty lazy bundle.
+      compilation.chunkGroups.filter(cg =>
+        !cg.isInitial() && cg.chunks.length > 0
+      ),
       cg => {
         // A `webpackChunkName` is user-provided (the react transform no longer
         // injects one) — group by it, after the `asyncChunkName` hook. Unnamed

--- a/packages/webpack/template-webpack-plugin/test/degenerate-lazy-bundle.test.ts
+++ b/packages/webpack/template-webpack-plugin/test/degenerate-lazy-bundle.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { rspack } from '@rspack/core';
+import type { Configuration, Stats } from '@rspack/core';
+import { describe, expect, test } from '@rstest/core';
+
+import { LynxEncodePlugin, LynxTemplatePlugin } from '../src/index.js';
+
+const CONTEXT = dirname(fileURLToPath(import.meta.url));
+
+function runRspack(config: Configuration): Promise<Stats> {
+  const compiler = rspack(config);
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err) return reject(err);
+      if (!stats) return reject(new Error('rspack returned empty stats'));
+      resolve(stats);
+      compiler.close(() => void 0);
+    });
+  });
+}
+
+async function build() {
+  const stats = await runRspack({
+    context: CONTEXT,
+    mode: 'development',
+    devtool: false,
+    entry: './fixtures/degenerate-lazy-bundle/entry.js',
+    output: { iife: false, path: mkdtempSync(join(tmpdir(), 'tmpl-degen-')) },
+    plugins: [
+      new LynxTemplatePlugin({
+        ...LynxTemplatePlugin.defaultOptions,
+        intermediate: '.rspeedy/main',
+      }),
+      new LynxEncodePlugin(),
+    ],
+  });
+
+  const { assets = [] } = stats.toJson({ assets: true });
+
+  return assets.map(asset => asset.name);
+}
+
+describe('degenerate lazy bundle', () => {
+  test('emits no template for an import() that is also imported statically', async () => {
+    const assetNames = await build();
+
+    expect(assetNames.some(name => name.includes('split'))).toBe(true);
+    expect(assetNames.some(name => name.includes('shared'))).toBe(false);
+  });
+});

--- a/packages/webpack/template-webpack-plugin/test/fixtures/degenerate-lazy-bundle/entry.js
+++ b/packages/webpack/template-webpack-plugin/test/fixtures/degenerate-lazy-bundle/entry.js
@@ -1,0 +1,5 @@
+import { shared } from './shared.js';
+
+export const eager = shared;
+export const alsoStatic = import('./shared.js');
+export const properlySplit = import('./split.js');

--- a/packages/webpack/template-webpack-plugin/test/fixtures/degenerate-lazy-bundle/shared.js
+++ b/packages/webpack/template-webpack-plugin/test/fixtures/degenerate-lazy-bundle/shared.js
@@ -1,0 +1,1 @@
+export const shared = 1;

--- a/packages/webpack/template-webpack-plugin/test/fixtures/degenerate-lazy-bundle/split.js
+++ b/packages/webpack/template-webpack-plugin/test/fixtures/degenerate-lazy-bundle/split.js
@@ -1,0 +1,1 @@
+export const split = 2;


### PR DESCRIPTION
## The bug

Importing a module both statically and dynamically produces a lazy bundle that
is emitted, loadable, and completely empty:

```js
import { a } from './LazyComponent.js'            // static
const C = lazy(() => import('./LazyComponent'))   // dynamic
```

On the Lynx target this silently ships a 181-byte template whose entry module
has an empty body. On the web target it crashes:

```
TypeError: last is not a function or its return value is not iterable
    at WebEncodePlugin.js:59
```

## Why

Rspack's `build_chunk_graph` tracks `min_available_modules` per chunk group. The
static import puts the module in the initial chunk, so when the async chunk
group asks for it, `add_and_enter_module` skips it -- the comment there is
literally `// if this module in parent chunks`:

```rust
if cgi.min_available_modules.bit(module_ordinal) {
  cgi.skipped_items.insert(item.module);
  return;
}
```

That leaves the async chunk with no modules. `RemoveEmptyChunksPlugin` then
removes the chunk, and `disconnect_chunk` -> `Chunk::disconnect_from_groups`
only calls `group.remove_chunk(...)` -- **the chunk group survives with zero
chunks**.

Rspack itself emits no file for it, silently. We key lazy bundles off chunk
groups rather than chunks, so we kept emitting a template for a group with
nothing in it, and `WebEncodePlugin` then read `last(Object.entries(manifest))`
on an empty manifest and destructured `undefined`.

This is core code-splitting behaviour, not a toggle: rspack has no
`removeAvailableModules` option, and the empty bundle reproduces in
`--mode development` too.

## The change

`#getAsyncChunkGroups` skips chunk groups that have no chunks. No diagnostic --
rspack drops the empty chunk silently, so this matches it.

Not emitting is safe: the main bundle holds **zero** references to the
degenerate bundle (verified against `examples/react-lazy-bundle` -- the three
healthy lazy bundles have 4 references each), because `import()` now resolves
locally.

## Verified

On `examples/react-lazy-bundle` with the static import added:

| | before | after |
| --- | --- | --- |
| web build | crashes | passes |
| `src_LazyComponent.tsx` template | emitted, empty | not emitted |

Regression test builds the case through rspack and asserts the healthy lazy
bundle is still emitted while the degenerate one is not; it fails without the
fix. Full suite: 102 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty lazy bundles from being generated when dynamically imported code is also imported statically.
  * Improved web-target stability by avoiding crashes caused by unused empty asynchronous chunks.

* **Tests**
  * Added regression coverage to verify valid split assets are produced without empty shared template assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->