### PR TITLE
feat: add an Examples tab to the MCP Apps playground

### DIFF
--- a/.changeset/mcp-apps-examples-showcase.md
+++ b/.changeset/mcp-apps-examples-showcase.md
@@ -1,0 +1,7 @@
+---
+
+---
+
+Add an Examples tab to the MCP Apps playground that showcases the registered
+Weather and Product renderer templates with editable render data and Web or
+Lynx previews.

--- a/.github/genui-playground.instructions.md
+++ b/.github/genui-playground.instructions.md
@@ -89,11 +89,13 @@ Component catalog examples are intentionally inline-only. Keep every bundled usa
 
 ## Example Showcase Architecture
 
-Keep the shared example-list page structure, preview queue, keyboard interaction, section rendering, and card layout in `pages/demos/DemosList.tsx`. Route both protocols through `pages/demos/DemosListPage.tsx`, and keep protocol-specific scenarios, sections, preview URL construction, and queue reset keys in `pages/demos/a2ui.ts` and `pages/demos/openui.ts`.
+Keep the shared example-list page structure, preview queue, keyboard interaction, section rendering, and card layout in `pages/demos/DemosList.tsx`. Route A2UI, OpenUI, and MCP Apps through `pages/demos/DemosListPage.tsx`, and keep protocol-specific scenarios, sections, preview URL construction, and queue reset keys in `pages/demos/a2ui.ts`, `pages/demos/openui.ts`, and `pages/demos/mcp-apps.ts`.
 
 Protocol-specific showcase sources may vary their header copy, section links, badges, layout mode, and preview payload construction, but must not duplicate the shared list-page JSX or card interaction logic.
 
-Keep the shared example-detail workspace, editor/preview resizing, playback state machine, progress bridge, scenario sidebar, and mobile tabs in `pages/demos/DemosPage.tsx`, with its styles in `pages/demos/DemosPage.css`. Keep protocol-specific editor configuration, commit validation, playback chunking, payload publishing, and `PreviewPanelSource` construction in the existing `pages/demos/a2ui.ts` and `pages/demos/openui.ts` source modules.
+Keep the shared example-detail workspace, editor/preview resizing, playback state machine, progress bridge, scenario sidebar, and mobile tabs in `pages/demos/DemosPage.tsx`, with its styles in `pages/demos/DemosPage.css`. Keep protocol-specific editor configuration, commit validation, playback chunking, payload publishing, and `PreviewPanelSource` construction in the respective `pages/demos/a2ui.ts`, `pages/demos/openui.ts`, and `pages/demos/mcp-apps.ts` source modules.
+
+Keep MCP Apps Examples aligned with the renderer registry in `lynx-src/mcp-apps/App.tsx`. Build their deterministic preview data through each renderer's sibling `api.ts`, validate edited data with the shared host parser plus the renderer-specific result parser, and render list and detail previews through the existing `mcp-apps.web.js` / `mcp-apps.lynx.js` bundles.
 
 ### Lynx XML
 

--- a/packages/genui/playground/src/App.tsx
+++ b/packages/genui/playground/src/App.tsx
@@ -52,7 +52,10 @@ const GENUI_TABS: TabDef[] = [
   { id: 'bench', label: 'Bench' },
 ];
 
