### PR TITLE
feat(rsbuild-plugin): let pluginLynx own the HMR websocket transport

### DIFF
--- a/.changeset/plain-donkeys-rest.md
+++ b/.changeset/plain-donkeys-rest.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+---
+
+Add `pluginLynx({ dev: { client: { websocketTransport } } })` for the module that provides the `WebSocket` used by HMR. It takes precedence over the one Rspeedy tunnels through the Rsbuild config.

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -19,9 +19,6 @@ export function toRsbuildConfig(
     dev: {
       assetPrefix: config.dev?.assetPrefix,
 
-      // TODO: move the Lynx-only `websocketTransport` to a Lynx-owned option.
-      client: config.dev?.client as NonNullable<RsbuildConfig['dev']>['client'],
-
       hmr: config.dev?.hmr ?? true,
       lazyCompilation: false,
       liveReload: config.dev?.liveReload ?? true,

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -15,7 +15,14 @@ function toLynxPluginOptions(config: Config): LynxPluginOptions {
     ? filename
     : filename?.bundle ?? filename?.template
 
-  return bundle === undefined ? {} : { output: { filename: { bundle } } }
+  const websocketTransport = config.dev?.client?.websocketTransport
+
+  return {
+    ...bundle === undefined ? {} : { output: { filename: { bundle } } },
+    ...websocketTransport === undefined
+      ? {}
+      : { dev: { client: { websocketTransport } } },
+  }
 }
 
 async function applyDebugPlugins(

--- a/packages/rspeedy/core/test/config/rsbuild.test.ts
+++ b/packages/rspeedy/core/test/config/rsbuild.test.ts
@@ -73,7 +73,6 @@ describe('Config - toRsBuildConfig', () => {
       expect(rsbuildConfig.dev).toMatchInlineSnapshot(`
         {
           "assetPrefix": undefined,
-          "client": undefined,
           "hmr": true,
           "lazyCompilation": false,
           "liveReload": true,

--- a/packages/rspeedy/core/test/createRspeedy.test.ts
+++ b/packages/rspeedy/core/test/createRspeedy.test.ts
@@ -49,6 +49,32 @@ describe('createRspeedy', () => {
     expect.assertions(1)
   })
 
+  test('dev.client.websocketTransport reaches the Lynx config', async () => {
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        dev: { client: { websocketTransport: '/transport' } },
+        plugins: [
+          {
+            name: 'test',
+            setup(api: RsbuildPluginAPI) {
+              api.modifyBundlerChain(() => {
+                expect(
+                  api.useExposed<LynxConfig>(
+                    Symbol.for('@lynx-js/rsbuild-plugin:config'),
+                  )?.dev.client?.websocketTransport,
+                ).toBe('/transport')
+              })
+            },
+          },
+        ],
+      },
+    })
+
+    await rspeedy.initConfigs()
+
+    expect.assertions(1)
+  })
+
   test('a user-applied pluginLynx replaces the Rspeedy one', async () => {
     const rspeedy = await createRspeedy({
       rspeedyConfig: {

--- a/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
@@ -17,8 +17,14 @@ export interface BundleFilenameContext {
     platform: string;
 }
 
+// @public
+export interface LynxClient {
+    websocketTransport?: string | undefined;
+}
+
 // @beta
 export interface LynxConfig {
+    readonly dev: LynxDev;
     readonly output: LynxOutput;
     resolveBundleFilename(context: {
         entryName: string;
@@ -27,6 +33,11 @@ export interface LynxConfig {
     resolveLazyBundleFilename(context: {
         platform: string;
     }): string | undefined;
+}
+
+// @public
+export interface LynxDev {
+    client?: LynxClient | undefined;
 }
 
 // @public
@@ -48,6 +59,7 @@ export interface LynxOutput {
 
 // @public
 export interface LynxPluginOptions {
+    dev?: LynxDev | undefined;
     output?: LynxOutput | undefined;
 }
 

--- a/packages/rspeedy/plugin-lynx/src/config.ts
+++ b/packages/rspeedy/plugin-lynx/src/config.ts
@@ -102,6 +102,37 @@ export interface LynxOutput {
 }
 
 /**
+ * The dev server client of the Lynx build engine.
+ *
+ * @public
+ */
+export interface LynxClient {
+  /**
+   * The module that provides the `WebSocket` used by HMR.
+   *
+   * @defaultValue `require.resolve('@lynx-js/websocket')`
+   *
+   * @remarks
+   *
+   * Lynx has no `WebSocket` global, so HMR resolves one from this module. The
+   * module has to export it as `default`.
+   */
+  websocketTransport?: string | undefined
+}
+
+/**
+ * The dev server options of the Lynx build engine.
+ *
+ * @public
+ */
+export interface LynxDev {
+  /**
+   * The dev server client.
+   */
+  client?: LynxClient | undefined
+}
+
+/**
  * The options of `pluginLynx`.
  *
  * @public
@@ -111,6 +142,11 @@ export interface LynxPluginOptions {
    * The build outputs.
    */
   output?: LynxOutput | undefined
+
+  /**
+   * The dev server.
+   */
+  dev?: LynxDev | undefined
 }
 
 /**
@@ -169,6 +205,11 @@ export interface LynxConfig {
   resolveLazyBundleFilename(
     context: { platform: string },
   ): string | undefined
+
+  /**
+   * The dev server.
+   */
+  readonly dev: LynxDev
 }
 
 // The key that `pluginLynx` exposes its `LynxConfig` with. It is not exported:
@@ -230,6 +271,8 @@ export function createLynxConfig(options: LynxPluginOptions): LynxConfig {
   // destructure them off the config.
   return {
     output,
+
+    dev: options.dev ?? {},
 
     resolveBundleFilename({ entryName, platform }) {
       return resolve(output.filename?.bundle, {

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -31,6 +31,8 @@ export type {
   BundleFilename,
   BundleFilenameContext,
   LynxConfig,
+  LynxClient,
+  LynxDev,
   LynxFilename,
   LynxMinify,
   LynxOutput,

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -23,10 +23,6 @@ const DEFAULT_IPV6_SERVER_HOST = '::'
 
 type RsbuildServerHost = NonNullable<RsbuildConfig['server']>['host']
 
-interface Client {
-  websocketTransport?: string | undefined
-}
-
 export function pluginDev(): RsbuildPlugin {
   return {
     name: 'lynx:rsbuild:dev',
@@ -315,13 +311,10 @@ export function pluginDev(): RsbuildPlugin {
             ])
           .end()
         if (isLynx(environment)) {
-          const client = api.getRsbuildConfig('original').dev?.client as
-            | Client
-            | undefined
           chain.plugin('lynx.hmr.provide.websocket')
             .use(ProvidePlugin, [{
               WebSocket: [
-                client?.websocketTransport
+                getLynxConfig(api).dev.client?.websocketTransport
                   ?? require.resolve('@lynx-js/websocket'),
                 'default',
               ],

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -709,12 +709,8 @@ describe('pluginDev', () => {
   })
 
   test('websocketTransport', async () => {
-    const rsbuild = await createDevStubRsbuild({
-      dev: {
-        client: {
-          websocketTransport: '/foo',
-        } as NonNullable<NonNullable<RsbuildConfig['dev']>['client']>,
-      },
+    const rsbuild = await createDevStubRsbuild({}, {
+      dev: { client: { websocketTransport: '/foo' } },
     })
 
     await rsbuild.unwrapConfig()


### PR DESCRIPTION
`dev.client.websocketTransport` is not an Rsbuild option, so Rspeedy tunnels it through Rsbuild's config namespace and `pluginDev` read it from there.

- `pluginLynx({ dev: { client } })` is the typed home for it.
- The tunneled location is still read as a fallback.