### PR TITLE
feat: external-bundle debug-metadata

### DIFF
--- a/.changeset/calm-dingos-debug-metadata.md
+++ b/.changeset/calm-dingos-debug-metadata.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/lynx-bundle-rslib-config": minor
+"@lynx-js/debug-metadata-rsbuild-plugin": minor
+---
+
+Support debug metadata for external bundles through the standard template
+lifecycle, including source maps and per-custom-section bytecode debug info,
+with a runnable React externals example.

--- a/examples/react-externals/README.md
+++ b/examples/react-externals/README.md
@@ -3,6 +3,7 @@
 In this example, we show:
 
 - Use `@lynx-js/lynx-bundle-rslib-config` to bundle a simple ReactLynx component library to a separate Lynx bundle.
+- Use `@lynx-js/debug-metadata-rsbuild-plugin` to collect source maps and per-custom-section TASM bytecode debug information for that external bundle.
 - Use `@lynx-js/external-bundle-rsbuild-plugin` to load the built-in ReactLynx runtime bundle (sync) and component bundle (async).
 
 ## Usage
@@ -13,3 +14,21 @@ pnpm dev
 ```
 
 The dev server will automatically serve the built-in ReactLynx runtime bundle and the component library bundle.
+
+## Inspecting debug metadata
+
+Run the dedicated debug build to retain intermediate assets and
+`debug-metadata.json` locally:
+
+```bash
+pnpm build:comp-lib:debug-metadata
+```
+
+The result is written to
+`dist-external-bundle/debug-metadata.json`. Its main-thread artifact is matched
+to bytecode debug information through the emitted asset's actual TASM
+`customSections` key; the example does not rely on an entry filename convention.
+
+The regular production build keeps the same plugin configuration for CI upload
+integrations, but the debug metadata plugin removes the local metadata asset
+after reporting unless debug mode is enabled.

--- a/examples/react-externals/package.json
+++ b/examples/react-externals/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "pnpm run build:comp-lib && rspeedy build && cross-env REACTLYNX_ASYNC=true pnpm run build:comp-lib && cross-env REACTLYNX_ASYNC=true rspeedy build",
     "build:comp-lib": "rslib build --config rslib-comp-lib.config.ts",
+    "build:comp-lib:debug-metadata": "cross-env DEBUG=rspeedy rslib build --config rslib-comp-lib.config.ts",
     "build:comp-lib:dev": "cross-env NODE_ENV=development rslib build --config rslib-comp-lib.config.ts",
     "dev": "pnpm run build:comp-lib && rspeedy dev",
     "dev:react-async": "cross-env REACTLYNX_ASYNC=true pnpm run build:comp-lib && cross-env REACTLYNX_ASYNC=true rspeedy dev",
@@ -16,6 +17,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/debug-metadata-rsbuild-plugin": "workspace:*",
     "@lynx-js/external-bundle-rsbuild-plugin": "workspace:*",
     "@lynx-js/lynx-bundle-rslib-config": "workspace:*",
     "@lynx-js/preact-devtools": "5.0.1-20260721114100-d7da994",

--- a/examples/react-externals/rslib-comp-lib.config.ts
+++ b/examples/react-externals/rslib-comp-lib.config.ts
@@ -1,3 +1,4 @@
+import { pluginLynxDebugMetadata } from '@lynx-js/debug-metadata-rsbuild-plugin';
 import { defineExternalBundleRslibConfig } from '@lynx-js/lynx-bundle-rslib-config';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
 
@@ -15,6 +16,7 @@ export default defineExternalBundleRslibConfig({
   },
   plugins: [
     pluginReactLynx(),
+    pluginLynxDebugMetadata(),
   ],
   // Sync and async share this config file, so rspack's persistent cache (keyed
   // on the config) would otherwise reuse one variant's compiled modules for the
@@ -32,6 +34,9 @@ export default defineExternalBundleRslibConfig({
     ...(isAsync && {
       distPath: { root: 'dist-external-bundle-react-async' },
     }),
+    sourceMap: {
+      js: 'source-map',
+    },
     globalObject: 'globalThis',
   },
 });

--- a/examples/react-externals/tsconfig.json
+++ b/examples/react-externals/tsconfig.json
@@ -19,6 +19,7 @@
   "references": [
     { "path": "../../packages/react/tsconfig.json" },
     { "path": "../../packages/rspeedy/core/tsconfig.build.json" },
+    { "path": "../../packages/rspeedy/plugin-debug-metadata/tsconfig.build.json" },
     { "path": "../../packages/rspeedy/plugin-qrcode/tsconfig.build.json" },
     { "path": "../../packages/rspeedy/plugin-react/tsconfig.build.json" },
   ],

--- a/packages/rspeedy/lynx-bundle-rslib-config/README.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/README.md
@@ -35,6 +35,40 @@ export default defineExternalBundleRslibConfig({
 This produces an external bundle whose React-related requests are mapped to the
 built-in `reactlynx` preset instead of a hand-written externals table.
 
+### Debug metadata
+
+External bundle builds participate in the standard `LynxTemplatePlugin`
+lifecycle, so `pluginLynxDebugMetadata` can collect source maps and per-section
+TASM bytecode debug information without an adapter:
+
+```ts
+import { pluginLynxDebugMetadata } from '@lynx-js/debug-metadata-rsbuild-plugin'
+
+export default defineExternalBundleRslibConfig({
+  source: {
+    entry: {
+      'component-runtime': {
+        import: './src/component-runtime.ts',
+        layer: 'main-thread',
+      },
+    },
+  },
+  output: {
+    sourceMap: {
+      js: 'source-map',
+    },
+  },
+  plugins: [
+    pluginReactLynx(),
+    pluginLynxDebugMetadata(),
+  ],
+})
+```
+
+Main-thread status comes from the configured entry layer. Metadata routing uses
+the emitted asset's actual TASM custom-section name, so entry names remain
+application-defined.
+
 ### Custom presets
 
 If your business bundle needs extra preset mappings, define them next to

--- a/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
+++ b/packages/rspeedy/lynx-bundle-rslib-config/etc/lynx-bundle-rslib-config.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { LibConfig } from '@rslib/core';
+import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin';
 import type { RslibConfig } from '@rslib/core';
 import type { Rspack } from '@rslib/core';
 
@@ -45,10 +46,15 @@ export interface ExternalBundleWebpackPluginOptions {
     enableJsBytecode?: boolean | undefined;
     encode: (opts: unknown) => {
         buffer: Buffer;
+        lepus_debug?: string;
+        css_diagnostics?: string;
     } | Promise<{
         buffer: Buffer;
+        lepus_debug?: string;
+        css_diagnostics?: string;
     }>;
     engineVersion?: string | undefined;
+    LynxTemplatePlugin: LynxTemplatePluginHooksProvider;
     mainThreadChunks?: string[] | undefined;
 }
 
@@ -79,6 +85,11 @@ export type ExternalsPresets = {
 export type ExternalsPresetValue = boolean | {
     async?: boolean;
 };
+
+// @public
+export interface LynxTemplatePluginHooksProvider {
+    getLynxTemplatePluginHooks: typeof LynxTemplatePlugin.getLynxTemplatePluginHooks;
+}
 
 // @public
 export class MainThreadRuntimeWrapperWebpackPlugin {

--- a/packages/rspeedy/lynx-bundle-rslib-config/package.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/package.json
@@ -42,8 +42,10 @@
     "@lynx-js/web-core": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/debug-metadata-rsbuild-plugin": "workspace:*",
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
+    "@lynx-js/template-webpack-plugin": "workspace:*",
     "@lynx-js/test-tools": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rslib/core": "catalog:rslib",

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/externalBundleRslibConfig.ts
@@ -8,6 +8,7 @@ import type { LibConfig, RslibConfig, Rspack } from '@rslib/core'
 import { RuntimeWrapperWebpackPlugin as BackgroundRuntimeWrapperWebpackPlugin } from '@lynx-js/runtime-wrapper-webpack-plugin'
 
 import { ExternalBundleWebpackPlugin } from './webpack/ExternalBundleWebpackPlugin.js'
+import type { LynxTemplatePluginHooksProvider } from './webpack/ExternalBundleWebpackPlugin.js'
 import { MainThreadRuntimeWrapperWebpackPlugin } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'
 
 /**
@@ -627,6 +628,15 @@ const externalBundleRsbuildPlugin = ({
   // ensure dsl plugin has exposed LAYERS
   enforce: 'post',
   setup(api) {
+    const exposed = api.useExposed<{
+      LynxTemplatePlugin: LynxTemplatePluginHooksProvider
+    }>(Symbol.for('LynxTemplatePlugin'))
+    if (!exposed) {
+      throw new Error(
+        'lynx-bundle-rslib-config requires exposed `LynxTemplatePlugin`. Please install a DSL plugin, for example `pluginReactLynx` for ReactLynx.',
+      )
+    }
+
     // Get layer names from react-rsbuild-plugin
     const LAYERS = api.useExposed<ExposedLayers>(
       Symbol.for('LAYERS'),
@@ -779,6 +789,7 @@ const externalBundleRsbuildPlugin = ({
               // For web the `JsBytecode` tag is routing-only (sections stay
               // raw JS), so it must survive regardless of the user option.
               enableJsBytecode: isWeb ? true : enableJsBytecode,
+              LynxTemplatePlugin: exposed.LynxTemplatePlugin,
             },
           ],
         )

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/index.ts
@@ -25,6 +25,9 @@ export type {
   OutputConfig,
 } from './externalBundleRslibConfig.js'
 export { ExternalBundleWebpackPlugin } from './webpack/ExternalBundleWebpackPlugin.js'
-export type { ExternalBundleWebpackPluginOptions } from './webpack/ExternalBundleWebpackPlugin.js'
+export type {
+  ExternalBundleWebpackPluginOptions,
+  LynxTemplatePluginHooksProvider,
+} from './webpack/ExternalBundleWebpackPlugin.js'
 export { MainThreadRuntimeWrapperWebpackPlugin } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'
 export type { MainThreadRuntimeWrapperWebpackPluginOptions } from './webpack/MainThreadRuntimeWrapperWebpackPlugin.js'

--- a/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/src/webpack/ExternalBundleWebpackPlugin.ts
@@ -5,6 +5,22 @@ import type { Rspack } from '@rslib/core'
 
 import { cssChunksToMap } from '@lynx-js/css-serializer'
 import type { LynxStyleNode } from '@lynx-js/css-serializer'
+import type {
+  LynxTemplatePlugin as LynxTemplatePluginClass,
+} from '@lynx-js/template-webpack-plugin'
+
+/**
+ * Provides the template lifecycle hooks exposed by an installed DSL plugin.
+ *
+ * @public
+ */
+export interface LynxTemplatePluginHooksProvider {
+  /**
+   * Returns the public template lifecycle hooks for a compilation.
+   */
+  getLynxTemplatePluginHooks:
+    typeof LynxTemplatePluginClass.getLynxTemplatePluginHooks
+}
 
 /**
  * The options for {@link ExternalBundleWebpackPlugin}.
@@ -12,6 +28,11 @@ import type { LynxStyleNode } from '@lynx-js/css-serializer'
  * @public
  */
 export interface ExternalBundleWebpackPluginOptions {
+  /**
+   * The template lifecycle hooks provider exposed by the installed DSL plugin.
+   */
+  LynxTemplatePlugin: LynxTemplatePluginHooksProvider
+
   /**
    * The external bundle filename.
    *
@@ -35,7 +56,19 @@ export interface ExternalBundleWebpackPluginOptions {
    * })
    * ```
    */
