### PR TITLE
feat: declare the build host as an optional peer dependency

### DIFF
--- a/.changeset/great-taxis-repeat.md
+++ b/.changeset/great-taxis-repeat.md
@@ -1,0 +1,12 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/react-rsbuild-plugin": patch
+"@lynx-js/vanilla-rsbuild-plugin": patch
+"@lynx-js/qrcode-rsbuild-plugin": patch
+"@lynx-js/config-rsbuild-plugin": patch
+"@lynx-js/debug-metadata-rsbuild-plugin": patch
+"@lynx-js/external-bundle-rsbuild-plugin": patch
+"@lynx-js/react-alias-rsbuild-plugin": patch
+---
+
+Declare the build host as an optional peer dependency. `@rsbuild/core` covers a plain Rsbuild build, and `@lynx-js/rspeedy` covers an Rspeedy one, so whichever host is installed is version-checked.

--- a/examples/rsbuild/package.json
+++ b/examples/rsbuild/package.json
@@ -13,7 +13,6 @@
   "devDependencies": {
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rsbuild-plugin": "workspace:*",
-    "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/types": "4.1.0",
     "@rsbuild/core": "catalog:rsbuild",
     "@types/react": "^19.2.18"

--- a/examples/rsbuild/rsbuild.config.ts
+++ b/examples/rsbuild/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginLynx } from '@lynx-js/rsbuild-plugin';
 
 export default defineConfig({
   environments: {
@@ -12,8 +13,13 @@ export default defineConfig({
     },
   },
   plugins: [
-    // `pluginLynx` is applied by `pluginReactLynx` when it is not already there,
-    // so this is the only plugin needed to build a Lynx bundle with Rsbuild.
+    pluginLynx({
+      output: {
+        filename: {
+          bundle: '[name].[platform].bundle',
+        },
+      },
+    }),
     pluginReactLynx(),
   ],
 });

--- a/packages/rspeedy/plugin-config/package.json
+++ b/packages/rspeedy/plugin-config/package.json
@@ -57,7 +57,16 @@
     "typia-rspack-plugin": "3.0.1"
   },
   "peerDependencies": {
-    "@lynx-js/rspeedy": "^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+    "@lynx-js/rspeedy": "^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0",
+    "@rsbuild/core": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@lynx-js/rspeedy": {
+      "optional": true
+    },
+    "@rsbuild/core": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18"

--- a/packages/rspeedy/plugin-debug-metadata/package.json
+++ b/packages/rspeedy/plugin-debug-metadata/package.json
@@ -42,6 +42,14 @@
     "@rollup/plugin-typescript": "^12.3.0",
     "@rsbuild/core": "catalog:rsbuild"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rsbuild/core": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/rspeedy/plugin-external-bundle/package.json
+++ b/packages/rspeedy/plugin-external-bundle/package.json
@@ -42,8 +42,21 @@
   },
   "devDependencies": {
     "@lynx-js/react-umd": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rsbuild/core": "catalog:rsbuild"
+  },
+  "peerDependencies": {
+    "@lynx-js/rspeedy": "^0.16.0",
+    "@rsbuild/core": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@lynx-js/rspeedy": {
+      "optional": true
+    },
+    "@rsbuild/core": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18"

--- a/packages/rspeedy/plugin-lynx/package.json
+++ b/packages/rspeedy/plugin-lynx/package.json
@@ -62,6 +62,11 @@
   "peerDependencies": {
     "@rsbuild/core": "^2.0.0"
   },
+  "peerDependenciesMeta": {
+    "@rsbuild/core": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=18"
   },