-const MCP_APPS_TABS: TabDef[] = [{ id: 'create', label: 'Create' }];
+const MCP_APPS_TABS: TabDef[] = [
+  { id: 'create', label: 'Create' },
+  { id: 'examples', label: 'Examples' },
+];
 const LYNX_XML_TABS: TabDef[] = [{ id: 'examples', label: 'Examples' }];
 
 function ensureDefaultRouteHash(): void {
@@ -165,7 +168,10 @@ export function App() {
 
   const handleProtocolSelect = useCallback((name: ProtocolName) => {
     if (name === 'mcp-apps') {
-      window.location.hash = buildRouteHash(name, 'create');
+      window.location.hash = buildRouteHash(
+        name,
+        route.tab === 'examples' ? 'examples' : 'create',
+      );
       return;
     }
     if (name === 'lynx-xml') {
@@ -198,7 +204,25 @@ export function App() {
       />
     );
 
-    if (protocol.name === 'mcp-apps') return createPage;
+    if (protocol.name === 'mcp-apps') {
+      if (route.tab !== 'examples') return createPage;
+      return route.demoId
+        ? (
+          <DemosPage
+            key='mcp-apps-examples-detail'
+            protocol={protocol}
+            demoId={route.demoId}
+            theme={theme}
+          />
+        )
+        : (
+          <DemosListPage
+            key='mcp-apps-examples-index'
+            protocol={protocol}
+            theme={theme}
+          />
+        );
+    }
 
     if (protocol.name === 'lynx-xml') {
       return route.demoId

--- a/packages/genui/playground/src/pages/demos/DemosListPage.tsx
+++ b/packages/genui/playground/src/pages/demos/DemosListPage.tsx
@@ -4,6 +4,7 @@
 import { A2UI_DEMOS_LIST_SOURCE } from './a2ui.js';
 import { DemosList } from './DemosList.js';
 import { LYNX_XML_DEMOS_LIST_SOURCE } from './lynx-xml.js';
+import { MCP_APPS_DEMOS_LIST_SOURCE } from './mcp-apps.js';
 import { OPENUI_DEMOS_LIST_SOURCE } from './openui.js';
 import type { Protocol } from '../../utils/protocol.js';
 
@@ -12,6 +13,10 @@ export function DemosListPage(
 ) {
   if (props.protocol.name === 'lynx-xml') {
     return <DemosList {...props} source={LYNX_XML_DEMOS_LIST_SOURCE} />;
+  }
+
+  if (props.protocol.name === 'mcp-apps') {
+    return <DemosList {...props} source={MCP_APPS_DEMOS_LIST_SOURCE} />;
   }
 
   if (props.protocol.name === 'openui') {

--- a/packages/genui/playground/src/pages/demos/DemosPage.tsx
+++ b/packages/genui/playground/src/pages/demos/DemosPage.tsx
@@ -7,6 +7,7 @@ import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
 
 import { A2UI_DEMOS_PAGE_SOURCE } from './a2ui.js';
 import { LYNX_XML_DEMOS_PAGE_SOURCE } from './lynx-xml.js';
+import { MCP_APPS_DEMOS_PAGE_SOURCE } from './mcp-apps.js';
 import { OPENUI_DEMOS_PAGE_SOURCE } from './openui.js';
 import type { DemoCommit, DemoPageScenario, DemosPageSource } from './type.js';
 import { Button } from '../../components/Button.js';
@@ -824,6 +825,16 @@ export function DemosPage(props: {
         key='lynx-xml'
         {...props}
         source={LYNX_XML_DEMOS_PAGE_SOURCE}
+      />
+    );
+  }
+
+  if (props.protocol.name === 'mcp-apps') {
+    return (
+      <DemosPageContent
+        key='mcp-apps'
+        {...props}
+        source={MCP_APPS_DEMOS_PAGE_SOURCE}
       />
     );
   }

--- a/packages/genui/playground/src/pages/demos/mcp-apps.test.ts
+++ b/packages/genui/playground/src/pages/demos/mcp-apps.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  MCP_APPS_DEMOS_LIST_SOURCE,
+  MCP_APPS_DEMOS_PAGE_SOURCE,
+  MCP_APPS_SCENARIOS,
+} from './mcp-apps.js';
+import { PROTOCOLS } from '../../utils/protocol.js';
+
+describe('MCP Apps templates', () => {
+  test('lists every renderer already registered by the playground host', () => {
+    expect(MCP_APPS_SCENARIOS.map(({ id, title }) => ({ id, title }))).toEqual([
+      { id: 'weather', title: 'Weather Card' },
+      { id: 'product', title: 'Product Card' },
+    ]);
+    expect(MCP_APPS_DEMOS_LIST_SOURCE.sections).toMatchObject([
+      { title: 'Templates', layout: 'flow' },
+    ]);
+  });
+
+  test('builds an MCP Apps preview for every template', () => {
+    for (const scenario of MCP_APPS_SCENARIOS) {
+      const url = new URL(MCP_APPS_DEMOS_LIST_SOURCE.createPreviewUrl({
+        baseUrl: 'https://lynx-stack.dev/genui/',
+        protocol: PROTOCOLS['mcp-apps'],
+        scenario,
+        theme: 'dark',
+      }));
+      expect(url.searchParams.get('protocol')).toBe('mcp-apps');
+      expect(url.searchParams.get('demoUrl')).toBe('./mcp-apps.web.js');
+      expect(url.searchParams.get('theme')).toBe('dark');
+      expect(url.searchParams.get('initData')).toBeTruthy();
+    }
+  });
+
+  test('uses the selected template as editable detail preview data', () => {
+    const scenario = MCP_APPS_SCENARIOS[0];
+    expect(scenario).toBeDefined();
+    if (!scenario) return;
+
+    const input = MCP_APPS_DEMOS_PAGE_SOURCE.createScenarioPreviewInput(
+      scenario,
+    );
+    expect(MCP_APPS_DEMOS_PAGE_SOURCE.createPreviewSource({
+      input,
+      isPlaybackActive: false,
+      protocol: PROTOCOLS['mcp-apps'],
+      theme: 'light',
+    })).toEqual({
+      kind: 'mcp-apps',
+      mcpAppData: scenario.renderData,
+      theme: 'light',
+    });
+  });
+
+  test('validates edited template data before rendering', () => {
+    for (const scenario of MCP_APPS_SCENARIOS) {
+      expect(MCP_APPS_DEMOS_PAGE_SOURCE.commit({
+        editorValue: JSON.stringify(scenario.renderData),
+        editorEdited: true,
+        scenario,
+      })).toMatchObject({
+        value: {
+          previewInput: { renderer: scenario.renderData.renderer },
+          playbackChunks: [],
+        },
+      });
+    }
+
+    const scenario = MCP_APPS_SCENARIOS[0];
+    expect(scenario).toBeDefined();
+    if (!scenario) return;
+    expect(MCP_APPS_DEMOS_PAGE_SOURCE.commit({
+      editorValue: '{',
+      editorEdited: true,
+      scenario,
+    })).toHaveProperty('error');
+    expect(MCP_APPS_DEMOS_PAGE_SOURCE.commit({
+      editorValue: JSON.stringify({
+        renderer: 'unknown',
+        input: {},
+        result: {},
+      }),
+      editorEdited: true,
+      scenario,
+    })).toEqual({
+      error:
+        'Expected valid render data for the weather or product MCP Apps template.',
+    });
+  });
+});

--- a/packages/genui/playground/src/pages/demos/mcp-apps.ts
+++ b/packages/genui/playground/src/pages/demos/mcp-apps.ts
@@ -1,0 +1,170 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { json } from '@codemirror/lang-json';
+
+import { readAppRenderData } from '@lynx-js/genui/mcp-apps/render';
+import type { AppRenderData } from '@lynx-js/genui/mcp-apps/render';
+
+import type { DemosListSource } from './DemosList.js';
+import type { DemosPageSource } from './type.js';
+import {
+  PRODUCT_RENDERER_ID,
+  callProductApi,
+  parseProductApiResult,
+} from '../../../lynx-src/mcp-apps/product/api.js';
+import {
+  WEATHER_RENDERER_ID,
+  callWeatherApi,
+  parseWeatherApiResult,
+} from '../../../lynx-src/mcp-apps/weather/api.js';
+import { buildMcpAppsRenderUrl } from '../../utils/renderUrl.js';
+
+interface McpAppsScenario {
+  id: string;
+  title: string;
+  badge: string;
+  renderData: AppRenderData;
+}
+
+const weatherInput = { city: 'Hangzhou', unit: 'celsius' };
+const productInput = { productId: 'limited-edition-sneaker' };
+
+export const MCP_APPS_SCENARIOS: readonly McpAppsScenario[] = [
+  {
+    id: WEATHER_RENDERER_ID,
+    title: 'Weather Card',
+    badge: 'Template',
+    renderData: {
+      renderer: WEATHER_RENDERER_ID,
+      input: weatherInput,
+      result: callWeatherApi(weatherInput),
+    },
+  },
+  {
+    id: PRODUCT_RENDERER_ID,
+    title: 'Product Card',
+    badge: 'Template',
+    renderData: {
+      renderer: PRODUCT_RENDERER_ID,
+      input: productInput,
+      result: callProductApi(productInput),
+    },
+  },
+];
+
+export const MCP_APPS_DEMOS_LIST_SOURCE = {
+  title: 'MCP Apps Templates',
+  description:
+    'Explore the renderer templates already registered by the MCP Apps client. Open a template to inspect its render data and preview it on Web or Lynx.',
+  scenarios: MCP_APPS_SCENARIOS,
+  sections: [
+    {
+      id: 'templates',
+      title: 'Templates',
+      scenarios: MCP_APPS_SCENARIOS,
+      layout: 'flow',
+    },
+  ],
+  createPreviewUrl({ baseUrl, scenario, theme }) {
+    return buildMcpAppsRenderUrl({
+      mcpAppData: scenario.renderData,
+      theme,
+    }, baseUrl);
+  },
+  createResetKey({ protocol, theme }) {
+    return `${protocol.name}|${theme}`;
+  },
+} satisfies DemosListSource<McpAppsScenario>;
+
+function findScenario(id?: string): McpAppsScenario | undefined {
+  if (!id) return undefined;
+  return MCP_APPS_SCENARIOS.find((scenario) => scenario.id === id);
+}
+
+function parseKnownRenderData(value: unknown): AppRenderData | null {
+  const renderData = readAppRenderData(value);
+  if (!renderData) return null;
+
+  if (renderData.renderer === WEATHER_RENDERER_ID) {
+    const result = parseWeatherApiResult(renderData.result);
+    return result ? { ...renderData, result } : null;
+  }
+  if (renderData.renderer === PRODUCT_RENDERER_ID) {
+    const result = parseProductApiResult(renderData.result);
+    return result ? { ...renderData, result } : null;
+  }
+  return null;
+}
+
+const jsonExtensions = [json()];
+
+export const MCP_APPS_DEMOS_PAGE_SOURCE = {
+  scenarios: MCP_APPS_SCENARIOS,
+  findScenario,
+  getEditorValue(scenario) {
+    return JSON.stringify(scenario.renderData, null, 2);
+  },
+  createScenarioPreviewInput(scenario) {
+    return scenario.renderData;
+  },
+  commit({ editorValue }) {
+    let value: unknown;
+    try {
+      value = JSON.parse(editorValue) as unknown;
+    } catch (error) {
+      return { error: `Invalid JSON: ${String(error)}` };
+    }
+
+    const renderData = parseKnownRenderData(value);
+    if (!renderData) {
+      return {
+        error:
+          'Expected valid render data for the weather or product MCP Apps template.',
+      };
+    }
+
+    return {
+      value: {
+        previewInput: renderData,
+        playbackChunks: [],
+        meta: undefined,
+      },
+    };
+  },
+  createPreviewSource({ input, theme }) {
+    return {
+      kind: 'mcp-apps',
+      mcpAppData: input,
+      theme,
+    };
+  },
+  formatPlaybackChunk(chunk) {
+    return chunk;
+  },
+  playback: false,
+  emptyEditorValue: '{}',
+  emptyPlaybackError: 'MCP Apps templates are rendered as a whole.',
+  resetPlaybackOnFill: true,
+  editor: {
+    title: 'MCP App Render Data',
+    badge: 'JSON',
+    extensions: jsonExtensions,
+    basicSetup: {
+      lineNumbers: true,
+      foldGutter: true,
+      bracketMatching: true,
+      closeBrackets: true,
+      autocompletion: true,
+    },
+    splitterAriaLabel: 'Resize Playback and MCP App data panels',
+    panelResizeAriaLabel: 'Resize MCP App data and preview panels',
+    emptyPreviewTitle: 'Select an MCP Apps template to preview',
+  },
+} satisfies DemosPageSource<
+  McpAppsScenario,
+  AppRenderData,
+  string,
+  undefined
+>;

--- a/packages/genui/playground/src/utils/appRoute.test.ts
+++ b/packages/genui/playground/src/utils/appRoute.test.ts
@@ -51,6 +51,14 @@ describe('app route hash', () => {
       protocol: { name: 'mcp-apps', version: '2026-01-26' },
       tab: 'create',
     });
+    expect(buildRouteHash('mcp-apps', 'examples')).toBe(
+      '#/mcp-apps/examples',
+    );
+    expect(parseRouteHash('#/mcp-apps/examples/weather')).toMatchObject({
+      protocol: { name: 'mcp-apps', version: '2026-01-26' },
+      tab: 'examples',
+      demoId: 'weather',
+    });
   });
 
   test('keeps deep links under the selected protocol', () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an MCP Apps **Examples** tab alongside Create.
  - Added Weather and Product showcase scenarios with editable render data.
  - Added Web and Lynx preview support with validation feedback.
  - Added navigation for browsing examples and opening specific demos.

- **Bug Fixes**
  - Improved MCP Apps route handling, including deep links and tab state preservation.

- **Tests**
  - Added coverage for example registration, preview URLs, editable data, routing, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
