### PR TITLE
feat(rsbuild-plugin): expose LynxTemplatePlugin from the build engine

### DIFF
--- a/.changeset/tidy-pianos-repeat.md
+++ b/.changeset/tidy-pianos-repeat.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/vanilla-rsbuild-plugin": patch
+---
+
+Expose `Symbol.for('LynxTemplatePlugin')` from `pluginLynx` instead of from each DSL plugin, so the plugins that tap the template hooks work with the build engine alone.

--- a/packages/rspeedy/plugin-config/test/pluginLynxConfig.test.ts
+++ b/packages/rspeedy/plugin-config/test/pluginLynxConfig.test.ts
@@ -2,9 +2,9 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { createRsbuild } from '@rsbuild/core'
 import { describe, expect, rstest, test } from '@rstest/core'
 
-import { createRspeedy } from '@lynx-js/rspeedy'
 import type { RsbuildPluginAPI } from '@lynx-js/rspeedy'
 import { compilerOptionsKeys, configKeys } from '@lynx-js/type-config'
 
@@ -13,15 +13,15 @@ describe('pluginLynxConfig', () => {
   test('should throw error when no LynxTemplatePlugin exposed', async () => {
     const { pluginLynxConfig } = await import('../src/pluginLynxConfig.js')
 
-    const rspeedy = await createRspeedy({
-      rspeedyConfig: {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
         plugins: [
           pluginLynxConfig({}),
         ],
       },
     })
 
-    await expect(() => rspeedy.initConfigs()).rejects
+    await expect(() => rsbuild.initConfigs()).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       [Error: [pluginLynxConfig] No \`LynxTemplatePlugin\` exposed to the plugin API https://rsbuild.rs/plugins/dev/core#apiexpose.
 
@@ -35,8 +35,8 @@ describe('pluginLynxConfig', () => {
   test('should throw error when lynx:react plugin exists', async () => {
     const { pluginLynxConfig } = await import('../src/pluginLynxConfig.js')
 
-    const rspeedy = await createRspeedy({
-      rspeedyConfig: {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
         plugins: [
           pluginLynxConfig({}),
           {
@@ -47,7 +47,7 @@ describe('pluginLynxConfig', () => {
       },
     })
 
-    await expect(() => rspeedy.initConfigs()).rejects
+    await expect(() => rsbuild.initConfigs()).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       [Error: [pluginLynxConfig] No \`LynxTemplatePlugin\` exposed to the plugin API https://rsbuild.rs/plugins/dev/core#apiexpose.
 
@@ -61,8 +61,8 @@ describe('pluginLynxConfig', () => {
   test('should throw error when lynx:vue plugin exists', async () => {
     const { pluginLynxConfig } = await import('../src/pluginLynxConfig.js')
 
-    const rspeedy = await createRspeedy({
-      rspeedyConfig: {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
         plugins: [
           pluginLynxConfig({}, {
             dslPluginName2PkgName: {
@@ -77,7 +77,7 @@ describe('pluginLynxConfig', () => {
       },
     })
 
-    await expect(() => rspeedy.initConfigs()).rejects
+    await expect(() => rsbuild.initConfigs()).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       [Error: [pluginLynxConfig] No \`LynxTemplatePlugin\` exposed to the plugin API https://rsbuild.rs/plugins/dev/core#apiexpose.
 
@@ -96,8 +96,8 @@ describe('pluginLynxConfig', () => {
 
     const LynxTemplatePlugin = rstest.fn()
 
-    const rspeedy = await createRspeedy({
-      rspeedyConfig: {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
         plugins: [
           pluginLynxConfig({ enableAccessibilityElement: true }),
           {
@@ -112,7 +112,7 @@ describe('pluginLynxConfig', () => {
       },
     })
 
-    await rspeedy.initConfigs()
+    await rsbuild.initConfigs()
 
     expect(LynxConfigWebpackPlugin).toHaveBeenCalledWith(
       {

--- a/packages/rspeedy/plugin-lynx/package.json
+++ b/packages/rspeedy/plugin-lynx/package.json
@@ -42,6 +42,7 @@
     "@lynx-js/cache-events-webpack-plugin": "workspace:^",
     "@lynx-js/chunk-loading-webpack-plugin": "workspace:^",
     "@lynx-js/debug-metadata-rsbuild-plugin": "workspace:^",
+    "@lynx-js/template-webpack-plugin": "workspace:^",
     "@lynx-js/web-rsbuild-server-middleware": "workspace:*",
     "@lynx-js/webpack-dev-transport": "workspace:^",
     "@lynx-js/websocket": "workspace:^",

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -18,6 +18,7 @@ import { pluginServer } from './plugins/server.plugin.js'
 import { pluginSourcemap } from './plugins/sourcemap.plugin.js'
 import { pluginSwc } from './plugins/swc.plugin.js'
 import { pluginTarget } from './plugins/target.plugin.js'
+import { pluginTemplate } from './plugins/template.plugin.js'
 
 /**
  * The name of the plugin that marks `pluginLynx` as applied. Use it with
@@ -65,5 +66,6 @@ export function pluginLynx(
     pluginSourcemap(),
     pluginSwc(),
     pluginTarget(),
+    pluginTemplate(),
   ]
 }

--- a/packages/rspeedy/plugin-lynx/src/plugins/template.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/template.plugin.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import type { RsbuildPlugin } from '@rsbuild/core'
+
+import { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
+
+export function pluginTemplate(): RsbuildPlugin {
+  return {
+    name: 'lynx:rsbuild:template',
+    setup(api) {
+      // Only `getLynxTemplatePluginHooks` is exposed, so the rest of
+      // `LynxTemplatePlugin` stays free to change without breaking the
+      // plugins that tap its hooks.
+      api.expose(Symbol.for('LynxTemplatePlugin'), {
+        LynxTemplatePlugin: {
+          getLynxTemplatePluginHooks: LynxTemplatePlugin
+            .getLynxTemplatePluginHooks.bind(LynxTemplatePlugin),
+        },
+      })
+    },
+  }
+}

--- a/packages/rspeedy/plugin-lynx/test/template.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/template.plugin.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createRsbuild } from '@rsbuild/core'
+import type { RsbuildPluginAPI } from '@rsbuild/core'
+import { describe, expect, test } from '@rstest/core'
+
+import type { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
+
+import { pluginLynx } from '../src/index.js'
+
+interface LynxTemplatePluginExposure {
+  LynxTemplatePlugin: Pick<
+    typeof LynxTemplatePlugin,
+    'getLynxTemplatePluginHooks'
+  >
+}
+
+describe('pluginTemplate', () => {
+  test('exposes LynxTemplatePlugin without a DSL plugin', async () => {
+    let exposed: LynxTemplatePluginExposure | undefined
+
+    const rsbuild = await createRsbuild({
+      cwd: path.dirname(fileURLToPath(import.meta.url)),
+      rsbuildConfig: {
+        environments: { lynx: {} },
+        plugins: [
+          ...pluginLynx(),
+          {
+            name: 'test:capture',
+            setup(api: RsbuildPluginAPI) {
+              api.modifyBundlerChain(() => {
+                exposed = api.useExposed<LynxTemplatePluginExposure>(
+                  Symbol.for('LynxTemplatePlugin'),
+                )
+              })
+            },
+          },
+        ],
+      },
+    })
+
+    await rsbuild.initConfigs()
+
+    expect(typeof exposed?.LynxTemplatePlugin.getLynxTemplatePluginHooks)
+      .toBe('function')
+  })
+})

--- a/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
+++ b/packages/rspeedy/plugin-react/src/pluginReactLynx.ts
@@ -22,7 +22,6 @@ import type {
   TransformBuiltinAttributeNamesOptions,
 } from '@lynx-js/react-transform'
 import { LAYERS } from '@lynx-js/react-webpack-plugin'
-import { LynxTemplatePlugin } from '@lynx-js/template-webpack-plugin'
 
 import { pluginAutoLynx } from './autoLynx.js'
 import { applyBackgroundOnly } from './backgroundOnly.js'
@@ -510,15 +509,6 @@ export function pluginReactLynx(
         }
 
         api.expose(Symbol.for('LAYERS'), LAYERS)
-        // Only expose `LynxTemplatePlugin.getLynxTemplatePluginHooks` to avoid
-        // other breaking changes in `LynxTemplatePlugin`
-        // breaks `pluginReactLynx`
-        api.expose(Symbol.for('LynxTemplatePlugin'), {
-          LynxTemplatePlugin: {
-            getLynxTemplatePluginHooks: LynxTemplatePlugin
-              .getLynxTemplatePluginHooks.bind(LynxTemplatePlugin),
-          },
-        })
         const require = createRequire(import.meta.url)
 
         const { version } = require('../package.json') as { version: string }

--- a/packages/rspeedy/plugin-react/test/expose.test.ts
+++ b/packages/rspeedy/plugin-react/test/expose.test.ts
@@ -44,10 +44,13 @@ describe('Expose', () => {
           {
             name: 'pluginThatUsesTemplateHooks',
             setup(api) {
-              expose = api.useExposed<
-                { LynxTemplatePlugin: LynxTemplatePlugin }
-              >(Symbol.for('LynxTemplatePlugin'))
               api.modifyBundlerChain(chain => {
+                // `pluginLynx` exposes this, and Rspeedy applies the engine
+                // after the user plugins, so it is read in a hook rather than
+                // in `setup`.
+                expose = api.useExposed<
+                  { LynxTemplatePlugin: LynxTemplatePlugin }
+                >(Symbol.for('LynxTemplatePlugin'))
                 const PLUGIN_NAME = 'pluginThatUsesTemplateHooks'
                 chain.plugin(PLUGIN_NAME).use({
                   apply(compiler) {

--- a/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
+++ b/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
@@ -218,12 +218,6 @@ function resolvePluginOptions(
 
 function exposeVanillaCapabilities(api: RsbuildPluginAPI): void {
   api.expose(Symbol.for('LAYERS'), LAYERS)
-  api.expose(Symbol.for('LynxTemplatePlugin'), {
-    LynxTemplatePlugin: {
-      getLynxTemplatePluginHooks: LynxTemplatePlugin
-        .getLynxTemplatePluginHooks.bind(LynxTemplatePlugin),
-    },
-  })
 }
 
 function disableVanillaHotUpdates(api: RsbuildPluginAPI): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1785,6 +1785,9 @@ importers:
       '@lynx-js/debug-metadata-rsbuild-plugin':
         specifier: workspace:^
         version: link:../plugin-debug-metadata
+      '@lynx-js/template-webpack-plugin':
+        specifier: workspace:^
+        version: link:../../webpack/template-webpack-plugin
       '@lynx-js/web-rsbuild-server-middleware':
         specifier: workspace:*
         version: link:../../web-platform/web-rsbuild-server-middleware


### PR DESCRIPTION
`Symbol.for('LynxTemplatePlugin')` is consumed by `pluginLynxDebugMetadata`, which `pluginLynx` applies itself, and by `pluginLynxConfig`. Both DSL plugins exposed it with the same bound method, so the engine depended on a DSL plugin to provide an API it needs.

- `pluginLynx` exposes it, so the debug metadata plugin is no longer silently inert when the engine is used without a DSL plugin.
- `pluginReactLynx` and `pluginVanillaLynx` drop their copies. `LAYERS` stays with them, since each DSL defines its own.
- Rspeedy applies the engine after the user plugins, so the value is now readable in a hook rather than during `setup`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Lynx build plugin now provides template integration capabilities directly, allowing compatible plugins to use template hooks without requiring a separate DSL plugin.
  * React and vanilla build configurations continue to support template integrations through the shared Lynx plugin.

* **Bug Fixes**
  * Improved plugin initialization timing for template capabilities, ensuring they are available when bundler configuration is processed.

* **Tests**
  * Added coverage verifying template capabilities are exposed correctly and updated configuration tests for the current build API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->