### PR TITLE
feat: add an examples-only Lynx XML playground

### DIFF
--- a/.changeset/lynx-xml-playground-showcase.md
+++ b/.changeset/lynx-xml-playground-showcase.md
@@ -1,0 +1,6 @@
+---
+
+---
+
+Add an examples-only Lynx XML playground with interactive Vanilla Lynx
+scenarios, shared A2UI showcase cards, source editing, and direct previews.

--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -95,6 +95,13 @@ Protocol-specific showcase sources may vary their header copy, section links, ba
 
 Keep the shared example-detail workspace, editor/preview resizing, playback state machine, progress bridge, scenario sidebar, and mobile tabs in `pages/demos/DemosPage.tsx`, with its styles in `pages/demos/DemosPage.css`. Keep protocol-specific editor configuration, commit validation, playback chunking, payload publishing, and `PreviewPanelSource` construction in the existing `pages/demos/a2ui.ts` and `pages/demos/openui.ts` source modules.
 
+### Lynx XML
+
+- Keep Lynx XML examples-only. Route its protocol root and unsupported tabs to Examples; do not expose Create, Catalog, or Bench.
+- Reuse the A2UI Playground Examples `flow` layout, `DemosList`, `ExamplePreviewCard`, and card styles without protocol-specific markup or CSS.
+- Keep complete `.lynxml` artifacts in `src/mock/lynx-xml`, import them as raw editor source, copy them to `dist/demos/lynx-xml`, and load their URLs directly in `<lynx-view>`. Do not add per-example compilation or a ReactLynx renderer. Keep edited-source Blob URLs keyed to their source and create and consume replacements in the same effect before revoking older URLs. Browser-local Blob URLs are not shareable: keep the Web and Native QR cards mounted with an unavailable placeholder instead of encoding the Blob URL or removing the QR pane. Use `@codemirror/lang-html` in the editor and keep Playback disabled.
+- Append the business root directly to the Element PAPI `page`; do not style the page or add a generic `app` wrapper. The root owns viewport, background, and layout styles, and must be a vertical scroll view when content may overflow. Because Lynx defaults to Linear layout, every layout container must explicitly use `display: flex` and declare its intended `flex-direction`.
+
 ## OpenUI Integration
 
 ### Lynx Entry Styling

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "renovate.json5": "jsonc",
     "*.mdx": "mdx",
     "*.snap.txt": "markdown",
+    "*.lynxml": "html",
   },
   "[javascript]": {
     "editor.defaultFormatter": "dprint.dprint",

--- a/packages/genui/playground/AGENTS.md
+++ b/packages/genui/playground/AGENTS.md
@@ -6,6 +6,7 @@ It supports:
 
 - `web` via `@rsbuild/core` (React DOM preview)
 - `lynx` via `@lynx-js/rspeedy` (Lynx preview)
+- zero-build Lynx XML examples loaded directly by Lynx for Web
 
 ## How It Works (Web Shell vs Lynx App)
 
@@ -66,6 +67,21 @@ Inside `lynx-src/App.tsx`:
 - Lynx config: `lynx.config.ts`
 - Web entrypoints: `src/entry.tsx`, `src/render.tsx`
 - Lynx entrypoint: `lynx-src/index.tsx`
+- Lynx XML examples: `src/mock/lynx-xml/*.lynxml`
+
+## Lynx XML Examples
+
+The `lynx-xml` protocol currently exposes only the Examples tab. Its example
+files are imported as raw source for the shared detail workspace and copied to
+`dist/demos/lynx-xml/` for the list previews. `render.html` passes the complete
+artifact URL to `<lynx-view>`; do not add a ReactLynx renderer or a per-example
+Rspeedy build for these files. Keep each Element PAPI tree directly under its
+page rather than adding a generic `app` wrapper. Lynx defaults to Linear
+layout, so every class used as a layout container must explicitly declare
+`display: flex` and the intended direction where it matters. Keep `page`
+unstyled and place viewport sizing, background, and entry layout on the first
+business view. When content can exceed one viewport, make that entry node a
+vertical scroll view instead of adding another wrapper.
 
 ## Common Commands
 

--- a/packages/genui/playground/README.md
+++ b/packages/genui/playground/README.md
@@ -1,9 +1,25 @@
 # GenUI Playground
 
 Interactive playground for the Lynx **GenUI** toolchain. Chat with an agent to
-generate A2UI / OpenUI surfaces, browse ready-made examples, and preview the
-result on the web or a real device — then rename, delete, or **share** any
-conversation as a durable preview link.
+generate A2UI / OpenUI surfaces, browse ready-made examples (including
+zero-build Lynx XML artifacts), and preview the result on the web or a real
+device — then rename, delete, or **share** any conversation as a durable
+preview link.
+
+The Lynx XML protocol currently exposes only its **Examples** surface at
+`#/lynx-xml/examples`. Each example is a single `.lynxml` file containing Lynx
+CSS plus main-thread and, where needed, background-thread JavaScript, loaded
+directly by `<lynx-view>`.
+
+The bundled cases are Counter, Travel Plan, Product Card, Weather Card, and
+Todo List. Together they cover main-thread interaction, subtree re-rendering,
+background-thread computation, selection state, and dynamic-list updates
+without external media assets. Their cards use the same flow-grid arrangement
+and shared card styles as A2UI Playground Examples. The Element PAPI trees
+attach an explicitly styled business root directly to an unstyled `page`; each
+layout container enables Flex instead of relying on Lynx's default Linear
+layout. Examples that can exceed one viewport use that business root itself as
+a vertical scroll view.
 
 > Private development app; it is not published to npm. For the published library
 > see [`@lynx-js/genui`](../README.md).

--- a/packages/genui/playground/package.json
+++ b/packages/genui/playground/package.json
@@ -14,6 +14,7 @@
     "test": "rstest"
   },
   "dependencies": {
+    "@codemirror/lang-html": "^6.4.12",
     "@codemirror/lang-json": "^6.0.2",
     "@lynx-js/genui": "workspace:*",
     "@lynx-js/luna-styles": "0.2.1",

--- a/packages/genui/playground/rsbuild.config.ts
+++ b/packages/genui/playground/rsbuild.config.ts
@@ -276,6 +276,10 @@ export default defineConfig({
         from: 'src/mock/a2ui-gallery/*.json',
         to: 'demos/[name][ext]',
       },
+      {
+        from: 'src/mock/lynx-xml/*.lynxml',
+        to: 'demos/lynx-xml/[name][ext]',
+      },
       ...(HAS_PHASE_TWO_SCREENSHOTS
         ? [{
           from: 'src/pages/bench/assets/phase-two/screenshots/*.png',
@@ -283,6 +287,19 @@ export default defineConfig({
         }]
         : []),
     ],
+  },
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.lynxml$/,
+            resourceQuery: /raw/,
+            type: 'asset/source',
+          },
+        ],
+      },
+    },
   },
   server: {
     port: PORT,

--- a/packages/genui/playground/rstest.config.ts
+++ b/packages/genui/playground/rstest.config.ts
@@ -13,4 +13,17 @@ export default defineConfig({
       __GENUI_SERVER_URL__: JSON.stringify(DEFAULT_GENUI_SERVER_URL),
     },
   },
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.lynxml$/,
+            resourceQuery: /raw/,
+            type: 'asset/source',
+          },
+        ],
+      },
+    },
+  },
 });

--- a/packages/genui/playground/src/App.tsx
+++ b/packages/genui/playground/src/App.tsx
@@ -53,6 +53,7 @@ const GENUI_TABS: TabDef[] = [
 ];
 
 const MCP_APPS_TABS: TabDef[] = [{ id: 'create', label: 'Create' }];
