### PR TITLE
feat(example): add react-shared-context

### DIFF
--- a/examples/react-shared-context/README.md
+++ b/examples/react-shared-context/README.md
@@ -1,0 +1,34 @@
+# react-shared-context
+
+Two pages that share one module instance when they run in the same LynxGroup.
+
+## What it shows
+
+`src/store.ts` is imported by both entries, so `splitChunks` moves it into a
+common chunk the pages load through `lynx.requireModuleAsync`. With
+`enableLynxGroupModuleSharing` on, the group evaluates it once:
+
+- **shared count** — moves together on both pages
+- **module instance** — identical on both pages when shared, different when not
+
+Only `src/store.ts` goes into the common chunk. The framework stays in each
+entry, so every page keeps its own renderer state.
+
+`src/app.ts` is the group-level runtime. It is declared as a background-only
+entry, so it builds to `app-runtime.js` with no main thread and no template;
+the QR schema passes that URL as `app_runtime`, and the host loads it into the
+group once, before any card.
+
+The module captures `setTimeout` and `Promise` at eval time on purpose. They
+belong to whichever page evaluated it first, so **+1 after 1.5s** keeps working
+from a second page only when the timers come from the standalone runtime.
+
+## Run
+
+```bash
+pnpm dev
+```
+
+Scan both QR codes. Both URLs carry `group=shared-context-demo`, which is what
+puts the two cards in one JS context. Drop the `group` query to compare against
+the isolated behavior.

--- a/examples/react-shared-context/lynx.config.js
+++ b/examples/react-shared-context/lynx.config.js
@@ -1,0 +1,65 @@
+import { pluginLynxConfig } from '@lynx-js/config-rsbuild-plugin';
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { configKeys as defaultConfigKeys } from '@lynx-js/type-config';
+
+export default defineConfig({
+  plugins: [
+    // `app` is the group-level runtime: no main thread, no template, just the
+    // background bundle the standalone runtime loads.
+    pluginReactLynx({ experimental_backgroundOnlyEntries: ['app'] }),
+    // `enableLynxGroupModuleSharing` is an engine page config; listing it
+    // explicitly keeps validation happy until `@lynx-js/type-config` picks the
+    // key up from the engine release that carries it.
+    pluginLynxConfig({ enableLynxGroupModuleSharing: true }, {
+      configKeys: [...defaultConfigKeys, 'enableLynxGroupModuleSharing'],
+      validate: (input) => input,
+    }),
+    pluginQRCode({
+      schema(url) {
+        // Cards opened with the same group share one JS context, which is what
+        // makes the two pages observe the same store instance. `app_runtime`
+        // points the group at the background-only bundle it loads once, before
+        // any card. Not fullscreen, so the toolbar keeps its entry for opening
+        // the second page.
+        const appRuntime = new URL('app-runtime.js', url).href;
+        return `${url}?group=shared-context-demo&app_runtime=${
+          encodeURIComponent(appRuntime)
+        }`;
+      },
+    }),
+  ],
+  dev: { assetPrefix: 'http://127.0.0.1:3000/' },
+  server: { port: 3000 },
+  source: {
+    entry: {
+      app: './src/app.ts',
+      pageA: './src/pageA.tsx',
+      pageB: './src/pageB.tsx',
+    },
+  },
+  // Both entries import the store, so `minChunks: 2` splits it into a chunk the
+  // pages load through `requireModuleAsync` — the path that shares module
+  // instances across the group. The framework stays in each entry, so every
+  // page keeps its own renderer state.
+  splitChunks: {
+    chunks: 'all',
+    minSize: 0,
+    minSizeReduction: 0,
+    maxInitialRequests: 100000,
+    maxAsyncRequests: 100000,
+    cacheGroups: {
+      default: false,
+      defaultVendors: false,
+      shared: {
+        test: /[\\/]src[\\/]store\.ts$/,
+        minChunks: 2,
+        enforce: true,
+      },
+    },
+  },
+  environments: {
+    lynx: {},
+  },
+});

