### PR TITLE
feat(react): add the useLynx hook

### DIFF
--- a/.changeset/use-lynx-hook.md
+++ b/.changeset/use-lynx-hook.md
@@ -1,0 +1,11 @@
+---
+"@lynx-js/react": minor
+---
+
+Add the `useLynx()` hook, which reads the `lynx` of the page a component is
+rendering in. Code in a chunk shared by several cards must not capture the
+module-scope `lynx`: that one belongs to whichever card evaluated the chunk
+and stops working when that card is destroyed.
+
+Falls back to the module-scope `lynx` when the tree has no render context, so
+single-page cards are unaffected.

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -70,7 +70,7 @@ export function createPortal(vnode: ComponentChild, container: NodesRef): ReactN
 export { createRef }
 
 // @public
-export function createRenderContext(_context: {
+export function createRenderContext(context: {
     lynx: unknown;
 }): Root;
 
@@ -209,6 +209,9 @@ export const useInitDataChanged: (callback: (data: InitData) => void) => void;
 
 // @public @deprecated
 export const useLayoutEffect: (effect: EffectCallback, deps?: DependencyList) => void;
+
+// @public
+export function useLynx(): typeof lynx;
 
 // @public
 export function useLynxGlobalEventListener<T extends (...args: any[]) => void>(eventName: string, listener: T): void;

--- a/packages/react/etc/react.api.md
+++ b/packages/react/etc/react.api.md
@@ -211,6 +211,9 @@ export const useInitDataChanged: (callback: (data: InitData) => void) => void;
 export const useLayoutEffect: (effect: EffectCallback, deps?: DependencyList) => void;
 
 // @public
+export function useLynx(): typeof lynx;
+
+// @public
 export function useLynxGlobalEventListener<T extends (...args: any[]) => void>(eventName: string, listener: T): void;
 
 // @public

--- a/packages/react/runtime/__test__/snapshot/lifecycle/renderContext.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/renderContext.test.jsx
@@ -4,7 +4,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createRenderContext, root } from '../../../src/index';
+import { createRenderContext, root, useLynx } from '../../../src/index';
 import { globalEnvManager } from '../utils/envManager';
 
 beforeEach(() => {
@@ -23,7 +23,7 @@ describe('createRenderContext', () => {
   it('returns a root that renders', () => {
     const context = createRenderContext({ lynx });
     expect(context.render).toBeTypeOf('function');
-    expect(context).toBe(root);
+    expect(context.registerDataProcessors).toBe(root.registerDataProcessors);
   });
 
   it('registers without rendering, so a deferred render keeps the callbacks', () => {
@@ -34,5 +34,28 @@ describe('createRenderContext', () => {
     // what lets the engine's queued first-screen events reach the runtime even
     // when the page defers rendering.
     expect(lynx.getApp().OnLifecycleEvent).toBeTypeOf('function');
+  });
+});
+
+describe('useLynx', () => {
+  it('falls back to the module-scope lynx outside a render context', () => {
+    let seen;
+    function Probe() {
+      seen = useLynx();
+      return null;
+    }
+    root.render(<Probe />);
+    expect(seen).toBe(lynx);
+  });
+
+  it('resolves to the lynx of the page rendering it', () => {
+    const pageLynx = { marker: 'page-b' };
+    let seen;
+    function Probe() {
+      seen = useLynx();
+      return null;
+    }
+    createRenderContext({ lynx: pageLynx }).render(<Probe />);
+    expect(seen).toBe(pageLynx);
   });
 });

--- a/packages/react/runtime/__test__/snapshot/lifecycle/renderContext.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/renderContext.test.jsx
@@ -4,7 +4,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createRenderContext, root } from '../../../src/index';
+import { createRenderContext, root, useLynx } from '../../../src/index';
 import { globalEnvManager } from '../utils/envManager';
 
 beforeEach(() => {
@@ -25,7 +25,7 @@ describe('createRenderContext', () => {
   it('returns a root that renders', () => {
     const context = createRenderContext({ lynx });
     expect(context.render).toBeTypeOf('function');
-    expect(context).toBe(root);
+    expect(context.registerDataProcessors).toBe(root.registerDataProcessors);
   });
 
   it('registers without rendering, so a deferred render keeps the callbacks', () => {
@@ -36,5 +36,28 @@ describe('createRenderContext', () => {
     // what lets the engine's queued first-screen events reach the runtime even
     // when the page defers rendering.
     expect(lynx.getApp().OnLifecycleEvent).toBeTypeOf('function');
+  });
+});
+
+describe('useLynx', () => {
+  it('falls back to the module-scope lynx outside a render context', () => {
+    let seen;
+    function Probe() {
+      seen = useLynx();
+      return null;
+    }
+    root.render(<Probe />);
+    expect(seen).toBe(lynx);
+  });
+
+  it('resolves to the lynx of the page rendering it', () => {
+    const pageLynx = { marker: 'page-b' };
+    let seen;
+    function Probe() {
+      seen = useLynx();
+      return null;
+    }
+    createRenderContext({ lynx: pageLynx }).render(<Probe />);
+    expect(seen).toBe(pageLynx);
   });
 });

--- a/packages/react/runtime/lazy/compat.js
+++ b/packages/react/runtime/lazy/compat.js
@@ -40,6 +40,7 @@ export const {
   useInitDataChanged,
   useGlobalProps,
   useGlobalPropsChanged,
+  useLynx,
   useLynxGlobalEventListener,
   useLayoutEffect,
   useMainThreadRef,

--- a/packages/react/runtime/lazy/react.js
+++ b/packages/react/runtime/lazy/react.js
@@ -38,6 +38,7 @@ export const {
   useImperativeHandle,
   useInitData,
   useInitDataChanged,
+  useLynx,
   useLynxGlobalEventListener,
   useGlobalProps,
   useGlobalPropsChanged,

--- a/packages/react/runtime/src/core/hooks/useLynx.ts
+++ b/packages/react/runtime/src/core/hooks/useLynx.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { Context } from 'preact';
+import { createContext } from 'preact/compat';
+import { useContext } from 'preact/hooks';
+
+/**
+ * Carries the `lynx` of the page a component is rendering in. Undefined for
+ * cards that never called `createRenderContext`, which is every single-page
+ * card.
+ */
+export const LynxContext: Context<unknown> = /*@__PURE__*/ createContext<unknown>(
+  undefined,
+);
+
+/**
+ * Reads the `lynx` of the page this component belongs to.
+ *
+ * Code in a chunk shared by several cards must not capture the module-scope
+ * `lynx`: that one belongs to whichever card evaluated the chunk, and stops
+ * working when that card is destroyed. Reading it per render through this
+ * hook resolves to the page actually rendering.
+ *
+ * Falls back to the module-scope `lynx` when the tree has no render context,
+ * so single-page cards behave as before.
+ *
+ * @example
+ *
+ * ```tsx
+ * function Popup() {
+ *   const lynx = useLynx()
+ *   return <view style={{ height: lynx.__globalProps.screenHeight }} />
+ * }
+ * ```
+ *
+ * @public
+ */
+export function useLynx(): typeof lynx {
+  // `preact/compat` and `preact/hooks` disagree on the Context type; the
+  // runtime object is the same one.
+  const value = useContext(
+    LynxContext as unknown as Parameters<typeof useContext>[0],
+  );
+  return (value as typeof lynx | undefined) ?? lynx;
+}

--- a/packages/react/runtime/src/lynx-api.ts
+++ b/packages/react/runtime/src/lynx-api.ts
@@ -8,6 +8,7 @@ import type { Consumer, FC, ReactNode } from 'react';
 
 import { createGlobalProps } from './core/globalProps.js';
 import type { GlobalProps } from './core/globalProps.js';
+import { LynxContext } from './core/hooks/useLynx.js';
 import { useLynxGlobalEventListener } from './core/hooks/useLynxGlobalEventListener.js';
 import { factory, withInitDataInState } from './core/initData.js';
 import { initBackgroundRuntime } from './lynx.js';
@@ -140,11 +141,18 @@ export const root: Root = {
  *
  * @public
  */
-export function createRenderContext(_context: { lynx: unknown }): Root {
+export function createRenderContext(context: { lynx: unknown }): Root {
   if (typeof __BACKGROUND__ !== 'undefined' && __BACKGROUND__) {
     initBackgroundRuntime();
   }
-  return root;
+  return {
+    ...root,
+    render: (jsx: ReactNode): void => {
+      root.render(
+        createElement(LynxContext.Provider, { value: context.lynx }, jsx) as ReactNode,
+      );
+    },
+  };
 }
 
 /**
@@ -587,6 +595,7 @@ export interface Lynx {
   registerDataProcessors: (dataProcessorDefinition?: DataProcessorDefinition) => void;
 }
 
+export { useLynx } from './core/hooks/useLynx.js';
 export { useLynxGlobalEventListener } from './core/hooks/useLynxGlobalEventListener.js';
 export { runOnBackground } from './core/background-function/run-on-background.js';
 export { runOnMainThread } from './snapshot/worklet/call/runOnMainThread.js';

--- a/packages/react/runtime/src/lynx-api.ts
+++ b/packages/react/runtime/src/lynx-api.ts
@@ -8,6 +8,7 @@ import type { Consumer, FC, ReactNode } from 'react';
 
 import { createGlobalProps } from './core/globalProps.js';
 import type { GlobalProps } from './core/globalProps.js';
+import { LynxContext } from './core/hooks/useLynx.js';
 import { useLynxGlobalEventListener } from './core/hooks/useLynxGlobalEventListener.js';
 import { factory, withInitDataInState } from './core/initData.js';
 import { initBackgroundRuntime } from './lynx.js';
@@ -144,7 +145,14 @@ export function createRenderContext(context: { lynx: unknown }): Root {
   if (typeof __BACKGROUND__ !== 'undefined' && __BACKGROUND__) {
     initBackgroundRuntime(context.lynx);
   }
-  return root;
+  return {
+    ...root,
+    render: (jsx: ReactNode): void => {
+      root.render(
+        createElement(LynxContext.Provider, { value: context.lynx }, jsx) as ReactNode,
+      );
+    },
+  };
 }
 
 /**
@@ -587,6 +595,7 @@ export interface Lynx {
   registerDataProcessors: (dataProcessorDefinition?: DataProcessorDefinition) => void;
 }
 
+export { useLynx } from './core/hooks/useLynx.js';
 export { useLynxGlobalEventListener } from './core/hooks/useLynxGlobalEventListener.js';
 export { runOnBackground } from './core/background-function/run-on-background.js';
 export { runOnMainThread } from './snapshot/worklet/call/runOnMainThread.js';


### PR DESCRIPTION
Stacked on #3654.

Code in a chunk shared by several cards must not capture the module-scope `lynx`: that one belongs to whichever card evaluated the chunk, and stops working once that card is destroyed.

`useLynx()` resolves per render to the page actually rendering, which `createRenderContext` provides through a context:

```tsx
function Popup() {
  const lynx = useLynx()
  return <view style={{ height: lynx.__globalProps.screenHeight }} />
}
```

Falls back to the module-scope `lynx` when the tree has no render context, so single-page cards are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `useLynx()` hook to access the page context associated with the currently rendering component.
  * Exported `useLynx()` through the React runtime and compatibility APIs.
  * Preserved fallback behavior for components rendered without a page context.

* **Tests**
  * Added coverage for page-specific context resolution and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->