+const LYNX_XML_TABS: TabDef[] = [{ id: 'examples', label: 'Examples' }];
 
 function ensureDefaultRouteHash(): void {
   if (!isEmptyRouteHash(window.location.hash)) return;
@@ -122,7 +123,9 @@ export function App() {
   const forcedTheme = useMemo(() => getForcedTheme(), []);
 
   const protocol = route.protocol;
-  const tabs = protocol.name === 'mcp-apps' ? MCP_APPS_TABS : GENUI_TABS;
+  const tabs = protocol.name === 'mcp-apps'
+    ? MCP_APPS_TABS
+    : (protocol.name === 'lynx-xml' ? LYNX_XML_TABS : GENUI_TABS);
 
   useLayoutEffect(() => {
     ensureDefaultRouteHash();
@@ -165,6 +168,10 @@ export function App() {
       window.location.hash = buildRouteHash(name, 'create');
       return;
     }
+    if (name === 'lynx-xml') {
+      window.location.hash = buildRouteHash(name, 'examples');
+      return;
+    }
     window.location.hash = buildRouteHash(name, route.tab);
   }, [route.tab]);
 
@@ -192,6 +199,25 @@ export function App() {
     );
 
     if (protocol.name === 'mcp-apps') return createPage;
+
+    if (protocol.name === 'lynx-xml') {
+      return route.demoId
+        ? (
+          <DemosPage
+            key='lynx-xml-examples-detail'
+            protocol={protocol}
+            demoId={route.demoId}
+            theme={theme}
+          />
+        )
+        : (
+          <DemosListPage
+            key='lynx-xml-examples-index'
+            protocol={protocol}
+            theme={theme}
+          />
+        );
+    }
 
     if (protocol.name === 'openui') {
       switch (route.tab) {
@@ -316,6 +342,9 @@ export function App() {
         <option value='openui'>OpenUI v{PROTOCOLS.openui.version}</option>
         <option value='mcp-apps'>
           MCP Apps v{PROTOCOLS['mcp-apps'].version}
+        </option>
+        <option value='lynx-xml'>
+          Lynx XML v{PROTOCOLS['lynx-xml'].version}
         </option>
       </select>
     </div>

--- a/packages/genui/playground/src/components/PreviewPanel.test.ts
+++ b/packages/genui/playground/src/components/PreviewPanel.test.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, test } from '@rstest/core';
+
+import { createPreviewQrCards } from './PreviewPanel.js';
+
+describe('PreviewPanel QR cards', () => {
+  test('keeps unavailable QR cards visible for edited Lynx XML', () => {
+    const cards = createPreviewQrCards(
+      {
+        kind: 'lynx-xml',
+        source: '<lynx></lynx>',
+        theme: 'light',
+      },
+      '',
+      '',
+    );
+
+    expect(cards).toHaveLength(2);
+    expect(cards.map(({ key }) => key)).toEqual([
+      'webPreview',
+      'nativePreview',
+    ]);
+    expect(cards.every(({ item }) => item.url === undefined)).toBe(true);
+    expect(cards.map(({ item }) => item.placeholder)).toEqual([
+      'QR unavailable for local edits',
+      'QR unavailable for local edits',
+    ]);
+  });
+
+  test('uses shareable URLs for an unedited Lynx XML example', () => {
+    const renderShareUrl =
+      'https://lynx-stack.dev/genui/render.html?protocol=lynx-xml';
+    const lynxDevUrl =
+      'https://lynx-stack.dev/genui/demos/lynx-xml/counter.lynxml';
+    const cards = createPreviewQrCards(
+      {
+        kind: 'lynx-xml',
+        source: '<lynx></lynx>',
+        sourcePath: 'demos/lynx-xml/counter.lynxml',
+        theme: 'light',
+      },
+      renderShareUrl,
+      lynxDevUrl,
+    );
+
+    expect(cards.map(({ item }) => item.url)).toEqual([
+      renderShareUrl,
+      lynxDevUrl,
+    ]);
+    expect(cards.every(({ item }) => item.showQrCode === true)).toBe(true);
+  });
+});

--- a/packages/genui/playground/src/components/PreviewPanel.tsx
+++ b/packages/genui/playground/src/components/PreviewPanel.tsx
@@ -31,8 +31,10 @@ import { publishOpenUIPayload } from '../utils/publishPayload.js';
 import type {
   LocalA2UIMessagesPayload,
   LocalA2UIMessagesPayloadCache,
+  LocalLynxXmlSourcePayloadCache,
 } from '../utils/renderUrl.js';
 import {
+  buildLynxXmlRenderUrl,
   buildMcpAppsRenderUrl,
   buildOpenUIRenderUrl,
   buildRenderUrl,
@@ -40,6 +42,8 @@ import {
   canInlineOpenUIRenderUrl,
   createLocalA2UIMessagesPayload,
   createLocalA2UIMessagesPayloadCache,
+  createLocalLynxXmlSourcePayload,
+  createLocalLynxXmlSourcePayloadCache,
   hasExternalA2UIRenderPayload,
   hasShareableA2UIRenderPayload,
   isPortableA2UIMessagesUrl,
@@ -119,6 +123,13 @@ export interface McpAppsPreviewSource {
   theme?: 'light' | 'dark';
 }
 
+export interface LynxXmlPreviewSource {
+  kind: 'lynx-xml';
+  source: string;
+  sourcePath?: string;
+  theme?: 'light' | 'dark';
+}
+
 interface PlaceholderPreviewSource {
   kind: 'placeholder';
   item: PreviewQrItem;
@@ -128,7 +139,92 @@ export type PreviewPanelSource =
   | A2UIPreviewSource
   | OpenUIPreviewSource
   | McpAppsPreviewSource
+  | LynxXmlPreviewSource
   | PlaceholderPreviewSource;
+
+export interface PreviewQrCard {
+  key: 'nativePreview' | 'webPreview';
+  item: PreviewQrItem;
+}
+
+export function createPreviewQrCards(
+  previewSource: PreviewPanelSource | undefined,
+  renderShareUrl: string,
+  lynxDevUrl: string,
+): PreviewQrCard[] {
+  if (!previewSource || previewSource.kind === 'placeholder') return [];
+
+  const showQrCode = previewSource.kind !== 'a2ui'
+    || hasShareableA2UIRenderPayload(previewSource);
+  const isLocalLynxXml = previewSource.kind === 'lynx-xml'
+    && !previewSource.sourcePath;
+  const cards: PreviewQrCard[] = [];
+
+  if (renderShareUrl) {
+    cards.push({
+      key: 'webPreview',
+      item: {
+        title: 'Web Preview',
+        description: 'Opens in any mobile browser via Lynx for Web.',
+        url: renderShareUrl,
+        urlTitle: renderShareUrl,
+        copyButtonTitle: 'Copy render URL',
+        showQrCode,
+      },
+    });
+  } else if (
+    previewSource.kind === 'a2ui'
+    && previewSource.liveAction === true
+  ) {
+    cards.push({
+      key: 'webPreview',
+      item: {
+        title: 'Web Preview',
+        description:
+          'This live preview stays in the current browser. Sharing requires a short published preview payload URL.',
+        placeholder: 'Share link unavailable',
+      },
+    });
+  } else if (isLocalLynxXml) {
+    cards.push({
+      key: 'webPreview',
+      item: {
+        title: 'Web Preview',
+        description:
+          'Edited Lynx XML is rendered only in the current browser. Reset to the example to restore its shareable URL.',
+        placeholder: 'QR unavailable for local edits',
+      },
+    });
+  }
+
+  if (lynxDevUrl) {
+    cards.push({
+      key: 'nativePreview',
+      item: {
+        title: 'Native Preview',
+        description: 'Opens in LynxExplorer for native rendering.',
+        url: lynxDevUrl,
+        urlTitle: lynxDevUrl,
+        copyButtonTitle: 'Copy Lynx dev bundle URL',
+        variant: 'alt',
+        showQrCode,
+      },
+    });
+  } else if (isLocalLynxXml) {
+    cards.push({
+      key: 'nativePreview',
+      item: {
+        title: 'Native Preview',
+        description:
+          'A browser-local edited source cannot be opened in LynxExplorer. Reset to the example to restore its native URL.',
+        placeholder: 'QR unavailable for local edits',
+        variant: 'alt',
+      },
+    });
+  }
+
+  return cards;
+}
 
 export type PreviewMetricName = 'fcp' | 'fmp' | 'tti' | 'render';
 
@@ -396,6 +492,16 @@ export function PreviewPanel(props: PreviewPanelProps) {
       createLocalA2UIMessagesPayload(messages, window.URL),
   });
   const localMessagesPayloadCache = localMessagesPayloadCacheRef.current;
+  const localLynxXmlSourcePayloadCacheRef = useRef<
+    LocalLynxXmlSourcePayloadCache | null
+  >(null);
+  localLynxXmlSourcePayloadCacheRef.current ??=
+    createLocalLynxXmlSourcePayloadCache({
+      createPayload: (source) =>
+        createLocalLynxXmlSourcePayload(source, window.URL),
+    });
+  const localLynxXmlSourcePayloadCache =
+    localLynxXmlSourcePayloadCacheRef.current;
   const speedInputId = useId();
   const rawMetricId = useId();
   const metricId = useMemo(
@@ -488,7 +594,6 @@ export function PreviewPanel(props: PreviewPanelProps) {
     }
     return u.toString();
   }, [baseUrl, rspeedyDevUrl]);
-
   const renderContext = useMemo<PreviewPanelRenderContextValue>(
     () => ({ renderUrl }),
     [renderUrl],
@@ -605,11 +710,15 @@ export function PreviewPanel(props: PreviewPanelProps) {
     return () => {
       window.removeEventListener('message', handleRuntimeReady);
       localMessagesPayloadCache.dispose();
+      localLynxXmlSourcePayloadCache.clear();
     };
-  }, [localMessagesPayloadCache]);
+  }, [localLynxXmlSourcePayloadCache, localMessagesPayloadCache]);
 
   useEffect(() => {
     const seq = ++buildSeqRef.current;
+    if (previewSource?.kind !== 'lynx-xml') {
+      localLynxXmlSourcePayloadCache.clear();
+    }
 
     if (!previewSource) {
       localMessagesPayloadCache.clear();
@@ -851,6 +960,52 @@ export function PreviewPanel(props: PreviewPanelProps) {
 
     localMessagesPayloadCache.clear();
 
+    if (previewSource.kind === 'lynx-xml') {
+      let sourceUrl = '';
+      if (previewSource.sourcePath) {
+        localLynxXmlSourcePayloadCache.clear();
+        sourceUrl = new URL(previewSource.sourcePath, baseUrl).toString();
+      } else if (previewSource.source) {
+        try {
+          sourceUrl = localLynxXmlSourcePayloadCache.ensure(
+            previewSource.source,
+          ).sourceUrl;
+        } catch {
+          localLynxXmlSourcePayloadCache.clear();
+        }
+      } else {
+        localLynxXmlSourcePayloadCache.clear();
+      }
+      if (!sourceUrl) {
+        setRenderUrl('');
+        setRenderShareUrl('');
+        setLynxDevUrl('');
+        return;
+      }
+
+      setRenderUrl(buildLynxXmlRenderUrl({
+        sourceUrl,
+        theme: previewSource.theme,
+      }, baseUrl));
+
+      if (!previewSource.sourcePath) {
+        setRenderShareUrl('');
+        setLynxDevUrl('');
+        return;
+      }
+
+      const shareSourceUrl = new URL(
+        previewSource.sourcePath,
+        shareBaseUrl,
+      ).toString();
+      setRenderShareUrl(buildLynxXmlRenderUrl({
+        sourceUrl: shareSourceUrl,
+        theme: previewSource.theme,
+      }, shareBaseUrl));
+      setLynxDevUrl(shareSourceUrl);
+      return;
+    }
+
     if (previewSource.kind === 'mcp-apps') {
       setRenderUrl(buildMcpAppsRenderUrl({
         mcpAppData: previewSource.mcpAppData,
@@ -968,6 +1123,7 @@ export function PreviewPanel(props: PreviewPanelProps) {
     })();
   }, [
     baseUrl,
+    localLynxXmlSourcePayloadCache,
     localMessagesPayloadCache,
     previewSource,
     rspeedyDevUrl,
@@ -999,56 +1155,11 @@ export function PreviewPanel(props: PreviewPanelProps) {
   }, [previewSource]);
 
   const previewQrCards = useMemo(() => {
-    if (!previewSource || previewSource.kind === 'placeholder') {
-      return [];
-    }
-
-    const showQrCode = previewSource.kind !== 'a2ui'
-      || hasShareableA2UIRenderPayload(previewSource);
-
-    const cards: Array<{ key: string; item: PreviewQrItem }> = [];
-    if (renderShareUrl) {
-      cards.push({
-        key: 'webPreview',
-        item: {
-          title: 'Web Preview',
-          description: 'Opens in any mobile browser via Lynx for Web.',
-          url: renderShareUrl,
-          urlTitle: renderShareUrl,
-          copyButtonTitle: 'Copy render URL',
-          showQrCode,
-        },
-      });
-    } else if (
-      previewSource.kind === 'a2ui'
-      && previewSource.liveAction === true
-    ) {
-      cards.push({
-        key: 'webPreview',
-        item: {
-          title: 'Web Preview',
-          description:
-            'This live preview stays in the current browser. Sharing requires a short published preview payload URL.',
-          placeholder: 'Share link unavailable',
-        },
-      });
-    }
-    if (lynxDevUrl) {
-      cards.push({
-        key: 'nativePreview',
-        item: {
-          title: 'Native Preview',
-          description: 'Opens in LynxExplorer for native rendering.',
-          url: lynxDevUrl,
-          urlTitle: lynxDevUrl,
-          copyButtonTitle: 'Copy Lynx dev bundle URL',
-          variant: 'alt',
-          showQrCode,
-        },
-      });
-    }
-
-    return cards;
+    return createPreviewQrCards(
+      previewSource,
+      renderShareUrl,
+      lynxDevUrl,
+    );
   }, [lynxDevUrl, previewSource, renderShareUrl]);
 
   const handleCopyUrl = (key: string, value: string) => {

--- a/packages/genui/playground/src/components/ProtocolSwitch.tsx
+++ b/packages/genui/playground/src/components/ProtocolSwitch.tsx
@@ -12,6 +12,8 @@ export function ProtocolSwitch(props: {
     label = 'A2UI';
   } else if (protocol.name === 'openui') {
     label = 'OpenUI';
+  } else if (protocol.name === 'lynx-xml') {
+    label = 'Lynx XML';
   }
   return (
     <div className='protocolSwitch' role='group' aria-label='Protocol version'>

--- a/packages/genui/playground/src/css.d.ts
+++ b/packages/genui/playground/src/css.d.ts
@@ -2,3 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 declare module '*.css';
+
+declare module '*.lynxml?raw' {
+  const source: string;
+  export default source;
+}

--- a/packages/genui/playground/src/mock/lynx-xml/counter.lynxml
+++ b/packages/genui/playground/src/mock/lynx-xml/counter.lynxml
@@ -1,0 +1,272 @@
+<!doctype lynx>
+<lynx engine-version="4.2">
+<style>
+.counter-card {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  border-radius: 24px;
+  background-color: #f2f5fb;
+  box-shadow: 0 12px 40px rgba(31, 50, 81, 0.12);
+}
+
+.eyebrow {
+  color: #6f7d95;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1.6px;
+}
+
+.title {
+  margin-top: 8px;
+  color: #172033;
+  font-size: 26px;
+  font-weight: 800;
+}
+
+.description {
+  margin-top: 8px;
+  color: #718096;
+  font-size: 14px;
+  line-height: 20px;
+  white-space: normal;
+}
+
+.value-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 24px;
+  padding: 24px 16px;
+  border-radius: 20px;
+  background-color: #f7f9fc;
+}
+
+.value-label {
+  color: #8a96aa;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.value {
+  margin-top: 4px;
+  color: #315efb;
+  font-size: 64px;
+  font-weight: 800;
+  line-height: 72px;
+}
+
+.value.negative {
+  color: #e55561;
+}
+
+.value-note {
+  margin-top: 2px;
+  color: #8792a6;
+  font-size: 12px;
+}
+
+.stepper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.step-button {
+  width: 72px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  background-color: #edf1ff;
+}
+
+.step-button.add {
+  margin-left: 12px;
+  background-color: #315efb;
+}
+
+.step-button:active,
+.reset-button:active {
+  opacity: 0.72;
+}
+
+.step-button-text {
+  color: #315efb;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.step-button-text.add {
+  color: #ffffff;
+}
+
+.reset-button {
+  width: 100%;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 12px;
+  border-radius: 14px;
+  background-color: #172033;
+}
+
+.reset-button-text {
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 700;
+}
+</style>
+<script thread="main">
+const engine = lynx.getEngine();
+const page = __CreatePage("0", 0);
+const pageId = __GetElementUniqueID(page);
+const tapOptions = {};
+const renderPageEventName = "__RenderPage";
+const destroyLifetimeEventName = "__DestroyLifetime";
+
+let count = 8;
+let countText;
+let noteText;
+let rendered = false;
+const buttonListeners = [];
+
+function createText(className, value) {
+  const text = __CreateText(pageId);
+  __SetClasses(text, className);
+  __AppendElement(text, __CreateRawText(value));
+  return text;
+}
+
+function replaceText(text, value) {
+  __ReplaceElements(
+    text,
+    [__CreateRawText(value)],
+    __GetChildren(text),
+  );
+}
+
+function bindTap(node, handler) {
+  __AddEventListener(node, "tap", handler, tapOptions);
+  buttonListeners.push({ node, handler });
+}
+
+function createButton(className, textClassName, label, ariaLabel, handler) {
+  const button = __CreateView(pageId);
+  __SetClasses(button, className);
+  __SetAttribute(button, "aria-label", ariaLabel);
+  __AppendElement(button, createText(textClassName, label));
+  bindTap(button, handler);
+  return button;
+}
+
+function syncCounter() {
+  replaceText(countText, String(count));
+  replaceText(
+    noteText,
+    count === 0
+      ? "Back at the starting point"
+      : `${Math.abs(count)} step${Math.abs(count) === 1 ? "" : "s"} ${count > 0 ? "above" : "below"} zero`,
+  );
+  __SetClasses(countText, count < 0 ? "value negative" : "value");
+  __FlushElementTree();
+}
+
+function decrement() {
+  count -= 1;
+  syncCounter();
+}
+
+function increment() {
+  count += 1;
+  syncCounter();
+}
+
+function reset() {
+  count = 0;
+  syncCounter();
+}
+
+function renderPage() {
+  if (rendered) return;
+  rendered = true;
+
+  const card = __CreateScrollView(pageId);
+  __SetClasses(card, "counter-card");
+  __SetAttribute(card, "scroll-orientation", "vertical");
+  __AppendElement(card, createText("eyebrow", "MAIN THREAD STATE"));
+  __AppendElement(card, createText("title", "Daily counter"));
+  __AppendElement(
+    card,
+    createText(
+      "description",
+      "A compact state example with immediate Element PAPI updates.",
+    ),
+  );
+
+  const valuePanel = __CreateView(pageId);
+  __SetClasses(valuePanel, "value-panel");
+  __AppendElement(valuePanel, createText("value-label", "CURRENT VALUE"));
+  countText = createText("value", String(count));
+  __AppendElement(valuePanel, countText);
+  noteText = createText("value-note", "8 steps above zero");
+  __AppendElement(valuePanel, noteText);
+  __AppendElement(card, valuePanel);
+
+  const stepper = __CreateView(pageId);
+  __SetClasses(stepper, "stepper");
+  __AppendElement(
+    stepper,
+    createButton(
+      "step-button",
+      "step-button-text",
+      "−",
+      "Decrease counter",
+      decrement,
+    ),
+  );
+  __AppendElement(
+    stepper,
+    createButton(
+      "step-button add",
+      "step-button-text add",
+      "+",
+      "Increase counter",
+      increment,
+    ),
+  );
+  __AppendElement(card, stepper);
+
+  __AppendElement(
+    card,
+    createButton(
+      "reset-button",
+      "reset-button-text",
+      "Reset counter",
+      "Reset counter",
+      reset,
+    ),
+  );
+  __AppendElement(page, card);
+}
+
+function cleanup() {
+  for (const { node, handler } of buttonListeners.splice(0)) {
+    __RemoveEventListener(node, "tap", handler, tapOptions);
+  }
+  engine.removeEventListener(renderPageEventName, renderPage);
+  engine.removeEventListener(destroyLifetimeEventName, cleanup);
+  countText = undefined;
+  noteText = undefined;
+}
+
+engine.addEventListener(renderPageEventName, renderPage);
+engine.addEventListener(destroyLifetimeEventName, cleanup);
+</script>
+</lynx>

--- a/packages/genui/playground/src/mock/lynx-xml/product-card.lynxml
+++ b/packages/genui/playground/src/mock/lynx-xml/product-card.lynxml
@@ -1,0 +1,441 @@
+<!doctype lynx>
+<lynx engine-version="4.2">
+<style>
+.product-card {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  border-radius: 26px;
+  background-color: #f4f0e9;
+  box-shadow: 0 14px 42px rgba(71, 55, 38, 0.14);
+}
+
+.visual {
+  height: 210px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #d9c5aa;
+}
+
+.visual-label {
+  color: rgba(40, 32, 23, 0.55);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 1.8px;
+}
+
+.product-shape {
+  width: 210px;
+  height: 74px;
+  margin-top: 18px;
+  border-radius: 40px 18px 28px 18px;
+  background-color: #fffdf9;
+  transform: rotate(-8deg);
+}
+
+.product-sole {
+  width: 220px;
+  height: 13px;
+  margin-top: -3px;
+  border-radius: 7px;
+  background-color: #4b4035;
+  transform: rotate(-8deg);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  padding: 22px;
+  background-color: #fffdf9;
+}
+
+.meta-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.category {
+  color: #9b7552;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 1.2px;
+}
+
+.rating {
+  color: #6d6257;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.title {
+  margin-top: 9px;
+  color: #29251f;
+  font-size: 25px;
+  font-weight: 800;
+}
+
+.description {
+  margin-top: 7px;
+  color: #81766c;
+  font-size: 13px;
+  line-height: 19px;
+  white-space: normal;
+}
+
+.option-label {
+  margin-top: 18px;
+  color: #554c43;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.swatches {
+  display: flex;
+  flex-direction: row;
+  margin-top: 10px;
+}
+
+.swatch {
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 19px;
+  background-color: #f0ebe4;
+}
+
+.swatch.second,
+.swatch.third {
+  margin-left: 10px;
+}
+
+.swatch.selected {
+  border: 3px solid #29251f;
+}
+
+.swatch-dot {
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  background-color: #c9aa82;
+}
+
+.swatch-dot.ink {
+  background-color: #39434f;
+}
+
+.swatch-dot.moss {
+  background-color: #68745c;
+}
+
+.purchase-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+.price-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.price-label {
+  color: #958a7e;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.price {
+  margin-top: 2px;
+  color: #29251f;
+  font-size: 23px;
+  font-weight: 800;
+}
+
+.quantity {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 5px;
+  border-radius: 14px;
+  background-color: #f1ece5;
+}
+
+.quantity-button {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background-color: #fffdf9;
+}
+
+.quantity-button-text {
+  color: #29251f;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.quantity-value {
+  width: 34px;
+  color: #29251f;
+  font-size: 14px;
+  font-weight: 800;
+  text-align: center;
+}
+
+.add-button {
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 16px;
+  border-radius: 15px;
+  background-color: #29251f;
+}
+
+.add-button.added {
+  background-color: #55705a;
+}
+
+.add-button:active,
+.quantity-button:active,
+.swatch:active {
+  opacity: 0.72;
+}
+
+.add-button-text {
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 800;
+}
+</style>
+<script thread="main">
+const engine = lynx.getEngine();
+const page = __CreatePage("0", 0);
+const pageId = __GetElementUniqueID(page);
+const tapOptions = {};
+const renderPageEventName = "__RenderPage";
+const destroyLifetimeEventName = "__DestroyLifetime";
+
+const colors = [
+  { name: "Sand", visual: "#d9c5aa" },
+  { name: "Ink", visual: "#aeb8c3" },
+  { name: "Moss", visual: "#b6bea9" },
+];
+const unitPrice = 128;
+let selectedColor = 0;
+let quantity = 1;
+let rendered = false;
+let visual;
+let optionLabel;
+let quantityText;
+let priceText;
+let addButton;
+let addButtonText;
+const swatchNodes = [];
+const buttonListeners = [];
+
+
+function createText(className, value) {
+  const text = __CreateText(pageId);
+  __SetClasses(text, className);
+  __AppendElement(text, __CreateRawText(value));
+  return text;
+}
+
+function replaceText(text, value) {
+  __ReplaceElements(text, [__CreateRawText(value)], __GetChildren(text));
+}
+
+function bindTap(node, handler) {
+  __AddEventListener(node, "tap", handler, tapOptions);
+  buttonListeners.push({ node, handler });
+}
+
+function createAction(className, textClass, label, ariaLabel, handler) {
+  const action = __CreateView(pageId);
+  __SetClasses(action, className);
+  __SetAttribute(action, "aria-label", ariaLabel);
+  __AppendElement(action, createText(textClass, label));
+  bindTap(action, handler);
+  return action;
+}
+
+function syncProduct() {
+  __SetInlineStyles(visual, `background-color: ${colors[selectedColor].visual};`);
+  replaceText(optionLabel, `Color · ${colors[selectedColor].name}`);
+  replaceText(quantityText, String(quantity));
+  replaceText(priceText, `$${unitPrice * quantity}`);
+  for (let index = 0; index < swatchNodes.length; index += 1) {
+    const position = index === 1 ? "second" : index === 2 ? "third" : "";
+    __SetClasses(
+      swatchNodes[index],
+      `swatch ${position}${index === selectedColor ? " selected" : ""}`,
+    );
+  }
+  __SetClasses(addButton, "add-button");
+  replaceText(addButtonText, "Add to bag");
+  __FlushElementTree();
+}
+
+function selectColor(index) {
+  selectedColor = index;
+  syncProduct();
+}
+
+function decrementQuantity() {
+  quantity = Math.max(1, quantity - 1);
+  syncProduct();
+}
+
+function incrementQuantity() {
+  quantity = Math.min(9, quantity + 1);
+  syncProduct();
+}
+
+function addToBag() {
+  __SetClasses(addButton, "add-button added");
+  replaceText(
+    addButtonText,
+    `${quantity} ${colors[selectedColor].name} pair${quantity === 1 ? "" : "s"} added`,
+  );
+  __FlushElementTree();
+}
+
+function createSwatch(index, dotClass) {
+  const swatch = __CreateView(pageId);
+  const position = index === 1 ? "second" : index === 2 ? "third" : "";
+  __SetClasses(
+    swatch,
+    `swatch ${position}${index === selectedColor ? " selected" : ""}`,
+  );
+  __SetAttribute(swatch, "aria-label", `Select ${colors[index].name}`);
+  const dot = __CreateView(pageId);
+  __SetClasses(dot, dotClass);
+  __AppendElement(swatch, dot);
+  swatchNodes.push(swatch);
+  bindTap(swatch, () => selectColor(index));
+  return swatch;
+}
+
+function renderPage() {
+  if (rendered) return;
+  rendered = true;
+
+  const card = __CreateScrollView(pageId);
+  __SetClasses(card, "product-card");
+  __SetAttribute(card, "scroll-orientation", "vertical");
+
+  visual = __CreateView(pageId);
+  __SetClasses(visual, "visual");
+  __AppendElement(visual, createText("visual-label", "FIELD NOTE / 04"));
+  const shape = __CreateView(pageId);
+  __SetClasses(shape, "product-shape");
+  __AppendElement(visual, shape);
+  const sole = __CreateView(pageId);
+  __SetClasses(sole, "product-sole");
+  __AppendElement(visual, sole);
+  __AppendElement(card, visual);
+
+  const content = __CreateView(pageId);
+  __SetClasses(content, "content");
+  const meta = __CreateView(pageId);
+  __SetClasses(meta, "meta-row");
+  __AppendElement(meta, createText("category", "EVERYDAY FOOTWEAR"));
+  __AppendElement(meta, createText("rating", "★ 4.9 · 86 reviews"));
+  __AppendElement(content, meta);
+  __AppendElement(content, createText("title", "Cloudstep Trainer"));
+  __AppendElement(
+    content,
+    createText(
+      "description",
+      "A lightweight city trainer with a soft recycled-knit upper.",
+    ),
+  );
+
+  optionLabel = createText("option-label", "Color · Sand");
+  __AppendElement(content, optionLabel);
+  const swatches = __CreateView(pageId);
+  __SetClasses(swatches, "swatches");
+  __AppendElement(swatches, createSwatch(0, "swatch-dot"));
+  __AppendElement(swatches, createSwatch(1, "swatch-dot ink"));
+  __AppendElement(swatches, createSwatch(2, "swatch-dot moss"));
+  __AppendElement(content, swatches);
+
+  const purchase = __CreateView(pageId);
+  __SetClasses(purchase, "purchase-row");
+  const priceBlock = __CreateView(pageId);
+  __SetClasses(priceBlock, "price-block");
+  __AppendElement(priceBlock, createText("price-label", "TOTAL"));
+  priceText = createText("price", "$128");
+  __AppendElement(priceBlock, priceText);
+  __AppendElement(purchase, priceBlock);
+
+  const quantityControl = __CreateView(pageId);
+  __SetClasses(quantityControl, "quantity");
+  __AppendElement(
+    quantityControl,
+    createAction(
+      "quantity-button",
+      "quantity-button-text",
+      "−",
+      "Decrease quantity",
+      decrementQuantity,
+    ),
+  );
+  quantityText = createText("quantity-value", "1");
+  __AppendElement(quantityControl, quantityText);
+  __AppendElement(
+    quantityControl,
+    createAction(
+      "quantity-button",
+      "quantity-button-text",
+      "+",
+      "Increase quantity",
+      incrementQuantity,
+    ),
+  );
+  __AppendElement(purchase, quantityControl);
+  __AppendElement(content, purchase);
+
+  addButton = __CreateView(pageId);
+  __SetClasses(addButton, "add-button");
+  __SetAttribute(addButton, "aria-label", "Add product to bag");
+  addButtonText = createText("add-button-text", "Add to bag");
+  __AppendElement(addButton, addButtonText);
+  bindTap(addButton, addToBag);
+  __AppendElement(content, addButton);
+  __AppendElement(card, content);
+  __AppendElement(page, card);
+}
+
+function cleanup() {
+  for (const { node, handler } of buttonListeners.splice(0)) {
+    __RemoveEventListener(node, "tap", handler, tapOptions);
+  }
+  engine.removeEventListener(renderPageEventName, renderPage);
+  engine.removeEventListener(destroyLifetimeEventName, cleanup);
+  swatchNodes.length = 0;
+  visual = undefined;
+  optionLabel = undefined;
+  quantityText = undefined;
+  priceText = undefined;
+  addButton = undefined;
+  addButtonText = undefined;
+}
+
+engine.addEventListener(renderPageEventName, renderPage);
+engine.addEventListener(destroyLifetimeEventName, cleanup);
+</script>
+</lynx>

--- a/packages/genui/playground/src/mock/lynx-xml/todo-list.lynxml
+++ b/packages/genui/playground/src/mock/lynx-xml/todo-list.lynxml
@@ -1,0 +1,461 @@
+<!doctype lynx>
+<lynx engine-version="4.2">
+<style>
+.scroll {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #f1f3f8;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  padding: 22px;
+  border-radius: 24px;
+  background-color: #5138a5;
+}
+
+.eyebrow {
+  color: #c8bdf4;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 1.4px;
+}
+
+.title {
+  margin-top: 7px;
+  color: #ffffff;
+  font-size: 27px;
+  font-weight: 800;
+}
+
+.summary {
+  margin-top: 7px;
+  color: #d8d1f5;
+  font-size: 13px;
+}
+
+.add-button {
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 18px;
+  border-radius: 14px;
+  background-color: #ffffff;
+}
+
+.add-button-text {
+  color: #5138a5;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.filter-row {
+  display: flex;
+  flex-direction: row;
+  margin-top: 18px;
+  padding: 5px;
+  border-radius: 15px;
+  background-color: #e4e7ef;
+}
+
+.filter-button {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 6px;
+  border-radius: 11px;
+}
+
+.filter-button.selected {
+  background-color: #ffffff;
+}
+
+.filter-text {
+  color: #7b8291;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.filter-text.selected {
+  color: #392878;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  margin-top: 12px;
+}
+
+.todo-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-top: 10px;
+  padding: 16px;
+  border-radius: 18px;
+  background-color: #ffffff;
+}
+
+.todo-row.done {
+  background-color: #e9ebf1;
+}
+
+.checkbox {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #b6b9c5;
+  border-radius: 8px;
+}
+
+.checkbox.done {
+  border-color: #6f59c5;
+  background-color: #6f59c5;
+}
+
+.checkmark {
+  color: transparent;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.checkmark.done {
+  color: #ffffff;
+}
+
+.todo-copy {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  margin-left: 13px;
+}
+
+.todo-title {
+  color: #282b35;
+  font-size: 14px;
+  font-weight: 700;
+  white-space: normal;
+}
+
+.todo-title.done {
+  color: #9397a3;
+  text-decoration: line-through;
+}
+
+.todo-tag {
+  margin-top: 5px;
+  color: #8a8f9d;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.empty {
+  margin-top: 10px;
+  padding: 28px 18px;
+  border-radius: 18px;
+  color: #8c92a0;
+  font-size: 13px;
+  text-align: center;
+  background-color: #ffffff;
+}
+
+.footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 16px;
+  padding: 0 4px 18px;
+}
+
+.footer-note {
+  color: #898f9c;
+  font-size: 11px;
+}
+
+.clear-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 9px 12px;
+  border-radius: 10px;
+  background-color: #e4ddfa;
+}
+
+.clear-button-text {
+  color: #5138a5;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.todo-row:active,
+.add-button:active,
+.filter-button:active,
+.clear-button:active {
+  opacity: 0.72;
+}
+</style>
+<script thread="main">
+const engine = lynx.getEngine();
+const page = __CreatePage("0", 0);
+const pageId = __GetElementUniqueID(page);
+const tapOptions = {};
+const renderPageEventName = "__RenderPage";
+const destroyLifetimeEventName = "__DestroyLifetime";
+
+const quickAdds = [
+  ["Review launch checklist", "WORK"],
+  ["Book dentist appointment", "PERSONAL"],
+  ["Send weekend photos", "SOCIAL"],
+];
+const todos = [
+  { id: 1, title: "Prepare design handoff", tag: "WORK", done: false },
+  { id: 2, title: "Pick up groceries", tag: "PERSONAL", done: true },
+  { id: 3, title: "Read 20 pages", tag: "FOCUS", done: false },
+];
+
+let nextId = 4;
+let nextQuickAdd = 0;
+let selectedFilter = "all";
+let rendered = false;
+let summaryText;
+let listHost;
+let footerNote;
+const filterButtons = [];
+const filterTexts = [];
+const persistentListeners = [];
+const rowListeners = [];
+
+
+function createText(className, value) {
+  const text = __CreateText(pageId);
+  __SetClasses(text, className);
+  __AppendElement(text, __CreateRawText(value));
+  return text;
+}
+
+function replaceText(text, value) {
+  __ReplaceElements(text, [__CreateRawText(value)], __GetChildren(text));
+}
+
+function bindTap(node, handler, listeners) {
+  __AddEventListener(node, "tap", handler, tapOptions);
+  listeners.push({ node, handler });
+}
+
+function clearListeners(listeners) {
+  for (const { node, handler } of listeners.splice(0)) {
+    __RemoveEventListener(node, "tap", handler, tapOptions);
+  }
+}
+
+function getVisibleTodos() {
+  if (selectedFilter === "active") {
+    return todos.filter((todo) => !todo.done);
+  }
+  if (selectedFilter === "done") {
+    return todos.filter((todo) => todo.done);
+  }
+  return todos;
+}
+
+function createTodoRow(todo) {
+  const row = __CreateView(pageId);
+  __SetClasses(row, todo.done ? "todo-row done" : "todo-row");
+  __SetAttribute(
+    row,
+    "aria-label",
+    `${todo.done ? "Mark active" : "Complete"}: ${todo.title}`,
+  );
+
+  const checkbox = __CreateView(pageId);
+  __SetClasses(checkbox, todo.done ? "checkbox done" : "checkbox");
+  __AppendElement(
+    checkbox,
+    createText(todo.done ? "checkmark done" : "checkmark", "✓"),
+  );
+  __AppendElement(row, checkbox);
+
+  const copy = __CreateView(pageId);
+  __SetClasses(copy, "todo-copy");
+  __AppendElement(
+    copy,
+    createText(todo.done ? "todo-title done" : "todo-title", todo.title),
+  );
+  __AppendElement(copy, createText("todo-tag", todo.tag));
+  __AppendElement(row, copy);
+  bindTap(row, () => toggleTodo(todo.id), rowListeners);
+  return row;
+}
+
+function syncFilterButtons() {
+  const names = ["all", "active", "done"];
+  for (let index = 0; index < names.length; index += 1) {
+    const selected = names[index] === selectedFilter;
+    __SetClasses(
+      filterButtons[index],
+      selected ? "filter-button selected" : "filter-button",
+    );
+    __SetClasses(
+      filterTexts[index],
+      selected ? "filter-text selected" : "filter-text",
+    );
+  }
+}
+
+function renderTodos() {
+  clearListeners(rowListeners);
+  const visible = getVisibleTodos();
+  const rows = visible.length > 0
+    ? visible.map(createTodoRow)
+    : [createText("empty", "Nothing here — enjoy the open space.")];
+  __ReplaceElements(listHost, rows, __GetChildren(listHost));
+
+  const remaining = todos.filter((todo) => !todo.done).length;
+  replaceText(
+    summaryText,
+    `${remaining} open · ${todos.length - remaining} completed`,
+  );
+  replaceText(
+    footerNote,
+    `${visible.length} item${visible.length === 1 ? "" : "s"} shown`,
+  );
+  syncFilterButtons();
+  __FlushElementTree();
+}
+
+function toggleTodo(id) {
+  const todo = todos.find((item) => item.id === id);
+  if (!todo) return;
+  todo.done = !todo.done;
+  renderTodos();
+}
+
+function selectFilter(filter) {
+  selectedFilter = filter;
+  renderTodos();
+}
+
+function addQuickTodo() {
+  const quickAdd = quickAdds[nextQuickAdd % quickAdds.length];
+  todos.unshift({
+    id: nextId,
+    title: quickAdd[0],
+    tag: quickAdd[1],
+    done: false,
+  });
+  nextId += 1;
+  nextQuickAdd += 1;
+  selectedFilter = "all";
+  renderTodos();
+}
+
+function clearCompleted() {
+  for (let index = todos.length - 1; index >= 0; index -= 1) {
+    if (todos[index].done) todos.splice(index, 1);
+  }
+  renderTodos();
+}
+
+function createFilter(label, filter) {
+  const button = __CreateView(pageId);
+  __SetClasses(
+    button,
+    selectedFilter === filter ? "filter-button selected" : "filter-button",
+  );
+  __SetAttribute(button, "aria-label", `Show ${filter} tasks`);
+  const text = createText(
+    selectedFilter === filter ? "filter-text selected" : "filter-text",
+    label,
+  );
+  __AppendElement(button, text);
+  filterButtons.push(button);
+  filterTexts.push(text);
+  bindTap(button, () => selectFilter(filter), persistentListeners);
+  return button;
+}
+
+function renderPage() {
+  if (rendered) return;
+  rendered = true;
+
+  const scroll = __CreateScrollView(pageId);
+  __SetClasses(scroll, "scroll");
+  __SetAttribute(scroll, "scroll-orientation", "vertical");
+  const content = __CreateView(pageId);
+  __SetClasses(content, "content");
+
+  const header = __CreateView(pageId);
+  __SetClasses(header, "header");
+  __AppendElement(header, createText("eyebrow", "TODAY · PERSONAL BOARD"));
+  __AppendElement(header, createText("title", "Make room for progress"));
+  summaryText = createText("summary", "2 open · 1 completed");
+  __AppendElement(header, summaryText);
+  const addButton = __CreateView(pageId);
+  __SetClasses(addButton, "add-button");
+  __SetAttribute(addButton, "aria-label", "Add a suggested task");
+  __AppendElement(addButton, createText("add-button-text", "+ Add suggested task"));
+  bindTap(addButton, addQuickTodo, persistentListeners);
+  __AppendElement(header, addButton);
+  __AppendElement(content, header);
+
+  const filters = __CreateView(pageId);
+  __SetClasses(filters, "filter-row");
+  __AppendElement(filters, createFilter("All", "all"));
+  __AppendElement(filters, createFilter("Active", "active"));
+  __AppendElement(filters, createFilter("Done", "done"));
+  __AppendElement(content, filters);
+
+  listHost = __CreateView(pageId);
+  __SetClasses(listHost, "list");
+  for (const todo of getVisibleTodos()) {
+    __AppendElement(listHost, createTodoRow(todo));
+  }
+  __AppendElement(content, listHost);
+
+  const footer = __CreateView(pageId);
+  __SetClasses(footer, "footer");
+  footerNote = createText("footer-note", "3 items shown");
+  __AppendElement(footer, footerNote);
+  const clearButton = __CreateView(pageId);
+  __SetClasses(clearButton, "clear-button");
+  __SetAttribute(clearButton, "aria-label", "Clear completed tasks");
+  __AppendElement(clearButton, createText("clear-button-text", "Clear completed"));
+  bindTap(clearButton, clearCompleted, persistentListeners);
+  __AppendElement(footer, clearButton);
+  __AppendElement(content, footer);
+
+  __AppendElement(scroll, content);
+  __AppendElement(page, scroll);
+}
+
+function cleanup() {
+  clearListeners(rowListeners);
+  clearListeners(persistentListeners);
+  engine.removeEventListener(renderPageEventName, renderPage);
+  engine.removeEventListener(destroyLifetimeEventName, cleanup);
+  filterButtons.length = 0;
+  filterTexts.length = 0;
+  summaryText = undefined;
+  listHost = undefined;
+  footerNote = undefined;
+}
+
+engine.addEventListener(renderPageEventName, renderPage);
+engine.addEventListener(destroyLifetimeEventName, cleanup);
+</script>
+</lynx>

--- a/packages/genui/playground/src/mock/lynx-xml/travel-plan.lynxml
+++ b/packages/genui/playground/src/mock/lynx-xml/travel-plan.lynxml
@@ -1,0 +1,452 @@
+<!doctype lynx>
+<lynx engine-version="4.2">
+<style>
+.scroll {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #eef2f7;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  padding: 22px;
+  border-radius: 24px;
+  background-color: #153448;
+}
+
+.hero-kicker {
+  color: #9ed8cc;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+}
+
+.hero-title {
+  margin-top: 8px;
+  color: #ffffff;
+  font-size: 27px;
+  font-weight: 800;
+}
+
+.hero-subtitle {
+  margin-top: 8px;
+  color: #bed0d9;
+  font-size: 14px;
+  line-height: 20px;
+  white-space: normal;
+}
+
+.hero-stats {
+  display: flex;
+  flex-direction: row;
+  margin-top: 20px;
+}
+
+.hero-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border-radius: 14px;
+  background-color: #21475d;
+}
+
+.hero-stat.second {
+  margin-left: 10px;
+}
+
+.hero-stat-label {
+  color: #91b3c1;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.hero-stat-value {
+  margin-top: 4px;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.section-title {
+  margin-top: 22px;
+  color: #1c2a36;
+  font-size: 18px;
+  font-weight: 800;
+}
+
+.day-tabs {
+  display: flex;
+  flex-direction: row;
+  margin-top: 12px;
+}
+
+.day-tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 8px;
+  border-radius: 14px;
+  background-color: #ffffff;
+}
+
+.day-tab.middle,
+.day-tab.last {
+  margin-left: 8px;
+}
+
+.day-tab.selected {
+  background-color: #ff7657;
+}
+
+.day-name {
+  color: #657381;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.day-date {
+  margin-top: 3px;
+  color: #1c2a36;
+  font-size: 18px;
+  font-weight: 800;
+  text-align: center;
+}
+
+.day-name.selected,
+.day-date.selected {
+  color: #ffffff;
+}
+
+.route-host {
+  display: flex;
+  flex-direction: column;
+}
+
+.route-card {
+  display: flex;
+  flex-direction: column;
+  margin-top: 12px;
+  padding: 18px;
+  border-radius: 22px;
+  background-color: #ffffff;
+}
+
+.route-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 14px;
+  border-bottom: 1px solid #edf0f4;
+}
+
+.route-label {
+  color: #7d8996;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.route-summary {
+  color: #ff7657;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.stop {
+  display: flex;
+  flex-direction: row;
+  margin-top: 16px;
+}
+
+.stop-time {
+  width: 54px;
+  color: #44515e;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.stop-marker {
+  width: 12px;
+  height: 12px;
+  margin-top: 2px;
+  border-radius: 6px;
+  background-color: #ff7657;
+}
+
+.stop-marker.food {
+  background-color: #22a68a;
+}
+
+.stop-marker.culture {
+  background-color: #7259d9;
+}
+
+.stop-copy {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+}
+
+.stop-title {
+  color: #1c2a36;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.stop-detail {
+  margin-top: 4px;
+  color: #7b8794;
+  font-size: 12px;
+  line-height: 17px;
+  white-space: normal;
+}
+
+.rerender-note {
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 12px;
+  color: #5c6b78;
+  font-size: 11px;
+  line-height: 16px;
+  white-space: normal;
+  background-color: #f5f7fa;
+}
+</style>
+<script thread="main">
+const engine = lynx.getEngine();
+const page = __CreatePage("0", 0);
+const pageId = __GetElementUniqueID(page);
+const tapOptions = {};
+const renderPageEventName = "__RenderPage";
+const destroyLifetimeEventName = "__DestroyLifetime";
+
+const days = [
+  {
+    name: "FRI",
+    date: "18",
+    summary: "3 stops · 5.2 km",
+    stops: [
+      ["10:30", "Hotel check-in", "Harbor House · leave bags", "default"],
+      ["12:00", "Mercado lunch", "Seasonal plates near the waterfront", "food"],
+      ["15:30", "Old town walk", "Tiles, bookshops, and river views", "culture"],
+    ],
+  },
+  {
+    name: "SAT",
+    date: "19",
+    summary: "4 stops · 8.7 km",
+    stops: [
+      ["09:00", "Garden breakfast", "Coffee and pastries in Cedofeita", "food"],
+      ["11:00", "Serralves Museum", "Contemporary art and sculpture park", "culture"],
+      ["16:00", "Foz coastline", "Ocean promenade at golden hour", "default"],
+      ["20:00", "Dinner booking", "Small plates at Rua das Flores", "food"],
+    ],
+  },
+  {
+    name: "SUN",
+    date: "20",
+    summary: "3 stops · 4.1 km",
+    stops: [
+      ["09:30", "Riverside market", "Local ceramics and picnic supplies", "food"],
+      ["12:30", "Bridge lookout", "Panoramic views above the Douro", "default"],
+      ["15:00", "Station departure", "Collect bags before the 16:10 train", "culture"],
+    ],
+  },
+];
+
+let selectedDay = 0;
+let routeHost;
+let rendered = false;
+const dayButtons = [];
+const dayNameTexts = [];
+const dayDateTexts = [];
+const buttonListeners = [];
+
+function createText(className, value) {
+  const text = __CreateText(pageId);
+  __SetClasses(text, className);
+  __AppendElement(text, __CreateRawText(value));
+  return text;
+}
+
+function bindTap(node, handler) {
+  __AddEventListener(node, "tap", handler, tapOptions);
+  buttonListeners.push({ node, handler });
+}
+
+function createStat(className, label, value) {
+  const stat = __CreateView(pageId);
+  __SetClasses(stat, className);
+  __AppendElement(stat, createText("hero-stat-label", label));
+  __AppendElement(stat, createText("hero-stat-value", value));
+  return stat;
+}
+
+function createStop(stop) {
+  const row = __CreateView(pageId);
+  __SetClasses(row, "stop");
+  __AppendElement(row, createText("stop-time", stop[0]));
+
+  const marker = __CreateView(pageId);
+  __SetClasses(marker, `stop-marker ${stop[3]}`);
+  __AppendElement(row, marker);
+
+  const copy = __CreateView(pageId);
+  __SetClasses(copy, "stop-copy");
+  __AppendElement(copy, createText("stop-title", stop[1]));
+  __AppendElement(copy, createText("stop-detail", stop[2]));
+  __AppendElement(row, copy);
+  return row;
+}
+
+function createRoute(day) {
+  const route = __CreateView(pageId);
+  __SetClasses(route, "route-card");
+
+  const header = __CreateView(pageId);
+  __SetClasses(header, "route-header");
+  __AppendElement(header, createText("route-label", `${day.name} ROUTE`));
+  __AppendElement(header, createText("route-summary", day.summary));
+  __AppendElement(route, header);
+
+  for (const stop of day.stops) {
+    __AppendElement(route, createStop(stop));
+  }
+
+  __AppendElement(
+    route,
+    createText(
+      "rerender-note",
+      "Selecting another day replaces this complete itinerary subtree.",
+    ),
+  );
+  return route;
+}
+
+function selectDay(index) {
+  if (selectedDay === index || !routeHost) return;
+  selectedDay = index;
+
+  for (let itemIndex = 0; itemIndex < dayButtons.length; itemIndex += 1) {
+    const selected = itemIndex === selectedDay;
+    const positionClass = itemIndex === 1
+      ? "middle"
+      : itemIndex === 2
+      ? "last"
+      : "";
+    __SetClasses(
+      dayButtons[itemIndex],
+      `day-tab ${positionClass}${selected ? " selected" : ""}`,
+    );
+    __SetClasses(dayNameTexts[itemIndex], selected ? "day-name selected" : "day-name");
+    __SetClasses(dayDateTexts[itemIndex], selected ? "day-date selected" : "day-date");
+  }
+
+  __ReplaceElements(
+    routeHost,
+    [createRoute(days[selectedDay])],
+    __GetChildren(routeHost),
+  );
+  __FlushElementTree();
+}
+
+function createDayTab(day, index) {
+  const tab = __CreateView(pageId);
+  const positionClass = index === 1 ? "middle" : index === 2 ? "last" : "";
+  __SetClasses(
+    tab,
+    `day-tab ${positionClass}${index === selectedDay ? " selected" : ""}`,
+  );
+  __SetAttribute(tab, "aria-label", `Show ${day.name} ${day.date} itinerary`);
+
+  const nameText = createText(
+    index === selectedDay ? "day-name selected" : "day-name",
+    day.name,
+  );
+  const dateText = createText(
+    index === selectedDay ? "day-date selected" : "day-date",
+    day.date,
+  );
+  __AppendElement(tab, nameText);
+  __AppendElement(tab, dateText);
+  dayButtons.push(tab);
+  dayNameTexts.push(nameText);
+  dayDateTexts.push(dateText);
+  bindTap(tab, () => selectDay(index));
+  return tab;
+}
+
+function renderPage() {
+  if (rendered) return;
+  rendered = true;
+
+  const scroll = __CreateScrollView(pageId);
+  __SetClasses(scroll, "scroll");
+  __SetAttribute(scroll, "scroll-orientation", "vertical");
+
+  const content = __CreateView(pageId);
+  __SetClasses(content, "content");
+
+  const hero = __CreateView(pageId);
+  __SetClasses(hero, "hero");
+  __AppendElement(hero, createText("hero-kicker", "WEEKEND PLAN"));
+  __AppendElement(hero, createText("hero-title", "Three days in Porto"));
+  __AppendElement(
+    hero,
+    createText(
+      "hero-subtitle",
+      "A relaxed city break balanced across food, culture, and the coast.",
+    ),
+  );
+  const stats = __CreateView(pageId);
+  __SetClasses(stats, "hero-stats");
+  __AppendElement(stats, createStat("hero-stat", "DATES", "18–20 OCT"));
+  __AppendElement(stats, createStat("hero-stat second", "BUDGET", "€420"));
+  __AppendElement(hero, stats);
+  __AppendElement(content, hero);
+
+  __AppendElement(content, createText("section-title", "Your itinerary"));
+  const tabs = __CreateView(pageId);
+  __SetClasses(tabs, "day-tabs");
+  for (let index = 0; index < days.length; index += 1) {
+    __AppendElement(tabs, createDayTab(days[index], index));
+  }
+  __AppendElement(content, tabs);
+
+  routeHost = __CreateView(pageId);
+  __SetClasses(routeHost, "route-host");
+  __AppendElement(routeHost, createRoute(days[selectedDay]));
+  __AppendElement(content, routeHost);
+  __AppendElement(scroll, content);
+  __AppendElement(page, scroll);
+}
+
+function cleanup() {
+  for (const { node, handler } of buttonListeners.splice(0)) {
+    __RemoveEventListener(node, "tap", handler, tapOptions);
+  }
+  engine.removeEventListener(renderPageEventName, renderPage);
+  engine.removeEventListener(destroyLifetimeEventName, cleanup);
+  dayButtons.length = 0;
+  dayNameTexts.length = 0;
+  dayDateTexts.length = 0;
+  routeHost = undefined;
+}
+
+engine.addEventListener(renderPageEventName, renderPage);
+engine.addEventListener(destroyLifetimeEventName, cleanup);
+</script>
+</lynx>

--- a/packages/genui/playground/src/mock/lynx-xml/weather-card.lynxml
+++ b/packages/genui/playground/src/mock/lynx-xml/weather-card.lynxml
@@ -1,0 +1,547 @@
+<!doctype lynx>
+<lynx engine-version="4.2">
+<style>
+.weather-card {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  border-radius: 28px;
+  background-color: #dfe8f7;
+  box-shadow: 0 16px 44px rgba(18, 43, 82, 0.24);
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  background-color: #24508e;
+}
+
+.top-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.location-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.location-label {
+  color: #a8c4ea;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 1.4px;
+}
+
+.location {
+  margin-top: 4px;
+  color: #ffffff;
+  font-size: 21px;
+  font-weight: 800;
+}
+
+.condition-icon {
+  width: 58px;
+  height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 29px;
+  color: #234a80;
+  font-size: 26px;
+  font-weight: 800;
+  background-color: #ffdb70;
+}
+
+.temperature-row {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  margin-top: 22px;
+}
+
+.temperature {
+  color: #ffffff;
+  font-size: 64px;
+  font-weight: 300;
+  line-height: 68px;
+}
+
+.condition-copy {
+  display: flex;
+  flex-direction: column;
+  margin-left: 14px;
+  padding-bottom: 8px;
+}
+
+.condition {
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.range {
+  margin-top: 4px;
+  color: #b9ceed;
+  font-size: 12px;
+}
+
+.city-tabs {
+  display: flex;
+  flex-direction: row;
+  margin-top: 22px;
+}
+
+.city-tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 5px;
+  border-radius: 12px;
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.city-tab.second,
+.city-tab.third {
+  margin-left: 8px;
+}
+
+.city-tab.selected {
+  background-color: #ffffff;
+}
+
+.city-tab-text {
+  color: #c3d7f2;
+  font-size: 11px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.city-tab-text.selected {
+  color: #234a80;
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  padding: 20px 24px 24px;
+  background-color: #173767;
+}
+
+.background-status {
+  color: #87a8d2;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 1px;
+}
+
+.metrics {
+  display: flex;
+  flex-direction: row;
+  margin-top: 16px;
+}
+
+.metric {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.metric.second {
+  margin-left: 22px;
+}
+
+.metric-label {
+  color: #8ba8cd;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.metric-value {
+  margin-top: 5px;
+  color: #ffffff;
+  font-size: 18px;
+  font-weight: 800;
+}
+
+.bar-track {
+  height: 6px;
+  display: flex;
+  flex-direction: row;
+  margin-top: 9px;
+  border-radius: 3px;
+  background-color: #294a76;
+}
+
+.bar-fill {
+  width: 64%;
+  height: 6px;
+  border-radius: 3px;
+  background-color: #66d0c0;
+}
+
+.bar-fill.wind {
+  width: 42%;
+  background-color: #ffca68;
+}
+
+.advisory {
+  margin-top: 20px;
+  padding: 14px;
+  border-radius: 14px;
+  color: #c4d8f3;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: normal;
+  background-color: #214475;
+}
+
+.refresh-button {
+  height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 14px;
+  border-radius: 14px;
+  background-color: #ffca68;
+}
+
+.refresh-button:active,
+.city-tab:active {
+  opacity: 0.72;
+}
+
+.refresh-button-text {
+  color: #173767;
+  font-size: 13px;
+  font-weight: 800;
+}
+</style>
+<script thread="main">
+const engine = lynx.getEngine();
+const backgroundThread = lynx.getJSContext();
+const page = __CreatePage("0", 0);
+const pageId = __GetElementUniqueID(page);
+const tapOptions = {};
+const forecastRequestEventName = "WeatherForecastRequest";
+const forecastResultEventName = "WeatherForecastResult";
+const renderPageEventName = "__RenderPage";
+const destroyLifetimeEventName = "__DestroyLifetime";
+
+const cities = ["Tokyo", "Singapore", "Paris"];
+let selectedCity = 0;
+let activeRequestId = 0;
+let rendered = false;
+let locationText;
+let temperatureText;
+let conditionText;
+let rangeText;
+let statusText;
+let humidityText;
+let windText;
+let humidityBar;
+let windBar;
+let advisoryText;
+const cityTabs = [];
+const cityTabTexts = [];
+const buttonListeners = [];
+
+function createText(className, value) {
+  const text = __CreateText(pageId);
+  __SetClasses(text, className);
+  __AppendElement(text, __CreateRawText(value));
+  return text;
+}
+
+function replaceText(text, value) {
+  __ReplaceElements(text, [__CreateRawText(value)], __GetChildren(text));
+}
+
+function bindTap(node, handler) {
+  __AddEventListener(node, "tap", handler, tapOptions);
+  buttonListeners.push({ node, handler });
+}
+
+function updateCityTabs() {
+  for (let index = 0; index < cityTabs.length; index += 1) {
+    const position = index === 1 ? "second" : index === 2 ? "third" : "";
+    const selected = index === selectedCity;
+    __SetClasses(
+      cityTabs[index],
+      `city-tab ${position}${selected ? " selected" : ""}`,
+    );
+    __SetClasses(
+      cityTabTexts[index],
+      selected ? "city-tab-text selected" : "city-tab-text",
+    );
+  }
+}
+
+function requestForecast(cityIndex) {
+  selectedCity = cityIndex;
+  activeRequestId += 1;
+  updateCityTabs();
+  replaceText(locationText, cities[selectedCity]);
+  replaceText(statusText, "BACKGROUND THREAD · CALCULATING…");
+  replaceText(advisoryText, "Refreshing the hourly sample in the background.");
+  __FlushElementTree();
+
+  backgroundThread.dispatchEvent({
+    type: forecastRequestEventName,
+    data: {
+      city: cities[selectedCity],
+      requestId: activeRequestId,
+    },
+  });
+}
+
+function onForecastResult(event) {
+  const result = event.data;
+  if (!result || result.requestId !== activeRequestId) return;
+  replaceText(temperatureText, `${result.temperature}°`);
+  replaceText(conditionText, result.condition);
+  replaceText(rangeText, `H ${result.high}° · L ${result.low}°`);
+  replaceText(statusText, "BACKGROUND THREAD · UPDATED NOW");
+  replaceText(humidityText, `${result.humidity}%`);
+  replaceText(windText, `${result.wind} km/h`);
+  replaceText(advisoryText, result.advisory);
+  __SetInlineStyles(humidityBar, `width: ${result.humidity}%;`);
+  __SetInlineStyles(windBar, `width: ${Math.min(result.wind * 3, 100)}%;`);
+  __FlushElementTree();
+}
+
+function createCityTab(city, index) {
+  const tab = __CreateView(pageId);
+  const position = index === 1 ? "second" : index === 2 ? "third" : "";
+  __SetClasses(
+    tab,
+    `city-tab ${position}${index === selectedCity ? " selected" : ""}`,
+  );
+  __SetAttribute(tab, "aria-label", `Load ${city} forecast`);
+  const label = createText(
+    index === selectedCity ? "city-tab-text selected" : "city-tab-text",
+    city,
+  );
+  __AppendElement(tab, label);
+  cityTabs.push(tab);
+  cityTabTexts.push(label);
+  bindTap(tab, () => requestForecast(index));
+  return tab;
+}
+
+function createMetric(className, label, value, barClass) {
+  const metric = __CreateView(pageId);
+  __SetClasses(metric, className);
+  __AppendElement(metric, createText("metric-label", label));
+  const valueNode = createText("metric-value", value);
+  __AppendElement(metric, valueNode);
+  const track = __CreateView(pageId);
+  __SetClasses(track, "bar-track");
+  const fill = __CreateView(pageId);
+  __SetClasses(fill, barClass);
+  __AppendElement(track, fill);
+  __AppendElement(metric, track);
+  return { metric, valueNode, fill };
+}
+
+function renderPage() {
+  if (rendered) return;
+  rendered = true;
+
+  const card = __CreateScrollView(pageId);
+  __SetClasses(card, "weather-card");
+  __SetAttribute(card, "scroll-orientation", "vertical");
+  const hero = __CreateView(pageId);
+  __SetClasses(hero, "hero");
+
+  const top = __CreateView(pageId);
+  __SetClasses(top, "top-row");
+  const locationBlock = __CreateView(pageId);
+  __SetClasses(locationBlock, "location-block");
+  __AppendElement(locationBlock, createText("location-label", "CURRENT LOCATION"));
+  locationText = createText("location", "Tokyo");
+  __AppendElement(locationBlock, locationText);
+  __AppendElement(top, locationBlock);
+  __AppendElement(top, createText("condition-icon", "☀"));
+  __AppendElement(hero, top);
+
+  const temperatureRow = __CreateView(pageId);
+  __SetClasses(temperatureRow, "temperature-row");
+  temperatureText = createText("temperature", "--°");
+  __AppendElement(temperatureRow, temperatureText);
+  const conditionCopy = __CreateView(pageId);
+  __SetClasses(conditionCopy, "condition-copy");
+  conditionText = createText("condition", "Loading forecast");
+  rangeText = createText("range", "H --° · L --°");
+  __AppendElement(conditionCopy, conditionText);
+  __AppendElement(conditionCopy, rangeText);
+  __AppendElement(temperatureRow, conditionCopy);
+  __AppendElement(hero, temperatureRow);
+
+  const cityTabsView = __CreateView(pageId);
+  __SetClasses(cityTabsView, "city-tabs");
+  for (let index = 0; index < cities.length; index += 1) {
+    __AppendElement(cityTabsView, createCityTab(cities[index], index));
+  }
+  __AppendElement(hero, cityTabsView);
+  __AppendElement(card, hero);
+
+  const details = __CreateView(pageId);
+  __SetClasses(details, "details");
+  statusText = createText("background-status", "BACKGROUND THREAD · WAITING");
+  __AppendElement(details, statusText);
+
+  const metrics = __CreateView(pageId);
+  __SetClasses(metrics, "metrics");
+  const humidity = createMetric("metric", "HUMIDITY", "--%", "bar-fill");
+  humidityText = humidity.valueNode;
+  humidityBar = humidity.fill;
+  __AppendElement(metrics, humidity.metric);
+  const wind = createMetric(
+    "metric second",
+    "WIND",
+    "-- km/h",
+    "bar-fill wind",
+  );
+  windText = wind.valueNode;
+  windBar = wind.fill;
+  __AppendElement(metrics, wind.metric);
+  __AppendElement(details, metrics);
+
+  advisoryText = createText(
+    "advisory",
+    "Preparing a local recommendation from the hourly sample.",
+  );
+  __AppendElement(details, advisoryText);
+
+  const refresh = __CreateView(pageId);
+  __SetClasses(refresh, "refresh-button");
+  __SetAttribute(refresh, "aria-label", "Refresh weather in background thread");
+  __AppendElement(refresh, createText("refresh-button-text", "Refresh forecast"));
+  bindTap(refresh, () => requestForecast(selectedCity));
+  __AppendElement(details, refresh);
+  __AppendElement(card, details);
+  __AppendElement(page, card);
+
+  requestForecast(0);
+}
+
+function cleanup() {
+  backgroundThread.dispatchEvent({ type: destroyLifetimeEventName });
+  backgroundThread.removeEventListener(
+    forecastResultEventName,
+    onForecastResult,
+  );
+  for (const { node, handler } of buttonListeners.splice(0)) {
+    __RemoveEventListener(node, "tap", handler, tapOptions);
+  }
+  engine.removeEventListener(renderPageEventName, renderPage);
+  engine.removeEventListener(destroyLifetimeEventName, cleanup);
+  cityTabs.length = 0;
+  cityTabTexts.length = 0;
+  locationText = undefined;
+  temperatureText = undefined;
+  conditionText = undefined;
+  rangeText = undefined;
+  statusText = undefined;
+  humidityText = undefined;
+  windText = undefined;
+  humidityBar = undefined;
+  windBar = undefined;
+  advisoryText = undefined;
+}
+
+backgroundThread.addEventListener(forecastResultEventName, onForecastResult);
+engine.addEventListener(renderPageEventName, renderPage);
+engine.addEventListener(destroyLifetimeEventName, cleanup);
+</script>
+<script thread="background">
+const mainThread = lynx.getCoreContext();
+const forecastRequestEventName = "WeatherForecastRequest";
+const forecastResultEventName = "WeatherForecastResult";
+const destroyLifetimeEventName = "__DestroyLifetime";
+
+const samples = {
+  Tokyo: {
+    hourly: [21, 23, 25, 24, 22],
+    condition: "Clear and bright",
+    high: 26,
+    low: 18,
+    humidity: 58,
+    wind: 12,
+    advisory: "Comfortable through sunset. A light layer is enough after 19:00.",
+  },
+  Singapore: {
+    hourly: [29, 31, 32, 31, 29],
+    condition: "Warm with showers",
+    high: 33,
+    low: 27,
+    humidity: 82,
+    wind: 9,
+    advisory: "A brief shower is likely after 16:00. Keep a compact umbrella nearby.",
+  },
+  Paris: {
+    hourly: [13, 15, 16, 14, 12],
+    condition: "Clouds clearing",
+    high: 17,
+    low: 10,
+    humidity: 67,
+    wind: 18,
+    advisory: "Breezy on exposed streets. The clearest window starts around 15:00.",
+  },
+};
+
+let forecastTimer;
+
+function onForecastRequest(event) {
+  const request = event.data;
+  if (
+    !request
+    || typeof request.city !== "string"
+    || typeof request.requestId !== "number"
+  ) return;
+  const sample = samples[request.city];
+  if (!sample) return;
+
+  if (forecastTimer !== undefined) clearTimeout(forecastTimer);
+  forecastTimer = setTimeout(() => {
+    forecastTimer = undefined;
+    const total = sample.hourly.reduce((sum, value) => sum + value, 0);
+    const temperature = Math.round(total / sample.hourly.length);
+    mainThread.dispatchEvent({
+      type: forecastResultEventName,
+      data: {
+        requestId: request.requestId,
+        temperature,
+        condition: sample.condition,
+        high: sample.high,
+        low: sample.low,
+        humidity: sample.humidity,
+        wind: sample.wind,
+        advisory: sample.advisory,
+      },
+    });
+  }, 260);
+}
+
+function cleanup() {
+  mainThread.removeEventListener(
+    forecastRequestEventName,
+    onForecastRequest,
+  );
+  mainThread.removeEventListener(destroyLifetimeEventName, cleanup);
+  if (forecastTimer !== undefined) {
+    clearTimeout(forecastTimer);
+    forecastTimer = undefined;
+  }
+}
+
+mainThread.addEventListener(forecastRequestEventName, onForecastRequest);
+mainThread.addEventListener(destroyLifetimeEventName, cleanup);
+</script>
+</lynx>

--- a/packages/genui/playground/src/pages/demos/DemosListPage.tsx
+++ b/packages/genui/playground/src/pages/demos/DemosListPage.tsx
@@ -3,12 +3,17 @@
 // LICENSE file in the root directory of this source tree.
 import { A2UI_DEMOS_LIST_SOURCE } from './a2ui.js';
 import { DemosList } from './DemosList.js';
+import { LYNX_XML_DEMOS_LIST_SOURCE } from './lynx-xml.js';
 import { OPENUI_DEMOS_LIST_SOURCE } from './openui.js';
 import type { Protocol } from '../../utils/protocol.js';
 
 export function DemosListPage(
   props: { protocol: Protocol; theme: 'light' | 'dark' },
 ) {
+  if (props.protocol.name === 'lynx-xml') {
+    return <DemosList {...props} source={LYNX_XML_DEMOS_LIST_SOURCE} />;
+  }
+
   if (props.protocol.name === 'openui') {
     return <DemosList {...props} source={OPENUI_DEMOS_LIST_SOURCE} />;
   }

--- a/packages/genui/playground/src/pages/demos/DemosPage.tsx
+++ b/packages/genui/playground/src/pages/demos/DemosPage.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
 
 import { A2UI_DEMOS_PAGE_SOURCE } from './a2ui.js';
+import { LYNX_XML_DEMOS_PAGE_SOURCE } from './lynx-xml.js';
 import { OPENUI_DEMOS_PAGE_SOURCE } from './openui.js';
 import type { DemoCommit, DemoPageScenario, DemosPageSource } from './type.js';
 import { Button } from '../../components/Button.js';
@@ -128,6 +129,7 @@ function DemosPageContent<
   const editorIsEditable = currentEditorView?.editable ?? true;
 
   const isPlaybackActive = playState !== 'idle';
+  const playbackEnabled = source.playback !== false;
   const isPlaying = playState === 'playing';
   const isPaused = playState === 'paused';
   const isDone = playState === 'done';
@@ -543,6 +545,7 @@ function DemosPageContent<
               : 'playbackSection top idle'}
             style={playbackPanelStyle}
             aria-label='Playback'
+            hidden={!playbackEnabled}
           >
             <header className='playbackSectionHeader'>
               <span className='playbackSectionTitle'>Playback</span>
@@ -560,7 +563,11 @@ function DemosPageContent<
                 )
                 : (
                   <span className='playbackIdleHint'>
-                    <Play size={11} strokeWidth={2.25} aria-hidden='true' />
+                    <Play
+                      size={11}
+                      strokeWidth={2.25}
+                      aria-hidden='true'
+                    />
                     Replay payload chunk by chunk
                   </span>
                 )}
@@ -652,6 +659,7 @@ function DemosPageContent<
             aria-label={source.editor.splitterAriaLabel}
             title='Drag to resize'
             onPointerDown={handlePlaybackResizeStart}
+            hidden={!playbackEnabled}
           >
             <span className='playbackSplitterGrip' aria-hidden='true' />
           </div>
@@ -780,6 +788,7 @@ function DemosPageContent<
           className='previewPanel examplesPreviewPanel'
           title='Lynx Preview'
           showPreviewModeSwitch
+          showSimulationBar={playbackEnabled}
           speed={playbackSpeed}
           onSpeedChange={setPlaybackSpeed}
           previewSource={previewSource}
@@ -809,6 +818,16 @@ export function DemosPage(props: {
   demoId?: string;
   theme: 'light' | 'dark';
 }) {
+  if (props.protocol.name === 'lynx-xml') {
+    return (
+      <DemosPageContent
+        key='lynx-xml'
+        {...props}
+        source={LYNX_XML_DEMOS_PAGE_SOURCE}
+      />
+    );
+  }
+
   if (props.protocol.name === 'openui') {
     return (
       <DemosPageContent

--- a/packages/genui/playground/src/pages/demos/lynx-xml.test.ts
+++ b/packages/genui/playground/src/pages/demos/lynx-xml.test.ts
@@ -1,0 +1,208 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  LYNX_XML_DEMOS_LIST_SOURCE,
+  LYNX_XML_DEMOS_PAGE_SOURCE,
+  LYNX_XML_SCENARIOS,
+} from './lynx-xml.js';
+import { PROTOCOLS } from '../../utils/protocol.js';
+
+const FLEX_LAYOUT_CLASSES: Readonly<Record<string, readonly string[]>> = {
+  counter: [
+    'counter-card',
+    'value-panel',
+    'stepper',
+    'step-button',
+    'reset-button',
+  ],
+  'travel-plan': [
+    'scroll',
+    'content',
+    'hero',
+    'hero-stats',
+    'hero-stat',
+    'day-tabs',
+    'day-tab',
+    'route-host',
+    'route-card',
+    'route-header',
+    'stop',
+    'stop-copy',
+  ],
+  'product-card': [
+    'product-card',
+    'visual',
+    'content',
+    'meta-row',
+    'swatches',
+    'swatch',
+    'purchase-row',
+    'price-block',
+    'quantity',
+    'quantity-button',
+    'add-button',
+  ],
+  'weather-card': [
+    'weather-card',
+    'hero',
+    'top-row',
+    'location-block',
+    'condition-icon',
+    'temperature-row',
+    'condition-copy',
+    'city-tabs',
+    'city-tab',
+    'details',
+    'metrics',
+    'metric',
+    'bar-track',
+    'refresh-button',
+  ],
+  'todo-list': [
+    'scroll',
+    'content',
+    'header',
+    'add-button',
+    'filter-row',
+    'filter-button',
+    'list',
+    'todo-row',
+    'checkbox',
+    'todo-copy',
+    'footer',
+    'clear-button',
+  ],
+};
+
+const ROW_LAYOUT_CLASSES: Readonly<Record<string, readonly string[]>> = {
+  counter: ['stepper'],
+  'travel-plan': ['hero-stats', 'day-tabs', 'route-header', 'stop'],
+  'product-card': ['meta-row', 'swatches', 'purchase-row', 'quantity'],
+  'weather-card': [
+    'top-row',
+    'temperature-row',
+    'city-tabs',
+    'metrics',
+    'bar-track',
+  ],
+  'todo-list': ['filter-row', 'todo-row', 'footer'],
+};
+
+function expectCssDeclaration(
+  source: string,
+  className: string,
+  declaration: string,
+): void {
+  expect(source).toMatch(
+    new RegExp(
+      `\\.${className}\\s*\\{[^}]*${declaration.replaceAll(' ', '\\s*')}`,
+      'u',
+    ),
+  );
+}
+
+describe('Lynx XML showcase', () => {
+  test('offers representative zero-build application scenarios', () => {
+    expect(LYNX_XML_SCENARIOS.map(({ id }) => id)).toEqual([
+      'counter',
+      'travel-plan',
+      'product-card',
+      'weather-card',
+      'todo-list',
+    ]);
+    for (const scenario of LYNX_XML_SCENARIOS) {
+      expect(scenario.source).toMatch(/^<!doctype lynx>/u);
+      expect(scenario.source).toContain('<lynx engine-version="4.2">');
+      expect(scenario.source).toContain('<script thread="main">');
+      expect(scenario.source).toMatch(/<\/lynx>\s*$/u);
+      expect(scenario.sourcePath).toMatch(/\.lynxml$/u);
+      expect(scenario.source).not.toMatch(/\.mp[34][?"']/iu);
+      expect(scenario.source).not.toContain('__SetClasses(page,');
+      expect(scenario.source).not.toContain('const app = __CreateView');
+      expect(scenario.source).not.toMatch(/\.page\s*\{/u);
+      expect(scenario.source).toMatch(
+        /__AppendElement\(page, (?:card|scroll)\);/u,
+      );
+    }
+    expect(LYNX_XML_SCENARIOS[1]!.source).toContain('__ReplaceElements');
+    expect(LYNX_XML_SCENARIOS[3]!.source).toContain(
+      '<script thread="background">',
+    );
+    expect(LYNX_XML_DEMOS_LIST_SOURCE.sections).toMatchObject([
+      { title: 'Examples', layout: 'flow' },
+    ]);
+  });
+
+  test('enables flex explicitly on every layout container', () => {
+    for (const scenario of LYNX_XML_SCENARIOS) {
+      for (const className of FLEX_LAYOUT_CLASSES[scenario.id] ?? []) {
+        expectCssDeclaration(scenario.source, className, 'display: flex;');
+      }
+      for (const className of ROW_LAYOUT_CLASSES[scenario.id] ?? []) {
+        expectCssDeclaration(
+          scenario.source,
+          className,
+          'flex-direction: row;',
+        );
+      }
+    }
+  });
+
+  test('uses the entry node itself as a vertical scroll view', () => {
+    for (const scenario of LYNX_XML_SCENARIOS) {
+      expect(scenario.source).toMatch(
+        /const (?:card|scroll) = __CreateScrollView\(pageId\);/u,
+      );
+      expect(scenario.source).toMatch(
+        /__SetAttribute\((?:card|scroll), "scroll-orientation", "vertical"\)/u,
+      );
+    }
+  });
+
+  test('enables HTML language support in the Lynx XML editor', () => {
+    expect(LYNX_XML_DEMOS_PAGE_SOURCE.editor.extensions).toHaveLength(1);
+  });
+
+  test('constructs a direct XML preview URL for each card', () => {
+    const scenario = LYNX_XML_SCENARIOS[0]!;
+    const previewUrl = new URL(
+      LYNX_XML_DEMOS_LIST_SOURCE.createPreviewUrl({
+        baseUrl: 'https://lynx-stack.dev/genui/',
+        protocol: PROTOCOLS['lynx-xml'],
+        scenario,
+        theme: 'light',
+      }),
+    );
+
+    expect(previewUrl.searchParams.get('protocol')).toBe('lynx-xml');
+    expect(previewUrl.searchParams.get('demoUrl')).toBe(
+      `https://lynx-stack.dev/genui/${scenario.sourcePath}`,
+    );
+  });
+
+  test('keeps static sources shareable until the editor changes them', () => {
+    const scenario = LYNX_XML_SCENARIOS[0]!;
+    expect(
+      LYNX_XML_DEMOS_PAGE_SOURCE.createScenarioPreviewInput(scenario),
+    ).toEqual({
+      source: scenario.source,
+      sourcePath: scenario.sourcePath,
+    });
+
+    const edited = LYNX_XML_DEMOS_PAGE_SOURCE.commit({
+      editorEdited: true,
+      editorValue: scenario.source.replace('WEEKEND EDIT', 'CUSTOM EDIT'),
+      scenario,
+    });
+    expect(edited).toMatchObject({
+      value: {
+        previewInput: { sourcePath: undefined },
+        playbackChunks: [],
+      },
+    });
+  });
+});

--- a/packages/genui/playground/src/pages/demos/lynx-xml.ts
+++ b/packages/genui/playground/src/pages/demos/lynx-xml.ts
@@ -1,0 +1,168 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { html } from '@codemirror/lang-html';
+
+import type { DemosListSource } from './DemosList.js';
+import type { DemosPageSource } from './type.js';
+import counterSource from '../../mock/lynx-xml/counter.lynxml?raw';
+import productCardSource from '../../mock/lynx-xml/product-card.lynxml?raw';
+import todoListSource from '../../mock/lynx-xml/todo-list.lynxml?raw';
+import travelPlanSource from '../../mock/lynx-xml/travel-plan.lynxml?raw';
+import weatherCardSource from '../../mock/lynx-xml/weather-card.lynxml?raw';
+import { buildLynxXmlRenderUrl } from '../../utils/renderUrl.js';
+
+interface LynxXmlScenario {
+  id: string;
+  title: string;
+  description: string;
+  badge: string;
+  sourcePath: string;
+  source: string;
+}
+
+interface LynxXmlPreviewInput {
+  source: string;
+  sourcePath?: string;
+}
+
+const htmlExtensions = [html({ autoCloseTags: false, selfClosingTags: true })];
+
+export const LYNX_XML_SCENARIOS: readonly LynxXmlScenario[] = [
+  {
+    id: 'counter',
+    title: 'Counter',
+    description:
+      'Updates local state and visible values immediately on the main thread.',
+    badge: 'Main thread',
+    sourcePath: 'demos/lynx-xml/counter.lynxml',
+    source: counterSource,
+  },
+  {
+    id: 'travel-plan',
+    title: 'Travel Plan',
+    description:
+      'Switches days and replaces the complete itinerary subtree on selection.',
+    badge: 'Re-render',
+    sourcePath: 'demos/lynx-xml/travel-plan.lynxml',
+    source: travelPlanSource,
+  },
+  {
+    id: 'product-card',
+    title: 'Product Card',
+    description:
+      'Selects a color, changes quantity, and confirms a purchase action.',
+    badge: 'Selection',
+    sourcePath: 'demos/lynx-xml/product-card.lynxml',
+    source: productCardSource,
+  },
+  {
+    id: 'weather-card',
+    title: 'Weather Card',
+    description:
+      'Computes a forecast on the background thread and returns a UI patch.',
+    badge: 'Background',
+    sourcePath: 'demos/lynx-xml/weather-card.lynxml',
+    source: weatherCardSource,
+  },
+  {
+    id: 'todo-list',
+    title: 'Todo List',
+    description:
+      'Adds, filters, toggles, and rebuilds a dynamic list with safe cleanup.',
+    badge: 'Dynamic list',
+    sourcePath: 'demos/lynx-xml/todo-list.lynxml',
+    source: todoListSource,
+  },
+];
+
+export const LYNX_XML_DEMOS_LIST_SOURCE = {
+  title: 'Lynx XML Showcase',
+  description:
+    'Explore zero-build Lynx interfaces authored as a single XML artifact with Lynx CSS and main-thread Element PAPI JavaScript.',
+  scenarios: LYNX_XML_SCENARIOS,
+  sections: [
+    {
+      id: 'typical-apps',
+      title: 'Examples',
+      scenarios: LYNX_XML_SCENARIOS,
+      layout: 'flow',
+    },
+  ],
+  createPreviewUrl({ baseUrl, scenario, theme }) {
+    return buildLynxXmlRenderUrl({
+      sourceUrl: new URL(scenario.sourcePath, baseUrl).toString(),
+      theme,
+    }, baseUrl);
+  },
+  createResetKey({ protocol, theme }) {
+    return `${protocol.name}|${theme}`;
+  },
+} satisfies DemosListSource<LynxXmlScenario>;
+
+function findScenario(id?: string): LynxXmlScenario | undefined {
+  if (!id) return undefined;
+  return LYNX_XML_SCENARIOS.find((scenario) => scenario.id === id);
+}
+
+export const LYNX_XML_DEMOS_PAGE_SOURCE = {
+  scenarios: LYNX_XML_SCENARIOS,
+  findScenario,
+  getEditorValue(scenario) {
+    return scenario.source;
+  },
+  createScenarioPreviewInput(scenario) {
+    return { source: scenario.source, sourcePath: scenario.sourcePath };
+  },
+  commit({ editorEdited, editorValue, scenario }) {
+    if (!editorValue.trim()) return { error: 'Lynx XML source is empty.' };
+    return {
+      value: {
+        previewInput: {
+          source: editorValue,
+          sourcePath: !editorEdited && scenario?.source === editorValue
+            ? scenario.sourcePath
+            : undefined,
+        },
+        playbackChunks: [],
+        meta: undefined,
+      },
+    };
+  },
+  createPreviewSource({ input, theme }) {
+    return {
+      kind: 'lynx-xml',
+      source: input.source,
+      sourcePath: input.sourcePath,
+      theme,
+    };
+  },
+  formatPlaybackChunk(chunk) {
+    return chunk;
+  },
+  playback: false,
+  emptyEditorValue: '',
+  emptyPlaybackError: 'Lynx XML artifacts are rendered as a whole.',
+  resetPlaybackOnFill: true,
+  editor: {
+    title: 'Lynx XML Source',
+    badge: 'XML',
+    basicSetup: {
+      lineNumbers: true,
+      foldGutter: true,
+      bracketMatching: true,
+      closeBrackets: true,
+      autocompletion: false,
+    },
+    extensions: htmlExtensions,
+    splitterAriaLabel: 'Resize Playback and Lynx XML panels',
+    panelResizeAriaLabel: 'Resize Lynx XML and preview panels',
+    emptyPreviewTitle: 'Select a Lynx XML example to preview',
+  },
+} satisfies DemosPageSource<
+  LynxXmlScenario,
+  LynxXmlPreviewInput,
+  string,
+  undefined
+>;

--- a/packages/genui/playground/src/pages/demos/type.ts
+++ b/packages/genui/playground/src/pages/demos/type.ts
@@ -72,6 +72,8 @@ export interface DemosPageSource<
     theme: 'light' | 'dark';
   }) => PreviewPanelSource;
   formatPlaybackChunk: (chunk: TChunk) => string;
+  /** Whole-artifact protocols can opt out of the incremental playback pane. */
+  playback?: false;
   emptyEditorValue: string;
   emptyPlaybackError: string;
   resetPlaybackOnFill?: boolean;

--- a/packages/genui/playground/src/render.tsx
+++ b/packages/genui/playground/src/render.tsx
@@ -27,7 +27,7 @@ import {
 } from './utils/renderUrl.js';
 
 interface InitData {
-  protocol?: '0.9' | 'a2ui' | 'openui' | 'mcp-apps';
+  protocol?: '0.9' | 'a2ui' | 'openui' | 'mcp-apps' | 'lynx-xml';
   messagesUrl?: string;
   messages?: unknown;
   actionMocksUrl?: string;
@@ -143,6 +143,7 @@ function readProtocol(value: unknown): InitData['protocol'] {
       || value === 'a2ui'
       || value === 'openui'
       || value === 'mcp-apps'
+      || value === 'lynx-xml'
     ? value
     : undefined;
 }

--- a/packages/genui/playground/src/utils/appRoute.test.ts
+++ b/packages/genui/playground/src/utils/appRoute.test.ts
@@ -27,6 +27,25 @@ describe('app route hash', () => {
     expect(buildRouteHash('mcp-apps', 'create')).toBe('#/mcp-apps');
   });
 
+  test('keeps Lynx XML on its examples-only surface', () => {
+    expect(buildRouteHash('lynx-xml', 'examples')).toBe(
+      '#/lynx-xml/examples',
+    );
+    expect(parseRouteHash('#/lynx-xml')).toMatchObject({
+      protocol: { name: 'lynx-xml', version: '0.1' },
+      tab: 'examples',
+    });
+    expect(parseRouteHash('#/lynx-xml/create')).toMatchObject({
+      protocol: { name: 'lynx-xml' },
+      tab: 'examples',
+    });
+    expect(parseRouteHash('#/lynx-xml/examples/counter')).toMatchObject({
+      protocol: { name: 'lynx-xml' },
+      tab: 'examples',
+      demoId: 'counter',
+    });
+  });
+
   test('recognizes the MCP Apps protocol root', () => {
     expect(parseRouteHash('#/mcp-apps')).toMatchObject({
       protocol: { name: 'mcp-apps', version: '2026-01-26' },

--- a/packages/genui/playground/src/utils/appRoute.ts
+++ b/packages/genui/playground/src/utils/appRoute.ts
@@ -45,6 +45,7 @@ export function parseRouteHash(hash: string): Route {
     parts[0] === 'a2ui'
     || parts[0] === 'openui'
     || parts[0] === 'mcp-apps'
+    || parts[0] === 'lynx-xml'
   ) {
     protocol = getProtocol(parts[0]);
     rest = parts.slice(1);
@@ -56,6 +57,11 @@ export function parseRouteHash(hash: string): Route {
       tab: 'examples',
       demoId: rest[1],
     };
+  }
+  // Lynx XML currently exposes only its example showcase. Keep protocol-root
+  // and unsupported-tab deep links inside that surface as the protocol grows.
+  if (protocol.name === 'lynx-xml') {
+    return { protocol, tab: 'examples' };
   }
   if (rest[0] === 'components' || rest[0] === 'catalog') {
     return {

--- a/packages/genui/playground/src/utils/protocol.ts
+++ b/packages/genui/playground/src/utils/protocol.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-export type ProtocolName = 'a2ui' | 'openui' | 'mcp-apps';
+export type ProtocolName = 'a2ui' | 'openui' | 'mcp-apps' | 'lynx-xml';
 
 export interface Protocol {
   name: ProtocolName;
@@ -13,6 +13,7 @@ export const PROTOCOLS: Record<ProtocolName, Protocol> = {
   a2ui: { name: 'a2ui', version: '0.9' },
   openui: { name: 'openui', version: '0.5' },
   'mcp-apps': { name: 'mcp-apps', version: '2026-01-26' },
+  'lynx-xml': { name: 'lynx-xml', version: '0.1' },
 };
 
 export const DEFAULT_PROTOCOL: Protocol = PROTOCOLS.a2ui;
@@ -20,5 +21,6 @@ export const DEFAULT_PROTOCOL: Protocol = PROTOCOLS.a2ui;
 export function getProtocol(name: string | null | undefined): Protocol {
   if (name === 'openui') return PROTOCOLS.openui;
   if (name === 'mcp-apps') return PROTOCOLS['mcp-apps'];
+  if (name === 'lynx-xml') return PROTOCOLS['lynx-xml'];
   return PROTOCOLS.a2ui;
 }

--- a/packages/genui/playground/src/utils/renderUrl.test.ts
+++ b/packages/genui/playground/src/utils/renderUrl.test.ts
@@ -8,6 +8,7 @@ import { PROTOCOLS } from './protocol.js';
 import {
   A2UI_INLINE_RENDER_URL_MAX_LENGTH,
   OPENUI_INLINE_RENDER_URL_MAX_LENGTH,
+  buildLynxXmlRenderUrl,
   buildMcpAppsRenderUrl,
   buildOpenUIRenderUrl,
   buildRenderUrl,
@@ -15,6 +16,8 @@ import {
   canInlineOpenUIRenderUrl,
   createLocalA2UIMessagesPayload,
   createLocalA2UIMessagesPayloadCache,
+  createLocalLynxXmlSourcePayload,
+  createLocalLynxXmlSourcePayloadCache,
   hasExternalA2UIRenderPayload,
   hasShareableA2UIRenderPayload,
   isPortableA2UIMessagesUrl,
@@ -271,5 +274,74 @@ describe('MCP Apps render URLs', () => {
       mcpAppData,
       theme: 'dark',
     });
+  });
+});
+
+describe('Lynx XML render URLs', () => {
+  test('keeps consecutive inline XML Blob URLs aligned with their source', async () => {
+    const readBlobContents: Array<() => Promise<string>> = [];
+    const lifecycle: string[] = [];
+    let nextId = 0;
+    const cache = createLocalLynxXmlSourcePayloadCache({
+      createPayload: (source) =>
+        createLocalLynxXmlSourcePayload(source, {
+          createObjectURL(blob) {
+            nextId += 1;
+            readBlobContents.push(() => blob.text());
+            lifecycle.push(`create:${nextId}`);
+            return `blob:https://lynx-stack.dev/lynx-xml-${nextId}`;
+          },
+          revokeObjectURL(url) {
+            lifecycle.push(`revoke:${url}`);
+          },
+        }),
+    });
+
+    const firstSource = '<lynx id="first"></lynx>';
+    const first = cache.ensure(firstSource);
+    const firstRenderUrl = new URL(buildLynxXmlRenderUrl({
+      sourceUrl: first.sourceUrl,
+    }, 'https://lynx-stack.dev/genui/'));
+
+    const secondSource = '<lynx id="second"></lynx>';
+    const second = cache.ensure(secondSource);
+    const secondRenderUrl = new URL(buildLynxXmlRenderUrl({
+      sourceUrl: second.sourceUrl,
+    }, 'https://lynx-stack.dev/genui/'));
+
+    expect(firstRenderUrl.searchParams.get('demoUrl')).toBe(first.sourceUrl);
+    expect(secondRenderUrl.searchParams.get('demoUrl')).toBe(second.sourceUrl);
+    expect(second.sourceUrl).not.toBe(first.sourceUrl);
+    expect(cache.ensure(secondSource)).toBe(second);
+    expect(lifecycle).toEqual([
+      'create:1',
+      'create:2',
+      `revoke:${first.sourceUrl}`,
+    ]);
+    expect(lifecycle).not.toContain(`revoke:${second.sourceUrl}`);
+    expect(await Promise.all(readBlobContents.map((read) => read()))).toEqual([
+      firstSource,
+      secondSource,
+    ]);
+
+    cache.clear();
+    expect(lifecycle[lifecycle.length - 1]).toBe(
+      `revoke:${second.sourceUrl}`,
+    );
+  });
+
+  test('loads the XML artifact URL directly in the Lynx runtime', () => {
+    const sourceUrl =
+      'https://lynx-stack.dev/genui/demos/lynx-xml/travel-plan.lynxml';
+    const url = new URL(buildLynxXmlRenderUrl({
+      sourceUrl,
+      theme: 'dark',
+    }, 'https://lynx-stack.dev/genui/'));
+
+    expect(url.pathname).toBe('/genui/render.html');
+    expect(url.searchParams.get('protocol')).toBe('lynx-xml');
+    expect(url.searchParams.get('demoUrl')).toBe(sourceUrl);
+    expect(url.searchParams.get('theme')).toBe('dark');
+    expect(url.searchParams.has('initData')).toBe(false);
   });
 });

--- a/packages/genui/playground/src/utils/renderUrl.ts
+++ b/packages/genui/playground/src/utils/renderUrl.ts
@@ -52,6 +52,11 @@ export interface McpAppsRenderInit {
   theme?: 'light' | 'dark';
 }
 
+export interface LynxXmlRenderInit {
+  sourceUrl: string;
+  theme?: 'light' | 'dark';
+}
+
 export function hasShareableA2UIRenderPayload(
   init: Pick<RenderInit, 'demoId' | 'messages' | 'messagesUrl'>,
 ): boolean {
@@ -87,6 +92,81 @@ interface ObjectURLRegistry {
   // eslint-disable-next-line n/no-unsupported-features/node-builtins
   createObjectURL(object: Blob): string;
   revokeObjectURL(url: string): void;
+}
+
+interface LocalBlobPayload {
+  url: string;
+  dispose: () => void;
+}
+
+function createLocalBlobPayload(
+  content: BlobPart,
+  type: string,
+  registry: ObjectURLRegistry,
+): LocalBlobPayload {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  const url = registry.createObjectURL(new Blob([content], { type }));
+  let disposed = false;
+  return {
+    url,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      registry.revokeObjectURL(url);
+    },
+  };
+}
+
+export interface LocalLynxXmlSourcePayload {
+  sourceUrl: string;
+  dispose: () => void;
+}
+
+export interface LocalLynxXmlSourcePayloadCache {
+  ensure: (source: string) => LocalLynxXmlSourcePayload;
+  clear: () => void;
+}
+
+interface LocalLynxXmlSourcePayloadCacheOptions {
+  createPayload: (source: string) => LocalLynxXmlSourcePayload;
+}
+
+export function createLocalLynxXmlSourcePayload(
+  source: string,
+  registry: ObjectURLRegistry = URL,
+): LocalLynxXmlSourcePayload {
+  const { url: sourceUrl, dispose } = createLocalBlobPayload(
+    source,
+    'application/xml;charset=utf-8',
+    registry,
+  );
+  return { sourceUrl, dispose };
+}
+
+export function createLocalLynxXmlSourcePayloadCache(
+  options: LocalLynxXmlSourcePayloadCacheOptions,
+): LocalLynxXmlSourcePayloadCache {
+  let current: {
+    payload: LocalLynxXmlSourcePayload;
+    source: string;
+  } | null = null;
+
+  return {
+    ensure: (source) => {
+      if (current?.source === source) return current.payload;
+
+      const payload = options.createPayload(source);
+      const previous = current;
+      current = { payload, source };
+      previous?.payload.dispose();
+      return payload;
+    },
+    clear: () => {
+      const previous = current;
+      current = null;
+      previous?.payload.dispose();
+    },
+  };
 }
 
 export interface LocalA2UIMessagesPayload {
@@ -125,21 +205,12 @@ export function createLocalA2UIMessagesPayload(
   if (serialized === undefined) {
     throw new Error('A2UI messages must be JSON serializable');
   }
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
-  const messagesUrl = registry.createObjectURL(
-    // eslint-disable-next-line n/no-unsupported-features/node-builtins
-    new Blob([serialized], { type: 'application/json' }),
+  const { url: messagesUrl, dispose } = createLocalBlobPayload(
+    serialized,
+    'application/json',
+    registry,
   );
-  let disposed = false;
-  return {
-    messagesUrl,
-    dispose: () => {
-      if (disposed) return;
-      disposed = true;
-      // eslint-disable-next-line n/no-unsupported-features/node-builtins
-      registry.revokeObjectURL(messagesUrl);
-    },
-  };
+  return { messagesUrl, dispose };
 }
 
 /**
@@ -369,6 +440,17 @@ export function buildMcpAppsRenderUrl(
       ...(init.theme ? { theme: init.theme } : {}),
     })),
   );
+  if (init.theme) url.searchParams.set('theme', init.theme);
+  return url.toString();
+}
+
+export function buildLynxXmlRenderUrl(
+  init: LynxXmlRenderInit,
+  baseUrl: string,
+): string {
+  const url = new URL('render.html', baseUrl);
+  url.searchParams.set('protocol', 'lynx-xml');
+  url.searchParams.set('demoUrl', init.sourceUrl);
   if (init.theme) url.searchParams.set('theme', init.theme);
   return url.toString();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,6 +1026,9 @@ importers:
 
   packages/genui/playground:
     dependencies:
+      '@codemirror/lang-html':
+        specifier: ^6.4.12
+        version: 6.4.12
       '@codemirror/lang-json':
         specifier: ^6.0.2
         version: 6.0.2
@@ -3466,6 +3469,15 @@ packages:
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.12':
+    resolution: {integrity: sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
   '@codemirror/lang-json@6.0.2':
     resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
 
@@ -4274,8 +4286,17 @@ packages:
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
+  '@lezer/css@1.3.6':
+    resolution: {integrity: sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g==}
+
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
 
   '@lezer/json@1.0.3':
     resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
@@ -13109,6 +13130,36 @@ snapshots:
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
 
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.6
+
+  '@codemirror/lang-html@6.4.12':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.6
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
   '@codemirror/lang-json@6.0.2':
     dependencies:
       '@codemirror/language': 6.12.3
@@ -13855,9 +13906,27 @@ snapshots:
 
   '@lezer/common@1.5.2': {}
 
+  '@lezer/css@1.3.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/highlight@1.2.3':
     dependencies:
       '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/json@1.0.3':
     dependencies:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Lynx XML examples section to the playground.
  * Added five interactive examples: counter, product card, todo list, travel plan, and weather card.
  * Added source editing, direct previews, and light/dark theme support.
  * Added shareable web and native preview links for unchanged examples.
  * Lynx XML examples open by default without playback controls.

* **Documentation**
  * Added setup and usage guidance for Lynx XML examples.
  * Added editor support for `.lynxml` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
