### PR TITLE
refactor: resolve the bundle filename through the Lynx engine API

### DIFF
--- a/.changeset/salty-pots-hug.md
+++ b/.changeset/salty-pots-hug.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/vanilla-rsbuild-plugin": patch
+"@lynx-js/qrcode-rsbuild-plugin": patch
+---
+
+Resolve the bundle filename through `getLynxConfig(api).resolveBundleFilename()` instead of reading `output.filename` out of the Rspeedy config. A configured filename is now honored when the plugins are used with Rsbuild directly.

--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@clack/prompts": "1.7.0",
+    "@lynx-js/rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rsbuild/core": "catalog:rsbuild",
@@ -56,7 +57,8 @@
     "uqr": "0.1.3"
   },
   "peerDependencies": {
-    "@lynx-js/rspeedy": "^0.16.0"
+    "@lynx-js/rspeedy": "^0.16.0",
+    "@rsbuild/core": "^2.0.0"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/rspeedy/plugin-qrcode/src/generateDevUrls.ts
+++ b/packages/rspeedy/plugin-qrcode/src/generateDevUrls.ts
@@ -3,9 +3,11 @@
 // LICENSE file in the root directory of this source tree.
 import type { RsbuildPluginAPI } from '@rsbuild/core'
 
-import type { ExposedAPI } from '@lynx-js/rspeedy'
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 
 import type { CustomizedSchemaFn } from './index.js'
+
+const S_LYNX_CONFIG = Symbol.for('@lynx-js/rsbuild-plugin:config')
 
 export default function generateDevUrls(
   api: RsbuildPluginAPI,
@@ -14,9 +16,6 @@ export default function generateDevUrls(
   port: number,
 ): Record<string, string> {
   const { dev: { assetPrefix } } = api.getNormalizedConfig()
-  const { config } = api.useExposed<ExposedAPI>(
-    Symbol.for('rspeedy.api'),
-  )!
 
   if (typeof assetPrefix !== 'string') {
     const errorMsg = 'dev.assetPrefix is not string, skip printing QRCode'
@@ -24,19 +23,24 @@ export default function generateDevUrls(
     throw new Error(errorMsg)
   }
 
-  const defaultFilename = '[name].[platform].bundle'
-  const { filename } = config.output ?? {}
-  const bundle = typeof filename === 'object'
-    ? filename.bundle ?? filename.template
-    : filename
+  // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React hook.
+  const lynxConfig = api.useExposed<LynxConfig>(S_LYNX_CONFIG)
+
+  if (!lynxConfig) {
+    throw new Error(
+      'No Lynx config exposed. `pluginLynx` has to be applied for the Lynx build engine to be configured.',
+    )
+  }
+
   // QRCode always points at the Lynx main bundle.
-  const name = (typeof bundle === 'function'
-    ? bundle({ lazyBundle: false, entryName: entry, platform: 'lynx' })
-    : bundle) ?? defaultFilename
+  const name = lynxConfig.resolveBundleFilename({
+    entryName: entry,
+    platform: 'lynx',
+  })
 
   const customSchema = schemaFn(
     new URL(
-      name.replace('[name]', entry).replace('[platform]', 'lynx'),
+      name,
       // <port> is supported in `dev.assetPrefix`, we should replace it with the real port
       assetPrefix.replaceAll('<port>', String(port)),
     ).toString(),

--- a/packages/rspeedy/plugin-qrcode/src/index.ts
+++ b/packages/rspeedy/plugin-qrcode/src/index.ts
@@ -13,8 +13,20 @@ import type {
   RsbuildConfig,
   RsbuildPlugin,
 } from '@rsbuild/core'
+import { logger } from '@rsbuild/core'
 
 import { registerConsoleShortcuts } from './shortcuts.js'
+
+// Rsbuild resolves the promise of `devServer.listen()` only after awaiting the
+// server-started hooks, so throwing here leaves it unsettled and the server
+// hangs. A QR code that cannot be printed should not take the server down.
+function logShortcutError(error: unknown): void {
+  logger.error(
+    `[lynx:rsbuild:qrcode] ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  )
+}
 
 /**
  * {@inheritdoc PluginQRCodeOptions.schema}
@@ -150,10 +162,15 @@ export function pluginQRCode(
 
       api.onAfterStartPreviewServer(async ({ environments, routes, port }) => {
         unregisterPreviewShortcuts?.()
-        unregisterPreviewShortcuts = await main(
-          getEntriesFromRoutes(routes, environments),
-          port,
-        )
+
+        try {
+          unregisterPreviewShortcuts = await main(
+            getEntriesFromRoutes(routes, environments),
+            port,
+          )
+        } catch (error) {
+          logShortcutError(error)
+        }
       })
 
       api.onAfterStartDevServer(async ({ environments, routes, port }) => {
@@ -163,16 +180,20 @@ export function pluginQRCode(
           return
         }
 
-        const unregister = await registerConsoleShortcuts(
-          {
-            entries,
-            api,
-            port,
-            schema: effectiveSchema,
-          },
-        )
-        if (unregister) {
-          api.onCloseDevServer(unregister)
+        try {
+          const unregister = await registerConsoleShortcuts(
+            {
+              entries,
+              api,
+              port,
+              schema: effectiveSchema,
+            },
+          )
+          if (unregister) {
+            api.onCloseDevServer(unregister)
+          }
+        } catch (error) {
+          logShortcutError(error)
         }
       })
 

--- a/packages/rspeedy/plugin-qrcode/test/index.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/index.test.ts
@@ -15,6 +15,7 @@ import type {
 } from '@rsbuild/core'
 import { beforeEach, describe, expect, onTestFinished, test, vi } from 'vitest'
 
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
 import type { Config, ExposedAPI } from '@lynx-js/rspeedy'
 
 import { getRandomNumberInRange } from './port.js'
@@ -26,6 +27,26 @@ import {
 
 const exit = vi.fn()
 
+// `pluginQRCode` reads the Lynx config the build engine exposes, so the stub
+// applies the engine's config plugin the way a real Lynx build does.
+const exposeLynxConfig = (api: RsbuildPluginAPI): void => {
+  let lynx: unknown
+
+  for (const plugin of pluginLynx()) {
+    void plugin.setup({
+      expose(_id: string | symbol, value: unknown) {
+        lynx = value
+      },
+    } as unknown as RsbuildPluginAPI)
+
+    if (lynx) {
+      break
+    }
+  }
+
+  api.expose(Symbol.for('@lynx-js/rsbuild-plugin:config'), lynx)
+}
+
 const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
   name: 'lynx:rsbuild:api',
   setup(api) {
@@ -36,6 +57,8 @@ const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
       logger,
       version: '1.0.0',
     })
+
+    exposeLynxConfig(api)
   },
 })
 
@@ -684,6 +707,40 @@ describe('Plugins - Terminal', () => {
           url: 'http://example.com/b.lynx.bundle?fullscreen=true',
         },
       ])
+    })
+  })
+
+  describe('without the Lynx build engine', () => {
+    test('reports instead of hanging the dev server', async () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      const errorSpy = vi.spyOn(logger, 'error').mockReturnValue(undefined)
+
+      const rsbuild = await createRsbuild({
+        rsbuildConfig: {
+          dev: { assetPrefix: 'http://example.com/' },
+          environments: { lynx: {} },
+          server: { port: getRandomNumberInRange(3000, 60000) },
+          source: {
+            entry: {
+              main: join(
+                dirname(fileURLToPath(import.meta.url)),
+                'fixtures',
+                'hello-world',
+              ),
+            },
+          },
+          // No `pluginLynx`, so no Lynx config is exposed.
+          plugins: [pluginQRCode({ fullscreen: false })],
+        },
+      })
+
+      await using server = await usingDevServer(rsbuild)
+
+      await server.waitDevCompileDone()
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('`pluginLynx` has to be applied'),
+      )
     })
   })
 

--- a/packages/rspeedy/plugin-qrcode/test/preview.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/preview.test.ts
@@ -2,8 +2,10 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { createRsbuild, logger } from '@rsbuild/core'
+import type { RsbuildPluginAPI } from '@rsbuild/core'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
 import type { Config, ExposedAPI, RsbuildPlugin } from '@lynx-js/rspeedy'
 
 import { getRandomNumberInRange } from './port.js'
@@ -13,6 +15,26 @@ vi.mock('uqr')
 vi.mock('@clack/prompts')
 
 const exit = vi.fn()
+
+// `pluginQRCode` reads the Lynx config the build engine exposes, so the stub
+// applies the engine's config plugin the way a real Lynx build does.
+const exposeLynxConfig = (api: RsbuildPluginAPI): void => {
+  let lynx: unknown
+
+  for (const plugin of pluginLynx()) {
+    void plugin.setup({
+      expose(_id: string | symbol, value: unknown) {
+        lynx = value
+      },
+    } as unknown as RsbuildPluginAPI)
+
+    if (lynx) {
+      break
+    }
+  }
+
+  api.expose(Symbol.for('@lynx-js/rsbuild-plugin:config'), lynx)
+}
 
 const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
   name: 'lynx:rsbuild:api',
@@ -24,6 +46,8 @@ const pluginStubRspeedyAPI = (config: Config = {}): RsbuildPlugin => ({
       logger,
       version: '1.0.0',
     })
+
+    exposeLynxConfig(api)
   },
 })
 

--- a/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
+++ b/packages/rspeedy/plugin-qrcode/test/shortcuts.test.ts
@@ -4,18 +4,45 @@
 import type { RsbuildPluginAPI } from '@rsbuild/core'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
+
 import { registerConsoleShortcuts } from '../src/shortcuts.js'
 
 vi.mock('@clack/prompts')
+
+// Built by `pluginLynx` itself, so the resolver under test is the real one
+// rather than a stub that fabricates it.
+function createLynxConfig(): LynxConfig {
+  let config: LynxConfig | undefined
+
+  for (const plugin of pluginLynx()) {
+    // `pluginConfig.setup` is synchronous, so the config is set before the
+    // check below.
+    void plugin.setup({
+      expose(_id: string | symbol, value: unknown) {
+        config = value as LynxConfig
+      },
+    } as unknown as RsbuildPluginAPI)
+
+    if (config) {
+      break
+    }
+  }
+
+  if (!config) {
+    throw new Error('pluginLynx exposed no Lynx config')
+  }
+
+  return config
+}
 
 describe('PluginQRCode - CLI Shortcuts', () => {
   const mockedRsbuildAPI = {
     getNormalizedConfig: vi.fn().mockReturnValue({
       dev: { assetPrefix: 'https://example.com/' },
     }),
-    useExposed: vi.fn().mockReturnValue({
-      config: { filename: '[name].[platform].bundle' },
-    }),
+    useExposed: vi.fn().mockReturnValue(createLynxConfig()),
   } as unknown as RsbuildPluginAPI
 
   beforeEach(() => {

--- a/packages/rspeedy/plugin-qrcode/tsconfig.build.json
+++ b/packages/rspeedy/plugin-qrcode/tsconfig.build.json
@@ -7,6 +7,7 @@
   },
   "references": [
     { "path": "../core/tsconfig.build.json" },
+    { "path": "../plugin-lynx/tsconfig.build.json" },
   ],
   "include": ["src"],
 }

--- a/packages/rspeedy/plugin-vanilla/package.json
+++ b/packages/rspeedy/plugin-vanilla/package.json
@@ -41,6 +41,7 @@
     "@lynx-js/template-webpack-plugin": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/test-tools": "workspace:*",
     "@rsbuild/core": "catalog:rsbuild",

--- a/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
+++ b/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
@@ -12,6 +12,7 @@ import type {
   RspackChain,
 } from '@rsbuild/core'
 
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 import { RuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
 import {
   LynxEncodePlugin,
@@ -19,10 +20,11 @@ import {
   WebEncodePlugin,
 } from '@lynx-js/template-webpack-plugin'
 
+const S_LYNX_CONFIG = Symbol.for('@lynx-js/rsbuild-plugin:config')
+
 const PLUGIN_NAME = 'lynx:vanilla'
 const VANILLA_WEBPACK_PLUGIN_NAME = 'VanillaLynxWebpackPlugin'
 const DEFAULT_ENGINE_VERSION = '3.5'
-const DEFAULT_BUNDLE_FILENAME = '[name].[platform].bundle'
 const INTERMEDIATE_DIR = '.rspeedy'
 
 /**
@@ -138,14 +140,6 @@ export interface PluginVanillaLynxOptions {
   targetSdkVersion?: string | undefined
 }
 
-interface RspeedyExposure {
-  config?: {
-    output?: {
-      filename?: RspeedyFilename | undefined
-    } | undefined
-  } | undefined
-}
-
 interface LynxConfigExposure {
   config?: {
     targetSdkVersion?: string | undefined
@@ -158,13 +152,6 @@ interface ResolvedVanillaEntry {
   styleSource?: string | undefined
 }
 
-type RspeedyFilename =
-  | string
-  | {
-    bundle?: VanillaBundleFilename | undefined
-    template?: string | undefined
-  }
-
 interface ResolvedPluginVanillaLynxOptions {
   bundleFilename?: VanillaBundleFilename | undefined
   engineVersion: string
@@ -175,7 +162,7 @@ interface VanillaEntryContext {
   bundleFilename?: VanillaBundleFilename | undefined
   engineVersion: string
   platform: string
-  rspeedyFilename?: RspeedyFilename | undefined
+  lynxConfig: LynxConfig
 }
 
 interface VanillaEntryArtifacts {
@@ -256,9 +243,15 @@ function setupVanillaBundler(
   options: ResolvedPluginVanillaLynxOptions,
 ): void {
   api.modifyBundlerChain((chain, { environment }) => {
-    const rspeedyFilename = api.useExposed<RspeedyExposure>(
-      Symbol.for('rspeedy.api'),
-    )?.config?.output?.filename
+    // biome-ignore lint/correctness/useHookAtTopLevel: This is not a React hook.
+    const lynxConfig = api.useExposed<LynxConfig>(S_LYNX_CONFIG)
+
+    if (!lynxConfig) {
+      throw new Error(
+        'No Lynx config exposed. `pluginLynx` has to be applied for the Lynx build engine to be configured.',
+      )
+    }
+
     const platform = getVanillaPlatform(environment.name)
 
     if (!platform) {
@@ -274,7 +267,7 @@ function setupVanillaBundler(
       bundleFilename: options.bundleFilename,
       engineVersion: options.engineVersion,
       platform: environment.name,
-      rspeedyFilename,
+      lynxConfig,
     }
 
     chain.entryPoints.clear()
@@ -338,8 +331,8 @@ function addVanillaEntry(
         ? [backgroundEntry, mainThreadEntry]
         : [mainThreadEntry],
       dsl: 'react_nodiff',
-      filename: resolveBundleFilename(
-        context.rspeedyFilename,
+      filename: resolveVanillaBundleFilename(
+        context.lynxConfig,
         context.bundleFilename,
         entryName,
         context.platform,
@@ -547,31 +540,23 @@ function resolveOptionalSource(
     : undefined
 }
 
-function resolveBundleFilename(
-  rspeedyFilename:
-    | string
-    | {
-      bundle?: VanillaBundleFilename | undefined
-      template?: string | undefined
-    }
-    | undefined,
+function resolveVanillaBundleFilename(
+  lynxConfig: LynxConfig,
   option: VanillaBundleFilename | undefined,
   entryName: string,
   platform: string,
 ): string {
-  const configured = option
-    ?? (typeof rspeedyFilename === 'object'
-      ? rspeedyFilename.bundle ?? rspeedyFilename.template
-      : rspeedyFilename)
-    ?? DEFAULT_BUNDLE_FILENAME
   const context: VanillaBundleFilenameContext = {
     entryName,
     lazyBundle: false,
     platform,
   }
-  const filename = typeof configured === 'function'
-    ? configured(context)
-    : configured
+
+  if (option === undefined) {
+    return lynxConfig.resolveBundleFilename({ entryName, platform })
+  }
+
+  const filename = typeof option === 'function' ? option(context) : option
 
   return filename
     .replaceAll('[name]', entryName)

--- a/packages/rspeedy/plugin-vanilla/test/pluginVanillaLynx.test.ts
+++ b/packages/rspeedy/plugin-vanilla/test/pluginVanillaLynx.test.ts
@@ -15,9 +15,43 @@ import type {
 } from '@rsbuild/core'
 import { afterAll, describe, expect, test } from '@rstest/core'
 
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
 import { createRspeedy } from '@lynx-js/rspeedy'
 
 import * as vanilla from '../src/index.js'
+
+// Built by `pluginLynx` itself, so the resolvers under test are the real ones
+// rather than a stub that fabricates them.
+function createLynxConfigStub(bundle?: string): LynxConfig {
+  let config: LynxConfig | undefined
+
+  // `pluginLynx` exposes the config from its second plugin, so the loop stops
+  // there instead of setting up the rest of the engine.
+  const options = bundle === undefined
+    ? {}
+    : { output: { filename: { bundle } } }
+
+  for (const plugin of pluginLynx(options)) {
+    // `pluginConfig.setup` is synchronous, so the config is set before the
+    // check below.
+    void plugin.setup({
+      expose(_id: string | symbol, value: unknown) {
+        config = value as LynxConfig
+      },
+    } as unknown as RsbuildPluginAPI)
+
+    if (config) {
+      break
+    }
+  }
+
+  if (!config) {
+    throw new Error('pluginLynx exposed no Lynx config')
+  }
+
+  return config
+}
 
 const tempDirs: string[] = []
 
@@ -35,10 +69,7 @@ interface HarnessOptions {
   lynxConfigTarget?: string | undefined
   pluginOptions?: vanilla.PluginVanillaLynxOptions | undefined
   rawEntries?: Record<string, EntryPointStub> | undefined
-  rspeedyFilename?: string | {
-    bundle?: vanilla.VanillaBundleFilename | undefined
-    template?: string | undefined
-  } | undefined
+  lynxBundleFilename?: string | undefined
 }
 
 interface HarnessResult {
@@ -66,11 +97,12 @@ async function runPluginHarness(
       config: { targetSdkVersion: options.lynxConfigTarget },
     })
   }
-  if (options.rspeedyFilename) {
-    exposed.set(Symbol.for('rspeedy.api'), {
-      config: { output: { filename: options.rspeedyFilename } },
-    })
-  }
+  // A real Lynx build always has the engine applied, so the config is always
+  // exposed here too.
+  exposed.set(
+    Symbol.for('@lynx-js/rsbuild-plugin:config'),
+    createLynxConfigStub(options.lynxBundleFilename),
+  )
 
   let bundlerChainModifier: BundlerChainModifier | undefined
   const api = {
@@ -443,7 +475,7 @@ describe('pluginVanillaLynx configuration', () => {
         },
         targetSdkVersion: '3.9',
       },
-      rspeedyFilename: '[name].ignored.bundle',
+      lynxBundleFilename: '[name].ignored.bundle',
     })
 
     expect(filenameContext).toEqual({
@@ -472,23 +504,20 @@ describe('pluginVanillaLynx configuration', () => {
       expectedTarget: string
       lynxConfigTarget?: string | undefined
       pluginOptions?: vanilla.PluginVanillaLynxOptions | undefined
-      rspeedyFilename?: HarnessOptions['rspeedyFilename']
+      lynxBundleFilename?: HarnessOptions['lynxBundleFilename']
     }> = [
       {
         expectedFilename: 'main.template.bundle',
         expectedTarget: '3.9',
         lynxConfigTarget: '3.8',
         pluginOptions: { targetSdkVersion: '3.9' },
-        rspeedyFilename: { template: '[name].template.bundle' },
+        lynxBundleFilename: '[name].template.bundle',
       },
       {
         expectedFilename: 'main.bundle-only',
         expectedTarget: '3.8',
         lynxConfigTarget: '3.8',
-        rspeedyFilename: {
-          bundle: '[name].bundle-only',
-          template: '[name].ignored',
-        },
+        lynxBundleFilename: '[name].bundle-only',
       },
       {
         expectedFilename: 'main.lynx.bundle',
@@ -503,7 +532,7 @@ describe('pluginVanillaLynx configuration', () => {
         rawEntries: {
           main: { values: () => ['virtual-main-thread'] },
         },
-        rspeedyFilename: scenario.rspeedyFilename,
+        lynxBundleFilename: scenario.lynxBundleFilename,
       })
 
       expect(getTemplateOptions(result, 'main')).toMatchObject({

--- a/packages/rspeedy/plugin-vanilla/tsconfig.build.json
+++ b/packages/rspeedy/plugin-vanilla/tsconfig.build.json
@@ -7,6 +7,7 @@
   },
   "include": ["src"],
   "references": [
+    { "path": "../plugin-lynx/tsconfig.build.json" },
     { "path": "../../webpack/runtime-wrapper-webpack-plugin/tsconfig.build.json" },
     { "path": "../../webpack/template-webpack-plugin/tsconfig.build.json" },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1809,6 +1809,9 @@ importers:
       '@clack/prompts':
         specifier: 1.7.0
         version: 1.7.0
+      '@lynx-js/rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../plugin-lynx
       '@lynx-js/rspeedy':
         specifier: workspace:*
         version: link:../core
@@ -1952,6 +1955,9 @@ importers:
         specifier: workspace:*
         version: link:../../webpack/template-webpack-plugin
     devDependencies:
+      '@lynx-js/rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../plugin-lynx
       '@lynx-js/rspeedy':
         specifier: workspace:*
         version: link:../core
@@ -8077,6 +8083,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
Stacked on #3650.

`pluginVanillaLynx` and `pluginQRCode` each reached into the Rspeedy config through `Symbol.for('rspeedy.api')` to read `output.filename`, then re-derived the bundle name with their own copy of the placeholder logic. Two Lynx plugins depending on the Rspeedy layer meant neither honored a configured filename when used with Rsbuild directly — `useExposed` returns `undefined` there, so both silently fell back to the default.

Both now call `getLynxApi(api).resolveBundleFilename()`. The resolution lives in the engine and works with or without Rspeedy.

`@lynx-js/example-react` still builds a byte-identical `main.lynx.bundle` (sha256 `63a8869d…`).