### PR TITLE
refactor(react): collect background init into a function

### DIFF
--- a/.changeset/widen-react-peer-range-127.md
+++ b/.changeset/widen-react-peer-range-127.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/react-signals": patch
+---
+
+Widen the `@lynx-js/react` peer range to include `^0.127.0`.

--- a/packages/react-signals/package.json
+++ b/packages/react-signals/package.json
@@ -46,7 +46,7 @@
     "preact": "catalog:lynxjs"
   },
   "peerDependencies": {
-    "@lynx-js/react": "^0.123.0 || ^0.124.0 || ^0.125.0 || ^0.126.0",
+    "@lynx-js/react": "^0.123.0 || ^0.124.0 || ^0.125.0 || ^0.126.0 || ^0.127.0",
     "preact": "*"
   },
   "engines": {

--- a/packages/react/runtime/src/lynx.ts
+++ b/packages/react/runtime/src/lynx.ts
@@ -69,7 +69,15 @@ if (typeof __ALOG_ELEMENT_API__ !== 'undefined' && __ALOG_ELEMENT_API__) {
   initElementPAPICallAlog();
 }
 
-if (typeof __BACKGROUND__ !== 'undefined' && __BACKGROUND__) {
+/**
+ * Installs everything the background runtime needs against the current `lynx`:
+ * the Preact adapters, the app-level callbacks and the commit/timing hooks.
+ *
+ * Kept as a function rather than inline module side effects so it can later be
+ * run once per page instead of once per module evaluation, which is what a
+ * runtime shared between several cards needs.
+ */
+function initBackgroundRuntime(): void {
   // Trick Preact and TypeScript to accept our custom document adapter.
   options.document = document as unknown as Document;
   options.requestAnimationFrame = lynxQueueMicrotask;
@@ -88,6 +96,10 @@ if (typeof __BACKGROUND__ !== 'undefined' && __BACKGROUND__) {
       initProfileHook();
     }
   }
+}
+
+if (typeof __BACKGROUND__ !== 'undefined' && __BACKGROUND__) {
+  initBackgroundRuntime();
 }
 
 setupLynxEnv();

--- a/packages/rspeedy/plugin-react/package.json
+++ b/packages/rspeedy/plugin-react/package.json
@@ -70,7 +70,7 @@
     "typia-rspack-plugin": "3.0.1"
   },
   "peerDependencies": {
-    "@lynx-js/react": "^0.124.0 || ^0.125.0 || ^0.126.0",
+    "@lynx-js/react": "^0.124.0 || ^0.125.0 || ^0.126.0 || ^0.127.0",
     "@lynx-js/rspeedy": "^0.17.0",
     "@rsbuild/core": "^2.0.0"
   },


### PR DESCRIPTION
First of a stack that lets several cards in one LynxGroup share the ReactLynx runtime.

The background runtime installs its Preact adapters, app-level callbacks and commit hooks as module side effects, so they run once per module evaluation. A runtime shared by a group is evaluated once for the whole group, which would leave every card after the first without them.

This moves the block into `initBackgroundRuntime()` and calls it from the same place. **No behavior change** — it only gives the later per-page work something to call.

**Stack**
1. **this PR** — extract the init block
2. `createRenderContext({ lynx })`
3. per-page module singletons + `useLynx`
4. event subscription replacing the property writes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal organization of background runtime initialization without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->