### PR TITLE
feat(web-core): support view-scoped console injection

### DIFF
--- a/.changeset/view-scoped-web-console.md
+++ b/.changeset/view-scoped-web-console.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/web-core": minor
+---
+
+Support a view-scoped `console` in background bundles through the
+`LynxConsoleModule` native module.

--- a/.github/web-core-view-console.instructions.md
+++ b/.github/web-core-view-console.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "packages/web-platform/web-core/ts/client/{background/background-apis/createChunkLoading.ts,mainthread/LynxView.ts},packages/web-platform/web-core/ts/types/BTSChunk.ts,packages/web-platform/web-core/tests/chunk-loading.spec.ts"
+---
+
+Keep ordinary `console.*` calls in background bundles scoped to the current
+Lynx view. Resolve the lexical `console` from
+`tt.NativeModules.LynxConsoleModule`, then `tt.sharedConsole`, then the Worker
+global console. Do not mutate `globalThis.console`; explicit
+`globalThis.console` access intentionally bypasses the per-view injection. Keep
+synchronous bundles and asynchronous chunks on the same initialization path.

--- a/packages/web-platform/web-core/tests/chunk-loading.spec.ts
+++ b/packages/web-platform/web-core/tests/chunk-loading.spec.ts
@@ -1,0 +1,134 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { describe, expect, rstest, test } from '@rstest/core';
+import { createChunkLoading } from '../ts/client/background/background-apis/createChunkLoading.js';
+import type { BundleInitReturnObj, NativeTTObject } from '../ts/types/index.js';
+
+const bundleSource = `
+  module.exports = {
+    lexicalConsole: console,
+    workerConsole: globalThis.console,
+  };
+`;
+
+function createTT(
+  NativeModules: Record<string, unknown>,
+  sharedConsole?: unknown,
+): NativeTTObject {
+  return {
+    NativeModules,
+    sharedConsole,
+  } as unknown as NativeTTObject;
+}
+
+function loadSyncBundle(source: string): BundleInitReturnObj {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'XMLHttpRequest',
+  );
+
+  Object.defineProperty(globalThis, 'XMLHttpRequest', {
+    configurable: true,
+    value: class {
+      responseText = source;
+      status = 200;
+
+      open() {}
+      send() {}
+    },
+  });
+
+  try {
+    return createChunkLoading('/main.web.bundle', 'react').loadScript(
+      'app-service.js',
+    );
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, 'XMLHttpRequest', descriptor);
+    } else {
+      delete (globalThis as { XMLHttpRequest?: unknown }).XMLHttpRequest;
+    }
+  }
+}
+
+async function loadAsyncBundle(source: string): Promise<BundleInitReturnObj> {
+  const fetch = globalThis.fetch;
+  globalThis.fetch = rstest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve(source),
+    } as Response)
+  );
+
+  try {
+    return await new Promise((resolve, reject) => {
+      createChunkLoading('/main.web.bundle', 'react').loadScriptAsync(
+        'async-chunk.js',
+        (message, bundle) => {
+          if (message || !bundle) {
+            reject(new Error(message ?? 'Bundle was not loaded'));
+          } else {
+            resolve(bundle);
+          }
+        },
+      );
+    });
+  } finally {
+    globalThis.fetch = fetch;
+  }
+}
+
+type BundleExports = {
+  lexicalConsole: unknown;
+  workerConsole: unknown;
+};
+
+describe('createChunkLoading', () => {
+  test('injects a view-scoped console without changing the Worker console', () => {
+    const bundle = loadSyncBundle(bundleSource);
+    const pageAConsole = { log: rstest.fn() };
+    const pageBConsole = { log: rstest.fn() };
+    const sharedConsole = { log: rstest.fn() };
+
+    const pageAExports = bundle.init({
+      tt: createTT({ LynxConsoleModule: pageAConsole }, sharedConsole),
+    }) as BundleExports;
+    const pageBExports = bundle.init({
+      tt: createTT({ LynxConsoleModule: pageBConsole }, sharedConsole),
+    }) as BundleExports;
+
+    expect(pageAExports.lexicalConsole).toBe(pageAConsole);
+    expect(pageBExports.lexicalConsole).toBe(pageBConsole);
+    expect(pageAExports.workerConsole).toBe(globalThis.console);
+    expect(pageBExports.workerConsole).toBe(globalThis.console);
+  });
+
+  test('falls back to the shared console and then the Worker console', () => {
+    const bundle = loadSyncBundle(bundleSource);
+    const sharedConsole = { log: rstest.fn() };
+
+    const sharedConsoleExports = bundle.init({
+      tt: createTT({}, sharedConsole),
+    }) as BundleExports;
+    const workerConsoleExports = bundle.init({
+      tt: createTT({}),
+    }) as BundleExports;
+
+    expect(sharedConsoleExports.lexicalConsole).toBe(sharedConsole);
+    expect(workerConsoleExports.lexicalConsole).toBe(globalThis.console);
+  });
+
+  test('injects the view-scoped console into asynchronously loaded chunks', async () => {
+    const bundle = await loadAsyncBundle(bundleSource);
+    const viewConsole = { log: rstest.fn() };
+
+    const exports = bundle.init({
+      tt: createTT({ LynxConsoleModule: viewConsole }),
+    }) as BundleExports;
+
+    expect(exports.lexicalConsole).toBe(viewConsole);
+    expect(exports.workerConsole).toBe(globalThis.console);
+  });
+});