-  encode: (opts: unknown) => { buffer: Buffer } | Promise<{ buffer: Buffer }>
+  encode: (
+    opts: unknown,
+  ) =>
+    | {
+      buffer: Buffer
+      lepus_debug?: string
+      css_diagnostics?: string
+    }
+    | Promise<{
+      buffer: Buffer
+      lepus_debug?: string
+      css_diagnostics?: string
+    }>
   /**
    * The engine version of the external bundle.
    *
@@ -116,7 +149,8 @@ export class ExternalBundleWebpackPlugin {
     // of `DEFAULT_EXTERNAL_BUNDLE_LIB_CONFIG`.
     const enableJsBytecode = this.options.enableJsBytecode
       ?? process.env['NODE_ENV'] !== 'development'
-    const { buffer, encodeOptions } = await this.#encode(
+    const { buffer, encodeOptions, hooks } = await this.#encode(
+      compilation,
       assets,
       enableJsBytecode,
     )
@@ -126,6 +160,9 @@ export class ExternalBundleWebpackPlugin {
       this.options.bundleFileName,
       new RawSource(buffer, false),
     )
+    await hooks.afterEmit.promise({
+      outputName: this.options.bundleFileName,
+    })
     if (isDebug()) {
       compilation.emitAsset(
         'tasm.json',
@@ -141,54 +178,15 @@ export class ExternalBundleWebpackPlugin {
   }
 
   async #encode(
+    compilation: Rspack.Compilation,
     assets: readonly Rspack.Asset[],
     enableJsBytecode: boolean,
   ) {
-    const customSections = assets
-      .reduce<
-        Record<string, {
-          content: string | {
-            ruleList: LynxStyleNode[]
-          }
-        }>
-      >(
-        (prev, cur) => {
-          switch (cur.info.assetType) {
-            case 'javascript':
-              return ({
-                ...prev,
-                [cur.name.replace(/\.js$/, '')]: {
-                  ...(enableJsBytecode
-                      && this.options.mainThreadChunks?.includes(cur.name)
-                    ? {
-                      'encoding': 'JsBytecode',
-                    }
-                    : {}),
-                  content: cur.source.source().toString(),
-                },
-              })
-            case 'extract-css':
-              return ({
-                ...prev,
-                [`${cur.name.replace(/\.css$/, '')}:CSS`]: {
-                  'encoding': 'CSS',
-                  content: {
-                    ruleList: cssChunksToMap(
-                      [cur.source.source().toString()],
-                      [],
-                      true,
-                    ).cssMap[0] ?? [],
-                  },
-                },
-              })
-            default:
-              return prev
-          }
-        },
-        {},
-      )
-
-    const compilerOptions: Record<string, unknown> = {
+    const compilerOptions: {
+      enableCSSSelector: boolean
+      targetSdkVersion: string
+      [key: string]: string | boolean
+    } = {
       enableFiberArch: true,
       useLepusNG: true,
       // `lynx.fetchBundle` and `lynx.loadScript` require engineVersion >= 3.5
@@ -198,16 +196,145 @@ export class ExternalBundleWebpackPlugin {
       debugInfoOutside: true,
     }
 
-    const encodeOptions = {
-      compilerOptions,
-      sourceContent: {
-        appType: 'DynamicComponent',
-      },
-      customSections,
+    const mainThreadChunkNames = new Set(this.options.mainThreadChunks ?? [])
+    const mainThreadAssets: Rspack.Asset[] = []
+    const cssAssets: Rspack.Asset[] = []
+
+    for (const asset of assets) {
+      let tasmSection: string[] | undefined
+      let isMainThread = false
+      if (asset.info.assetType === 'javascript') {
+        isMainThread = mainThreadChunkNames.has(asset.name)
+        tasmSection = ['customSections', asset.name.replace(/\.js$/, '')]
+        if (isMainThread) {
+          mainThreadAssets.push(asset)
+        }
+      } else if (asset.info.assetType === 'extract-css') {
+        tasmSection = [
+          'customSections',
+          `${asset.name.replace(/\.css$/, '')}:CSS`,
+        ]
+        cssAssets.push(asset)
+      }
+
+      if (!tasmSection) continue
+      compilation.updateAsset(asset.name, asset.source, {
+        ...asset.info,
+        ...(asset.info.assetType === 'javascript'
+          ? { 'lynx:main-thread': isMainThread }
+          : {}),
+        'lynx:tasm-section': tasmSection,
+      })
     }
 
-    const { buffer } = await this.options.encode(encodeOptions)
+    const customSections = this.#createAssetSections(
+      compilation,
+      mainThreadChunkNames,
+      enableJsBytecode,
+    )
+    const chunkGroups = [...compilation.entrypoints.values()]
+    const hooks = this.options.LynxTemplatePlugin.getLynxTemplatePluginHooks(
+      compilation as unknown as Parameters<
+        typeof this.options.LynxTemplatePlugin.getLynxTemplatePluginHooks
+      >[0],
+    )
+    const intermediateAssets: string[] = []
+    const beforeEncode = await hooks.beforeEncode.promise({
+      encodeData: {
+        compilerOptions,
+        lepusCode: {
+          root: undefined,
+          chunks: [],
+          filename: this.options.bundleFileName,
+        },
+        manifest: {},
+        css: {
+          chunks: [],
+          cssMap: {},
+          cssSource: {},
+          contentMap: new Map(),
+        },
+        customSections,
+        sourceContent: {
+          dsl: 'external-bundle',
+          appType: 'DynamicComponent',
+          config: {},
+        },
+      },
+      filenameTemplate: this.options.bundleFileName,
+      chunkGroups: chunkGroups as unknown as Parameters<
+        typeof hooks.beforeEncode.promise
+      >[0]['chunkGroups'],
+      intermediate: '',
+      intermediateAssets,
+    })
 
-    return { buffer, encodeOptions }
+    const { lepusCode: _lepusCode, manifest: _manifest, css: _css, ...rest } =
+      beforeEncode.encodeData
+    const encodeOptions = {
+      ...rest,
+      lepusCode: undefined,
+    }
+
+    const result = await this.options.encode(encodeOptions)
+
+    const beforeEmit = await hooks.beforeEmit.promise({
+      finalEncodeOptions: encodeOptions,
+      debugInfo: result.lepus_debug ?? '',
+      ...(result.css_diagnostics === undefined
+        ? {}
+        : { cssDiagnostics: result.css_diagnostics }),
+      template: result.buffer,
+      outputName: this.options.bundleFileName,
+      mainThreadAssets,
+      cssChunks: cssAssets,
+      chunkGroups: chunkGroups as unknown as Parameters<
+        typeof hooks.beforeEmit.promise
+      >[0]['chunkGroups'],
+    })
+
+    return {
+      buffer: beforeEmit.template,
+      encodeOptions,
+      hooks,
+    }
+  }
+
+  #createAssetSections(
+    compilation: Rspack.Compilation,
+    mainThreadChunkNames: Set<string>,
+    enableJsBytecode: boolean,
+  ): Record<string, {
+    encoding?: 'JsBytecode' | 'CSS'
+    content: string | { ruleList: LynxStyleNode[] }
+  }> {
+    return compilation.getAssets().reduce<
+      Record<string, {
+        encoding?: 'JsBytecode' | 'CSS'
+        content: string | { ruleList: LynxStyleNode[] }
+      }>
+    >((sections, asset) => {
+      if (asset.info.assetType === 'javascript') {
+        const isMainThread = mainThreadChunkNames.has(asset.name)
+        sections[asset.name.replace(/\.js$/, '')] = {
+          ...(enableJsBytecode && isMainThread
+            ? { encoding: 'JsBytecode' as const }
+            : {}),
+          content: asset.source.source().toString(),
+        }
+      } else if (asset.info.assetType === 'extract-css') {
+        sections[`${asset.name.replace(/\.css$/, '')}:CSS`] = {
+          encoding: 'CSS',
+          content: {
+            ruleList: cssChunksToMap(
+              [asset.source.source().toString()],
+              [],
+              true,
+            ).cssMap[0] ?? [],
+          },
+        }
+      }
+      return sections
+    }, {})
   }
 }

--- a/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
+++ b/packages/rspeedy/lynx-bundle-rslib-config/test/external-bundle.test.ts
@@ -18,7 +18,9 @@ import {
   rstest,
 } from '@rstest/core'
 
+import { pluginLynxDebugMetadata } from '@lynx-js/debug-metadata-rsbuild-plugin'
 import { LAYERS, pluginReactLynx } from '@lynx-js/react-rsbuild-plugin'
+import { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
 
 import { decodeTemplate } from './utils.js'
 import { defineExternalBundleRslibConfig } from '../src/index.js'
@@ -998,6 +1000,12 @@ describe('DSL plugin without layer loaders', () => {
           name: 'test:dsl-without-layer-loaders',
           setup(api) {
             api.expose(Symbol.for('LAYERS'), LAYERS)
+            api.expose(Symbol.for('LynxTemplatePlugin'), {
+              LynxTemplatePlugin: {
+                getLynxTemplatePluginHooks: LynxTemplatePlugin
+                  .getLynxTemplatePluginHooks.bind(LynxTemplatePlugin),
+              },
+            })
           },
         } satisfies rsbuild.RsbuildPlugin,
       ],
@@ -1032,6 +1040,89 @@ describe('debug info outside', () => {
         fs.readFileSync(path.join(distRoot, 'tasm.json'), 'utf-8'),
       ) as { compilerOptions: Record<string, unknown> }
       expect(tasmJson.compilerOptions['debugInfoOutside']).toBe(true)
+    } finally {
+      rstest.unstubAllEnvs()
+    }
+  })
+})
+
+describe('debug metadata', () => {
+  const fixtureDir = path.join(__dirname, './fixtures/utils-lib')
+
+  it('matches main-thread bytecode metadata by custom section names', async () => {
+    rstest.stubEnv('DEBUG', 'rspeedy')
+    try {
+      const distRoot = path.join(fixtureDir, 'dist')
+      await build(defineExternalBundleRslibConfig({
+        source: {
+          entry: {
+            'widget-alpha': {
+              import: path.join(fixtureDir, 'index.ts'),
+              layer: LAYERS.MAIN_THREAD,
+            },
+            'widget-beta': {
+              import: path.join(fixtureDir, 'index.ts'),
+              layer: LAYERS.MAIN_THREAD,
+            },
+          },
+        },
+        id: 'feature-library',
+        output: {
+          distPath: {
+            root: distRoot,
+          },
+          sourceMap: {
+            js: 'source-map',
+          },
+        },
+        plugins: [
+          pluginReactLynx(),
+          pluginLynxDebugMetadata(),
+        ],
+      }))
+
+      const tasmJson = JSON.parse(
+        fs.readFileSync(path.join(distRoot, 'tasm.json'), 'utf-8'),
+      ) as {
+        customSections: Record<string, { encoding?: string }>
+      }
+      expect(tasmJson).toMatchObject({
+        customSections: {
+          'widget-alpha': {
+            encoding: 'JsBytecode',
+          },
+          'widget-beta': {
+            encoding: 'JsBytecode',
+          },
+        },
+      })
+
+      const metadata = JSON.parse(
+        fs.readFileSync(path.join(distRoot, 'debug-metadata.json'), 'utf-8'),
+      ) as {
+        artifacts: Array<{
+          kind: string
+          filename: string
+          path: string
+          tasmSection?: string[]
+          debugSources: Array<{ kind: string }>
+        }>
+      }
+      for (const sectionName of ['widget-alpha', 'widget-beta']) {
+        const artifact = metadata.artifacts.find(
+          item => item.path === `${sectionName}.js`,
+        )
+
+        expect(artifact).toMatchObject({
+          kind: 'main-thread',
+          filename: sectionName,
+          tasmSection: ['customSections', sectionName],
+        })
+        expect(artifact?.debugSources.map(source => source.kind)).toEqual([
+          'bytecode-debug-info',
+          'source-map',
+        ])
+      }
     } finally {
       rstest.unstubAllEnvs()
     }

--- a/packages/rspeedy/lynx-bundle-rslib-config/tsconfig.build.json
+++ b/packages/rspeedy/lynx-bundle-rslib-config/tsconfig.build.json
@@ -5,5 +5,8 @@
     "outDir": "./lib",
     "rootDir": "./src",
   },
+  "references": [
+    { "path": "../../webpack/template-webpack-plugin/tsconfig.build.json" },
+  ],
   "include": ["src"],
 }

--- a/packages/rspeedy/plugin-debug-metadata/README.md
+++ b/packages/rspeedy/plugin-debug-metadata/README.md
@@ -54,6 +54,7 @@ The legacy `debug-info.json` is **no longer written to disk** — its contents a
 ## Contents
 
 - `pluginLynxDebugMetadata` — the Rsbuild plugin wrapper (the only public export), applied by `applyDefaultPlugins` in `@lynx-js/rspeedy/core`. Internally it taps `LynxTemplatePlugin.beforeEncode` to assemble + emit the metadata asset and to rewrite JS / CSS source-map trailers, and `beforeEmit` to enrich the asset with `tasmSection` paths and bytecode debug info.
+- External bundles created by `@lynx-js/lynx-bundle-rslib-config` are also supported. Their main-thread artifacts are matched to bytecode debug info by the actual TASM `customSections` key recorded on each emitted asset.
 
 ## Convention for plugin authors
 

--- a/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/LynxDebugMetadataPlugin.ts
@@ -16,7 +16,10 @@ import type {
 } from '@lynx-js/template-webpack-plugin'
 
 import { collectArtifacts } from './collectors/artifacts.js'
-import { parseLepusNGDebugInfo } from './collectors/bytecode-debug-info.js'
+import {
+  parseCustomSectionDebugInfo,
+  parseLepusNGDebugInfo,
+} from './collectors/bytecode-debug-info.js'
 import {
   collectEntryPathMap,
   collectLazyBundleEntryResources,
@@ -203,6 +206,11 @@ export class LynxDebugMetadataPluginImpl {
               rspeedy,
             },
           }
+          // for customSections
+          for (const artifact of asset.artifacts) {
+            const section = readTasmSection(compilation, artifact.path)
+            if (section) artifact.tasmSection = section
+          }
           const intermediate = args.intermediate.replace(/\\/g, '/')
           const debugMetadataAssetName = path.posix.format({
             dir: intermediate,
@@ -229,9 +237,16 @@ export class LynxDebugMetadataPluginImpl {
             const debugMetadataUrl =
               `${devServerOrigin}/${debugMetadataAssetName}`
             const rootName = args.encodeData.lepusCode.root?.name
-            const mainThreadBasename = rootName
-              ? path.posix.basename(rootName.replace(/\\/g, '/'))
-              : 'main-thread.js'
+            const mainThreadArtifact = asset.artifacts.find(artifact =>
+              artifact.kind === 'main-thread'
+            )
+            const mainThreadBasename =
+              mainThreadArtifact?.tasmSection?.[0] === 'customSections'
+                ? mainThreadArtifact.tasmSection[1]
+                  ?? mainThreadArtifact.filename
+                : (rootName
+                  ? path.posix.basename(rootName.replace(/\\/g, '/'))
+                  : mainThreadArtifact?.filename ?? 'main-thread.js')
             args.encodeData.sourceContent.config['debugMetadataUrl'] =
               debugMetadataUrl
             args.encodeData.compilerOptions['templateDebugUrl'] =
@@ -273,6 +288,30 @@ export class LynxDebugMetadataPluginImpl {
           for (const artifact of metadata.artifacts) {
             const section = readTasmSection(compilation, artifact.path)
             if (section) artifact.tasmSection = section
+          }
+
+          const sections = parseCustomSectionDebugInfo(args.debugInfo)
+          if (sections) {
+            for (const artifact of metadata.artifacts) {
+              if (
+                artifact.kind !== 'main-thread'
+                || artifact.tasmSection?.[0] !== 'customSections'
+              ) {
+                continue
+              }
+              const sectionName = artifact.tasmSection[1]
+              if (!sectionName) continue
+              const debugInfo = sections[sectionName]
+              if (!debugInfo) continue
+
+              // TASM reports custom-section stack frames with the section
+              // key, not the intermediate JavaScript asset name.
+              artifact.filename = sectionName
+              artifact.debugSources.unshift({
+                kind: 'bytecode-debug-info',
+                debugInfo,
+              })
+            }
           }
 
           const lepusNG = parseLepusNGDebugInfo(args.debugInfo)
@@ -335,8 +374,9 @@ export interface RewriteSourceMappingURLsOptions {
 }
 
 /**
- * Rewrite the `//# sourceMappingURL=...` directive of every JS asset in the
- * current template to an absolute URL. No-op when `debugMetadataUrl`
+ * Rewrite sourceMappingURL directives in assets represented by the current
+ * template, including string-valued custom sections, to an absolute URL.
+ * No-op when `debugMetadataUrl`
  * (`args.encodeData.sourceContent.config['debugMetadataUrl']`) is unset.
  *
  * @public
@@ -364,6 +404,16 @@ export function rewriteSourceMappingURLs(
   for (const chunk of args.encodeData.css.chunks) {
     assetNames.push(chunk.name)
   }
+  for (const asset of compilation.getAssets()) {
+    const section = readTasmSection(compilation, asset.name)
+    if (
+      section?.[0] === 'customSections'
+      && section[1] !== undefined
+      && section[1] in args.encodeData.customSections
+    ) {
+      assetNames.push(asset.name)
+    }
+  }
   const seen = new Set<string>()
   for (const assetName of assetNames) {
     if (seen.has(assetName)) continue
@@ -382,6 +432,13 @@ export function rewriteSourceMappingURLs(
     if (after === undefined) continue
     const newSource = new RawSource(after)
     compilation.updateAsset(assetName, newSource, asset.info)
+    const section = readTasmSection(compilation, assetName)
+    if (section?.[0] === 'customSections' && section[1] !== undefined) {
+      const customSection = args.encodeData.customSections[section[1]]
+      if (customSection && typeof customSection.content === 'string') {
+        customSection.content = after
+      }
+    }
     if (!assetName.endsWith('.js')) continue
     if (assetName in args.encodeData.manifest) {
       args.encodeData.manifest[assetName] = after

--- a/packages/rspeedy/plugin-debug-metadata/src/collectors/bytecode-debug-info.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/collectors/bytecode-debug-info.ts
@@ -19,3 +19,48 @@ export function parseLepusNGDebugInfo(
   if (!maybe.lepusNG_debug_info) return undefined
   return maybe as LepusNGDebugInfo
 }
+
+/**
+ * Parse the per-section debug-info shape returned when TASM compiles
+ * `customSections` as `JsBytecode`.
+ *
+ * Each top-level key is the actual custom-section name used in runtime stack
+ * frames. Its value has the same shape as `lepusNG_debug_info`, but without
+ * the ordinary template encoder's outer envelope.
+ */
+export function parseCustomSectionDebugInfo(
+  debugInfoJson: string,
+): Record<string, LepusNGDebugInfo> | undefined {
+  if (!debugInfoJson) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(debugInfoJson)
+  } catch {
+    return undefined
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined
+  }
+
+  const sections: Record<string, LepusNGDebugInfo> = {}
+  for (const [sectionName, debugInfo] of Object.entries(parsed)) {
+    // The ordinary encoder envelope may coexist with custom-section payloads.
+    // It is not itself a custom section and must keep using the root fallback.
+    if (sectionName === 'lepusNG_debug_info') continue
+    if (
+      !debugInfo
+      || typeof debugInfo !== 'object'
+      || Array.isArray(debugInfo)
+      || !Array.isArray(
+        (debugInfo as { function_info?: unknown }).function_info,
+      )
+    ) {
+      continue
+    }
+    sections[sectionName] = {
+      lepusNG_debug_info: debugInfo as LepusNGDebugInfo['lepusNG_debug_info'],
+    }
+  }
+
+  return Object.keys(sections).length > 0 ? sections : undefined
+}

