### PR TITLE
feat(rsbuild-plugin): write the bundle to disk during dev by default

### DIFF
--- a/.changeset/olive-pears-shave.md
+++ b/.changeset/olive-pears-shave.md
@@ -1,0 +1,6 @@
+---
+"@lynx-js/rsbuild-plugin": patch
+"@lynx-js/rspeedy": patch
+---
+
+Write the bundle to disk during `dev` by default. A Lynx client reads it from disk as often as it reads it from the dev server, so the Lynx build engine now carries the default that only Rspeedy used to apply.

--- a/examples/rsbuild/package.json
+++ b/examples/rsbuild/package.json
@@ -11,6 +11,7 @@
     "@lynx-js/react": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/react-rsbuild-plugin": "workspace:*",
     "@lynx-js/rsbuild-plugin": "workspace:*",
     "@lynx-js/types": "4.1.0",

--- a/examples/rsbuild/rsbuild.config.ts
+++ b/examples/rsbuild/rsbuild.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
 import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
 import { pluginLynx } from '@lynx-js/rsbuild-plugin';
 
@@ -21,5 +22,6 @@ export default defineConfig({
       },
     }),
     pluginReactLynx(),
+    pluginQRCode(),
   ],
 });

--- a/packages/rspeedy/core/src/config/rsbuild/index.ts
+++ b/packages/rspeedy/core/src/config/rsbuild/index.ts
@@ -23,8 +23,7 @@ export function toRsbuildConfig(
       lazyCompilation: false,
       liveReload: config.dev?.liveReload ?? true,
       watchFiles: config.dev?.watchFiles,
-      // We expect to use different default writeToDisk with Rsbuild
-      writeToDisk: config.dev?.writeToDisk ?? true,
+      writeToDisk: config.dev?.writeToDisk,
 
       progressBar: config.dev?.progressBar ?? true,
     },

--- a/packages/rspeedy/core/test/config/rsbuild.test.ts
+++ b/packages/rspeedy/core/test/config/rsbuild.test.ts
@@ -78,7 +78,7 @@ describe('Config - toRsBuildConfig', () => {
           "liveReload": true,
           "progressBar": true,
           "watchFiles": undefined,
-          "writeToDisk": true,
+          "writeToDisk": undefined,
         }
       `)
     })

--- a/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
+++ b/packages/rspeedy/plugin-lynx/src/plugins/dev.plugin.ts
@@ -158,6 +158,10 @@ export function pluginDev(): RsbuildPlugin {
                 host: hostname,
                 port: '<port>',
               },
+              // A Lynx client reads the bundle from disk as often as it reads
+              // it from the dev server, so the default is the opposite of
+              // Rsbuild's.
+              writeToDisk: original.dev?.writeToDisk ?? true,
             },
             // When using `rspeedy dev --mode production`
             // Rsbuild would use `output.assetPrefix` instead of `dev.assetPrefix`

--- a/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
+++ b/packages/rspeedy/plugin-lynx/test/dev.plugin.test.ts
@@ -5,7 +5,11 @@ import { isIP, isIPv4 } from 'node:net'
 import type { AddressInfo } from 'node:net'
 import path from 'node:path'
 
-import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core'
+import type {
+  RsbuildConfig,
+  RsbuildPlugin,
+  RsbuildPluginAPI,
+} from '@rsbuild/core'
 import { beforeEach, describe, expect, rstest, test } from '@rstest/core'
 
 import { createStubRsbuild } from './createStubRsbuild.js'
@@ -706,6 +710,45 @@ describe('pluginDev', () => {
       '@lynx-js/webpack-dev-transport/client',
       expect.stringContaining('live-reload=true'),
     )
+  })
+
+  test('writeToDisk defaults to true', async () => {
+    let writeToDisk: unknown
+
+    const rsbuild = await createDevStubRsbuild({
+      plugins: [{
+        name: 'test:capture',
+        setup(api: RsbuildPluginAPI) {
+          api.modifyBundlerChain(() => {
+            writeToDisk = api.getNormalizedConfig().dev.writeToDisk
+          })
+        },
+      }],
+    })
+
+    await rsbuild.unwrapConfig()
+
+    expect(writeToDisk).toBe(true)
+  })
+
+  test('writeToDisk keeps a user value', async () => {
+    let writeToDisk: unknown
+
+    const rsbuild = await createDevStubRsbuild({
+      dev: { writeToDisk: false },
+      plugins: [{
+        name: 'test:capture',
+        setup(api: RsbuildPluginAPI) {
+          api.modifyBundlerChain(() => {
+            writeToDisk = api.getNormalizedConfig().dev.writeToDisk
+          })
+        },
+      }],
+    })
+
+    await rsbuild.unwrapConfig()
+
+    expect(writeToDisk).toBe(false)
   })
 
   test('websocketTransport', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react
     devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin':
+        specifier: workspace:*
+        version: link:../../packages/rspeedy/plugin-qrcode
       '@lynx-js/react-rsbuild-plugin':
         specifier: workspace:*
         version: link:../../packages/rspeedy/plugin-react


### PR DESCRIPTION
A Lynx client reads the bundle from disk as often as it reads it from the dev server, so `dev.writeToDisk` now defaults to `true` in `pluginLynx` instead of following Rsbuild's default. Rspeedy forwards the user's value and no longer sets its own default.

The Rsbuild example also gains `pluginQRCode` so the dev server prints a scannable URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added QR code support to the Rsbuild example application.
  - Development builds now write bundles to disk by default, supporting Lynx clients that read bundles locally.

- **Bug Fixes**
  - Preserved explicit `dev.writeToDisk` settings instead of overriding them.
  - Updated development configuration behavior to distinguish unset options from enabled options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->