### PR TITLE
docs(testing-library): fix environment package link

### DIFF
--- a/packages/testing-library/README.md
+++ b/packages/testing-library/README.md
@@ -6,7 +6,7 @@ Unit testing library for lynx, same as https://github.com/testing-library.
 
 | Package                                                    | Description                               | Equivalent                                                                           |
 | ---------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------ |
-| [@lynx-js/testing-environment](./lynx-environment/)        | Lynx equivalent of jsdom                  | [jsdom](https://github.com/jsdom/jsdom)                                              |
+| [@lynx-js/testing-environment](./testing-environment/)     | Lynx equivalent of jsdom                  | [jsdom](https://github.com/jsdom/jsdom)                                              |
 | [@lynx-js/react/testing-library](../react/testing-library) | Lynx equivalent of preact-testing-library | [@testing-library/preact](https://github.com/testing-library/preact-testing-library) |
 
 ## Documentation


### PR DESCRIPTION
## Summary

- update the Testing Library overview to link to the renamed `testing-environment` package directory
- remove the stale `lynx-environment` relative target left after #704

Fixes #3637

## Validation

- `node_modules/.bin/dprint check packages/testing-library/README.md`
- verified the new relative target exists and contains 23 tracked entries
- verified the old target no longer occurs in the README
- `git diff --check`

## Checklist

- [x] Tests updated (or **not required** — documentation-only link correction).
- [x] Documentation updated.
- [x] Changeset added (or not required — no package behavior or published API changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the package link for `@lynx-js/testing-environment` in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->