### PR TITLE
feat(chunk-loading): keep an installed chunk's module instances on the chunk

### DIFF
--- a/.changeset/chunk-loading-shared-module-cache.md
+++ b/.changeset/chunk-loading-shared-module-cache.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/chunk-loading-webpack-plugin": patch
+---
+
+Keep an installed chunk's module instances on the chunk object rather than in
+the loading page's module cache. A loader that hands the same chunk object to
+several pages now gives them one instance of each of that chunk's modules; a
+loader that returns a fresh object per page keeps the previous behavior.

--- a/codecov.yml
+++ b/codecov.yml
@@ -33,6 +33,9 @@ ignore:
   - "rstest.config.ts"
   - "**/rstest.config.ts"
   - "**/__test__/**/fixtures/**"
+  # Stringified into build output, never executed in-process.
+  - "packages/webpack/chunk-loading-webpack-plugin/src/runtime/css/**"
+  - "packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/**"
 
 fixes:
   - "/home/runner/_work/lynx-stack::"

--- a/packages/webpack/chunk-loading-webpack-plugin/src/ChunkLoadingWebpackPlugin.ts
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/ChunkLoadingWebpackPlugin.ts
@@ -68,6 +68,7 @@ export class ChunkLoadingWebpackPluginImpl {
         if (!isEnabledForChunk(chunk)) return;
         runtimeRequirements.add(RuntimeGlobals.getChunkUpdateScriptFilename);
         runtimeRequirements.add(RuntimeGlobals.moduleFactoriesAddOnly);
+        runtimeRequirements.add(RuntimeGlobals.moduleCache);
         runtimeRequirements.add(RuntimeGlobals.hasOwnProperty);
         runtimeRequirements.add(RuntimeGlobals.publicPath);
         runtimeRequirements.add(LynxRuntimeGlobals.lynxAsyncChunkIds);

--- a/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/install-chunk.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/src/runtime/javascript/install-chunk.js
@@ -10,15 +10,30 @@
 /* istanbul ignore file */
 
 export default function() {
+  var aliasModuleCache = function(moduleCache, moduleId) {
+    Object.defineProperty($RuntimeGlobals_moduleCache$, moduleId, {
+      configurable: true,
+      get: function() {
+        return moduleCache[moduleId];
+      },
+      set: function(module) {
+        moduleCache[moduleId] = module;
+      },
+    });
+  };
   // object to store loaded chunks
   // "1" means "loaded", otherwise not loaded yet
   var installChunk = function(chunk) {
     var moreModules = chunk.modules,
       chunkIds = chunk.ids,
       runtime = chunk.runtime;
+    // Module instances live on the chunk object, so they are shared exactly
+    // when the loader hands the same chunk object to more than one page.
+    var moduleCache = chunk.__moduleCache || (chunk.__moduleCache = {});
     for (var moduleId in moreModules) {
       if ($RuntimeGlobals_hasOwnProperty$(moreModules, moduleId)) {
         $RuntimeGlobals_moduleFactories$[moduleId] = moreModules[moduleId];
+        aliasModuleCache(moduleCache, moduleId);
       }
     }
     if (runtime) runtime(__webpack_require__);

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/shared-module-cache/dynamic.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/shared-module-cache/dynamic.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/shared-module-cache/index.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/shared-module-cache/index.js
@@ -1,0 +1,48 @@
+/// <reference types="@rstest/core/globals" />
+
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(__filename);
+
+const loadedChunks = [];
+
+globalThis.lynx = {
+  requireModuleAsync: rstest.fn(function requireModuleAsync(request, callback) {
+    return Promise.resolve().then(() => {
+      try {
+        const chunk = require(path.join(__dirname, request));
+        loadedChunks.push(chunk);
+        callback(null, chunk);
+      } catch (error) {
+        callback(error);
+      }
+    });
+  }),
+};
+
+it('keeps the instances of an installed chunk on the chunk object', async () => {
+  await import('./dynamic.js');
+
+  const [chunk] = loadedChunks;
+  expect(chunk.__moduleCache).toBeTypeOf('object');
+
+  const instances = Object.values(chunk.__moduleCache);
+  expect(instances.some(module => module.exports.value === 1)).toBe(true);
+});
+
+it('resolves the chunk modules through the chunk-held instances', async () => {
+  const module = await import('./dynamic.js');
+
+  const [chunk] = loadedChunks;
+  const moduleId = Object.keys(chunk.modules).find(id =>
+    chunk.__moduleCache[id]?.exports.value === 1
+  );
+
+  // Dropping the instance from the chunk makes the page re-run the factory,
+  // which is what proves the page reads through the chunk rather than through
+  // a cache of its own.
+  delete chunk.__moduleCache[moduleId];
+  expect(__webpack_require__(moduleId).value).toBe(1);
+  expect(chunk.__moduleCache[moduleId].exports).not.toBe(module);
+});

--- a/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/shared-module-cache/rspack.config.js
+++ b/packages/webpack/chunk-loading-webpack-plugin/test/cases/chunk-loading/shared-module-cache/rspack.config.js
@@ -1,0 +1,17 @@
+import { ChunkLoadingWebpackPlugin } from '../../../../lib/index.js';
+
+/** @type {import('@rspack/core').Configuration} */
+export default {
+  mode: 'production',
+  output: {
+    chunkLoading: 'lynx',
+    chunkFormat: 'commonjs',
+    chunkFilename: '[id].rspack.bundle.cjs',
+  },
+  optimization: {
+    chunkIds: 'named',
+  },
+  plugins: [
+    new ChunkLoadingWebpackPlugin(),
+  ],
+};


### PR DESCRIPTION
An installed chunk's module instances lived in the loading page's module cache, so every page that loaded the same chunk ran its factories again.

They now live on the chunk object. A loader that hands the same chunk object to several pages gives them one instance of each of that chunk's modules; a loader that returns a fresh object per page keeps the previous behavior, so nothing changes unless the loader shares.