### PR TITLE
feat(react): receive app-level callbacks by subscription

### DIFF
--- a/.changeset/react-app-event-subscription.md
+++ b/.changeset/react-app-event-subscription.md
@@ -1,0 +1,15 @@
+---
+"@lynx-js/react": patch
+---
+
+Receive the app-level callbacks by subscription instead of by assigning handlers
+onto the app object. The engine and lynx-core look those callbacks up on the app
+by name, and that object is per card, so a runtime shared by a LynxGroup could
+only ever serve whichever card assigned last.
+
+Element events, card data, global props, reload and destroy now come from the
+page's own context proxies; `__OnLifecycleEvent` uses lynx-core's replaying
+subscription, because a card's first lifecycle event is dispatched before its
+background bundle has finished evaluating, and falls back to the method on an
+engine that does not offer it. Each page keeps its own handlers, and
+`createRenderContext({ lynx })` registers against that page's app.

--- a/packages/react/runtime/__test__/snapshot/lifecycle/appEvents.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/appEvents.test.jsx
@@ -1,0 +1,233 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AppEvents, registerAppEventHandlers, unregisterAppEventHandlers } from '../../../src/core/app-events';
+
+/** A proxy that records listeners and can dispatch to them, like the engine. */
+function stubProxy() {
+  const listeners = new Map();
+  return {
+    addEventListener: vi.fn((type, listener) => {
+      if (!listeners.has(type)) listeners.set(type, []);
+      listeners.get(type).push(listener);
+    }),
+    removeEventListener: vi.fn((type, listener) => {
+      listeners.set(type, (listeners.get(type) ?? []).filter(l => l !== listener));
+    }),
+    emit: (type, data) => {
+      for (const listener of listeners.get(type) ?? []) listener({ data });
+    },
+    count: (type) => (listeners.get(type) ?? []).length,
+  };
+}
+
+function stubPage() {
+  const lifecycleListeners = [];
+  const app = {
+    addLifecycleEventListener: vi.fn((listener) => {
+      lifecycleListeners.push(listener);
+      return () => {
+        lifecycleListeners.splice(lifecycleListeners.indexOf(listener), 1);
+      };
+    }),
+    emitLifecycle: (args) => lifecycleListeners.forEach((l) => l(args)),
+    lifecycleCount: () => lifecycleListeners.length,
+  };
+  const core = stubProxy();
+  const native = stubProxy();
+  const pageLynx = {
+    getApp: () => app,
+    getCoreContext: () => core,
+    getNative: () => native,
+  };
+  vi.stubGlobal('lynx', pageLynx);
+  return { app, core, native, pageLynx };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('registerAppEventHandlers', () => {
+  it('routes every app-level event to the registered handler', () => {
+    const { app, core, native } = stubPage();
+    const handlers = {
+      OnLifecycleEvent: vi.fn(),
+      publishEvent: vi.fn(),
+      publicComponentEvent: vi.fn(),
+      updateGlobalProps: vi.fn(),
+      onAppReload: vi.fn(),
+      updateCardData: vi.fn(),
+      callDestroyLifetimeFun: vi.fn(),
+    };
+
+    registerAppEventHandlers(handlers);
+
+    app.emitLifecycle(['rLynxFirstScreen', {}]);
+    expect(handlers.OnLifecycleEvent).toBeCalledWith(['rLynxFirstScreen', {}]);
+
+    core.emit(AppEvents.pageEvent, ['', '1:0:', { a: 1 }]);
+    expect(handlers.publishEvent).toBeCalledWith('1:0:', { a: 1 });
+
+    core.emit(AppEvents.componentEvent, ['card', '2:0:', { b: 2 }]);
+    expect(handlers.publicComponentEvent).toBeCalledWith('card', '2:0:', { b: 2 });
+
+    core.emit(AppEvents.globalProps, [{ c: 3 }]);
+    expect(handlers.updateGlobalProps).toBeCalledWith({ c: 3 });
+
+    core.emit(AppEvents.cardData, [{ d: 4 }, undefined]);
+    expect(handlers.updateCardData).toBeCalledWith({ d: 4 }, undefined);
+
+    core.emit(AppEvents.appReload, [{ e: 5 }]);
+    expect(handlers.onAppReload).toBeCalledWith({ e: 5 });
+
+    native.emit(AppEvents.destroy, undefined);
+    expect(handlers.callDestroyLifetimeFun).toBeCalled();
+  });
+
+  it('replaces only the handlers a later registration passes', () => {
+    const { app, core } = stubPage();
+    const first = { publishEvent: vi.fn(), OnLifecycleEvent: vi.fn() };
+    registerAppEventHandlers(first);
+
+    const second = { publishEvent: vi.fn() };
+    registerAppEventHandlers(second);
+
+    core.emit(AppEvents.pageEvent, ['', '1:0:', {}]);
+    expect(second.publishEvent).toBeCalled();
+    expect(first.publishEvent).not.toBeCalled();
+
+    app.emitLifecycle(['x', {}]);
+    expect(first.OnLifecycleEvent).toBeCalled();
+  });
+
+  it('subscribes once however often handlers are registered', () => {
+    const { core } = stubPage();
+
+    registerAppEventHandlers({ publishEvent: vi.fn() });
+    registerAppEventHandlers({ publishEvent: vi.fn() });
+
+    expect(core.count(AppEvents.pageEvent)).toBe(1);
+  });
+
+  it('keeps each page on its own subscription', () => {
+    const a = stubPage();
+    const aHandler = vi.fn();
+    registerAppEventHandlers({ publishEvent: aHandler }, a.pageLynx);
+
+    const b = stubPage();
+    const bHandler = vi.fn();
+    registerAppEventHandlers({ publishEvent: bHandler }, b.pageLynx);
+
+    a.core.emit(AppEvents.pageEvent, ['', '1:0:', {}]);
+    expect(aHandler).toBeCalled();
+    expect(bHandler).not.toBeCalled();
+  });
+
+  it('tolerates an event with no handler registered', () => {
+    const { core } = stubPage();
+    registerAppEventHandlers({});
+
+    expect(() => core.emit(AppEvents.pageEvent, ['', '1:0:', {}])).not.toThrow();
+  });
+
+  it('runs the app hook before a page event reaches its handler', () => {
+    const { app, core } = stubPage();
+    const order = [];
+    app.callBeforePublishEvent = vi.fn(() => order.push('hook'));
+    registerAppEventHandlers({ publishEvent: () => order.push('handler') });
+
+    core.emit(AppEvents.pageEvent, ['', '1:0:', { a: 1 }]);
+
+    expect(app.callBeforePublishEvent).toBeCalledWith({ a: 1 });
+    expect(order).toEqual(['hook', 'handler']);
+  });
+
+  it('falls back to the app method when lynx-core cannot replay', () => {
+    const { app, pageLynx } = stubPage();
+    delete app.addLifecycleEventListener;
+    const OnLifecycleEvent = vi.fn();
+
+    registerAppEventHandlers({ OnLifecycleEvent }, pageLynx);
+    app.OnLifecycleEvent(['rLynxFirstScreen', {}]);
+
+    expect(OnLifecycleEvent).toBeCalledWith(['rLynxFirstScreen', {}]);
+
+    unregisterAppEventHandlers(pageLynx);
+    expect(app.OnLifecycleEvent).toBeUndefined();
+  });
+
+  it('skips a runtime that has no context proxies of its own', () => {
+    const app = {};
+    const standalone = { getApp: () => app };
+
+    const OnLifecycleEvent = vi.fn();
+    const handlers = {
+      OnLifecycleEvent,
+      publishEvent: vi.fn(),
+      publicComponentEvent: vi.fn(),
+      updateGlobalProps: vi.fn(),
+      updateCardData: vi.fn(),
+      onAppReload: vi.fn(),
+      callDestroyLifetimeFun: vi.fn(),
+    };
+    registerAppEventHandlers(handlers, standalone);
+
+    // No proxies, so the host's method calls carry every callback.
+    app.OnLifecycleEvent(['rLynxFirstScreen', {}]);
+    expect(OnLifecycleEvent).toBeCalledWith(['rLynxFirstScreen', {}]);
+
+    app.publishEvent('1:0:', { a: 1 });
+    expect(handlers.publishEvent).toBeCalledWith('1:0:', { a: 1 });
+    app.publicComponentEvent('card', '2:0:', { b: 2 });
+    expect(handlers.publicComponentEvent).toBeCalledWith('card', '2:0:', { b: 2 });
+    app.updateGlobalProps({ c: 3 });
+    expect(handlers.updateGlobalProps).toBeCalledWith({ c: 3 });
+    app.updateCardData({ d: 4 });
+    expect(handlers.updateCardData).toBeCalledWith({ d: 4 });
+    app.onAppReload({ e: 5 });
+    expect(handlers.onAppReload).toBeCalledWith({ e: 5 });
+    app.callDestroyLifetimeFun();
+    expect(handlers.callDestroyLifetimeFun).toBeCalled();
+    expect(() => app.processCardConfig()).not.toThrow();
+
+    unregisterAppEventHandlers(standalone);
+    expect(app.OnLifecycleEvent).toBeUndefined();
+  });
+
+  it('upgrades from the methods to subscriptions once proxies appear', () => {
+    const app = {};
+    const core = stubProxy();
+    const native = stubProxy();
+    const early = { getApp: () => app };
+    const later = { getApp: () => app, getCoreContext: () => core, getNative: () => native };
+    const publishEvent = vi.fn();
+
+    // Registered before the page has its proxies: the methods carry the events.
+    registerAppEventHandlers({ publishEvent }, early);
+    expect(typeof app.publishEvent).toBe('function');
+    expect(core.count(AppEvents.pageEvent)).toBe(0);
+
+    registerAppEventHandlers({ publishEvent }, later);
+
+    expect(app.publishEvent).toBeUndefined();
+    expect(core.count(AppEvents.pageEvent)).toBe(1);
+    core.emit(AppEvents.pageEvent, ['', '1:0:', { a: 1 }]);
+    expect(publishEvent).toBeCalledWith('1:0:', { a: 1 });
+  });
+
+  it('drops the subscription on unregister', () => {
+    const { core, pageLynx } = stubPage();
+    const publishEvent = vi.fn();
+    registerAppEventHandlers({ publishEvent }, pageLynx);
+
+    unregisterAppEventHandlers(pageLynx);
+
+    expect(core.count(AppEvents.pageEvent)).toBe(0);
+    core.emit(AppEvents.pageEvent, ['', '1:0:', {}]);
+    expect(publishEvent).not.toBeCalled();
+  });
+});

--- a/packages/react/runtime/__test__/snapshot/lifecycle/reload.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/reload.test.jsx
@@ -291,7 +291,7 @@ describe('reload', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynx.getApp().onAppReload({ text: 'Enjoy' });
+      // the main thread already forwarded __OnAppReload
       expect(lynx.getNativeApp().callLepusMethod).not.toBeCalled();
     }
 
@@ -709,7 +709,7 @@ describe('reload', () => {
     {
       globalEnvManager.switchToBackground();
       lynx.getNativeApp().callLepusMethod.mockClear();
-      lynx.getApp().onAppReload({ text: 'Enjoy' });
+      // the main thread already forwarded __OnAppReload
       expect(lynx.getNativeApp().callLepusMethod).not.toBeCalled();
     }
 
@@ -1316,7 +1316,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
-          "data": "{"patchList":[{"snapshotPatch":[2,-11,-12,0,"__snapshot_a94a8_test_3",2,0,"__snapshot_a94a8_test_2",3,4,3,[{"dataX":"WorldX"}],0,null,4,4,4,["Hello 2"],1,3,4,null,0,0,null,5,4,5,["World"],1,3,5,null,1,0,"__snapshot_a94a8_test_1",6,4,6,[{"attr":{"dataX":"WorldX"}}],1,3,6,null,2,1,2,3,null,0,1,-11,2,null,0],"id":21}]}",
+          "data": "{"patchList":[{"snapshotPatch":[2,-11,-12,0,"__snapshot_a94a8_test_3",2,0,"__snapshot_a94a8_test_2",3,4,3,[{"dataX":"WorldX"}],0,null,4,4,4,["Hello 2"],1,3,4,null,0,0,null,5,4,5,["World"],1,3,5,null,1,0,"__snapshot_a94a8_test_1",6,4,6,[{"attr":{"dataX":"WorldX"}}],1,3,6,null,2,1,2,3,null,0,1,-11,2,null,0],"id":23}]}",
           "patchOptions": {
             "isHydration": true,
             "pipelineOptions": {
@@ -1326,7 +1326,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
               "pipelineOrigin": "reactLynxHydrate",
               "stage": "hydrate",
             },
-            "reloadVersion": 5,
+            "reloadVersion": 6,
           },
         }
       `);
@@ -1519,7 +1519,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
-          "data": "{"patchList":[{"snapshotPatch":[],"id":23}]}",
+          "data": "{"patchList":[{"snapshotPatch":[],"id":25}]}",
           "patchOptions": {
             "isHydration": true,
             "pipelineOptions": {
@@ -1529,7 +1529,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
               "pipelineOrigin": "reactLynxHydrate",
               "stage": "hydrate",
             },
-            "reloadVersion": 5,
+            "reloadVersion": 6,
           },
         }
       `);
@@ -1683,7 +1683,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
-          "data": "{"patchList":[{"snapshotPatch":[],"id":25}]}",
+          "data": "{"patchList":[{"snapshotPatch":[],"id":27}]}",
           "patchOptions": {
             "isHydration": true,
             "pipelineOptions": {
@@ -1693,7 +1693,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
               "pipelineOrigin": "reactLynxHydrate",
               "stage": "hydrate",
             },
-            "reloadVersion": 5,
+            "reloadVersion": 6,
           },
         }
       `);
@@ -1876,7 +1876,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
       expect(lynx.getNativeApp().callLepusMethod).toHaveBeenCalledTimes(1);
       expect(lynx.getNativeApp().callLepusMethod.mock.calls[0][1]).toMatchInlineSnapshot(`
         {
-          "data": "{"patchList":[{"snapshotPatch":[2,-11,-12,0,"__snapshot_a94a8_test_3",2,0,"__snapshot_a94a8_test_2",3,4,3,[{"dataX":"WorldX"}],0,null,4,4,4,["Hello 2"],1,3,4,null,0,0,null,5,4,5,["World"],1,3,5,null,1,0,"__snapshot_a94a8_test_1",6,4,6,[{"attr":{"dataX":"WorldX"}}],1,3,6,null,2,1,2,3,null,0,1,-11,2,null,0],"id":27}]}",
+          "data": "{"patchList":[{"snapshotPatch":[2,-11,-12,0,"__snapshot_a94a8_test_3",2,0,"__snapshot_a94a8_test_2",3,4,3,[{"dataX":"WorldX"}],0,null,4,4,4,["Hello 2"],1,3,4,null,0,0,null,5,4,5,["World"],1,3,5,null,1,0,"__snapshot_a94a8_test_1",6,4,6,[{"attr":{"dataX":"WorldX"}}],1,3,6,null,2,1,2,3,null,0,1,-11,2,null,0],"id":33}]}",
           "patchOptions": {
             "isHydration": true,
             "pipelineOptions": {
@@ -1886,7 +1886,7 @@ describe('firstScreenSyncTiming - jsReady', () => {
               "pipelineOrigin": "reactLynxHydrate",
               "stage": "hydrate",
             },
-            "reloadVersion": 7,
+            "reloadVersion": 10,
           },
         }
       `);

--- a/packages/react/runtime/__test__/snapshot/lifecycle/renderContext.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/lifecycle/renderContext.test.jsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createRenderContext, root, useLynx } from '../../../src/index';
 import { globalEnvManager } from '../utils/envManager';
@@ -11,15 +11,37 @@ beforeEach(() => {
   globalEnvManager.switchToBackground();
 });
 
+function stubPage() {
+  const app = {};
+  const proxy = () => ({ addEventListener: vi.fn(), removeEventListener: vi.fn() });
+  const core = proxy();
+  const native = proxy();
+  return { app, core, native, pageLynx: { getApp: () => app, getCoreContext: () => core, getNative: () => native } };
+}
+
 describe('createRenderContext', () => {
-  it('installs the app-level callbacks against the given lynx', () => {
-    const app = { name: 'page-a' };
+  it('subscribes on the context proxies of the given lynx', () => {
+    const page = stubPage();
+    createRenderContext({ lynx: page.pageLynx });
 
-    createRenderContext({ lynx: { getApp: () => app } });
+    expect(page.core.addEventListener).toBeCalledWith(
+      '__SendPageEvent',
+      expect.any(Function),
+    );
+    expect(page.native.addEventListener).toBeCalledWith(
+      '__DestroyLifetime',
+      expect.any(Function),
+    );
+  });
 
-    // The page's own app receives them, rather than only the ambient one.
-    expect(app.OnLifecycleEvent).toBeTypeOf('function');
-    expect(app.publishEvent).toBeTypeOf('function');
+  it('gives each page its own handlers', () => {
+    const a = stubPage();
+    const b = stubPage();
+    createRenderContext({ lynx: a.pageLynx });
+    createRenderContext({ lynx: b.pageLynx });
+
+    expect(a.app.__reactHandlers).not.toBe(b.app.__reactHandlers);
+    expect(b.core.addEventListener).toBeCalled();
   });
 
   it('returns a root that renders', () => {
@@ -29,13 +51,13 @@ describe('createRenderContext', () => {
   });
 
   it('registers without rendering, so a deferred render keeps the callbacks', () => {
-    lynx.getApp().OnLifecycleEvent = undefined;
     createRenderContext({ lynx });
 
     // No render() call here: registration must already have happened, which is
     // what lets the engine's queued first-screen events reach the runtime even
     // when the page defers rendering.
-    expect(lynx.getApp().OnLifecycleEvent).toBeTypeOf('function');
+    expect(lynx.getApp().__reactHandlers?.OnLifecycleEvent).toBeTypeOf('function');
+    expect(lynx.getApp().__reactHandlers?.publishEvent).toBeTypeOf('function');
   });
 });
 
@@ -51,7 +73,7 @@ describe('useLynx', () => {
   });
 
   it('resolves to the lynx of the page rendering it', () => {
-    const pageLynx = { marker: 'page-b' };
+    const pageLynx = { marker: 'page-b', ...stubPage().pageLynx };
     let seen;
     function Probe() {
       seen = useLynx();

--- a/packages/react/runtime/__test__/snapshot/lynx/lazy-bundle.test.js
+++ b/packages/react/runtime/__test__/snapshot/lynx/lazy-bundle.test.js
@@ -220,7 +220,7 @@ describe('loadLazyBundle', () => {
         .stubGlobal('__JS__', true)
         // Force the QueryComponent fetcher path (see main-thread block).
         .stubGlobal('__LAZY_BUNDLE_FETCHER__', 'QueryComponent')
-        .stubGlobal('lynx', { QueryComponent, getApp: () => ({ getDynamicComponentExports }) });
+        .stubGlobal('lynx', { ...globalThis.lynx, QueryComponent, getApp: () => ({ getDynamicComponentExports }) });
     });
 
     test('blocking QueryComponent', async () => {
@@ -542,6 +542,8 @@ describe('loadLazyBundle', () => {
         callback({ code: 0, detail: { schema: source } });
       });
       vi.stubGlobal('lynx', {
+        ...globalThis.lynx,
+        QueryComponent: undefined,
         getNativeLynx: () => ({ QueryComponent }),
         getApp: () => ({ getDynamicComponentExports }),
       });

--- a/packages/react/runtime/__test__/snapshot/utils/globals.js
+++ b/packages/react/runtime/__test__/snapshot/utils/globals.js
@@ -36,6 +36,14 @@ const native = {
   }),
   _clear: () => {
     native._listeners = {};
+    // Clearing the listeners drops the runtime's subscription; re-establish it
+    // so a test that destroys a page does not disarm the ones after it.
+    const app = typeof globalThis.lynx?.getApp === 'function' ? globalThis.lynx.getApp() : undefined;
+    if (app) {
+      delete app.__reactUnsubscribe;
+      app.__clearLifecycleListeners?.();
+      globalThis.__reactInjectTt?.();
+    }
     native.onTriggerEvent = undefined;
     native.postMessage.mockClear();
     native.addEventListener.mockClear();
@@ -151,12 +159,43 @@ function injectGlobals() {
   globalThis.__FIRST_SCREEN_SYNC_TIMING__ = 'immediately';
   globalThis.__GLOBAL_PROPS_MODE__ = 'reactive';
   globalThis.globDynamicComponentEntry = '__Card__';
+  // Stands in for the engine: the runtime subscribes on the core context, and
+  // the app methods the tests call dispatch the matching event.
+  const coreListeners = new Map();
+  const coreContext = {
+    addEventListener: (type, listener) => {
+      if (!coreListeners.has(type)) coreListeners.set(type, []);
+      coreListeners.get(type).push(listener);
+    },
+    dispatchEvent: ({ type, data }) => {
+      for (const listener of coreListeners.get(type) ?? []) listener({ data });
+    },
+  };
+  const dispatchCore = (type, data) => coreContext.dispatchEvent({ type, data });
+  const lifecycleListeners = [];
   const lynxApp = {
+    addLifecycleEventListener: (listener) => {
+      lifecycleListeners.push(listener);
+      return () => {
+        lifecycleListeners.splice(lifecycleListeners.indexOf(listener), 1);
+      };
+    },
+    OnLifecycleEvent: (args) => lifecycleListeners.forEach((listener) => listener(args)),
+    __clearLifecycleListeners: () => {
+      lifecycleListeners.length = 0;
+    },
     GlobalEventEmitter: getJSModule('GlobalEventEmitter'),
+    publishEvent: (name, data) => dispatchCore('__SendPageEvent', ['', name, data]),
+    publicComponentEvent: (id, name, data) => dispatchCore('__PublishComponentEvent', [id, name, data]),
+    updateGlobalProps: (props) => dispatchCore('__UpdateGlobalProps', [props]),
+    updateCardData: (data, options) => dispatchCore('__UpdateCardData', [data, options]),
+    onAppReload: (data) => dispatchCore('__OnAppReload', [data]),
+    callDestroyLifetimeFun: () => native.dispatchEvent({ type: '__DestroyLifetime' }),
   };
   globalThis.lynx = {
     queueMicrotask: Promise.prototype.then.bind(Promise.resolve()),
     getApp: () => lynxApp,
+    getCoreContext: () => coreContext,
     getNativeApp: () => app,
     getNative: () => native,
     performance,

--- a/packages/react/runtime/__test__/snapshot/utils/setup.js
+++ b/packages/react/runtime/__test__/snapshot/utils/setup.js
@@ -4,6 +4,11 @@
 import { __injectElementApi } from './inject.ts';
 import '../../../src/lynx.ts';
 import { document } from '../../../src/document.ts';
+import { registerAppEventHandlers } from '../../../src/core/app-events.ts';
+
+// The harness clears the native listeners between tests, which drops the
+// runtime's subscription; this lets it re-subscribe synchronously.
+globalThis.__reactInjectTt = () => registerAppEventHandlers({});
 import { SnapshotInstance } from '../../../src/snapshot/index.ts';
 
 import { afterEach, expect } from 'vitest';

--- a/packages/react/runtime/__test__/snapshot/worklet/onPost.test.js
+++ b/packages/react/runtime/__test__/snapshot/worklet/onPost.test.js
@@ -12,6 +12,7 @@ afterEach(() => {
 
 describe('WorkletOnPost', () => {
   it('error when sdk version not fulfilled', async function() {
+    const getCoreContext = lynx.getCoreContext;
     lynx.getCoreContext = undefined;
     const reportError = lynx.reportError;
     lynx.reportError = vi.fn();
@@ -22,6 +23,7 @@ describe('WorkletOnPost', () => {
 
     expect(lynx.reportError).toHaveBeenCalledTimes(1);
     lynx.reportError = reportError;
+    lynx.getCoreContext = getCoreContext;
   });
 
   it('should return when worklet is null', async function() {

--- a/packages/react/runtime/__test__/snapshot/worklet/runOnBackground.test.js
+++ b/packages/react/runtime/__test__/snapshot/worklet/runOnBackground.test.js
@@ -159,6 +159,12 @@ describe('runOnBackground', () => {
 });
 
 describe('EventListeners', () => {
+  beforeEach(() => {
+    // the runtime's own app-event subscription is not what these count
+    lynx.getCoreContext().addEventListener.mockClear();
+    lynx.getCoreContext().removeEventListener.mockClear();
+  });
+
   it('should get impl and destroy', () => {
     expect(lynx.getCoreContext().addEventListener).toHaveBeenCalledTimes(0);
     onPostWorkletCtx({});

--- a/packages/react/runtime/__test__/snapshot/worklet/workletRef.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/worklet/workletRef.test.jsx
@@ -266,7 +266,7 @@ describe('WorkletRef in js', () => {
           [
             "rLynxChange",
             {
-              "data": "{"patchList":[{"snapshotPatch":[],"id":6}]}",
+              "data": "{"patchList":[{"snapshotPatch":[2,-1,-2],"id":16}]}",
               "patchOptions": {
                 "isHydration": true,
                 "pipelineOptions": {
@@ -276,7 +276,7 @@ describe('WorkletRef in js', () => {
                   "pipelineOrigin": "reactLynxHydrate",
                   "stage": "hydrate",
                 },
-                "reloadVersion": 1,
+                "reloadVersion": 6,
               },
             },
             [Function],

--- a/packages/react/runtime/src/core/app-events.ts
+++ b/packages/react/runtime/src/core/app-events.ts
@@ -1,0 +1,199 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * How the runtime receives lynx-core's app-level callbacks.
+ *
+ * The runtime used to assign each callback onto the app object, which a runtime
+ * shared by several cards cannot do: the last card to register wins. It now
+ * subscribes on the page's own context proxies instead, so each page receives
+ * only its own events and no card overwrites another's handlers.
+ *
+ * `__OnLifecycleEvent` is subscribed through lynx-core rather than on a proxy:
+ * a card's first lifecycle event is dispatched before the card's own bundle has
+ * finished evaluating, so only a subscription that replays what it missed can
+ * carry it. `addLifecycleEventListener` is that subscription; an engine without
+ * it keeps the method it already calls.
+ *
+ * `updateCardData`, `onAppReload` and `updateGlobalProps` have no
+ * background-bound event of their own; the main thread forwards them (see
+ * `snapshot/lynx/calledByNative.ts` and `snapshot/lifecycle/reload.ts`).
+ */
+
+export const AppEvents = {
+  pageEvent: '__SendPageEvent',
+  componentEvent: '__PublishComponentEvent',
+  cardData: '__UpdateCardData',
+  appReload: '__OnAppReload',
+  globalProps: '__UpdateGlobalProps',
+  destroy: '__DestroyLifetime',
+} as const;
+
+export interface AppEventHandlers {
+  // A method rather than a property so a handler may narrow the lifecycle type.
+  OnLifecycleEvent?(args: [string, unknown]): void;
+  publishEvent?: (handlerName: string, data: any) => void;
+  publicComponentEvent?: (componentId: string, handlerName: string, data: any) => void;
+  updateGlobalProps?: (newData: Record<string, any>) => void;
+  updateCardData?: (...args: any[]) => void;
+  onAppReload?: (...args: any[]) => void;
+  callDestroyLifetimeFun?: () => void;
+}
+
+interface AppEventProxy {
+  addEventListener(type: string, listener: (event: { data: any }) => void): void;
+  removeEventListener(type: string, listener: (event: { data: any }) => void): void;
+}
+
+interface PageLynx {
+  getApp(): {
+    __reactHandlers?: AppEventHandlers;
+    __reactUnsubscribe?: () => void;
+    __reactFallback?: boolean;
+    addLifecycleEventListener?: (listener: (args: unknown) => void) => () => void;
+    OnLifecycleEvent?: (args: [string, unknown]) => void;
+    publishEvent?: (name: string, data: unknown) => void;
+    publicComponentEvent?: (id: string, name: string, data: unknown) => void;
+    updateGlobalProps?: (props: Record<string, unknown>) => void;
+    updateCardData?: (...args: unknown[]) => void;
+    onAppReload?: (...args: unknown[]) => void;
+    callDestroyLifetimeFun?: () => void;
+    processCardConfig?: () => void;
+    callBeforePublishEvent?: (data: unknown) => void;
+  };
+  getCoreContext(): AppEventProxy;
+  getNative(): AppEventProxy;
+}
+
+/**
+ * Registers app-level callbacks for the page of `pageLynx`, or of the ambient
+ * `lynx` when a page does not name one.
+ *
+ * Registering again replaces only the handlers passed in, which is how the
+ * first-screen swap from the delayed handlers to the real ones works. The
+ * subscription itself is made once per page.
+ */
+export function registerAppEventHandlers(
+  next: AppEventHandlers,
+  pageLynx?: unknown,
+): void {
+  // A page may hand over a lynx that carries no app of its own, so fall back.
+  const given = pageLynx as PageLynx | undefined;
+  const scope = typeof given?.getApp === 'function' ? given : (lynx as unknown as PageLynx);
+  const app = scope.getApp();
+  const handlers: AppEventHandlers = (app.__reactHandlers ??= {});
+  Object.assign(handlers, next);
+
+  const hasProxies = typeof scope.getCoreContext === 'function'
+    && typeof scope.getNative === 'function';
+  if (app.__reactUnsubscribe) {
+    // The first registration can land before the page has its proxies, so a
+    // later one that does see them upgrades from the methods to subscriptions.
+    if (!app.__reactFallback || !hasProxies) {
+      return;
+    }
+    app.__reactUnsubscribe();
+  }
+
+  // Lifecycle events do not ride a context proxy, so they are taken first: a
+  // runtime with no proxies of its own still receives them.
+  const onLifecycle = (args: [string, unknown]) => handlers.OnLifecycleEvent?.(args);
+  // An engine without the replaying subscription still calls the method, so
+  // fall back to it there. A card evaluated first then wins on a shared
+  // runtime, which is what the method already did before.
+  const dropLifecycle = app.addLifecycleEventListener?.(onLifecycle as (args: unknown) => void)
+    ?? ((app.OnLifecycleEvent = onLifecycle), () => {
+      delete app.OnLifecycleEvent;
+    });
+
+  // Without context proxies there is nothing to subscribe on, so take the
+  // callbacks the host invokes by name instead. That covers a standalone group
+  // runtime, an engine that predates the proxies, and a test environment that
+  // drives the runtime through the app object.
+  if (!hasProxies) {
+    app.__reactFallback = true;
+    app.publishEvent = (name, data) => handlers.publishEvent?.(name, data);
+    app.publicComponentEvent = (id, name, data) => handlers.publicComponentEvent?.(id, name, data);
+    app.updateGlobalProps = (props) => handlers.updateGlobalProps?.(props);
+    app.updateCardData = (...args) => handlers.updateCardData?.(...args);
+    app.onAppReload = (...args) => handlers.onAppReload?.(...args);
+    app.callDestroyLifetimeFun = () => handlers.callDestroyLifetimeFun?.();
+    app.processCardConfig = () => {};
+    app.__reactUnsubscribe = () => {
+      dropLifecycle();
+      delete app.publishEvent;
+      delete app.publicComponentEvent;
+      delete app.updateGlobalProps;
+      delete app.updateCardData;
+      delete app.onAppReload;
+      delete app.callDestroyLifetimeFun;
+      delete app.processCardConfig;
+      delete app.__reactFallback;
+      delete app.__reactUnsubscribe;
+    };
+    return;
+  }
+
+  // Each proxy is taken on its own: a page may stub one of them.
+  const core = scope.getCoreContext();
+  const native = scope.getNative();
+  const added: [AppEventProxy, string, (event: { data: any }) => void][] = [];
+  const on = (
+    proxy: AppEventProxy,
+    type: string,
+    listener: (event: { data: any }) => void,
+  ) => {
+    proxy.addEventListener(type, listener);
+    added.push([proxy, type, listener]);
+  };
+  // Both element-event transports carry
+  // [<page name or component id>, handler name, event data].
+  on(core, AppEvents.pageEvent, (event) => {
+    const [, handlerName, data] = event.data as [string, string, unknown];
+    // A prototype method reading `this`, so it stays a method call, and it is
+    // taken from this page's app rather than the ambient one.
+    app.callBeforePublishEvent?.(data);
+    handlers.publishEvent?.(handlerName, data);
+  });
+  on(core, AppEvents.componentEvent, (event) => {
+    const [componentId, handlerName, data] = event.data as [string, string, unknown];
+    handlers.publicComponentEvent?.(componentId, handlerName, data);
+  });
+  on(core, AppEvents.globalProps, (event) => {
+    const [props] = event.data as [Record<string, unknown>];
+    handlers.updateGlobalProps?.(props);
+  });
+  on(core, AppEvents.cardData, (event) => {
+    const [newData, options] = event.data as [unknown, unknown];
+    handlers.updateCardData?.(newData, options);
+  });
+  on(core, AppEvents.appReload, (event) => {
+    const [updateData] = event.data as [unknown];
+    handlers.onAppReload?.(updateData);
+  });
+  // Destruction comes from the host, not the engine, so it rides the native
+  // proxy. The engine only takes this path while a listener is registered.
+  on(native, AppEvents.destroy, () => {
+    handlers.callDestroyLifetimeFun?.();
+  });
+
+  app.__reactUnsubscribe = () => {
+    for (const [proxy, type, listener] of added) {
+      proxy.removeEventListener(type, listener);
+    }
+    added.length = 0;
+    dropLifecycle?.();
+    delete app.__reactUnsubscribe;
+  };
+}
+
+/**
+ * Drops this page's subscriptions. A runtime shared by several cards outlives
+ * any one of them, so a destroyed page must not leave its listeners behind.
+ */
+export function unregisterAppEventHandlers(pageLynx?: unknown): void {
+  const given = pageLynx as PageLynx | undefined;
+  const scope = typeof given?.getApp === 'function' ? given : (lynx as unknown as PageLynx);
+  scope.getApp().__reactUnsubscribe?.();
+}

--- a/packages/react/runtime/src/core/send-to-background.ts
+++ b/packages/react/runtime/src/core/send-to-background.ts
@@ -1,0 +1,16 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Forwards a main-thread callback to the background thread.
+ *
+ * `updateCardData`, `onAppReload` and `updateGlobalProps` reach the main
+ * thread only; the engine has no background-bound event for them. The main
+ * thread therefore relays them over its own proxy to the background thread,
+ * where `registerAppEventHandlers` subscribes.
+ */
+export function sendToBackground(type: string, data: unknown[]): void {
+  // A runtime attached to no card of its own has no background thread to reach.
+  lynx.getJSContext?.().dispatchEvent({ type, data });
+}

--- a/packages/react/runtime/src/lynx.ts
+++ b/packages/react/runtime/src/lynx.ts
@@ -72,11 +72,12 @@ if (typeof __ALOG_ELEMENT_API__ !== 'undefined' && __ALOG_ELEMENT_API__) {
 let installed = false;
 
 /**
- * Installs everything the background runtime needs against the current `lynx`:
- * the Preact adapters, the app-level callbacks and the commit/timing hooks.
+ * Installs everything the background runtime needs: the Preact adapters and the
+ * commit/timing hooks once per runtime, and the app-level callbacks on the app
+ * of `pageLynx` — the ambient `lynx` when a page does not name one.
  *
- * The adapters and hooks belong to the runtime, so they are installed once; a
- * page that calls this again only re-registers its app-level callbacks.
+ * Kept as a function rather than inline module side effects so a runtime shared
+ * between several cards can register each page's callbacks.
  */
 export function initBackgroundRuntime(pageLynx?: unknown): void {
   injectTt(pageLynx);

--- a/packages/react/runtime/src/snapshot/lifecycle/reload.ts
+++ b/packages/react/runtime/src/snapshot/lifecycle/reload.ts
@@ -11,7 +11,9 @@ import { render } from 'preact';
 
 import { destroyBackground } from './destroy.js';
 import { renderMainThread } from './render.js';
+import { AppEvents } from '../../core/app-events.js';
 import { increaseReloadVersion } from '../../core/reload-version.js';
+import { sendToBackground } from '../../core/send-to-background.js';
 import { __root, setRoot } from '../../root.js';
 import { profileEnd, profileStart } from '../../shared/profile.js';
 import { isEmptyObject } from '../../utils.js';
@@ -31,6 +33,7 @@ function reloadMainThread(data: unknown, options: UpdatePageOption): void {
   }
 
   increaseReloadVersion();
+  sendToBackground(AppEvents.appReload, [data]);
 
   if (typeof data == 'object' && data !== null && !isEmptyObject(data)) {
     Object.assign(lynx.__initData, data);

--- a/packages/react/runtime/src/snapshot/lynx/calledByNative.ts
+++ b/packages/react/runtime/src/snapshot/lynx/calledByNative.ts
@@ -1,9 +1,12 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { AppEvents } from '../../core/app-events.js';
 import { applyUpdatePageData } from '../../core/lynx-page-data.js';
 import { markTiming, setPipeline } from '../../core/performance.js';
+import { sendToBackground } from '../../core/send-to-background.js';
 import { __root, setRoot } from '../../root.js';
+import { isEmptyObject } from '../../utils.js';
 import { LifecycleConstant } from '../lifecycle/constant.js';
 import {
   firstScreenEventIdSwap,
@@ -124,6 +127,11 @@ function updatePage(data: Record<string, unknown> | undefined, options?: UpdateP
   }
 
   applyUpdatePageData(data, options);
+  // Same condition `applyUpdatePageData` uses, so the background thread is
+  // told exactly when the data actually changed.
+  if (typeof data === 'object' && data !== null && !isEmptyObject(data)) {
+    sendToBackground(AppEvents.cardData, [data, options]);
+  }
 
   const flushOptions = options ?? {};
   if (!isFirstScreenSynced) {
@@ -166,7 +174,8 @@ function updatePage(data: Record<string, unknown> | undefined, options?: UpdateP
   __FlushElementTree(__page, flushOptions);
 }
 
-function updateGlobalProps(_data: any, options?: UpdatePageOption): void {
+function updateGlobalProps(data: any, options?: UpdatePageOption): void {
+  sendToBackground(AppEvents.globalProps, [data]);
   if (options) {
     __FlushElementTree(__page, options);
   } else {

--- a/packages/react/runtime/src/snapshot/lynx/tt.ts
+++ b/packages/react/runtime/src/snapshot/lynx/tt.ts
@@ -4,6 +4,7 @@
 import { process, render } from 'preact';
 
 import { runWithForce } from './runWithForce.js';
+import { registerAppEventHandlers, unregisterAppEventHandlers } from '../../core/app-events.js';
 import { updateGlobalProps as updateGlobalPropsCore } from '../../core/globalProps.js';
 import { updateCardData } from '../../core/lynx-update-data.js';
 import { PerformanceTimingFlags, PipelineOrigins, beginPipeline, markTiming } from '../../core/performance.js';
@@ -38,23 +39,23 @@ import { sendMTRefInitValueToMainThread } from '../worklet/ref/updateInitValue.j
 export { runWithForce };
 
 function injectTt(pageLynx?: unknown): void {
-  // A page may hand over a lynx that carries no app of its own, so fall back.
-  const scope = pageLynx as typeof lynx | undefined;
-  const tt = (typeof scope?.getApp === 'function' ? scope : lynx).getApp();
-  tt.OnLifecycleEvent = onLifecycleEvent;
-  tt.publishEvent = delayedPublishEvent;
-  tt.publicComponentEvent = delayedPublicComponentEvent;
-  tt.callDestroyLifetimeFun = () => {
-    removeCtxNotFoundEventListener();
-    destroyWorklet();
-    destroyBackground();
-  };
-  tt.updateGlobalProps = updateGlobalProps;
-  tt.updateCardData = updateCardData;
-  tt.onAppReload = reloadBackground;
-  tt.processCardConfig = () => {
-    // used to updateTheme, no longer rely on this function
-  };
+  registerAppEventHandlers({
+    OnLifecycleEvent: onLifecycleEvent,
+    publishEvent: delayedPublishEvent,
+    publicComponentEvent: delayedPublicComponentEvent,
+    callDestroyLifetimeFun: () => {
+      removeCtxNotFoundEventListener();
+      destroyWorklet();
+      try {
+        destroyBackground();
+      } finally {
+        unregisterAppEventHandlers(pageLynx);
+      }
+    },
+    updateGlobalProps,
+    updateCardData,
+    onAppReload: reloadBackground,
+  }, pageLynx);
 }
 
 function onLifecycleEvent([type, data]: [LifecycleConstant, unknown]) {
@@ -152,8 +153,7 @@ function onLifecycleEventImpl(type: LifecycleConstant, data: unknown): void {
         delayedEvents.length = 0;
       }
 
-      lynx.getApp().publishEvent = publishEvent;
-      lynx.getApp().publicComponentEvent = publicComponentEvent;
+      registerAppEventHandlers({ publishEvent, publicComponentEvent });
 
       // console.debug("********** After hydration:");
       // printSnapshotInstance(__root as BackgroundSnapshotInstance);
@@ -210,7 +210,6 @@ function flushDelayedLifecycleEvents(): void {
 }
 
 function publishEvent(handlerName: string, data: EventDataType) {
-  lynx.getApp().callBeforePublishEvent?.(data);
   let snapshotId: number | undefined;
   const getSnapshotId = () => snapshotId ??= Number(handlerName.split(':')[0]);
   const eventHandler = backgroundSnapshotInstanceManager.getValueBySign(

--- a/packages/react/runtime/types/types.d.ts
+++ b/packages/react/runtime/types/types.d.ts
@@ -223,6 +223,20 @@ declare global {
     onAppReload: (updateData: Record<string, any>) => void;
     processCardConfig: () => void;
     callBeforePublishEvent?: (data: unknown) => void;
+
+    /**
+     * Subscribes to `__OnLifecycleEvent`, replaying the events that arrived
+     * before the first subscriber. Absent on engines that predate it.
+     */
+    addLifecycleEventListener?: (listener: (args: unknown) => void) => () => void;
+
+    /**
+     * The runtime's own handler table and the teardown for its subscriptions.
+     * Stored on the app object so each page keeps its own set even when the
+     * runtime module is shared across a group.
+     */
+    __reactHandlers?: Record<string, unknown>;
+    __reactUnsubscribe?: () => void;
     getDynamicComponentExports: (schema: string) => { default: React.ComponentType<any> } | null | undefined;
     GlobalEventEmitter: EventEmitter;
   }


### PR DESCRIPTION
The engine and lynx-core look the app-level callbacks up on the app object by name, and that object is per card, so a runtime shared by a LynxGroup could only ever serve whichever card assigned last.

Element events, card data, global props, reload and destroy are now taken from the page's own context proxies. `__OnLifecycleEvent` uses lynx-core's replaying subscription instead: a card's first lifecycle event is dispatched before its background bundle has finished evaluating, so a listener registered from that bundle would always miss it.

Card data, reload and global props reach the main thread only, so the main thread forwards them to the background thread over its own proxy.

Each page keeps its own handlers in a record on its app, and the subscriptions are dropped when the page is destroyed so a shared runtime does not outlive them.

Needs lynx-family/lynx#9091 for the `__OnLifecycleEvent` subscription; the call is optional, so an engine without it keeps working except that the first-screen lifecycle event does not reach the background thread.