### PR TITLE
feat(rsbuild-plugin): build named entries as background-only runtimes

### DIFF
--- a/.changeset/background-only-entries.md
+++ b/.changeset/background-only-entries.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/react-rsbuild-plugin": minor
+---
+
+Add `experimental_backgroundOnlyEntries`, which builds the named entries as
+background-only runtimes: no main thread and no template, just the background
+bundle, for a host that runs it outside of any card. Such an entry still takes
+part in chunk splitting, so it shares chunks with the pages built alongside it.

--- a/packages/rspeedy/plugin-react/etc/react-rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-react/etc/react-rsbuild-plugin.api.md
@@ -80,6 +80,8 @@ export interface PluginReactLynxOptions {
     enableUiSourceMap?: boolean;
     engineVersion?: string;
     // @alpha
+    experimental_backgroundOnlyEntries?: string[];
+    // @alpha
     experimental_isLazyBundle?: boolean;
     experimental_transformBuiltinAttributeNames?: boolean | TransformBuiltinAttributeNamesOptions;
     experimental_useElementTemplate?: boolean;

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -61,8 +61,11 @@ export function applyEntry(
     extractStr: originalExtractStr,
 
     experimental_isLazyBundle,
+    experimental_backgroundOnlyEntries,
     experimental_transformBuiltinAttributeNames,
   } = options
+
+  const backgroundOnlyEntries = new Set(experimental_backgroundOnlyEntries)
 
   const lazyBundleFetcher = resolveLazyBundleFetcher(targetSdkVersion)
   const runtimeConfig: RuntimeConfigWebpackPluginOptions = {}
@@ -144,49 +147,61 @@ export function applyEntry(
           `${entryName}/main-thread.js`,
         )
 
-        const backgroundName = path.posix.join(
-          isLynx
-            ? lynxConfig.resolveIntermediateDir()
-            // For non-Lynx environment, the entry is not deleted.
-            // So we do not put it in the intermediate.
-            : '',
-          getBackgroundFilename(
-            entryName,
-            environment.config,
-            isProd,
-            experimental_isLazyBundle,
-          ),
-        )
+        // A background-only entry is the host's own runtime rather than a card,
+        // so it has no template to be packed into and its bundle is the
+        // deliverable — keep it out of the intermediate that gets cleaned.
+        const isBackgroundOnly = backgroundOnlyEntries.has(entryName)
+
+        const backgroundName = isBackgroundOnly
+          ? `${entryName}-runtime.js`
+          : path.posix.join(
+            isLynx
+              ? lynxConfig.resolveIntermediateDir()
+              // For non-Lynx environment, the entry is not deleted.
+              // So we do not put it in the intermediate.
+              : '',
+            getBackgroundFilename(
+              entryName,
+              environment.config,
+              isProd,
+              experimental_isLazyBundle,
+            ),
+          )
 
         const backgroundEntry = entryName
 
-        mainThreadChunks.push(mainThreadName)
+        if (!isBackgroundOnly) {
+          mainThreadChunks.push(mainThreadName)
 
-        entryPairs.push({
-          mainThread: mainThreadEntry,
-          background: backgroundEntry,
-        })
+          entryPairs.push({
+            mainThread: mainThreadEntry,
+            background: backgroundEntry,
+          })
+        }
 
         chain
-          .entry(mainThreadEntry)
-          .add({
-            layer: LAYERS.MAIN_THREAD,
-            import: imports,
-            filename: mainThreadName,
-          })
-          .when(enabledHMR, entry => {
-            const require = createRequire(import.meta.url)
-            // use prepend to make sure it does not affect the exports
-            // from the entry
-            entry
-              .prepend({
+          .when(!isBackgroundOnly, chain => {
+            chain
+              .entry(mainThreadEntry)
+              .add({
                 layer: LAYERS.MAIN_THREAD,
-                import: require.resolve(
-                  '@lynx-js/css-extract-webpack-plugin/runtime/hotModuleReplacement.lepus.cjs',
-                ),
+                import: imports,
+                filename: mainThreadName,
               })
+              .when(enabledHMR, entry => {
+                const require = createRequire(import.meta.url)
+                // use prepend to make sure it does not affect the exports
+                // from the entry
+                entry
+                  .prepend({
+                    layer: LAYERS.MAIN_THREAD,
+                    import: require.resolve(
+                      '@lynx-js/css-extract-webpack-plugin/runtime/hotModuleReplacement.lepus.cjs',
+                    ),
+                  })
+              })
+              .end()
           })
-          .end()
           .entry(backgroundEntry)
           .add({
             layer: LAYERS.BACKGROUND,
@@ -219,31 +234,34 @@ export function applyEntry(
               })
           })
           .end()
-          .plugin(`${PLUGIN_NAME_TEMPLATE}-${entryName}`)
-          .use(LynxTemplatePlugin, [{
-            dsl: 'react_nodiff',
-            chunks: [mainThreadEntry, backgroundEntry],
-            filename: templateFilename,
-            ...(lazyBundleFilename ? { lazyBundleFilename } : {}),
-            intermediate: lynxConfig.resolveIntermediateDir({ entryName }),
-            customCSSInheritanceList,
-            debugInfoOutside,
-            defaultDisplayLinear,
-            enableA11y: true,
-            enableAccessibilityElement,
-            enableCSSInheritance,
-            enableCSSInvalidation,
-            enableCSSSelector,
-            enableNewGesture,
-            enableRemoveCSSScope: enableRemoveCSSScope ?? true,
-            removeDescendantSelectorScope,
-            targetSdkVersion,
+          .when(!isBackgroundOnly, chain => {
+            chain
+              .plugin(`${PLUGIN_NAME_TEMPLATE}-${entryName}`)
+              .use(LynxTemplatePlugin, [{
+                dsl: 'react_nodiff',
+                chunks: [mainThreadEntry, backgroundEntry],
+                filename: templateFilename,
+                ...(lazyBundleFilename ? { lazyBundleFilename } : {}),
+                intermediate: lynxConfig.resolveIntermediateDir({ entryName }),
+                customCSSInheritanceList,
+                debugInfoOutside,
+                defaultDisplayLinear,
+                enableA11y: true,
+                enableAccessibilityElement,
+                enableCSSInheritance,
+                enableCSSInvalidation,
+                enableCSSSelector,
+                enableNewGesture,
+                enableRemoveCSSScope: enableRemoveCSSScope ?? true,
+                removeDescendantSelectorScope,
+                targetSdkVersion,
 
-            experimental_isLazyBundle,
-            lazyBundleFetcher,
-            cssPlugins: [],
-          }])
-          .end()
+                experimental_isLazyBundle,
+                lazyBundleFetcher,
+                cssPlugins: [],
+              }])
+              .end()
+          })
       })
     }
 

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -344,6 +344,20 @@ export interface PluginReactLynxOptions {
   experimental_isLazyBundle?: boolean
 
   /**
+   * Entry names to build as background-only runtimes.
+   *
+   * Such an entry has no main thread and no template: it emits the background
+   * bundle alone, for a host that runs it outside of any card. It still takes
+   * part in chunk splitting, so it shares chunks with the pages built alongside
+   * it.
+   *
+   * @defaultValue `[]`
+   *
+   * @alpha
+   */
+  experimental_backgroundOnlyEntries?: string[]
+
+  /**
    * Enable Element Template compile and runtime entries.
    *
    * @defaultValue `false`
@@ -415,6 +429,7 @@ export function pluginReactLynx(
     globalPropsMode: 'reactive',
 
     experimental_isLazyBundle: false,
+    experimental_backgroundOnlyEntries: [],
     experimental_transformBuiltinAttributeNames: false,
     experimental_useElementTemplate: false,
     optimizeBundleSize: false,

--- a/packages/rspeedy/plugin-react/test/background-only-entries.test.ts
+++ b/packages/rspeedy/plugin-react/test/background-only-entries.test.ts
@@ -1,0 +1,66 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, rstest, test } from '@rstest/core'
+
+import { createStubRspeedy as createRspeedy } from './createRspeedy.js'
+
+rstest
+  .stubEnv('USE_RSPACK', 'true')
+  .stubEnv('NODE_ENV', 'production')
+
+async function entryNamesOf(
+  experimental_backgroundOnlyEntries: string[] | undefined,
+) {
+  const { pluginReactLynx } = await import('../src/pluginReactLynx.js')
+
+  const rsbuild = await createRspeedy({
+    rspeedyConfig: {
+      plugins: [
+        pluginReactLynx(
+          experimental_backgroundOnlyEntries
+            ? { experimental_backgroundOnlyEntries }
+            : {},
+        ),
+      ],
+      source: {
+        entry: {
+          app: './src/app.ts',
+          page: './src/page.tsx',
+        },
+      },
+    },
+  })
+
+  const [config] = await rsbuild.initConfigs()
+  return Object.keys(config?.entry ?? {})
+}
+
+describe('experimental_backgroundOnlyEntries', () => {
+  test('every entry gets a main-thread entry by default', async () => {
+    const names = await entryNamesOf(undefined)
+
+    expect(names).toContain('app__main-thread')
+    expect(names).toContain('page__main-thread')
+  })
+
+  test('a listed entry drops its main-thread entry', async () => {
+    const names = await entryNamesOf(['app'])
+
+    expect(names).not.toContain('app__main-thread')
+    expect(names).toContain('app')
+  })
+
+  test('an entry that is not listed keeps its main-thread entry', async () => {
+    const names = await entryNamesOf(['app'])
+
+    expect(names).toContain('page__main-thread')
+  })
+
+  test('an unknown entry name changes nothing', async () => {
+    const names = await entryNamesOf(['nope'])
+
+    expect(names).toContain('app__main-thread')
+    expect(names).toContain('page__main-thread')
+  })
+})


### PR DESCRIPTION
A host that runs a runtime outside of any card — a group-level app runtime, for instance — needs a plain background bundle: no main thread to render with, and no template to be packed into.

`experimental_backgroundOnlyEntries` names the entries to build that way. They emit `<name>-runtime.js` and skip the main-thread entry and the template plugin, while still going through the normal entry wiring, so they take part in chunk splitting and share chunks with the pages built alongside them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the experimental `experimental_backgroundOnlyEntries` option for configuring named entries as background-only runtimes.
  * Background-only entries generate runtime bundles without main-thread or template output while continuing to participate in shared chunk splitting.
  * Entries not listed in the option continue to build with their existing main-thread behavior.

* **Tests**
  * Added coverage for default behavior, configured background-only entries, unlisted entries, and unknown entry names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->