### PR TITLE
feat(rsbuild-plugin): let pluginLynx own the per-thread minifier options

### DIFF
--- a/.changeset/olive-hounds-drum.md
+++ b/.changeset/olive-hounds-drum.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Add `pluginLynx({ output: { minify } })` for the per-thread minifier options. They are merged on top of the ones Rspeedy tunnels through the Rsbuild config, and the Lynx options take precedence.

--- a/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { RsbuildPlugin } from '@rsbuild/core';
+import type { Rspack } from '@rsbuild/core';
 
 // @public
 export type BundleFilename = string | ((context: BundleFilenameContext) => string);
@@ -34,8 +35,15 @@ export interface LynxFilename {
 }
 
 // @public
+export interface LynxMinify {
+    backgroundOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined;
+    mainThreadOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined;
+}
+
+// @public
 export interface LynxOutput {
     filename?: LynxFilename | undefined;
+    minify?: LynxMinify | undefined;
 }
 
 // @public

--- a/packages/rspeedy/plugin-lynx/src/config.ts
+++ b/packages/rspeedy/plugin-lynx/src/config.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import type { RsbuildPluginAPI } from '@rsbuild/core'
+import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core'
 
 /**
  * The context passed to the {@link LynxFilename.bundle} function.
@@ -62,6 +62,29 @@ export interface LynxFilename {
 }
 
 /**
+ * The minifier options of the Lynx threads.
+ *
+ * @public
+ *
+ * @remarks
+ *
+ * Lynx emits one bundle per thread, and each thread may need different
+ * minifier settings. These are merged on top of the Rsbuild
+ * `output.minify.jsOptions` and applied to that thread only.
+ */
+export interface LynxMinify {
+  /**
+   * The minifier options of the main thread.
+   */
+  mainThreadOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined
+
+  /**
+   * The minifier options of the background thread.
+   */
+  backgroundOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined
+}
+
+/**
  * The build outputs of the Lynx build engine.
  *
  * @public
@@ -71,6 +94,11 @@ export interface LynxOutput {
    * The names of the emitted files.
    */
   filename?: LynxFilename | undefined
