### PR TITLE
feat: let a user-applied pluginLynx own the Lynx build engine options

### DIFF
--- a/.changeset/warm-pandas-guess.md
+++ b/.changeset/warm-pandas-guess.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/qrcode-rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Skip the built-in `pluginLynx` when one is already applied, so a user who needs to configure the Lynx build engine can apply `pluginLynx` themselves and have their options win. `@lynx-js/rspeedy` becomes an optional peer dependency of `pluginReactLynx` and `pluginQRCode`.

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -52,9 +52,17 @@ export async function applyDefaultPlugins(
 
   const promises: Promise<void>[] = [
     Promise.all(defaultPlugins).then(async plugins => {
-      const { pluginLynx } = await import('@lynx-js/rsbuild-plugin')
+      const { PLUGIN_LYNX_NAME, pluginLynx } = await import(
+        '@lynx-js/rsbuild-plugin'
+      )
+
+      // A user who needs to configure the build engine applies `pluginLynx`
+      // themselves. Applying it again here would build a second config from
+      // the Rspeedy options and overwrite theirs.
       rsbuildInstance.addPlugins([
-        ...pluginLynx(toLynxPluginOptions(config)),
+        ...rsbuildInstance.isPluginExists(PLUGIN_LYNX_NAME)
+          ? []
+          : pluginLynx(toLynxPluginOptions(config)),
         ...plugins,
       ])
     }),

--- a/packages/rspeedy/core/test/createRspeedy.test.ts
+++ b/packages/rspeedy/core/test/createRspeedy.test.ts
@@ -4,6 +4,9 @@
 import type { RsbuildPluginAPI } from '@rsbuild/core'
 import { describe, expect, test } from '@rstest/core'
 
+import { pluginLynx } from '@lynx-js/rsbuild-plugin'
+import type { LynxConfig } from '@lynx-js/rsbuild-plugin'
+
 import { createRspeedy } from '../src/create-rspeedy.js'
 
 describe('createRspeedy', () => {
@@ -35,6 +38,36 @@ describe('createRspeedy', () => {
             name: 'test',
             setup(api: RsbuildPluginAPI) {
               expect(api.context.callerName).toBe('my-custom-framework')
+            },
+          },
+        ],
+      },
+    })
+
+    await rspeedy.initConfigs()
+
+    expect.assertions(1)
+  })
+
+  test('a user-applied pluginLynx replaces the Rspeedy one', async () => {
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        output: { filename: { bundle: '[name].rspeedy.bundle' } },
+        plugins: [
+          ...pluginLynx({
+            output: { filename: { bundle: '[name].user.bundle' } },
+          }),
+          {
+            name: 'test',
+            setup(api: RsbuildPluginAPI) {
+              expect(
+                api.useExposed<LynxConfig>(
+                  Symbol.for('@lynx-js/rsbuild-plugin:config'),
+                )?.resolveBundleFilename({
+                  entryName: 'main',
+                  platform: 'lynx',
+                }),
+              ).toBe('main.user.bundle')
             },
           },
         ],

--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -60,6 +60,11 @@
     "@lynx-js/rspeedy": "^0.16.0",
     "@rsbuild/core": "^2.0.0"
   },
+  "peerDependenciesMeta": {
+    "@lynx-js/rspeedy": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },

--- a/packages/rspeedy/plugin-react/package.json
+++ b/packages/rspeedy/plugin-react/package.json
@@ -69,10 +69,14 @@
     "typia-rspack-plugin": "3.0.1"
   },
   "peerDependencies": {
-    "@lynx-js/react": "^0.124.0 || ^0.125.0"
+    "@lynx-js/react": "^0.124.0 || ^0.125.0",
+    "@lynx-js/rspeedy": "^0.16.0"
   },
   "peerDependenciesMeta": {
     "@lynx-js/react": {
+      "optional": true
+    },
+    "@lynx-js/rspeedy": {
       "optional": true
     }
   },


### PR DESCRIPTION
`pluginLynx` carries the Lynx options that Rsbuild does not know about, but only whoever applies it can pass them. Rspeedy and `pluginReactLynx` both apply it themselves, so a user had no way in.

- Rspeedy skips its own `pluginLynx` when one is already applied, so applying `pluginLynx(options)` in `plugins` is how those options are configured. `pluginReactLynx` already skipped for the same reason.
- `@lynx-js/rspeedy` becomes an optional peer of `pluginReactLynx` and `pluginQRCode`, which both work with plain Rsbuild.