--- a/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
+++ b/packages/rspeedy/plugin-debug-metadata/src/pluginLynxDebugMetadata.ts
@@ -162,7 +162,6 @@ export function pluginLynxDebugMetadata(): RsbuildPlugin {
         const exposed = api.useExposed<LynxTemplatePluginExposure>(
           Symbol.for('LynxTemplatePlugin'),
         )
-
         if (isLocalProductionBuild(isProd)) return
 
         // Non-lynx envs (e.g. the `web` env in a multi-env build) share
@@ -171,13 +170,15 @@ export function pluginLynxDebugMetadata(): RsbuildPlugin {
         // the lynx one with web-asset paths, and rewriting web JS
         // trailers would point them at a metadata file whose artifacts
         // don't include the web asset paths. Web JS source maps work
-        // fine via the default `.map` sibling; skip cleanly.
+        // fine via the default `.map` sibling. Rslib is allowed because it
+        // does not install this plugin implicitly; an explicit registration
+        // may drive the same hooks for an external bundle.
         const isLynx = environment.name === 'lynx'
           || environment.name.startsWith('lynx-')
-        if (!isLynx) return
+        const isRslib = api.context.callerName === 'rslib'
+        if (!isLynx && !isRslib) return
 
         if (!exposed) return
-
         chain.plugin(PLUGIN_NAME).use(LynxDebugMetadataPlugin, [{
           LynxTemplatePlugin: exposed.LynxTemplatePlugin,
           rsbuildEntry: environment.entry,

--- a/packages/rspeedy/plugin-debug-metadata/test/bytecode-debug-info.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/bytecode-debug-info.test.ts
@@ -4,7 +4,10 @@
 
 import { describe, expect, test } from 'vitest'
 
-import { parseLepusNGDebugInfo } from '../src/collectors/bytecode-debug-info.js'
+import {
+  parseCustomSectionDebugInfo,
+  parseLepusNGDebugInfo,
+} from '../src/collectors/bytecode-debug-info.js'
 
 const validEnvelope = {
   lepusNG_debug_info: {
@@ -49,5 +52,30 @@ describe('parseLepusNGDebugInfo', () => {
     expect(parsed?.lepusNG_debug_info.function_info[0]?.function_name).toBe(
       'foo',
     )
+  })
+})
+
+describe('parseCustomSectionDebugInfo', () => {
+  test('does not treat the ordinary LepusNG envelope as a section', () => {
+    expect(parseCustomSectionDebugInfo(JSON.stringify(validEnvelope)))
+      .toBeUndefined()
+  })
+
+  test('wraps valid section payloads in the LepusNG envelope', () => {
+    const section = validEnvelope.lepusNG_debug_info
+    expect(
+      parseCustomSectionDebugInfo(JSON.stringify({
+        ...validEnvelope,
+        'widget-alpha': section,
+        invalid: { function_info: 'not-an-array' },
+      })),
+    ).toEqual({
+      'widget-alpha': validEnvelope,
+    })
+  })
+
+  test('returns undefined when no section contains function info', () => {
+    expect(parseCustomSectionDebugInfo(JSON.stringify({ empty: {} })))
+      .toBeUndefined()
   })
 })

--- a/packages/rspeedy/plugin-debug-metadata/test/local-prod-gate.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/local-prod-gate.test.ts
@@ -16,7 +16,10 @@ function noop(): void {
   return
 }
 
-function runChain(utils: ChainUtils): string[] {
+function runChain(
+  utils: ChainUtils,
+  options: { callerName?: string } = {},
+): string[] {
   const registered: string[] = []
   const chain = {
     plugin(name: string) {
@@ -29,7 +32,7 @@ function runChain(utils: ChainUtils): string[] {
     onBeforeStartDevServer: noop,
     useExposed: () => ({ LynxTemplatePlugin: class {} }),
     getNormalizedConfig: () => ({ dev: { assetPrefix: '' } }),
-    context: {},
+    context: { callerName: options.callerName },
     modifyBundlerChain: (
       callback: (chain: typeof chain, utils: ChainUtils) => void,
     ) => {
@@ -98,5 +101,16 @@ describe('pluginLynxDebugMetadata production gate', () => {
 
     expect(runChain({ environment: { name: 'web', entry: {} }, isProd: true }))
       .not.toContain('lynx:debug-metadata')
+  })
+
+  test('emits for an explicitly configured Rslib environment on CI', () => {
+    vi.stubEnv('CI', 'true')
+
+    expect(
+      runChain(
+        { environment: { name: 'component-library', entry: {} }, isProd: true },
+        { callerName: 'rslib' },
+      ),
+    ).toContain('lynx:debug-metadata')
   })
 })

--- a/packages/rspeedy/plugin-debug-metadata/test/rewrite-source-mapping-urls.test.ts
+++ b/packages/rspeedy/plugin-debug-metadata/test/rewrite-source-mapping-urls.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { Rspack } from '@rsbuild/core'
+import { describe, expect, test } from 'vitest'
+
+import { rewriteSourceMappingURLs } from '../src/index.js'
+
+class FakeSource {
+  constructor(private readonly value: string) {}
+
+  source(): string {
+    return this.value
+  }
+}
+
+function createCompilation(
+  initialAssets: Array<
+    { name: string, source: string, info: Record<string, unknown> }
+  >,
+): {
+  compilation: Rspack.Compilation
+  readAsset: (name: string) => string | undefined
+} {
+  const assets = new Map(
+    initialAssets.map(asset => [
+      asset.name,
+      {
+        name: asset.name,
+        source: new FakeSource(asset.source),
+        info: asset.info,
+      },
+    ]),
+  )
+  const compilation = {
+    compiler: {
+      webpack: {
+        sources: { RawSource: FakeSource },
+      },
+    },
+    getAssets() {
+      return [...assets.values()]
+    },
+    getAsset(name: string) {
+      return assets.get(name)
+    },
+    updateAsset(
+      name: string,
+      source: FakeSource,
+      info: Record<string, unknown>,
+    ) {
+      assets.set(name, { name, source, info })
+    },
+  } as unknown as Rspack.Compilation
+
+  return {
+    compilation,
+    readAsset: name => assets.get(name)?.source.source(),
+  }
+}
+
+describe('rewriteSourceMappingURLs', () => {
+  test('synchronizes rewritten custom-section assets back to encodeData', () => {
+    const before = 'console.log(42)\n//# sourceMappingURL=widget-alpha.js.map'
+    const { compilation, readAsset } = createCompilation([{
+      name: 'widget-alpha.js',
+      source: before,
+      info: {
+        'lynx:tasm-section': ['customSections', 'widget-alpha'],
+      },
+    }])
+    const args = {
+      encodeData: {
+        compilerOptions: {},
+        lepusCode: { root: undefined, chunks: [] },
+        manifest: {},
+        css: { chunks: [] },
+        customSections: {
+          'widget-alpha': {
+            content: before,
+            encoding: 'JsBytecode',
+          },
+        },
+        sourceContent: {
+          config: {
+            debugMetadataUrl:
+              'http://localhost:3000/.rspeedy/debug-metadata.json',
+          },
+        },
+      },
+    } as unknown as Parameters<typeof rewriteSourceMappingURLs>[1]
+
+    rewriteSourceMappingURLs(compilation, args)
+
+    const expected =
+      'http://localhost:3000/.rspeedy/debug-metadata.json?field=source-map&path=widget-alpha.js.map'
+    expect(readAsset('widget-alpha.js')).toContain(expected)
+    expect(args.encodeData.customSections['widget-alpha']?.content).toContain(
+      expected,
+    )
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react
     devDependencies:
+      '@lynx-js/debug-metadata-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-debug-metadata
       '@lynx-js/external-bundle-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-external-bundle
@@ -1646,12 +1649,18 @@ importers:
         specifier: workspace:*
         version: link:../../web-platform/web-core
     devDependencies:
+      '@lynx-js/debug-metadata-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../plugin-debug-metadata
       '@lynx-js/react':
         specifier: workspace:*
         version: link:../../react
       '@lynx-js/react-rsbuild-plugin':
         specifier: workspace:*
         version: link:../plugin-react
+      '@lynx-js/template-webpack-plugin':
+        specifier: workspace:*
+        version: link:../../webpack/template-webpack-plugin
       '@lynx-js/test-tools':
         specifier: workspace:*
         version: link:../../webpack/test-tools


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

<!-- The AI summary below will be auto-generated - feel free to replace it with your own. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debug metadata support for external bundles, including source maps and per-section bytecode debugging information.
  * Added support for matching debug data to emitted TASM custom sections.
  * Added a runnable React externals debug-build example.
* **Documentation**
  * Documented configuration, generated metadata, custom-section matching, and production-build behavior.
* **Bug Fixes**
  * Improved source-map URL rewriting for custom-section assets.
  * Preserved debug metadata generation for supported production component-library builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
- [ ] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required).