+
+  /**
+   * The per-thread minifier options.
+   */
+  minify?: LynxMinify | undefined
 }
 
 /**

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -32,6 +32,7 @@ export type {
   BundleFilenameContext,
   LynxConfig,
   LynxFilename,
+  LynxMinify,
   LynxOutput,
   LynxPluginOptions,
 } from './config.js'

--- a/packages/rspeedy/plugin-lynx/src/plugins/minify.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/minify.plugin.ts
@@ -5,18 +5,18 @@
 import { mergeRsbuildConfig } from '@rsbuild/core'
 import type { RsbuildConfig, RsbuildPlugin, Rspack } from '@rsbuild/core'
 
+import { getLynxConfig } from '../config.js'
 import { debug } from '../debug.js'
 
 const MAIN_THREAD_JS_PATTERN = /.*main-thread(?:\.[A-Fa-f0-9]*)?\.js$/
 const BACKGROUND_JS_PATTERN = /.*background(?:\.[A-Fa-f0-9]*)?\.js$/
 
-// TODO: `mainThreadOptions` and `backgroundOptions` are non-standard keys
-// tunneled through the Rsbuild config. They should be supported by the DSL
-// plugin (e.g. `pluginReactLynx`) with typed options instead of being read
-// here in `pluginLynx`.
 interface Minify {
   js?: boolean | undefined
   jsOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined
+  // Rspeedy passes the per-thread options through the Rsbuild config, which
+  // does not know them. `pluginLynx(options)` is the typed home, and it takes
+  // precedence.
   mainThreadOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined
   backgroundOptions?: Rspack.SwcJsMinimizerRspackPluginOptions | undefined
 }
@@ -30,6 +30,21 @@ function mergeJsOptions(
     { output: { minify: { jsOptions: threadOptions } } },
   )
   return (merged.output?.minify as Minify | undefined)?.jsOptions ?? {}
+}
+
+function mergeThreadOptions(
+  fromRsbuildConfig: NonNullable<Minify['jsOptions']> | undefined,
+  fromLynxConfig: NonNullable<Minify['jsOptions']> | undefined,
+): NonNullable<Minify['jsOptions']> | undefined {
+  if (fromRsbuildConfig === undefined) {
+    return fromLynxConfig
+  }
+
+  if (fromLynxConfig === undefined) {
+    return fromRsbuildConfig
+  }
+
+  return mergeJsOptions(fromRsbuildConfig, fromLynxConfig)
 }
 
 export function pluginMinify(): RsbuildPlugin {
@@ -155,10 +170,23 @@ export function pluginMinify(): RsbuildPlugin {
           return
         }
 
+        const fromLynxConfig = getLynxConfig(api).output.minify
+
+        const threadOptions = {
+          mainThreadOptions: mergeThreadOptions(
+            minify.mainThreadOptions,
+            fromLynxConfig?.mainThreadOptions,
+          ),
+          backgroundOptions: mergeThreadOptions(
+            minify.backgroundOptions,
+            fromLynxConfig?.backgroundOptions,
+          ),
+        }
+
         // No thread options, skip
         if (
-          minify.mainThreadOptions === undefined
-          && minify.backgroundOptions === undefined
+          threadOptions.mainThreadOptions === undefined
+          && threadOptions.backgroundOptions === undefined
         ) {
           return
         }
@@ -187,7 +215,7 @@ export function pluginMinify(): RsbuildPlugin {
         // 2. Main thread minimizer
         const mainThreadOptions = mergeJsOptions(
           jsOptions,
-          minify.mainThreadOptions,
+          threadOptions.mainThreadOptions,
         )
         const mtInclude = [MAIN_THREAD_JS_PATTERN]
         mainThreadOptions.include = mainThreadOptions.include
@@ -204,7 +232,7 @@ export function pluginMinify(): RsbuildPlugin {
         // 3. Background thread minimizer
         const backgroundOptions = mergeJsOptions(
           jsOptions,
-          minify.backgroundOptions,
+          threadOptions.backgroundOptions,
         )
         const bgInclude = [BACKGROUND_JS_PATTERN]
         backgroundOptions.include = backgroundOptions.include

--- a/packages/rspeedy/plugin-lynx/test/minify.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/minify.plugin.test.ts
@@ -120,4 +120,61 @@ describe('pluginMinify', () => {
     expect(mainThreadOptions?.include).toEqual([mainThreadPattern])
     expect(backgroundOptions?.include).toEqual([backgroundPattern])
   })
+
+  test('thread options from the Lynx options', async () => {
+    const rsbuild = await createStubRsbuild({ mode: 'production' }, undefined, {
+      output: {
+        minify: {
+          mainThreadOptions: {
+            minimizerOptions: {
+              compress: { pure_funcs: ['from.lynx-config'] },
+            },
+          },
+        },
+      },
+    })
+    const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+    const minimizers = findJsMinimizers(config)
+    expect(minimizers.length).toBe(3)
+    expect(
+      JSON.stringify(minimizers.map((minimizer) => minimizer._args[0])),
+    ).toContain('from.lynx-config')
+  })
+
+  test('merges the Rsbuild-config thread options with the Lynx options', async () => {
+    const rsbuild = await createStubRsbuild(
+      {
+        mode: 'production',
+        output: {
+          minify: {
+            mainThreadOptions: {
+              minimizerOptions: {
+                compress: { pure_funcs: ['from.rsbuild-config'] },
+              },
+            },
+          } as NonNullable<NonNullable<RsbuildConfig['output']>['minify']>,
+        },
+      },
+      undefined,
+      {
+        output: {
+          minify: {
+            mainThreadOptions: {
+              minimizerOptions: {
+                compress: { pure_funcs: ['from.lynx-config'] },
+              },
+            },
+          },
+        },
+      },
+    )
+    const config = await rsbuild.unwrapConfig({ action: 'build' })
+
+    const serialized = JSON.stringify(
+      findJsMinimizers(config).map((minimizer) => minimizer._args[0]),
+    )
+    expect(serialized).toContain('from.rsbuild-config')
+    expect(serialized).toContain('from.lynx-config')
+  })
 })


### PR DESCRIPTION
`output.minify.mainThreadOptions` and `output.minify.backgroundOptions` are not Rsbuild options, so Rspeedy tunnels them through Rsbuild's config namespace and `pluginMinify` read them from there.

- `pluginLynx({ output: { minify } })` is the typed home for them.
- The tunneled location is still read as a lower-priority layer, so the two merge when both are set.