--- a/packages/web-platform/web-core/ts/client/background/background-apis/createChunkLoading.ts
+++ b/packages/web-platform/web-core/ts/client/background/background-apis/createChunkLoading.ts
@@ -73,6 +73,7 @@ export function createChunkLoading(
       'clearInterval',
       'clearTimeout',
       'NativeModules',
+      'console',
       ...(cardType !== 'react' ? ['Component'] : []),
       'ReactLynx',
       'nativeAppId',
@@ -121,6 +122,9 @@ export function createChunkLoading(
           tt.clearInterval,
           tt.clearTimeout,
           tt.NativeModules,
+          tt.NativeModules?.LynxConsoleModule
+            ?? tt.sharedConsole
+            ?? globalThis.console,
           ...(cardType !== 'react' ? [tt.Component.bind(tt)] : []),
           tt.ReactLynx,
           tt.nativeAppId,

--- a/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
+++ b/packages/web-platform/web-core/ts/client/mainthread/LynxView.ts
@@ -37,6 +37,8 @@ export interface BrowserConfig {
  * @property {Cloneable} globalProps [optional] (attribute: "global-props") The globalProps value of this Lynx card
  * @property {Cloneable} initData [optional] (attribute: "init-data") The initial data of this Lynx card
  * @property {NativeModulesMap} nativeModulesMap [optional] use to customize NativeModules. key is module-name, value is esm url.
+ * A `LynxConsoleModule` whose factory returns a Console-like object provides
+ * the lexical `console` for this view's background bundles.
  * @property {NativeModulesCall} onNativeModulesCall [optional] the NativeModules value handler. Arguments will be cached before this property is assigned.
  * @property {"auto" | null} height [optional] (attribute: "height") set it to "auto" for height auto-sizing
  * @property {"auto" | null} width [optional] (attribute: "width") set it to "auto" for width auto-sizing
@@ -95,6 +97,8 @@ export class LynxViewElement extends HTMLElement {
    * @public
    * @property nativeModulesMap
    * @default {}
+   * A `LynxConsoleModule` whose factory returns a Console-like object provides
+   * the lexical `console` for this view's background bundles.
    */
   nativeModulesMap: NativeModulesMap | undefined;
 

--- a/packages/web-platform/web-core/ts/types/BTSChunk.ts
+++ b/packages/web-platform/web-core/ts/types/BTSChunk.ts
@@ -13,6 +13,7 @@ export type BTSChunkEntry = (
   clearInterval: unknown,
   clearTimeout: unknown,
   NativeModules: unknown,
+  console: unknown,
   Component: unknown,
   ReactLynx: unknown,
   nativeAppId: unknown,


### PR DESCRIPTION
## Summary

- inject a per-view lexical `console` for background bundles from `NativeModules.LynxConsoleModule`
- fall back to `tt.sharedConsole` and then the Worker global console while preserving explicit `globalThis.console` access
- cover synchronous and asynchronous chunk initialization and document the extension point

Closes #3647

## Testing

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm turbo build` (72/72 tasks)
- [x] `pnpm --filter @lynx-js/web-core test -- chunk-loading.spec.ts` (401/401 tests)
- [x] `pnpm turbo api-extractor -- --local` (25/25 tasks)
- [x] `pnpm dprint check`
- [x] `NODE_OPTIONS=--max-old-space-size=32768 pnpm eslint .` (0 errors; 15 existing warnings)
- [x] `pnpm changeset status`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background bundles now use a console scoped to the active view when available.
  * Console resolution falls back to shared or worker-level consoles when needed.
  * View-scoped console behavior also applies to asynchronously loaded chunks.

* **Documentation**
  * Added guidance for configuring view-scoped console access and preserving explicit global console access.

* **Bug Fixes**
  * Improved consistency of console availability across synchronous and asynchronous bundle loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->