### PR TITLE
feat(rsbuild-plugin): let pluginLynx own the intermediate directory

### DIFF
--- a/.changeset/olive-melons-count.md
+++ b/.changeset/olive-melons-count.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/vanilla-rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Honor `output.distPath.intermediate`. The Lynx build engine now resolves the intermediate directory, so the option is no longer ignored by the plugins that emit a Lynx bundle.

--- a/packages/rspeedy/core/src/plugins/index.ts
+++ b/packages/rspeedy/core/src/plugins/index.ts
@@ -15,10 +15,15 @@ function toLynxPluginOptions(config: Config): LynxPluginOptions {
     ? filename
     : filename?.bundle ?? filename?.template
 
+  const intermediate = config.output?.distPath?.intermediate
+
   const websocketTransport = config.dev?.client?.websocketTransport
 
   return {
-    ...bundle === undefined ? {} : { output: { filename: { bundle } } },
+    output: {
+      ...intermediate === undefined ? {} : { distPath: { intermediate } },
+      ...bundle === undefined ? {} : { filename: { bundle } },
+    },
     ...websocketTransport === undefined
       ? {}
       : { dev: { client: { websocketTransport } } },

--- a/packages/rspeedy/core/test/createRspeedy.test.ts
+++ b/packages/rspeedy/core/test/createRspeedy.test.ts
@@ -104,4 +104,30 @@ describe('createRspeedy', () => {
 
     expect.assertions(1)
   })
+
+  test('output.distPath.intermediate reaches the Lynx config', async () => {
+    const rspeedy = await createRspeedy({
+      rspeedyConfig: {
+        output: { distPath: { intermediate: '.lynx' } },
+        plugins: [
+          {
+            name: 'test',
+            setup(api: RsbuildPluginAPI) {
+              api.modifyBundlerChain(() => {
+                expect(
+                  api.useExposed<LynxConfig>(
+                    Symbol.for('@lynx-js/rsbuild-plugin:config'),
+                  )?.resolveIntermediateDir({ entryName: 'main' }),
+                ).toBe('.lynx/main')
+              })
+            },
+          },
+        ],
+      },
+    })
+
+    await rspeedy.initConfigs()
+
+    expect.assertions(1)
+  })
 })

--- a/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
+++ b/packages/rspeedy/plugin-lynx/etc/rsbuild-plugin.api.md
@@ -30,6 +30,9 @@ export interface LynxConfig {
         entryName: string;
         platform: string;
     }): string;
+    resolveIntermediateDir(context?: {
+        entryName?: string | undefined;
+    }): string;
     resolveLazyBundleFilename(context: {
         platform: string;
     }): string | undefined;