--- a/packages/rspeedy/plugin-qrcode/package.json
+++ b/packages/rspeedy/plugin-qrcode/package.json
@@ -63,6 +63,9 @@
   "peerDependenciesMeta": {
     "@lynx-js/rspeedy": {
       "optional": true
+    },
+    "@rsbuild/core": {
+      "optional": true
     }
   },
   "engines": {

--- a/packages/rspeedy/plugin-react-alias/package.json
+++ b/packages/rspeedy/plugin-react-alias/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@lynx-js/react": "workspace:*",
     "@lynx-js/react-webpack-plugin": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/test-tools": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@rsbuild/core": "catalog:rsbuild",
@@ -46,6 +47,18 @@
     "@rstest/core": "catalog:rstest",
     "@types/semver": "^7.8.0",
     "semver": "^7.8.5"
+  },
+  "peerDependencies": {
+    "@lynx-js/rspeedy": "^0.16.0",
+    "@rsbuild/core": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@lynx-js/rspeedy": {
+      "optional": true
+    },
+    "@rsbuild/core": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18"

--- a/packages/rspeedy/plugin-react/package.json
+++ b/packages/rspeedy/plugin-react/package.json
@@ -70,13 +70,17 @@
   },
   "peerDependencies": {
     "@lynx-js/react": "^0.124.0 || ^0.125.0",
-    "@lynx-js/rspeedy": "^0.16.0"
+    "@lynx-js/rspeedy": "^0.16.0",
+    "@rsbuild/core": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@lynx-js/react": {
       "optional": true
     },
     "@lynx-js/rspeedy": {
+      "optional": true
+    },
+    "@rsbuild/core": {
       "optional": true
     }
   },

--- a/packages/rspeedy/plugin-vanilla/package.json
+++ b/packages/rspeedy/plugin-vanilla/package.json
@@ -47,6 +47,18 @@
     "@rsbuild/core": "catalog:rsbuild",
     "@rstest/core": "catalog:rstest"
   },
+  "peerDependencies": {
+    "@lynx-js/rspeedy": "^0.16.0",
+    "@rsbuild/core": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@lynx-js/rspeedy": {
+      "optional": true
+    },
+    "@rsbuild/core": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -796,9 +796,6 @@ importers:
       '@lynx-js/rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-lynx
-      '@lynx-js/rspeedy':
-        specifier: workspace:*
-        version: link:../../packages/rspeedy/core
       '@lynx-js/types':
         specifier: 4.1.0
         version: 4.1.0
@@ -1767,6 +1764,9 @@ importers:
       '@lynx-js/react-umd':
         specifier: workspace:*
         version: link:../../react-umd
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../core
       '@microsoft/api-extractor':
         specifier: 'catalog:'
         version: 7.58.12(@types/node@24.13.3)
@@ -1949,6 +1949,9 @@ importers:
       '@lynx-js/react-webpack-plugin':
         specifier: workspace:*
         version: link:../../webpack/react-webpack-plugin
+      '@lynx-js/rspeedy':
+        specifier: workspace:*
+        version: link:../core
       '@lynx-js/test-tools':
         specifier: workspace:*
         version: link:../../webpack/test-tools


### PR DESCRIPTION
Rspeedy carries `@rsbuild/core` as a dependency, so an Rspeedy user never installs it and a peer on it alone is never checked: the Rsbuild version a plugin runs against is whichever one Rspeedy ships. Declaring both hosts as optional peers makes whichever one is installed version-checked.

- Every plugin declares `@rsbuild/core`, matching how the Rsbuild plugins declare it themselves.
- The plugins a user installs next to a host also declare `@lynx-js/rspeedy`. `pluginLynx` and the debug metadata plugin do not: Rspeedy depends on them, so the pair is already resolved together and a peer back would be a workspace cycle.
- `examples/rsbuild` drops its unused `@lynx-js/rspeedy` and configures the bundle filename through `pluginLynx`, which is what applying the engine yourself is for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using Lynx build plugins with either Rsbuild or Rspeedy.
  * Build host compatibility is now version-checked automatically when installed.

* **Improvements**
  * Updated the Rsbuild example to register the Lynx plugin explicitly.
  * Build plugins now treat supported build hosts as optional, improving setup flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->