--- a/examples/react-shared-context/package.json
+++ b/examples/react-shared-context/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@lynx-js/example-react-shared-context",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "@lynx-js/react": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/config-rsbuild-plugin": "workspace:*",
+    "@lynx-js/preact-devtools": "5.0.1-20260721114100-d7da994",
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
+    "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/type-config": "4.2.0",
+    "@lynx-js/types": "4.1.0",
+    "@types/react": "^19.2.18"
+  }
+}

--- a/examples/react-shared-context/src/Page.tsx
+++ b/examples/react-shared-context/src/Page.tsx
@@ -1,0 +1,72 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { useLynx } from '@lynx-js/react';
+import { useEffect, useState } from '@lynx-js/react';
+
+import {
+  getCount,
+  increment,
+  incrementLater,
+  instanceId,
+  subscribe,
+} from './store.js';
+
+export function Page(props: { name: string }): JSX.Element {
+  const lynx = useLynx();
+  const [count, setCount] = useState(getCount());
+  const [pending, setPending] = useState(false);
+  // The main thread has its own copy of the store, so read the shared instance
+  // after mount, when the background thread owns the tree.
+  const [sharedInstance, setSharedInstance] = useState('');
+
+  useEffect(() => {
+    setSharedInstance(instanceId);
+    return subscribe(() => setCount(getCount()));
+  }, []);
+
+  return (
+    <view style={{ padding: '24px', display: 'flex', flexDirection: 'column' }}>
+      <text style={{ fontSize: '28px', fontWeight: 'bold' }}>{props.name}</text>
+
+      <text style={{ marginTop: '16px', fontSize: '20px' }}>
+        shared count: {count}
+      </text>
+      <text style={{ marginTop: '4px', fontSize: '12px', color: '#888' }}>
+        module instance: {sharedInstance}
+      </text>
+      <text style={{ marginTop: '4px', fontSize: '12px', color: '#888' }}>
+        page lynx: {String(lynx === globalThis.lynx)}
+      </text>
+
+      <view
+        bindtap={increment}
+        style={{
+          marginTop: '20px',
+          padding: '12px',
+          backgroundColor: '#2d7ff9',
+        }}
+      >
+        <text style={{ color: '#fff' }}>+1 now</text>
+      </view>
+
+      <view
+        bindtap={() => {
+          setPending(true);
+          void incrementLater().then(() =>
+            setPending(false)
+          );
+        }}
+        style={{
+          marginTop: '12px',
+          padding: '12px',
+          backgroundColor: '#0f9d58',
+        }}
+      >
+        <text style={{ color: '#fff' }}>
+          {pending ? '+1 in flight…' : '+1 after 1.5s'}
+        </text>
+      </view>
+    </view>
+  );
+}

--- a/examples/react-shared-context/src/app.ts
+++ b/examples/react-shared-context/src/app.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// The group-level runtime: built without a main thread and without a template,
+// loaded once per LynxGroup before any card and kept alive after the cards are
+// gone. It owns the timers and the Promise the shared modules capture, which is
+// what lets work started by one page outlive it.
+
+console.info('[app] group runtime started');

--- a/examples/react-shared-context/src/pageA.tsx
+++ b/examples/react-shared-context/src/pageA.tsx
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { createRenderContext } from '@lynx-js/react';
+
+import { Page } from './Page.jsx';
+
+// Registration is synchronous, so the runtime is bound to this page's lynx
+// before the engine replays the events it queued while app-service.js loaded.
+// Rendering may be deferred; registration may not.
+createRenderContext({ lynx }).render(<Page name='Page A' />);

--- a/examples/react-shared-context/src/pageB.tsx
+++ b/examples/react-shared-context/src/pageB.tsx
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { createRenderContext } from '@lynx-js/react';
+
+import { Page } from './Page.jsx';
+
+// Registration is synchronous, so the runtime is bound to this page's lynx
+// before the engine replays the events it queued while app-service.js loaded.
+// Rendering may be deferred; registration may not.
+createRenderContext({ lynx }).render(<Page name='Page B' />);