@@ -38,6 +41,11 @@ export interface LynxConfig {
 // @public
 export interface LynxDev {
     client?: LynxClient | undefined;
+}
+
+// @public
+export interface LynxDistPath {
+    intermediate?: string | undefined;
 }
 
 // @public
@@ -53,6 +61,7 @@ export interface LynxMinify {
 
 // @public
 export interface LynxOutput {
+    distPath?: LynxDistPath | undefined;
     filename?: LynxFilename | undefined;
     minify?: LynxMinify | undefined;
 }

--- a/packages/rspeedy/plugin-lynx/src/config.ts
+++ b/packages/rspeedy/plugin-lynx/src/config.ts
@@ -1,6 +1,8 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+import { posix } from 'node:path'
+
 import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core'
 
 /**
@@ -85,11 +87,35 @@ export interface LynxMinify {
 }
 
 /**
+ * The output directories of the Lynx build engine.
+ *
+ * @public
+ */
+export interface LynxDistPath {
+  /**
+   * The directory of the intermediate files of a bundle.
+   *
+   * @defaultValue `'.rspeedy'`
+   *
+   * @remarks
+   *
+   * A Lynx bundle is encoded from per-thread JS, CSS and HMR outputs. They are
+   * emitted into this directory, per entry, instead of next to the bundle.
+   */
+  intermediate?: string | undefined
+}
+
+/**
  * The build outputs of the Lynx build engine.
  *
  * @public
  */
 export interface LynxOutput {
+  /**
+   * The output directories.
+   */
+  distPath?: LynxDistPath | undefined
+
   /**
    * The names of the emitted files.
    */
@@ -188,6 +214,16 @@ export interface LynxConfig {
   ): string
 
   /**
+   * Resolve the directory of the intermediate files.
+   *
+   * @param context - The entry to resolve the directory for. Without an entry
+   * name, the directory that holds every entry's is returned.
+   */
+  resolveIntermediateDir(
+    context?: { entryName?: string | undefined },
+  ): string
+
+  /**
    * Resolve the name of the lazy bundle files.
    *
    * @param context - The environment to resolve the name for.
@@ -237,6 +273,8 @@ export function getLynxConfig(api: RsbuildPluginAPI): LynxConfig {
 
 const DEFAULT_BUNDLE_FILENAME = '[name].[platform].bundle'
 
+const DEFAULT_DIST_PATH_INTERMEDIATE = '.rspeedy'
+
 function resolve(
   bundle: BundleFilename | undefined,
   context: BundleFilenameContext,
@@ -280,6 +318,13 @@ export function createLynxConfig(options: LynxPluginOptions): LynxConfig {
         entryName,
         platform,
       })
+    },
+
+    resolveIntermediateDir(context) {
+      const dir = output.distPath?.intermediate
+        ?? DEFAULT_DIST_PATH_INTERMEDIATE
+
+      return context?.entryName ? posix.join(dir, context.entryName) : dir
     },
 
     resolveLazyBundleFilename({ platform }) {

--- a/packages/rspeedy/plugin-lynx/src/index.ts
+++ b/packages/rspeedy/plugin-lynx/src/index.ts
@@ -34,6 +34,7 @@ export type {
   LynxConfig,
   LynxClient,
   LynxDev,
+  LynxDistPath,
   LynxFilename,
   LynxMinify,
   LynxOutput,

--- a/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/output.plugin.ts
@@ -4,7 +4,7 @@
 
 import type { RsbuildPlugin } from '@rsbuild/core'
 
-const DEFAULT_DIST_PATH_INTERMEDIATE = '.rspeedy'
+import { getLynxConfig } from '../config.js'
 
 export function pluginOutput(): RsbuildPlugin {
   return {
@@ -39,7 +39,8 @@ export function pluginOutput(): RsbuildPlugin {
                 // We override the default value of Rsbuild(`static/css`) here.
                 // Since all the CSS should be encoded into the template in
                 // Lynx.
-                css: originalDistPath?.css ?? DEFAULT_DIST_PATH_INTERMEDIATE,
+                css: originalDistPath?.css
+                  ?? getLynxConfig(api).resolveIntermediateDir(),
               },
               filename: {
                 css: originalFilename?.css ?? '[name]/[name].css',

--- a/packages/rspeedy/plugin-lynx/test/config.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/config.plugin.test.ts
@@ -137,6 +137,24 @@ describe('pluginConfig', () => {
     })).toBe('lazy/[name].lynx.bundle')
   })
 
+  test('resolveIntermediateDir defaults to .rspeedy', async () => {
+    const lynx = await usingLynxConfig()
+
+    expect(lynx.resolveIntermediateDir()).toBe('.rspeedy')
+    expect(lynx.resolveIntermediateDir({ entryName: 'main' }))
+      .toBe('.rspeedy/main')
+  })
+
+  test('resolveIntermediateDir uses output.distPath.intermediate', async () => {
+    const lynx = await usingLynxConfig({
+      output: { distPath: { intermediate: '.lynx' } },
+    })
+
+    expect(lynx.resolveIntermediateDir()).toBe('.lynx')
+    expect(lynx.resolveIntermediateDir({ entryName: 'main' }))
+      .toBe('.lynx/main')
+  })
+
   test('throws when pluginLynx is not applied', async () => {
     let error: unknown
 

--- a/packages/rspeedy/plugin-react/src/entry.ts
+++ b/packages/rspeedy/plugin-react/src/entry.ts
@@ -31,7 +31,6 @@ const PLUGIN_NAME_TEMPLATE = 'lynx:template'
 const PLUGIN_NAME_RUNTIME_WRAPPER = 'lynx:runtime-wrapper'
 const PLUGIN_NAME_WEB = 'lynx:web'
 
-const DEFAULT_DIST_PATH_INTERMEDIATE = '.rspeedy'
 const DEFAULT_FILENAME_HASH = '.[contenthash:8]'
 const EMPTY_HASH = ''
 
@@ -128,8 +127,7 @@ export function applyEntry(
 
         const mainThreadName = path.posix.join(
           isLynx
-            // TODO: config intermediate
-            ? DEFAULT_DIST_PATH_INTERMEDIATE
+            ? lynxConfig.resolveIntermediateDir()
             // For non-Lynx environment, the entry is not deleted.
             // So we do not put it in the intermediate.
             : '',
@@ -138,8 +136,7 @@ export function applyEntry(
 
         const backgroundName = path.posix.join(
           isLynx
-            // TODO: config intermediate
-            ? DEFAULT_DIST_PATH_INTERMEDIATE
+            ? lynxConfig.resolveIntermediateDir()
             // For non-Lynx environment, the entry is not deleted.
             // So we do not put it in the intermediate.
             : '',
@@ -218,10 +215,7 @@ export function applyEntry(
             chunks: [mainThreadEntry, backgroundEntry],
             filename: templateFilename,
             ...(lazyBundleFilename ? { lazyBundleFilename } : {}),
-            intermediate: path.posix.join(
-              DEFAULT_DIST_PATH_INTERMEDIATE,
-              entryName,
-            ),
+            intermediate: lynxConfig.resolveIntermediateDir({ entryName }),
             customCSSInheritanceList,
             debugInfoOutside,
             defaultDisplayLinear,

--- a/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
+++ b/packages/rspeedy/plugin-vanilla/src/pluginVanillaLynx.ts
@@ -25,7 +25,6 @@ const S_LYNX_CONFIG = Symbol.for('@lynx-js/rsbuild-plugin:config')
 const PLUGIN_NAME = 'lynx:vanilla'
 const VANILLA_WEBPACK_PLUGIN_NAME = 'VanillaLynxWebpackPlugin'
 const DEFAULT_ENGINE_VERSION = '3.5'
-const INTERMEDIATE_DIR = '.rspeedy'
 
 /**
  * Rspack layers used by Vanilla Lynx entries.
@@ -290,16 +289,11 @@ function addVanillaEntry(
 
   const backgroundEntry = `${entryName}__background`
   const mainThreadEntry = `${entryName}__main-thread`
-  const backgroundAsset = path.posix.join(
-    INTERMEDIATE_DIR,
+  const intermediateDir = context.lynxConfig.resolveIntermediateDir({
     entryName,
-    'background.js',
-  )
-  const mainThreadAsset = path.posix.join(
-    INTERMEDIATE_DIR,
-    entryName,
-    'main-thread.js',
-  )
+  })
+  const backgroundAsset = path.posix.join(intermediateDir, 'background.js')
+  const mainThreadAsset = path.posix.join(intermediateDir, 'main-thread.js')
 
   if (hasBackground) {
     chain.entry(backgroundEntry).add({
@@ -331,7 +325,7 @@ function addVanillaEntry(
         entryName,
         context.platform,
       ),
-      intermediate: path.posix.join(INTERMEDIATE_DIR, entryName),
+      intermediate: intermediateDir,
       targetSdkVersion: context.engineVersion,
     }],
   )


### PR DESCRIPTION
`LynxTemplatePlugin.intermediate` documents itself as inheriting Rspeedy's `output.distPath.intermediate`, but nothing read that option: `'.rspeedy'` was hardcoded in four places, two of them behind a `TODO: config intermediate`.

- `pluginLynx({ output: { distPath: { intermediate } } })` is the typed home, and `LynxConfig.resolveIntermediateDir()` derives the per-entry directory the way the bundle filename is derived.
- Rspeedy forwards its option, so it now takes effect.
- The engine and both DSL plugins read the resolved value instead of keeping their own copy of the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Lynx intermediate output directory.
  * Intermediate files now resolve to the configured location, including entry-specific paths.
  * Added a public configuration API for resolving intermediate directories.
  * Defaults remain `.rspeedy` when no custom directory is specified.

* **Bug Fixes**
  * Ensured configured intermediate paths are consistently applied across React, vanilla, CSS, and bundle outputs.

* **Tests**
  * Added coverage for default and custom intermediate directory resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->