### PR TITLE
fix(genui): hide disabled playback controls

### DIFF
--- a/packages/genui/playground/src/pages/demos/DemosPage.css
+++ b/packages/genui/playground/src/pages/demos/DemosPage.css
@@ -725,6 +725,11 @@
   transition: height 220ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
+.playbackSplitter[hidden],
+.playbackSection[hidden] {
+  display: none;
+}
+
 /* When playback sits above the editor, drop the top border — the page header
    already separates it and the splitter handles the bottom edge. */
 .playbackSection.top {


### PR DESCRIPTION
## Summary

- preserve the `hidden` state for the playback panel and splitter when a demo source disables playback
- prevent Lynx XML examples from exposing an inapplicable Play action

Fixes #3636

## Validation

- `node_modules/.bin/dprint check packages/genui/playground/src/pages/demos/DemosPage.css`
- `node_modules/.bin/biome check packages/genui/playground/src/pages/demos/DemosPage.css`
- `pnpm -C packages/genui/playground exec rstest run src/pages/demos/lynx-xml.test.ts` (6 tests passed)
- `git diff --check`

The repository-wide `pnpm turbo build` was also attempted before focused tests, but this Windows environment does not have `cargo`; the build stops in the Rust-backed SWC/WebAssembly packages before reaching the playground build.

## Checklist

- [x] Tests updated (or **not required** — existing Lynx XML focused suite passes; this is a CSS cascade fix).
- [x] Documentation updated (or not required).
- [x] Changeset added (or not required — `genui-playground` is private).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playback splitters and playback sections are now fully hidden when disabled, preventing empty or unwanted UI elements from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->