### PR TITLE
fix(react): keep ref in props for function components on the main thread

### DIFF
--- a/.changeset/main-thread-ref-prop.md
+++ b/.changeset/main-thread-ref-prop.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/react": patch
+---
+
+Keep `ref` in props for function components on the main thread, matching the background thread.

--- a/packages/react/runtime/__test__/element-template/imports/jsx-runtime.test.ts
+++ b/packages/react/runtime/__test__/element-template/imports/jsx-runtime.test.ts
@@ -27,7 +27,7 @@ describe('element-template jsx-runtime', () => {
     expect(vnode?.props).toEqual({});
   });
 
-  it('strips ref and applies defaultProps for function components', () => {
+  it('keeps ref and applies defaultProps for function components', () => {
     function Foo() {
       return null;
     }
@@ -37,8 +37,21 @@ describe('element-template jsx-runtime', () => {
 
     expect(vnode.props).toEqual({
       foo: 'bar',
+      ref: 'ref',
       extra: 1,
     });
+  });
+
+  it('strips ref for class components', () => {
+    class Foo {
+      render() {
+        return null;
+      }
+    }
+
+    const vnode = jsx(Foo, { ref: 'ref', extra: 1 });
+
+    expect(vnode.props).toEqual({ extra: 1 });
   });
 
   it('returns undefined for unsupported vnode types', () => {

--- a/packages/react/runtime/__test__/snapshot/jsx-runtime-lepus.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/jsx-runtime-lepus.test.jsx
@@ -20,7 +20,7 @@ describe('lepus jsx-runtime createVNode', () => {
     expect(vnode).toBeInstanceOf(SnapshotInstance);
   });
 
-  it('should strip ref and apply defaultProps for function components', () => {
+  it('should keep ref and apply defaultProps for function components', () => {
     function Foo() {
       return null;
     }
@@ -28,6 +28,18 @@ describe('lepus jsx-runtime createVNode', () => {
 
     const vnode = jsx(Foo, { foo: undefined, ref: 'ref', extra: 1 });
     expect(vnode.props.foo).toBe('bar');
+    expect(vnode.props.extra).toBe(1);
+    expect(vnode.props.ref).toBe('ref');
+  });
+
+  it('should strip ref for class components', () => {
+    class Foo {
+      render() {
+        return null;
+      }
+    }
+
+    const vnode = jsx(Foo, { ref: 'ref', extra: 1 });
     expect(vnode.props.extra).toBe(1);
     expect('ref' in vnode.props).toBe(false);
   });

--- a/packages/react/runtime/__test__/snapshot/ref-parity.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/ref-parity.test.jsx
@@ -58,6 +58,13 @@ describe('ref parity between the main and background threads', () => {
     });
   });
 
+  it('createElement lifts ref off props for host elements, like the background thread', () => {
+    const background = backgroundJsx('view', { ref, id: 'x' });
+    const mainThread = createElement('view', { ref, id: 'x' });
+
+    expect(mainThread.props).toEqual(background.props);
+  });
+
   it('renders the same tree on both threads when a component reads props.ref', () => {
     function Branching(props) {
       return props.ref ? 'with-ref' : 'without-ref';

--- a/packages/react/runtime/__test__/snapshot/ref-parity.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/ref-parity.test.jsx
@@ -1,0 +1,71 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { Component } from 'preact';
+import { jsx as backgroundJsx } from 'preact/jsx-runtime';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import '../../src/index';
+import { createElement, cloneElement } from '../../lepus';
+import { jsx as mainThreadJsx } from '../../lepus/jsx-runtime';
+import { snapshotCreatorMap } from '../../src/snapshot';
+
+describe('ref parity between the main and background threads', () => {
+  function FunctionComponent() {
+    return null;
+  }
+
+  class ClassComponent extends Component {
+    render() {
+      return null;
+    }
+  }
+
+  const ref = () => {};
+
+  beforeEach(() => {
+    snapshotCreatorMap['view'] = () => {};
+  });
+
+  afterEach(() => {
+    delete snapshotCreatorMap['view'];
+  });
+
+  describe.each([
+    ['function component', FunctionComponent],
+    ['class component', ClassComponent],
+  ])('%s', (_, type) => {
+    it('jsx keeps the same ref prop as the background thread', () => {
+      const background = backgroundJsx(type, { ref, id: 'x' });
+      const mainThread = mainThreadJsx(type, { ref, id: 'x' });
+
+      expect(mainThread.props).toEqual(background.props);
+    });
+
+    it('createElement keeps the same ref prop as the background thread', () => {
+      const background = backgroundJsx(type, { ref, id: 'x' });
+      const mainThread = createElement(type, { ref, id: 'x' });
+
+      expect(mainThread.props).toEqual(background.props);
+    });
+
+    it('cloneElement keeps the same ref prop as the background thread', () => {
+      const background = backgroundJsx(type, { ref, id: 'x' });
+      const mainThread = cloneElement(createElement(type, { id: 'x' }), { ref });
+
+      expect(mainThread.props).toEqual(background.props);
+    });
+  });
+
+  it('renders the same tree on both threads when a component reads props.ref', () => {
+    function Branching(props) {
+      return props.ref ? 'with-ref' : 'without-ref';
+    }
+
+    const background = Branching(backgroundJsx(Branching, { ref }).props);
+    const mainThread = Branching(mainThreadJsx(Branching, { ref }).props);
+
+    expect(mainThread).toBe(background);
+  });
+});

--- a/packages/react/runtime/__test__/snapshot/renderToOpcodes.test.jsx
+++ b/packages/react/runtime/__test__/snapshot/renderToOpcodes.test.jsx
@@ -1229,12 +1229,14 @@ describe('renderOpcodesInto', () => {
   it('should render component with ref', () => {
     scratch.ensureElements();
 
-    function Counter({ ref, count: _ }) {
-      expect(ref).toBe(undefined);
+    const ref = vi.fn();
+
+    function Counter({ ref: r, count: _ }) {
+      expect(r).toBe(ref);
       return <view />;
     }
 
-    renderToString(<Counter ref={vi.fn()} count={1} />, scratch);
+    renderToString(<Counter ref={ref} count={1} />, scratch);
     // renderOpcodesInto(opcodes, scratch);
     expect(scratch.__element_root).toMatchInlineSnapshot(`
       <page
@@ -1395,13 +1397,15 @@ describe('createElement', () => {
     `);
   });
 
-  it('ref should not be accessible to developer', () => {
-    function Key({ ref }) {
-      expect(ref).toBe(undefined);
+  it('ref should be accessible to developer', () => {
+    const ref = vi.fn();
+
+    function Key({ ref: r }) {
+      expect(r).toBe(ref);
       return <view />;
     }
 
-    const opcodes1 = renderToString(<Key key={1} {...s} ref={vi.fn()} />);
+    const opcodes1 = renderToString(<Key key={1} {...s} ref={ref} />);
     expect(opcodes1).toMatchInlineSnapshot(`
       [
         0,
@@ -1416,7 +1420,7 @@ describe('createElement', () => {
         1,
       ]
     `);
-    const opcodes2 = renderToString(<Key {...s} key={1} ref={vi.fn()} />);
+    const opcodes2 = renderToString(<Key {...s} key={1} ref={ref} />);
     expect(opcodes2).toMatchInlineSnapshot(`
       [
         0,

--- a/packages/react/runtime/lepus/index.js
+++ b/packages/react/runtime/lepus/index.js
@@ -21,7 +21,7 @@ export function createElement(type, props, children) {
     i;
   for (i in props) {
     if (i == 'key') key = props[i];
-    else if (i == 'ref') ref = props[i];
+    else if (i == 'ref' && typeof type != 'function') ref = props[i];
     else normalizedProps[i] = props[i];
   }
 
@@ -65,7 +65,7 @@ export function cloneElement(vnode, props, children) {
 
   for (i in props) {
     if (i == 'key') key = props[i];
-    else if (i == 'ref') ref = props[i];
+    else if (i == 'ref' && typeof vnode.type != 'function') ref = props[i];
     else if (props[i] === undefined && defaultProps !== undefined) {
       normalizedProps[i] = defaultProps[i];
     } else {

--- a/packages/react/runtime/lepus/jsx-runtime/index.js
+++ b/packages/react/runtime/lepus/jsx-runtime/index.js
@@ -38,13 +38,10 @@ function createVNode(type, props, _key) {
   } else if (typeof type === 'function') {
     let normalizedProps = props;
 
-    // let ref;
-    if ('ref' in normalizedProps) {
+    if ('ref' in normalizedProps && 'prototype' in type && type.prototype.render) {
       normalizedProps = {};
       for (let i in props) {
-        if (i == 'ref') {
-          // ref = props[i];
-        } else {
+        if (i != 'ref') {
           normalizedProps[i] = props[i];
         }
       }

--- a/packages/react/runtime/src/element-template/jsx-runtime/index.ts
+++ b/packages/react/runtime/src/element-template/jsx-runtime/index.ts
@@ -6,6 +6,7 @@ import { CHILDREN, COMPONENT, DIFF, DOM, FLAGS, INDEX, PARENT } from '../../shar
 
 type ComponentLike = ((...args: unknown[]) => unknown) & {
   defaultProps?: Record<string, unknown>;
+  prototype?: { render?: unknown };
 };
 
 interface ElementTemplateVNode {
@@ -44,7 +45,7 @@ function createVNode(
   } else if (typeof type === 'function') {
     let normalizedProps = props;
 
-    if (normalizedProps && 'ref' in normalizedProps) {
+    if (normalizedProps && 'ref' in normalizedProps && type.prototype?.render) {
       normalizedProps = {};
       for (const i in props) {
         if (i !== 'ref') {


### PR DESCRIPTION
Preact 11 forwards `ref` as a normal prop to function components ([preactjs/preact#4658](https://github.com/preactjs/preact/pull/4658)). It only lifts `ref` off props for host elements, and — via `preact/compat`'s `options.vnode` — for class components.

The three main-thread element factories still stripped it unconditionally, so a function component reading `props.ref` saw `undefined` on the main thread and the ref on the background thread.

First commit is the failing parity test, second is the fix.

Reported by @Yradex in #3450.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Function components now retain the `ref` prop across main-thread and background-thread rendering.
  * Class components continue to handle `ref` separately, while host elements preserve existing behavior.
  * `ref` handling is now consistent across JSX, element creation, cloning, and server-side rendering.

* **Tests**
  * Added coverage to verify consistent `ref` behavior across component types and rendering environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->