### PR TITLE
refactor: use the Rspack devtool type for output.sourceMap.js

### DIFF
--- a/.changeset/olive-pumas-count.md
+++ b/.changeset/olive-pumas-count.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/rspeedy": patch
+---
+
+Use the Rspack `DevTool` type for `output.sourceMap.js`. It already covers the `'-debugids'` suffix, so Rspeedy no longer restates it.

--- a/packages/rspeedy/core/etc/rspeedy.api.md
+++ b/packages/rspeedy/core/etc/rspeedy.api.md
@@ -353,7 +353,7 @@ export interface Source {
 // @public
 export interface SourceMap {
     css?: boolean | undefined;
-    js?: Rspack.DevTool | undefined | `${Exclude<Rspack.DevTool, false | 'eval'>}-debugids`;
+    js?: Rspack.DevTool | undefined;
 }
 
 // @public

--- a/packages/rspeedy/core/src/config/output/source-map.ts
+++ b/packages/rspeedy/core/src/config/output/source-map.ts
@@ -68,10 +68,7 @@ export interface SourceMap {
    * })
    * ```
    */
-  js?:
-    | Rspack.DevTool
-    | undefined
-    | `${Exclude<Rspack.DevTool, false | 'eval'>}-debugids`
+  js?: Rspack.DevTool | undefined
 
   /**
    * Whether to generate CSS source maps.

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { ConsoleType, RsbuildConfig, SourceMap } from '@rsbuild/core'
+import type { ConsoleType, RsbuildConfig } from '@rsbuild/core'
 import type { UndefinedOnPartialDeep } from 'type-fest'
 
 import { toRsbuildEntry } from './entry.js'
@@ -60,8 +60,7 @@ export function toRsbuildConfig(
 
       polyfill: 'off',
 
-      // TODO: update the Rsbuild type to allow `sourceMap.js` to be `*-debugids`
-      sourceMap: config.output?.sourceMap as SourceMap,
+      sourceMap: config.output?.sourceMap,
     },
     resolve: {
       alias: toRsbuildAlias(config),


### PR DESCRIPTION
`Rspack.DevTool` gained the `'-debugids'` suffix, so the extra union member that Rspeedy declared is now a restatement of it, and the assertion that smuggled the value past the Rsbuild type is no longer needed.