--- a/examples/react-shared-context/src/store.ts
+++ b/examples/react-shared-context/src/store.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// This module is pulled into the common chunk, so with sharing enabled every
+// page in the group evaluates it once and observes the same state. Without
+// sharing each page gets its own copy and the counters move independently.
+
+// Captured at eval time, on purpose. They belong to whichever page evaluated
+// this module first, which is exactly what breaks once that page is closed
+// unless the timers come from the standalone runtime.
+const capturedSetTimeout = setTimeout;
+const CapturedPromise = Promise;
+
+/** Distinguishes module instances: equal across pages only when shared. */
+export const instanceId = `${Date.now()}-${
+  Math.random().toString(36).slice(2, 7)
+}`;
+
+let count = 0;
+const listeners = new Set<() => void>();
+
+export function getCount(): number {
+  return count;
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function increment(): void {
+  count += 1;
+  listeners.forEach((listener) => listener());
+}
+
+/**
+ * Bumps the counter after a delay, through the captured timer and Promise.
+ * Close the page that evaluated this module, then run it from another page:
+ * it still resolves when the timers come from the standalone runtime.
+ */
+export function incrementLater(delayMs = 1500): Promise<void> {
+  return new CapturedPromise<void>((resolve) => {
+    capturedSetTimeout(() => {
+      increment();
+      resolve();
+    }, delayMs);
+  });
+}

--- a/examples/react-shared-context/tsconfig.json
+++ b/examples/react-shared-context/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@lynx-js/react",
+    "noEmit": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedDeclarations": false,
+  },
+  "include": ["src", "lynx.config.js", "test", "vitest.config.ts"],
+  "references": [
+    { "path": "../../packages/react/tsconfig.json" },
+    { "path": "../../packages/rspeedy/core/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-qrcode/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-react/tsconfig.build.json" },
+  ],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,6 +880,37 @@ importers:
         specifier: ^19.2.18
         version: 19.2.18
 
+  examples/react-shared-context:
+    dependencies:
+      '@lynx-js/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+    devDependencies:
+      '@lynx-js/config-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-config
+      '@lynx-js/preact-devtools':
+        specifier: 5.0.1-20260721114100-d7da994
+        version: 5.0.1-20260721114100-d7da994
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-qrcode
+      '@lynx-js/react-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-react
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/core
+      '@lynx-js/type-config':
+        specifier: 4.2.0
+        version: 4.2.0
+      '@lynx-js/types':
+        specifier: 4.1.0
+        version: 4.1.0
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+
   examples/react-signals:
     dependencies:
       '@lynx-js/react':
@@ -4827,6 +4858,9 @@ packages:
     peerDependenciesMeta:
       '@lynx-js/types':
         optional: true
+
+  '@lynx-js/preact-devtools@5.0.1-20260721114100-d7da994':
+    resolution: {integrity: sha512-UdP8IdKQVkE3LqhhQ+hqEuacfhPOoG/9qGeR856sDvbrFXOLLAik+gf5QH+GEfcVh/YG1/IiaRbGd1TUPlD+jg==}
 
   '@lynx-js/preact-devtools@5.0.1-20260827072047-5f77e12':
     resolution: {integrity: sha512-S4zV+qtL+M8MBT9G4I2jkeaDsbLVyX4kt5m+XyS9w7drBSrJlgOdxZ/lMtG3ngZVhpo7TuE6UODZGexB0QbZdA==}
@@ -14665,6 +14699,11 @@ snapshots:
       - '@emotion/is-prop-valid'
       - react
       - react-dom
+
+  '@lynx-js/preact-devtools@5.0.1-20260721114100-d7da994':
+    dependencies:
+      errorstacks: 2.4.1
+      htm: 3.1.1
 
   '@lynx-js/preact-devtools@5.0.1-20260827072047-5f77e12':
     dependencies:


### PR DESCRIPTION
Stacked on #3655, and needs #3659 for the pages to end up on one module instance.

Two page entries importing one store module, split into a common chunk so a LynxGroup evaluates it once:

- **shared count** moves together on both pages
- **module instance** is identical across pages when shared, different when not

Only the store goes into the common chunk. The framework stays in each entry, so every page keeps its own renderer state.

The store captures `setTimeout` and `Promise` at eval time on purpose. They belong to whichever page evaluated it first, so **+1 after 1.5s** run from a second page after closing the first is the regression trigger for the standalone-runtime timers.

Both QR codes carry `group=shared-context-demo`, which is what puts the cards in one JS context; drop the query to compare against the isolated behavior.